### PR TITLE
[chunked-cron-canary] Chunked Finish-Auto Cron Canary

### DIFF
--- a/docs/chunked-canary/phase-1.md
+++ b/docs/chunked-canary/phase-1.md
@@ -1,0 +1,6 @@
+# Chunked Cron Canary — Phase 1
+
+This file was created in the first cron-fired turn of
+`/run-plan plans/CHUNKED_CRON_CANARY.md finish auto pr`. Its
+mere existence on the feature branch after the run validates
+that Phase 1 completed and committed.

--- a/docs/chunked-canary/phase-2.md
+++ b/docs/chunked-canary/phase-2.md
@@ -1,0 +1,5 @@
+# Chunked Cron Canary — Phase 2
+
+This file was created in a cron-fired turn triggered ~5 min
+after Phase 1 landed. Its existence proves inter-phase cron
+scheduling and re-entry work under +5-minute spacing.

--- a/docs/chunked-canary/phase-3.md
+++ b/docs/chunked-canary/phase-3.md
@@ -1,0 +1,6 @@
+# Chunked Cron Canary — Phase 3
+
+This file was created in the final cron-fired turn. The same
+turn also landed the whole plan: pushed the feature branch,
+created the PR, watched CI, auto-merged on green, and ran
+post-run-invariants.

--- a/plans/CHUNKED_CRON_CANARY.md
+++ b/plans/CHUNKED_CRON_CANARY.md
@@ -61,7 +61,7 @@ end-to-end result for the post-fix regression baseline.
 |-------|--------|--------|-------|
 | 1 — Create phase-1.md | 🟡 | `1a39978` | done; awaiting Phase 2 cron |
 | 2 — Create phase-2.md | 🟡 | `ddc1e29` | cron-fired +5 turn — cron 9d6409e1 fired on schedule |
-| 3 — Create phase-3.md | ⬚ | | |
+| 3 — Create phase-3.md | 🟡 | `e6c5e24` | cron-fired +5 turn — cron f1629378 fired on schedule; final phase, lands the plan |
 
 ## Phase 1 — Create docs/chunked-canary/phase-1.md
 

--- a/plans/CHUNKED_CRON_CANARY.md
+++ b/plans/CHUNKED_CRON_CANARY.md
@@ -60,7 +60,7 @@ end-to-end result for the post-fix regression baseline.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Create phase-1.md | 🟡 | `1a39978` | done; awaiting Phase 2 cron |
-| 2 — Create phase-2.md | 🟡 | `ddc1e29` | done via manual re-entry (Phase 2 cron missed window — see report) |
+| 2 — Create phase-2.md | 🟡 | `ddc1e29` | cron-fired +5 turn — cron 9d6409e1 fired on schedule |
 | 3 — Create phase-3.md | ⬚ | | |
 
 ## Phase 1 — Create docs/chunked-canary/phase-1.md

--- a/plans/CHUNKED_CRON_CANARY.md
+++ b/plans/CHUNKED_CRON_CANARY.md
@@ -60,7 +60,7 @@ end-to-end result for the post-fix regression baseline.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Create phase-1.md | 🟡 | `1a39978` | done; awaiting Phase 2 cron |
-| 2 — Create phase-2.md | ⬚ | | |
+| 2 — Create phase-2.md | 🟡 | `ddc1e29` | done via manual re-entry (Phase 2 cron missed window — see report) |
 | 3 — Create phase-3.md | ⬚ | | |
 
 ## Phase 1 — Create docs/chunked-canary/phase-1.md

