### PR TITLE
[canary2-noauto] Canary 2 — Auto-merge disabled

### DIFF
--- a/canary/c2.txt
+++ b/canary/c2.txt
@@ -1,0 +1,1 @@
+canary 2 — pr-ready fallback — 2026-04-13T22:07:32-04:00


### PR DESCRIPTION
Validates pr-ready fallback when auto-merge is unavailable.