### PR TITLE
fix(quickfix): include untracked files in DIRTY_AFTER integrity check

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -476,21 +476,28 @@ When `MODE == "agent-dispatched"`:
    - **Do NOT** `git commit`, `git add`, or modify the index
    - **Do NOT** run tests, builds, linters, or formatters
    - When finished, list newly untracked files in the "done" report
+   - **IMPORTANT:** Only leave files untracked that you intend to commit
+     as part of this change. Delete any scratch, debug, or log files you
+     created during exploration before reporting done. The skill will
+     include all your remaining untracked files in the commit — any
+     lingering scratch will ship in the PR.
 4. After the Agent returns, verify:
    - `POST_HEAD=$(git rev-parse HEAD)`; if `POST_HEAD != PRE_HEAD`, the
      agent committed unexpectedly → exit 5 with cleanup (checkout base,
      delete branch).
-   - `DIRTY_AFTER=$(git diff --name-only HEAD)` — tracked modifications
-     only. Deliberately **excludes** `git ls-files --others
-     --exclude-standard` because agents routinely leave build artifacts,
-     log files, and scratch files that should NOT be part of the commit
-     (per R2-M2). Untracked files from the agent must be named in the
-     description-to-touch if they are intentional.
+   - `DIRTY_AFTER` is the sorted union of tracked modifications AND
+     newly untracked files. The agent is expected (per step 3's
+     IMPORTANT clause) to have cleaned up scratch/debug/log files
+     before reporting done, so any remaining untracked files ARE part
+     of the intended commit and SHOULD be staged. Definition:
+     ```bash
+     DIRTY_AFTER=$(printf '%s\n%s\n' "$(git diff --name-only HEAD)" "$(git ls-files --others --exclude-standard)" | sed '/^$/d' | sort -u)
+     ```
    - If `DIRTY_AFTER` is empty, the agent did not change the tree →
      exit 5 with cleanup.
 5. Populate:
    ```bash
-   CHANGED_FILES=$(printf '%s\n' "$DIRTY_AFTER" | sed '/^$/d' | sort -u)
+   CHANGED_FILES="$DIRTY_AFTER"
    DELS=$(git diff --name-only --diff-filter=D HEAD)
    ```
 6. Proceed to the test gate (WI 1.12).

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -476,21 +476,28 @@ When `MODE == "agent-dispatched"`:
    - **Do NOT** `git commit`, `git add`, or modify the index
    - **Do NOT** run tests, builds, linters, or formatters
    - When finished, list newly untracked files in the "done" report
+   - **IMPORTANT:** Only leave files untracked that you intend to commit
+     as part of this change. Delete any scratch, debug, or log files you
+     created during exploration before reporting done. The skill will
+     include all your remaining untracked files in the commit — any
+     lingering scratch will ship in the PR.
 4. After the Agent returns, verify:
    - `POST_HEAD=$(git rev-parse HEAD)`; if `POST_HEAD != PRE_HEAD`, the
      agent committed unexpectedly → exit 5 with cleanup (checkout base,
      delete branch).
-   - `DIRTY_AFTER=$(git diff --name-only HEAD)` — tracked modifications
-     only. Deliberately **excludes** `git ls-files --others
-     --exclude-standard` because agents routinely leave build artifacts,
-     log files, and scratch files that should NOT be part of the commit
-     (per R2-M2). Untracked files from the agent must be named in the
-     description-to-touch if they are intentional.
+   - `DIRTY_AFTER` is the sorted union of tracked modifications AND
+     newly untracked files. The agent is expected (per step 3's
+     IMPORTANT clause) to have cleaned up scratch/debug/log files
+     before reporting done, so any remaining untracked files ARE part
+     of the intended commit and SHOULD be staged. Definition:
+     ```bash
+     DIRTY_AFTER=$(printf '%s\n%s\n' "$(git diff --name-only HEAD)" "$(git ls-files --others --exclude-standard)" | sed '/^$/d' | sort -u)
+     ```
    - If `DIRTY_AFTER` is empty, the agent did not change the tree →
      exit 5 with cleanup.
 5. Populate:
    ```bash
-   CHANGED_FILES=$(printf '%s\n' "$DIRTY_AFTER" | sed '/^$/d' | sort -u)
+   CHANGED_FILES="$DIRTY_AFTER"
    DELS=$(git diff --name-only --diff-filter=D HEAD)
    ```
 6. Proceed to the test gate (WI 1.12).

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -807,14 +807,19 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Case 37 — DIRTY_AFTER excludes untracked (R2-M2 per plan line 50).
-# Assert the SKILL.md comment about excluding `git ls-files --others
-# --exclude-standard` (so agent scratch/artifact files aren't committed).
+# Case 37 — DIRTY_AFTER includes untracked (new-file integrity).
+# Assert the SKILL.md's WI 1.11 DIRTY_AFTER definition now unions
+# tracked modifications with `git ls-files --others --exclude-standard`
+# so new files created by the dispatched agent are counted. Also
+# assert the old exclusion wording is gone — a present "excludes ...
+# git ls-files --others" comment would mean the old behavior
+# regressed.
 # ────────────────────────────────────────────────────────────────────
-if grep -q "excludes.*git ls-files --others" "$SKILL"; then
-  pass "37 DIRTY_AFTER excludes untracked (R2-M2): comment present"
+if grep -q 'git ls-files --others --exclude-standard' "$SKILL" \
+   && ! grep -q "excludes.*git ls-files --others" "$SKILL"; then
+  pass "37 DIRTY_AFTER includes untracked (new-file integrity): union present, old exclusion wording gone"
 else
-  fail "37 DIRTY_AFTER R2-M2 comment missing"
+  fail "37 DIRTY_AFTER includes untracked: union-def missing or old exclusion wording still present"
 fi
 
 # ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a latent bug in /quickfix's agent-dispatched mode (WI 1.11 step 4): the integrity check used `git diff --name-only HEAD` which only reports tracked modifications. When the dispatched agent legitimately creates a new untracked file as part of its task, the check saw "no change" and triggered the `agent made no changes` cleanup-and-abort path — as surfaced by an earlier agent trying to create `.nojekyll` for GitHub Pages.

## Changes

- WI 1.11 step 4: `DIRTY_AFTER` now includes both tracked modifications AND newly untracked files (sorted union).
- WI 1.11 step 3: agent dispatch prompt gains an explicit scratch-file hygiene clause — agents must delete scratch/debug/log files before reporting done, since remaining untracked files WILL ship in the commit.
- WI 1.11 step 5: `CHANGED_FILES` simplifies to `$DIRTY_AFTER` (already the sorted union).
- `tests/test-quickfix.sh` Case 37: assertion inverted to match new semantics.

## Test plan

- [x] tests/test-hooks.sh passes (unit_cmd gate, 306/306)
- [x] tests/test-quickfix.sh passes (50/50 including the new Case 37)

🤖 Generated with /quickfix