### PR TITLE
[canary-failure-injection] Phase 4: block-agents.sh reproducers

### DIFF
--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 3/5 | Phase 3 pending PR landing (feat/canary-failure-injection) |
+| [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 4/5 | Phase 4 pending PR landing (feat/canary-failure-injection) |
 | [plan-ephemeral-to-tmp.md](reports/plan-ephemeral-to-tmp.md) | 4/4 | **Complete** — all phases landed |
 | [plan-canary10-pr-mode.md](reports/plan-canary10-pr-mode.md) | 2 | Landed |
 | [plan-canary7-chunked-finish.md](reports/plan-canary7-chunked-finish.md) | 2 | Landed |

--- a/plans/CANARY_FAILURE_INJECTION.md
+++ b/plans/CANARY_FAILURE_INJECTION.md
@@ -77,7 +77,7 @@ which now includes the previous phase's changes.
 | 1 — Scaffold + block-unsafe-generic.sh stash | ✅ Done | `cace895` | 18 tests (6+7+5) |
 | 2 — land-phase.sh | ✅ Done | `e78a224` | 10 tests (1+4+3+1+guard) |
 | 3 — post-run-invariants.sh | ✅ Done | `a922e27` | 13 tests (1+1+2+2+2+2+3) |
-| 4 — block-agents.sh | 🟡 In Progress | | |
+| 4 — block-agents.sh | ✅ Done | `2eba026` | 12 tests (1+6+1+1+2+1) |
 | 5 — /commit reviewer + Phase 7 | ⬚ | | |
 
 ## Shared conventions (all phases)

--- a/plans/CANARY_FAILURE_INJECTION.md
+++ b/plans/CANARY_FAILURE_INJECTION.md
@@ -77,7 +77,7 @@ which now includes the previous phase's changes.
 | 1 — Scaffold + block-unsafe-generic.sh stash | ✅ Done | `cace895` | 18 tests (6+7+5) |
 | 2 — land-phase.sh | ✅ Done | `e78a224` | 10 tests (1+4+3+1+guard) |
 | 3 — post-run-invariants.sh | ✅ Done | `a922e27` | 13 tests (1+1+2+2+2+2+3) |
-| 4 — block-agents.sh | ⬚ | | |
+| 4 — block-agents.sh | 🟡 In Progress | | |
 | 5 — /commit reviewer + Phase 7 | ⬚ | | |
 
 ## Shared conventions (all phases)

--- a/reports/plan-canary-failure-injection.md
+++ b/reports/plan-canary-failure-injection.md
@@ -1,5 +1,56 @@
 # Plan Report — Canary Failure Injection
 
+## Phase — 4 block-agents.sh reproducers [UNFINALIZED]
+
+**Plan:** `plans/CANARY_FAILURE_INJECTION.md`
+**Status:** Completed (verified), pending PR landing
+**Worktree:** `/tmp/zskills-pr-canary-failure-injection`
+**Branch:** `feat/canary-failure-injection`
+**Commits:** `2eba026` (impl + tests + fixtures), `dc566ce` (tracker 🟡)
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | `section "block-agents: family filter rejects synthetic (1 case)"` | Done | `2eba026` |
+| 2 | `section "block-agents: ordinal comparison (6 cases)"` — haiku/sonnet/opus × min/dispatch | Done | `2eba026` |
+| 3 | `section "block-agents: unknown family passes through (1 case)"` | Done | `2eba026` |
+| 4 | `section "block-agents: auto fallback to Sonnet (1 case)"` — locks in CURRENT behavior | Done | `2eba026` |
+| 5 | `section "block-agents: auto success path (2 cases)"` | Done | `2eba026` |
+| 6 | `section "block-agents: min_model not configured (1 case)"` | Done | `2eba026` |
+| 7 | `tests/fixtures/canary/transcript-synthetic.jsonl` (Opus + `<synthetic>`) | Done | `2eba026` |
+| 8 | `tests/fixtures/canary/transcript-opus.jsonl` (Opus only) | Done | `2eba026` |
+
+### Verification
+
+- `/verify-changes worktree` — **PASS**. Scope Assessment clean.
+- Canary suite: `Canary failure-injection: 53 passed, 0 failed` (baseline 41 + 12 new).
+- Full aggregator: `Overall: 288/288 passed, 0 failed` (baseline 276 + 12 new).
+- CWD-robust (scaffold fix from Phase 3 confirmed working).
+- Hygiene: `.worktreepurpose` / `.zskills-tracked` untracked; only the 3 in-scope paths staged.
+
+### Acceptance Criteria
+
+- [x] 6 sections present, 12 tests total.
+- [x] Each test overrides `REPO_ROOT` per-test — never reads live canary config.
+- [x] 2 transcript fixtures committed with correct content.
+- [x] Auto Sonnet-fallback test locks in CURRENT behavior (not a prescription).
+- [x] `bash tests/test-canary-failures.sh` → 53 passed, 0 failed.
+- [x] `bash tests/run-all.sh` → 288/288.
+
+### Deviations from Plan
+
+Verifier noted: plan's inline AC prose at line 370 of the verbatim phase text says "52 tests passing (40 + 12)". The actual pre-Phase-4 canary count was 41 (Phase 2 added a +1 guard test). 41 + 12 = 53, which matches the parent's primary AC and the suite output. Plan prose drift, not a Phase 4 defect; noted for downstream phases that cite cumulative counts.
+
+Cumulative plan-wide count adjustment (running total):
+- Phase 1: 18
+- Phase 2: 27 (9 + array-drift guard pass)
+- Phase 3: 40
+- Phase 4: 52 → **53**
+- Final expected after Phase 5: plan says 78/68; actual will be 79/69 (+1 from Phase 2's guard, still tracking).
+
+---
+
 ## Phase — 3 post-run-invariants.sh reproducers
 
 **Plan:** `plans/CANARY_FAILURE_INJECTION.md`

--- a/reports/plan-canary-failure-injection.md
+++ b/reports/plan-canary-failure-injection.md
@@ -1,6 +1,6 @@
 # Plan Report — Canary Failure Injection
 
-## Phase — 4 block-agents.sh reproducers [UNFINALIZED]
+## Phase — 4 block-agents.sh reproducers
 
 **Plan:** `plans/CANARY_FAILURE_INJECTION.md`
 **Status:** Completed (verified), pending PR landing

--- a/tests/fixtures/canary/transcript-opus.jsonl
+++ b/tests/fixtures/canary/transcript-opus.jsonl
@@ -1,0 +1,1 @@
+{"model":"claude-opus-4-6"}

--- a/tests/fixtures/canary/transcript-synthetic.jsonl
+++ b/tests/fixtures/canary/transcript-synthetic.jsonl
@@ -1,0 +1,2 @@
+{"model":"claude-opus-4-6"}
+{"model":"<synthetic>"}

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -453,6 +453,153 @@ else
   fail "invariant #7 Case C — rc=$i7c_rc (want 0); squash-divergence WARN present? out: $i7c_out"
 fi
 
+# ---------------------------------------------------------------------------
+# Phase 4 — block-agents.sh.template reproducers
+# ---------------------------------------------------------------------------
+# The hook reads $REPO_ROOT/.claude/zskills-config.json; each test overrides
+# REPO_ROOT to a per-test fixture dir so it reads the fixture config rather
+# than the live one. AGENTS_HOOK is set once (from the enclosing script's
+# $REPO_ROOT) to keep the two REPO_ROOTs visually distinct.
+AGENTS_HOOK="$REPO_ROOT/hooks/block-agents.sh.template"
+
+expect_agent_deny_substring() {
+  local label="$1" input_json="$2" want="$3" repo_root="$4"
+  local result
+  result=$(REPO_ROOT="$repo_root" bash "$AGENTS_HOOK" <<<"$input_json" 2>/dev/null) || true
+  if [[ "$result" == *'"permissionDecision":"deny"'* && "$result" == *"$want"* ]]; then
+    pass "$label"
+  else
+    fail "$label — want deny with '$want', got: $result"
+  fi
+}
+
+expect_agent_allow() {
+  local label="$1" input_json="$2" repo_root="$3"
+  local result
+  result=$(REPO_ROOT="$repo_root" bash "$AGENTS_HOOK" <<<"$input_json" 2>/dev/null) || true
+  if [[ -z "$result" ]]; then
+    pass "$label"
+  else
+    fail "$label — expected empty stdout, got: $result"
+  fi
+}
+
+setup_agent_config() {
+  # $1 = json string (config body); $2 = tmp repo_root
+  local json="$1" root="$2"
+  mkdir -p "$root/.claude"
+  printf '%s' "$json" > "$root/.claude/zskills-config.json"
+}
+
+build_agent_input() {
+  # $1 model, $2 transcript_path (may be empty string)
+  MODEL="$1" TPATH="$2" python3 -c '
+import json, os
+d = {"tool_name": "Agent",
+     "tool_input": {"subagent_type": "Explore", "model": os.environ["MODEL"]},
+     "transcript_path": os.environ.get("TPATH", "")}
+print(json.dumps(d))'
+}
+
+section "block-agents: family filter rejects synthetic (1 case)"
+# Transcript contains Opus then <synthetic>; the hook filters to
+# haiku/sonnet/opus only, so the effective floor resolves to Opus. A Sonnet
+# dispatch must be denied.
+a1_root=$(mktemp -d)
+FIXTURE_DIRS+=("$a1_root")
+setup_agent_config '{"agents":{"min_model":"auto"}}' "$a1_root"
+a1_input=$(build_agent_input "claude-sonnet-4-6" "$FIXTURES/transcript-synthetic.jsonl")
+expect_agent_deny_substring \
+  "family filter: <synthetic> skipped, Opus floor enforced against Sonnet dispatch" \
+  "$a1_input" \
+  "agents.min_model requires claude-opus-4-6 or higher" \
+  "$a1_root"
+
+section "block-agents: ordinal comparison (6 cases)"
+# Each case: fresh tmp REPO_ROOT with explicit min_model (not auto), no
+# transcript needed. Matrix covers haiku/sonnet/opus × allow/deny.
+for pair in \
+  "claude-haiku-4-5|claude-haiku-4-5-20251001|allow|" \
+  "claude-haiku-4-5|claude-sonnet-4-6|allow|" \
+  "claude-sonnet-4-6|claude-haiku-4-5-20251001|deny|agents.min_model requires" \
+  "claude-sonnet-4-6|claude-sonnet-4-6|allow|" \
+  "claude-opus-4-6|claude-sonnet-4-6|deny|agents.min_model requires" \
+  "claude-opus-4-6|claude-opus-4-6|allow|"; do
+  IFS='|' read -r min_model dispatch expected want <<<"$pair"
+  o_root=$(mktemp -d)
+  FIXTURE_DIRS+=("$o_root")
+  setup_agent_config "{\"agents\":{\"min_model\":\"$min_model\"}}" "$o_root"
+  o_input=$(build_agent_input "$dispatch" "")
+  if [ "$expected" = "allow" ]; then
+    expect_agent_allow "ordinal: min=$min_model dispatch=$dispatch → allow" "$o_input" "$o_root"
+  else
+    expect_agent_deny_substring \
+      "ordinal: min=$min_model dispatch=$dispatch → deny" \
+      "$o_input" "$want" "$o_root"
+  fi
+done
+
+section "block-agents: unknown family passes through (1 case)"
+# claude-foo-99 has no haiku/sonnet/opus substring → ordinal=0 → always allow.
+# Locks in the intentional "future-model escape valve".
+a3_root=$(mktemp -d)
+FIXTURE_DIRS+=("$a3_root")
+setup_agent_config '{"agents":{"min_model":"claude-sonnet-4-6"}}' "$a3_root"
+a3_input=$(build_agent_input "claude-foo-99" "")
+expect_agent_allow \
+  "unknown family: claude-foo-99 passes through (future-model escape valve)" \
+  "$a3_input" \
+  "$a3_root"
+
+section "block-agents: auto fallback to Sonnet (1 case)"
+# Locks in CURRENT behavior at hooks/block-agents.sh.template:68-69: when
+# 'auto' resolution fails (no transcript), the hook falls back to a Sonnet
+# floor. If the fallback is ever intentionally changed (e.g. fail-closed to
+# Opus), this test MUST be updated in the same PR — treat as a design
+# decision with its own review.
+a4_root=$(mktemp -d)
+FIXTURE_DIRS+=("$a4_root")
+setup_agent_config '{"agents":{"min_model":"auto"}}' "$a4_root"
+a4_input=$(build_agent_input "claude-haiku-4-5-20251001" "")
+expect_agent_deny_substring \
+  "auto fallback: no transcript → Sonnet floor denies Haiku dispatch" \
+  "$a4_input" \
+  "agents.min_model requires claude-sonnet-4-6 or higher" \
+  "$a4_root"
+
+section "block-agents: auto success path (2 cases)"
+# Transcript has Opus — resolution succeeds to Opus floor.
+a5_root=$(mktemp -d)
+FIXTURE_DIRS+=("$a5_root")
+setup_agent_config '{"agents":{"min_model":"auto"}}' "$a5_root"
+a5a_input=$(build_agent_input "claude-opus-4-6" "$FIXTURES/transcript-opus.jsonl")
+expect_agent_allow \
+  "auto success: Opus transcript, Opus dispatch → allow" \
+  "$a5a_input" \
+  "$a5_root"
+
+a5b_root=$(mktemp -d)
+FIXTURE_DIRS+=("$a5b_root")
+setup_agent_config '{"agents":{"min_model":"auto"}}' "$a5b_root"
+a5b_input=$(build_agent_input "claude-sonnet-4-6" "$FIXTURES/transcript-opus.jsonl")
+expect_agent_deny_substring \
+  "auto success: Opus transcript, Sonnet dispatch → deny" \
+  "$a5b_input" \
+  "agents.min_model requires claude-opus-4-6 or higher" \
+  "$a5b_root"
+
+section "block-agents: min_model not configured (1 case)"
+# Config file present but 'agents' object has no min_model key → pass-through
+# per hooks/block-agents.sh.template:36-38.
+a6_root=$(mktemp -d)
+FIXTURE_DIRS+=("$a6_root")
+setup_agent_config '{"agents":{}}' "$a6_root"
+a6_input=$(build_agent_input "claude-haiku-4-5-20251001" "")
+expect_agent_allow \
+  "min_model unset: pass-through regardless of dispatch model" \
+  "$a6_input" \
+  "$a6_root"
+
 echo
 echo "Canary failure-injection: $PASS_COUNT passed, $FAIL_COUNT failed"
 exit $((FAIL_COUNT > 0))


### PR DESCRIPTION
## Plan: Canary Failure Injection — Phase 4 of 5

Lock in `hooks/block-agents.sh.template` min_model enforcement. 12 new tests:

- **Family filter rejects synthetic** (1) — filter skips `<synthetic>` and resolves to last-Opus entry.
- **Ordinal comparison** (6) — haiku/sonnet/opus × min/dispatch matrix.
- **Unknown family pass-through** (1) — future-model escape valve (ordinal 0 always allows).
- **Auto fallback to Sonnet** (1) — **locks in CURRENT behavior** (hooks/block-agents.sh.template:68-69). If the fallback direction ever changes, update this test in the SAME PR.
- **Auto success path** (2) — transcript-opus.jsonl fixture; Opus allow + Sonnet deny.
- **Min_model not configured** (1) — pass-through when no config key.

### Fixture transcripts (committed)

- `tests/fixtures/canary/transcript-synthetic.jsonl` (Opus + synthetic)
- `tests/fixtures/canary/transcript-opus.jsonl` (Opus only)

### Verification

- `/verify-changes worktree` PASS. Scope Assessment clean.
- Canary: 53 passed. Full: 288/288 passed (baseline 276 + 12 new).

**Report:** `reports/plan-canary-failure-injection.md`.

---
Generated by `/run-plan plans/CANARY_FAILURE_INJECTION.md 4 auto pr`.