### PR TITLE
[execution-modes] Phase 5b + 5c: Execution Skills, Docs, Cleanup, Model Gate, Baseline

### DIFF
--- a/.claude/hooks/block-agents.sh
+++ b/.claude/hooks/block-agents.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Block Agent (subagent) dispatches that use a model below agents.min_model.
+# Registered under the Agent PreToolUse matcher in .claude/settings.json.
+#
+# Ordinal: haiku=1, sonnet=2, opus=3, unknown=0 (always pass — future model families)
+#
+# Model field lookup order:
+#   1. tool_input.model (present when Agent tool explicitly sets a model)
+#   2. .claude/agents/<subagent_type>.md YAML frontmatter model: field
+#   3. Not found → ordinal=0 (unknown, always passes)
+#
+# This script enforces the hard floor. Skill-side reminders (at each Agent
+# dispatch site in run-plan, fix-issues, do) cover the residual case where
+# neither tool input nor agent definition specifies a model (subagent inherits
+# from parent session, which is typically Opus or Sonnet).
+
+INPUT=$(cat)
+
+# Only filter Agent tool calls
+if [[ "$INPUT" != *'"tool_name":"Agent"'* ]] && [[ "$INPUT" != *'"tool_name": "Agent"'* ]]; then
+  exit 0
+fi
+
+# Read agents.min_model from config
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+CONFIG_FILE="$REPO_ROOT/.claude/zskills-config.json"
+
+MIN_MODEL=""
+if [ -f "$CONFIG_FILE" ]; then
+  # Extract agents.min_model — handles both compact and spaced JSON
+  MIN_MODEL=$(grep -o '"min_model"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" 2>/dev/null \
+    | head -1 | sed 's/.*"min_model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+fi
+
+# If min_model not configured, pass through — no enforcement
+if [ -z "$MIN_MODEL" ]; then
+  exit 0
+fi
+
+# Convert model string to ordinal
+# Ordinal: haiku=1, sonnet=2, opus=3, unknown=0 (always allow)
+model_ordinal() {
+  local model="$1"
+  # Normalize: lowercase, extract family name
+  local lower
+  lower=$(echo "$model" | tr '[:upper:]' '[:lower:]')
+  if [[ "$lower" == *"haiku"* ]]; then
+    echo 1
+  elif [[ "$lower" == *"sonnet"* ]]; then
+    echo 2
+  elif [[ "$lower" == *"opus"* ]]; then
+    echo 3
+  else
+    echo 0  # Unknown family — always allow (pass-through for new Claude models)
+  fi
+}
+
+MIN_ORDINAL=$(model_ordinal "$MIN_MODEL")
+
+# Step 1: Try to extract model from tool_input JSON
+# The Agent tool input may include an optional "model" field
+DISPATCH_MODEL=""
+if [[ "$INPUT" =~ \"tool_input\"[[:space:]]*:\{[^}]*\"model\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  DISPATCH_MODEL="${BASH_REMATCH[1]}"
+fi
+# Also try without the tool_input wrapper (simpler JSON structures)
+if [ -z "$DISPATCH_MODEL" ]; then
+  if [[ "$INPUT" =~ \"model\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    DISPATCH_MODEL="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# Step 2: If model not in tool_input, try reading agent definition frontmatter
+if [ -z "$DISPATCH_MODEL" ]; then
+  # Extract subagent_type from tool_input (e.g., "subagent_type": "general-purpose")
+  SUBAGENT_TYPE=""
+  if [[ "$INPUT" =~ \"subagent_type\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    SUBAGENT_TYPE="${BASH_REMATCH[1]}"
+  fi
+
+  if [ -n "$SUBAGENT_TYPE" ]; then
+    AGENT_DEF="$REPO_ROOT/.claude/agents/${SUBAGENT_TYPE}.md"
+    if [ -f "$AGENT_DEF" ]; then
+      # Parse YAML frontmatter (between --- delimiters) for model: field
+      IN_FRONTMATTER=false
+      while IFS= read -r line; do
+        if [ "$line" = "---" ]; then
+          if $IN_FRONTMATTER; then
+            break  # End of frontmatter
+          else
+            IN_FRONTMATTER=true
+            continue
+          fi
+        fi
+        if $IN_FRONTMATTER && [[ "$line" =~ ^model:[[:space:]]*(.+)$ ]]; then
+          DISPATCH_MODEL="${BASH_REMATCH[1]}"
+          # Strip surrounding quotes if present
+          DISPATCH_MODEL="${DISPATCH_MODEL#\"}"
+          DISPATCH_MODEL="${DISPATCH_MODEL%\"}"
+          DISPATCH_MODEL=$(echo "$DISPATCH_MODEL" | tr -d '[:space:]')
+          break
+        fi
+      done < "$AGENT_DEF"
+    fi
+  fi
+fi
+
+# Step 3: Apply ordinal check
+# If DISPATCH_MODEL is empty, ordinal=0 (unknown) → always pass
+if [ -z "$DISPATCH_MODEL" ]; then
+  exit 0
+fi
+
+DISPATCH_ORDINAL=$(model_ordinal "$DISPATCH_MODEL")
+
+# Ordinal 0 (unknown family) always passes — future Claude model families
+if [ "$DISPATCH_ORDINAL" -eq 0 ]; then
+  exit 0
+fi
+
+# Block if dispatch model is below the configured minimum
+if [ "$DISPATCH_ORDINAL" -lt "$MIN_ORDINAL" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"agents.min_model requires %s or higher (ordinal %d); got %s (ordinal %d). Update your Agent dispatch to use a higher model."}}\n' \
+    "$MIN_MODEL" "$MIN_ORDINAL" "$DISPATCH_MODEL" "$DISPATCH_ORDINAL"
+  exit 0
+fi
+
+# Model meets or exceeds minimum — allow
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/briefing/SKILL.md
+++ b/.claude/skills/briefing/SKILL.md
@@ -238,8 +238,10 @@ The agent runs `node scripts/briefing.cjs <subcommand>` and captures stdout.
 
 Each worktree is classified into exactly one category:
 
-- **`landed-full`** — `.landed` file with `status: full` (all commits on main)
-- **`landed-partial`** — `.landed` file with `status: partial` (some commits skipped)
+- **`landed-full`** — `.landed` file with `status: full` (fix-issues cherry-pick, all commits on main) or `status: landed` (run-plan cherry-pick or merged PR)
+- **`landed-partial`** — `.landed` file with `status: partial` (some commits skipped, needs review)
+- **`landed-pr-ready`** — `.landed` file with `status: pr-ready` (PR is open; worktree is safe to remove, remote branch must NOT be deleted — it supports the open PR)
+- **`landed-pr-needs-attention`** — `.landed` file with `status: pr-ci-failing`, `status: pr-failed`, or `status: conflict` (PR-mode errors that need manual action)
 - **`done-needs-review`** — No `.landed`, has commits, inactive > 2 hours
 - **`possibly-active`** — No `.landed`, modified within last 2 hours
 - **`empty`** — No `.landed`, zero commits ahead of main

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -5,11 +5,11 @@ description: >-
   Safe commit workflow with optional scope hint. Inventories all changes,
   classifies related vs. unrelated files, traces dependencies, protects
   other agents' work, and optionally pushes or lands worktree commits.
-  Usage: /commit [scope] [push|land]
-argument-hint: "[scope] [push|land]"
+  Usage: /commit [pr] [scope] [push|land]
+argument-hint: "[pr] [scope] [push|land]"
 ---
 
-# /commit [scope] [push|land] — Safe Commit Workflow
+# /commit [pr] [scope] [push|land] — Safe Commit Workflow
 
 Commit current work without picking up or harming unrelated changes.
 
@@ -19,10 +19,26 @@ Commit current work without picking up or harming unrelated changes.
 - `/commit push` — commit and push to remote
 - `/commit parser reset button fix push` — scope-guided commit + push
 - `/commit land` — cherry-pick worktree commits into main (worktree only)
+- `/commit pr` — push current branch and create a PR to main (requires clean working tree)
+- `/commit pr fix pr comments` — PR mode with scope hint "fix pr comments"
 
-**Parsing:** `push` and `land` are reserved keywords. Everything else in the
-arguments is the **scope hint** — a free-form description of what this commit
-is about. The scope hint is optional; without one, classify from diffs alone.
+**Parsing:** `pr` is recognized ONLY when it is the **FIRST token** in
+`$ARGUMENTS`. This prevents false-triggering on scope hints that contain
+"pr" mid-string. `push` and `land` are reserved keywords for non-PR mode.
+
+```bash
+FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
+if [[ "$FIRST_TOKEN" == "pr" ]]; then
+  # PR subcommand mode
+  SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
+  # ... see Phase 6 (PR mode) below
+fi
+```
+
+Disambiguation:
+- `/commit pr` → PR mode (first token is `pr`)
+- `/commit pr comments fix` → PR mode (first token is `pr`), scope hint: "comments fix"
+- `/commit fix pr format` → scope hint "fix pr format", regular commit (first token is "fix")
 
 Examples:
 - `/commit` → scope: *(none)*, action: commit
@@ -31,6 +47,8 @@ Examples:
 - `/commit push` → scope: *(none)*, action: commit + push
 - `/commit land` → scope: *(none)*, action: land
 - `/commit parser fixes land` → scope: "parser fixes", action: land
+- `/commit pr` → action: PR mode (push + create PR)
+- `/commit pr fix pr comments` → PR mode, scope hint: "fix pr comments"
 
 ## Phase 1 — Inventory
 
@@ -204,6 +222,95 @@ git push -u origin <branch-name>
 **NEVER force-push to main/master.** If push is rejected, tell the user why
 and ask what to do.
 
+## Phase 6 (PR subcommand) — PR Mode (if `pr` is the first token)
+
+**This phase runs INSTEAD OF Phases 1–5 when `pr` is the first token.**
+It pushes the current branch and creates a PR to main.
+
+**Step 1 — Pre-check: clean working tree required:**
+```bash
+DIRTY=$(git status --porcelain 2>/dev/null)
+if [ -n "$DIRTY" ]; then
+  echo "ERROR: Working tree has uncommitted changes."
+  echo "Run \`/commit\` first to create a commit, then \`/commit pr\` to push and create the PR."
+  exit 1
+fi
+```
+
+**Step 2 — Branch guard:**
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "ERROR: Cannot create PR from main. Create a feature branch first."
+  exit 1
+fi
+```
+
+**Step 3 — Rebase onto latest main before pushing:**
+```bash
+git fetch origin main
+git rebase origin/main
+if [ $? -ne 0 ]; then
+  echo "ERROR: Rebase conflict. Resolve manually, then re-run \`/commit pr\`."
+  exit 1
+fi
+```
+
+**Step 4 — Push:**
+```bash
+git push -u origin "$BRANCH"
+```
+
+**Step 5 — Create PR:**
+```bash
+# PR title: strip branch prefix, convert hyphens to spaces
+BRANCH_SHORT="${BRANCH##*/}"  # remove prefix like feat/
+PR_TITLE=$(echo "$BRANCH_SHORT" | tr '-' ' ' | sed 's/\b./\u&/g')
+# Body: recent commits since divergence from origin/main (not local main — may be stale after rebase)
+PR_BODY=$(git log origin/main..HEAD --format='- %h %s' | head -15)
+
+EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL=$(gh pr view "$EXISTING_PR" --json url --jq '.url')
+  echo "PR already exists: $PR_URL"
+else
+  PR_URL=$(gh pr create --base main --head "$BRANCH" \
+    --title "$PR_TITLE" --body "$PR_BODY")
+  echo "Created PR: $PR_URL"
+fi
+```
+
+**Step 6 — Poll CI checks (report only, no fix cycle):**
+```bash
+if [ -n "$PR_URL" ]; then
+  PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+  CHECK_COUNT=0
+  for _i in 1 2 3; do
+    CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
+    [ "$CHECK_COUNT" != "0" ] && break
+    sleep 10
+  done
+  if [ "$CHECK_COUNT" != "0" ]; then
+    if timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null; then
+      echo "CI checks passed."
+    else
+      echo "CI checks failed. Run /verify-changes to diagnose."
+    fi
+  fi
+fi
+```
+
+Note: `PR_NUMBER` is derived from `$PR_URL` returned by `gh pr create` or
+`gh pr view "$EXISTING_PR"` — NOT via a bare `gh pr view` call (which relies
+on ambient branch autodetect and is subject to race conditions).
+
+**PR mode does NOT:**
+- Dispatch fix agents for CI failures
+- Write `.landed` markers
+- Run Phases 1–5 (all commits must already exist — clean tree is required)
+
+**After Step 6, exit.** Skip Phases 1–5 and 7.
+
 ## Phase 7 — Land (if `land` argument)
 
 Only if `land` was in the arguments.
@@ -296,3 +403,11 @@ This is for landing worktree work onto main via cherry-pick.
   diffs. Some related files won't match the hint keywords, and some keyword
   matches may be unrelated. The hint narrows the search; it doesn't replace
   judgment.
+- **`/commit pr` requires a clean working tree** — all changes must be
+  committed before running PR mode. The pre-check enforces this.
+- **`/commit pr` keyword is first-token-only** — prevents false-triggering
+  on scope hints that contain "pr" mid-string.
+- **PR body uses `git log origin/main..HEAD`** — not `git log main..HEAD`
+  (local main may be stale after rebase).
+- **PR number from URL, not bare `gh pr view`** — bare view uses ambient
+  branch autodetect, which is subject to race conditions.

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: do
 disable-model-invocation: true
-argument-hint: "<description> [worktree] [push] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [worktree] [push] [pr] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Supports scheduling with every/now/next/stop.
-  Usage: /do <description> [worktree] [push] [every SCHEDULE] [now] | stop | next.
+  Usage: /do <description> [worktree] [push] [pr] [every SCHEDULE] [now] | stop | next.
 ---
 
-# /do \<description> [worktree] [push] [every SCHEDULE] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [worktree] [push] [pr] [every SCHEDULE] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or auto-push. Can be scheduled for recurring maintenance
@@ -35,16 +35,21 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
 ## Arguments
 
 ```
-/do <description> [worktree] [push] [every SCHEDULE] [now]
+/do <description> [worktree] [push] [pr] [every SCHEDULE] [now]
 /do stop | next
 ```
 
 - **description** (required) — what to do, in natural language
-- **worktree** (optional) — use `isolation: "worktree"` for riskier or
-  larger tasks. Without this flag, work happens directly on main.
+- **worktree** (optional) — isolate work in a named worktree at
+  `/tmp/<project>-do-<slug>/` for riskier or larger tasks. Without this
+  flag, work happens directly on main.
 - **push** (optional) — auto-push to remote after verification passes.
   Upgrades verification to use a **separate verification agent** running
   `/verify-changes`. Push never happens without verification passing first.
+- **pr** (optional) — work in a named worktree on a named branch, then
+  push and create a PR to main. Dispatches an implementation agent to do
+  the work, waits for completion, rebases onto latest main, pushes, creates
+  PR, and polls CI (report only).
 - **every SCHEDULE** (optional) — self-schedule recurring runs via cron:
   - Accepts intervals: `4h`, `2h`, `30m`, `12h`
   - Accepts time-of-day: `day at 9am`, `day at 14:00`, `weekday at 9am`
@@ -71,8 +76,18 @@ If the first word is NOT a meta-command, it's a regular task. Parse
 trailing flags from the END backward:
 - `push` — recognized at the end
 - `worktree` — recognized at the end
+- `pr` — recognized at the end (use extended pattern with `.!?` punctuation, since
+  task descriptions are prose-like and "pr" may appear as "PR." at end of sentence)
 - `every <schedule>` — recognized at the end (e.g., `every 4h`, `every day at 9am`)
 - `now` — recognized at the end (only meaningful with `every`: run now AND schedule)
+
+**PR flag detection pattern** (use extended `.!?` punctuation):
+```bash
+LANDING_MODE="default"
+if [[ "$REMAINING" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_MODE="pr"
+fi
+```
 
 Everything before the trailing flags is the task description.
 
@@ -87,6 +102,7 @@ This means:
 - `/do Update the presentation push` — description + push flag
 - `/do Fix the tooltip bug worktree push` — description + both flags
 - `/do Check docs every day at 9am` — schedule "Check docs" daily
+- `/do Add dark mode. pr` — description + pr flag (PR mode)
 
 Examples:
 - `/do Add example models for Integrator and Derivative blocks`
@@ -95,6 +111,7 @@ Examples:
 - `/do Update the presentation with Phase 3 results push`
 - `/do Make sure docs are up to date every day at 9am`
 - `/do Check for broken links in examples every 12h now`
+- `/do Add dark mode to editor pr`
 - `/do next` — all scheduled tasks
 - `/do next Check docs` — specific task
 - `/do stop` — cancel all
@@ -221,24 +238,241 @@ Before touching anything:
    take 1000+ lines of changes, has complex dependencies), suggest
    `/run-plan` instead and ask the user.
 
+## Phase 1.5 — Argument Parsing (always before Phase 1 research)
+
+Before any research or execution, parse flags from `$ARGUMENTS`.
+
+**Step 1: Check for `pr` flag** (trailing, using extended punctuation pattern):
+```bash
+REMAINING="$ARGUMENTS"
+LANDING_MODE="default"
+if [[ "$REMAINING" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_MODE="pr"
+  # Strip the pr token from description
+  TASK_DESCRIPTION=$(echo "$REMAINING" | sed -E 's/(^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?])/ /')
+  TASK_DESCRIPTION=$(echo "$TASK_DESCRIPTION" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
+  if [ -z "$TASK_DESCRIPTION" ]; then
+    echo "ERROR: Task description required. Usage: /do <task description> pr"
+    exit 1
+  fi
+fi
+```
+
+If `LANDING_MODE` is not `pr`, then `TASK_DESCRIPTION` is the full `$ARGUMENTS` minus the other trailing flags (`push`, `worktree`, `every ...`, `now`).
+
+**Step 2: Check for `worktree` flag** (trailing, plain word match):
+```bash
+if [[ "$REMAINING" =~ (^|[[:space:]])worktree($|[[:space:]]) ]]; then
+  USE_WORKTREE=true
+fi
+```
+
+**Step 3: Check for `push` flag** (trailing):
+```bash
+if [[ "$REMAINING" =~ (^|[[:space:]])push($|[[:space:]]) ]]; then
+  USE_PUSH=true
+fi
+```
+
+`pr` takes precedence: if `LANDING_MODE="pr"`, ignore `worktree` and `push` flags.
+
 ## Phase 2 — Execute
 
-1. **Do the work.** By default, work directly on main. If `worktree` flag
-   is present, dispatch with `isolation: "worktree"`.
+Choose execution path based on parsed flags:
 
-2. **Follow existing conventions:**
-   - Example models → `/model-design` skill guidelines
-   - Newsletter entries → existing NEWSLETTER.md format
-   - Documentation → existing doc style in the repo
-   - Code → existing patterns in the codebase
+### Path A: PR mode (`pr` flag)
 
-3. **Commit discipline:**
-   - **On main:** commit when the work is complete. Clean, descriptive
-     message. `npm run test:all` before committing if code was touched.
-     If tests fail after two fix attempts on the same error, STOP — report
-     what you tried and let the user decide.
-   - **In worktree:** the verification agent commits after tests pass.
-     One logical unit per commit.
+**This path replaces the normal Phase 2–5 flow entirely. After the PR is created, skip to Phase 5 Report.**
+
+**Step A1 — Compute task slug:**
+```bash
+# N = min(4, word_count) words from TASK_DESCRIPTION
+WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
+N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
+TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
+  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
+  | tr '[:upper:]' '[:lower:]' \
+  | cut -c1-30 \
+  | sed 's/-$//')
+```
+
+**Step A2 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
+```bash
+PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel)")
+if [ -d "/tmp/${PROJECT_NAME}-do-${TASK_SLUG}" ]; then
+  TASK_SLUG="${TASK_SLUG}-$(date +%s | tail -c 5)"
+fi
+```
+
+**Step A3 — Derive BRANCH_NAME and WORKTREE_PATH from (possibly suffixed) TASK_SLUG:**
+```bash
+BRANCH_PREFIX=$(jq -r '.execution.branch_prefix // "feat/"' .claude/zskills-config.json 2>/dev/null || echo "feat/")
+BRANCH_NAME="${BRANCH_PREFIX}do-${TASK_SLUG}"
+WORKTREE_PATH="/tmp/${PROJECT_NAME}-do-${TASK_SLUG}"
+```
+
+**Step A4 — ff-merge main + worktree creation:**
+```bash
+git fetch origin main 2>/dev/null || true
+git merge --ff-only origin/main 2>/dev/null \
+  || echo "WARNING: local main not fast-forwarded — worktree uses local main as-is"
+git worktree prune
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" main 2>/dev/null \
+  || git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+```
+
+**Step A5 — Write tracking marker immediately after worktree creation:**
+```bash
+PIPELINE_ID="do.${TASK_SLUG}"
+echo "$PIPELINE_ID" > "$WORKTREE_PATH/.zskills-tracked"
+```
+Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` in the main session — write only to the worktree file.
+
+**Step A6 — Dispatch implementation agent (wait for completion):**
+
+Dispatch an Agent (without `isolation: "worktree"` — the worktree already exists) with this prompt:
+
+```
+You are implementing: $TASK_DESCRIPTION
+
+FIRST: cd $WORKTREE_PATH
+All work happens in that directory. Do NOT work in any other directory.
+You are on branch $BRANCH_NAME (already checked out in the worktree).
+
+Implement the task. Commit changes when done:
+- Stage files by name (not git add .)
+- Do NOT commit to main
+- Commit message should summarize what was implemented
+
+Check agents.min_model in .claude/zskills-config.json before dispatching
+any sub-agents. Use that model or higher (haiku=1 < sonnet=2 < opus=3).
+```
+
+Wait for the implementation agent to complete. If the agent reports failure or exits without committing:
+```bash
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: conflict
+date: $(TZ=America/New_York date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+LANDED
+```
+Exit with error directing the user to inspect `$WORKTREE_PATH`.
+
+**Step A7 — Rebase + push + PR creation (after implementation agent completes):**
+```bash
+cd "$WORKTREE_PATH"
+# Rebase onto latest main before push
+git fetch origin main
+git rebase origin/main || { echo "ERROR: Rebase conflict. Resolve manually in $WORKTREE_PATH."; exit 1; }
+
+git push -u origin "$BRANCH_NAME"
+
+# PR body: explicit title and body, not --fill
+PR_TITLE="do: $(echo "$TASK_DESCRIPTION" | cut -c1-60)"
+PR_BODY="Task: ${TASK_DESCRIPTION}
+
+Worktree: ${WORKTREE_PATH}
+Commits: $(git log origin/main..HEAD --format='%h %s' | head -10)"
+
+EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL=$(gh pr view "$EXISTING_PR" --json url --jq '.url')
+  echo "PR already exists: $PR_URL"
+else
+  PR_URL=$(gh pr create --base main --head "$BRANCH_NAME" \
+    --title "$PR_TITLE" --body "$PR_BODY")
+  echo "Created PR: $PR_URL"
+fi
+```
+
+**Step A8 — CI poll (report only, no fix cycle):**
+```bash
+if [ -n "$PR_URL" ]; then
+  PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+  CHECK_COUNT=0
+  for _i in 1 2 3; do
+    CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
+    [ "$CHECK_COUNT" != "0" ] && break
+    sleep 10
+  done
+  CI_STATUS="none"
+  if [ "$CHECK_COUNT" != "0" ]; then
+    if timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null; then
+      CI_STATUS="passed"
+      echo "CI checks passed."
+    else
+      CI_STATUS="failed"
+      echo "CI checks failed. Inspect the PR to diagnose failures."
+    fi
+  fi
+fi
+```
+
+**Step A9 — Write `.landed` marker:**
+```bash
+# Check if PR was auto-merged
+PR_STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "OPEN")
+if [ "$PR_STATE" = "MERGED" ]; then
+  LANDED_STATUS="landed"
+elif [ "$CI_STATUS" = "failed" ]; then
+  LANDED_STATUS="pr-ci-failing"
+else
+  LANDED_STATUS="pr-ready"
+fi
+
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: $LANDED_STATUS
+date: $(TZ=America/New_York date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+pr: $PR_URL
+LANDED
+```
+
+After writing `.landed`, output the Phase 5 PR report and **exit** (skip Phases 3-4).
+
+### Path B: Worktree mode (`worktree` flag, no `pr`)
+
+Create a named worktree at `../do-<slug>/` using manual `git worktree add`:
+
+```bash
+# Compute slug from task description
+WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
+N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
+TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
+  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
+  | tr '[:upper:]' '[:lower:]' \
+  | cut -c1-30 \
+  | sed 's/-$//')
+WORKTREE_PATH="../do-${TASK_SLUG}"
+# Collision check
+if [ -d "$WORKTREE_PATH" ]; then
+  TASK_SLUG="${TASK_SLUG}-$(date +%s | tail -c 5)"
+  WORKTREE_PATH="../do-${TASK_SLUG}"
+fi
+git worktree add "$WORKTREE_PATH"
+```
+
+Do the work inside the worktree. The verification agent commits after tests pass (one logical unit per commit).
+
+### Path C: Direct (default, no `pr`, no `worktree`)
+
+Work directly on main.
+
+**Follow existing conventions in all paths:**
+- Example models → `/model-design` skill guidelines
+- Newsletter entries → existing NEWSLETTER.md format
+- Documentation → existing doc style in the repo
+- Code → existing patterns in the codebase
+
+**Commit discipline (Paths B and C):**
+- **On main (Path C):** commit when the work is complete. Clean, descriptive
+  message. `npm run test:all` before committing if code was touched.
+  If tests fail after two fix attempts on the same error, STOP — report
+  what you tried and let the user decide.
+- **In worktree (Path B):** the verification agent commits after tests pass.
+  One logical unit per commit.
 
 ## Phase 3 — Verify
 
@@ -277,16 +511,16 @@ Verification intensity matches the change type (from Phase 1):
 - Spot-check the content portion
 - If `push`: full `/verify-changes` via separate agent
 
-## Phase 4 — Push (if `push` flag present)
+## Phase 4 — Push (if `push` flag present, Path C/B only)
 
-Only reached if Phase 3 verification passed.
+Only reached if Phase 3 verification passed. Not applicable to PR mode (Path A — PR mode has its own push in Phase 2 Step A7).
 
-1. **If on main:**
+1. **If on main (Path C):**
    ```bash
    git push
    ```
 
-2. **If in worktree:** cherry-pick to main first, then push:
+2. **If in worktree (Path B):** cherry-pick to main first, then push:
    - Protect uncommitted work on main (`git stash -u` if needed)
    - Cherry-pick worktree commits to main sequentially
    - If any cherry-pick conflicts: **abort and clean up:**
@@ -343,6 +577,16 @@ Verification: clean (/verify-changes clean)
 Worktree: ../do-<slug>/ (can be removed)
 ```
 
+**PR mode (pr flag):**
+```
+Done. [1-2 sentence summary of what was implemented]
+PR: <PR_URL>
+Branch: <BRANCH_NAME>
+Worktree: <WORKTREE_PATH>
+CI: passed | failed | no checks
+Status: pr-ready | pr-ci-failing | landed
+```
+
 ## Error Handling
 
 - **Test failures (code changes):** stop, fix the code, re-test. Never
@@ -353,6 +597,12 @@ Worktree: ../do-<slug>/ (can be removed)
 - **Push failure (auth, remote, etc.):** stop, report the error.
 - **Task is bigger than expected:** stop, suggest `/run-plan` instead.
   Ask the user before continuing.
+- **PR mode: rebase conflict:** write `.landed` with `status: conflict`,
+  report to user, direct them to inspect `$WORKTREE_PATH`.
+- **PR mode: CI failure:** write `.landed` with `status: pr-ci-failing`,
+  report the failure. Do NOT dispatch fix agents.
+- **PR mode: implementation agent fails without committing:** write
+  `.landed` with `status: conflict` and exit with an error message.
 - **If stuck on anything:** report the state and ask the user for
   guidance. Do not retry the same approach in a loop.
 
@@ -366,14 +616,26 @@ Worktree: ../do-<slug>/ (can be removed)
   checkout-old-commit, no comparison worktrees.
 - **Protect other agents' work** — do not commit unrelated changes that
   happen to be in the working tree. Stage only files related to the task.
-- **Worktree naming** — use `../do-<slug>/` where `<slug>` is a short
-  kebab-case description derived from the task (e.g., `do-sort-screenshots`,
-  `do-integrator-examples`). Include a timestamp suffix if a worktree
-  with that name already exists.
+- **Worktree naming (worktree flag)** — use `../do-<slug>/` where `<slug>`
+  is a short kebab-case description derived from the task (e.g.,
+  `do-sort-screenshots`, `do-integrator-examples`). Include a timestamp
+  suffix if a worktree with that name already exists. Uses manual
+  `git worktree add` — NOT `isolation: "worktree"`.
+- **Worktree naming (pr flag)** — use `/tmp/<project>-do-<slug>/` with
+  a named branch `<branch_prefix>do-<slug>`. Both BRANCH_NAME and
+  WORKTREE_PATH derive from TASK_SLUG (after any collision suffix).
 - **No persistent report files** — `/do` outputs results inline. It does
   NOT write SPRINT_REPORT.md, PLAN_REPORT.md, or any other report file.
   The commit is the artifact.
 - **Push requires verification** — `push` always dispatches a separate
   verification agent before pushing. No exceptions.
+- **PR mode CI is report-only** — `/do pr` polls CI and reports status.
+  It does NOT dispatch fix agents. For automated fix cycles, use
+  `/run-plan` or `/fix-issues` in PR mode.
+- **PR body uses `git log origin/main..HEAD`** — never `git log main..HEAD`
+  (local main may be stale after rebase).
+- **PR titles and bodies are explicit** — never use `--fill` in `gh pr create`.
+- **Slug collision suffix targets TASK_SLUG itself** — not just WORKTREE_PATH.
+  Both BRANCH_NAME and WORKTREE_PATH must pick up the suffix.
 - **Respect CLAUDE.md** — all standard rules apply (no external deps, no
   bundlers, no weakened tests, etc.)

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -330,6 +330,10 @@ Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` in the main session — write 
 
 **Step A6 — Dispatch implementation agent (wait for completion):**
 
+**Before dispatching:** Check `agents.min_model` in `.claude/zskills-config.json`. If set,
+use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch with a
+lower-ordinal model than the configured minimum.
+
 Dispatch an Agent (without `isolation: "worktree"` — the worktree already exists) with this prompt:
 
 ```

--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -362,6 +362,15 @@ Checks for completeness, correctness, and feasibility:
 - Are formulas and algorithms correct?
 - Will `/run-plan` be able to parse phases and status from this format?
 
+**Evidence discipline.** When a finding makes an empirical claim (a
+file, function, tool, or library has/lacks property X), include a
+concrete **Verification:** line — the exact file:line, grep, schema
+quote, or command output that reproduces the evidence. The refiner will
+re-run these checks before acting. Structural/judgment findings don't
+need a reproducer but should say `Verification: judgment — no verifiable
+anchor` explicitly. Never write an empirical-sounding claim without
+something the refiner can independently re-check.
+
 ### Devil's advocate agent
 
 Genuinely adversarial — tries to find ways the plan will fail:
@@ -390,6 +399,13 @@ generic concerns. "Phase 3 might be complex" is useless. "Phase 3 says
 matrix factorization approach, or convergence criteria — the agent will have
 to guess all three" is actionable.
 
+The same **evidence discipline** from the reviewer section applies:
+every empirical claim needs a `Verification:` line. The devil's advocate
+is *especially* prone to generating plausible-sounding-but-false claims
+because its job is pattern-generating failure modes, not verifying them.
+Discipline is load-bearing here — the refiner will re-check, and claims
+whose evidence doesn't reproduce will not drive fixes.
+
 ### Post-review tracking
 
 After both reviewer and devil's advocate agents return their findings,
@@ -407,13 +423,46 @@ A single agent receives:
 - The reviewer's findings
 - The devil's advocate's findings
 
+### Verify-before-fix (mandatory)
+
+Before touching the draft, the refiner must **attempt to reproduce the
+cited evidence for each finding**. The reviewer/DA produce hypotheses;
+the refiner is the gate that tests them against reality.
+
+For each finding with an empirical claim:
+1. Read the `Verification:` line and run its check (Read the file, run
+   the grep, check the schema, run the command).
+2. Record outcome: **Verified** (evidence reproduces → act on finding),
+   **Not reproduced** (evidence does not match reality → justify, do NOT
+   fix based on this finding), or **No anchor** (empirical-sounding
+   claim without verifiable citation → scrutinize, either locate an
+   anchor yourself or justify-not-fix).
+
+Judgment findings (marked `Verification: judgment`) skip step 1 and go
+straight to fix-or-justify on merit.
+
+**Why this exists.** Devil's-advocate findings are by role generated to
+be plausible failure modes, not verified truths. Past failure: a DA
+claimed a tool's input lacked a field, citing a tangentially-related
+file; the refiner accepted and rewrote a whole phase on a false premise.
+A 30-second check of the tool schema would have caught it. Verify-before-fix
+is the gate that turns "the DA said so" into "I checked."
+
+### Address every finding
+
 It produces an improved draft that **addresses every finding**. For each
 finding, it must either:
 1. **Fix it** — update the plan to resolve the issue
-2. **Justify** — explain why it's not actually a problem (with evidence)
+2. **Justify** — explain why it's not actually a problem (with evidence,
+   including the "evidence did not reproduce" and "claim not verifiable"
+   cases from the verify-before-fix block)
 
 It may NOT ignore findings or defer them. The refiner's output is the new
 draft for the next round.
+
+The refiner's output must include a **disposition table** listing each
+finding with an Evidence column (Verified / Not reproduced / No anchor
+/ Judgment) and the disposition (Fixed / Justified + reason).
 
 ## Phase 5 — Convergence Check
 
@@ -497,6 +546,13 @@ printf 'skill: draft-plan\nid: %s\noutput: %s\nstatus: complete\ndate: %s\n' \
 - **Every finding must be addressed.** The refiner cannot ignore or defer
   reviewer/devil's-advocate findings. Fix it or justify why it's not a
   problem.
+- **Verify findings before baking fixes.** Reviewer and DA findings are
+  hypotheses, not mandates. The refiner must reproduce each empirical
+  claim before acting on it. A plausible-sounding claim with no
+  verifiable anchor — or one whose evidence doesn't reproduce — is not
+  a mandate to fix. Devil's advocate findings are *especially* prone to
+  confidently-false empirical claims because the role incentivizes
+  plausibility, not truth.
 - **Convergence means no new substantive issues.** Not "the same issues
   rephrased." If the devil's advocate keeps finding real new problems, the
   plan isn't ready.

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -194,6 +194,10 @@ candidates and waits for the user to select which to close.
 
 ### Step 2 — Research & verify
 
+**Before dispatching any Agent:** check `agents.min_model` in `.claude/zskills-config.json`.
+If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch
+with a lower-ordinal model than the configured minimum.
+
 Dispatch research agents for every open issue that lacks a research blurb
 in its tracker file. Each agent does:
 
@@ -661,6 +665,10 @@ and dispatches agents WITHOUT `isolation: "worktree"`.** See the "PR mode
 (Phase 3)" section below for the exact worktree setup. For `cherry-pick` and
 `direct` modes, use the default `isolation: "worktree"` pattern described here.
 
+**Before dispatching any fix Agent:** check `agents.min_model` in `.claude/zskills-config.json`.
+If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch
+with a lower-ordinal model than the configured minimum.
+
 **1 issue per agent, parallel dispatch.** Each issue gets its own agent
 in its own worktree (`isolation: "worktree"` for cherry-pick/direct, or a
 manually-created `fix/issue-NNN` worktree for `pr` mode). **Dispatch at
@@ -818,6 +826,11 @@ printf 'skill: verify-changes\nparent: fix-issues\nmode: sprint\ndate: %s\n' \
   "$(TZ=America/New_York date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/requires.verify-changes.sprint"
 ```
+
+**Before dispatching any verification Agent:** check `agents.min_model` in
+`.claude/zskills-config.json`. If set, use that model or higher (ordinal:
+haiku=1 < sonnet=2 < opus=3). Never dispatch with a lower-ordinal model than
+the configured minimum.
 
 After each agent completes, **dispatch a fresh agent** to run `/verify-changes
 worktree` in its worktree. Do NOT run verification yourself — you wrote

--- a/.claude/skills/fix-report/SKILL.md
+++ b/.claude/skills/fix-report/SKILL.md
@@ -295,12 +295,31 @@ Check all worktrees for `.landed` markers:
 
 ```bash
 for wt in $(git worktree list | awk '{print $1}' | tail -n +2); do
-  if [ -f "$wt/.landed" ] && grep -q "^status: full" "$wt/.landed"; then
-    echo "SAFE: $wt ($(head -1 $wt/.landed))"
-  elif [ -f "$wt/.landed" ]; then
-    echo "PARTIAL: $wt — has unlanded work"
+  if [ -f "$wt/.landed" ]; then
+    STATUS=$(grep "^status:" "$wt/.landed" | cut -d' ' -f2)
+    PR_URL=$(grep "^pr:" "$wt/.landed" | cut -d' ' -f2)
+    case "$STATUS" in
+      full|landed)
+        echo "SAFE: $wt (status: $STATUS) ✓"
+        ;;
+      pr-ready)
+        echo "SAFE (worktree only): $wt (status: pr-ready, PR: ${PR_URL:-unknown}) ✓"
+        ;;
+      pr-ci-failing)
+        echo "NEEDS ATTENTION: $wt — CI failing on PR ${PR_URL:-unknown} ⚠"
+        ;;
+      pr-failed)
+        echo "NEEDS ATTENTION: $wt — PR creation failed, branch pushed ⚠"
+        ;;
+      conflict)
+        echo "NEEDS ATTENTION: $wt — rebase conflict, needs manual resolution ⚠"
+        ;;
+      *)
+        echo "PARTIAL: $wt — status: $STATUS (has unlanded or unresolved work) ⚠"
+        ;;
+    esac
   else
-    echo "ACTIVE: $wt — no .landed marker"
+    echo "ACTIVE: $wt — no .landed marker ⚠"
   fi
 done
 ```
@@ -309,20 +328,34 @@ Present the results:
 ```
 Worktrees:
   wt-123 — SAFE (status: full, landed 2026-03-16) ✓
-  wt-456 — SAFE (status: full, landed 2026-03-16) ✓
+  wt-456 — SAFE (status: landed, merged 2026-03-16) ✓
+  wt-pr-789 — SAFE (worktree only): status: pr-ready, PR: https://github.com/... ✓
+  wt-ci-101 — NEEDS ATTENTION: CI failing on PR https://github.com/... ⚠
   wt-789 — PARTIAL — skipped commits, needs review ⚠
   physics module-phase4 — ACTIVE — no .landed marker (long-running dev) ⚠
 
-Remove SAFE worktrees? (wt-123, wt-456)
+Remove SAFE worktrees? (wt-123, wt-456, wt-pr-789)
 ```
 
 **Wait for user approval** before removing anything.
 
-**Only remove worktrees with `status: full` in `.landed`.** Never remove
-PARTIAL or ACTIVE worktrees. After removing, also clean up the branch:
+**Safe-to-remove statuses:** `status: full` (fix-issues cherry-pick), `status: landed`
+(run-plan cherry-pick or merged PR), and `status: pr-ready` (open PR — worktree is safe
+to remove since the branch is already pushed). For `pr-ready`, remove the worktree
+only — do NOT delete the remote branch (it supports the open PR).
+
+**Never remove** worktrees with `status: pr-ci-failing`, `status: pr-failed`,
+`status: conflict`, `status: partial`, or ACTIVE worktrees (no `.landed`).
+
+After removing SAFE worktrees:
 ```bash
+# For status: full or status: landed:
 git worktree remove <path>
 git branch -d <branch-name>
+
+# For status: pr-ready (open PR — keep remote branch):
+git worktree remove <path>
+git branch -d <branch-name>   # local branch only; remote branch stays for the PR
 ```
 
 ## Step 7 — Write FIX_REPORT.md

--- a/.claude/skills/refine-plan/SKILL.md
+++ b/.claude/skills/refine-plan/SKILL.md
@@ -213,6 +213,16 @@ these six dimensions:
 Each finding must be **specific and actionable**: cite the exact section,
 line, or reference that's wrong and what it should say instead.
 
+**Evidence discipline.** When a finding makes an empirical claim (a file
+has/lacks X, a function does Y, a tool's input contains Z), include a
+concrete **Verification:** line — the exact file:line, grep, schema
+quote, or command output that reproduces the evidence. The refiner will
+re-run these checks before acting. Structural/judgment findings
+("this phase mixes too many concerns") don't need a reproducer, but
+mark them explicitly: `Verification: judgment — no verifiable anchor`.
+Never write an empirical-sounding claim without something the refiner
+can independently re-check.
+
 ### Devil's Advocate agent
 
 Genuinely adversarial — tries to find ways the remaining plan will fail
@@ -247,6 +257,13 @@ export pipeline' but doesn't specify the serialization format, and
 Phase 1 already committed to MessagePack in `src/io.ts` — the agent will
 have to guess or conflict" is actionable.
 
+The same **evidence discipline** from the reviewer section applies:
+every empirical claim needs a `Verification:` line (file:line, grep,
+schema quote, etc.). The devil's advocate is *especially* prone to
+generating plausible-sounding-but-false claims because its job is
+pattern-generating failure modes, not verifying them. Discipline is
+load-bearing here.
+
 ### Write findings
 
 Write combined findings to `/tmp/refine-plan-review-round-N-<slug>.md`
@@ -272,11 +289,50 @@ A single agent receives:
 - Completed phases as **READ-ONLY CONTEXT** (for reference only)
 - The parsed state file path
 
+### Verify-before-fix (mandatory)
+
+Before touching any phase text, the refiner must **attempt to reproduce
+the cited evidence for each finding**. The reviewer/DA produce hypotheses;
+the refiner is the gate that tests them against reality. This is not
+optional.
+
+For each finding with an empirical claim:
+1. Read the `Verification:` line and run its check (Read the file, run
+   the grep, check the schema, run the command).
+2. Record one of three outcomes in the disposition table:
+   - **Verified** — evidence reproduces. Proceed with fix or justification.
+   - **Not reproduced** — the cited evidence does not match reality.
+     Disposition: **Justified — evidence did not reproduce**. Note what
+     was actually found. Do NOT fix based on this finding.
+   - **No anchor** — finding is empirical-sounding but lacks a verifiable
+     citation. Disposition: **Justified — claim not verifiable as stated**
+     unless the refiner can locate a verifiable anchor itself.
+
+Judgment findings (those explicitly marked `Verification: judgment`) skip
+step 1 and go straight to fix-or-justify based on merit.
+
+**Why this exists.** Past failure: a devil's advocate claimed a Claude
+Code tool's input JSON lacked a `model` field and cited the hook
+template as evidence. The hook template was real but irrelevant — the
+actual falsifier was the tool's own schema, which did contain the field.
+The refiner accepted the claim and pivoted a whole phase's architecture
+based on nothing. If the refiner had tried to reproduce the evidence, it
+would have discovered the claim was unsupported. Verify-before-fix turns
+"I believe the DA" into "I checked."
+
+### Address every finding
+
 The agent addresses **every finding**. For each finding, it must either:
 1. **Fix it** — update the remaining phase text to resolve the issue
 2. **Justify** — explain with evidence why it's not actually a problem
+   (including the "evidence did not reproduce" and "claim not verifiable"
+   cases from the verify-before-fix block)
 
 It may NOT ignore findings or defer them. Every finding gets a disposition.
+
+The disposition table (written to the refined output) must include an
+**Evidence** column with the outcome: `Verified`, `Not reproduced`,
+`No anchor`, or `Judgment` (for non-empirical findings).
 
 **Completed phases are NEVER modified.** The refiner operates only on
 remaining phase text. If a finding suggests a completed phase has a
@@ -419,6 +475,13 @@ printf 'skill: refine-plan\nid: %s\nplan: %s\nstatus: complete\ndate: %s\n' \
 - **Every finding must be addressed.** The refiner cannot ignore or defer
   reviewer/devil's-advocate findings. Fix it or justify why it's not a
   problem — with evidence.
+- **Verify findings before baking fixes.** Reviewer and DA findings are
+  hypotheses, not mandates. The refiner must reproduce each empirical
+  claim before acting on it. A plausible-sounding claim with no
+  verifiable anchor — or one whose evidence doesn't reproduce — is not a
+  mandate to fix. It's a signal to scrutinize harder. Devil's advocate
+  findings are *especially* prone to confidently-false empirical claims
+  because the role incentivizes plausibility, not truth.
 - **Convergence means no new substantive issues.** Not "the same issues
   rephrased." If the devil's advocate keeps finding real new problems, the
   plan isn't ready.

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -536,6 +536,12 @@ agent hasn't returned after 2 hours, declare it **failed**:
 
 2. **Dispatch implementation agent WITHOUT `isolation: "worktree"`.** The
    prompt tells the agent the worktree path and requires absolute paths:
+
+   **Before dispatching any Agent:** check `agents.min_model` in
+   `.claude/zskills-config.json`. If set, use that model or higher
+   (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch with a
+   lower-ordinal model than the configured minimum.
+
    ```
    You are working in worktree: $WORKTREE_PATH
 
@@ -807,7 +813,13 @@ If this phase used delegate execution, verification runs on **main**:
 1. **Dispatch verification agent** targeting the worktree's changes. The
    verification agent is dispatched **without** `isolation: "worktree"` — the
    Agent tool's `isolation` parameter creates a NEW worktree, it cannot attach
-   to an existing one. Instead, give the verification agent:
+   to an existing one.
+
+   **Before dispatching:** check `agents.min_model` in `.claude/zskills-config.json`.
+   If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never
+   dispatch with a lower-ordinal model than the configured minimum.
+
+   Give the verification agent:
    - The **worktree path** from Phase 2 (so it can read files and run tests
      there via `cd <worktree-path> && npm run test:all`)
    - The **worktree branch name** (so it can diff against main:
@@ -818,6 +830,18 @@ If this phase used delegate execution, verification runs on **main**:
      orchestrator with implementer bias.
    - The **work items checklist** — verify each item was actually implemented,
      not stubbed or skipped
+   - The **`.test-baseline.txt` file** captured before implementation started
+     (if `FULL_TEST_CMD` is configured). The verification agent should:
+     - Read `.test-baseline.txt` (baseline captured before implementation)
+     - Compare against `.test-results.txt` (results after running tests now)
+     - **New failures** (in results but not in baseline) → regressions, must
+       be fixed before the phase can commit
+     - **Pre-existing failures** (in both baseline and results) → note in report,
+       do not fix (these predate this phase)
+     - **Resolved failures** (in baseline but not in results) → note positively
+       as improvements
+     - If `.test-baseline.txt` is absent (`FULL_TEST_CMD` not configured), treat
+       all failures as potentially new — report all of them
 
 2. **Additional plan-specific checks** (the verifier checks these against the
    verbatim plan text — not against a summary):
@@ -1594,6 +1618,10 @@ Attempting fix..."
     fi
 
     # --- Dispatch CI fix agent ---
+    # Before dispatching: check agents.min_model in .claude/zskills-config.json.
+    # If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3).
+    # Never dispatch with a lower-ordinal model than the configured minimum.
+    #
     # The /run-plan ORCHESTRATOR dispatches this agent via the Agent tool.
     # The agent does NOT use isolation: "worktree" -- the worktree already
     # exists. Instead, the agent's prompt tells it to work in $WORKTREE_PATH.

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -512,14 +512,26 @@ Then register the hooks in `.claude/settings.json`. The format is:
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }
 }
 ```
 
-Note: only the `Bash` matcher is used for PreToolUse hooks. The hook scripts
-themselves only process Bash tool inputs (they exit early for other tools).
+Note: both `Bash` and `Agent` matchers are used for PreToolUse hooks. The `Bash`
+matcher hooks enforce command safety and tracking. The `Agent` matcher hook
+enforces `agents.min_model` — blocking subagent dispatches that specify a model
+below the configured minimum (haiku=1 < sonnet=2 < opus=3).
 
 Report: "Installed N hooks: [list]"
 

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -276,6 +276,21 @@ found, missing otherwise.
 | 12 | Enumerate before guessing | `"enumerate before guessing"` |
 | 13 | Never skip hooks | `"never.*--no-verify"` or `"skip.*pre-commit hooks"` |
 
+### Step 2.5 — Documentation presence audit (execution modes)
+
+Search the project's `CLAUDE.md` for these documentation-presence signals.
+Mark each present/missing based on **case-insensitive substring match**:
+
+| Check | Key phrase(s) to search in CLAUDE.md |
+|-------|--------------------------------------|
+| Execution Modes section | `## Execution Modes` (heading) |
+| Landing mode keywords documented | `cherry-pick` AND `pr` AND `direct` |
+| Direct mode description present | `Work directly on main` |
+
+Report in the same pass/fail format as Step 2. Missing items are
+**recommendations, not errors** — this is a documentation-only gap with
+no enforcement consequence.
+
 ### Step 3 — Check hooks
 
 Look in `.claude/hooks/` for these 2 files:
@@ -317,6 +332,11 @@ Skill Dependencies: all satisfied | K missing
 CLAUDE.md Rules: M/13 present (K missing)
   Missing:
   - [rule name]: [key phrase not found]
+  ...
+
+Execution Mode Docs: M/3 present (K missing/recommended)
+  Missing (recommendation only):
+  - [check name]: [key phrase not found]
   ...
 
 Hooks: M/2 installed (K missing)

--- a/.claude/zskills-config.json
+++ b/.claude/zskills-config.json
@@ -30,5 +30,9 @@
   "ci": {
     "auto_fix": true,
     "max_fix_attempts": 2
+  },
+
+  "agents": {
+    "min_model": "claude-sonnet-4-20250514"
   }
 }

