### PR TITLE
refactor(do,update-zskills): drop last external jq usages

### DIFF
--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -30,7 +30,17 @@ fi
 
 **Step A3 — Derive BRANCH_NAME and WORKTREE_PATH from (possibly suffixed) TASK_SLUG:**
 ```bash
-BRANCH_PREFIX=$(jq -r '.execution.branch_prefix // "feat/"' .claude/zskills-config.json 2>/dev/null || echo "feat/")
+# Read .execution.branch_prefix via bash-regex (no external jq dependency).
+# Preserve empty-string when the key is present-but-empty; default "feat/"
+# only when the key is absent or the config file is missing.
+BRANCH_PREFIX="feat/"
+if [ -f .claude/zskills-config.json ]; then
+  _CFG=$(cat .claude/zskills-config.json)
+  if [[ "$_CFG" =~ \"branch_prefix\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    BRANCH_PREFIX="${BASH_REMATCH[1]}"
+  fi
+  unset _CFG
+fi
 BRANCH_NAME="${BRANCH_PREFIX}do-${TASK_SLUG}"
 WORKTREE_PATH="/tmp/${PROJECT_NAME}-do-${TASK_SLUG}"
 ```

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -228,7 +228,7 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    field resolving. Default value:
    `"Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`. Match the
    same style used for other optional-field backfills — a targeted
-   `Edit` or small jq rewrite that preserves every other field unchanged.
+   `Edit` or small `sed`-based rewrite that preserves every other field unchanged.
    If the `commit` key is absent, add the whole block; if the `commit`
    block exists but lacks `co_author`, add only that field. Idempotent:
    re-running on an already-backfilled config is a no-op.

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -30,7 +30,17 @@ fi
 
 **Step A3 — Derive BRANCH_NAME and WORKTREE_PATH from (possibly suffixed) TASK_SLUG:**
 ```bash
-BRANCH_PREFIX=$(jq -r '.execution.branch_prefix // "feat/"' .claude/zskills-config.json 2>/dev/null || echo "feat/")
+# Read .execution.branch_prefix via bash-regex (no external jq dependency).
+# Preserve empty-string when the key is present-but-empty; default "feat/"
+# only when the key is absent or the config file is missing.
+BRANCH_PREFIX="feat/"
+if [ -f .claude/zskills-config.json ]; then
+  _CFG=$(cat .claude/zskills-config.json)
+  if [[ "$_CFG" =~ \"branch_prefix\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    BRANCH_PREFIX="${BASH_REMATCH[1]}"
+  fi
+  unset _CFG
+fi
 BRANCH_NAME="${BRANCH_PREFIX}do-${TASK_SLUG}"
 WORKTREE_PATH="/tmp/${PROJECT_NAME}-do-${TASK_SLUG}"
 ```

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -228,7 +228,7 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    field resolving. Default value:
    `"Claude Opus 4.7 (1M context) <noreply@anthropic.com>"`. Match the
    same style used for other optional-field backfills — a targeted
-   `Edit` or small jq rewrite that preserves every other field unchanged.
+   `Edit` or small `sed`-based rewrite that preserves every other field unchanged.
    If the `commit` key is absent, add the whole block; if the `commit`
    block exists but lacks `co_author`, add only that field. Idempotent:
    re-running on an already-backfilled config is a no-op.


### PR DESCRIPTION
## Summary

Closes the last traces of external jq from zskills:

1. **skills/do/modes/pr.md line 33** — replaced `BRANCH_PREFIX=$(jq -r ...)` with bash-regex config parsing matching `/update-zskills` Step 0.5's canonical pattern. Preserves empty-string-when-present and missing-config-file fallback.
2. **skills/update-zskills/SKILL.md line 231** — changed prose "Edit or small jq rewrite" to "Edit or small sed-based rewrite" (PR #43 regression).

`gh --jq` flag usages (~27 across various modes/pr.md files) are untouched — those use gh's bundled go-gojq parser, not an external jq dependency.

After this PR, `grep -rnE '(^|[^-])\bjq[[:space:]]' skills/ .claude/skills/ | grep -v '\-\-jq' | grep -v 'no.*jq\|dependency'` returns zero hits. zskills is now fully jq-free for external dependencies.

## Test plan

- [x] tests/test-hooks.sh passes (306/306)
- [x] External jq grep verified empty

🤖 Generated with /quickfix