### PR TITLE
[canary10-pr-mode] Canary 10 — PR Mode End-to-End

### DIFF
--- a/canary/canary10.txt
+++ b/canary/canary10.txt
@@ -1,1 +1,2 @@
 Canary 10 Phase 1: PR mode
+Canary 10 Phase 2: PR mode

--- a/canary/canary10.txt
+++ b/canary/canary10.txt
@@ -1,0 +1,1 @@
+Canary 10 Phase 1: PR mode

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -37,7 +37,7 @@ confirmed they're happy to run this manually.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 -- Create canary10 file | ⬜ | | Trivial file create (PR mode) |
+| 1 -- Create canary10 file | 🟡 In Progress | `bbec8c3` | PR-mode, commit on feature branch |
 | 2 -- Append second line   | ⬜ | | Trivial append (PR mode)      |
 
 ## Phase 1 -- Create canary10 file

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -38,7 +38,7 @@ confirmed they're happy to run this manually.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 -- Create canary10 file | 🟡 In Progress | `bbec8c3` | PR-mode, commit on feature branch |
-| 2 -- Append second line   | ⬜ | | Trivial append (PR mode)      |
+| 2 -- Append second line   | 🟡 In Progress | `b5ea9be` | PR-mode, commit on feature branch |
 
 ## Phase 1 -- Create canary10 file
 

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -1,7 +1,7 @@
 ---
 title: Canary 10 — PR Mode End-to-End
 created: 2026-04-16
-status: active
+status: complete
 ---
 
 # Plan: Canary 10 — PR Mode End-to-End
@@ -37,8 +37,8 @@ confirmed they're happy to run this manually.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 -- Create canary10 file | 🟡 In Progress | `bbec8c3` | PR-mode, commit on feature branch |
-| 2 -- Append second line   | 🟡 In Progress | `b5ea9be` | PR-mode, commit on feature branch |
+| 1 -- Create canary10 file | ✅ Done | `bbec8c3` | PR-mode (landed via squash) |
+| 2 -- Append second line   | ✅ Done | `b5ea9be` | PR-mode (landed via squash) |
 
 ## Phase 1 -- Create canary10 file
 

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,6 +1,6 @@
 # Plan Report — Canary 10 PR Mode End-to-End
 
-## Phase — 2 Append second line [UNFINALIZED]
+## Phase — 2 Append second line (landed)
 
 **Plan:** plans/CANARY10_PR_MODE.md
 **Status:** Completed (verified, committed on feature branch)
@@ -22,7 +22,7 @@
 ### Phase 2 timing signal (cron-fired Turn 2)
 Phase 1 implement marker: 1776346750. Phase 2 implement marker: 1776347085. Delta: 335s (>>60s threshold). Confirms Phase 2 ran in a SEPARATE cron-fired turn from Phase 1, not inline.
 
-## Phase — 1 Create canary10 file [UNFINALIZED]
+## Phase — 1 Create canary10 file (landed)
 
 **Plan:** plans/CANARY10_PR_MODE.md
 **Status:** Completed (verified, committed on feature branch)

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,0 +1,25 @@
+# Plan Report — Canary 10 PR Mode End-to-End
+
+## Phase — 1 Create canary10 file [UNFINALIZED]
+
+**Plan:** plans/CANARY10_PR_MODE.md
+**Status:** Completed (verified, committed on feature branch)
+**Worktree:** /tmp/zskills-pr-canary10-pr-mode
+**Branch:** feat/canary10-pr-mode
+**Commit:** bbec8c3 (on feature branch; not yet landed on main — awaits PR merge)
+
+### Work Items
+| # | Item | Status |
+|---|------|--------|
+| 1 | Create canary/canary10.txt with exact one-line content | Done |
+
+### Verification
+- `canary/canary10.txt` on feature branch with exactly one line: `Canary 10 Phase 1: PR mode`
+- Tests: 177/177 passed (tests/test-hooks.sh)
+- Scope: 1 file (canary/canary10.txt) — no out-of-scope changes
+- Fresh-eyes verifier: ACCEPT
+- Commit committed on feature branch only; main NOT advanced (per PR-mode semantics)
+
+### Chunking signal
+Phase 5c will schedule a one-shot cron for Phase 2
+(`Run /run-plan plans/CANARY10_PR_MODE.md finish auto pr`). Phase 2 runs in a SEPARATE cron-fired turn, commits on the same feature branch, then triggers Phase 5b (frontmatter complete) and Phase 6 PR-mode landing (push + gh pr create + CI poll + auto-merge).

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,5 +1,27 @@
 # Plan Report — Canary 10 PR Mode End-to-End
 
+## Phase — 2 Append second line [UNFINALIZED]
+
+**Plan:** plans/CANARY10_PR_MODE.md
+**Status:** Completed (verified, committed on feature branch)
+**Worktree:** /tmp/zskills-pr-canary10-pr-mode
+**Branch:** feat/canary10-pr-mode
+**Commit:** b5ea9be (on feature branch; awaits PR merge)
+
+### Work Items
+| # | Item | Status |
+|---|------|--------|
+| 1 | Append second line to canary/canary10.txt | Done |
+
+### Verification
+- `canary/canary10.txt` on feature branch has 2 lines in correct order
+- Tests: 177/177 (tests/test-hooks.sh)
+- Scope: 1 file modified, no out-of-scope changes
+- Fresh-eyes verifier: ACCEPT
+
+### Phase 2 timing signal (cron-fired Turn 2)
+Phase 1 implement marker: 1776346750. Phase 2 implement marker: 1776347085. Delta: 335s (>>60s threshold). Confirms Phase 2 ran in a SEPARATE cron-fired turn from Phase 1, not inline.
+
 ## Phase — 1 Create canary10 file [UNFINALIZED]
 
 **Plan:** plans/CANARY10_PR_MODE.md


### PR DESCRIPTION
## Plan: Canary 10 — PR Mode End-to-End

Validates PR mode `finish auto pr` execution end-to-end. 2 phases, both committed on this feature branch via separate cron-fired turns (chunked execution).

**Phases completed:**
- Phase 1 — Create canary10.txt (commit bbec8c3)
- Phase 2 — Append second line (commit b5ea9be)

**Cumulative diff:** `canary/canary10.txt` (new file, 2 lines), plus orchestrator bookkeeping (tracker + report).

**Report:** See `reports/plan-canary10-pr-mode.md` for details.

---
Generated by `/run-plan` (CANARY10 manual canary execution)