### PR TITLE
fix(config,ci): run full test suite at commit + CI, not just hooks

### DIFF
--- a/.claude/zskills-config.json
+++ b/.claude/zskills-config.json
@@ -14,8 +14,8 @@
   },
 
   "testing": {
-    "unit_cmd": "bash tests/test-hooks.sh",
-    "full_cmd": "bash tests/test-hooks.sh",
+    "unit_cmd": "bash tests/run-all.sh",
+    "full_cmd": "bash tests/run-all.sh",
     "output_file": ".test-results.txt",
     "file_patterns": ["tests/**/*.sh"]
   },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
           git config --global user.name "CI Test Runner"
           git config --global init.defaultBranch main
 
-      - name: Run hook tests
-        run: bash tests/test-hooks.sh
+      - name: Run full test suite
+        run: bash tests/run-all.sh
 
       - name: Bash syntax check on hooks and scripts
         run: |


### PR DESCRIPTION
## Summary

Restores the proper full-test gate at both /quickfix's commit-time check and GitHub CI. Both were narrowed to `bash tests/test-hooks.sh` (hook tests only) and missed regressions in `test-quickfix.sh`, `test-skill-conformance.sh`, `test-skill-invariants.sh`, etc.

## Root cause

Commit `04a39ff chore: set full_cmd to tests/test-hooks.sh directly` weakened `testing.full_cmd` from `bash scripts/test-all.sh` (a downstream-template runner with unreplaced `{{PLACEHOLDERS}}` in zskills itself) to `bash tests/test-hooks.sh` (too narrow). The agent picked "make it not crash" over "point at the correct zskills runner." The config schema is explicit: `full_cmd` is "Command to run all tests (unit + integration + E2E)." `tests/run-all.sh` is that runner.

## Changes

- `.claude/zskills-config.json`: `testing.unit_cmd` and `testing.full_cmd` both → `bash tests/run-all.sh`.
- `.github/workflows/test.yml`: step renamed "Run hook tests" → "Run full test suite"; command changed `bash tests/test-hooks.sh` → `bash tests/run-all.sh`.

Other CI steps (bash syntax check, skill-source/mirror drift check, stdin bash-ism check) preserved — those are CI-specific niceties that `run-all.sh` doesn't cover.

## Effect

- /quickfix's WI 1.12 test gate now runs the full suite before every commit (~15-30s vs. ~1s for hooks-only). Cost per /quickfix goes up; correctness guarantee is real.
- CI on every PR + every push to main runs the full suite. Regressions in any test file are caught at the PR stage, not at ship-to-prod.
- PR #45's `test-skill-conformance.sh` regression would have been caught at either gate under this configuration.

## Test plan

- [x] `bash tests/run-all.sh`: 733/733
- [x] No other changes to skills or scripts.

🤖 Generated with /quickfix