### PR TITLE
refactor(commit): read Co-Authored-By trailer from commit.co_author config

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -198,12 +198,37 @@ For every file classified as "related":
 
    If the agent approves: proceed to step 4.
 
-4. Commit using a HEREDOC for clean formatting:
-   ```bash
-   git commit -m "$(cat <<'EOF'
-   <type>: <message>
+4. Resolve the Co-Authored-By trailer from config, then commit.
 
-   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   The trailer value lives in `.claude/zskills-config.json` under
+   `commit.co_author`. Read it with the same pure-bash regex idiom used
+   in `/update-zskills` Step 0.5 — no external JSON parser dependency,
+   matching the rest of /commit. Fall back to the default if the field
+   is absent or the file is missing:
+
+   ```bash
+   CO_AUTHOR="Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+   if [[ -f .claude/zskills-config.json ]]; then
+     CONFIG_CONTENT=$(cat .claude/zskills-config.json)
+     if [[ "$CONFIG_CONTENT" =~ \"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+       CO_AUTHOR="${BASH_REMATCH[1]}"
+     fi
+   fi
+   ```
+
+   Commit using a HEREDOC for clean formatting. The heredoc delimiter
+   **must stay quoted (`<<'EOF'`)** so that any `$(...)`, backticks, or
+   `$VAR` substrings that happen to appear in `<type>` or `<message>`
+   are treated as literal text rather than executed by the shell. The
+   trailer is injected separately via `git commit --trailer`, which
+   handles RFC 5322 formatting and keeps `$CO_AUTHOR` out of the
+   heredoc body entirely:
+
+   ```bash
+   git commit \
+     --trailer "Co-Authored-By: $CO_AUTHOR" \
+     -m "$(cat <<'EOF'
+   <type>: <message>
    EOF
    )"
    ```

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -198,12 +198,37 @@ For every file classified as "related":
 
    If the agent approves: proceed to step 4.
 
-4. Commit using a HEREDOC for clean formatting:
-   ```bash
-   git commit -m "$(cat <<'EOF'
-   <type>: <message>
+4. Resolve the Co-Authored-By trailer from config, then commit.
 
-   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   The trailer value lives in `.claude/zskills-config.json` under
+   `commit.co_author`. Read it with the same pure-bash regex idiom used
+   in `/update-zskills` Step 0.5 — no external JSON parser dependency,
+   matching the rest of /commit. Fall back to the default if the field
+   is absent or the file is missing:
+
+   ```bash
+   CO_AUTHOR="Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+   if [[ -f .claude/zskills-config.json ]]; then
+     CONFIG_CONTENT=$(cat .claude/zskills-config.json)
+     if [[ "$CONFIG_CONTENT" =~ \"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+       CO_AUTHOR="${BASH_REMATCH[1]}"
+     fi
+   fi
+   ```
+
+   Commit using a HEREDOC for clean formatting. The heredoc delimiter
+   **must stay quoted (`<<'EOF'`)** so that any `$(...)`, backticks, or
+   `$VAR` substrings that happen to appear in `<type>` or `<message>`
+   are treated as literal text rather than executed by the shell. The
+   trailer is injected separately via `git commit --trailer`, which
+   handles RFC 5322 formatting and keeps `$CO_AUTHOR` out of the
+   heredoc body entirely:
+
+   ```bash
+   git commit \
+     --trailer "Co-Authored-By: $CO_AUTHOR" \
+     -m "$(cat <<'EOF'
+   <type>: <message>
    EOF
    )"
    ```


### PR DESCRIPTION
## Summary

Removes the last hardcoded `Claude Opus 4.6` model reference in the /commit skill (Phase 5 Step 4, line 206). Trailer value now resolves at commit-time from `.claude/zskills-config.json`'s `commit.co_author` field (the same config field `/quickfix` was converted to use in PR #43), falling back to `Claude Opus 4.7 (1M context) <noreply@anthropic.com>` when the config is missing or the field is absent.

## Approach

Approach (a) from the three injection-safe options: `git commit --trailer "Co-Authored-By: \$CO_AUTHOR"` invoked alongside the existing quoted-heredoc body. This keeps `\$CO_AUTHOR` out of the heredoc entirely and preserves the `<<'EOF'` delimiter that prevents command injection from user-provided `<type>` / `<message>` text. A brief prose note above the example documents why the quoted delimiter is load-bearing.

## Invariants preserved

- `grep jq skills/commit/SKILL.md` → 0 hits (/commit stays jq-free; config read uses the BASH_REMATCH idiom from /update-zskills Step 0.5).
- `<<'EOF'` quoted delimiter preserved.
- Source and `.claude/` mirror byte-identical.
- No other files modified; no test updates (no `tests/test-commit.sh` exists).

## Test plan

- Nothing to run locally — the skill is prose + examples consumed by the model at invocation time. Ship-to-prod pipeline's `tests/run-all.sh` gate will exercise the file's invariants (skill-invariants test).

🤖 Generated with /do pr