--- a/.worktreepurpose
+++ b/.worktreepurpose
@@ -1,0 +1,1 @@
+EXECUTION_MODES: Phase 5b (finish auto pr)

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -128,6 +128,35 @@ URLs, or creating files from scratch, check what already exists: `ls` the
 directory, `grep` for the term, read the relevant file. Agents consistently
 skip this step and guess instead of looking.
 
+## Execution Modes
+
+Three landing modes control how agent work reaches main:
+
+| Mode | Keyword | How it works |
+|------|---------|-------------|
+| Cherry-pick | (default) | Work in auto-named worktree, cherry-pick to main |
+| PR | `pr` | Work in named worktree, push branch, create PR |
+| Direct | `direct` | Work directly on main, no landing step |
+
+**Usage:** Append keyword to any execution skill:
+- `/run-plan plans/X.md finish auto pr`
+- `/fix-issues 10 pr`
+- `/research-and-go Build an RPG. pr`
+- `/do Add dark mode. pr`
+
+**Config default:** Set in `.claude/zskills-config.json`:
+
+    {
+      "execution": {
+        "landing": "pr",
+        "main_protected": true,
+        "branch_prefix": "feat/"
+      }
+    }
+
+When `main_protected: true`, agents cannot commit, cherry-pick, or push
+to main. Use PR mode or feature branches.
+
 ## Tracking Enforcement
 
 Tracking file enforcement is active when `.zskills/tracking/` exists and the session is associated with a pipeline (via `.zskills-tracked` file or transcript). Skills create tracking files during pipeline execution; hooks check them before allowing `git commit`, `git cherry-pick`, and `git push`. Pipeline scoping (suffix matching on pipeline ID) ensures one pipeline's markers don't block another. The orchestrator writes `.zskills-tracked` (single-line pipeline ID) in both the worktree and main repo roots before dispatching agents, and removes it after pipeline completion. The `clear-tracking.sh` script in `scripts/` lets the user manually clear stale tracking state -- agents are blocked from running it directly.

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -157,6 +157,8 @@ Three landing modes control how agent work reaches main:
 When `main_protected: true`, agents cannot commit, cherry-pick, or push
 to main. Use PR mode or feature branches.
 