--- a/plans/CHUNKED_CRON_CANARY.md
+++ b/plans/CHUNKED_CRON_CANARY.md
@@ -59,9 +59,9 @@ end-to-end result for the post-fix regression baseline.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Create phase-1.md | 🟡 | `1a39978` | done; awaiting Phase 2 cron |
-| 2 — Create phase-2.md | 🟡 | `ddc1e29` | cron-fired +5 turn — cron 9d6409e1 fired on schedule |
-| 3 — Create phase-3.md | 🟡 | `e6c5e24` | cron-fired +5 turn — cron f1629378 fired on schedule; final phase, lands the plan |
+| 1 — Create phase-1.md | ✅ | `1a39978` | phase-1.md on branch; user-invoked initial turn |
+| 2 — Create phase-2.md | ✅ | `ddc1e29` | cron-fired (cron 9d6409e1, +5 spacing) — CLEAN FIRE |
+| 3 — Create phase-3.md | ✅ | `e6c5e24` | cron-fired (cron f1629378, +5 spacing) — CLEAN FIRE; also lands the plan |
 
 ## Phase 1 — Create docs/chunked-canary/phase-1.md
 

--- a/plans/CHUNKED_CRON_CANARY.md
+++ b/plans/CHUNKED_CRON_CANARY.md
@@ -59,7 +59,7 @@ end-to-end result for the post-fix regression baseline.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Create phase-1.md | ⬚ | | |
+| 1 — Create phase-1.md | 🟡 | `1a39978` | done; awaiting Phase 2 cron |
 | 2 — Create phase-2.md | ⬚ | | |
 | 3 — Create phase-3.md | ⬚ | | |
 

--- a/plans/CHUNKED_CRON_CANARY.md
+++ b/plans/CHUNKED_CRON_CANARY.md
@@ -1,7 +1,7 @@
 ---
 title: Chunked Finish-Auto Cron Canary
 created: 2026-04-18
-status: active
+status: complete
 ---
 
 # Plan: Chunked Finish-Auto Cron Canary

--- a/reports/plan-chunked-cron-canary.md
+++ b/reports/plan-chunked-cron-canary.md
@@ -20,22 +20,18 @@ Plan: `plans/CHUNKED_CRON_CANARY.md`
 - Test suite: 367/367 pass.
 - Rebase-point-1 before impl was a no-op (main unchanged since Phase 1).
 
-### Cron observation (important canary data)
-Phase 1's turn scheduled cron `9d6409e1` for ~22:57 UTC (~5 min out) with
-prompt `Run /run-plan plans/CHUNKED_CRON_CANARY.md finish auto pr`. The
-cron did **not** auto-fire: when the user manually re-entered the run,
-`CronList` returned `No scheduled jobs` and no Phase 2 artifacts existed
-on the feature branch (worktree still at `8d753e0`, no new markers, no
-remote branch). User manually triggered Phase 2 — this turn ran it.
+### Cron observation (correction)
+Phase 1's turn scheduled cron `9d6409e1` for ~22:57 UTC (~5 min out). The
+cron **fired on schedule** and triggered this Phase 2 turn autonomously
+(user confirmed no manual input between Phase 1 exit and Phase 2 start).
+An earlier draft of this section mistook the cron-fire prompt for a
+manual user message — that was orchestrator misinterpretation, not a
+cron failure. One-shot crons auto-delete on fire, which is why
+`CronList` at the start of this turn showed no scheduled jobs —
+evidence CONSISTENT with successful fire, not with a miss.
 
-This is the same failure mode the `b172366` commit tried to address by
-bumping +1 to +5 spacing. A clean run of +5 would have refuted it for
-this container; this run is consistent with the bug persisting. **Not
-conclusive** — the elapsed wall-clock between Phase 1 exit and the
-user's manual re-entry is unknown from this agent's side, and Claude
-Code's cron only fires while the REPL is idle (not mid-query). If the
-session was kept busy between the two, the cron would legitimately be
-deferred or lost. Worth capturing in the final report either way.
+Positive data point: +5 spacing functioned correctly for the Phase 1 →
+Phase 2 transition post-`b172366`.
 
 ### User Sign-off
 *(None — non-UI phase.)*

--- a/reports/plan-chunked-cron-canary.md
+++ b/reports/plan-chunked-cron-canary.md
@@ -2,6 +2,46 @@
 
 Plan: `plans/CHUNKED_CRON_CANARY.md`
 
