### PR TITLE
[canary10-pr-mode] Canary 10 — PR Mode End-to-End (correctness-fixes gate)

### DIFF
--- a/canary/canary10.txt
+++ b/canary/canary10.txt
@@ -1,1 +1,2 @@
 Canary 10 Phase 1: PR mode
+Canary 10 Phase 2: PR mode

--- a/canary/canary10.txt
+++ b/canary/canary10.txt
@@ -1,0 +1,1 @@
+Canary 10 Phase 1: PR mode

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -1,7 +1,7 @@
 ---
 title: Canary 10 — PR Mode End-to-End
 created: 2026-04-16
-status: active
+status: complete
 ---
 
 # Plan: Canary 10 — PR Mode End-to-End
@@ -38,7 +38,7 @@ confirmed they're happy to run this manually.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 -- Create canary10 file | ✅ Done | `9904fb9` | PR-mode (feature branch) |
-| 2 -- Append second line   | ⬚ | | PR-mode |
+| 2 -- Append second line   | ✅ Done | `4dba90d` | PR-mode (feature branch) |
 
 ## Phase 1 -- Create canary10 file
 

--- a/plans/CANARY10_PR_MODE.md
+++ b/plans/CANARY10_PR_MODE.md
@@ -37,7 +37,7 @@ confirmed they're happy to run this manually.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 -- Create canary10 file | ⬚ | | PR-mode |
+| 1 -- Create canary10 file | ✅ Done | `9904fb9` | PR-mode (feature branch) |
 | 2 -- Append second line   | ⬚ | | PR-mode |
 
 ## Phase 1 -- Create canary10 file

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,5 +1,28 @@
 # Plan Report — Canary 10 PR Mode End-to-End (post-correctness-fixes re-run)
 
+## Phase — 2 Append second line (verified on feature branch; pre-push)
+
+**Plan:** plans/CANARY10_PR_MODE.md
+**Status:** Committed on feat/canary10-pr-mode; awaiting push + PR + CI + auto-merge
+**Commit:** 4dba90d (`canary(canary10): append second line — Phase 2`)
+
+### Work Item
+- Appended `Canary 10 Phase 2: PR mode` as line 2 of `canary/canary10.txt`
+
+### Verification
+- Two-line content in order; `wc -l` = 2
+- Tests 259/259 (`bash tests/test-hooks.sh`) — orchestrator re-ran to confirm verifier's method was wrong (verifier looked at `scripts/test-all.sh`, which is the template-for-downstream-projects and has `{{PLACEHOLDERS}}`; canonical test is `bash tests/test-hooks.sh` per config)
+- `git log main..HEAD` → 4 commits; `git log HEAD..main` → empty; main at `97c7d19` unchanged
+- Hygiene: no tracked ephemerals
+
+### Cron-fired Phase 2 entry (in-vivo validation of PR-mode read-authority fix)
+- Phase 2's fresh turn read tracker from `/tmp/zskills-pr-canary10-pr-mode/plans/CANARY10_PR_MODE.md` (feature branch) — **not** main's stale copy
+- Step 0 classification: status=active, phase1_done=1, phase2_done=0 → Case 4 targeting Phase 2 (correct)
+- If the read-authority fix were absent, Step 0 would have read main (both ⬚), targeted Phase 1, and re-executed — validated by comparing: main's row shows Phase 1 ⬚ vs feature-branch row shows Phase 1 ✅
+
+### Methodological note (flag to user)
+The verifier agent's dispatch prompt didn't specify the exact test command. The agent searched the repo and landed on `scripts/test-all.sh` (template file). Result: it committed while reporting "tests not meaningfully runnable" — a mild "noted as gap" pattern. Orchestrator re-ran tests directly to confirm 259/259 before continuing. Future verifier prompts should name the test command explicitly from config (`testing.full_cmd`).
+
 ## Phase — 1 Create canary10 file (verified on feature branch)
 
 **Plan:** plans/CANARY10_PR_MODE.md

--- a/reports/plan-canary10-pr-mode.md
+++ b/reports/plan-canary10-pr-mode.md
@@ -1,44 +1,34 @@
-# Plan Report — Canary 10 PR Mode End-to-End (Re-run)
+# Plan Report — Canary 10 PR Mode End-to-End (post-correctness-fixes re-run)
 
-## Phase — 2 Append second line (verified, on feature branch; pending PR merge)
-
-**Plan:** plans/CANARY10_PR_MODE.md
-**Status:** Committed on feat/canary10-pr-mode; awaiting push + PR + CI + auto-merge
-**Worktree:** /tmp/zskills-pr-canary10-pr-mode
-**Branch:** feat/canary10-pr-mode
-**Commit:** 4f799f8 (`canary(canary10): append second line — Phase 2`)
-
-### Work Items
-- `canary/canary10.txt` appended with `Canary 10 Phase 2: PR mode`
-
-### Verification
-- File content: 2 lines in order (`Canary 10 Phase 1: PR mode` / `Canary 10 Phase 2: PR mode`)
-- Tests: 255/255 (tests/test-hooks.sh)
-- `main` still unchanged
-- `git log main..HEAD` shows Phase 1 + Phase 2 impl + bookkeeping commits
-
-### Chunked-execution timing
-Phase 1 complete marker: 2026-04-20T01:13:09 ET.
-Phase 2 impl commit: 2026-04-20T01:14+ ET.
-Delta across cron chunking: ~1 min (Design 2a `*/1 * * * *` recurring cron is operating as designed).
-
-## Phase — 1 Create canary10 file (verified, on feature branch)
+## Phase — 1 Create canary10 file (verified on feature branch)
 
 **Plan:** plans/CANARY10_PR_MODE.md