+**Agent model minimum:** When dispatching an Agent (subagent), always use Sonnet or higher. Never dispatch Haiku — even for "simple" tasks. The minimum model is configured at `agents.min_model` in `.claude/zskills-config.json` and enforced by the `block-agents.sh` hook at dispatch time.
+
 ## Tracking Enforcement
 
 Tracking file enforcement is active when `.zskills/tracking/` exists and the session is associated with a pipeline (via `.zskills-tracked` file or transcript). Skills create tracking files during pipeline execution; hooks check them before allowing `git commit`, `git cherry-pick`, and `git push`. Pipeline scoping (suffix matching on pipeline ID) ensures one pipeline's markers don't block another. The orchestrator writes `.zskills-tracked` (single-line pipeline ID) in both the worktree and main repo roots before dispatching agents, and removes it after pipeline completion. The `clear-tracking.sh` script in `scripts/` lets the user manually clear stale tracking state -- agents are blocked from running it directly.

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,6 +10,6 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-canary6-multi-pr.md](reports/plan-canary6-multi-pr.md) | 1 | Pending landing |
-| [plan-execution-modes.md](reports/plan-execution-modes.md) | 2 | Pending landing |
-| [plan-canary5-autonomous.md](reports/plan-canary5-autonomous.md) | 2 | Pending landing |
+| [plan-execution-modes.md](reports/plan-execution-modes.md) | 10 (5b+5c implemented this run) | Landing via PR |
+| [plan-canary6-multi-pr.md](reports/plan-canary6-multi-pr.md) | 2 | Landed |
+| [plan-canary5-autonomous.md](reports/plan-canary5-autonomous.md) | 2 | Landed |

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -112,6 +112,16 @@
           "description": "Maximum fix-and-push cycles when CI fails. 0 = poll and report only (no fix attempts). Each attempt comments on the PR with failure context."
         }
       }
+    },
+    "agents": {
+      "type": "object",
+      "description": "Agent dispatch configuration.",
+      "properties": {
+        "min_model": {
+          "type": "string",
+          "description": "Minimum model for subagent dispatch. The block-agents.sh hook enforces this at Agent tool dispatch time. Ordinal: haiku=1 < sonnet=2 < opus=3. Unknown model families always pass (future-proofing). Example: claude-sonnet-4-20250514"
+        }
+      }
     }
   }
 }

