### PR TITLE
Replace /quickfix hardcoded Co-Authored-By trailer with value read fro

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -552,12 +552,14 @@ COMMIT_EOF
 )
 else
   # agent-dispatched: include Co-Authored-By, matching skills/commit/SKILL.md trailer.
+  # Resolve the co-author line from config; default falls back to Claude Opus 4.7.
+  CO_AUTHOR=$(jq -r '.commit.co_author // "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"' "$MAIN_ROOT/.claude/zskills-config.json")
   COMMIT_BODY=$(cat <<COMMIT_EOF
 $COMMIT_MSG
 
 🤖 Generated with /quickfix (agent-dispatched)
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+Co-Authored-By: $CO_AUTHOR
 COMMIT_EOF
 )
 fi

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -215,8 +215,23 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    if [[ "$CONFIG_CONTENT" =~ \"max_fix_attempts\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
      CI_MAX_ATTEMPTS="${BASH_REMATCH[1]}"
    fi
+   # Extract commit.co_author (optional — backfilled below if missing):
+   if [[ "$CONFIG_CONTENT" =~ \"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+     CO_AUTHOR="${BASH_REMATCH[1]}"
+   fi
    ```
 3. For each template placeholder, use the config value if non-empty.
+3.5. **Backfill `commit.co_author` if absent.** If the existing config
+   does not contain a `"commit"` block with a `"co_author"` field (e.g.
+   configs written before this field was introduced), splice in the
+   default so downstream skills (`/quickfix`, `/commit`) can rely on the
+   field resolving. Default value:
+   `"Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`. Match the
+   same style used for other optional-field backfills — a targeted
+   `Edit` or small jq rewrite that preserves every other field unchanged.
+   If the `commit` key is absent, add the whole block; if the `commit`
+   block exists but lacks `co_author`, add only that field. Idempotent:
+   re-running on an already-backfilled config is a no-op.
 4. Copy `config/zskills-config.schema.json` from `$PORTABLE` to
    `.claude/zskills-config.schema.json` in the target project (so the
    `$schema` reference in the config resolves correctly).
@@ -249,6 +264,9 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
        "landing": "<preset.landing>",
        "main_protected": <preset.main_protected>,
        "branch_prefix": "feat/"
+     },
+     "commit": {
+       "co_author": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
      },
      "testing": {
        "unit_cmd": "<detected>",

--- a/.claude/zskills-config.json
+++ b/.claude/zskills-config.json
@@ -9,6 +9,10 @@
     "branch_prefix": "feat/"
   },
 
+  "commit": {
+    "co_author": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+  },
+
   "testing": {
     "unit_cmd": "bash tests/test-hooks.sh",
     "full_cmd": "bash tests/test-hooks.sh",

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -45,6 +45,17 @@
         }
       }
     },
+    "commit": {
+      "type": "object",
+      "description": "Commit metadata written by agent-authored commits.",
+      "properties": {
+        "co_author": {
+          "type": "string",
+          "description": "Co-Authored-By trailer line written by /quickfix and /commit when an agent authored the change.",
+          "default": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+        }
+      }
+    },
     "testing": {
       "type": "object",
       "description": "Test commands and patterns.",

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -552,12 +552,14 @@ COMMIT_EOF
 )
 else
   # agent-dispatched: include Co-Authored-By, matching skills/commit/SKILL.md trailer.
+  # Resolve the co-author line from config; default falls back to Claude Opus 4.7.
+  CO_AUTHOR=$(jq -r '.commit.co_author // "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"' "$MAIN_ROOT/.claude/zskills-config.json")
   COMMIT_BODY=$(cat <<COMMIT_EOF
 $COMMIT_MSG
 
 🤖 Generated with /quickfix (agent-dispatched)
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+Co-Authored-By: $CO_AUTHOR
 COMMIT_EOF
 )
 fi

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -215,8 +215,23 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    if [[ "$CONFIG_CONTENT" =~ \"max_fix_attempts\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
      CI_MAX_ATTEMPTS="${BASH_REMATCH[1]}"
    fi
+   # Extract commit.co_author (optional — backfilled below if missing):
+   if [[ "$CONFIG_CONTENT" =~ \"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+     CO_AUTHOR="${BASH_REMATCH[1]}"
+   fi
    ```
 3. For each template placeholder, use the config value if non-empty.
+3.5. **Backfill `commit.co_author` if absent.** If the existing config
+   does not contain a `"commit"` block with a `"co_author"` field (e.g.
+   configs written before this field was introduced), splice in the
+   default so downstream skills (`/quickfix`, `/commit`) can rely on the
+   field resolving. Default value:
+   `"Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`. Match the
+   same style used for other optional-field backfills — a targeted
+   `Edit` or small jq rewrite that preserves every other field unchanged.
+   If the `commit` key is absent, add the whole block; if the `commit`
+   block exists but lacks `co_author`, add only that field. Idempotent:
+   re-running on an already-backfilled config is a no-op.
 4. Copy `config/zskills-config.schema.json` from `$PORTABLE` to
    `.claude/zskills-config.schema.json` in the target project (so the
    `$schema` reference in the config resolves correctly).
@@ -249,6 +264,9 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
        "landing": "<preset.landing>",
        "main_protected": <preset.main_protected>,
        "branch_prefix": "feat/"
+     },
+     "commit": {
+       "co_author": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
      },
      "testing": {
        "unit_cmd": "<detected>",

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -357,7 +357,13 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Case 10 — Commit trailer contract (WI 1.13)
+# Case 10 — Commit trailer contract (WI 1.13). Co-author is now read
+# from .commit.co_author in zskills-config.json via jq BEFORE the
+# heredoc is built; the heredoc body itself carries `Co-Authored-By:
+# $CO_AUTHOR`, not a literal model string. Asserts:
+#   - user-edited body never contains a Co-Authored-By line
+#   - agent-dispatched body contains `Co-Authored-By: $CO_AUTHOR`
+#   - the jq-read form for .commit.co_author is present in the skill
 # ────────────────────────────────────────────────────────────────────
 USER_EDITED_BODY=$(awk '
   /🤖 Generated with \/quickfix \(user-edited\)/  { want=1; found=1 }
@@ -373,9 +379,10 @@ AGENT_BODY=$(awk '
 
 if [ -n "$USER_EDITED_BODY" ] \
    && [ -n "$AGENT_BODY" ] \
-   && ! printf '%s' "$USER_EDITED_BODY" | grep -q 'Co-Authored-By: Claude' \
-   &&   printf '%s' "$AGENT_BODY"       | grep -q 'Co-Authored-By: Claude'; then
-  pass "10 commit trailer: user-edited omits Co-Authored-By; agent-dispatched includes it"
+   && ! printf '%s' "$USER_EDITED_BODY" | grep -q 'Co-Authored-By:' \
+   &&   printf '%s' "$AGENT_BODY"       | grep -qE 'Co-Authored-By: \$CO_AUTHOR' \
+   && grep -qE 'jq -r .*\.commit\.co_author' "$SKILL"; then
+  pass "10 commit trailer: user-edited omits Co-Authored-By; agent-dispatched uses jq-read \$CO_AUTHOR from .commit.co_author"
 else
   fail "10 commit trailer: trailer contract not satisfied"
 fi


### PR DESCRIPTION
## Summary

Replace /quickfix hardcoded Co-Authored-By trailer with value read from .claude/zskills-config.json commit.co_author field; update schema, config, /quickfix skill, /update-zskills skill, and tests

Mode: `agent-dispatched`
Base: `main`
Slug: `replace-quickfix-hardcoded-co-authored-b`

Replaces the hardcoded "Claude Opus 4.6" trailer value with one read from `.claude/zskills-config.json` `commit.co_author`. Default falls back to 4.7. `/update-zskills` now (a) writes the field in greenfield configs and (b) backfills it on re-run for pre-existing projects.

## Test plan

- Ran project `unit_cmd` before commit (306/306 hook tests pass).
- Full suite will run in ship-to-prod pipeline.

🤖 Generated with /quickfix