-**Status:** Committed on feat/canary10-pr-mode; pending PR merge at plan completion
+**Status:** Committed on feat/canary10-pr-mode; awaiting Phase 2 cron + push + PR + CI + merge
 **Worktree:** /tmp/zskills-pr-canary10-pr-mode
 **Branch:** feat/canary10-pr-mode
-**Commit:** 9aa2fa4 (`canary(canary10): create canary10.txt — Phase 1`)
+**Commit:** 9904fb9 (`canary(canary10): create canary10.txt — Phase 1`)
 
-### Work Items
+### Work Item
 - `canary/canary10.txt` created with exactly `Canary 10 Phase 1: PR mode`
 
 ### Verification
-- File content: `cat canary/canary10.txt` prints one line matching the spec
-- Tests: 255/255 (tests/test-hooks.sh) — baseline preserved, no regression
-- `main` not advanced by this phase
-- `git log main..HEAD --oneline` shows the one Phase 1 impl commit
-- Hygiene: `.worktreepurpose`, `.zskills-tracked` untracked (gitignored)
+- File content: 1 line matching spec
+- `wc -l` = 1
+- `bash tests/test-hooks.sh` → 259/259 (no regression)
+- `git log main..HEAD` → 1 commit (Phase 1 impl); `git log HEAD..main` → empty
+- Main unchanged at `97c7d19`
 
-### In-vivo gate validation
-This run is the **WI 2.8 gate** for CREATE_WORKTREE_SKILL Phase 2 (PR-mode migration). The worktree at this path was created by the orchestrator calling the newly-migrated `scripts/create-worktree.sh --prefix pr --branch-name feat/canary10-pr-mode --allow-resume --purpose ...`. That call produced `rc=0`, the correct branch, the correct path, the sanitized `.zskills-tracked`, and the `.worktreepurpose` marker — proving the PR-mode migration works end-to-end.
+### In-vivo validation of correctness fixes
+This run is the PROPER Phase 3 WI 3.8 gate re-run after three fixes landed on main:
+
+1. `1512389` — `--pipeline-id` required in `scripts/create-worktree.sh`; env fallback deleted. Validated: worktree's `.zskills-tracked` contains `run-plan.canary10-pr-mode` (the canonical pipeline ID), with NO env-var workaround anywhere in the orchestrator. The flag alone plumbed it through.
+2. `7895525` — Phase 1 Step 0 + Parse Plan read from `$PLAN_FILE_FOR_READ`, which resolves to the feature-branch worktree in PR mode. Phase 2's cron-fired turn (next) will exercise this: it must correctly see "Phase 1 ✅ Done" on the feature branch and advance without re-executing Phase 1.
+3. `97c7d19` — `clear-tracking.sh` recurses into per-pipeline subdirs with a post-clear residual assertion. Validated via `--force` run before this canary: 73 bookkeeping files cleared across 20+ pipelines; 30 completion records preserved.
+
+### Chunking design
+Design 2a recurring `*/1 * * * *` cron scheduled below. Phase 2 will fire in a fresh top-level turn within ~60 seconds of Phase 1's landing.
+
+### Not yet validated (Phase 2's job)
+- Phase 2 re-entry reading from feature branch (the critical test of fix #2)
+- Rebase + push + PR + CI + auto-merge end-to-end (Design 2a + PR mode full cycle)
+- Local main fast-forward post-merge


### PR DESCRIPTION
## Plan: Canary 10 — PR Mode End-to-End

Re-run as Phase 3 WI 3.8 gate after three correctness fixes landed on main.

**In-vivo validated (this run):**
- `1512389` — `scripts/create-worktree.sh` requires `--pipeline-id` flag (no env fallback). Worktree's `.zskills-tracked` = `run-plan.canary10-pr-mode` (canonical), plumbed via flag only.
- `7895525` — PR-mode Phase 1 Step 0 + Parse Plan read `$PLAN_FILE_FOR_READ`, which resolves to feature-branch worktree. Phase 2's cron-fired turn correctly saw Phase 1 ✅ Done on the feature branch (main's tracker row was still ⬚ at that moment — proves the fix).
- `97c7d19` — `clear-tracking.sh` recurses per-pipeline subdirs + post-clear residual assertion. Used `--force` to wipe 73 bookkeeping files pre-run.

**Phases:**
- 1 — Create canary10 file (`9904fb9`)
- 2 — Append second line (`4dba90d`)

**Report:** `reports/plan-canary10-pr-mode.md`

---
Generated by `/run-plan plans/CANARY10_PR_MODE.md finish auto pr` (no manual intervention; cron-fired Phase 2 transition validated end-to-end)