### PR TITLE
[canary-failure-injection] Phase 1: Scaffold + stash reproducers

### DIFF
--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,6 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
+| [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 1/5 | Phase 1 pending PR landing (feat/canary-failure-injection) |
 | [plan-ephemeral-to-tmp.md](reports/plan-ephemeral-to-tmp.md) | 4/4 | **Complete** — all phases landed |
 | [plan-canary10-pr-mode.md](reports/plan-canary10-pr-mode.md) | 2 | Landed |
 | [plan-canary7-chunked-finish.md](reports/plan-canary7-chunked-finish.md) | 2 | Landed |

--- a/plans/CANARY_FAILURE_INJECTION.md
+++ b/plans/CANARY_FAILURE_INJECTION.md
@@ -74,7 +74,7 @@ which now includes the previous phase's changes.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Scaffold + block-unsafe-generic.sh stash | 🟡 In Progress | | |
+| 1 — Scaffold + block-unsafe-generic.sh stash | ✅ Done | `cace895` | 18 tests (6+7+5) |
 | 2 — land-phase.sh | ⬚ | | |
 | 3 — post-run-invariants.sh | ⬚ | | |
 | 4 — block-agents.sh | ⬚ | | |

--- a/plans/CANARY_FAILURE_INJECTION.md
+++ b/plans/CANARY_FAILURE_INJECTION.md
@@ -74,7 +74,7 @@ which now includes the previous phase's changes.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Scaffold + block-unsafe-generic.sh stash | ⬚ | | |
+| 1 — Scaffold + block-unsafe-generic.sh stash | 🟡 In Progress | | |
 | 2 — land-phase.sh | ⬚ | | |
 | 3 — post-run-invariants.sh | ⬚ | | |
 | 4 — block-agents.sh | ⬚ | | |

--- a/reports/plan-canary-failure-injection.md
+++ b/reports/plan-canary-failure-injection.md
@@ -1,6 +1,6 @@
 # Plan Report — Canary Failure Injection
 
-## Phase — 1 Scaffold + block-unsafe-generic.sh stash reproducers [UNFINALIZED]
+## Phase — 1 Scaffold + block-unsafe-generic.sh stash reproducers
 
 **Plan:** `plans/CANARY_FAILURE_INJECTION.md`
 **Status:** Completed (verified), pending PR landing

--- a/reports/plan-canary-failure-injection.md
+++ b/reports/plan-canary-failure-injection.md
@@ -1,0 +1,41 @@
+# Plan Report — Canary Failure Injection
+
+## Phase — 1 Scaffold + block-unsafe-generic.sh stash reproducers [UNFINALIZED]
+
+**Plan:** `plans/CANARY_FAILURE_INJECTION.md`
+**Status:** Completed (verified), pending PR landing
+**Worktree:** `/tmp/zskills-pr-canary-failure-injection`
+**Branch:** `feat/canary-failure-injection`
+**Commits:** `cace895` (impl + tests), `5da8705` (tracker 🟡)
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | `tests/test-canary-failures.sh` scaffold (shebang, helpers, trap cleanup, summary footer, executable) | Done | `cace895` |
+| 2 | `tests/fixtures/canary/.gitkeep` (empty dir tracked) | Done | `cace895` |
+| 3 | `tests/run-all.sh` integration — 1 new `run_suite` line after `test-scope-halt.sh` | Done | `cace895` |
+| 4 | `section "Stash writes denied (6 cases)"` — bare / -u / save / push / drop / clear | Done | `cace895` |
+| 5 | `section "Stash reads allowed (7 cases)"` — apply / list / show / pop / create / store / branch | Done | `cace895` |
+| 6 | `section "Stash overmatch prevention (5 cases)"` — commit msg / echo / grep / printf / heredoc | Done | `cace895` |
+
+### Verification
+
+- `/verify-changes worktree` — **PASS** (fresh subagent, independent context from impl).
+- Scope Assessment — all rows `Yes`, no violations.
+- Worktree test suite: `Canary failure-injection: 18 passed, 0 failed` (exit 0).
+- Full aggregator: `Overall: 253/253 passed, 0 failed` (baseline was 235; +18 from this phase as expected).
+- Hygiene: `.worktreepurpose`, `.zskills-tracked`, `.landed` all untracked and not staged. Only the three in-scope paths in the commit.
+- No regressions vs `.test-baseline.txt`.
+
+### Acceptance Criteria
+
+- [x] `tests/test-canary-failures.sh` exists and is executable.
+- [x] `tests/fixtures/canary/` directory exists with `.gitkeep`.
+- [x] `tests/run-all.sh` diff shows exactly one new `run_suite` line.
+- [x] `bash tests/test-canary-failures.sh` reports `18 passed, 0 failed`.
+- [x] `bash tests/run-all.sh` exits 0 and includes the new suite in its output.
+
+### Deviations from Plan
+
+None. Scaffold copied verbatim (`set -u` not `set -eo pipefail`, Python JSON escape, trap-based `FIXTURE_DIRS` cleanup with unset-array guard). 6+7+5 = 18 tests match the plan tables exactly. All tests passed on first run; no retries needed.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -40,6 +40,7 @@ run_suite "test-briefing-parity.sh" "tests/test-briefing-parity.sh"
 run_suite "test-skill-invariants.sh" "tests/test-skill-invariants.sh"
 run_suite "test-phase-5b-gate.sh" "tests/test-phase-5b-gate.sh"
 run_suite "test-scope-halt.sh" "tests/test-scope-halt.sh"
+run_suite "test-canary-failures.sh" "tests/test-canary-failures.sh"
 
 echo ""
 echo "=============================="

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# tests/test-canary-failures.sh — regression suite for silent-failure catches.
+#
+# Each section asserts loud-failure behavior for one enforcing layer
+# (hook / script / skill prompt). Run standalone or via tests/run-all.sh.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+FIXTURES="$REPO_ROOT/tests/fixtures/canary"
+PASS_COUNT=0
+FAIL_COUNT=0
+FIXTURE_DIRS=()
+
+cleanup_fixtures() {
+  if [ "${#FIXTURE_DIRS[@]}" -eq 0 ]; then return; fi
+  local d
+  for d in "${FIXTURE_DIRS[@]}"; do
+    [ -n "$d" ] && [ -d "$d" ] && chmod -R u+w "$d" 2>/dev/null
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+}
+trap cleanup_fixtures EXIT
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+section() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+# Hook helper: construct JSON on stdin, assert deny + substring
+expect_deny_substring() {
+  local label="$1" cmd="$2" want="$3" hook="$4"
+  local json result
+  json=$(printf '{"tool_name":"Bash","tool_input":{"command":%s}}' \
+    "$(printf '%s' "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+  result=$(printf '%s' "$json" | bash "$hook" 2>/dev/null) || true
+  if [[ "$result" == *'"permissionDecision":"deny"'* && "$result" == *"$want"* ]]; then
+    pass "$label"
+  else
+    fail "$label — want deny with '$want', got: $result"
+  fi
+}
+
+expect_allow() {
+  local label="$1" cmd="$2" hook="$3"
+  local json result
+  json=$(printf '{"tool_name":"Bash","tool_input":{"command":%s}}' \
+    "$(printf '%s' "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+  result=$(printf '%s' "$json" | bash "$hook" 2>/dev/null) || true
+  if [[ -z "$result" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected empty stdout, got: $result"
+  fi
+}
+
+# Script helper: run a command, assert rc + stderr substring
+expect_script_exit() {
+  local label="$1" want_rc="$2" want_stderr="$3"
+  shift 3
+  local out rc
+  out=$("$@" 2>&1) || rc=$?
+  rc=${rc:-0}
+  if [ "$rc" -eq "$want_rc" ] && [[ "$out" == *"$want_stderr"* ]]; then
+    pass "$label"
+  else
+    fail "$label — rc=$rc want=$want_rc; '$want_stderr' substring? $out"
+  fi
+}
+
+# Fixture helper: throwaway git repo, auto-cleanup
+setup_fixture_repo() {
+  local tmp
+  tmp=$(mktemp -d)
+  FIXTURE_DIRS+=("$tmp")
+  git -C "$tmp" init -q
+  git -C "$tmp" config user.email "canary@test.local"
+  git -C "$tmp" config user.name "canary"
+  git -C "$tmp" commit --allow-empty -q -m "init"
+  echo "$tmp"
+}
+
+setup_bare_origin() {
+  local tmp
+  tmp=$(mktemp -d)
+  FIXTURE_DIRS+=("$tmp")
+  git init -q --bare "$tmp"
+  echo "$tmp"
+}
+
+mkdir -p "$FIXTURES"
+
+# --- test sections appended by each phase ---
+
+# (Phase 1 adds: stash)
+# (Phase 2 adds: land-phase)
+# (Phase 3 adds: invariants)
+# (Phase 4 adds: block-agents)
+# (Phase 5 adds: commit-reviewer)
+
+HOOK="$REPO_ROOT/hooks/block-unsafe-generic.sh"
+
+section "Stash writes denied (6 cases)"
+STASH_WRITE_DENY="BLOCKED: git-stash write subcommand forbidden"
+STASH_DESTRUCTIVE_DENY="BLOCKED: git stash drop/clear destroys stashed work permanently"
+expect_deny_substring "git stash"              "git stash"              "$STASH_WRITE_DENY"       "$HOOK"
+expect_deny_substring "git stash -u"           "git stash -u"           "$STASH_WRITE_DENY"       "$HOOK"
+expect_deny_substring 'git stash save "msg"'   'git stash save "msg"'   "$STASH_WRITE_DENY"       "$HOOK"
+expect_deny_substring 'git stash push -m "msg"' 'git stash push -m "msg"' "$STASH_WRITE_DENY"     "$HOOK"
+expect_deny_substring "git stash drop"         "git stash drop"         "$STASH_DESTRUCTIVE_DENY" "$HOOK"
+expect_deny_substring "git stash clear"        "git stash clear"        "$STASH_DESTRUCTIVE_DENY" "$HOOK"
+
+section "Stash reads allowed (7 cases)"
+expect_allow "git stash apply"         "git stash apply"         "$HOOK"
+expect_allow "git stash list"          "git stash list"          "$HOOK"
+expect_allow "git stash show"          "git stash show"          "$HOOK"
+expect_allow "git stash pop"           "git stash pop"           "$HOOK"
+expect_allow "git stash create"        "git stash create"        "$HOOK"
+expect_allow "git stash store abc123"  "git stash store abc123"  "$HOOK"
+expect_allow "git stash branch foo"    "git stash branch foo"    "$HOOK"
+
+section "Stash overmatch prevention (5 cases)"
+expect_allow 'commit message mentions git stash' 'git commit -m "refactor: remove old git stash logic"' "$HOOK"
+expect_allow 'echo "git stash push"'   'echo "git stash push"'   "$HOOK"
+expect_allow 'grep "git stash" file'   'grep "git stash" somefile.txt' "$HOOK"
+expect_allow "printf 'git stash save\\n'" "printf 'git stash save\\n'" "$HOOK"
+expect_allow 'heredoc containing git stash -u' "$(printf 'cat <<EOF\ngit stash -u\nEOF')" "$HOOK"
+
+echo
+echo "Canary failure-injection: $PASS_COUNT passed, $FAIL_COUNT failed"
+exit $((FAIL_COUNT > 0))


### PR DESCRIPTION
## Plan: Canary Failure Injection

Phase 1 of 5 in the shareability-gate canary: locks in hardened-pipeline
loud-failure behavior so external users can verify their install catches
known silent-failure modes via `bash tests/run-all.sh`.

### This phase (18 tests)

- Scaffold `tests/test-canary-failures.sh` (pure-bash regression suite,
  `set -u`, trap fixture cleanup, Python JSON escape helper).
- Wire into `tests/run-all.sh` aggregator (1 new `run_suite` line).
- **Stash writes denied (6)** — bare, -u, save, push, drop, clear.
- **Stash reads allowed (7)** — apply, list, show, pop, create, store, branch.
- **Overmatch prevention (5)** — commit msg, echo, grep, printf, heredoc.

### Verification

- `/verify-changes worktree` PASS (fresh subagent, Scope Assessment all Yes).
- Local: `Overall: 253/253 passed, 0 failed` (baseline 235 + 18 new).
- No hygiene leaks (`.worktreepurpose`/`.zskills-tracked` stay untracked).

**Report:** `reports/plan-canary-failure-injection.md`.

---
Generated by `/run-plan plans/CANARY_FAILURE_INJECTION.md 1 auto pr`.