### PR TITLE
[canary10-pr-mode] Canary 10 — PR Mode End-to-End

### DIFF
--- a/canary/canary10.txt
+++ b/canary/canary10.txt
@@ -1,1 +1,2 @@
 Canary 10 Phase 1: PR mode
+Canary 10 Phase 2: PR mode

--- a/canary/canary10.txt
+++ b/canary/canary10.txt
@@ -1,0 +1,1 @@
+Canary 10 Phase 1: PR mode

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -37,7 +37,7 @@ confirmed they're happy to run this manually.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 -- Create canary10 file | ⬚ | | PR-mode |
+| 1 -- Create canary10 file | ✅ Done | `9aa2fa4` | PR-mode (feature branch) |
 | 2 -- Append second line   | ⬚ | | PR-mode |
 
 ## Phase 1 -- Create canary10 file

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -1,7 +1,7 @@
 ---
 title: Canary 10 — PR Mode End-to-End
 created: 2026-04-16
-status: active
+status: complete
 ---
 
 # Plan: Canary 10 — PR Mode End-to-End
@@ -38,7 +38,7 @@ confirmed they're happy to run this manually.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 -- Create canary10 file | ✅ Done | `9aa2fa4` | PR-mode (feature branch) |
-| 2 -- Append second line   | ⬚ | | PR-mode |
+| 2 -- Append second line   | ✅ Done | `4f799f8` | PR-mode (feature branch) |
 
 ## Phase 1 -- Create canary10 file
 

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,47 +1,22 @@
-# Plan Report — Canary 10 PR Mode End-to-End
+# Plan Report — Canary 10 PR Mode End-to-End (Re-run)
 
-## Phase — 2 Append second line (landed)
-
-**Plan:** plans/CANARY10_PR_MODE.md
-**Status:** Completed (verified, committed on feature branch)
-**Worktree:** /tmp/zskills-pr-canary10-pr-mode
-**Branch:** feat/canary10-pr-mode
-**Commit:** b5ea9be (on feature branch; awaits PR merge)
-
-### Work Items
-| # | Item | Status |
-|---|------|--------|
-| 1 | Append second line to canary/canary10.txt | Done |
-
-### Verification
-- `canary/canary10.txt` on feature branch has 2 lines in correct order
-- Tests: 177/177 (tests/test-hooks.sh)
-- Scope: 1 file modified, no out-of-scope changes
-- Fresh-eyes verifier: ACCEPT
-
-### Phase 2 timing signal (cron-fired Turn 2)
-Phase 1 implement marker: 1776346750. Phase 2 implement marker: 1776347085. Delta: 335s (>>60s threshold). Confirms Phase 2 ran in a SEPARATE cron-fired turn from Phase 1, not inline.
-
-## Phase — 1 Create canary10 file (landed)
+## Phase — 1 Create canary10 file (verified, on feature branch)
 
 **Plan:** plans/CANARY10_PR_MODE.md
-**Status:** Completed (verified, committed on feature branch)
+**Status:** Committed on feat/canary10-pr-mode; pending PR merge at plan completion
 **Worktree:** /tmp/zskills-pr-canary10-pr-mode
 **Branch:** feat/canary10-pr-mode
-**Commit:** bbec8c3 (on feature branch; not yet landed on main — awaits PR merge)
+**Commit:** 9aa2fa4 (`canary(canary10): create canary10.txt — Phase 1`)
 
 ### Work Items
-| # | Item | Status |
-|---|------|--------|
-| 1 | Create canary/canary10.txt with exact one-line content | Done |
+- `canary/canary10.txt` created with exactly `Canary 10 Phase 1: PR mode`
 
 ### Verification
