### PR TITLE
[execution-modes] Phase 5a: Skill Propagation

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -196,6 +196,56 @@ A single agent produces the initial plan based on the consolidated research
 and user feedback. The plan MUST follow a format that `/run-plan` can
 consume:
 
+### Landing mode hint
+
+Before writing the plan, determine which landing mode hint (if any) to
+embed near the top. Resolution order:
+
+1. **Explicit description suffix** — if the description passed to
+   `/draft-plan` ends with `Landing mode: pr` or `Landing mode: direct`
+   (as appended by `/research-and-plan`), that wins. Strip this suffix
+   from the description before using it in the plan body.
+2. **Config default** — otherwise read `.claude/zskills-config.json`
+   for `execution.landing`:
+
+   ```bash
+   PROJECT_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+   CONFIG_FILE="$PROJECT_ROOT/.claude/zskills-config.json"
+   LANDING_HINT=""
+   if [ -f "$CONFIG_FILE" ]; then
+     CONFIG_CONTENT=$(cat "$CONFIG_FILE")
+     if [[ "$CONFIG_CONTENT" =~ \"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+       LANDING_HINT="${BASH_REMATCH[1]}"
+     fi
+   fi
+   ```
+
+3. **Fallback** — if neither the description suffix nor the config
+   specifies a mode, treat it as `cherry-pick` (the default) — no hint
+   emitted.
+
+Based on the resolved mode, prepend one of the following blockquotes
+immediately after the `# Plan: <Title>` heading and before `## Overview`:
+
+- `pr`:
+  ```markdown
+  > **Landing mode: PR** -- This plan targets PR-based landing. All phases
+  > use worktree isolation with a named feature branch.
+  ```
+- `direct`:
+  ```markdown
+  > **Landing mode: direct** -- This plan targets direct-to-main landing.
+  > No worktree isolation.
+  ```
+- `cherry-pick` or absent: **no blockquote** (default behavior — do not
+  emit a hint).
+
+**This is a hint, not enforcement.** The hint exists so the implementing
+agent (and any human reader) knows which landing model the plan was
+drafted for. At execution time the `/run-plan` argument (`pr`, `direct`,
+or unspecified) always takes precedence — the embedded hint never
+overrides an explicit `/run-plan` flag.
+
 ### Required plan structure
 
 Every plan file MUST begin with YAML frontmatter so that `/run-plan` can
