### PR TITLE
Add a period to the end of the /fix-issues bundle bullet in CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 - `/research-and-plan`: `auto` flag skips decomposition confirmation checkpoint
 - `/research-and-go`: explicitly passes `auto` to `/research-and-plan`
 - `/fix-issues`: orchestrator may bundle related issues (same component, same
-  root cause) into one worktree beyond N count
+  root cause) into one worktree beyond N count.
 - `/fix-issues`: Phase 1 enforcement — complete ALL sync steps before Phase 2
 - `/briefing`: Z Skills update check in summary/report modes
 - `/briefing`: "present verbatim" enforcement with past-failure reference


### PR DESCRIPTION
## Summary

Add a period to the end of the /fix-issues bundle bullet in CHANGELOG.md 2026-03-29

Mode: `agent-dispatched`
Base: `main`
Slug: `add-a-period-to-the-end-of-the-fix-issue`

## Test plan

- Ran project `unit_cmd` before commit.
- Review diff.

🤖 Generated with /quickfix