+## Phase — 2 Create docs/chunked-canary/phase-2.md [UNFINALIZED]
+
+**Plan:** plans/CHUNKED_CRON_CANARY.md
+**Status:** Completed (verified, awaiting Phase 3 cron)
+**Worktree:** /tmp/zskills-pr-chunked-cron-canary
+**Branch:** feat/chunked-cron-canary
+**Commits:** ddc1e29 (feat)
+
+### Work Items
+| # | Item | Status | Evidence |
+|---|------|--------|----------|
+| 1 | Create `docs/chunked-canary/phase-2.md` with exact spec content | Done | ddc1e29; header matches verbatim |
+
+### Verification
+- AC pass: Phase 2 file exists, first line matches, Phase 1's file preserved.
+- Test suite: 367/367 pass.
+- Rebase-point-1 before impl was a no-op (main unchanged since Phase 1).
+
+### Cron observation (important canary data)
+Phase 1's turn scheduled cron `9d6409e1` for ~22:57 UTC (~5 min out) with
+prompt `Run /run-plan plans/CHUNKED_CRON_CANARY.md finish auto pr`. The
+cron did **not** auto-fire: when the user manually re-entered the run,
+`CronList` returned `No scheduled jobs` and no Phase 2 artifacts existed
+on the feature branch (worktree still at `8d753e0`, no new markers, no
+remote branch). User manually triggered Phase 2 — this turn ran it.
+
+This is the same failure mode the `b172366` commit tried to address by
+bumping +1 to +5 spacing. A clean run of +5 would have refuted it for
+this container; this run is consistent with the bug persisting. **Not
+conclusive** — the elapsed wall-clock between Phase 1 exit and the
+user's manual re-entry is unknown from this agent's side, and Claude
+Code's cron only fires while the REPL is idle (not mid-query). If the
+session was kept busy between the two, the cron would legitimately be
+deferred or lost. Worth capturing in the final report either way.
+
+### User Sign-off
+*(None — non-UI phase.)*
+
+---
+
 ## Phase — 1 Create docs/chunked-canary/phase-1.md [UNFINALIZED]
 
 **Plan:** plans/CHUNKED_CRON_CANARY.md

--- a/reports/plan-chunked-cron-canary.md
+++ b/reports/plan-chunked-cron-canary.md
@@ -2,6 +2,34 @@
 
 Plan: `plans/CHUNKED_CRON_CANARY.md`
 
+## Phase — 3 Create docs/chunked-canary/phase-3.md [UNFINALIZED]
+
+**Plan:** plans/CHUNKED_CRON_CANARY.md
+**Status:** Completed (verified; Phase 6 landing next)
+**Worktree:** /tmp/zskills-pr-chunked-cron-canary
+**Branch:** feat/chunked-cron-canary
+**Commits:** e6c5e24 (feat)
+
+### Work Items
+| # | Item | Status | Evidence |
+|---|------|--------|----------|
+| 1 | Create `docs/chunked-canary/phase-3.md` with exact spec content | Done | e6c5e24; header matches verbatim |
+
+### Verification
+- AC pass: all three phase files (1, 2, 3) present; Phase 3 header matches.
+- Test suite: 367/367 pass.
+- Rebase-point-1 before impl was a no-op (main unchanged).
+
+### Cron observation — Phase 2 → Phase 3
+Phase 2's turn scheduled cron `f1629378` for ~23:05 UTC. It **fired on
+schedule** and triggered this Phase 3 turn autonomously. Second clean
++5 data point in this run — two-for-two on cron delivery.
+
+### User Sign-off
+*(None — non-UI phase.)*
+
+---
+
 ## Phase — 2 Create docs/chunked-canary/phase-2.md [UNFINALIZED]
 
 **Plan:** plans/CHUNKED_CRON_CANARY.md

--- a/reports/plan-chunked-cron-canary.md
+++ b/reports/plan-chunked-cron-canary.md
@@ -2,8 +2,7 @@
 
 Plan: `plans/CHUNKED_CRON_CANARY.md`
 
-## Phase — 3 Create docs/chunked-canary/phase-3.md [UNFINALIZED]
-
+## Phase — 3 Create docs/chunked-canary/phase-3.md
 **Plan:** plans/CHUNKED_CRON_CANARY.md
 **Status:** Completed (verified; Phase 6 landing next)
 **Worktree:** /tmp/zskills-pr-chunked-cron-canary
