### PR TITLE
[canary-failure-injection] Phase 2: land-phase.sh reproducers

### DIFF
--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 1/5 | Phase 1 pending PR landing (feat/canary-failure-injection) |
+| [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 2/5 | Phase 2 pending PR landing (feat/canary-failure-injection) |
 | [plan-ephemeral-to-tmp.md](reports/plan-ephemeral-to-tmp.md) | 4/4 | **Complete** — all phases landed |
 | [plan-canary10-pr-mode.md](reports/plan-canary10-pr-mode.md) | 2 | Landed |
 | [plan-canary7-chunked-finish.md](reports/plan-canary7-chunked-finish.md) | 2 | Landed |

--- a/plans/CANARY_FAILURE_INJECTION.md
+++ b/plans/CANARY_FAILURE_INJECTION.md
@@ -75,7 +75,7 @@ which now includes the previous phase's changes.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Scaffold + block-unsafe-generic.sh stash | ✅ Done | `cace895` | 18 tests (6+7+5) |
-| 2 — land-phase.sh | 🟡 In Progress | | |
+| 2 — land-phase.sh | ✅ Done | `e78a224` | 10 tests (1+4+3+1+guard) |
 | 3 — post-run-invariants.sh | ⬚ | | |
 | 4 — block-agents.sh | ⬚ | | |
 | 5 — /commit reviewer + Phase 7 | ⬚ | | |

--- a/plans/CANARY_FAILURE_INJECTION.md
+++ b/plans/CANARY_FAILURE_INJECTION.md
@@ -75,7 +75,7 @@ which now includes the previous phase's changes.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Scaffold + block-unsafe-generic.sh stash | ✅ Done | `cace895` | 18 tests (6+7+5) |
-| 2 — land-phase.sh | ⬚ | | |
+| 2 — land-phase.sh | 🟡 In Progress | | |
 | 3 — post-run-invariants.sh | ⬚ | | |
 | 4 — block-agents.sh | ⬚ | | |
 | 5 — /commit reviewer + Phase 7 | ⬚ | | |

--- a/reports/plan-canary-failure-injection.md
+++ b/reports/plan-canary-failure-injection.md
@@ -1,5 +1,54 @@
 # Plan Report — Canary Failure Injection
 
+## Phase — 2 land-phase.sh reproducers [UNFINALIZED]
+
+**Plan:** `plans/CANARY_FAILURE_INJECTION.md`
+**Status:** Completed (verified), pending PR landing
+**Worktree:** `/tmp/zskills-pr-canary-failure-injection`
+**Branch:** `feat/canary-failure-injection`
+**Commits:** `e78a224` (impl + tests), `527c301` (tracker 🟡)
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Section `land-phase.sh: dirty worktree refused (1 case)` | Done | `e78a224` |
+| 2 | Section `land-phase.sh: tracked ephemeral rejected (4 cases)` + array-drift guard | Done | `e78a224` |
+| 3 | Section `land-phase.sh: ls-remote exit code handling (3 cases)` — rc=0/2/128 | Done | `e78a224` |
+| 4 | Section `land-phase.sh: /tmp test-output dir cleanup (1 case)` — locks in 66d9138 | Done | `e78a224` |
+
+### Verification
+
+- `/verify-changes worktree` — **PASS**. Scope Assessment clean, all cells "Yes".
+- Canary suite: `Canary failure-injection: 28 passed, 0 failed` (up from 18 post-Phase-1).
+- Full aggregator: `Overall: 263/263 passed, 0 failed` (baseline 253 + 10 new).
+- No regressions vs baseline.
+- Hygiene: `.worktreepurpose`/`.zskills-tracked`/`.landed` untracked; `/tmp/zskills-tests/...` outside worktree; only `tests/test-canary-failures.sh` modified.
+
+### Acceptance Criteria
+
+- [x] Section "dirty worktree" passes 1 test.
+- [x] Section "tracked ephemeral" passes 4 tests + array-drift guard.
+- [x] Section "ls-remote" passes 3 tests (rc=0/2/128 distinction).
+- [x] Section "/tmp cleanup" passes 1 test.
+- [x] `bash tests/test-canary-failures.sh` → `28 passed, 0 failed`.
+- [x] `bash tests/run-all.sh` → `Overall: 263/263 passed, 0 failed`.
+
+### Deviations from Plan
+
+Minor +1 count: the plan's headline count is "9 tests" but the AC wording
+also lists the array-drift guard as a distinct assertion ("...AND the
+array-drift guard passes"). The impl agent implemented the guard as its
+own `pass` call so drift is visible in test output. Net: 10 new passing
+assertions instead of 9. Total canary count: 28.
+
+Cumulative plan-wide count adjustment:
+- Phase 2 internal: 9 → 10
+- Final expected (installed-copy present): 78 → 79
+- Final expected (installed-copy skipped): 68 → 69
+
+---
+
 ## Phase — 1 Scaffold + block-unsafe-generic.sh stash reproducers
 
 **Plan:** `plans/CANARY_FAILURE_INJECTION.md`

--- a/reports/plan-canary-failure-injection.md
+++ b/reports/plan-canary-failure-injection.md
@@ -1,6 +1,6 @@
 # Plan Report — Canary Failure Injection
 
-## Phase — 2 land-phase.sh reproducers [UNFINALIZED]
+## Phase — 2 land-phase.sh reproducers
 
 **Plan:** `plans/CANARY_FAILURE_INJECTION.md`
 **Status:** Completed (verified), pending PR landing

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -125,6 +125,141 @@ expect_allow 'grep "git stash" file'   'grep "git stash" somefile.txt' "$HOOK"
 expect_allow "printf 'git stash save\\n'" "printf 'git stash save\\n'" "$HOOK"
 expect_allow 'heredoc containing git stash -u' "$(printf 'cat <<EOF\ngit stash -u\nEOF')" "$HOOK"
 
+# ---------------------------------------------------------------------------
+# Phase 2 — land-phase.sh reproducers
+# ---------------------------------------------------------------------------
+# Script signature is ONE arg: `bash scripts/land-phase.sh <worktree-path>`.
+# MAIN_ROOT resolution uses `git rev-parse --git-common-dir` from CWD, so
+# every invocation subshell-cd's into the fixture's primary repo first.
+SCRIPT="$REPO_ROOT/scripts/land-phase.sh"
+
+section "land-phase.sh: dirty worktree refused (1 case)"
+dirty_primary=$(setup_fixture_repo)
+dirty_worktree=$(mktemp -u)
+FIXTURE_DIRS+=("$dirty_worktree")
+git -C "$dirty_primary" worktree add -q "$dirty_worktree" -b canary/test
+printf 'status: landed\n' > "$dirty_worktree/.landed"
+printf 'dirty\n' > "$dirty_worktree/untracked.txt"
+expect_script_exit \
+  "dirty worktree: rc=1 with cleanliness error" \
+  1 \
+  "ERROR: Worktree $dirty_worktree is not clean — cannot safely remove." \
+  bash -c "cd \"$dirty_primary\" && bash \"$SCRIPT\" \"$dirty_worktree\""
+
+section "land-phase.sh: tracked ephemeral rejected (4 cases)"
+# Array-drift guard: confirm scripts/land-phase.sh still lists exactly the
+# four ephemeral names we cover below. If the script's list drifts from
+# this plan's list, fail loudly so test authors update this phase rather
+# than silently passing against a changed list.
+EXPECTED_EPHEMERAL='EPHEMERAL_FILES=(".test-results.txt" ".test-baseline.txt" ".worktreepurpose" ".zskills-tracked")'
+if grep -qxF "$EXPECTED_EPHEMERAL" "$REPO_ROOT/scripts/land-phase.sh"; then
+  pass "array-drift guard: scripts/land-phase.sh EPHEMERAL_FILES matches plan"
+else
+  fail "array-drift guard: scripts/land-phase.sh EPHEMERAL_FILES does NOT match plan list — update this phase"
+fi
+
+for eph in ".test-results.txt" ".test-baseline.txt" ".worktreepurpose" ".zskills-tracked"; do
+  eph_primary=$(setup_fixture_repo)
+  eph_worktree=$(mktemp -u)
+  FIXTURE_DIRS+=("$eph_worktree")
+  git -C "$eph_primary" worktree add -q "$eph_worktree" -b "canary/eph"
+  # Commit the ephemeral file into the feature branch so it is tracked in
+  # the worktree when land-phase.sh runs.
+  printf 'tracked ephemeral\n' > "$eph_worktree/$eph"
+  git -C "$eph_worktree" add -- "$eph"
+  git -C "$eph_worktree" commit -q -m "add tracked ephemeral $eph"
+  printf 'status: landed\n' > "$eph_worktree/.landed"
+  expect_script_exit \
+    "tracked ephemeral $eph: rc=1 with rejection error" \
+    1 \
+    "ERROR: $eph is git-tracked in $eph_worktree but should be untracked." \
+    bash -c "cd \"$eph_primary\" && bash \"$SCRIPT\" \"$eph_worktree\""
+done
+
+section "land-phase.sh: ls-remote exit code handling (3 cases)"
+
+# Case A — origin has the branch, ls-remote rc=0 → delete path taken,
+# script succeeds and emits `Worktree removed:`.
+ca_primary=$(setup_fixture_repo)
+ca_origin=$(setup_bare_origin)
+git -C "$ca_primary" remote add origin "$ca_origin"
+git -C "$ca_primary" push -q origin HEAD:refs/heads/main
+ca_worktree=$(mktemp -u)
+FIXTURE_DIRS+=("$ca_worktree")
+git -C "$ca_primary" worktree add -q "$ca_worktree" -b "canary/ls-a"
+git -C "$ca_worktree" push -q origin canary/ls-a
+printf 'status: landed\n' > "$ca_worktree/.landed"
+expect_script_exit \
+  "ls-remote Case A (rc=0 → delete): success, worktree removed" \
+  0 \
+  "Worktree removed:" \
+  bash -c "cd \"$ca_primary\" && bash \"$SCRIPT\" \"$ca_worktree\""
+
+# Case B — origin does NOT have the branch, ls-remote rc=2 → skip-delete
+# path taken, script succeeds and emits `already absent — skipping delete.`
+cb_primary=$(setup_fixture_repo)
+cb_origin=$(setup_bare_origin)
+git -C "$cb_primary" remote add origin "$cb_origin"
+git -C "$cb_primary" push -q origin HEAD:refs/heads/main
+cb_worktree=$(mktemp -u)
+FIXTURE_DIRS+=("$cb_worktree")
+git -C "$cb_primary" worktree add -q "$cb_worktree" -b "canary/ls-b"
+# Intentionally do NOT push canary/ls-b to origin.
+printf 'status: landed\n' > "$cb_worktree/.landed"
+expect_script_exit \
+  "ls-remote Case B (rc=2 → absent): success, skipping delete" \
+  0 \
+  "Remote branch canary/ls-b already absent — skipping delete." \
+  bash -c "cd \"$cb_primary\" && bash \"$SCRIPT\" \"$cb_worktree\""
+
+# Case C — origin URL points at a path that does not exist, ls-remote
+# rc=128 → loud failure. Confirm sentinel path genuinely absent before we
+# rely on it for the rc=128 repro.
+cc_sentinel="/nonexistent/bare-repo-canary"
+if [ -e "$cc_sentinel" ]; then
+  fail "ls-remote Case C precondition: $cc_sentinel unexpectedly exists — rc=128 repro unreliable"
+else
+  cc_primary=$(setup_fixture_repo)
+  cc_origin=$(setup_bare_origin)
+  git -C "$cc_primary" remote add origin "$cc_origin"
+  git -C "$cc_primary" push -q origin HEAD:refs/heads/main
+  cc_worktree=$(mktemp -u)
+  FIXTURE_DIRS+=("$cc_worktree")
+  git -C "$cc_primary" worktree add -q "$cc_worktree" -b "canary/ls-c"
+  printf 'status: landed\n' > "$cc_worktree/.landed"
+  # Overwrite origin URL to nonexistent path AFTER all setup so the
+  # push to main above still worked. Now ls-remote will fail with 128.
+  git -C "$cc_primary" remote set-url origin "file://$cc_sentinel"
+  expect_script_exit \
+    "ls-remote Case C (rc=128 → unreachable): loud failure" \
+    1 \
+    "ERROR: git ls-remote for canary/ls-c failed with exit 128 — origin unreachable, misconfigured, or auth failure" \
+    bash -c "cd \"$cc_primary\" && bash \"$SCRIPT\" \"$cc_worktree\""
+fi
+
+section "land-phase.sh: /tmp test-output dir cleanup (1 case)"
+# Rationale: commit 66d9138 extended land-phase.sh to remove
+# /tmp/zskills-tests/<basename-of-worktree>/ on successful landing. Lock
+# this in so a future edit can't silently regress it.
+tc_primary=$(setup_fixture_repo)
+tc_origin=$(setup_bare_origin)
+git -C "$tc_primary" remote add origin "$tc_origin"
+git -C "$tc_primary" push -q origin HEAD:refs/heads/main
+tc_worktree=$(mktemp -u)
+FIXTURE_DIRS+=("$tc_worktree")
+git -C "$tc_primary" worktree add -q "$tc_worktree" -b "canary/tmp-clean"
+git -C "$tc_worktree" push -q origin canary/tmp-clean
+printf 'status: landed\n' > "$tc_worktree/.landed"
+tc_tmpdir="/tmp/zskills-tests/$(basename "$tc_worktree")"
+mkdir -p "$tc_tmpdir"
+touch "$tc_tmpdir/.canary-sentinel"
+tc_out=$(cd "$tc_primary" && bash "$SCRIPT" "$tc_worktree" 2>&1); tc_rc=$?
+if [ "$tc_rc" -eq 0 ] && [ ! -d "$tc_tmpdir" ]; then
+  pass "/tmp test-output dir cleanup: rc=0 and $tc_tmpdir removed"
+else
+  fail "/tmp test-output dir cleanup — rc=$tc_rc (want 0); dir still present? [ -d \"$tc_tmpdir\" ]=$([ -d "$tc_tmpdir" ] && echo yes || echo no); output: $tc_out"
+fi
+
 echo
 echo "Canary failure-injection: $PASS_COUNT passed, $FAIL_COUNT failed"
 exit $((FAIL_COUNT > 0))


### PR DESCRIPTION
## Plan: Canary Failure Injection — Phase 2 of 5

Lock in scripts/land-phase.sh loud-failure behavior. 10 new tests:

- **Dirty worktree refused (1)** — script aborts rc=1 with exact error substring.
- **Tracked ephemeral rejected (4 + guard)** — each of `.test-results.txt`,
  `.test-baseline.txt`, `.worktreepurpose`, `.zskills-tracked` triggers
  a specific error if committed; array-drift guard confirms the script's
  EPHEMERAL_FILES list matches the plan's list.
- **ls-remote exit code handling (3)** — rc=0 deletes, rc=2 skips with
  log, rc=128 (origin unreachable) fails loudly (no silent skip).
- **/tmp test-output dir cleanup (1)** — locks in `66d9138`
  (EPHEMERAL_TO_TMP Phase 3) behavior: `/tmp/zskills-tests/<basename>`
  is removed on successful landing.

### Verification

- `/verify-changes worktree` PASS (Scope Assessment clean).
- Local: `Overall: 263/263 passed, 0 failed` (baseline 253 + 10 new).
- No hygiene leaks.

**Report:** `reports/plan-canary-failure-injection.md`.

---
Generated by `/run-plan plans/CANARY_FAILURE_INJECTION.md 2 auto pr`.