-- `canary/canary10.txt` on feature branch with exactly one line: `Canary 10 Phase 1: PR mode`
-- Tests: 177/177 passed (tests/test-hooks.sh)
-- Scope: 1 file (canary/canary10.txt) — no out-of-scope changes
-- Fresh-eyes verifier: ACCEPT
-- Commit committed on feature branch only; main NOT advanced (per PR-mode semantics)
+- File content: `cat canary/canary10.txt` prints one line matching the spec
+- Tests: 255/255 (tests/test-hooks.sh) — baseline preserved, no regression
+- `main` not advanced by this phase
+- `git log main..HEAD --oneline` shows the one Phase 1 impl commit
+- Hygiene: `.worktreepurpose`, `.zskills-tracked` untracked (gitignored)
 
-### Chunking signal
-Phase 5c will schedule a one-shot cron for Phase 2
-(`Run /run-plan plans/CANARY10_PR_MODE.md finish auto pr`). Phase 2 runs in a SEPARATE cron-fired turn, commits on the same feature branch, then triggers Phase 5b (frontmatter complete) and Phase 6 PR-mode landing (push + gh pr create + CI poll + auto-merge).
+### In-vivo gate validation
+This run is the **WI 2.8 gate** for CREATE_WORKTREE_SKILL Phase 2 (PR-mode migration). The worktree at this path was created by the orchestrator calling the newly-migrated `scripts/create-worktree.sh --prefix pr --branch-name feat/canary10-pr-mode --allow-resume --purpose ...`. That call produced `rc=0`, the correct branch, the correct path, the sanitized `.zskills-tracked`, and the `.worktreepurpose` marker — proving the PR-mode migration works end-to-end.

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,5 +1,27 @@
 # Plan Report — Canary 10 PR Mode End-to-End (Re-run)
 
+## Phase — 2 Append second line (verified, on feature branch; pending PR merge)
+
+**Plan:** plans/CANARY10_PR_MODE.md
+**Status:** Committed on feat/canary10-pr-mode; awaiting push + PR + CI + auto-merge
+**Worktree:** /tmp/zskills-pr-canary10-pr-mode
+**Branch:** feat/canary10-pr-mode
+**Commit:** 4f799f8 (`canary(canary10): append second line — Phase 2`)
+
+### Work Items
+- `canary/canary10.txt` appended with `Canary 10 Phase 2: PR mode`
+
+### Verification
+- File content: 2 lines in order (`Canary 10 Phase 1: PR mode` / `Canary 10 Phase 2: PR mode`)
+- Tests: 255/255 (tests/test-hooks.sh)
+- `main` still unchanged
+- `git log main..HEAD` shows Phase 1 + Phase 2 impl + bookkeeping commits
+
+### Chunked-execution timing
+Phase 1 complete marker: 2026-04-20T01:13:09 ET.
+Phase 2 impl commit: 2026-04-20T01:14+ ET.
+Delta across cron chunking: ~1 min (Design 2a `*/1 * * * *` recurring cron is operating as designed).
+
 ## Phase — 1 Create canary10 file (verified, on feature branch)
 
 **Plan:** plans/CANARY10_PR_MODE.md


### PR DESCRIPTION
## Plan: Canary 10 — PR Mode End-to-End

Re-run as WI 2.8 gate for plans/CREATE_WORKTREE_SKILL.md Phase 2 (PR-mode migration).

**Phases completed:**
- 1 — Create canary10 file (commit 9aa2fa4)
- 2 — Append second line (commit 4f799f8)

**In-vivo gate validation:** The feature branch at `feat/canary10-pr-mode` was created by the orchestrator calling the newly-migrated `scripts/create-worktree.sh --prefix pr --branch-name feat/canary10-pr-mode --allow-resume --purpose ...`. That call produced rc=0, the correct branch name and path, sanitized `.zskills-tracked`, and the `.worktreepurpose` marker — proving the PR-mode migration works end-to-end.

**Report:** See `reports/plan-canary10-pr-mode.md` for details.

---
Generated by `/run-plan plans/CANARY10_PR_MODE.md finish auto pr`