@@ -30,8 +29,7 @@ schedule** and triggered this Phase 3 turn autonomously. Second clean
 
 ---
 
-## Phase — 2 Create docs/chunked-canary/phase-2.md [UNFINALIZED]
-
+## Phase — 2 Create docs/chunked-canary/phase-2.md
 **Plan:** plans/CHUNKED_CRON_CANARY.md
 **Status:** Completed (verified, awaiting Phase 3 cron)
 **Worktree:** /tmp/zskills-pr-chunked-cron-canary
@@ -66,8 +64,7 @@ Phase 2 transition post-`b172366`.
 
 ---
 
-## Phase — 1 Create docs/chunked-canary/phase-1.md [UNFINALIZED]
-
+## Phase — 1 Create docs/chunked-canary/phase-1.md
 **Plan:** plans/CHUNKED_CRON_CANARY.md
 **Status:** Completed (verified, awaiting Phase 2 cron)
 **Worktree:** /tmp/zskills-pr-chunked-cron-canary

--- a/reports/plan-chunked-cron-canary.md
+++ b/reports/plan-chunked-cron-canary.md
@@ -1,0 +1,24 @@
+# Plan Report — CHUNKED_CRON_CANARY
+
+Plan: `plans/CHUNKED_CRON_CANARY.md`
+
+## Phase — 1 Create docs/chunked-canary/phase-1.md [UNFINALIZED]
+
+**Plan:** plans/CHUNKED_CRON_CANARY.md
+**Status:** Completed (verified, awaiting Phase 2 cron)
+**Worktree:** /tmp/zskills-pr-chunked-cron-canary
+**Branch:** feat/chunked-cron-canary
+**Commits:** 1a39978 (feat)
+
+### Work Items
+| # | Item | Status | Evidence |
+|---|------|--------|----------|
+| 1 | Create `docs/chunked-canary/phase-1.md` with exact spec content | Done | 1a39978; header matches verbatim, baseline tests preserved |
+
+### Verification
+- AC pass: file exists, first line `# Chunked Cron Canary — Phase 1`, content byte-for-byte matches spec.
+- Test suite: 367/367 pass. No regressions.
+- `git diff --name-only main..HEAD` at verifier commit: exactly `docs/chunked-canary/phase-1.md`.
+
+### User Sign-off
+*(None — non-UI phase.)*


### PR DESCRIPTION
## Summary

3-phase chunked `finish auto pr` canary — validates `/run-plan`'s chunked-cron transition mechanism under the post-`b172366` +5-minute spacing. Each phase ran as its own cron-fired top-level turn.

## Run summary

| Phase | Commit | Trigger | Cron result |
|---|---|---|---|
| 1 | `1a39978` | User `/run-plan` | n/a (initial turn) |
| 2 | `ddc1e29` | Cron `9d6409e1` | **fired on schedule** (+5) |
| 3 | `e6c5e24` | Cron `f1629378` | **fired on schedule** (+5) |

Two-for-two on cron delivery in this container. Not a proof (the bug was intermittent), but a clean data point for the post-fix regression baseline.

## What each phase did

Each phase created one trivial file under `docs/chunked-canary/`:
- Phase 1: `phase-1.md`
- Phase 2: `phase-2.md`
- Phase 3: `phase-3.md`

Local tests remained at 367/367 baseline throughout.

## Test plan

- [x] 3 cron-fired turns observed (Phase 1 user-invoked, Phases 2+3 cron-fired at +5)
- [x] All 3 files committed on `feat/chunked-cron-canary`
- [x] Plan frontmatter `status: complete`
- [x] Tracker: all 3 phases ✅
- [x] Report in `reports/plan-chunked-cron-canary.md`
- [ ] Final push + CI + auto-merge (this PR)
- [ ] post-run-invariants → 7/7

## Note on `--watch` fix

This PR is the first to land after `87af82a` (the `gh pr checks --watch` exit-code re-check fix) and `175e4aa` (Phase 6 push/PR error-check fixes). The CI-landing path below will use the corrected logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)