@@ -223,6 +273,14 @@ status: active    # active | complete
 
 ```markdown
 # Plan: <Title>
+
+> **Landing mode: PR** -- This plan targets PR-based landing. All phases
+> use worktree isolation with a named feature branch.
+<!-- OR, if direct mode:
+> **Landing mode: direct** -- This plan targets direct-to-main landing.
+> No worktree isolation.
+-->
+<!-- Omit the blockquote entirely when landing mode is cherry-pick or unset. -->
 
 ## Overview
 Brief description of what this plan accomplishes and why.

--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -136,11 +136,52 @@ corresponding requirement as completed. For example, include
 
 ## Step 2 — Execute
 
-Immediately run:
+### Landing mode detection
+
+Before constructing the `/run-plan` invocation, detect whether the original
+`$GOAL` text contains `pr` or `direct` as a distinct word (same pattern as
+Phase 3a in `/run-plan` and `/fix-issues`, extended to recognize sentence
+punctuation `.!?` since this is prose-like goal text):
+
+```bash
+LANDING_ARG=""
+if [[ "$GOAL" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="pr"
+elif [[ "$GOAL" =~ (^|[[:space:]])[dD][iI][rR][eE][cC][tT]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="direct"
+fi
+```
+
+Where `$GOAL` is the original description passed to `/research-and-go`.
+If the goal text does not mention either keyword, `LANDING_ARG` stays
+empty and `/run-plan` falls back to its config default (normally
+`cherry-pick`). Do NOT pass a literal empty token to `/run-plan` — omit
+the argument entirely when `LANDING_ARG=""`.
+
+### Construct the /run-plan cron prompt
+
+The cron prompt MUST place `$LANDING_ARG` between `auto` and `every` so
+that `/run-plan` parses it correctly. Build the prompt conditionally to
+avoid empty-token confusion:
+
+```bash
+if [ -n "$LANDING_ARG" ]; then
+  RUN_PROMPT="Run /run-plan <meta-plan-path> finish auto $LANDING_ARG every 4h now"
+else
+  RUN_PROMPT="Run /run-plan <meta-plan-path> finish auto every 4h now"
+fi
+```
+
+Immediately run the resulting invocation — conceptually:
 
 ```
-/run-plan <meta-plan-path> finish auto
+/run-plan <meta-plan-path> finish auto [pr|direct] every 4h now
 ```
+
+Concrete examples:
+- Goal "Add dark mode" → `/run-plan <meta-plan-path> finish auto`
+- Goal "Add thermal domain. PR." → `/run-plan <meta-plan-path> finish auto pr`
+- Goal "Refactor logs direct" → `/run-plan <meta-plan-path> finish auto direct`
 
 This executes all implementation phases sequentially — each delegating
 to `/run-plan` on the corresponding sub-plan. Full verification,

--- a/.claude/skills/research-and-plan/SKILL.md
+++ b/.claude/skills/research-and-plan/SKILL.md
@@ -86,6 +86,28 @@ out. The agent rationalizes "I'll go faster" and skips adversarial review.
 It does NOT go faster — it produces plans with 10+ CRITICAL issues that
 require full restarts.
 
+### Landing mode detection
+
+Before dispatching `/draft-plan` agents, detect whether the original
+goal/description text contains `pr` or `direct` as a distinct word. Use
+the same pattern as Phase 3a, extended with sentence punctuation `.!?`
+since this is prose-like goal text:
+
+```bash
+LANDING_ARG=""
+if [[ "$GOAL" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="pr"
+elif [[ "$GOAL" =~ (^|[[:space:]])[dD][iI][rR][eE][cC][tT]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="direct"
+fi
+```
+
+Where `$GOAL` is the full description passed to `/research-and-plan`.
+If `LANDING_ARG` is empty, no landing-mode suffix is added to the
+`/draft-plan` invocation. This is a hint for generated plans — it does
+NOT enforce landing behavior. The `/run-plan` argument always takes
+precedence at execution time.
+
 For each sub-problem:
 
 1. Determine the sub-plan output path: `plans/<SLUG>_<N>.md` (or let the
@@ -93,6 +115,12 @@ For each sub-problem:
 2. If research from Step 1 was written to a file, pass that path to the
    `/draft-plan` agent so it has the decomposition context.
 3. Dispatch: `/draft-plan output <path> <sub-problem description>`
+   - **If `LANDING_ARG` is non-empty**, append `. Landing mode: <LANDING_ARG>`
+     to the description so `/draft-plan` can embed the matching hint in
+     the generated plan. Example:
+     `/draft-plan output plans/X.md rounds 2 <description>. Landing mode: pr`
+   - If `LANDING_ARG` is empty, omit the suffix entirely — do NOT pass
+     an empty `Landing mode:` token.
 4. Wait for each `/draft-plan` batch to complete before dispatching the
    next batch (see parallelism rules below).
 

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,5 +10,5 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-execution-modes.md](reports/plan-execution-modes.md) | 1 | Pending landing |
+| [plan-execution-modes.md](reports/plan-execution-modes.md) | 1 | Landed (PR #10) |
 | [plan-canary5-autonomous.md](reports/plan-canary5-autonomous.md) | 2 | Pending landing |

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,5 +10,5 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-execution-modes.md](reports/plan-execution-modes.md) | 1 | Landed (PR #10) |
+| [plan-execution-modes.md](reports/plan-execution-modes.md) | 2 | Pending landing |
 | [plan-canary5-autonomous.md](reports/plan-canary5-autonomous.md) | 2 | Pending landing |

--- a/plans/EXECUTION_MODES.md
+++ b/plans/EXECUTION_MODES.md
@@ -22,7 +22,7 @@ The tracking system is DONE and working. This plan builds on top of it. Tracking
 | 3b-i -- Worktree Unification + Landing Script | ✅ Done | `9cc1dc2` | Manual worktrees, land-phase.sh, preflight, 7 tests |
 | 3b-ii -- PR Mode Happy Path | ✅ Done | `36af895` | Named branches, rebase, push+PR, .landed, 9 tests |
 | 3b-iii -- CI Integration + Fix Cycle + Auto-Merge | ✅ Done | `e24d8ad` | CI polling, fix cycle, auto-merge, PR comments, 4 tests |
-| 4 -- /fix-issues PR Landing | 🟡 In Progress | `793d2f9` | Per-issue branches, PR creation, 3 tests |
+| 4 -- /fix-issues PR Landing | ✅ Done | `e9d4a82` | Per-issue branches, PR #10, 3 tests |
 | 5a -- Skill Propagation | ⬜ | | research-and-go, research-and-plan, draft-plan |
 | 5b -- Execution Skills + Documentation | ⬜ | | do, commit, CLAUDE_TEMPLATE, update-zskills |
 | 5c -- Infrastructure: Cleanup, Model Gate, Baseline | ⬜ | | cleanup tooling, agents.min_model, baseline snapshot |

--- a/plans/EXECUTION_MODES.md
+++ b/plans/EXECUTION_MODES.md
@@ -23,7 +23,7 @@ The tracking system is DONE and working. This plan builds on top of it. Tracking
 | 3b-ii -- PR Mode Happy Path | ✅ Done | `36af895` | Named branches, rebase, push+PR, .landed, 9 tests |
 | 3b-iii -- CI Integration + Fix Cycle + Auto-Merge | ✅ Done | `e24d8ad` | CI polling, fix cycle, auto-merge, PR comments, 4 tests |
 | 4 -- /fix-issues PR Landing | ✅ Done | `e9d4a82` | Per-issue branches, PR #10, 3 tests |
-| 5a -- Skill Propagation | ⬜ | | research-and-go, research-and-plan, draft-plan |
+| 5a -- Skill Propagation | 🟡 In Progress | `a13211f` | research-and-go, research-and-plan, draft-plan |
 | 5b -- Execution Skills + Documentation | ⬜ | | do, commit, CLAUDE_TEMPLATE, update-zskills |
 | 5c -- Infrastructure: Cleanup, Model Gate, Baseline | ⬜ | | cleanup tooling, agents.min_model, baseline snapshot |
 

--- a/reports/plan-execution-modes.md
+++ b/reports/plan-execution-modes.md
@@ -1,12 +1,12 @@
 # Plan Report — Execution Modes
 
-## Phase — 4 /fix-issues PR Landing [UNFINALIZED]
+## Phase — 4 /fix-issues PR Landing
 
 **Plan:** plans/EXECUTION_MODES.md
-**Status:** Completed (verified, landing in progress)
-**Worktree:** /tmp/zskills-pr-execution-modes
-**Branch:** feat/execution-modes
-**Commits:** 793d2f9
+**Status:** Landed (PR #10 merged)
+**Branch:** feat/execution-modes (merged + deleted)
+**PR:** https://github.com/zeveck/zskills-dev/pull/10
+**Commits:** e9d4a82 (feature), c82cafc (tracker), 82fbe96 (report)
 
 ### Work Items
 | # | Item | Status | Commit |

--- a/reports/plan-execution-modes.md
+++ b/reports/plan-execution-modes.md
@@ -1,5 +1,37 @@
 # Plan Report — Execution Modes
 
+## Phase — 5a Skill Propagation [UNFINALIZED]
+
+**Plan:** plans/EXECUTION_MODES.md
+**Status:** Completed (verified, landing in progress)
+**Worktree:** /tmp/zskills-pr-execution-modes
+**Branch:** feat/execution-modes
+**Commits:** a13211f
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | 5a.1 — `/research-and-go` detect mode + pass to `/run-plan` cron | Done | a13211f |
+| 2 | 5a.2 — `/research-and-plan` pass mode to `/draft-plan` | Done | a13211f |
+| 3 | 5a.3 — `/draft-plan` embed landing hint in generated plans | Done | a13211f |
+| 4 | 5a.4 — Sync 3 installed copies | Done | a13211f |
+
+### Verification
+- Test suite: 116 passed, 0 failed (no regression — phase is text only)
+- Drift check: clean (3/3 source↔installed pairs identical)
+- Acceptance criteria: all met
+- No automated tests required (per spec — skill text only)
+
+### Notes
+- Regex pattern extends Phase 3a's word-boundary class with `.!?` to match
+  goal/prose text in `/research-and-go` and `/research-and-plan`.
+- `/draft-plan` resolves landing mode in 3 tiers: description suffix
+  (`. Landing mode: pr` from `/research-and-plan`) → config
+  `execution.landing` → fallback `cherry-pick` (no hint).
+- Hint placement: blockquote after `# Plan: <Title>` H1, before `## Overview`.
+- Hints are advisory — `/run-plan` arguments always take precedence at
+  execution time (documented in each skill).
+
 ## Phase — 4 /fix-issues PR Landing
 
 **Plan:** plans/EXECUTION_MODES.md

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -196,6 +196,56 @@ A single agent produces the initial plan based on the consolidated research
 and user feedback. The plan MUST follow a format that `/run-plan` can
 consume:
 
+### Landing mode hint
+
+Before writing the plan, determine which landing mode hint (if any) to
+embed near the top. Resolution order:
+
+1. **Explicit description suffix** — if the description passed to
+   `/draft-plan` ends with `Landing mode: pr` or `Landing mode: direct`
+   (as appended by `/research-and-plan`), that wins. Strip this suffix
+   from the description before using it in the plan body.
+2. **Config default** — otherwise read `.claude/zskills-config.json`
+   for `execution.landing`:
+
+   ```bash
+   PROJECT_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+   CONFIG_FILE="$PROJECT_ROOT/.claude/zskills-config.json"
+   LANDING_HINT=""
+   if [ -f "$CONFIG_FILE" ]; then
+     CONFIG_CONTENT=$(cat "$CONFIG_FILE")
+     if [[ "$CONFIG_CONTENT" =~ \"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+       LANDING_HINT="${BASH_REMATCH[1]}"
+     fi
+   fi
+   ```
+
+3. **Fallback** — if neither the description suffix nor the config
+   specifies a mode, treat it as `cherry-pick` (the default) — no hint
+   emitted.
+
+Based on the resolved mode, prepend one of the following blockquotes
+immediately after the `# Plan: <Title>` heading and before `## Overview`:
+
+- `pr`:
+  ```markdown
+  > **Landing mode: PR** -- This plan targets PR-based landing. All phases
+  > use worktree isolation with a named feature branch.
+  ```
+- `direct`:
+  ```markdown
+  > **Landing mode: direct** -- This plan targets direct-to-main landing.
+  > No worktree isolation.
+  ```
+- `cherry-pick` or absent: **no blockquote** (default behavior — do not
+  emit a hint).
+
+**This is a hint, not enforcement.** The hint exists so the implementing
+agent (and any human reader) knows which landing model the plan was
+drafted for. At execution time the `/run-plan` argument (`pr`, `direct`,
+or unspecified) always takes precedence — the embedded hint never
+overrides an explicit `/run-plan` flag.
+
 ### Required plan structure
 
 Every plan file MUST begin with YAML frontmatter so that `/run-plan` can
@@ -223,6 +273,14 @@ status: active    # active | complete
 
 ```markdown
 # Plan: <Title>
+
+> **Landing mode: PR** -- This plan targets PR-based landing. All phases
+> use worktree isolation with a named feature branch.
+<!-- OR, if direct mode:
+> **Landing mode: direct** -- This plan targets direct-to-main landing.
+> No worktree isolation.
+-->
+<!-- Omit the blockquote entirely when landing mode is cherry-pick or unset. -->
 
 ## Overview
 Brief description of what this plan accomplishes and why.

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -136,11 +136,52 @@ corresponding requirement as completed. For example, include
 
 ## Step 2 — Execute
 
-Immediately run:
+### Landing mode detection
+
+Before constructing the `/run-plan` invocation, detect whether the original
+`$GOAL` text contains `pr` or `direct` as a distinct word (same pattern as
+Phase 3a in `/run-plan` and `/fix-issues`, extended to recognize sentence
+punctuation `.!?` since this is prose-like goal text):
+
+```bash
+LANDING_ARG=""
+if [[ "$GOAL" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="pr"
+elif [[ "$GOAL" =~ (^|[[:space:]])[dD][iI][rR][eE][cC][tT]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="direct"
+fi
+```
+
+Where `$GOAL` is the original description passed to `/research-and-go`.
+If the goal text does not mention either keyword, `LANDING_ARG` stays
+empty and `/run-plan` falls back to its config default (normally
+`cherry-pick`). Do NOT pass a literal empty token to `/run-plan` — omit
+the argument entirely when `LANDING_ARG=""`.
+
+### Construct the /run-plan cron prompt
+
+The cron prompt MUST place `$LANDING_ARG` between `auto` and `every` so
+that `/run-plan` parses it correctly. Build the prompt conditionally to
+avoid empty-token confusion:
+
+```bash
+if [ -n "$LANDING_ARG" ]; then
+  RUN_PROMPT="Run /run-plan <meta-plan-path> finish auto $LANDING_ARG every 4h now"
+else
+  RUN_PROMPT="Run /run-plan <meta-plan-path> finish auto every 4h now"
+fi
+```
+
+Immediately run the resulting invocation — conceptually:
 
 ```
-/run-plan <meta-plan-path> finish auto
+/run-plan <meta-plan-path> finish auto [pr|direct] every 4h now
 ```
+
+Concrete examples:
+- Goal "Add dark mode" → `/run-plan <meta-plan-path> finish auto`
+- Goal "Add thermal domain. PR." → `/run-plan <meta-plan-path> finish auto pr`
+- Goal "Refactor logs direct" → `/run-plan <meta-plan-path> finish auto direct`
 
 This executes all implementation phases sequentially — each delegating
 to `/run-plan` on the corresponding sub-plan. Full verification,

--- a/skills/research-and-plan/SKILL.md
+++ b/skills/research-and-plan/SKILL.md
@@ -86,6 +86,28 @@ out. The agent rationalizes "I'll go faster" and skips adversarial review.
 It does NOT go faster — it produces plans with 10+ CRITICAL issues that
 require full restarts.
 
+### Landing mode detection
+
+Before dispatching `/draft-plan` agents, detect whether the original
+goal/description text contains `pr` or `direct` as a distinct word. Use
+the same pattern as Phase 3a, extended with sentence punctuation `.!?`
+since this is prose-like goal text:
+
+```bash
+LANDING_ARG=""
+if [[ "$GOAL" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="pr"
+elif [[ "$GOAL" =~ (^|[[:space:]])[dD][iI][rR][eE][cC][tT]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_ARG="direct"
+fi
+```
+
+Where `$GOAL` is the full description passed to `/research-and-plan`.
+If `LANDING_ARG` is empty, no landing-mode suffix is added to the
+`/draft-plan` invocation. This is a hint for generated plans — it does
+NOT enforce landing behavior. The `/run-plan` argument always takes
+precedence at execution time.
+
 For each sub-problem:
 
 1. Determine the sub-plan output path: `plans/<SLUG>_<N>.md` (or let the
@@ -93,6 +115,12 @@ For each sub-problem:
 2. If research from Step 1 was written to a file, pass that path to the
    `/draft-plan` agent so it has the decomposition context.
 3. Dispatch: `/draft-plan output <path> <sub-problem description>`
+   - **If `LANDING_ARG` is non-empty**, append `. Landing mode: <LANDING_ARG>`
+     to the description so `/draft-plan` can embed the matching hint in
+     the generated plan. Example:
+     `/draft-plan output plans/X.md rounds 2 <description>. Landing mode: pr`
+   - If `LANDING_ARG` is empty, omit the suffix entirely — do NOT pass
+     an empty `Landing mode:` token.
 4. Wait for each `/draft-plan` batch to complete before dispatching the
    next batch (see parallelism rules below).
 


### PR DESCRIPTION
## Plan: Execution Modes

**Phase 5a — Skill Propagation**

Threads landing-mode awareness through the upstream skill chain:
- `/research-and-go` detects `pr`/`direct` in goal text, injects into `/run-plan` cron prompt
- `/research-and-plan` detects mode and appends to `/draft-plan` invocation
- `/draft-plan` reads `execution.landing` from config and embeds blockquote hint near the top of generated plans (resolution: description suffix → config → fallback)

Hints are advisory — `/run-plan` arguments always win at execution time.

Skill text only — no automated tests required (per spec).

Includes Phase 4 finalization commit (`cb5e9dc`) that wasn't yet on main.

Report: `reports/plan-execution-modes.md`.

Generated by `/run-plan`.