### PR TITLE
[canary3-fixcycle] Canary 3 — Fix Cycle

### DIFF
--- a/hooks/canary3-bad.sh
+++ b/hooks/canary3-bad.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # canary 3 — deliberate syntax error
-if then
+if true; then
   echo "bad"
 fi

--- a/hooks/canary3-bad.sh
+++ b/hooks/canary3-bad.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# canary 3 — deliberate syntax error
+if then
+  echo "bad"
+fi


### PR DESCRIPTION
Deliberate bash syntax error to test the CI fix cycle. Expected: CI fails → fix agent dispatched → fixes file → re-push → CI passes → auto-merge.