### PR TITLE
[parallel-canaryb] Parallel Pipeline Canary B — concurrent run validation

### DIFF
--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -11,6 +11,7 @@ No items currently awaiting sign-off.
 | Report | Phases | Status |
 |--------|--------|--------|
 | [plan-parallel-canarya.md](reports/plan-parallel-canarya.md) | 1/1 | **Complete** — concurrent-pipeline in-vivo canary (pending this PR) |
+| [plan-parallel-canaryb.md](reports/plan-parallel-canaryb.md) | 1/1 | Landing via PR (this run) — concurrent with canary-A |
 | [plan-unify-tracking-names.md](reports/plan-unify-tracking-names.md) | 6/6 | **Complete** — all phases landed via PR squash |
 | [plan-fix-worktree-poisoned-branch.md](reports/plan-fix-worktree-poisoned-branch.md) | 2/2 | **Complete** — both phases landed via PR squash |
 | [plan-fix-pr-state-rate-limit.md](reports/plan-fix-pr-state-rate-limit.md) | 2/2 | **Complete** — both phases landed via PR (#27, this PR) |

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -11,7 +11,7 @@ No items currently awaiting sign-off.
 | Report | Phases | Status |
 |--------|--------|--------|
 | [plan-parallel-canarya.md](reports/plan-parallel-canarya.md) | 1/1 | **Complete** — concurrent-pipeline in-vivo canary (pending this PR) |
-| [plan-parallel-canaryb.md](reports/plan-parallel-canaryb.md) | 1/1 | Landing via PR (this run) — concurrent with canary-A |
+| [plan-parallel-canaryb.md](reports/plan-parallel-canaryb.md) | 1/1 | **Complete** — concurrent-pipeline in-vivo canary (pending this PR) |
 | [plan-unify-tracking-names.md](reports/plan-unify-tracking-names.md) | 6/6 | **Complete** — all phases landed via PR squash |
 | [plan-fix-worktree-poisoned-branch.md](reports/plan-fix-worktree-poisoned-branch.md) | 2/2 | **Complete** — both phases landed via PR squash |
 | [plan-fix-pr-state-rate-limit.md](reports/plan-fix-pr-state-rate-limit.md) | 2/2 | **Complete** — both phases landed via PR (#27, this PR) |

--- a/docs/canary-parallel-B.md
+++ b/docs/canary-parallel-B.md
@@ -1,0 +1,9 @@
+# Parallel Pipeline Canary B
+
+Marker file from PARALLEL_CANARYB.
+
+This file validates that two concurrent `/run-plan` sessions
+operating on the same repository complete without tracking-marker
+cross-pollination, worktree collisions, or branch collisions.
+
+Companion: docs/canary-parallel-A.md (written by PARALLEL_CANARYA).

--- a/plans/PARALLEL_CANARYB.md
+++ b/plans/PARALLEL_CANARYB.md
@@ -29,7 +29,7 @@ alone):
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Create canary-B.md | 🟡 In Progress | `53c62e2` | One file, baseline tests preserved |
+| 1 — Create canary-B.md | ✅ Done | `9c53e92` | One file, baseline tests preserved; landed via PR alongside concurrent PARALLEL_CANARYA |
 
 ## Phase 1 — Create docs/canary-parallel-B.md
 

--- a/plans/PARALLEL_CANARYB.md
+++ b/plans/PARALLEL_CANARYB.md
@@ -29,7 +29,7 @@ alone):
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Create canary-B.md | ⬚ | | |
+| 1 — Create canary-B.md | 🟡 In Progress | `53c62e2` | One file, baseline tests preserved |
 
 ## Phase 1 — Create docs/canary-parallel-B.md
 

--- a/plans/PARALLEL_CANARYB.md
+++ b/plans/PARALLEL_CANARYB.md
@@ -1,7 +1,7 @@
 ---
 title: Parallel Pipeline Canary B
 created: 2026-04-18
-status: active
+status: complete
 ---
 
 # Plan: Parallel Pipeline Canary B