--- a/hooks/block-agents.sh.template
+++ b/hooks/block-agents.sh.template
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Block Agent (subagent) dispatches that use a model below agents.min_model.
+# Registered under the Agent PreToolUse matcher in .claude/settings.json.
+#
+# Ordinal: haiku=1, sonnet=2, opus=3, unknown=0 (always pass — future model families)
+#
+# Model field lookup order:
+#   1. tool_input.model (present when Agent tool explicitly sets a model)
+#   2. .claude/agents/<subagent_type>.md YAML frontmatter model: field
+#   3. Not found → ordinal=0 (unknown, always passes)
+#
+# This script enforces the hard floor. Skill-side reminders (at each Agent
+# dispatch site in run-plan, fix-issues, do) cover the residual case where
+# neither tool input nor agent definition specifies a model (subagent inherits
+# from parent session, which is typically Opus or Sonnet).
+
+INPUT=$(cat)
+
+# Only filter Agent tool calls
+if [[ "$INPUT" != *'"tool_name":"Agent"'* ]] && [[ "$INPUT" != *'"tool_name": "Agent"'* ]]; then
+  exit 0
+fi
+
+# Read agents.min_model from config
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+CONFIG_FILE="$REPO_ROOT/.claude/zskills-config.json"
+
+MIN_MODEL=""
+if [ -f "$CONFIG_FILE" ]; then
+  # Extract agents.min_model — handles both compact and spaced JSON
+  MIN_MODEL=$(grep -o '"min_model"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" 2>/dev/null \
+    | head -1 | sed 's/.*"min_model"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+fi
+
+# If min_model not configured, pass through — no enforcement
+if [ -z "$MIN_MODEL" ]; then
+  exit 0
+fi
+
+# Convert model string to ordinal
+# Ordinal: haiku=1, sonnet=2, opus=3, unknown=0 (always allow)
+model_ordinal() {
+  local model="$1"
+  # Normalize: lowercase, extract family name
+  local lower
+  lower=$(echo "$model" | tr '[:upper:]' '[:lower:]')
+  if [[ "$lower" == *"haiku"* ]]; then
+    echo 1
+  elif [[ "$lower" == *"sonnet"* ]]; then
+    echo 2
+  elif [[ "$lower" == *"opus"* ]]; then
+    echo 3
+  else
+    echo 0  # Unknown family — always allow (pass-through for new Claude models)
+  fi
+}
+
+MIN_ORDINAL=$(model_ordinal "$MIN_MODEL")
+
+# Step 1: Try to extract model from tool_input JSON
+# The Agent tool input may include an optional "model" field
+DISPATCH_MODEL=""
+if [[ "$INPUT" =~ \"tool_input\"[[:space:]]*:\{[^}]*\"model\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  DISPATCH_MODEL="${BASH_REMATCH[1]}"
+fi
+# Also try without the tool_input wrapper (simpler JSON structures)
+if [ -z "$DISPATCH_MODEL" ]; then
+  if [[ "$INPUT" =~ \"model\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    DISPATCH_MODEL="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# Step 2: If model not in tool_input, try reading agent definition frontmatter
+if [ -z "$DISPATCH_MODEL" ]; then
+  # Extract subagent_type from tool_input (e.g., "subagent_type": "general-purpose")
+  SUBAGENT_TYPE=""
+  if [[ "$INPUT" =~ \"subagent_type\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    SUBAGENT_TYPE="${BASH_REMATCH[1]}"
+  fi
+
+  if [ -n "$SUBAGENT_TYPE" ]; then
+    AGENT_DEF="$REPO_ROOT/.claude/agents/${SUBAGENT_TYPE}.md"
+    if [ -f "$AGENT_DEF" ]; then
+      # Parse YAML frontmatter (between --- delimiters) for model: field
+      IN_FRONTMATTER=false
+      while IFS= read -r line; do
+        if [ "$line" = "---" ]; then
+          if $IN_FRONTMATTER; then
+            break  # End of frontmatter
+          else
+            IN_FRONTMATTER=true
+            continue
+          fi
+        fi
+        if $IN_FRONTMATTER && [[ "$line" =~ ^model:[[:space:]]*(.+)$ ]]; then
+          DISPATCH_MODEL="${BASH_REMATCH[1]}"
+          # Strip surrounding quotes if present
+          DISPATCH_MODEL="${DISPATCH_MODEL#\"}"
+          DISPATCH_MODEL="${DISPATCH_MODEL%\"}"
+          DISPATCH_MODEL=$(echo "$DISPATCH_MODEL" | tr -d '[:space:]')
+          break
+        fi
+      done < "$AGENT_DEF"
+    fi
+  fi
+fi
+
+# Step 3: Apply ordinal check
+# If DISPATCH_MODEL is empty, ordinal=0 (unknown) → always pass
+if [ -z "$DISPATCH_MODEL" ]; then
+  exit 0
+fi
+
+DISPATCH_ORDINAL=$(model_ordinal "$DISPATCH_MODEL")
+
+# Ordinal 0 (unknown family) always passes — future Claude model families
+if [ "$DISPATCH_ORDINAL" -eq 0 ]; then
+  exit 0
+fi
+
+# Block if dispatch model is below the configured minimum
+if [ "$DISPATCH_ORDINAL" -lt "$MIN_ORDINAL" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"agents.min_model requires %s or higher (ordinal %d); got %s (ordinal %d). Update your Agent dispatch to use a higher model."}}\n' \
+    "$MIN_MODEL" "$MIN_ORDINAL" "$DISPATCH_MODEL" "$DISPATCH_ORDINAL"
+  exit 0
+fi
+
+# Model meets or exceeds minimum — allow
+exit 0

--- a/plans/EXECUTION_MODES.md
+++ b/plans/EXECUTION_MODES.md
@@ -1,7 +1,7 @@
 ---
 title: Execution Modes
 created: 2026-04-13
-status: active
+status: complete
 ---
 
 # Plan: Execution Modes
@@ -24,8 +24,8 @@ The tracking system is DONE and working. This plan builds on top of it. Tracking
 | 3b-iii -- CI Integration + Fix Cycle + Auto-Merge | ✅ Done | `e24d8ad` | CI polling, fix cycle, auto-merge, PR comments, 4 tests |
 | 4 -- /fix-issues PR Landing | ✅ Done | `e9d4a82` | Per-issue branches, PR #10, 3 tests |
 | 5a -- Skill Propagation | ✅ Done | `d5b46c5` | research-and-go, research-and-plan, draft-plan |
-| 5b -- Execution Skills + Documentation | ⬜ | | do, commit, CLAUDE_TEMPLATE, update-zskills |
-| 5c -- Infrastructure: Cleanup, Model Gate, Baseline | ⬜ | | cleanup tooling, agents.min_model, baseline snapshot |
+| 5b -- Execution Skills + Documentation | ✅ Done | `bfc5893` | /do pr, /commit pr, CLAUDE_TEMPLATE Execution Modes, update-zskills Step 2.5 |
+| 5c -- Infrastructure: Cleanup, Model Gate, Baseline | ✅ Done | `1839bb8` | fix-report + briefing scripts, block-agents.sh hook, .test-baseline compare |
 
 ---
 

--- a/plans/EXECUTION_MODES.md
+++ b/plans/EXECUTION_MODES.md
@@ -23,7 +23,7 @@ The tracking system is DONE and working. This plan builds on top of it. Tracking
 | 3b-ii -- PR Mode Happy Path | ✅ Done | `36af895` | Named branches, rebase, push+PR, .landed, 9 tests |
 | 3b-iii -- CI Integration + Fix Cycle + Auto-Merge | ✅ Done | `e24d8ad` | CI polling, fix cycle, auto-merge, PR comments, 4 tests |
 | 4 -- /fix-issues PR Landing | ✅ Done | `e9d4a82` | Per-issue branches, PR #10, 3 tests |
-| 5a -- Skill Propagation | 🟡 In Progress | `a13211f` | research-and-go, research-and-plan, draft-plan |
+| 5a -- Skill Propagation | ✅ Done | `d5b46c5` | research-and-go, research-and-plan, draft-plan |
 | 5b -- Execution Skills + Documentation | ⬜ | | do, commit, CLAUDE_TEMPLATE, update-zskills |
 | 5c -- Infrastructure: Cleanup, Model Gate, Baseline | ⬜ | | cleanup tooling, agents.min_model, baseline snapshot |
 
@@ -2321,24 +2321,200 @@ Add execution mode support to downstream skills (`/do`, `/commit`), document exe
 
 #### 5b.1 -- /do: `pr` option
 
-Modify `skills/do/SKILL.md` to accept a `pr` argument. `/do <task> pr` creates a worktree with a named branch, does the work, pushes, and creates a PR. Same PR landing flow as 3b-ii/3b-iii, with these differences:
+Modify `skills/do/SKILL.md` to accept a `pr` argument. `/do <task> pr` creates a named worktree on a named branch, does the work, pushes, and creates a PR. Same PR landing flow as 3b-ii/3b-iii, with these differences:
 
-- Branch name: `{branch_prefix}{task-slug}` (task slug derived from first few words of task description, lowercased, hyphenated)
-- Worktree: `/tmp/<project>-do-<task-slug>`
-- Single-phase: only rebase point 2 applies (before push)
-- CI check + auto-merge: same pattern as 3b-iii
-- `.landed` marker: `source: do`
+**Argument detection:** Recognize `pr` as a trailing flag (same END-backward parsing as existing `push` and `worktree` flags). Use the extended detection pattern including sentence punctuation since `/do` receives prose-like task descriptions:
 
-- [ ] Add `pr` argument detection to `/do`
-- [ ] PR mode creates named worktree, pushes, creates PR
-- [ ] Rebase onto latest main before push (same pattern as 3b.3, rebase point 2)
-- [ ] CI check + auto-merge (same pattern as 3b-iii)
-- [ ] `.landed` marker with `source: do`
+```bash
+LANDING_MODE="cherry-pick"  # default
+if [[ "$REMAINING" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_MODE="pr"
+  # Strip the pr token from description (same as research-and-go/research-and-plan Phase 5a)
+fi
+```
+
+This is the same `.!?` extended pattern used by `/research-and-go` (skills/research-and-go/SKILL.md lines 147-151) — appropriate because `/do` receives prose-like descriptions where "pr" may appear as "PR." at end of sentence.
+
+**Task description extraction (must precede slug computation):**
+
+```bash
+# Strip pr flag and extract task description
+TASK_DESCRIPTION=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?])//')
+TASK_DESCRIPTION=$(echo "$TASK_DESCRIPTION" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
+if [ -z "$TASK_DESCRIPTION" ]; then
+  echo "ERROR: Task description required. Usage: /do <task description> pr"
+  exit 1
+fi
+```
+
+This block must appear BEFORE the slug computation. `$TASK_DESCRIPTION` is the stripped description used for the slug, PR title, and PR body.
+
+**Slug algorithm:** First N words of the task description where N = min(4, word_count) — always at least 1 word, up to 4. If the task has fewer than 4 words, use all available words. Lowercased, all non-alphanumeric characters replaced with hyphens, consecutive hyphens collapsed, max 30 characters. Example: "Add dark mode to editor" → "add-dark-mode-to".
+
+**Slug collision handling (order matters):** When `/tmp/<project>-do-<slug>` already exists, the suffix must be applied to `TASK_SLUG` itself — not just to the path — so that both `WORKTREE_PATH` and `BRANCH_NAME` receive the updated value:
+
+1. Compute base slug from `$TASK_DESCRIPTION`
+2. Check if `/tmp/<project>-do-<slug>` exists
+3. If collision: append `-<last-5-chars-of-unix-epoch>` (via `date +%s | tail -c 5`) to `TASK_SLUG` itself (same collision strategy as existing `/do worktree` flag per `skills/do/SKILL.md` line 371)
+4. Derive `BRANCH_NAME` and `WORKTREE_PATH` from the (possibly suffixed) `TASK_SLUG`
+
+Computing `BRANCH_NAME` before the collision check (from the un-suffixed slug) would cause `git worktree add -b` to fail with "branch already exists" on a second invocation with the same description.
+
+**Worktree and branch setup (PR mode):**
+
+```bash
+# 1. Compute base slug
+TASK_SLUG="<derived per slug algorithm from $TASK_DESCRIPTION>"
+# 2. Collision check — BEFORE deriving BRANCH_NAME or WORKTREE_PATH
+PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel)")
+if [ -d "/tmp/${PROJECT_NAME}-do-${TASK_SLUG}" ]; then
+  TASK_SLUG="${TASK_SLUG}-$(date +%s | tail -c 5)"
+fi
+# 3. Derive both names from the (possibly suffixed) TASK_SLUG
+BRANCH_PREFIX=$(jq -r '.execution.branch_prefix // "feat/"' .claude/zskills-config.json 2>/dev/null || echo "feat/")
+BRANCH_NAME="${BRANCH_PREFIX}do-${TASK_SLUG}"
+WORKTREE_PATH="/tmp/${PROJECT_NAME}-do-${TASK_SLUG}"
+
+# ff-merge main before branching (PR #17 pattern, run-plan/SKILL.md lines 694-696)
+git fetch origin main 2>/dev/null || true
+git merge --ff-only origin/main 2>/dev/null \
+  || echo "WARNING: local main not fast-forwarded — worktree uses local main as-is"
+git worktree prune
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" main 2>/dev/null \
+  || git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+```
+
+**Tracking context:** `/do pr` is NOT a run-plan pipeline. But it must write its own tracking marker so the hook's pipeline-association check scopes enforcement to this context (preventing a same-session run-plan pipeline from false-blocking the push via Tier 2 transcript read). Immediately after worktree creation:
+
+```bash
+PIPELINE_ID="do.${TASK_SLUG}"
+echo "$PIPELINE_ID" > "$WORKTREE_PATH/.zskills-tracked"
+```
+
+This makes `TRACKING_SESSION_HAS_PIPELINE=true` for this worktree via Tier 1 (.zskills-tracked). The `/do pr` pipeline has no `requires.*` markers, so tracking enforcement passes — it just scopes away from any ambient run-plan pipeline.
+
+Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` in the main session; write only to the worktree file.
+
+**Implementation-agent dispatch (after `.zskills-tracked`, before rebase+push):**
+
+After writing `.zskills-tracked`, dispatch the implementation agent to do the actual work:
+
+Dispatch an Agent (without `isolation: "worktree"` — the worktree already exists) with this prompt:
+
+```
+You are implementing: $TASK_DESCRIPTION
+
+FIRST: cd $WORKTREE_PATH
+All work happens in that directory. Do NOT work in any other directory.
+You are on branch $BRANCH_NAME (already checked out in the worktree).
+
+Implement the task. Commit changes when done:
+- Stage files by name (not git add .)
+- Do NOT commit to main
+- Commit message should summarize what was implemented
+
+Check agents.min_model in .claude/zskills-config.json before dispatching
+any sub-agents. Use that model or higher (haiku=1 < sonnet=2 < opus=3).
+```
+
+Wait for the implementation agent to complete. If the agent reports failure or exits without committing, write `.landed` with `status: conflict` and exit with an error message directing the user to inspect `$WORKTREE_PATH`.
+
+The implementation sequence is: worktree creation → write `.zskills-tracked` → **dispatch implementation agent (wait for completion)** → rebase → push → PR creation → CI poll → write `.landed`. The PR is created AFTER implementation completes, so `git log origin/main..HEAD` in the PR body will contain actual commits.
+
+**PR creation:**
+
+```bash
+cd "$WORKTREE_PATH"
+# Rebase onto latest main before push (rebase point 2 — same as 3b-iii)
+git fetch origin main
+git rebase origin/main || { echo "ERROR: Rebase conflict. Resolve manually in $WORKTREE_PATH."; exit 1; }
+
+git push -u origin "$BRANCH_NAME"
+
+# PR body: explicit title and body, not --fill
+PR_TITLE="do: $(echo "$TASK_DESCRIPTION" | cut -c1-60)"
+PR_BODY="Task: ${TASK_DESCRIPTION}
+
+Worktree: ${WORKTREE_PATH}
+Commits: $(git log origin/main..HEAD --format='%h %s' | head -10)"
+
+EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL=$(gh pr view "$EXISTING_PR" --json url --jq '.url')
+  echo "PR already exists: $PR_URL"
+else
+  PR_URL=$(gh pr create --base main --head "$BRANCH_NAME" \
+    --title "$PR_TITLE" --body "$PR_BODY")
+  echo "Created PR: $PR_URL"
+fi
+```
+
+**Bookkeeping rule (PR #13):** `/do pr` does NOT commit plan reports or tracker updates (it has no plan). If the implementation leaves `.zskills-tracked` or other tracking artifacts in the worktree, they are fine — they stay on the feature branch (not committed to main).
+
+**CI check and `.landed` marker:**
+
+CI poll is **report-only** (same poll mechanism as 3b-iii.2 — `gh pr checks --watch`, 600s timeout — but NOT the fix-cycle). `/do pr` is a user-initiated convenience command; users resolve CI failures themselves. For orchestrated fix cycles, use `/run-plan` or `/fix-issues` in PR mode.
+
+Write `.landed` on completion. Use `status: pr-ready` if CI passes (or no CI), `status: pr-ci-failing` if CI fails:
+
+```bash
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: pr-ready
+date: $(TZ=America/New_York date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+pr: $PR_URL
+LANDED
+```
+
+If CI fails, write `status: pr-ci-failing` instead of `status: pr-ready`. If the PR is auto-merged before `.landed` is written, write `status: landed`.
+
+**Existing `worktree` flag migration:** The current `/do worktree` flag uses `isolation: "worktree"`. Phase 3b-i replaced all `isolation: "worktree"` with manual `git worktree add` at `/tmp/` paths — the same reason applies here (stale origin/HEAD base). As part of this work item, convert the existing `worktree` flag to use `../do-<slug>/` path with manual `git worktree add`, matching the worktree naming documented in `skills/do/SKILL.md` line 369.
+
+Work items checklist:
+- [ ] Add `pr` trailing-flag detection to `/do` using extended `.!?` pattern (same as research-and-go)
+- [ ] Add `TASK_DESCRIPTION` extraction block (strip `pr` flag from `$ARGUMENTS`; error if empty after stripping)
+- [ ] Convert existing `worktree` flag from `isolation: "worktree"` to manual `git worktree add ../do-<slug>/`
+- [ ] PR mode: ff-merge main → worktree creation (PR #17 pattern)
+- [ ] Write `.zskills-tracked` with `do.${TASK_SLUG}` pipeline ID in worktree immediately after creation
+- [ ] Task slug: compute base slug (N = min(4, word_count) words, lowercase, non-alphanum→hyphen, collapsed, max 30 chars); check collision BEFORE deriving `BRANCH_NAME` and `WORKTREE_PATH`; if collision, append timestamp suffix to `TASK_SLUG` itself, then derive both names from the (possibly suffixed) slug
+- [ ] Branch prefix from `execution.branch_prefix` config (default `feat/`)
+- [ ] Dispatch implementation agent to worktree (no `isolation: "worktree"`): cd `$WORKTREE_PATH`, implement `$TASK_DESCRIPTION`, commit; check `agents.min_model` before any sub-agent dispatch
+- [ ] Wait for implementation agent to complete before rebasing/pushing; write `status: conflict` `.landed` and exit if agent fails
+- [ ] Rebase onto latest main before push
+- [ ] PR: explicit `--title "do: <first 60 chars of $TASK_DESCRIPTION>"` and `--body` (task + worktree path + `git log origin/main..HEAD` commits) — NOT `--fill`
+- [ ] Handle existing PR (check with `gh pr list --head`)
+- [ ] CI poll + report only (poll mechanism same as 3b-iii.2; no fix agents dispatched)
+- [ ] Write `.landed` marker with `source: do`; `status: pr-ready` (CI pass/none), `status: pr-ci-failing` (CI fail), `status: landed` (if PR auto-merged)
 - [ ] Sync installed copy
 
 #### 5b.2 -- /commit: `pr` subcommand
 
-Modify `skills/commit/SKILL.md` to accept a `pr` subcommand. `/commit pr` pushes the current branch and creates a PR to main:
+Modify `skills/commit/SKILL.md` to accept a `pr` subcommand. `/commit pr` pushes the current branch and creates a PR to main.
+
+**Argument parsing:** `pr` is recognized ONLY when it is the FIRST token in `$ARGUMENTS` (before any scope hint). This prevents false-triggering on scope hints that contain "pr" mid-string (e.g., `/commit fix pr comments` has scope hint "fix pr comments", no PR mode). Disambiguation rule: `/commit pr` → PR mode; `/commit pr comments fix` → PR mode (first token); `/commit fix pr format` → scope hint "fix pr format", no PR mode.
+
+```bash
+FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
+if [[ "$FIRST_TOKEN" == "pr" ]]; then
+  # PR subcommand mode
+  SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
+  # ... PR flow below
+fi
+```
+
+**Pre-check — clean working tree required:**
+
+```bash
+DIRTY=$(git status --porcelain 2>/dev/null)
+if [ -n "$DIRTY" ]; then
+  echo "ERROR: Working tree has uncommitted changes."
+  echo "Run \`/commit\` first to create a commit, then \`/commit pr\` to push and create the PR."
+  exit 1
+fi
+```
+
+**PR creation flow:**
 
 ```bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -2350,23 +2526,33 @@ fi
 # Rebase onto latest main before pushing
 git fetch origin main
 git rebase origin/main
-# If rebase conflicts: report and stop. The user needs to resolve.
+# If rebase conflicts: report and stop — user must resolve
+if [ $? -ne 0 ]; then
+  echo "ERROR: Rebase conflict. Resolve manually, then re-run \`/commit pr\`."
+  exit 1
+fi
 
 git push -u origin "$BRANCH"
+
+# PR title: strip branch prefix, convert hyphens to spaces
+BRANCH_SHORT="${BRANCH##*/}"  # remove prefix like feat/
+PR_TITLE=$(echo "$BRANCH_SHORT" | tr '-' ' ' | sed 's/\b./\u&/g')
+# Body: recent commits since divergence from origin/main (not local main — may be stale after rebase)
+PR_BODY=$(git log origin/main..HEAD --format='- %h %s' | head -15)
 
 EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null)
 if [ -n "$EXISTING_PR" ]; then
   PR_URL=$(gh pr view "$EXISTING_PR" --json url --jq '.url')
   echo "PR already exists: $PR_URL"
 else
-  PR_URL=$(gh pr create --base main --head "$BRANCH" --fill)
+  PR_URL=$(gh pr create --base main --head "$BRANCH" \
+    --title "$PR_TITLE" --body "$PR_BODY")
   echo "Created PR: $PR_URL"
 fi
 
 # Poll CI if PR was created/exists
 if [ -n "$PR_URL" ]; then
-  PR_NUMBER=$(gh pr view --json number --jq '.number')
-  # CI pre-check with retry (same pattern as 3b-iii.2)
+  PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
   CHECK_COUNT=0
   for _i in 1 2 3; do
     CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
@@ -2384,24 +2570,31 @@ if [ -n "$PR_URL" ]; then
 fi
 ```
 
+Note: `PR_NUMBER` is derived from `$PR_URL` returned by `gh pr create` or `gh pr view "$EXISTING_PR"`, NOT via a bare `gh pr view` call (which relies on ambient branch autodetect and is subject to race conditions).
+
 **Differences from 3b:** This is a convenience command for manual PR creation. It does NOT dispatch fix agents or write `.landed` markers. It rebases, pushes, creates PR, and reports CI status.
 
-- [ ] Add `pr` subcommand to `/commit`
-- [ ] Rebase onto latest main before pushing
-- [ ] Push current branch + create PR
-- [ ] PR number via `gh pr view --json number --jq '.number'` (NOT URL regex)
-- [ ] Poll CI checks after PR creation (report only, no fix cycle)
+Work items checklist:
+- [ ] Add `pr` subcommand detection — first token ONLY, not mid-string
+- [ ] Pre-check: clean working tree required; error message directs user to `/commit` first
 - [ ] Error if on main/master
-- [ ] Handle existing PR
+- [ ] Rebase onto latest main before push
+- [ ] Push current branch
+- [ ] PR title: derived from branch name (strip prefix, hyphens → spaces); body: `git log origin/main..HEAD` (not `main..HEAD` — local main may be stale after rebase)
+- [ ] Handle existing PR (check with `gh pr list --head`)
+- [ ] PR number from `gh pr create` URL output or `gh pr view "$EXISTING_PR"` — NOT bare `gh pr view` (no branch arg)
+- [ ] Poll CI checks after PR creation (report only, no fix cycle)
 - [ ] Sync installed copy
 
 #### 5b.3 -- CLAUDE_TEMPLATE.md: document execution modes
 
-Add a section to `CLAUDE_TEMPLATE.md` documenting execution modes:
+**Implement AFTER 5b.1.** The `/do Add dark mode. pr` usage example requires the `pr` flag to exist in `skills/do/SKILL.md` before this documentation is accurate.
 
-```markdown
-## Execution Modes
+Add an `## Execution Modes` section to `CLAUDE_TEMPLATE.md` with this content (shown with indented code to avoid nested fence conflicts — write as actual markdown in the file, not as a fenced block inside a fenced block):
 
+The section heading is `## Execution Modes`. Under it:
+
+```
 Three landing modes control how agent work reaches main:
 
 | Mode | Keyword | How it works |
@@ -2417,65 +2610,100 @@ Three landing modes control how agent work reaches main:
 - `/do Add dark mode. pr`
 
 **Config default:** Set in `.claude/zskills-config.json`:
-```json
-{
-  "execution": {
-    "landing": "pr",
-    "main_protected": true,
-    "branch_prefix": "feat/"
-  }
-}
-```
+
+    {
+      "execution": {
+        "landing": "pr",
+        "main_protected": true,
+        "branch_prefix": "feat/"
+      }
+    }
 
 When `main_protected: true`, agents cannot commit, cherry-pick, or push
 to main. Use PR mode or feature branches.
 ```
 
-- [ ] Add execution modes section to `CLAUDE_TEMPLATE.md`
-- [ ] Document all three modes with usage examples
-- [ ] Document config defaults
+Note: The JSON config block uses 4-space indentation (not triple-backtick fences) to avoid nested fence rendering issues in the final CLAUDE_TEMPLATE.md file.
 
-#### 5b.4 -- /update-zskills: audit execution mode rules
+Work items checklist:
+- [ ] Implement AFTER 5b.1 (documents features 5b.1 ships)
+- [ ] Add `## Execution Modes` section to `CLAUDE_TEMPLATE.md`
+- [ ] Document all three modes with the usage examples table
+- [ ] Config JSON block as indented code (4-space), not a nested fenced block
 
-Add execution mode key phrases to the `/update-zskills` audit checklist:
+#### 5b.4 -- /update-zskills: audit execution mode rules (Step 2.5)
 
-```markdown
-**Execution mode audit items:**
-- "Execution Modes" section exists in CLAUDE.md
-- "main_protected" mentioned if config has it enabled
-- "PR" and "direct" keywords documented
-- `.claude/zskills-config.json` referenced
-```
+Add execution mode checking as a new **Step 2.5** in `skills/update-zskills/SKILL.md`, separate from Step 2's 13-rule key-phrase table. Step 2.5 is a documentation-presence audit that searches CLAUDE.md for heading and keyword presence — no config file inspection.
 
-- [ ] Add execution mode audit items to `/update-zskills`
+**Step 2.5 — Documentation presence audit (execution modes)**
+
+After Step 2 (13-rule key-phrase table), add Step 2.5:
+
+> Search the project's `CLAUDE.md` for these documentation-presence signals. Mark each present/missing based on case-insensitive substring match:
+>
+> | Check | Key phrase(s) to search in CLAUDE.md |
+> |-------|--------------------------------------|
+> | Execution Modes section | `## Execution Modes` (heading) |
+> | Landing mode keywords documented | `cherry-pick` AND `pr` AND `direct` |
+> | Direct mode description present | `Work directly on main` |
+>
+> Report in the same pass/fail format as Step 2. Missing items are recommendations, not errors — documentation-only gap, no enforcement consequence.
+
+Work items checklist:
+- [ ] Depends on 5b.3 — key phrases to search are the actual text strings 5b.3 adds to CLAUDE_TEMPLATE.md / CLAUDE.md
+- [ ] Add Step 2.5 to `skills/update-zskills/SKILL.md` with the documentation-presence table above
+- [ ] Step 2.5 uses CLAUDE.md substring search ONLY — no config file inspection
+- [ ] Output format matches Step 2 (present/missing per check)
 - [ ] Sync installed copy
 
 #### 5b.5 -- Sync all installed copies
 
-- [ ] `skills/do/SKILL.md` -> `.claude/skills/do/SKILL.md`
-- [ ] `skills/commit/SKILL.md` -> `.claude/skills/commit/SKILL.md`
+- [ ] `skills/do/SKILL.md` → `.claude/skills/do/SKILL.md`
+- [ ] `skills/commit/SKILL.md` → `.claude/skills/commit/SKILL.md`
 - [ ] `CLAUDE_TEMPLATE.md` updated
-- [ ] `skills/update-zskills/SKILL.md` -> `.claude/skills/update-zskills/SKILL.md`
+- [ ] `skills/update-zskills/SKILL.md` → `.claude/skills/update-zskills/SKILL.md`
 - [ ] Verify all installed copies match sources
 
 ### Design & Constraints (5b)
 
 - **`/commit pr` is a convenience.** It's for manual use from any feature branch, not tied to the pipeline. No fix agents, no `.landed` markers.
-- **CLAUDE_TEMPLATE.md is documentation.** It tells the LLM about execution modes so it can make informed decisions.
+- **`/commit pr` requires a clean working tree.** All changes must be committed before rebasing. If the tree is dirty, report: "Working tree has uncommitted changes. Run `/commit` first to create a commit, then `/commit pr` to push and create the PR."
+- **`/commit pr` keyword is first-token-only.** `/commit pr` → PR mode; `/commit fix pr format` → scope hint "fix pr format", no PR mode. This prevents false-triggering on scope hints that contain "pr" mid-string.
+- **`/do pr` is NOT pipeline-tracked by run-plan.** It writes its own `.zskills-tracked` with `do.${TASK_SLUG}` to scope tracking enforcement. Without this, an ambient run-plan pipeline ID in the same transcript would false-block the push via the hook's Tier 2 transcript read.
+- **Both `/do` worktree flags use manual worktree creation.** Both `worktree` and `pr` flags must use manual `git worktree add` (not `isolation: "worktree"`) — same reason as Phase 3b-i.
+- **CLAUDE_TEMPLATE.md is documentation.** It tells the LLM about execution modes so it can make informed decisions. The JSON config block uses indented code, not nested fenced blocks.
+- **PR titles and bodies must be explicit.** Never use `--fill` in `gh pr create` — it produces inconsistent results across `gh` versions and with terse commit messages.
+- **`/do pr` CI behavior is report-only.** When CI fails, write `.landed` with `status: pr-ci-failing` and report the failure. Do NOT dispatch fix agents — `/do` is a lightweight dispatcher; CI fix-cycles require the full run-plan infrastructure. "Same poll pattern as 3b-iii.2" means the poll mechanism only (`gh pr checks --watch`, 600s timeout) — not the fix-cycle.
+- **`/do pr` implementation sequence is fixed.** Worktree creation → `.zskills-tracked` → implementation agent (wait) → rebase → push → PR → CI → `.landed`. Do not reorder. The PR must be created after implementation so `git log origin/main..HEAD` in the body contains real commits.
+- **`TASK_DESCRIPTION` is always derived from `$ARGUMENTS` after stripping the `pr` flag.** It is never the raw `$ARGUMENTS` string. It must be assigned before the slug computation; the slug, PR title, and PR body all use it.
+- **Slug minimum-words rule.** N = min(4, word_count). If task description has 1 word, slug = that word (truncated). If 0 words after stripping, error and exit.
+- **Slug collision suffix targets `TASK_SLUG` itself.** When a collision is detected, append the timestamp suffix to `TASK_SLUG` before deriving `BRANCH_NAME` and `WORKTREE_PATH`. Do NOT derive `BRANCH_NAME` first and then patch only the path — the branch would already exist from the prior invocation, causing `git worktree add -b` to fail.
+- **PR body divergence reference is `origin/main`, not `main`.** Both `/do pr` and `/commit pr` rebase onto `origin/main` before pushing. Local `main` may be stale (ff-merge is best-effort with a warning fallback). Use `git log origin/main..HEAD` for PR bodies in both skills.
+- **Push remote is `origin` (matches existing run-plan/fix-issues patterns).** Projects with named remotes (e.g., `dev`) can override via config in a future enhancement.
 
 ### Acceptance Criteria (5b)
 
-- [ ] `/do pr` creates worktree, rebases onto main before push, pushes, creates PR, polls CI
-- [ ] `/commit pr` rebases onto main, pushes, creates PR, polls CI
-- [ ] `CLAUDE_TEMPLATE.md` documents all three execution modes
-- [ ] `/update-zskills` audit includes execution mode checks
+- [ ] `/do pr` creates worktree (manual, not `isolation: "worktree"`), writes `.zskills-tracked` with `do.<slug>` pipeline ID, dispatches implementation agent (waits for completion), rebases onto main before push, pushes, creates PR with explicit title/body, polls CI (report only)
+- [ ] `/do pr` slug collision: timestamp suffix applied to `TASK_SLUG` before deriving `BRANCH_NAME` and `WORKTREE_PATH`; second invocation with same description succeeds (new path AND new branch)
+- [ ] `/do worktree` flag converted from `isolation: "worktree"` to manual `git worktree add ../do-<slug>/`
+- [ ] `/commit pr` requires clean working tree (errors with instructions if dirty)
+- [ ] `/commit pr` recognized only when `pr` is the first token in $ARGUMENTS
+- [ ] `/commit pr` rebases onto main, pushes, creates PR with explicit title/body (no `--fill`), polls CI
+- [ ] PR body uses `git log origin/main..HEAD` (not `main..HEAD`) in both `/do pr` and `/commit pr`
+- [ ] PR number always derived from PR URL (not bare `gh pr view` ambient-branch lookup)
+- [ ] `CLAUDE_TEMPLATE.md` has `## Execution Modes` section with all three modes, usage examples, config block as indented code
+- [ ] `/update-zskills` has Step 2.5 with documentation-presence checks (CLAUDE.md heading + keyword substring search, no config inspection)
 - [ ] All installed skill copies synced and verified
 
 ### Dependencies (5b)
 
-Phase 3a (landing mode detection pattern).
+Phase 3a (landing mode detection pattern — base regex; 5b.1 extends it with `.!?` punctuation as in Phase 5a).
 Phase 3b-ii (PR mode worktree setup, push+PR pattern).
 Phase 3b-iii (CI integration, auto-merge pattern).
+PR #13 (`21e5c67`): PR-mode bookkeeping commits go in the worktree on the feature branch, not on main. Phase 5b.1 `/do pr` must not commit to main during the PR workflow.
+PR #17 (`e72f26e`): Worktree creation must include `git fetch origin main && git merge --ff-only origin/main` before branching. Phase 5b.1 worktree creation for `/do pr` must include this step (same as run-plan/SKILL.md lines 694-696).
+5b.1 is a hard prerequisite for 5b.3 (documentation references `/do pr` feature that must exist first).
+5b.3 is a hard prerequisite for 5b.4 (Step 2.5 audit searches for phrases 5b.3 adds).
 
 ---
 
@@ -2483,35 +2711,101 @@ Phase 3b-iii (CI integration, auto-merge pattern).
 
 ### Goal
 
-Update cleanup tooling for new `.landed` statuses, add `agents.min_model` config enforcement, and add baseline test snapshot capture. These are infrastructure improvements that support the execution mode system but are independent of the skill text changes in 5b.
+Update cleanup tooling for PR-mode `.landed` statuses, add `agents.min_model` config field with hook-based enforcement (primary) and skill-side reminders (belt-and-suspenders), and add baseline test comparison instructions to the verification agent. These are infrastructure improvements that support the execution mode system but are independent of the skill text changes in 5b.
 
 ### Work Items
 
-#### 5c.1 -- Cleanup tooling: recognize new `.landed` statuses
+#### 5c.1 -- Cleanup tooling: recognize PR-mode `.landed` statuses
 
-Update `/briefing` and `/fix-report` to classify the new `.landed` status values.
-Existing tooling only recognizes `status: landed` (safe) and treats everything else
-as unknown. The new statuses need distinct handling:
+Update `/fix-report` Step 6 worktree cleanup and `scripts/briefing.py` / `scripts/briefing.cjs` classification to handle the PR-mode `.landed` statuses written by `/run-plan` PR mode.
 
-| Status | Classification | Action |
-|--------|---------------|--------|
-| `landed` | Safe to remove | Worktree cleanup OK |
-| `pr-ready` | Safe to remove | Work preserved in PR |
-| `pr-ci-failing` | Needs attention | CI failing, may need manual fix |
-| `pr-failed` | Needs attention | PR creation failed, manual `gh pr create` |
-| `conflict` | Needs attention | Rebase conflict, manual resolution |
-| `not-landed` | Agent done | Review before removing |
+**Current gap analysis (verified against actual code):**
 
-- [ ] Update `/briefing` worktree classification to recognize all 6 statuses
-- [ ] Update `/fix-report` sprint summary to show PR URLs and CI status
-- [ ] `landed` and `pr-ready` -> safe for cleanup; others -> flag for user
+`skills/fix-report/SKILL.md` Step 6 (line 298) only removes worktrees with `status: full`:
+```bash
+grep -q "^status: full" "$wt/.landed"
+```
+But `/run-plan` cherry-pick mode writes `status: landed` (run-plan/SKILL.md line 1177), and `/run-plan` PR mode writes `status: pr-ready` or `status: landed` (run-plan/SKILL.md lines 1717-1725). `/fix-issues` cherry-pick mode writes `status: full` (fix-issues/SKILL.md line 994). The `land-phase.sh` cleanup script correctly accepts both `status: landed` and `status: pr-ready` as safe (line 23: `grep -qE 'status: (landed|pr-ready)'`). `/fix-report` Step 6 is behind by two statuses.
+
+`scripts/briefing.py` `classify_worktrees()` function (defined at line 156; internal status classification block at lines 260-286) and `scripts/briefing.cjs` `classifyWorktrees()` function (defined at line 150; status block lines 257-283) only recognize `status == 'full'` → `landed-full` and `status == 'partial'` → `landed-partial`. All PR-mode statuses (`pr-ready`, `pr-ci-failing`, `pr-failed`, `conflict`) fall through to the "no .landed" path and are misclassified as `possibly-active` or `empty`. The `skills/briefing/SKILL.md` text is conceptual description — the executable classification is in the scripts.
+
+Note: `status: not-landed` is NOT written by any current skill. It is documented in CLAUDE.md as a sentinel agents can write manually. Do NOT add it to the status table as an automatic output — no skill writes it automatically.
+
+**Status vocabulary (actual written values):**
+
+| Status | Written by | Classification | Cleanup action |
+|--------|-----------|---------------|----------------|
+| `full` | fix-issues cherry-pick | Safe to remove | Worktree + branch cleanup OK |
+| `landed` | run-plan cherry-pick; run-plan PR mode (merged) | Safe to remove | Worktree cleanup OK; land-phase.sh deletes remote branch |
+| `pr-ready` | run-plan PR mode (open PR) | Safe to remove (worktree only) | Worktree cleanup OK; remote branch must NOT be deleted (supports open PR) |
+| `pr-ci-failing` | run-plan PR mode (CI failing) | Needs attention | Flag for user; show PR URL |
+| `pr-failed` | run-plan PR mode (push succeeded, PR creation failed) | Needs attention | Flag for user; show branch |
+| `conflict` | run-plan PR mode (rebase conflict) | Needs attention | Flag for user; worktree left for user to resolve |
+
+**Constraint on `pr-ready` branch deletion:** When classifying `pr-ready` as safe for WORKTREE removal, do NOT delete the remote branch — the branch supports the open PR. `scripts/land-phase.sh` correctly implements this at line 88 (only deletes remote branch when `status: landed`). Do NOT modify land-phase.sh to delete remote branches for `pr-ready` worktrees.
+
+Work items checklist:
+- [ ] Update `/fix-report` Step 6 worktree cleanup check to accept `status: full` (fix-issues cherry-pick), `status: landed` (run-plan cherry-pick and PR merged), AND `status: pr-ready` (open PR, worktree safe to remove) as safe-to-remove — matching land-phase.sh gate at line 23
+- [ ] Update `/fix-report` Step 6 output messages to distinguish safe-to-remove statuses (show PR URL for `pr-ready`) from needs-attention statuses (`pr-ci-failing`, `pr-failed`, `conflict`)
+- [ ] Update `/fix-report` Step 6 narrative example text: lines 311-312 (update example to show `status: landed` and `status: pr-ready` as SAFE alongside `status: full`); line 321 (expand instruction text to list all three safe-to-remove statuses: `full`, `landed`, `pr-ready`)
+- [ ] Update `scripts/briefing.py` `classify_worktrees()` function (defined at line 156; status block lines 260-286) to handle PR-mode statuses: `pr-ready` → new category `landed-pr-ready`; `pr-ci-failing`, `pr-failed`, `conflict` → new category `landed-pr-needs-attention` (or similar distinct categories)
+- [ ] Update `scripts/briefing.cjs` `classifyWorktrees()` function (defined at line 150; status block lines 257-283) with the same new category logic
+- [ ] Update `scripts/briefing.py` display functions to handle the new PR-mode categories. Locate all call sites with: `grep -n "landed-full\|landed-partial\|possibly-active" scripts/briefing.py` — each hit is a site that may need to handle `landed-pr-ready` and `landed-pr-needs-attention`. Key functions to update:
+  - `format_summary()` (line 759): add `landed-pr-needs-attention` to NEEDS ATTENTION bucket (bucket comment at line 779) alongside `done-needs-review` and `landed-partial`
+  - `format_summary()` (line 759): WORKTREES count block — add `landed-pr-ready` and `landed-pr-needs-attention` to the listed categories so they appear in the summary line
+  - `format_report()` (line 922): `landed_count` — decide whether `landed-pr-ready` counts as "landed" (recommended: yes, it's safe-to-remove) and include it
+  - `format_current()` (line 1117): if `landed-pr-ready` worktrees exist, show them (they are not in-flight, but the PR is open)
+  - `format_verify()` (line 1026): `landed-pr-needs-attention` should appear in verification output similarly to `landed-partial`
+- [ ] Apply the same display function updates to `scripts/briefing.cjs`: `classifyWorktrees()` (status block lines 257-283); `formatSummary()` (line 666); `formatReport()` (line 858); `formatVerify()` (line 982); `formatCurrent()` (line 1102)
+- [ ] Update `skills/briefing/SKILL.md` Worktree Categories section to document the new PR-mode categories
 - [ ] Sync installed copies of briefing and fix-report skills
 
-#### 5c.2 -- `agents.min_model` config field + hook enforcement
+#### 5c.2 -- `agents.min_model` config field + hook-based enforcement
 
-Add an `agents.min_model` field to the config schema and enforce it in the hook. This prevents agents from dispatching subagents with models below a minimum quality threshold.
+**Architectural decision:** Hook-based enforcement of `agents.min_model` IS viable. The two real infrastructure blockers are both fixable, and the third claimed blocker was false.
 
-**Config addition:**
+**Blocker analysis (verified):**
+
+1. **Matcher — FIXABLE.** `.claude/settings.json` only registers a `"matcher": "Bash"` entry — the hook is never invoked for `Agent` tool calls. Fix: add a `"matcher": "Agent"` entry to the `PreToolUse` array in `.claude/settings.json`. Propagation to target projects: update the embedded settings.json JSON block in `skills/update-zskills/SKILL.md` Step C (around line 475 — the embedded JSON is the source of truth for what `/update-zskills` writes into target projects).
+
+2. **Hook file — FIXABLE.** `hooks/block-unsafe-project.sh.template` lines 13-16 have an unconditional early-exit for any non-Bash tool. Fix (preferred): add a new hook file `hooks/block-agents.sh.template` registered under the `Agent` matcher. Cleaner separation than modifying the existing Bash-focused hook.
+
+3. **Model field — NOT A BLOCKER (claim was false).** The prior refinement asserted "Agent tool input JSON contains no `model` field — verified." This claim is false. The Agent (Task) tool's input schema includes an optional `model` field with enum `["sonnet", "opus", "haiku"]`. When present, the hook can inspect it directly. The "no precedent in hooks/" evidence was a non-sequitur — absence of prior use is not absence of the field in the schema.
+
+**Hook implementation (`hooks/block-agents.sh.template`):**
+
+The new hook fires on every `Agent` (subagent) dispatch via the `Agent` PreToolUse matcher. It:
+1. Reads `agents.min_model` from `.claude/zskills-config.json` — if not set, exits 0 (pass-through)
+2. Extracts `model` from the tool input JSON if present
+3. If `model` is absent from tool input, reads the agent definition at `.claude/agents/<subagent_type>.md` and parses its YAML frontmatter for a `model:` field
+4. Converts the model string to an ordinal: `haiku=1`, `sonnet=2`, `opus=3`, `unknown=0`
+5. `unknown=0` means unknown model families always pass — pass-through for new Claude model families not yet in the ordinal map
+6. If the dispatch model ordinal < min_model ordinal: block with exit 2, print error: "agents.min_model requires <min_model> or higher; got <model>"
+
+**Residual blind spot (narrow):** If neither the `tool_input` nor the agent definition's frontmatter specifies a model, the subagent inherits from the parent session. This edge case is narrow because top-level Claude Code sessions run Opus or Sonnet. Skill-side reminders (in CLAUDE.md and at each orchestrator dispatch site) cover this case as belt-and-suspenders.
+
+**Ordinal comparison reference:**
+- `haiku = 1`
+- `sonnet = 2`
+- `opus = 3`
+- `unknown = 0` (always allowed — pass-through for new model families)
+
+**Config addition** (`config/zskills-config.schema.json`):
+
+```json
+"agents": {
+  "type": "object",
+  "description": "Agent dispatch configuration.",
+  "properties": {
+    "min_model": {
+      "type": "string",
+      "description": "Minimum model for subagent dispatch. Hook enforces this at Agent tool dispatch time. Example: claude-sonnet-4-20250514"
+    }
+  }
+}
+```
+
+**Dogfood config addition** (`.claude/zskills-config.json`):
 
 ```json
 {
@@ -2521,96 +2815,113 @@ Add an `agents.min_model` field to the config schema and enforce it in the hook.
 }
 ```
 
-**Schema addition:**
+**CLAUDE.md rule (add to CLAUDE_TEMPLATE.md alongside 5b.3 section):**
 
-```json
-"agents": {
-  "type": "object",
-  "description": "Agent dispatch configuration.",
-  "properties": {
-    "min_model": {
-      "type": "string",
-      "description": "Minimum model for Agent tool calls. Hook blocks Agent calls with model_name below this. Example: claude-sonnet-4-20250514"
-    }
-  }
-}
-```
+> When dispatching an Agent (subagent), always use Sonnet or higher. Never dispatch Haiku — even for "simple" tasks. The minimum model is configured at `agents.min_model` in `.claude/zskills-config.json`.
 
-**Hook enforcement:** In `hooks/block-unsafe-project.sh.template`, when the tool is `Agent` and the input contains a `model` or `model_name` field, extract it and compare against `agents.min_model` from config. Block if the specified model is below the minimum.
+**Skill-side reminders (belt-and-suspenders):** When any orchestrator skill (run-plan, fix-issues, do) constructs an Agent dispatch, the skill text includes a reminder to read `agents.min_model` and respect the minimum. This covers the residual blind spot where neither tool input nor agent definition specifies a model. Example addition to dispatch sections:
 
-The comparison uses an ordinal lookup on the model family, NOT lexicographic (since `opus < sonnet` alphabetically, which is backwards). Extract the family name from the model string and map to an ordinal: `haiku=1, sonnet=2, opus=3`. Compare ordinals: if the requested model's ordinal is less than the minimum model's ordinal, block. If `min_model` is `claude-sonnet-4-*` (ordinal 2), block `claude-haiku-*` (ordinal 1) but allow `claude-sonnet-4-*` (ordinal 2) and `claude-opus-*` (ordinal 3).
+> Before dispatching any Agent: check `agents.min_model` in `.claude/zskills-config.json`. If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch with a lower-ordinal model than the configured minimum.
 
-```bash
-model_ordinal() {
-  case "$1" in
-    *haiku*) echo 1 ;;
-    *sonnet*) echo 2 ;;
-    *opus*) echo 3 ;;
-    *) echo 99 ;;  # unknown/future model family, allow by default
-  esac
-}
-```
+Work items checklist:
+- [ ] Add `agents.min_model` to `config/zskills-config.schema.json` with schema definition
+- [ ] Add `agents` section to dogfood config (`.claude/zskills-config.json`)
+- [ ] Add `"matcher": "Agent"` entry to `.claude/settings.json` `PreToolUse` array
+- [ ] Add the Agent matcher JSON block to the embedded settings template in `skills/update-zskills/SKILL.md` Step C (~line 475) and update the note at ~line 501-502 ("only the Bash matcher is used") to reflect the new Agent matcher
+- [ ] Create `hooks/block-agents.sh.template`: read `agents.min_model` from config; extract `model` from tool input JSON; fall back to reading `.claude/agents/<subagent_type>.md` frontmatter if tool input has no `model`; apply ordinal check (haiku=1, sonnet=2, opus=3, unknown=0 always passes); block with exit 2 if dispatch model < min_model
+- [ ] Add CLAUDE.md rule to `CLAUDE_TEMPLATE.md`: "When dispatching Agent, use Sonnet or higher. Never Haiku."
+- [ ] Add skill-side reminder (belt-and-suspenders) to `skills/run-plan/SKILL.md` at each Agent dispatch point: implementation agent dispatch (~line 537), verification agent dispatch (~line 807), CI fix-cycle dispatch (~line 1596) — add `agents.min_model` check reminder at each
+- [ ] Add skill-side reminder to `skills/fix-issues/SKILL.md` at Agent dispatch sections (research agent dispatch, fix agent dispatch, verification agent dispatch — verify line numbers before editing)
+- [ ] Add skill-side reminder to `skills/do/SKILL.md` implementation-agent dispatch section added in 5b.1
+- [ ] For `skills/research-and-go/SKILL.md`: the skill delegates entirely through `/research-and-plan` (Skill invocation at line 86) — no direct Agent tool dispatch exists in this file. No skill-side reminder needed here. If the implementer finds an actual Agent dispatch via grep, add the reminder at that site.
+- [ ] Document ordinal comparison (haiku=1, sonnet=2, opus=3, unknown=0) in hook comments and skill dispatch instructions
+- [ ] Sync installed skill copies and new hook file
 
-- [ ] Add `agents.min_model` to config schema
-- [ ] Add `agents` section to dogfood config
-- [ ] Add hook enforcement: block Agent calls with model below minimum
-- [ ] Model comparison: ordinal (haiku=1, sonnet=2, opus=3), not lexicographic
-- [ ] Tests in `tests/test-hooks.sh` (config/hook tests belong there)
+Acceptance criterion for this item: (a) hook `block-agents.sh.template` fires on Agent dispatch and blocks haiku when `agents.min_model` is sonnet; (b) skill-side `agents.min_model` reminder text is present at each direct Agent dispatch site in run-plan (implementation ~537, verification ~807, CI fix ~1596), fix-issues (research, fix, verification dispatches), and do (implementation dispatch from 5b.1). research-and-go requires no change unless implementer locates an actual Agent dispatch in the file.
 
-#### 5c.3 -- Baseline test snapshot
+#### 5c.3 -- Baseline test snapshot: comparison instructions only
 
-`/run-plan` captures test results BEFORE the implementation agent starts, so the verification agent can compare against a known-good baseline. This detects regressions introduced by the implementation (as opposed to pre-existing failures).
-
-**Mechanism:** Before dispatching the implementation agent for each phase:
+**Baseline capture already shipped (Phase 5a).** `/run-plan/SKILL.md` lines 740-750 contain the complete baseline capture:
 
 ```bash
-# Capture baseline test results in the worktree
+# Orchestrator captures baseline BEFORE impl agent starts
 cd "$WORKTREE_PATH"
-$FULL_TEST_CMD > .test-baseline.txt 2>&1 || true
-# The || true ensures we capture output even if some tests fail pre-existing.
-# The verification agent compares .test-results.txt against .test-baseline.txt
-# to distinguish new failures from pre-existing ones.
+if [ -n "$FULL_TEST_CMD" ]; then
+  $FULL_TEST_CMD > .test-baseline.txt 2>&1 || true
+fi
 ```
 
-**Verification agent instructions (added to prompt):**
+`scripts/land-phase.sh` lines 49-52 already delete `.test-baseline.txt` as part of worktree cleanup. The capture and cleanup infrastructure is complete as of commit `d5b46c5` (Phase 5a via PR #11).
 
-```markdown
-After running tests, compare `.test-results.txt` against `.test-baseline.txt`:
-- New failures (in results but not in baseline) -> must be fixed before commit
-- Pre-existing failures (in both baseline and results) -> note in report, do not fix
-- Resolved failures (in baseline but not in results) -> positive, note in report
-```
+**Only remaining work:** The verification agent dispatch section in `skills/run-plan/SKILL.md` (approximately lines 807-855) does not include instructions to compare `.test-results.txt` against `.test-baseline.txt`. Add these comparison instructions to the verification agent prompt.
 
-- [ ] Capture `.test-baseline.txt` before implementation agent dispatch
-- [ ] Add comparison instructions to verification agent prompt
-- [ ] Handle missing `FULL_TEST_CMD` (skip baseline if no test command configured)
-- [ ] Tests in `tests/test-hooks.sh`
+Add to the verification agent dispatch (in the "give the verification agent:" list at ~line 814):
+- The `.test-baseline.txt` file captured before implementation started
+- Instructions to compare `.test-results.txt` against `.test-baseline.txt`:
+  - New failures (in results but not in baseline) → regressions, must be fixed before commit
+  - Pre-existing failures (in both baseline and results) → note in report, do not fix
+  - Resolved failures (in baseline but not in results) → positive improvement, note in report
+
+**Validation:** The baseline snapshot feature is validated manually (integration test) — run a plan phase and confirm `.test-baseline.txt` is present in the worktree before the implementation agent starts, and that the verification agent report distinguishes new from pre-existing failures. This is orchestrator behavior, not a hook — it cannot be meaningfully unit-tested in `tests/test-hooks.sh`.
+
+Work items checklist:
+- [ ] Add baseline comparison instructions to verification agent dispatch prompt in `skills/run-plan/SKILL.md` (~line 814 onward)
+- [ ] Handle missing `.test-baseline.txt` in instructions: "If `.test-baseline.txt` is absent (FULL_TEST_CMD not configured), treat all failures as potentially new — report all of them"
+- [ ] Sync installed copy of run-plan skill
+- [ ] Manual integration test: run a plan phase, confirm `.test-baseline.txt` present before impl agent; confirm verification report distinguishes new vs pre-existing failures
 
 #### 5c.4 -- Sync all installed copies
 
 - [ ] `config/zskills-config.schema.json` updated with `agents` section
-- [ ] Sync installed copies of briefing and fix-report skills
+- [ ] `.claude/zskills-config.json` updated with `agents.min_model`
+- [ ] `.claude/settings.json` updated with `"matcher": "Agent"` PreToolUse entry
+- [ ] `skills/update-zskills/SKILL.md` Step C (embedded settings.json template at ~line 475) updated with `"matcher": "Agent"` entry + adjusted note about matchers
+- [ ] `hooks/block-agents.sh.template` created and installed
+- [ ] `CLAUDE_TEMPLATE.md` updated (5b.3 Execution Modes section + 5c.2 min_model rule)
+- [ ] `skills/briefing/SKILL.md` → `.claude/skills/briefing/SKILL.md`
+- [ ] `skills/fix-report/SKILL.md` → `.claude/skills/fix-report/SKILL.md`
+- [ ] `skills/run-plan/SKILL.md` → `.claude/skills/run-plan/SKILL.md`
+- [ ] `skills/fix-issues/SKILL.md` → `.claude/skills/fix-issues/SKILL.md`
+- [ ] `skills/do/SKILL.md` → `.claude/skills/do/SKILL.md`
+- [ ] `scripts/briefing.py` and `scripts/briefing.cjs` updated (not just SKILL.md — these contain the runtime classification logic)
 - [ ] Verify all installed copies match sources
 
 ### Design & Constraints (5c)
 
-- **`agents.min_model` uses ordinal comparison.** We extract the model family (haiku=1, sonnet=2, opus=3) and compare ordinals. NOT lexicographic -- `opus < sonnet` alphabetically, which gives the wrong result. Unknown families get ordinal 0 (allowed by default).
-- **Baseline snapshot is best-effort.** If `FULL_TEST_CMD` is not configured, skip the baseline. The verification agent still runs tests; it just can't distinguish new vs pre-existing failures.
-- **Phase 5c tests go in `tests/test-hooks.sh`.** Config/hook tests (min_model, baseline) belong in the hook test file.
+- **Hook enforcement of `agents.min_model` IS viable via new `block-agents.sh.template`.** The two real blockers (Bash-only matcher in settings.json; Bash-only early-exit in block-unsafe-project.sh.template) are both fixable. The third claimed blocker ("Agent tool input lacks model field") was false — the Agent tool schema includes an optional `model` field. Add Agent matcher to `.claude/settings.json` (main repo) AND to the embedded settings.json template inside `skills/update-zskills/SKILL.md` Step C (so `/update-zskills` writes it into target projects); create a separate hook file `hooks/block-agents.sh.template` for Agent enforcement.
+- **`block-agents.sh.template` reads model from tool input first, then agent definition fallback.** When `model` is present in tool_input JSON, use it directly. When absent, read `.claude/agents/<subagent_type>.md` frontmatter for a `model:` field. When neither specifies a model, ordinal = 0 (unknown, always passes). This edge case is covered by skill-side reminders.
+- **`agents.min_model` uses ordinal comparison — for both hook and skills.** Hook enforces at runtime; skills carry reminders as belt-and-suspenders. Ordinal: haiku=1, sonnet=2, opus=3, unknown=0 (unknown families always allowed — pass-through for new Claude model families).
+- **Skill-side reminders are belt-and-suspenders, not the primary enforcement.** The hook is primary. Skill reminders cover the residual case where a model is not specified in tool_input or agent definition (subagent inherits from parent session).
+- **Baseline snapshot is best-effort.** If `FULL_TEST_CMD` is not configured, skip the baseline (already handled in lines 747-749 of run-plan/SKILL.md). The verification agent still runs tests; it just can't distinguish new vs pre-existing failures.
+- **briefing classification lives in scripts, not SKILL.md.** Updating `skills/briefing/SKILL.md` alone does NOT fix runtime behavior. The executable classification is in `scripts/briefing.py` (`classify_worktrees()` defined at line 156, status block lines 260-286) and `scripts/briefing.cjs` (`classifyWorktrees()` defined at line 150, status block lines 257-283) — both must be updated.
+- **briefing display functions must be updated alongside `classify_worktrees()`.** Adding new categories to `classify_worktrees()` without updating `format_summary()` (line 759), `format_report()` (line 922), `format_current()` (line 1117), and `format_verify()` (line 1026) in briefing.py — and their cjs counterparts `formatSummary()` (line 666), `formatReport()` (line 858), `formatVerify()` (line 982), `formatCurrent()` (line 1102) — causes new categories to be silently invisible in all output modes. Both the classifier and all downstream display functions must be updated atomically.
+- **`pr-ready` worktrees are safe to remove; `pr-ready` branches are not.** The worktree is expendable once the branch is pushed; the branch supports the open PR. `land-phase.sh` correctly handles this at line 88. Do NOT change land-phase.sh remote-branch-delete logic.
+- **Skill-side reminder covers run-plan, fix-issues, and do.** research-and-go delegates through the skill chain (no direct Agent dispatch in research-and-go/SKILL.md — line 86 is a Skill invocation). No reminder needed in research-and-go unless implementer finds an actual Agent dispatch via grep.
+- **Push remote is `origin` (matches existing run-plan/fix-issues patterns).** Projects with named remotes (e.g., `dev`) can override via config in a future enhancement.
 
 ### Acceptance Criteria (5c)
 
-- [ ] `/briefing` and `/fix-report` classify all 6 `.landed` statuses correctly
-- [ ] `agents.min_model` config field exists with schema definition
-- [ ] Hook blocks Agent calls with model below `agents.min_model`
-- [ ] Baseline test snapshot captured before implementation agent dispatch
-- [ ] Verification agent compares `.test-results.txt` against `.test-baseline.txt`
-- [ ] All installed skill copies synced and verified
+- [ ] `/fix-report` Step 6 accepts `status: full` (fix-issues cherry-pick) AND `status: landed` (run-plan cherry-pick + PR merged) AND `status: pr-ready` (open PR, worktree safe) as safe-to-remove
+- [ ] `/fix-report` Step 6 flags `pr-ci-failing`, `pr-failed`, `conflict` as needs-attention with appropriate messages
+- [ ] `/fix-report` Step 6 narrative text (example at lines 311-312 and instruction at line 321) updated to list all three safe-to-remove statuses (`full`, `landed`, `pr-ready`)
+- [ ] `scripts/briefing.py` and `scripts/briefing.cjs` classify PR-mode statuses as distinct categories (not misclassified as `possibly-active` or `empty`)
+- [ ] New briefing categories (`landed-pr-ready`, `landed-pr-needs-attention`) are visible in briefing output in all modes (summary, report, current, verify), not silently dropped — verified by running briefing with a test worktree that has a `pr-ready` `.landed` file
+- [ ] `agents.min_model` config field exists in `config/zskills-config.schema.json` with schema definition
+- [ ] Dogfood config (`.claude/zskills-config.json`) has `agents.min_model` set to sonnet
+- [ ] `.claude/settings.json` AND the embedded settings.json template in `skills/update-zskills/SKILL.md` Step C both have `"matcher": "Agent"` PreToolUse entry
+- [ ] `hooks/block-agents.sh.template` created: reads `agents.min_model` from config, reads `model` from tool input (falls back to agent definition frontmatter), applies ordinal check, blocks with exit 2 if below minimum
+- [ ] CLAUDE_TEMPLATE.md includes rule: "When dispatching Agent, use Sonnet or higher. Never Haiku."
+- [ ] Skill-side `agents.min_model` reminder text present at each direct Agent dispatch site in run-plan (~lines 537, 807, 1596), fix-issues (research/fix/verification dispatches), and do (implementation dispatch from 5b.1). research-and-go: no change needed (no direct Agent dispatch in the skill file).
+- [ ] `skills/run-plan/SKILL.md` verification agent dispatch includes comparison instructions for `.test-results.txt` vs `.test-baseline.txt`
+- [ ] All installed skill copies synced and verified (including script files and new hook)
 
 ### Dependencies (5c)
 
 Phase 3b-ii (`.landed` statuses, PR mode patterns).
-Phase 4 (fix-issues PR mode, for sprint report PR URLs).
+Phase 4 (`02e0f6b`) — fix-issues PR mode; fix-report already handles 5-status vocabulary at skill text level (Step 1 lines 109-134, Step 4 lines 216-225); 5c.1 closes the Step 6 cleanup gap.
+Phase 5a (`d5b46c5`) — baseline capture already implemented; 5c.3 adds only the comparison instructions.
+PR #13 (`21e5c67`) — PR-mode bookkeeping rule (relevant for understanding the worktree/branch lifecycle that 5c.1 cleanup must handle correctly).
+5b.1 (5c.2 skill-side reminder for `/do` requires the dispatch section 5b.1 adds to exist first).
 
 ---
 
@@ -2686,6 +2997,34 @@ Structural comparison of the plan as originally drafted (`adb4752`) vs current s
 - Baseline test snapshot — agents falsely claim failures are "pre-existing"
 - `agents.min_model` config — Sonnet minimum, no Haiku ever
 
+
+**Post-Phase-5a refinement additions (documented during /refine-plan round 2, 2026-04-14):**
+
+- **5c.2 architectural pivot.** `agents.min_model` hook enforcement replaced with CLAUDE.md rule + skill-side reminder. Three independent blockers confirmed from the codebase: (a) `.claude/settings.json` only has a `Bash` matcher; (b) `hooks/block-unsafe-project.sh.template` lines 13-16 exit for any non-Bash tool; (c) Agent tool input JSON contains no `model` field. All three prevent hook-based enforcement.
+- **5c.3 baseline already shipped.** Baseline capture (run-plan/SKILL.md ~lines 740-750) and cleanup (land-phase.sh lines 49-52) landed in Phase 5a (commit `d5b46c5`). Remaining 5c.3 scope reduced to adding comparison instructions at the verification agent dispatch.
+- **5c.1 real gap identified.** `/fix-report` already handles 5 PR statuses at the narrative level (post-Phase 4). The actual remaining gaps: (a) `/fix-report` Step 6 hardcodes `status: full`, missing `status: landed`; (b) `scripts/briefing.py` and `scripts/briefing.cjs` only recognize `full`/`partial` at runtime — all PR-mode statuses misclassified; (c) briefing display functions hardcode old category names, so fixing `classify_worktree()` alone makes new categories silently invisible.
+- **5b.1 scope tightened.** Slug algorithm specified (first N≤4 words, lowercased, non-alphanum→hyphen, collapsed, max 30 chars, timestamp on collision). Extended detection regex with `.!?` (same as Phase 5a research-and-go). Implementation-agent dispatch step added between `.zskills-tracked` write and rebase+push. `TASK_DESCRIPTION` extraction from `$ARGUMENTS` made explicit. Existing `/do worktree` flag scheduled for conversion from `isolation: "worktree"` to manual `git worktree add` (same reason as Phase 3b-i).
+- **5b.1 `.zskills-tracked` pipeline scoping.** `/do pr` must write its own `do.${TASK_SLUG}` pipeline ID in the worktree's `.zskills-tracked` to prevent ambient run-plan pipeline IDs (via Tier 2 transcript read) from false-blocking the push.
+- **5b.2 hardening.** `pr` recognized only as first token in `$ARGUMENTS` (prevents collision with scope hints like "fix pr comments"). Clean-tree pre-check added. `gh pr create --fill` replaced with explicit `--title`/`--body`. PR_NUMBER extracted from PR URL (not bare `gh pr view` ambient-branch lookup).
+- **PR #13 and PR #17 added as dependencies of 5b.** PR #13 (`21e5c67`) established the PR-mode bookkeeping rule (feature-branch commits, not main). PR #17 (`e72f26e`) added the `git fetch origin main && git merge --ff-only origin/main` step before worktree creation. Both landed after Phase 5a and must be followed by 5b.1.
+- **Tracker drift: Phase 5a.** Progress Tracker shows Phase 5a as `🟡 In Progress` but reality shows it landed via PR #11 (commit `d5b46c5`). Tracker left unchanged per `/refine-plan` byte-identical rule; drift noted here for visibility.
+
+
+**Post-Phase-5a re-refinement additions (2026-04-15, second /refine-plan run with verify-before-fix discipline):**
+
+- **5c.2 architecture corrected back to hook-based.** The prior refinement's skill-side-only pivot was driven by a false DA claim that "Agent tool input JSON has no `model` field — verified." The actual Agent (Task) tool schema includes an optional `model` field with enum `["sonnet","opus","haiku"]`. Hook enforcement is viable with: (a) `"matcher": "Agent"` entry in `.claude/settings.json` AND the embedded template in `skills/update-zskills/SKILL.md` Step C; (b) new `hooks/block-agents.sh.template` under the Agent matcher; (c) hook reads `model` from tool_input, falls back to agent-definition frontmatter at `.claude/agents/<subagent_type>.md`, applies ordinal check against `agents.min_model`. Skill-side reminders retained as belt-and-suspenders for the parent-session-inheritance edge case.
+
+- **`/do pr` + `/commit pr` PR body:** `git log main..HEAD` → `git log origin/main..HEAD` (after `git fetch origin main && git rebase origin/main`, local main may be stale; origin/main is the correct divergence reference).
+
+- **5b.1 slug collision:** Suffix (`-<last-5-chars-of-unix-epoch>` via `date +%s | tail -c 5`) now applies to `TASK_SLUG` BEFORE `BRANCH_NAME` and `WORKTREE_PATH` are derived, so both path and branch pick up the suffix. Prior ordering would have failed on a second invocation with same slug because the un-suffixed branch already existed.
+
+- **5c.1 briefing function citations corrected:** Actual locations: `classify_worktrees()` at briefing.py:156 (plural form, not singular); display functions at briefing.py:759 (format_summary), 922 (format_report), 1026 (format_verify), 1117 (format_current); briefing.cjs: classifyWorktrees() at 150, formatSummary() at 666, formatReport() at 858, formatVerify() at 982, formatCurrent() at 1102.
+
+- **5c.1 fix-report Step 6 narrative text added to update scope:** Lines 311-312 example output ("status: full") and line 321 instruction text both need updating to list full/landed/pr-ready as safe-to-remove, not just full.
+
+- **5c.2 research-and-go removed from Agent dispatch sites:** Line 86 is a `/research-and-plan` Skill tool call, not an Agent tool dispatch; the `agents.min_model` reminder doesn't apply there. Implementer grep-check noted if uncertain about other Agent dispatches in the skill.
+
+- **Meta: evidence discipline added to /refine-plan + /draft-plan.** Reviewer/DA findings must include `Verification:` lines (file:line, grep, schema quote); refiner's new mandatory verify-before-fix pass reproduces each empirical claim before acting. Findings whose evidence doesn't reproduce are justified-not-fixed. The DA-2 failure class above — confidently-false empirical claim cascading into architectural pivot — is the specific failure this discipline prevents.
 ## Plan Review (/refine-plan)
 
 **Refinement process:** /refine-plan with 2 rounds of adversarial review
@@ -2697,3 +3036,32 @@ Structural comparison of the plan as originally drafted (`adb4752`) vs current s
 |-------|-------------------|---------------------------|-------------|----------|
 | 1 | 2 critical, 3 important, 1 minor | 4 critical, 3 important, 1 minor | 11 | 11/11 |
 | 2 | 1 note (model_ordinal) | 1 issue (model_ordinal) | 1 | 1/1 (fixed: unknown=99) |
+
+### Round History — Post-Phase-5a refinement (2026-04-14)
+
+**Refinement process:** /refine-plan with 2 rounds of adversarial review (grounded-in-reality preamble per PR #12)
+**Convergence:** Max rounds reached (2); final round resolved all findings — no remaining concerns.
+
+| Round | Reviewer Findings | Devil's Advocate Findings | Substantive | Resolved |
+|-------|-------------------|---------------------------|-------------|----------|
+| 1 | 5 critical, 9 important, 3 minor | 4 critical, 5 important, 2 minor | 28 | 28/28 |
+| 2 | 2 important, 2 minor | 1 critical, 2 important, 1 minor | 8 | 8/8 |
+
+**Round 1 critical fixes:** (a) 5c.2 hook enforcement rewritten to skill-side (Agent tool input lacks `model` field; Bash-only matcher + early-exit); (b) ordinal-0/99 contradiction resolved to 0; (c) `/commit pr` `gh pr view` bug fixed; (d) 5c.1 scope corrected around actual fix-report/briefing-script gaps; (e) 5c.3 reframed because baseline capture already shipped in Phase 5a.
+
+**Round 2 critical fix:** briefing display functions (format_summary/report/current/verify) update added to 5c.1 — classifier fix alone would make new PR-mode categories silently invisible in all output modes.
+
+**Remaining concerns:** None — all 36 findings across both rounds resolved.
+
+### Round History — Re-refinement pass (2026-04-15)
+
+**Refinement process:** /refine-plan re-run with verify-before-fix discipline (new in /refine-plan v2)
+**Reason for re-run:** The prior /refine-plan run accepted a false DA claim (Agent tool input JSON has no `model` field); the refiner baked it into 5c.2 as an architectural pivot. /refine-plan was then upgraded with evidence-verification; this re-run corrects the bad pivot.
+**Convergence:** Converged — round 1 fixed 16 findings (1 critical + 8 important + 5 minor + 2 informational-pass); lightweight round-2 validation found 2 cleanup issues (phantom `hooks/settings.json.template` references; prose/code mismatch on suffix length), both fixed directly without a third refinement cycle.
+
+| Round | Reviewer | DA | Substantive | Resolved |
+|-------|----------|-----|-------------|----------|
+| 1 | 1 critical, 4 important, 3 minor, 2 pass | 1 critical, 4 important, 1 minor | 14 | 14/14 (+ 2 pass) |
+| 2 (validation) | 2 regressions | — | 2 | 2/2 direct-fixed |
+
+**Remaining concerns:** None. 5c.2 corrected to hook-based enforcement with settings.json Agent matcher + new block-agents.sh.template + model-field read with agent-definition frontmatter fallback. Residual parent-session-inheritance blind spot covered by skill-side reminders (belt-and-suspenders).

--- a/reports/plan-execution-modes.md
+++ b/reports/plan-execution-modes.md
@@ -1,5 +1,70 @@
 # Plan Report — Execution Modes
 
+## Phase — 5c Infrastructure: Cleanup Tooling, Model Gate, Baseline Snapshot
+
+**Plan:** plans/EXECUTION_MODES.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-execution-modes
+**Branch:** feat/execution-modes
+**Commits:** 1839bb8
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 5c.1 | fix-report Step 6 + briefing.py/.cjs classifier + display functions + briefing/SKILL.md categories | Done | 1839bb8 |
+| 5c.2 | agents.min_model hook enforcement: block-agents.sh.template, Agent matcher in settings.json + update-zskills Step C, schema + config, CLAUDE_TEMPLATE rule, skill-side reminders at 7 dispatch sites | Done | 1839bb8 |
+| 5c.3 | Baseline comparison instructions in run-plan verification agent dispatch (~lines 833-844) | Done | 1839bb8 |
+| 5c.4 | Installed copies synced (6 skill pairs byte-identical) | Done | 1839bb8 |
+
+### Verification
+- Test suite: 124/124 passed (8 new tests for block-agents.sh)
+- Hook functional spot-check: haiku+min=sonnet → deny; sonnet+min=sonnet → allow; no-model+no-config → allow
+- Acceptance criteria: all met
+- Verified tool_name for Agent PreToolUse is `"Agent"` (not `"Task"`) — hook matcher correct
+
+### Notes
+- Hook uses JSON `permissionDecision: deny` output (not exit 2) — matches established protocol in block-unsafe-project.sh.template.
+- 5c.2 architecture corrected via /refine-plan re-run with verify-before-fix discipline. Prior refinement had falsely concluded hook enforcement was architecturally impossible; the Agent tool input schema DOES include an optional `model` field (enum: sonnet/opus/haiku). Hook reads from tool_input, falls back to agent-definition frontmatter.
+
+## Phase — 5b Execution Skills + Documentation
+
+**Plan:** plans/EXECUTION_MODES.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-execution-modes
+**Branch:** feat/execution-modes
+**Commits:** bfc5893
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 5b.1 | /do gains pr flag: extended detection, slug algo (N=min(4,words)), collision-safe TASK_SLUG → BRANCH_NAME, tracking scoping via do.${TASK_SLUG}, ff-merge + manual worktree, impl agent dispatch, rebase + push + explicit-title/body PR, CI poll report-only, .landed marker | Done | bfc5893 |
+| 5b.1b | /do existing `worktree` flag migrated from `isolation: "worktree"` to manual `git worktree add ../do-<slug>/` | Done | bfc5893 |
+| 5b.2 | /commit gains pr subcommand: first-token-only recognition, clean-tree pre-check with user-facing error, rebase onto origin/main, push, PR with explicit title/body, CI poll report-only (no fix cycle), PR_NUMBER from URL | Done | bfc5893 |
+| 5b.3 | CLAUDE_TEMPLATE.md Execution Modes section: three-mode table, usage examples, config JSON as indented code (no nested fences) | Done | bfc5893 |
+| 5b.4 | /update-zskills Step 2.5: CLAUDE.md documentation-presence audit for execution modes | Done | bfc5893 |
+| 5b.5 | Installed copies synced (do, commit, update-zskills) | Done | bfc5893 |
+
+### Verification
+- Test suite: 116/116 passed (pre-5c baseline)
+- Acceptance criteria: all met
+- Installed copies: byte-identical
+
+---
+
+## Pre-run context (this run)
+
+Before executing 5b/5c, /refine-plan was re-run to correct a prior bad pivot in 5c.2. The prior /refine-plan had accepted a confidently-false devil's-advocate claim that the Agent tool input JSON lacks a `model` field. New verify-before-fix discipline in /refine-plan + /draft-plan caught the error by mandating evidence reproduction. The refined 5c.2 restored hook-based enforcement.
+
+**Upstream commits bundled in this PR** (squash-merge):
+- a7c9509 — /refine-plan + /draft-plan verify-before-fix discipline
+- e1aa108 — plan refinement + 5a tracker Done correction
+- bfc5893 — Phase 5b implementation
+- 1839bb8 — Phase 5c implementation
+
+---
+
 ## Phase — 5a Skill Propagation [UNFINALIZED]
 
 **Plan:** plans/EXECUTION_MODES.md

--- a/scripts/briefing.cjs
+++ b/scripts/briefing.cjs
@@ -254,7 +254,7 @@ function classifyWorktrees(opts = {}) {
       }
     }
 
-    if (landedData && landedData.status === 'full') {
+    if (landedData && (landedData.status === 'full' || landedData.status === 'landed')) {
       return {
         path: wt.path,
         name,
@@ -282,7 +282,35 @@ function classifyWorktrees(opts = {}) {
       };
     }
 
-    // No .landed — check mtime
+    if (landedData && landedData.status === 'pr-ready') {
+      return {
+        path: wt.path,
+        name,
+        branch,
+        category: 'landed-pr-ready',
+        isNamed: false,
+        ahead: counts.ahead,
+        behind: counts.behind,
+        landed: landedData,
+        purpose,
+      };
+    }
+
+    if (landedData && ['pr-ci-failing', 'pr-failed', 'conflict'].includes(landedData.status)) {
+      return {
+        path: wt.path,
+        name,
+        branch,
+        category: 'landed-pr-needs-attention',
+        isNamed: false,
+        ahead: counts.ahead,
+        behind: counts.behind,
+        landed: landedData,
+        purpose,
+      };
+    }
+
+    // No .landed (or unrecognized status) — check mtime
     const mtime = getWorktreeMtime(wt.path, name, mainPath);
 
     if (counts.ahead === 0) {
@@ -700,6 +728,15 @@ function formatSummary(worktrees, checkboxes, commits, opts = {}) {
     needsAttention.push(`  ! worktree ${wt.name} — ${skippedCount} skipped ${skipWord}`);
   }
 
+  // PR-mode needs-attention worktrees
+  const prNeedsAttention = worktrees.filter(wt => wt.category === 'landed-pr-needs-attention');
+  for (const wt of prNeedsAttention) {
+    const status = wt.landed ? wt.landed.status : 'unknown';
+    const prUrl = wt.landed ? wt.landed.pr || '' : '';
+    const prNote = prUrl ? ` — PR: ${prUrl}` : '';
+    needsAttention.push(`  ! worktree ${wt.name} — status: ${status}${prNote}`);
+  }
+
   // Uncommitted changes on main
   const uncommitted = opts.uncommitted !== undefined
     ? opts.uncommitted
@@ -809,6 +846,8 @@ function formatSummary(worktrees, checkboxes, commits, opts = {}) {
     if (wtCounts['done-needs-review']) parts.push(`${wtCounts['done-needs-review']} need review`);
     if (wtCounts['possibly-active']) parts.push(`${wtCounts['possibly-active']} active`);
     if (wtCounts['landed-full']) parts.push(`${wtCounts['landed-full']} landed`);
+    if (wtCounts['landed-pr-ready']) parts.push(`${wtCounts['landed-pr-ready']} pr-ready`);
+    if (wtCounts['landed-pr-needs-attention']) parts.push(`${wtCounts['landed-pr-needs-attention']} pr-needs-attention`);
     if (wtCounts['empty']) parts.push(`${wtCounts['empty']} empty`);
     if (wtCounts['named']) parts.push(`${wtCounts['named']} named`);
     if (wtCounts['orphaned']) parts.push(`${wtCounts['orphaned']} orphaned`);
@@ -869,7 +908,7 @@ function formatReport(worktrees, checkboxes, commits, opts = {}) {
   // Summary counts
   const needReview = worktrees.filter(wt => wt.category === 'done-needs-review').length;
   const inFlightCount = worktrees.filter(wt => wt.category === 'possibly-active').length;
-  const landedCount = worktrees.filter(wt => wt.category === 'landed-full' || wt.category === 'landed-partial').length;
+  const landedCount = worktrees.filter(wt => ['landed-full', 'landed-partial', 'landed-pr-ready'].includes(wt.category)).length;
   const uncheckedCount = checkboxes.length;
   const cbFiles = new Set(checkboxes.map(cb => cb.file));
 
@@ -882,7 +921,8 @@ function formatReport(worktrees, checkboxes, commits, opts = {}) {
   // Needs Attention
   const doneReview = worktrees.filter(wt => wt.category === 'done-needs-review');
   const landedPartial = worktrees.filter(wt => wt.category === 'landed-partial');
-  if (doneReview.length > 0 || landedPartial.length > 0 || checkboxes.length > 0) {
+  const prNeedsAttention = worktrees.filter(wt => wt.category === 'landed-pr-needs-attention');
+  if (doneReview.length > 0 || landedPartial.length > 0 || prNeedsAttention.length > 0 || checkboxes.length > 0) {
     lines.push('## Needs Attention');
     lines.push('');
 
@@ -924,6 +964,15 @@ function formatReport(worktrees, checkboxes, commits, opts = {}) {
       for (const s of skipped) {
         lines.push(`- Skipped: ${s}`);
       }
+      lines.push('');
+    }
+
+    // PR-mode needs-attention
+    for (const wt of prNeedsAttention) {
+      const status = wt.landed ? wt.landed.status : 'unknown';
+      const prUrl = wt.landed ? wt.landed.pr || '' : '';
+      const prNote = prUrl ? ` — PR: ${prUrl}` : '';
+      lines.push(`### [ ] PR attention: ${wt.name} (status: ${status}${prNote})`);
       lines.push('');
     }
   }
@@ -1078,6 +1127,20 @@ function formatVerify(worktrees, checkboxes, opts = {}) {
     lines.push('');
   }
 
+  // PR-mode needs attention
+  const prAttention = worktrees.filter(wt => wt.category === 'landed-pr-needs-attention');
+  if (prAttention.length > 0) {
+    hasContent = true;
+    lines.push(`PR NEEDS ATTENTION (${prAttention.length} — inspect and resolve)`);
+    for (const wt of prAttention) {
+      const status = wt.landed ? wt.landed.status : 'unknown';
+      const prUrl = wt.landed ? wt.landed.pr || '' : '';
+      const prNote = prUrl ? ` — ${prUrl}` : '';
+      lines.push(`  ${wt.name} (status: ${status}${prNote})`);
+    }
+    lines.push('');
+  }
+
   if (!hasContent) {
     return 'ALL CLEAR — no pending items.';
   }
@@ -1128,6 +1191,31 @@ function formatCurrent(worktrees, opts = {}) {
       const commitWord = wt.ahead === 1 ? 'commit' : 'commits';
       const age = wt.mtime ? formatRelativeTime(now - wt.mtime) : 'unknown';
       lines.push(`  ${wt.name}  ${wt.ahead} ${commitWord}  ${age}`);
+    }
+    lines.push('');
+  }
+
+  // PR-ready worktrees (worktree safe to remove; open PR)
+  const prReady = worktrees.filter(wt => wt.category === 'landed-pr-ready');
+  if (prReady.length > 0) {
+    lines.push(`PR OPEN — WORKTREE SAFE TO REMOVE (${prReady.length})`);
+    for (const wt of prReady) {
+      const prUrl = wt.landed ? wt.landed.pr || '' : '';
+      const prNote = prUrl ? `  PR: ${prUrl}` : '';
+      lines.push(`  ${wt.name}${prNote}`);
+    }
+    lines.push('');
+  }
+
+  // PR-mode needs attention
+  const prAttention = worktrees.filter(wt => wt.category === 'landed-pr-needs-attention');
+  if (prAttention.length > 0) {
+    lines.push(`PR NEEDS ATTENTION (${prAttention.length})`);
+    for (const wt of prAttention) {
+      const status = wt.landed ? wt.landed.status : 'unknown';
+      const prUrl = wt.landed ? wt.landed.pr || '' : '';
+      const prNote = prUrl ? `  PR: ${prUrl}` : '';
+      lines.push(`  ${wt.name}  status: ${status}${prNote}`);
     }
     lines.push('');
   }

--- a/scripts/briefing.py
+++ b/scripts/briefing.py
@@ -257,7 +257,7 @@ def classify_worktrees(repo_root=None):
             except Exception:
                 pass
 
-        if landed_data and landed_data.get('status') == 'full':
+        if landed_data and landed_data.get('status') in ('full', 'landed'):
             results.append({
                 'path': wt['path'],
                 'name': name,
@@ -285,7 +285,35 @@ def classify_worktrees(repo_root=None):
             })
             continue
 
-        # No .landed — check mtime
+        if landed_data and landed_data.get('status') == 'pr-ready':
+            results.append({
+                'path': wt['path'],
+                'name': name,
+                'branch': branch,
+                'category': 'landed-pr-ready',
+                'isNamed': False,
+                'ahead': counts['ahead'],
+                'behind': counts['behind'],
+                'landed': landed_data,
+                'purpose': purpose,
+            })
+            continue
+
+        if landed_data and landed_data.get('status') in ('pr-ci-failing', 'pr-failed', 'conflict'):
+            results.append({
+                'path': wt['path'],
+                'name': name,
+                'branch': branch,
+                'category': 'landed-pr-needs-attention',
+                'isNamed': False,
+                'ahead': counts['ahead'],
+                'behind': counts['behind'],
+                'landed': landed_data,
+                'purpose': purpose,
+            })
+            continue
+
+        # No .landed (or unrecognized status) — check mtime
         mtime = get_worktree_mtime(wt['path'], name, main_path)
 
         if counts['ahead'] == 0:
@@ -793,6 +821,14 @@ def format_summary(worktrees, checkboxes, commits, opts=None):
         skip_word = 'commit' if skipped_count == 1 else 'commits'
         needs_attention.append(f'  ! worktree {wt["name"]} — {skipped_count} skipped {skip_word}')
 
+    # PR-mode needs-attention worktrees
+    pr_needs_attention = [wt for wt in worktrees if wt['category'] == 'landed-pr-needs-attention']
+    for wt in pr_needs_attention:
+        status = wt.get('landed', {}).get('status', 'unknown') if wt.get('landed') else 'unknown'
+        pr_url = wt.get('landed', {}).get('pr', '') if wt.get('landed') else ''
+        pr_note = f' — PR: {pr_url}' if pr_url else ''
+        needs_attention.append(f'  ! worktree {wt["name"]} — status: {status}{pr_note}')
+
     # Uncommitted changes on main
     uncommitted = opts.get('uncommitted')
     if uncommitted is None:
@@ -882,6 +918,10 @@ def format_summary(worktrees, checkboxes, commits, opts=None):
             parts.append(f'{wt_counts["possibly-active"]} active')
         if wt_counts.get('landed-full'):
             parts.append(f'{wt_counts["landed-full"]} landed')
+        if wt_counts.get('landed-pr-ready'):
+            parts.append(f'{wt_counts["landed-pr-ready"]} pr-ready')
+        if wt_counts.get('landed-pr-needs-attention'):
+            parts.append(f'{wt_counts["landed-pr-needs-attention"]} pr-needs-attention')
         if wt_counts.get('empty'):
             parts.append(f'{wt_counts["empty"]} empty')
         if wt_counts.get('named'):
@@ -935,7 +975,7 @@ def format_report(worktrees, checkboxes, commits, opts=None):
     # Summary counts
     need_review = len([wt for wt in worktrees if wt['category'] == 'done-needs-review'])
     in_flight_count = len([wt for wt in worktrees if wt['category'] == 'possibly-active'])
-    landed_count = len([wt for wt in worktrees if wt['category'] in ('landed-full', 'landed-partial')])
+    landed_count = len([wt for wt in worktrees if wt['category'] in ('landed-full', 'landed-partial', 'landed-pr-ready')])
     unchecked_count = len(checkboxes)
     cb_files = set(cb['file'] for cb in checkboxes)
 
@@ -948,7 +988,8 @@ def format_report(worktrees, checkboxes, commits, opts=None):
     # Needs Attention
     done_review = [wt for wt in worktrees if wt['category'] == 'done-needs-review']
     landed_partial = [wt for wt in worktrees if wt['category'] == 'landed-partial']
-    if done_review or landed_partial or checkboxes:
+    pr_needs_attention = [wt for wt in worktrees if wt['category'] == 'landed-pr-needs-attention']
+    if done_review or landed_partial or pr_needs_attention or checkboxes:
         lines.append('## Needs Attention')
         lines.append('')
 
@@ -983,6 +1024,14 @@ def format_report(worktrees, checkboxes, commits, opts=None):
             lines.append(f'### [ ] Partial: {wt["name"]} ({len(skipped)} skipped)')
             for s in skipped:
                 lines.append(f'- Skipped: {s}')
+            lines.append('')
+
+        # PR-mode needs-attention
+        for wt in pr_needs_attention:
+            status = wt.get('landed', {}).get('status', 'unknown') if wt.get('landed') else 'unknown'
+            pr_url = wt.get('landed', {}).get('pr', '') if wt.get('landed') else ''
+            pr_note = f' — PR: {pr_url}' if pr_url else ''
+            lines.append(f'### [ ] PR attention: {wt["name"]} (status: {status}{pr_note})')
             lines.append('')
 
     # Landed on Main
@@ -1104,6 +1153,18 @@ def format_verify(worktrees, checkboxes, opts=None):
                 lines.append(f'    Skipped: {s}')
         lines.append('')
 
+    # PR-mode needs attention
+    pr_attention = [wt for wt in worktrees if wt['category'] == 'landed-pr-needs-attention']
+    if pr_attention:
+        has_content = True
+        lines.append(f'PR NEEDS ATTENTION ({len(pr_attention)} — inspect and resolve)')
+        for wt in pr_attention:
+            status = wt.get('landed', {}).get('status', 'unknown') if wt.get('landed') else 'unknown'
+            pr_url = wt.get('landed', {}).get('pr', '') if wt.get('landed') else ''
+            pr_note = f' — {pr_url}' if pr_url else ''
+            lines.append(f'  {wt["name"]} (status: {status}{pr_note})')
+        lines.append('')
+
     if not has_content:
         return 'ALL CLEAR — no pending items.'
 
@@ -1143,6 +1204,27 @@ def format_current(worktrees, opts=None):
             commit_word = 'commit' if wt['ahead'] == 1 else 'commits'
             age = format_relative_time(now - wt['mtime']) if wt.get('mtime') else 'unknown'
             lines.append(f'  {wt["name"]}  {wt["ahead"]} {commit_word}  {age}')
+        lines.append('')
+
+    # PR-ready worktrees (worktree safe to remove; open PR)
+    pr_ready = [wt for wt in worktrees if wt['category'] == 'landed-pr-ready']
+    if pr_ready:
+        lines.append(f'PR OPEN — WORKTREE SAFE TO REMOVE ({len(pr_ready)})')
+        for wt in pr_ready:
+            pr_url = wt.get('landed', {}).get('pr', '') if wt.get('landed') else ''
+            pr_note = f'  PR: {pr_url}' if pr_url else ''
+            lines.append(f'  {wt["name"]}{pr_note}')
+        lines.append('')
+
+    # PR-mode needs attention
+    pr_attention = [wt for wt in worktrees if wt['category'] == 'landed-pr-needs-attention']
+    if pr_attention:
+        lines.append(f'PR NEEDS ATTENTION ({len(pr_attention)})')
+        for wt in pr_attention:
+            status = wt.get('landed', {}).get('status', 'unknown') if wt.get('landed') else 'unknown'
+            pr_url = wt.get('landed', {}).get('pr', '') if wt.get('landed') else ''
+            pr_note = f'  PR: {pr_url}' if pr_url else ''
+            lines.append(f'  {wt["name"]}  status: {status}{pr_note}')
         lines.append('')
 
     # Empty worktrees

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -238,8 +238,10 @@ The agent runs `node scripts/briefing.cjs <subcommand>` and captures stdout.
 
 Each worktree is classified into exactly one category:
 
-- **`landed-full`** — `.landed` file with `status: full` (all commits on main)
-- **`landed-partial`** — `.landed` file with `status: partial` (some commits skipped)
+- **`landed-full`** — `.landed` file with `status: full` (fix-issues cherry-pick, all commits on main) or `status: landed` (run-plan cherry-pick or merged PR)
+- **`landed-partial`** — `.landed` file with `status: partial` (some commits skipped, needs review)
+- **`landed-pr-ready`** — `.landed` file with `status: pr-ready` (PR is open; worktree is safe to remove, remote branch must NOT be deleted — it supports the open PR)
+- **`landed-pr-needs-attention`** — `.landed` file with `status: pr-ci-failing`, `status: pr-failed`, or `status: conflict` (PR-mode errors that need manual action)
 - **`done-needs-review`** — No `.landed`, has commits, inactive > 2 hours
 - **`possibly-active`** — No `.landed`, modified within last 2 hours
 - **`empty`** — No `.landed`, zero commits ahead of main

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -5,11 +5,11 @@ description: >-
   Safe commit workflow with optional scope hint. Inventories all changes,
   classifies related vs. unrelated files, traces dependencies, protects
   other agents' work, and optionally pushes or lands worktree commits.
-  Usage: /commit [scope] [push|land]
-argument-hint: "[scope] [push|land]"
+  Usage: /commit [pr] [scope] [push|land]
+argument-hint: "[pr] [scope] [push|land]"
 ---
 
-# /commit [scope] [push|land] — Safe Commit Workflow
+# /commit [pr] [scope] [push|land] — Safe Commit Workflow
 
 Commit current work without picking up or harming unrelated changes.
 
@@ -19,10 +19,26 @@ Commit current work without picking up or harming unrelated changes.
 - `/commit push` — commit and push to remote
 - `/commit parser reset button fix push` — scope-guided commit + push
 - `/commit land` — cherry-pick worktree commits into main (worktree only)
+- `/commit pr` — push current branch and create a PR to main (requires clean working tree)
+- `/commit pr fix pr comments` — PR mode with scope hint "fix pr comments"
 
-**Parsing:** `push` and `land` are reserved keywords. Everything else in the
-arguments is the **scope hint** — a free-form description of what this commit
-is about. The scope hint is optional; without one, classify from diffs alone.
+**Parsing:** `pr` is recognized ONLY when it is the **FIRST token** in
+`$ARGUMENTS`. This prevents false-triggering on scope hints that contain
+"pr" mid-string. `push` and `land` are reserved keywords for non-PR mode.
+
+```bash
+FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
+if [[ "$FIRST_TOKEN" == "pr" ]]; then
+  # PR subcommand mode
+  SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
+  # ... see Phase 6 (PR mode) below
+fi
+```
+
+Disambiguation:
+- `/commit pr` → PR mode (first token is `pr`)
+- `/commit pr comments fix` → PR mode (first token is `pr`), scope hint: "comments fix"
+- `/commit fix pr format` → scope hint "fix pr format", regular commit (first token is "fix")
 
 Examples:
 - `/commit` → scope: *(none)*, action: commit
@@ -31,6 +47,8 @@ Examples:
 - `/commit push` → scope: *(none)*, action: commit + push
 - `/commit land` → scope: *(none)*, action: land
 - `/commit parser fixes land` → scope: "parser fixes", action: land
+- `/commit pr` → action: PR mode (push + create PR)
+- `/commit pr fix pr comments` → PR mode, scope hint: "fix pr comments"
 
 ## Phase 1 — Inventory
 
@@ -204,6 +222,95 @@ git push -u origin <branch-name>
 **NEVER force-push to main/master.** If push is rejected, tell the user why
 and ask what to do.
 
+## Phase 6 (PR subcommand) — PR Mode (if `pr` is the first token)
+
+**This phase runs INSTEAD OF Phases 1–5 when `pr` is the first token.**
+It pushes the current branch and creates a PR to main.
+
+**Step 1 — Pre-check: clean working tree required:**
+```bash
+DIRTY=$(git status --porcelain 2>/dev/null)
+if [ -n "$DIRTY" ]; then
+  echo "ERROR: Working tree has uncommitted changes."
+  echo "Run \`/commit\` first to create a commit, then \`/commit pr\` to push and create the PR."
+  exit 1
+fi
+```
+
+**Step 2 — Branch guard:**
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "ERROR: Cannot create PR from main. Create a feature branch first."
+  exit 1
+fi
+```
+
+**Step 3 — Rebase onto latest main before pushing:**
+```bash
+git fetch origin main
+git rebase origin/main
+if [ $? -ne 0 ]; then
+  echo "ERROR: Rebase conflict. Resolve manually, then re-run \`/commit pr\`."
+  exit 1
+fi
+```
+
+**Step 4 — Push:**
+```bash
+git push -u origin "$BRANCH"
+```
+
+**Step 5 — Create PR:**
+```bash
+# PR title: strip branch prefix, convert hyphens to spaces
+BRANCH_SHORT="${BRANCH##*/}"  # remove prefix like feat/
+PR_TITLE=$(echo "$BRANCH_SHORT" | tr '-' ' ' | sed 's/\b./\u&/g')
+# Body: recent commits since divergence from origin/main (not local main — may be stale after rebase)
+PR_BODY=$(git log origin/main..HEAD --format='- %h %s' | head -15)
+
+EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL=$(gh pr view "$EXISTING_PR" --json url --jq '.url')
+  echo "PR already exists: $PR_URL"
+else
+  PR_URL=$(gh pr create --base main --head "$BRANCH" \
+    --title "$PR_TITLE" --body "$PR_BODY")
+  echo "Created PR: $PR_URL"
+fi
+```
+
+**Step 6 — Poll CI checks (report only, no fix cycle):**
+```bash
+if [ -n "$PR_URL" ]; then
+  PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+  CHECK_COUNT=0
+  for _i in 1 2 3; do
+    CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
+    [ "$CHECK_COUNT" != "0" ] && break
+    sleep 10
+  done
+  if [ "$CHECK_COUNT" != "0" ]; then
+    if timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null; then
+      echo "CI checks passed."
+    else
+      echo "CI checks failed. Run /verify-changes to diagnose."
+    fi
+  fi
+fi
+```
+
+Note: `PR_NUMBER` is derived from `$PR_URL` returned by `gh pr create` or
+`gh pr view "$EXISTING_PR"` — NOT via a bare `gh pr view` call (which relies
+on ambient branch autodetect and is subject to race conditions).
+
+**PR mode does NOT:**
+- Dispatch fix agents for CI failures
+- Write `.landed` markers
+- Run Phases 1–5 (all commits must already exist — clean tree is required)
+
+**After Step 6, exit.** Skip Phases 1–5 and 7.
+
 ## Phase 7 — Land (if `land` argument)
 
 Only if `land` was in the arguments.
@@ -296,3 +403,11 @@ This is for landing worktree work onto main via cherry-pick.
   diffs. Some related files won't match the hint keywords, and some keyword
   matches may be unrelated. The hint narrows the search; it doesn't replace
   judgment.
+- **`/commit pr` requires a clean working tree** — all changes must be
+  committed before running PR mode. The pre-check enforces this.
+- **`/commit pr` keyword is first-token-only** — prevents false-triggering
+  on scope hints that contain "pr" mid-string.
+- **PR body uses `git log origin/main..HEAD`** — not `git log main..HEAD`
+  (local main may be stale after rebase).
+- **PR number from URL, not bare `gh pr view`** — bare view uses ambient
+  branch autodetect, which is subject to race conditions.

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: do
 disable-model-invocation: true
-argument-hint: "<description> [worktree] [push] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [worktree] [push] [pr] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Supports scheduling with every/now/next/stop.
-  Usage: /do <description> [worktree] [push] [every SCHEDULE] [now] | stop | next.
+  Usage: /do <description> [worktree] [push] [pr] [every SCHEDULE] [now] | stop | next.
 ---
 
-# /do \<description> [worktree] [push] [every SCHEDULE] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [worktree] [push] [pr] [every SCHEDULE] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or auto-push. Can be scheduled for recurring maintenance
@@ -35,16 +35,21 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
 ## Arguments
 
 ```
-/do <description> [worktree] [push] [every SCHEDULE] [now]
+/do <description> [worktree] [push] [pr] [every SCHEDULE] [now]
 /do stop | next
 ```
 
 - **description** (required) — what to do, in natural language
-- **worktree** (optional) — use `isolation: "worktree"` for riskier or
-  larger tasks. Without this flag, work happens directly on main.
+- **worktree** (optional) — isolate work in a named worktree at
+  `/tmp/<project>-do-<slug>/` for riskier or larger tasks. Without this
+  flag, work happens directly on main.
 - **push** (optional) — auto-push to remote after verification passes.
   Upgrades verification to use a **separate verification agent** running
   `/verify-changes`. Push never happens without verification passing first.
+- **pr** (optional) — work in a named worktree on a named branch, then
+  push and create a PR to main. Dispatches an implementation agent to do
+  the work, waits for completion, rebases onto latest main, pushes, creates
+  PR, and polls CI (report only).
 - **every SCHEDULE** (optional) — self-schedule recurring runs via cron:
   - Accepts intervals: `4h`, `2h`, `30m`, `12h`
   - Accepts time-of-day: `day at 9am`, `day at 14:00`, `weekday at 9am`
@@ -71,8 +76,18 @@ If the first word is NOT a meta-command, it's a regular task. Parse
 trailing flags from the END backward:
 - `push` — recognized at the end
 - `worktree` — recognized at the end
+- `pr` — recognized at the end (use extended pattern with `.!?` punctuation, since
+  task descriptions are prose-like and "pr" may appear as "PR." at end of sentence)
 - `every <schedule>` — recognized at the end (e.g., `every 4h`, `every day at 9am`)
 - `now` — recognized at the end (only meaningful with `every`: run now AND schedule)
+
+**PR flag detection pattern** (use extended `.!?` punctuation):
+```bash
+LANDING_MODE="default"
+if [[ "$REMAINING" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_MODE="pr"
+fi
+```
 
 Everything before the trailing flags is the task description.
 
@@ -87,6 +102,7 @@ This means:
 - `/do Update the presentation push` — description + push flag
 - `/do Fix the tooltip bug worktree push` — description + both flags
 - `/do Check docs every day at 9am` — schedule "Check docs" daily
+- `/do Add dark mode. pr` — description + pr flag (PR mode)
 
 Examples:
 - `/do Add example models for Integrator and Derivative blocks`
@@ -95,6 +111,7 @@ Examples:
 - `/do Update the presentation with Phase 3 results push`
 - `/do Make sure docs are up to date every day at 9am`
 - `/do Check for broken links in examples every 12h now`
+- `/do Add dark mode to editor pr`
 - `/do next` — all scheduled tasks
 - `/do next Check docs` — specific task
 - `/do stop` — cancel all
@@ -221,24 +238,241 @@ Before touching anything:
    take 1000+ lines of changes, has complex dependencies), suggest
    `/run-plan` instead and ask the user.
 
+## Phase 1.5 — Argument Parsing (always before Phase 1 research)
+
+Before any research or execution, parse flags from `$ARGUMENTS`.
+
+**Step 1: Check for `pr` flag** (trailing, using extended punctuation pattern):
+```bash
+REMAINING="$ARGUMENTS"
+LANDING_MODE="default"
+if [[ "$REMAINING" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
+  LANDING_MODE="pr"
+  # Strip the pr token from description
+  TASK_DESCRIPTION=$(echo "$REMAINING" | sed -E 's/(^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?])/ /')
+  TASK_DESCRIPTION=$(echo "$TASK_DESCRIPTION" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
+  if [ -z "$TASK_DESCRIPTION" ]; then
+    echo "ERROR: Task description required. Usage: /do <task description> pr"
+    exit 1
+  fi
+fi
+```
+
+If `LANDING_MODE` is not `pr`, then `TASK_DESCRIPTION` is the full `$ARGUMENTS` minus the other trailing flags (`push`, `worktree`, `every ...`, `now`).
+
+**Step 2: Check for `worktree` flag** (trailing, plain word match):
+```bash
+if [[ "$REMAINING" =~ (^|[[:space:]])worktree($|[[:space:]]) ]]; then
+  USE_WORKTREE=true
+fi
+```
+
+**Step 3: Check for `push` flag** (trailing):
+```bash
+if [[ "$REMAINING" =~ (^|[[:space:]])push($|[[:space:]]) ]]; then
+  USE_PUSH=true
+fi
+```
+
+`pr` takes precedence: if `LANDING_MODE="pr"`, ignore `worktree` and `push` flags.
+
 ## Phase 2 — Execute
 
-1. **Do the work.** By default, work directly on main. If `worktree` flag
-   is present, dispatch with `isolation: "worktree"`.
+Choose execution path based on parsed flags:
 
-2. **Follow existing conventions:**
-   - Example models → `/model-design` skill guidelines
-   - Newsletter entries → existing NEWSLETTER.md format
-   - Documentation → existing doc style in the repo
-   - Code → existing patterns in the codebase
+### Path A: PR mode (`pr` flag)
 
-3. **Commit discipline:**
-   - **On main:** commit when the work is complete. Clean, descriptive
-     message. `npm run test:all` before committing if code was touched.
-     If tests fail after two fix attempts on the same error, STOP — report
-     what you tried and let the user decide.
-   - **In worktree:** the verification agent commits after tests pass.
-     One logical unit per commit.
+**This path replaces the normal Phase 2–5 flow entirely. After the PR is created, skip to Phase 5 Report.**
+
+**Step A1 — Compute task slug:**
+```bash
+# N = min(4, word_count) words from TASK_DESCRIPTION
+WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
+N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
+TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
+  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
+  | tr '[:upper:]' '[:lower:]' \
+  | cut -c1-30 \
+  | sed 's/-$//')
+```
+
+**Step A2 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
+```bash
+PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel)")
+if [ -d "/tmp/${PROJECT_NAME}-do-${TASK_SLUG}" ]; then
+  TASK_SLUG="${TASK_SLUG}-$(date +%s | tail -c 5)"
+fi
+```
+
+**Step A3 — Derive BRANCH_NAME and WORKTREE_PATH from (possibly suffixed) TASK_SLUG:**
+```bash
+BRANCH_PREFIX=$(jq -r '.execution.branch_prefix // "feat/"' .claude/zskills-config.json 2>/dev/null || echo "feat/")
+BRANCH_NAME="${BRANCH_PREFIX}do-${TASK_SLUG}"
+WORKTREE_PATH="/tmp/${PROJECT_NAME}-do-${TASK_SLUG}"
+```
+
+**Step A4 — ff-merge main + worktree creation:**
+```bash
+git fetch origin main 2>/dev/null || true
+git merge --ff-only origin/main 2>/dev/null \
+  || echo "WARNING: local main not fast-forwarded — worktree uses local main as-is"
+git worktree prune
+git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" main 2>/dev/null \
+  || git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
+```
+
+**Step A5 — Write tracking marker immediately after worktree creation:**
+```bash
+PIPELINE_ID="do.${TASK_SLUG}"
+echo "$PIPELINE_ID" > "$WORKTREE_PATH/.zskills-tracked"
+```
+Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` in the main session — write only to the worktree file.
+
+**Step A6 — Dispatch implementation agent (wait for completion):**
+
+Dispatch an Agent (without `isolation: "worktree"` — the worktree already exists) with this prompt:
+
+```
+You are implementing: $TASK_DESCRIPTION
+
+FIRST: cd $WORKTREE_PATH
+All work happens in that directory. Do NOT work in any other directory.
+You are on branch $BRANCH_NAME (already checked out in the worktree).
+
+Implement the task. Commit changes when done:
+- Stage files by name (not git add .)
+- Do NOT commit to main
+- Commit message should summarize what was implemented
+
+Check agents.min_model in .claude/zskills-config.json before dispatching
+any sub-agents. Use that model or higher (haiku=1 < sonnet=2 < opus=3).
+```
+
+Wait for the implementation agent to complete. If the agent reports failure or exits without committing:
+```bash
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: conflict
+date: $(TZ=America/New_York date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+LANDED
+```
+Exit with error directing the user to inspect `$WORKTREE_PATH`.
+
+**Step A7 — Rebase + push + PR creation (after implementation agent completes):**
+```bash
+cd "$WORKTREE_PATH"
+# Rebase onto latest main before push
+git fetch origin main
+git rebase origin/main || { echo "ERROR: Rebase conflict. Resolve manually in $WORKTREE_PATH."; exit 1; }
+
+git push -u origin "$BRANCH_NAME"
+
+# PR body: explicit title and body, not --fill
+PR_TITLE="do: $(echo "$TASK_DESCRIPTION" | cut -c1-60)"
+PR_BODY="Task: ${TASK_DESCRIPTION}
+
+Worktree: ${WORKTREE_PATH}
+Commits: $(git log origin/main..HEAD --format='%h %s' | head -10)"
+
+EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null)
+if [ -n "$EXISTING_PR" ]; then
+  PR_URL=$(gh pr view "$EXISTING_PR" --json url --jq '.url')
+  echo "PR already exists: $PR_URL"
+else
+  PR_URL=$(gh pr create --base main --head "$BRANCH_NAME" \
+    --title "$PR_TITLE" --body "$PR_BODY")
+  echo "Created PR: $PR_URL"
+fi
+```
+
+**Step A8 — CI poll (report only, no fix cycle):**
+```bash
+if [ -n "$PR_URL" ]; then
+  PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
+  CHECK_COUNT=0
+  for _i in 1 2 3; do
+    CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
+    [ "$CHECK_COUNT" != "0" ] && break
+    sleep 10
+  done
+  CI_STATUS="none"
+  if [ "$CHECK_COUNT" != "0" ]; then
+    if timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null; then
+      CI_STATUS="passed"
+      echo "CI checks passed."
+    else
+      CI_STATUS="failed"
+      echo "CI checks failed. Inspect the PR to diagnose failures."
+    fi
+  fi
+fi
+```
+
+**Step A9 — Write `.landed` marker:**
+```bash
+# Check if PR was auto-merged
+PR_STATE=$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "OPEN")
+if [ "$PR_STATE" = "MERGED" ]; then
+  LANDED_STATUS="landed"
+elif [ "$CI_STATUS" = "failed" ]; then
+  LANDED_STATUS="pr-ci-failing"
+else
+  LANDED_STATUS="pr-ready"
+fi
+
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: $LANDED_STATUS
+date: $(TZ=America/New_York date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+pr: $PR_URL
+LANDED
+```
+
+After writing `.landed`, output the Phase 5 PR report and **exit** (skip Phases 3-4).
+
+### Path B: Worktree mode (`worktree` flag, no `pr`)
+
+Create a named worktree at `../do-<slug>/` using manual `git worktree add`:
+
+```bash
+# Compute slug from task description
+WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
+N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
+TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
+  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
+  | tr '[:upper:]' '[:lower:]' \
+  | cut -c1-30 \
+  | sed 's/-$//')
+WORKTREE_PATH="../do-${TASK_SLUG}"
+# Collision check
+if [ -d "$WORKTREE_PATH" ]; then
+  TASK_SLUG="${TASK_SLUG}-$(date +%s | tail -c 5)"
+  WORKTREE_PATH="../do-${TASK_SLUG}"
+fi
+git worktree add "$WORKTREE_PATH"
+```
+
+Do the work inside the worktree. The verification agent commits after tests pass (one logical unit per commit).
+
+### Path C: Direct (default, no `pr`, no `worktree`)
+
+Work directly on main.
+
+**Follow existing conventions in all paths:**
+- Example models → `/model-design` skill guidelines
+- Newsletter entries → existing NEWSLETTER.md format
+- Documentation → existing doc style in the repo
+- Code → existing patterns in the codebase
+
+**Commit discipline (Paths B and C):**
+- **On main (Path C):** commit when the work is complete. Clean, descriptive
+  message. `npm run test:all` before committing if code was touched.
+  If tests fail after two fix attempts on the same error, STOP — report
+  what you tried and let the user decide.
+- **In worktree (Path B):** the verification agent commits after tests pass.
+  One logical unit per commit.
 
 ## Phase 3 — Verify
 
@@ -277,16 +511,16 @@ Verification intensity matches the change type (from Phase 1):
 - Spot-check the content portion
 - If `push`: full `/verify-changes` via separate agent
 
-## Phase 4 — Push (if `push` flag present)
+## Phase 4 — Push (if `push` flag present, Path C/B only)
 
-Only reached if Phase 3 verification passed.
+Only reached if Phase 3 verification passed. Not applicable to PR mode (Path A — PR mode has its own push in Phase 2 Step A7).
 
-1. **If on main:**
+1. **If on main (Path C):**
    ```bash
    git push
    ```
 
-2. **If in worktree:** cherry-pick to main first, then push:
+2. **If in worktree (Path B):** cherry-pick to main first, then push:
    - Protect uncommitted work on main (`git stash -u` if needed)
    - Cherry-pick worktree commits to main sequentially
    - If any cherry-pick conflicts: **abort and clean up:**
@@ -343,6 +577,16 @@ Verification: clean (/verify-changes clean)
 Worktree: ../do-<slug>/ (can be removed)
 ```
 
+**PR mode (pr flag):**
+```
+Done. [1-2 sentence summary of what was implemented]
+PR: <PR_URL>
+Branch: <BRANCH_NAME>
+Worktree: <WORKTREE_PATH>
+CI: passed | failed | no checks
+Status: pr-ready | pr-ci-failing | landed
+```
+
 ## Error Handling
 
 - **Test failures (code changes):** stop, fix the code, re-test. Never
@@ -353,6 +597,12 @@ Worktree: ../do-<slug>/ (can be removed)
 - **Push failure (auth, remote, etc.):** stop, report the error.
 - **Task is bigger than expected:** stop, suggest `/run-plan` instead.
   Ask the user before continuing.
+- **PR mode: rebase conflict:** write `.landed` with `status: conflict`,
+  report to user, direct them to inspect `$WORKTREE_PATH`.
+- **PR mode: CI failure:** write `.landed` with `status: pr-ci-failing`,
+  report the failure. Do NOT dispatch fix agents.
+- **PR mode: implementation agent fails without committing:** write
+  `.landed` with `status: conflict` and exit with an error message.
 - **If stuck on anything:** report the state and ask the user for
   guidance. Do not retry the same approach in a loop.
 
@@ -366,14 +616,26 @@ Worktree: ../do-<slug>/ (can be removed)
   checkout-old-commit, no comparison worktrees.
 - **Protect other agents' work** — do not commit unrelated changes that
   happen to be in the working tree. Stage only files related to the task.
-- **Worktree naming** — use `../do-<slug>/` where `<slug>` is a short
-  kebab-case description derived from the task (e.g., `do-sort-screenshots`,
-  `do-integrator-examples`). Include a timestamp suffix if a worktree
-  with that name already exists.
+- **Worktree naming (worktree flag)** — use `../do-<slug>/` where `<slug>`
+  is a short kebab-case description derived from the task (e.g.,
+  `do-sort-screenshots`, `do-integrator-examples`). Include a timestamp
+  suffix if a worktree with that name already exists. Uses manual
+  `git worktree add` — NOT `isolation: "worktree"`.
+- **Worktree naming (pr flag)** — use `/tmp/<project>-do-<slug>/` with
+  a named branch `<branch_prefix>do-<slug>`. Both BRANCH_NAME and
+  WORKTREE_PATH derive from TASK_SLUG (after any collision suffix).
 - **No persistent report files** — `/do` outputs results inline. It does
   NOT write SPRINT_REPORT.md, PLAN_REPORT.md, or any other report file.
   The commit is the artifact.
 - **Push requires verification** — `push` always dispatches a separate
   verification agent before pushing. No exceptions.
+- **PR mode CI is report-only** — `/do pr` polls CI and reports status.
+  It does NOT dispatch fix agents. For automated fix cycles, use
+  `/run-plan` or `/fix-issues` in PR mode.
+- **PR body uses `git log origin/main..HEAD`** — never `git log main..HEAD`
+  (local main may be stale after rebase).
+- **PR titles and bodies are explicit** — never use `--fill` in `gh pr create`.
+- **Slug collision suffix targets TASK_SLUG itself** — not just WORKTREE_PATH.
+  Both BRANCH_NAME and WORKTREE_PATH must pick up the suffix.
 - **Respect CLAUDE.md** — all standard rules apply (no external deps, no
   bundlers, no weakened tests, etc.)

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -330,6 +330,10 @@ Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` in the main session — write 
 
 **Step A6 — Dispatch implementation agent (wait for completion):**
 
+**Before dispatching:** Check `agents.min_model` in `.claude/zskills-config.json`. If set,
+use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch with a
+lower-ordinal model than the configured minimum.
+
 Dispatch an Agent (without `isolation: "worktree"` — the worktree already exists) with this prompt:
 
 ```

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -362,6 +362,15 @@ Checks for completeness, correctness, and feasibility:
 - Are formulas and algorithms correct?
 - Will `/run-plan` be able to parse phases and status from this format?
 
+**Evidence discipline.** When a finding makes an empirical claim (a
+file, function, tool, or library has/lacks property X), include a
+concrete **Verification:** line — the exact file:line, grep, schema
+quote, or command output that reproduces the evidence. The refiner will
+re-run these checks before acting. Structural/judgment findings don't
+need a reproducer but should say `Verification: judgment — no verifiable
+anchor` explicitly. Never write an empirical-sounding claim without
+something the refiner can independently re-check.
+
 ### Devil's advocate agent
 
 Genuinely adversarial — tries to find ways the plan will fail:
@@ -390,6 +399,13 @@ generic concerns. "Phase 3 might be complex" is useless. "Phase 3 says
 matrix factorization approach, or convergence criteria — the agent will have
 to guess all three" is actionable.
 
+The same **evidence discipline** from the reviewer section applies:
+every empirical claim needs a `Verification:` line. The devil's advocate
+is *especially* prone to generating plausible-sounding-but-false claims
+because its job is pattern-generating failure modes, not verifying them.
+Discipline is load-bearing here — the refiner will re-check, and claims
+whose evidence doesn't reproduce will not drive fixes.
+
 ### Post-review tracking
 
 After both reviewer and devil's advocate agents return their findings,
@@ -407,13 +423,46 @@ A single agent receives:
 - The reviewer's findings
 - The devil's advocate's findings
 
+### Verify-before-fix (mandatory)
+
+Before touching the draft, the refiner must **attempt to reproduce the
+cited evidence for each finding**. The reviewer/DA produce hypotheses;
+the refiner is the gate that tests them against reality.
+
+For each finding with an empirical claim:
+1. Read the `Verification:` line and run its check (Read the file, run
+   the grep, check the schema, run the command).
+2. Record outcome: **Verified** (evidence reproduces → act on finding),
+   **Not reproduced** (evidence does not match reality → justify, do NOT
+   fix based on this finding), or **No anchor** (empirical-sounding
+   claim without verifiable citation → scrutinize, either locate an
+   anchor yourself or justify-not-fix).
+
+Judgment findings (marked `Verification: judgment`) skip step 1 and go
+straight to fix-or-justify on merit.
+
+**Why this exists.** Devil's-advocate findings are by role generated to
+be plausible failure modes, not verified truths. Past failure: a DA
+claimed a tool's input lacked a field, citing a tangentially-related
+file; the refiner accepted and rewrote a whole phase on a false premise.
+A 30-second check of the tool schema would have caught it. Verify-before-fix
+is the gate that turns "the DA said so" into "I checked."
+
+### Address every finding
+
 It produces an improved draft that **addresses every finding**. For each
 finding, it must either:
 1. **Fix it** — update the plan to resolve the issue
-2. **Justify** — explain why it's not actually a problem (with evidence)
+2. **Justify** — explain why it's not actually a problem (with evidence,
+   including the "evidence did not reproduce" and "claim not verifiable"
+   cases from the verify-before-fix block)
 
 It may NOT ignore findings or defer them. The refiner's output is the new
 draft for the next round.
+
+The refiner's output must include a **disposition table** listing each
+finding with an Evidence column (Verified / Not reproduced / No anchor
+/ Judgment) and the disposition (Fixed / Justified + reason).
 
 ## Phase 5 — Convergence Check
 
@@ -497,6 +546,13 @@ printf 'skill: draft-plan\nid: %s\noutput: %s\nstatus: complete\ndate: %s\n' \
 - **Every finding must be addressed.** The refiner cannot ignore or defer
   reviewer/devil's-advocate findings. Fix it or justify why it's not a
   problem.
+- **Verify findings before baking fixes.** Reviewer and DA findings are
+  hypotheses, not mandates. The refiner must reproduce each empirical
+  claim before acting on it. A plausible-sounding claim with no
+  verifiable anchor — or one whose evidence doesn't reproduce — is not
+  a mandate to fix. Devil's advocate findings are *especially* prone to
+  confidently-false empirical claims because the role incentivizes
+  plausibility, not truth.
 - **Convergence means no new substantive issues.** Not "the same issues
   rephrased." If the devil's advocate keeps finding real new problems, the
   plan isn't ready.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -194,6 +194,10 @@ candidates and waits for the user to select which to close.
 
 ### Step 2 — Research & verify
 
+**Before dispatching any Agent:** check `agents.min_model` in `.claude/zskills-config.json`.
+If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch
+with a lower-ordinal model than the configured minimum.
+
 Dispatch research agents for every open issue that lacks a research blurb
 in its tracker file. Each agent does:
 
@@ -661,6 +665,10 @@ and dispatches agents WITHOUT `isolation: "worktree"`.** See the "PR mode
 (Phase 3)" section below for the exact worktree setup. For `cherry-pick` and
 `direct` modes, use the default `isolation: "worktree"` pattern described here.
 
+**Before dispatching any fix Agent:** check `agents.min_model` in `.claude/zskills-config.json`.
+If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch
+with a lower-ordinal model than the configured minimum.
+
 **1 issue per agent, parallel dispatch.** Each issue gets its own agent
 in its own worktree (`isolation: "worktree"` for cherry-pick/direct, or a
 manually-created `fix/issue-NNN` worktree for `pr` mode). **Dispatch at
@@ -818,6 +826,11 @@ printf 'skill: verify-changes\nparent: fix-issues\nmode: sprint\ndate: %s\n' \
   "$(TZ=America/New_York date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/requires.verify-changes.sprint"
 ```
+
+**Before dispatching any verification Agent:** check `agents.min_model` in
+`.claude/zskills-config.json`. If set, use that model or higher (ordinal:
+haiku=1 < sonnet=2 < opus=3). Never dispatch with a lower-ordinal model than
+the configured minimum.
 
 After each agent completes, **dispatch a fresh agent** to run `/verify-changes
 worktree` in its worktree. Do NOT run verification yourself — you wrote

--- a/skills/fix-report/SKILL.md
+++ b/skills/fix-report/SKILL.md
@@ -295,12 +295,31 @@ Check all worktrees for `.landed` markers:
 
 ```bash
 for wt in $(git worktree list | awk '{print $1}' | tail -n +2); do
-  if [ -f "$wt/.landed" ] && grep -q "^status: full" "$wt/.landed"; then
-    echo "SAFE: $wt ($(head -1 $wt/.landed))"
-  elif [ -f "$wt/.landed" ]; then
-    echo "PARTIAL: $wt — has unlanded work"
+  if [ -f "$wt/.landed" ]; then
+    STATUS=$(grep "^status:" "$wt/.landed" | cut -d' ' -f2)
+    PR_URL=$(grep "^pr:" "$wt/.landed" | cut -d' ' -f2)
+    case "$STATUS" in
+      full|landed)
+        echo "SAFE: $wt (status: $STATUS) ✓"
+        ;;
+      pr-ready)
+        echo "SAFE (worktree only): $wt (status: pr-ready, PR: ${PR_URL:-unknown}) ✓"
+        ;;
+      pr-ci-failing)
+        echo "NEEDS ATTENTION: $wt — CI failing on PR ${PR_URL:-unknown} ⚠"
+        ;;
+      pr-failed)
+        echo "NEEDS ATTENTION: $wt — PR creation failed, branch pushed ⚠"
+        ;;
+      conflict)
+        echo "NEEDS ATTENTION: $wt — rebase conflict, needs manual resolution ⚠"
+        ;;
+      *)
+        echo "PARTIAL: $wt — status: $STATUS (has unlanded or unresolved work) ⚠"
+        ;;
+    esac
   else
-    echo "ACTIVE: $wt — no .landed marker"
+    echo "ACTIVE: $wt — no .landed marker ⚠"
   fi
 done
 ```
@@ -309,20 +328,34 @@ Present the results:
 ```
 Worktrees:
   wt-123 — SAFE (status: full, landed 2026-03-16) ✓
-  wt-456 — SAFE (status: full, landed 2026-03-16) ✓
+  wt-456 — SAFE (status: landed, merged 2026-03-16) ✓
+  wt-pr-789 — SAFE (worktree only): status: pr-ready, PR: https://github.com/... ✓
+  wt-ci-101 — NEEDS ATTENTION: CI failing on PR https://github.com/... ⚠
   wt-789 — PARTIAL — skipped commits, needs review ⚠
   physics module-phase4 — ACTIVE — no .landed marker (long-running dev) ⚠
 
-Remove SAFE worktrees? (wt-123, wt-456)
+Remove SAFE worktrees? (wt-123, wt-456, wt-pr-789)
 ```
 
 **Wait for user approval** before removing anything.
 
-**Only remove worktrees with `status: full` in `.landed`.** Never remove
-PARTIAL or ACTIVE worktrees. After removing, also clean up the branch:
+**Safe-to-remove statuses:** `status: full` (fix-issues cherry-pick), `status: landed`
+(run-plan cherry-pick or merged PR), and `status: pr-ready` (open PR — worktree is safe
+to remove since the branch is already pushed). For `pr-ready`, remove the worktree
+only — do NOT delete the remote branch (it supports the open PR).
+
+**Never remove** worktrees with `status: pr-ci-failing`, `status: pr-failed`,
+`status: conflict`, `status: partial`, or ACTIVE worktrees (no `.landed`).
+
+After removing SAFE worktrees:
 ```bash
+# For status: full or status: landed:
 git worktree remove <path>
 git branch -d <branch-name>
+
+# For status: pr-ready (open PR — keep remote branch):
+git worktree remove <path>
+git branch -d <branch-name>   # local branch only; remote branch stays for the PR
 ```
 
 ## Step 7 — Write FIX_REPORT.md

--- a/skills/refine-plan/SKILL.md
+++ b/skills/refine-plan/SKILL.md
@@ -213,6 +213,16 @@ these six dimensions:
 Each finding must be **specific and actionable**: cite the exact section,
 line, or reference that's wrong and what it should say instead.
 
+**Evidence discipline.** When a finding makes an empirical claim (a file
+has/lacks X, a function does Y, a tool's input contains Z), include a
+concrete **Verification:** line — the exact file:line, grep, schema
+quote, or command output that reproduces the evidence. The refiner will
+re-run these checks before acting. Structural/judgment findings
+("this phase mixes too many concerns") don't need a reproducer, but
+mark them explicitly: `Verification: judgment — no verifiable anchor`.
+Never write an empirical-sounding claim without something the refiner
+can independently re-check.
+
 ### Devil's Advocate agent
 
 Genuinely adversarial — tries to find ways the remaining plan will fail
@@ -247,6 +257,13 @@ export pipeline' but doesn't specify the serialization format, and
 Phase 1 already committed to MessagePack in `src/io.ts` — the agent will
 have to guess or conflict" is actionable.
 
+The same **evidence discipline** from the reviewer section applies:
+every empirical claim needs a `Verification:` line (file:line, grep,
+schema quote, etc.). The devil's advocate is *especially* prone to
+generating plausible-sounding-but-false claims because its job is
+pattern-generating failure modes, not verifying them. Discipline is
+load-bearing here.
+
 ### Write findings
 
 Write combined findings to `/tmp/refine-plan-review-round-N-<slug>.md`
@@ -272,11 +289,50 @@ A single agent receives:
 - Completed phases as **READ-ONLY CONTEXT** (for reference only)
 - The parsed state file path
 
+### Verify-before-fix (mandatory)
+
+Before touching any phase text, the refiner must **attempt to reproduce
+the cited evidence for each finding**. The reviewer/DA produce hypotheses;
+the refiner is the gate that tests them against reality. This is not
+optional.
+
+For each finding with an empirical claim:
+1. Read the `Verification:` line and run its check (Read the file, run
+   the grep, check the schema, run the command).
+2. Record one of three outcomes in the disposition table:
+   - **Verified** — evidence reproduces. Proceed with fix or justification.
+   - **Not reproduced** — the cited evidence does not match reality.
+     Disposition: **Justified — evidence did not reproduce**. Note what
+     was actually found. Do NOT fix based on this finding.
+   - **No anchor** — finding is empirical-sounding but lacks a verifiable
+     citation. Disposition: **Justified — claim not verifiable as stated**
+     unless the refiner can locate a verifiable anchor itself.
+
+Judgment findings (those explicitly marked `Verification: judgment`) skip
+step 1 and go straight to fix-or-justify based on merit.
+
+**Why this exists.** Past failure: a devil's advocate claimed a Claude
+Code tool's input JSON lacked a `model` field and cited the hook
+template as evidence. The hook template was real but irrelevant — the
+actual falsifier was the tool's own schema, which did contain the field.
+The refiner accepted the claim and pivoted a whole phase's architecture
+based on nothing. If the refiner had tried to reproduce the evidence, it
+would have discovered the claim was unsupported. Verify-before-fix turns
+"I believe the DA" into "I checked."
+
+### Address every finding
+
 The agent addresses **every finding**. For each finding, it must either:
 1. **Fix it** — update the remaining phase text to resolve the issue
 2. **Justify** — explain with evidence why it's not actually a problem
+   (including the "evidence did not reproduce" and "claim not verifiable"
+   cases from the verify-before-fix block)
 
 It may NOT ignore findings or defer them. Every finding gets a disposition.
+
+The disposition table (written to the refined output) must include an
+**Evidence** column with the outcome: `Verified`, `Not reproduced`,
+`No anchor`, or `Judgment` (for non-empirical findings).
 
 **Completed phases are NEVER modified.** The refiner operates only on
 remaining phase text. If a finding suggests a completed phase has a
@@ -419,6 +475,13 @@ printf 'skill: refine-plan\nid: %s\nplan: %s\nstatus: complete\ndate: %s\n' \
 - **Every finding must be addressed.** The refiner cannot ignore or defer
   reviewer/devil's-advocate findings. Fix it or justify why it's not a
   problem — with evidence.
+- **Verify findings before baking fixes.** Reviewer and DA findings are
+  hypotheses, not mandates. The refiner must reproduce each empirical
+  claim before acting on it. A plausible-sounding claim with no
+  verifiable anchor — or one whose evidence doesn't reproduce — is not a
+  mandate to fix. It's a signal to scrutinize harder. Devil's advocate
+  findings are *especially* prone to confidently-false empirical claims
+  because the role incentivizes plausibility, not truth.
 - **Convergence means no new substantive issues.** Not "the same issues
   rephrased." If the devil's advocate keeps finding real new problems, the
   plan isn't ready.

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -536,6 +536,12 @@ agent hasn't returned after 2 hours, declare it **failed**:
 
 2. **Dispatch implementation agent WITHOUT `isolation: "worktree"`.** The
    prompt tells the agent the worktree path and requires absolute paths:
+
+   **Before dispatching any Agent:** check `agents.min_model` in
+   `.claude/zskills-config.json`. If set, use that model or higher
+   (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch with a
+   lower-ordinal model than the configured minimum.
+
    ```
    You are working in worktree: $WORKTREE_PATH
 
@@ -807,7 +813,13 @@ If this phase used delegate execution, verification runs on **main**:
 1. **Dispatch verification agent** targeting the worktree's changes. The
    verification agent is dispatched **without** `isolation: "worktree"` — the
    Agent tool's `isolation` parameter creates a NEW worktree, it cannot attach
-   to an existing one. Instead, give the verification agent:
+   to an existing one.
+
+   **Before dispatching:** check `agents.min_model` in `.claude/zskills-config.json`.
+   If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never
+   dispatch with a lower-ordinal model than the configured minimum.
+
+   Give the verification agent:
    - The **worktree path** from Phase 2 (so it can read files and run tests
      there via `cd <worktree-path> && npm run test:all`)
    - The **worktree branch name** (so it can diff against main:
@@ -818,6 +830,18 @@ If this phase used delegate execution, verification runs on **main**:
      orchestrator with implementer bias.
    - The **work items checklist** — verify each item was actually implemented,
      not stubbed or skipped
+   - The **`.test-baseline.txt` file** captured before implementation started
+     (if `FULL_TEST_CMD` is configured). The verification agent should:
+     - Read `.test-baseline.txt` (baseline captured before implementation)
+     - Compare against `.test-results.txt` (results after running tests now)
+     - **New failures** (in results but not in baseline) → regressions, must
+       be fixed before the phase can commit
+     - **Pre-existing failures** (in both baseline and results) → note in report,
+       do not fix (these predate this phase)
+     - **Resolved failures** (in baseline but not in results) → note positively
+       as improvements
+     - If `.test-baseline.txt` is absent (`FULL_TEST_CMD` not configured), treat
+       all failures as potentially new — report all of them
 
 2. **Additional plan-specific checks** (the verifier checks these against the
    verbatim plan text — not against a summary):
@@ -1594,6 +1618,10 @@ Attempting fix..."
     fi
 
     # --- Dispatch CI fix agent ---
+    # Before dispatching: check agents.min_model in .claude/zskills-config.json.
+    # If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3).
+    # Never dispatch with a lower-ordinal model than the configured minimum.
+    #
     # The /run-plan ORCHESTRATOR dispatches this agent via the Agent tool.
     # The agent does NOT use isolation: "worktree" -- the worktree already
     # exists. Instead, the agent's prompt tells it to work in $WORKTREE_PATH.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -512,14 +512,26 @@ Then register the hooks in `.claude/settings.json`. The format is:
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }
 }
 ```
 
-Note: only the `Bash` matcher is used for PreToolUse hooks. The hook scripts
-themselves only process Bash tool inputs (they exit early for other tools).
+Note: both `Bash` and `Agent` matchers are used for PreToolUse hooks. The `Bash`
+matcher hooks enforce command safety and tracking. The `Agent` matcher hook
+enforces `agents.min_model` — blocking subagent dispatches that specify a model
+below the configured minimum (haiku=1 < sonnet=2 < opus=3).
 
 Report: "Installed N hooks: [list]"
 

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -276,6 +276,21 @@ found, missing otherwise.
 | 12 | Enumerate before guessing | `"enumerate before guessing"` |
 | 13 | Never skip hooks | `"never.*--no-verify"` or `"skip.*pre-commit hooks"` |
 
+### Step 2.5 — Documentation presence audit (execution modes)
+
+Search the project's `CLAUDE.md` for these documentation-presence signals.
+Mark each present/missing based on **case-insensitive substring match**:
+
+| Check | Key phrase(s) to search in CLAUDE.md |
+|-------|--------------------------------------|
+| Execution Modes section | `## Execution Modes` (heading) |
+| Landing mode keywords documented | `cherry-pick` AND `pr` AND `direct` |
+| Direct mode description present | `Work directly on main` |
+
+Report in the same pass/fail format as Step 2. Missing items are
+**recommendations, not errors** — this is a documentation-only gap with
+no enforcement consequence.
+
 ### Step 3 — Check hooks
 
 Look in `.claude/hooks/` for these 2 files:
@@ -317,6 +332,11 @@ Skill Dependencies: all satisfied | K missing
 CLAUDE.md Rules: M/13 present (K missing)
   Missing:
   - [rule name]: [key phrase not found]
+  ...
+
+Execution Mode Docs: M/3 present (K missing/recommended)
+  Missing (recommendation only):
+  - [check name]: [key phrase not found]
   ...
 
 Hooks: M/2 installed (K missing)

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1140,6 +1140,105 @@ else
 fi
 
 echo ""
+
+# ─── block-agents.sh.template tests ───
+echo "=== block-agents.sh — agents.min_model enforcement ==="
+
+AGENTS_HOOK="$REPO_ROOT/hooks/block-agents.sh.template"
+
+# Helper: run agent hook with tool_name=Agent, optional model field
+run_agent_hook() {
+  local model_field="$1"    # e.g. '"model":"haiku"' or ""
+  local config_json="$2"    # content of .claude/zskills-config.json or ""
+  local tmp_repo
+  tmp_repo=$(mktemp -d)
+  mkdir -p "$tmp_repo/.claude"
+  (cd "$tmp_repo" && git init -q 2>/dev/null)
+
+  if [ -n "$config_json" ]; then
+    printf '%s\n' "$config_json" > "$tmp_repo/.claude/zskills-config.json"
+  fi
+
+  local tool_input
+  if [ -n "$model_field" ]; then
+    tool_input="{\"tool_name\":\"Agent\",\"tool_input\":{${model_field},\"prompt\":\"Do something\"}}"
+  else
+    tool_input="{\"tool_name\":\"Agent\",\"tool_input\":{\"prompt\":\"Do something\"}}"
+  fi
+
+  local result
+  result=$(echo "$tool_input" | REPO_ROOT="$tmp_repo" bash "$AGENTS_HOOK" 2>/dev/null)
+  rm -rf "$tmp_repo"
+  echo "$result"
+}
+
+# 1. No config → pass through (no enforcement)
+result=$(run_agent_hook '"model":"haiku"' "")
+if [[ -z "$result" ]]; then
+  pass "no config → always allow"
+else
+  fail "no config → expected allow, got: $result"
+fi
+
+# 2. min_model=sonnet, dispatch model=haiku → deny
+CONFIG_SONNET='{"agents":{"min_model":"claude-sonnet-4-20250514"}}'
+result=$(run_agent_hook '"model":"claude-haiku-4-20250514"' "$CONFIG_SONNET")
+if [[ "$result" == *"permissionDecision"*"deny"* ]]; then
+  pass "min_model=sonnet, model=haiku → deny"
+else
+  fail "min_model=sonnet, model=haiku → expected deny, got: $result"
+fi
+
+# 3. min_model=sonnet, dispatch model=sonnet → allow
+result=$(run_agent_hook '"model":"claude-sonnet-4-20250514"' "$CONFIG_SONNET")
+if [[ -z "$result" ]]; then
+  pass "min_model=sonnet, model=sonnet → allow"
+else
+  fail "min_model=sonnet, model=sonnet → expected allow, got: $result"
+fi
+
+# 4. min_model=sonnet, dispatch model=opus → allow
+result=$(run_agent_hook '"model":"claude-opus-4-20250514"' "$CONFIG_SONNET")
+if [[ -z "$result" ]]; then
+  pass "min_model=sonnet, model=opus → allow"
+else
+  fail "min_model=sonnet, model=opus → expected allow, got: $result"
+fi
+
+# 5. min_model=sonnet, no model in tool_input → allow (unknown=0, pass-through)
+result=$(run_agent_hook "" "$CONFIG_SONNET")
+if [[ -z "$result" ]]; then
+  pass "min_model=sonnet, no model field → allow (residual case)"
+else
+  fail "min_model=sonnet, no model field → expected allow, got: $result"
+fi
+
+# 6. Non-Agent tool_name → ignore entirely
+result=$(echo '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | bash "$AGENTS_HOOK" 2>/dev/null)
+if [[ -z "$result" ]]; then
+  pass "non-Agent tool_name → pass through (not our concern)"
+else
+  fail "non-Agent tool_name → expected silent pass, got: $result"
+fi
+
+# 7. min_model=haiku, dispatch model=haiku → allow (haiku meets haiku)
+CONFIG_HAIKU='{"agents":{"min_model":"claude-haiku-4-20250514"}}'
+result=$(run_agent_hook '"model":"claude-haiku-4-20250514"' "$CONFIG_HAIKU")
+if [[ -z "$result" ]]; then
+  pass "min_model=haiku, model=haiku → allow"
+else
+  fail "min_model=haiku, model=haiku → expected allow, got: $result"
+fi
+
+# 8. Unknown model family → always allow (future-proofing)
+result=$(run_agent_hook '"model":"claude-nova-4-20250514"' "$CONFIG_SONNET")
+if [[ -z "$result" ]]; then
+  pass "unknown model family (claude-nova) → allow (ordinal=0 passes)"
+else
+  fail "unknown model family → expected allow, got: $result"
+fi
+
+echo ""
 echo "---"
 printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$((PASS_COUNT + FAIL_COUNT))"
 


### PR DESCRIPTION
## Plan: Execution Modes

**Phases completed this run:**
- 5b — Execution Skills + Documentation (bfc5893) — /do pr, /commit pr, CLAUDE_TEMPLATE Execution Modes, update-zskills Step 2.5
- 5c — Infrastructure: Cleanup + Model Gate + Baseline (1839bb8) — fix-report + briefing scripts, hooks/block-agents.sh.template, .test-baseline comparison

**Pre-run cleanup bundled:**
- /refine-plan + /draft-plan evidence-discipline (a7c9509)
- Plan refinement (e1aa108) — corrects 5c.2 back to hook-based enforcement (prior refinement was driven by a false DA claim that the Agent tool input lacks a `model` field)

**Report:** See `reports/plan-execution-modes.md`.

**Tests:** 124/124 passing (8 new for block-agents.sh). Hook spot-check verified: haiku+min=sonnet → deny; sonnet+min=sonnet → allow; no-model+no-config → allow.

**Landing:** Squash-merge expected to bring local + origin main into alignment.

---
Generated by `/run-plan plans/EXECUTION_MODES.md finish auto pr`