### PR TITLE
fix(hook): narrow main-push guard to stop variable false-positives

### DIFF
--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -605,13 +605,30 @@ if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]]; then
 fi
 
 # --- main_protected: block git push to main ---
+# Trade-off: this rule trusts variable-bearing push targets (e.g.,
+# origin "$BRANCH"). If a skill or agent sets a push-target variable to
+# "main" and pushes, this rule allows it. Acceptable because
+# (1) skills derive their branch names from config + slug with default
+# "feat/" prefix, so reaching branch="main" requires a buggy skill or
+# adversarial description; (2) a compromised agent that controls the
+# bash has easier paths (eval, concatenation, obfuscation) the hook
+# cannot defend against anyway; (3) the strict alternative (block all
+# variable-bearing push-target forms) produces false-positives on
+# legitimate worktree-scoped pushes without closing a realistic attack
+# vector.
 if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected; then
-  # Check if pushing to main/master (explicit refspec or default branch)
-  if is_on_main; then
-    # On main branch, default push targets main
-    if [[ ! "$COMMAND" =~ origin[[:space:]]+[a-zA-Z] ]] || [[ "$COMMAND" =~ origin[[:space:]]+(main|master) ]]; then
-      block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
-    fi
+  # (a) Explicit origin main/master (optionally force-prefixed with +):
+  if [[ "$COMMAND" =~ origin[[:space:]]+\+?(main|master)([[:space:]]|$|\") ]]; then
+    block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
+  fi
+  # (b) HEAD:main or HEAD:master refspec:
+  if [[ "$COMMAND" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
+    block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
+  fi
+  # (c) Naked push (no origin arg) while on main — defaults to pushing
+  # the current branch, which is main:
+  if ! [[ "$COMMAND" =~ origin[[:space:]] ]] && is_on_main; then
+    block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
 fi
 

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -605,13 +605,30 @@ if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]]; then
 fi
 
 # --- main_protected: block git push to main ---
+# Trade-off: this rule trusts variable-bearing push targets (e.g.,
+# origin "$BRANCH"). If a skill or agent sets a push-target variable to
+# "main" and pushes, this rule allows it. Acceptable because
+# (1) skills derive their branch names from config + slug with default
+# "feat/" prefix, so reaching branch="main" requires a buggy skill or
+# adversarial description; (2) a compromised agent that controls the
+# bash has easier paths (eval, concatenation, obfuscation) the hook
+# cannot defend against anyway; (3) the strict alternative (block all
+# variable-bearing push-target forms) produces false-positives on
+# legitimate worktree-scoped pushes without closing a realistic attack
+# vector.
 if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected; then
-  # Check if pushing to main/master (explicit refspec or default branch)
-  if is_on_main; then
-    # On main branch, default push targets main
-    if [[ ! "$COMMAND" =~ origin[[:space:]]+[a-zA-Z] ]] || [[ "$COMMAND" =~ origin[[:space:]]+(main|master) ]]; then
-      block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
-    fi
+  # (a) Explicit origin main/master (optionally force-prefixed with +):
+  if [[ "$COMMAND" =~ origin[[:space:]]+\+?(main|master)([[:space:]]|$|\") ]]; then
+    block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
+  fi
+  # (b) HEAD:main or HEAD:master refspec:
+  if [[ "$COMMAND" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
+    block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
+  fi
+  # (c) Naked push (no origin arg) while on main — defaults to pushing
+  # the current branch, which is main:
+  if ! [[ "$COMMAND" =~ origin[[:space:]] ]] && is_on_main; then
+    block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
 fi
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1040,6 +1040,80 @@ else
   fail "main_protected: push on feature branch should be allowed, got: $RESULT"
 fi
 
+# Test: main_protected allows literal feature-branch refspec (regression guard —
+# the old `origin[[:space:]]+[a-zA-Z]` heuristic accepted this; make sure the
+# new three-case rule still allows it).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin feat/foo")
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin feat/foo (literal feature branch) allowed"
+else
+  fail "main_protected: push origin feat/foo should be allowed, got: $RESULT"
+fi
+
+# Test: main_protected allows variable-bearing push target (the false-positive
+# the new rule is designed to eliminate). Old rule blocked because
+# `origin[[:space:]]+[a-zA-Z]` didn't match `origin "$BRANCH"` (starts with `"`),
+# which flipped the negated check into "looks like a bare push → block".
+# Note: on `main`, because the helper's git repo has main_protected=true. The
+# command's refspec is a variable — hook can't statically prove it isn't "main",
+# but the rule deliberately trusts it (see the block comment in the hook).
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' 'git push -u origin \"$BRANCH\"')
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin \"\$BRANCH\" (variable-bearing target) allowed"
+else
+  fail "main_protected: push origin \"\$BRANCH\" should be allowed, got: $RESULT"
+fi
+
+# Test: alternative variable name — same semantics.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' 'git push origin \"$BRANCH_NAME\"')
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin \"\$BRANCH_NAME\" (variable-bearing target) allowed"
+else
+  fail "main_protected: push origin \"\$BRANCH_NAME\" should be allowed, got: $RESULT"
+fi
+
+# Test: main_protected still blocks master explicitly (paired with the main case).
+RESULT=$(run_main_protected_test "master" '{"execution": {"main_protected": true}}' "git push origin master")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin master blocked"
+else
+  fail "main_protected: push origin master should be blocked, got: $RESULT"
+fi
+
+# Test: main_protected blocks force-push to main (new `+main` case explicitly
+# covered by rule (a)).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin +main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin +main (force-prefix) blocked"
+else
+  fail "main_protected: push origin +main should be blocked, got: $RESULT"
+fi
+
+# Test: main_protected blocks HEAD:main refspec (new rule (b)).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin HEAD:main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin HEAD:main (refspec) blocked"
+else
+  fail "main_protected: push origin HEAD:main should be blocked, got: $RESULT"
+fi
+
+# Test: main_protected blocks HEAD:master refspec (new rule (b)).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin HEAD:master")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin HEAD:master (refspec) blocked"
+else
+  fail "main_protected: push origin HEAD:master should be blocked, got: $RESULT"
+fi
+
+# Test: main_protected blocks naked `git push` while on main (rule (c) — the
+# default push targets the current branch).
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "git push")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: naked git push on main blocked"
+else
+  fail "main_protected: naked git push on main should be blocked, got: $RESULT"
+fi
+
 echo ""
 echo "=== Project hook: main_protected — worktree-cd awareness ==="
 


### PR DESCRIPTION
## Summary

Replaces the brittle "origin-followed-by-alpha-char" heuristic in the main-push guard with three narrower literal checks: (a) explicit `origin main|master` (optionally force-prefixed), (b) `HEAD:main|master` refspec, (c) naked push from main. Variable-bearing push targets (e.g., `origin "$BRANCH"`) are now allowed — the old rule false-positive-blocked them, producing friction on legitimate worktree-scoped feature-branch pushes.

## Trade-off (documented in the hook comment block)

This rule trusts variable-bearing push targets. If a skill or agent sets a push-target variable to `main`, the push goes through. Accepted because:

1. zskills skills derive branch names from config + slug with default `feat/` prefix; reaching `branch=main` requires a buggy skill or adversarial description.
2. A compromised agent that controls the bash already has easier paths (eval, concatenation, obfuscation) the hook cannot defend against.
3. The strict alternative produces false-positives on legitimate worktree-scoped pushes without closing a realistic attack vector.

Net: equal-or-stricter for literal-pattern attacks (explicit `origin main`, force-prefixed, refspec, naked-from-main), with the false-positive removed.

## Pre-existing bug surfaced (not patched here)

The agent doing the edit found that the hook's COMMAND-extraction sed (hooks/block-unsafe-project.sh:32) is greedy — it captures trailing JSON fields (e.g., `"},"transcript_path":"..."`) into `$COMMAND` when the test harness or runtime layers additional JSON after `command`. This means patterns at the "end of the real command" can have unexpected trailing text. One regex in this PR was relaxed to accommodate that quirk. Worth a separate follow-up to fix the greedy extractor properly.

## Test plan

- [x] tests/test-hooks.sh: 314/314 (8 new cases: 3 ALLOW for variable-bearing pushes, 5 DENY covering +main force, HEAD:main, HEAD:master, naked-from-main, and master literal)
- [x] tests/run-all.sh: full suite green

🤖 Generated with /quickfix