--- a/reports/plan-parallel-canaryb.md
+++ b/reports/plan-parallel-canaryb.md
@@ -1,0 +1,28 @@
+# Plan Report — Parallel Pipeline Canary B
+
+## Phase — 1 Create docs/canary-parallel-B.md [UNFINALIZED]
+
+**Plan:** plans/PARALLEL_CANARYB.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-parallel-canaryb
+**Branch:** feat/parallel-canaryb
+**Commits:** 53c62e2 (impl), b4d0504 (tracker → In Progress)
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Create docs/canary-parallel-B.md | Done | 53c62e2 |
+
+### Verification
+- Acceptance: `test -f docs/canary-parallel-B.md` → pass
+- Acceptance: first line is `# Parallel Pipeline Canary B` → pass
+- Tests: `bash tests/test-hooks.sh` → 183/183 passed, 0 failed (byte-identical to baseline)
+- Tests: `bash tests/run-all.sh` → 364/364 passed
+- Scope: `git diff --name-only main..HEAD` returned exactly `docs/canary-parallel-B.md` (plus tracker bookkeeping commits)
+- Scope-violation flag: none raised by verification agent
+
+### Parallel-pipeline validation notes
+- Pipeline ID: `run-plan.parallel-canaryb`
+- Sibling pipeline `run-plan.parallel-canarya` ran concurrently in `/tmp/zskills-pr-parallel-canarya`.
+- No shared files. No branch collision (`feat/parallel-canaryb` vs `feat/parallel-canarya`).
+- Tracking markers live only under `.zskills/tracking/run-plan.parallel-canaryb/`.

--- a/reports/plan-parallel-canaryb.md
+++ b/reports/plan-parallel-canaryb.md
@@ -1,12 +1,13 @@
 # Plan Report — Parallel Pipeline Canary B
 
-## Phase — 1 Create docs/canary-parallel-B.md [UNFINALIZED]
+## Phase — 1 Create docs/canary-parallel-B.md
 
 **Plan:** plans/PARALLEL_CANARYB.md
-**Status:** Completed (verified)
+**Status:** Completed (verified, landed via PR)
 **Worktree:** /tmp/zskills-pr-parallel-canaryb
 **Branch:** feat/parallel-canaryb
-**Commits:** 53c62e2 (impl), b4d0504 (tracker → In Progress)
+**Commits (post-rebase):** 9c53e92 (impl), 7675985 (tracker → In Progress), 7fd41c0 (plan report), d839c65 (mark plan complete)
+**Post-rebase note:** Branch rebased onto origin/main after sibling PARALLEL_CANARYA landed first; PLAN_REPORT.md merge conflict resolved by preserving both canary entries. Post-rebase re-verification: 183/183 tests passed, diff narrow to 4 expected files.
 
 ### Work Items
 | # | Item | Status | Commit |


### PR DESCRIPTION
## Plan: Parallel Pipeline Canary B

Minimal single-phase plan — adds `docs/canary-parallel-B.md`. Run concurrently
with `plans/PARALLEL_CANARYA.md` as an in-vivo validation of parallel
`/run-plan` pipelines on the same repository.

**Phases completed:**
- Phase 1 — Create `docs/canary-parallel-B.md` (commit `9c53e92`)

**Concurrent-pipeline observations:**
- Sibling pipeline PARALLEL_CANARYA landed first while this pipeline was running.
- `git rebase origin/main` on `feat/parallel-canaryb` produced a `PLAN_REPORT.md`
  conflict (both pipelines prepended table rows). Resolved by preserving both
  canary entries.
- No shared code files, no branch collision, no cross-contamination in
  `.zskills/tracking/run-plan.parallel-canary-{a,b}/` subdirs.
- Post-rebase re-verification: 183/183 tests passed.

**Report:** See `reports/plan-parallel-canaryb.md`.

---
Generated by `/run-plan plans/PARALLEL_CANARYB.md auto pr`.