### PR TITLE
[fix-pr-state-rate-limit] Phase 2: Invariant #8 + canary tests

### DIFF
--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-fix-pr-state-rate-limit.md](reports/plan-fix-pr-state-rate-limit.md) | 2/2 | Phase 2 landing via PR — plan completing |
+| [plan-fix-pr-state-rate-limit.md](reports/plan-fix-pr-state-rate-limit.md) | 2/2 | **Complete** — both phases landed via PR (#27, this PR) |
 | [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 5/5 | **Complete** — 79 tests, 314/314 on main (pending this PR) |
 | [plan-ephemeral-to-tmp.md](reports/plan-ephemeral-to-tmp.md) | 4/4 | **Complete** — all phases landed |
 | [plan-canary10-pr-mode.md](reports/plan-canary10-pr-mode.md) | 2 | Landed |

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-fix-pr-state-rate-limit.md](reports/plan-fix-pr-state-rate-limit.md) | 1/2 | Phase 1 landed via PR — Phase 2 pending |
+| [plan-fix-pr-state-rate-limit.md](reports/plan-fix-pr-state-rate-limit.md) | 2/2 | Phase 2 landing via PR — plan completing |
 | [plan-canary-failure-injection.md](reports/plan-canary-failure-injection.md) | 5/5 | **Complete** — 79 tests, 314/314 on main (pending this PR) |
 | [plan-ephemeral-to-tmp.md](reports/plan-ephemeral-to-tmp.md) | 4/4 | **Complete** — all phases landed |
 | [plan-canary10-pr-mode.md](reports/plan-canary10-pr-mode.md) | 2 | Landed |

--- a/plans/FIX_PR_STATE_RATE_LIMIT.md
+++ b/plans/FIX_PR_STATE_RATE_LIMIT.md
@@ -40,7 +40,7 @@ when the ambiguous state is recorded.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Retry + pr-state-unknown at call sites | ✅ | `3679056` | landed via PR (squashed on main) |
-| 2 — Invariant #8 + canary tests | ⬚ | | |
+| 2 — Invariant #8 + canary tests | 🟡 | | |
 
 ## Shared Conventions
 

--- a/plans/FIX_PR_STATE_RATE_LIMIT.md
+++ b/plans/FIX_PR_STATE_RATE_LIMIT.md
@@ -2,7 +2,7 @@
 issue: 26
 title: Fix gh pr view Rate-Limit Silent Default to OPEN (zombie feature branches)
 created: 2026-04-17
-status: active
+status: complete
 ---
 
 # Plan: Fix gh pr view Rate-Limit Silent Default to OPEN

--- a/plans/FIX_PR_STATE_RATE_LIMIT.md
+++ b/plans/FIX_PR_STATE_RATE_LIMIT.md
@@ -40,7 +40,7 @@ when the ambiguous state is recorded.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Retry + pr-state-unknown at call sites | ✅ | `3679056` | landed via PR (squashed on main) |
-| 2 — Invariant #8 + canary tests | 🟡 | | |
+| 2 — Invariant #8 + canary tests | ✅ | `7073075` | landed via PR (squashed on main) |
 
 ## Shared Conventions
 

--- a/reports/plan-fix-pr-state-rate-limit.md
+++ b/reports/plan-fix-pr-state-rate-limit.md
@@ -3,6 +3,33 @@
 Issue: [#26](https://github.com/zeveck/zskills-dev/issues/26)
 Plan: `plans/FIX_PR_STATE_RATE_LIMIT.md`
 
+## Phase — 2 Invariant #8 + canary tests [UNFINALIZED]
+
+**Plan:** plans/FIX_PR_STATE_RATE_LIMIT.md
+**Status:** Completed (verified, awaiting landing)
+**Worktree:** /tmp/zskills-pr-fix-pr-state-rate-limit
+**Branch:** feat/fix-pr-state-rate-limit
+**Commits:** 7073075 (feat), 0e1a97f (tracker → in progress)
+
+### Work Items
+| # | Item | Status | Evidence |
+|---|------|--------|----------|
+| 1 | `scripts/post-run-invariants.sh` invariant #8 block (lines 123-130) | Done | 7073075 |
+| 2 | `tests/test-canary-failures.sh` 3-case section (lines 509-562) | Done | 7073075 |
+
+### Verification
+- Content match: `^status: pr-state-unknown$` anchored grep, `[ -n "$WORKTREE_PATH" ]` guard, `INVARIANT_FAILED=1` set, stderr echo present.
+- Placement: FAIL-before-WARN ordering confirmed (`grep -nE 'INVARIANT-(FAIL|WARN)'` shows FAIL 1,2,3,4,5,6,**8** then WARN 7). `grep -cE 'INVARIANT-FAIL.*#[0-9]'` = 7 (correct — #7 is WARN).
+- Canary section: 3 cases cover fire-on-pr-state-unknown (Case 1), silent-on-pr-ready (Case 2, asserts substring absence — #1 co-fires by design), silent-on-missing-.landed (Case 3, `mktemp -u` so #1 also stays silent, rc=0 clean).
+- Bonus: anchored regex correctly rejects `status: pr-state-unknown-extra` (verifier hand-test).
+- Test suite: 321/321 pass (baseline 318 + 3 new). Zero regression.
+
+### User Sign-off
+
+*(None — non-UI phase; no user verification required.)*
+
+---
+
 ## Phase — 1 Retry + pr-state-unknown at call sites
 
 **Plan:** plans/FIX_PR_STATE_RATE_LIMIT.md

--- a/reports/plan-fix-pr-state-rate-limit.md
+++ b/reports/plan-fix-pr-state-rate-limit.md
@@ -3,10 +3,10 @@
 Issue: [#26](https://github.com/zeveck/zskills-dev/issues/26)
 Plan: `plans/FIX_PR_STATE_RATE_LIMIT.md`
 
-## Phase — 2 Invariant #8 + canary tests [UNFINALIZED]
+## Phase — 2 Invariant #8 + canary tests
 
 **Plan:** plans/FIX_PR_STATE_RATE_LIMIT.md
-**Status:** Completed (verified, awaiting landing)
+**Status:** Completed (verified, landed via PR squash)
 **Worktree:** /tmp/zskills-pr-fix-pr-state-rate-limit
 **Branch:** feat/fix-pr-state-rate-limit
 **Commits:** 7073075 (feat), 0e1a97f (tracker → in progress)

--- a/scripts/post-run-invariants.sh
+++ b/scripts/post-run-invariants.sh
@@ -120,6 +120,15 @@ if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
   fi
 fi
 
+# #8: .landed recorded an UNKNOWN PR state (gh pr view rate-limited)
+# — manual reconciliation required.
+if [ -n "$WORKTREE_PATH" ] && [ -f "$WORKTREE_PATH/.landed" ]; then
+  if grep -q '^status: pr-state-unknown$' "$WORKTREE_PATH/.landed"; then
+    INVARIANT_FAILED=1
+    echo "INVARIANT-FAIL (#8): $WORKTREE_PATH/.landed has status: pr-state-unknown — gh pr view could not verify; manual reconciliation required" >&2
+  fi
+fi
+
 # 7. Local main reconcilable with origin/main — WARN not FAIL
 # Users may have legitimate unpushed work on local main; we don't reject,
 # but we surface it clearly so squash-merge divergence doesn't accumulate

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -506,6 +506,64 @@ else
   fail "invariant #7 Case C — rc=$i7c_rc (want 0); squash-divergence WARN present? out: $i7c_out"
 fi
 
+section "post-run-invariants.sh: #8 pr-state-unknown (3 cases)"
+# Invariant #8 fires when a worktree's .landed recorded an UNKNOWN PR state
+# (gh pr view rate-limited during land-phase). Contract string with Phase 1's
+# writer: anchored '^status: pr-state-unknown$'. The guard
+# [ -f "$WORKTREE_PATH/.landed" ] short-circuits when no marker exists.
+#
+# Isolation note: invariant #1 fires whenever WORKTREE_PATH points at an
+# existing directory. #8's tests necessarily set WORKTREE_PATH to a dir
+# that contains (or could contain) a .landed file, so #1 co-fires in
+# Cases 1 & 2. We assert ONLY the #8 substring presence/absence — not
+# overall rc — because #1 is out-of-scope for this section and has its
+# own dedicated canary above.
+
+# Case 1 — fire: .landed with status: pr-state-unknown → #8 in stderr, rc=1.
+# #1 also fires (worktree dir exists); rc=1 either way, substring check is
+# the load-bearing assertion.
+i8a_primary=$(setup_fixture_repo)
+i8a_worktree=$(mktemp -d /tmp/canary-phase2-inv8-1.XXXXXX)
+FIXTURE_DIRS+=("$i8a_worktree")
+printf 'status: pr-state-unknown\n' > "$i8a_worktree/.landed"
+expect_script_exit \
+  "invariant #8 fire: .landed has status: pr-state-unknown" \
+  1 \
+  "INVARIANT-FAIL (#8): $i8a_worktree/.landed has status: pr-state-unknown" \
+  bash -c "cd \"$i8a_primary\" && bash \"$INVARIANTS_SCRIPT\" --worktree \"$i8a_worktree\" --branch \"\" --landed-status \"\" --plan-slug \"\" --plan-file \"\""
+
+# Case 2 — silent on pr-ready: .landed present but status differs → no #8
+# (assert absence of #8 substring regardless of overall rc; #1 fires and
+# is expected to, being out-of-scope here).
+i8b_primary=$(setup_fixture_repo)
+i8b_worktree=$(mktemp -d /tmp/canary-phase2-inv8-2.XXXXXX)
+FIXTURE_DIRS+=("$i8b_worktree")
+printf 'status: pr-ready\n' > "$i8b_worktree/.landed"
+i8b_out=$(cd "$i8b_primary" && bash "$INVARIANTS_SCRIPT" \
+  --worktree "$i8b_worktree" --branch "" --landed-status pr-ready \
+  --plan-slug "" --plan-file "" 2>&1) || true
+if [[ "$i8b_out" != *"INVARIANT-FAIL (#8):"* ]]; then
+  pass "invariant #8 negative: pr-ready .landed does not fire #8"
+else
+  fail "invariant #8 negative (pr-ready) — '#8' unexpectedly present in: $i8b_out"
+fi
+
+# Case 3 — silent on no .landed: guard [ -f ... ] short-circuits → no #8.
+# Use mktemp -u so the worktree dir does NOT exist — then #1 also stays
+# quiet and we can additionally assert rc=0 to prove the guard, not some
+# unrelated fire, caused the silence.
+i8c_primary=$(setup_fixture_repo)
+i8c_worktree=$(mktemp -u /tmp/canary-phase2-inv8-3.XXXXXX)
+# No FIXTURE_DIRS entry — nothing was created. No .landed either.
+i8c_out=$(cd "$i8c_primary" && bash "$INVARIANTS_SCRIPT" \
+  --worktree "$i8c_worktree" --branch "" --landed-status "" \
+  --plan-slug "" --plan-file "" 2>&1); i8c_rc=$?
+if [ "$i8c_rc" -eq 0 ] && [[ "$i8c_out" != *"INVARIANT-FAIL (#8):"* ]]; then
+  pass "invariant #8 negative: no .landed, guard short-circuits, no #8"
+else
+  fail "invariant #8 negative (no .landed) — rc=$i8c_rc (want 0); '#8' absent? out: $i8c_out"
+fi
+
 # ---------------------------------------------------------------------------
 # Phase 4 — block-agents.sh.template reproducers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Plan: Fix gh pr view Rate-Limit Silent Default to OPEN (COMPLETES PLAN)

Adds `INVARIANT-FAIL (#8)` to `scripts/post-run-invariants.sh` — the mechanical gate that FAILs a run when `.landed` has `status: pr-state-unknown`. This closes the silent-failure cascade that Phase 1 introduced the sentinel for: if `gh pr view` rate-limits 3 times in a row during auto-merge verification, Phase 1 now writes the sentinel; this phase now makes the post-run invariant suite trip on it instead of only WARN-ing on the downstream symptom (local main divergence).

**Canary coverage** (3 new cases, suite now 321/321):
- Case 1: fires on `pr-state-unknown` (rc=1, `INVARIANT-FAIL (#8)` in stderr)
- Case 2: silent on `pr-ready` (no `#8` in stderr, even though other invariants may co-fire by design)
- Case 3: silent on missing `.landed` (guard short-circuits; rc=0)

**Placement**: invariant #8 sits between FAIL #6 and WARN #7 — preserves FAIL→WARN ordering of the script.

**Phases completed:**
- Phase 1 — Retry + pr-state-unknown at call sites (PR #27, landed 2026-04-17)
- Phase 2 — Invariant #8 + canary tests (this PR)

**Plan status:** `complete` (frontmatter flipped in `3eec75a`).

**Report:** `reports/plan-fix-pr-state-rate-limit.md`
**Tests:** 321/321 pass (baseline 318, +3 new).

---
Generated by `/run-plan plans/FIX_PR_STATE_RATE_LIMIT.md auto pr`