### PR TITLE
fix: 2 canary-flagged silent-failure risks (invariant #6 scope + .landed atomic-write helper)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -367,13 +367,12 @@ This is for landing worktree work onto main via cherry-pick.
 6. **Write `.landed` marker** on the worktree (so `/fix-report` knows
    it's safe to remove):
    ```bash
-   cat > "<worktree-path>/.landed.tmp" <<LANDED
+   cat <<LANDED | bash scripts/write-landed.sh "<worktree-path>"
    status: full
    date: $(TZ=America/New_York date -Iseconds)
    source: commit-land
    commits: <list of cherry-picked hashes>
    LANDED
-   mv "<worktree-path>/.landed.tmp" "<worktree-path>/.landed"
    ```
 
 7. **Verify:**

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -1020,18 +1020,17 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
         ```
      b. Write `.landed` marker (atomic):
         ```bash
-        cat > "<worktree>/.landed.tmp" <<LANDED
+        cat <<LANDED | bash scripts/write-landed.sh "<worktree>"
         status: full
         date: $(TZ=America/New_York date -Iseconds)
         source: fix-issues
         commits:
           <list of cherry-picked commit hashes and messages>
         LANDED
-        mv "<worktree>/.landed.tmp" "<worktree>/.landed"
         ```
      c. For tiers that were SKIPPED (conflict), write partial marker:
         ```bash
-        cat > "<worktree>/.landed.tmp" <<LANDED
+        cat <<LANDED | bash scripts/write-landed.sh "<worktree>"
         status: partial
         date: $(TZ=America/New_York date -Iseconds)
         source: fix-issues
@@ -1039,7 +1038,6 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
         skipped: <hashes that conflicted>
         reason: cherry-pick conflict
         LANDED
-        mv "<worktree>/.landed.tmp" "<worktree>/.landed"
         ```
   6. **Commit extracted logs:**
      ```bash
@@ -1116,7 +1114,7 @@ if [ $? -ne 0 ]; then
     git rebase --abort
   fi
   echo "REBASE CONFLICT for issue #$ISSUE_NUM."
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: conflict
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
@@ -1125,7 +1123,6 @@ branch: $BRANCH_NAME
 issue: $ISSUE_NUM
 reason: rebase-conflict
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
   continue  # Move to next issue
 fi
 if [ "$(git rev-parse HEAD)" != "$PRE_REBASE" ]; then
@@ -1189,7 +1186,7 @@ EOF
   # If PR creation failed, write pr-failed marker and continue.
   if [ -z "$PR_URL" ]; then
     echo "WARNING: PR creation failed for issue #$ISSUE_NUM. Branch pushed but PR not created."
-    cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: pr-failed
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
@@ -1199,7 +1196,6 @@ issue: $ISSUE_NUM
 pr:
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-    mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
     continue
   fi
 
@@ -1222,7 +1218,7 @@ LANDED
 
   # --- .landed marker (per issue) ---
   # $LANDED_STATUS, $CI_STATUS, $PR_STATE come from the CI/auto-merge block.
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: $LANDED_STATUS
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
@@ -1234,7 +1230,6 @@ pr_state: $PR_STATE
 issue: $ISSUE_NUM
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
   echo "Issue #$ISSUE_NUM -> PR: $PR_URL (status: $LANDED_STATUS)"
 
@@ -1390,14 +1385,13 @@ Do NOT invoke for:
 crashes, or times out, the ORCHESTRATOR (not the failed agent) writes a
 failure marker on the worktree:
 ```bash
-cat > "<worktree>/.landed.tmp" <<LANDED
+cat <<LANDED | bash scripts/write-landed.sh "<worktree>"
 status: failed
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
 issues: <issue numbers attempted>
 reason: <agent returned no commits / agent crashed / tests failed>
 LANDED
-mv "<worktree>/.landed.tmp" "<worktree>/.landed"
 ```
 This ensures `/fix-report` can distinguish failed worktrees from active
 ones. The issues stay open for the next sprint.

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1619,14 +1619,13 @@ Before ANY cherry-pick to main, verify ALL of these. If any fails, STOP.
   5. **Mark worktree as landed:**
      Write `.landed` marker (atomic: `.tmp` → `mv`):
      ```bash
-     cat > "<worktree-path>/.landed.tmp" <<LANDED
+     cat <<LANDED | bash scripts/write-landed.sh "<worktree-path>"
      status: landed
      date: $(TZ=America/New_York date -Iseconds)
      source: run-plan
      phase: <phase name>
      commits: <list of cherry-picked hashes>
      LANDED
-     mv "<worktree-path>/.landed.tmp" "<worktree-path>/.landed"
      ```
   6. **Run `scripts/land-phase.sh`** — atomic post-landing cleanup:
      ```bash
@@ -1714,7 +1713,7 @@ if [ $? -ne 0 ]; then
     git rebase --abort
   fi
 
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: conflict
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -1725,7 +1724,6 @@ reason: rebase-conflict-between-phases
 conflict_files: $CONFLICT_FILES
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
   # CLEAR communication: tell the user exactly what happened and how to resume.
   echo ""
@@ -1788,7 +1786,7 @@ if [ $? -ne 0 ]; then
     git rebase --abort
   fi
 
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: conflict
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -1798,7 +1796,6 @@ reason: rebase-conflict-before-push
 conflict_files: $CONFLICT_FILES
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
   echo ""
   echo "=========================================="
@@ -1906,7 +1903,7 @@ fi
 if [ -z "$PR_URL" ]; then
   echo "WARNING: PR creation failed. Branch pushed but PR not created."
   echo "Manual fallback: gh pr create --base main --head $BRANCH_NAME"
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: pr-failed
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -1915,7 +1912,6 @@ branch: $BRANCH_NAME
 pr:
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
   # Report and stop -- PR creation failed
 fi
 ```
@@ -2204,7 +2200,7 @@ else
 fi
 
 # --- Upgrade .landed marker ---
-cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: $LANDED_STATUS
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -2215,7 +2211,6 @@ ci: $CI_STATUS
 pr_state: $PR_STATE
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
 # --- Cleanup on merge ---
 # When PR was merged (status: landed), call land-phase.sh to remove the worktree.

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -300,12 +300,16 @@ Look in `.claude/hooks/` for these 2 files:
 
 ### Step 4 — Check scripts
 
-Look in `scripts/` for these 4 files:
+Look in `scripts/` for these files (all required by installed skills):
 
 - `port.sh`
 - `test-all.sh`
 - `briefing.cjs` OR `briefing.py` (either counts — Node or Python version)
 - `clear-tracking.sh`
+- `land-phase.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for atomic post-landing cleanup
+- `post-run-invariants.sh` — referenced by `/run-plan` as mandatory end-of-run gate (7 invariants)
+- `write-landed.sh` — referenced by `/run-plan`, `/fix-issues`, `/commit` for rc-checked atomic `.landed` marker writes
+- `statusline.sh` — session statusline helper (optional but should be installed if the user has it)
 
 ### Step 5 — Check skills with additional requirements
 

--- a/scripts/post-run-invariants.sh
+++ b/scripts/post-run-invariants.sh
@@ -107,11 +107,15 @@ if [ -n "$PLAN_SLUG" ]; then
   fi
 fi
 
-# 6. No 🟡 In Progress rows linger in the tracker
+# 6. No 🟡 In Progress rows linger in the tracker.
+# Scoped to markdown table rows (lines starting with '|'). Bare whole-file
+# grep false-positives on prose, Drift Log sections, and code-fence
+# examples that mention the sentinel character — the invariant's real
+# concern is the Progress Tracker table, which is always pipe-delimited.
 if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
-  if grep -q '🟡' "$PLAN_FILE"; then
+  if grep -qE '^\|.*🟡' "$PLAN_FILE"; then
     echo "INVARIANT-FAIL (#6): plan $PLAN_FILE still has 🟡 In Progress rows after run" >&2
-    grep -n '🟡' "$PLAN_FILE" >&2
+    grep -nE '^\|.*🟡' "$PLAN_FILE" >&2
     INVARIANT_FAILED=1
   fi
 fi

--- a/scripts/write-landed.sh
+++ b/scripts/write-landed.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# scripts/write-landed.sh — atomic .landed marker write with rc checks.
+#
+# Replaces the ad-hoc `cat > .landed.tmp <<EOF ... EOF ; mv .landed.tmp .landed`
+# pattern that appeared at 12 sites across skills/. The ad-hoc pattern silently
+# wrote empty / partial markers when `cat` failed (disk full, permission
+# denied, heredoc parse error) — and the follow-on `mv` succeeded moving the
+# broken file, so downstream readers got a corrupt or empty .landed.
+#
+# Usage:
+#   cat <<LANDED | bash scripts/write-landed.sh <worktree-path>
+#   status: landed
+#   date: ...
+#   ...
+#   LANDED
+#
+# Arg: <worktree-path>   — must be an existing directory
+# Stdin:                 — the marker body (any content)
+# Writes: <worktree-path>/.landed (atomic via .tmp + mv)
+# Exits:
+#   0  — wrote both .tmp and renamed .landed successfully
+#   1  — missing/empty arg, worktree doesn't exist, cat failed, or mv failed
+#
+# On any failure, the .tmp is removed (best-effort) and the error is written
+# to stderr — callers get loud exit-1 instead of silent success with broken
+# marker.
+
+set -u
+
+WORKTREE="${1:-}"
+
+if [ -z "$WORKTREE" ]; then
+  echo "ERROR: write-landed.sh requires a worktree-path arg" >&2
+  echo "  Usage: cat <body> | bash write-landed.sh <worktree-path>" >&2
+  exit 1
+fi
+
+if [ ! -d "$WORKTREE" ]; then
+  echo "ERROR: write-landed.sh: worktree path does not exist: $WORKTREE" >&2
+  exit 1
+fi
+
+TMP="$WORKTREE/.landed.tmp"
+FINAL="$WORKTREE/.landed"
+
+# Read stdin into .tmp. If cat fails (disk full, permission denied,
+# read-only FS), rm the partial .tmp and exit loudly.
+if ! cat > "$TMP"; then
+  echo "ERROR: write-landed.sh: failed to write $TMP (disk full? read-only FS? permissions?)" >&2
+  rm -f "$TMP"
+  exit 1
+fi
+
+# Atomic rename. If mv fails (cross-device, permission, etc.), the stale
+# .landed at $FINAL remains whatever it was — the caller sees a loud
+# error and can decide whether to retry, inspect, or escalate.
+if ! mv "$TMP" "$FINAL"; then
+  echo "ERROR: write-landed.sh: failed to rename $TMP to $FINAL" >&2
+  echo "  If $FINAL exists, it is NOT the new marker — retry or inspect manually." >&2
+  rm -f "$TMP"
+  exit 1
+fi
+
+exit 0

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -367,13 +367,12 @@ This is for landing worktree work onto main via cherry-pick.
 6. **Write `.landed` marker** on the worktree (so `/fix-report` knows
    it's safe to remove):
    ```bash
-   cat > "<worktree-path>/.landed.tmp" <<LANDED
+   cat <<LANDED | bash scripts/write-landed.sh "<worktree-path>"
    status: full
    date: $(TZ=America/New_York date -Iseconds)
    source: commit-land
    commits: <list of cherry-picked hashes>
    LANDED
-   mv "<worktree-path>/.landed.tmp" "<worktree-path>/.landed"
    ```
 
 7. **Verify:**

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -1020,18 +1020,17 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
         ```
      b. Write `.landed` marker (atomic):
         ```bash
-        cat > "<worktree>/.landed.tmp" <<LANDED
+        cat <<LANDED | bash scripts/write-landed.sh "<worktree>"
         status: full
         date: $(TZ=America/New_York date -Iseconds)
         source: fix-issues
         commits:
           <list of cherry-picked commit hashes and messages>
         LANDED
-        mv "<worktree>/.landed.tmp" "<worktree>/.landed"
         ```
      c. For tiers that were SKIPPED (conflict), write partial marker:
         ```bash
-        cat > "<worktree>/.landed.tmp" <<LANDED
+        cat <<LANDED | bash scripts/write-landed.sh "<worktree>"
         status: partial
         date: $(TZ=America/New_York date -Iseconds)
         source: fix-issues
@@ -1039,7 +1038,6 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
         skipped: <hashes that conflicted>
         reason: cherry-pick conflict
         LANDED
-        mv "<worktree>/.landed.tmp" "<worktree>/.landed"
         ```
   6. **Commit extracted logs:**
      ```bash
@@ -1116,7 +1114,7 @@ if [ $? -ne 0 ]; then
     git rebase --abort
   fi
   echo "REBASE CONFLICT for issue #$ISSUE_NUM."
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: conflict
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
@@ -1125,7 +1123,6 @@ branch: $BRANCH_NAME
 issue: $ISSUE_NUM
 reason: rebase-conflict
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
   continue  # Move to next issue
 fi
 if [ "$(git rev-parse HEAD)" != "$PRE_REBASE" ]; then
@@ -1189,7 +1186,7 @@ EOF
   # If PR creation failed, write pr-failed marker and continue.
   if [ -z "$PR_URL" ]; then
     echo "WARNING: PR creation failed for issue #$ISSUE_NUM. Branch pushed but PR not created."
-    cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: pr-failed
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
@@ -1199,7 +1196,6 @@ issue: $ISSUE_NUM
 pr:
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-    mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
     continue
   fi
 
@@ -1222,7 +1218,7 @@ LANDED
 
   # --- .landed marker (per issue) ---
   # $LANDED_STATUS, $CI_STATUS, $PR_STATE come from the CI/auto-merge block.
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: $LANDED_STATUS
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
@@ -1234,7 +1230,6 @@ pr_state: $PR_STATE
 issue: $ISSUE_NUM
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
   echo "Issue #$ISSUE_NUM -> PR: $PR_URL (status: $LANDED_STATUS)"
 
@@ -1390,14 +1385,13 @@ Do NOT invoke for:
 crashes, or times out, the ORCHESTRATOR (not the failed agent) writes a
 failure marker on the worktree:
 ```bash
-cat > "<worktree>/.landed.tmp" <<LANDED
+cat <<LANDED | bash scripts/write-landed.sh "<worktree>"
 status: failed
 date: $(TZ=America/New_York date -Iseconds)
 source: fix-issues
 issues: <issue numbers attempted>
 reason: <agent returned no commits / agent crashed / tests failed>
 LANDED
-mv "<worktree>/.landed.tmp" "<worktree>/.landed"
 ```
 This ensures `/fix-report` can distinguish failed worktrees from active
 ones. The issues stay open for the next sprint.

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1619,14 +1619,13 @@ Before ANY cherry-pick to main, verify ALL of these. If any fails, STOP.
   5. **Mark worktree as landed:**
      Write `.landed` marker (atomic: `.tmp` → `mv`):
      ```bash
-     cat > "<worktree-path>/.landed.tmp" <<LANDED
+     cat <<LANDED | bash scripts/write-landed.sh "<worktree-path>"
      status: landed
      date: $(TZ=America/New_York date -Iseconds)
      source: run-plan
      phase: <phase name>
      commits: <list of cherry-picked hashes>
      LANDED
-     mv "<worktree-path>/.landed.tmp" "<worktree-path>/.landed"
      ```
   6. **Run `scripts/land-phase.sh`** — atomic post-landing cleanup:
      ```bash
@@ -1714,7 +1713,7 @@ if [ $? -ne 0 ]; then
     git rebase --abort
   fi
 
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: conflict
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -1725,7 +1724,6 @@ reason: rebase-conflict-between-phases
 conflict_files: $CONFLICT_FILES
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
   # CLEAR communication: tell the user exactly what happened and how to resume.
   echo ""
@@ -1788,7 +1786,7 @@ if [ $? -ne 0 ]; then
     git rebase --abort
   fi
 
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: conflict
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -1798,7 +1796,6 @@ reason: rebase-conflict-before-push
 conflict_files: $CONFLICT_FILES
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
   echo ""
   echo "=========================================="
@@ -1906,7 +1903,7 @@ fi
 if [ -z "$PR_URL" ]; then
   echo "WARNING: PR creation failed. Branch pushed but PR not created."
   echo "Manual fallback: gh pr create --base main --head $BRANCH_NAME"
-  cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: pr-failed
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -1915,7 +1912,6 @@ branch: $BRANCH_NAME
 pr:
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-  mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
   # Report and stop -- PR creation failed
 fi
 ```
@@ -2204,7 +2200,7 @@ else
 fi
 
 # --- Upgrade .landed marker ---
-cat > "$WORKTREE_PATH/.landed.tmp" <<LANDED
+cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
 status: $LANDED_STATUS
 date: $(TZ=America/New_York date -Iseconds)
 source: run-plan
@@ -2215,7 +2211,6 @@ ci: $CI_STATUS
 pr_state: $PR_STATE
 commits: $(git log main.."$BRANCH_NAME" --format='%h' | tr '\n' ' ')
 LANDED
-mv "$WORKTREE_PATH/.landed.tmp" "$WORKTREE_PATH/.landed"
 
 # --- Cleanup on merge ---
 # When PR was merged (status: landed), call land-phase.sh to remove the worktree.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -300,12 +300,16 @@ Look in `.claude/hooks/` for these 2 files:
 
 ### Step 4 — Check scripts
 
-Look in `scripts/` for these 4 files:
+Look in `scripts/` for these files (all required by installed skills):
 
 - `port.sh`
 - `test-all.sh`
 - `briefing.cjs` OR `briefing.py` (either counts — Node or Python version)
 - `clear-tracking.sh`
+- `land-phase.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for atomic post-landing cleanup
+- `post-run-invariants.sh` — referenced by `/run-plan` as mandatory end-of-run gate (7 invariants)
+- `write-landed.sh` — referenced by `/run-plan`, `/fix-issues`, `/commit` for rc-checked atomic `.landed` marker writes
+- `statusline.sh` — session statusline helper (optional but should be installed if the user has it)
 
 ### Step 5 — Check skills with additional requirements
 

--- a/tests/fixtures/canary/plan-prose-sentinel.md
+++ b/tests/fixtures/canary/plan-prose-sentinel.md
@@ -1,0 +1,37 @@
+<!--
+  FIXTURE — NOT A REAL PLAN.
+
+  This file contains the yellow-circle emoji (U+1F7E1) in PROSE only
+  (never in a markdown table row starting with '|'). The fixture tests
+  that scripts/post-run-invariants.sh invariant #6 does NOT false-positive
+  on prose mentions of the sentinel after the row-scoped grep fix.
+
+  If invariant #6 ever regresses to whole-file grep, this fixture will
+  fire #6 and the canary regression test will fail.
+-->
+
+# Prose-Sentinel Fixture
+
+## Overview
+
+This plan discusses the in-progress sentinel — the 🟡 emoji — extensively
+in prose. For instance, the Progress Tracker uses 🟡 to mark a phase
+that is currently running. Drift Log entries may also reference 🟡 when
+explaining historical phase transitions.
+
+## Progress Tracker
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| 1 — Example | ✅ Done | `abc1234` | all clean |
+| 2 — Example | ⬚ | | |
+
+## Drift Log
+
+The phase progression from ⬚ to 🟡 to ✅ tracks:
+- ⬚: not started
+- 🟡: in progress (mid-execution)
+- ✅: done (landed)
+
+This prose must NOT trigger invariant #6 because the table rows above
+only contain ✅ and ⬚ — no 🟡 in any row.

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -374,21 +374,22 @@ else
   fail "invariant #5 negative — rc=$i5b_rc (want 0); '#5' absent? out: $i5b_out"
 fi
 
-section "Invariant #6: in-progress sentinel in plan (2 cases)"
+section "Invariant #6: in-progress sentinel in plan (3 cases)"
 # Fixture files are committed to the repo (tests/fixtures/canary/). Pass
 # the path through --plan-file; invariant #6 reads only that file.
 i6_fire_plan="$REPO_ROOT/tests/fixtures/canary/plan-with-sentinel.md"
 i6_negative_plan="$REPO_ROOT/tests/fixtures/canary/plan-without-sentinel.md"
+i6_prose_plan="$REPO_ROOT/tests/fixtures/canary/plan-prose-sentinel.md"
 
-# Fire case: fixture contains the in-progress sentinel.
+# Fire case: fixture has 🟡 in a markdown table row.
 i6a_primary=$(setup_fixture_repo)
 expect_script_exit \
-  "invariant #6 fire: plan contains in-progress sentinel" \
+  "invariant #6 fire: plan has sentinel in a table row" \
   1 \
   "INVARIANT-FAIL (#6):" \
   bash -c "cd \"$i6a_primary\" && bash \"$INVARIANTS_SCRIPT\" --worktree \"\" --branch \"\" --landed-status \"\" --plan-slug \"\" --plan-file \"$i6_fire_plan\""
 
-# Negative case: fixture has no sentinel — must not fire #6.
+# Negative case A: clean plan (no sentinel anywhere) — must not fire #6.
 i6b_primary=$(setup_fixture_repo)
 i6b_out=$(cd "$i6b_primary" && bash "$INVARIANTS_SCRIPT" \
   --worktree "" --branch "" --landed-status "" --plan-slug "" \
@@ -397,6 +398,20 @@ if [ "$i6b_rc" -eq 0 ] && [[ "$i6b_out" != *"INVARIANT-FAIL (#6):"* ]]; then
   pass "invariant #6 negative: clean plan, no #6 failure"
 else
   fail "invariant #6 negative — rc=$i6b_rc (want 0); '#6' absent? out: $i6b_out"
+fi
+
+# Negative case B (regression guard for row-scoped grep): plan mentions
+# the sentinel in PROSE only — table rows are all ✅/⬚. Must NOT fire
+# #6. If invariant #6 ever regresses to whole-file grep, this test
+# fails loudly.
+i6c_primary=$(setup_fixture_repo)
+i6c_out=$(cd "$i6c_primary" && bash "$INVARIANTS_SCRIPT" \
+  --worktree "" --branch "" --landed-status "" --plan-slug "" \
+  --plan-file "$i6_prose_plan" 2>&1); i6c_rc=$?
+if [ "$i6c_rc" -eq 0 ] && [[ "$i6c_out" != *"INVARIANT-FAIL (#6):"* ]]; then
+  pass "invariant #6 prose-regression: sentinel in prose only, no #6 failure"
+else
+  fail "invariant #6 prose-regression — rc=$i6c_rc (want 0); '#6' absent? out: $i6c_out"
 fi
 
 section "Invariant #7: main divergence WARN (3 cases)"

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -138,6 +138,44 @@ expect_allow 'heredoc containing git stash -u' "$(printf 'cat <<EOF\ngit stash -
 # every invocation subshell-cd's into the fixture's primary repo first.
 SCRIPT="$REPO_ROOT/scripts/land-phase.sh"
 
+section "write-landed.sh: rc-checked atomic marker writes (3 cases)"
+# Locks in the rc-check behavior introduced with scripts/write-landed.sh.
+# The ad-hoc cat+mv pattern this helper replaces silently wrote empty/
+# partial markers on disk-full / read-only failures; the helper catches
+# those via `if ! cat ...` and `if ! mv ...` with loud stderr + rc=1.
+
+WRITE_LANDED="$REPO_ROOT/scripts/write-landed.sh"
+
+# Case 1: happy path — cat body into helper, .landed ends up with correct content.
+wl_primary=$(setup_fixture_repo)
+wl_worktree=$(mktemp -u)
+FIXTURE_DIRS+=("$wl_worktree")
+git -C "$wl_primary" worktree add -q "$wl_worktree" -b canary/wl-happy
+if printf 'status: landed\ndate: now\n' | bash "$WRITE_LANDED" "$wl_worktree" \
+   && [ -f "$wl_worktree/.landed" ] \
+   && grep -qxF 'status: landed' "$wl_worktree/.landed" \
+   && [ ! -f "$wl_worktree/.landed.tmp" ]; then
+  pass "write-landed.sh happy path: .landed written, .tmp cleaned"
+else
+  fail "write-landed.sh happy path — .landed content or .tmp-cleanup wrong"
+fi
+
+# Case 2: missing/bad worktree arg — exit 1 with specific error.
+wl_bad_out=$(printf 'status: landed\n' | bash "$WRITE_LANDED" 2>&1); wl_bad_rc=$?
+if [ "$wl_bad_rc" -eq 1 ] && [[ "$wl_bad_out" == *"requires a worktree-path arg"* ]]; then
+  pass "write-landed.sh missing arg: rc=1 with usage error"
+else
+  fail "write-landed.sh missing arg — rc=$wl_bad_rc; out: $wl_bad_out"
+fi
+
+# Case 3: worktree path doesn't exist — exit 1 with specific error.
+wl_nx_out=$(printf 'status: landed\n' | bash "$WRITE_LANDED" /tmp/write-landed-nx-$$-canary 2>&1); wl_nx_rc=$?
+if [ "$wl_nx_rc" -eq 1 ] && [[ "$wl_nx_out" == *"worktree path does not exist"* ]]; then
+  pass "write-landed.sh nonexistent path: rc=1 with path error"
+else
+  fail "write-landed.sh nonexistent path — rc=$wl_nx_rc; out: $wl_nx_out"
+fi
+
 section "land-phase.sh: dirty worktree refused (1 case)"
 dirty_primary=$(setup_fixture_repo)
 dirty_worktree=$(mktemp -u)


### PR DESCRIPTION
Addresses 2 of the 5 follow-up issues documented in the CANARY_FAILURE_INJECTION plan. The small ones — earned now.

## Fix 1 — Invariant #6 grep scope (commit `4804165`)

`scripts/post-run-invariants.sh` previously did whole-file `grep -q 🟡` on the plan file. False-positives on:
- prose mentions of the sentinel
- Drift Log entries
- code-fence examples describing tracker format

Change to `grep -qE '^\|.*🟡'` — only markdown table rows (which always start with `|`). Add fixture `plan-prose-sentinel.md` + regression test so any future revert to whole-file grep fails the canary loudly.

Canary: 79 → 80 tests.

## Fix 2 — `.landed` atomic-write helper (commit `32781c9`)

Replace 12 ad-hoc `cat > .landed.tmp <<LANDED ... LANDED ; mv ...` sites across `skills/{run-plan,fix-issues,commit}/SKILL.md` with a single rc-checked helper `scripts/write-landed.sh`.

Silent-failure mode closed: when `cat` fails (disk full, read-only FS, permission denied) the ad-hoc pattern wrote empty/partial markers; `mv` then succeeded moving the broken file. Helper's `if ! cat ...` + `if ! mv ...` now fails loudly with rc=1.

**Bonus gap closed:** `skills/update-zskills/SKILL.md` script-list expanded from 4 entries (port.sh, test-all.sh, briefing.{cjs,py}, clear-tracking.sh) to include the critical but previously-unlisted: `write-landed.sh`, `land-phase.sh`, `post-run-invariants.sh`, `statusline.sh`. External users running `/update-zskills` now get all required scripts — without this, skills fail at runtime with "no such file or directory."

Canary: 80 → 83 tests.

## Verification

- `bash tests/run-all.sh` → **318/318 passed, 0 failed** (baseline 314 + 4 new).
- Canary suite standalone: **83 passed, 0 failed**.

---
Generated post-CANARY_FAILURE_INJECTION follow-up.