### PR TITLE
fix(tests): narrow shadow-bin in case 16 to hide gh on CI runners

### DIFF
--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -456,15 +456,22 @@ rm -f -- "$ERR"
 
 # ────────────────────────────────────────────────────────────────────
 # Case 16 — gh missing exits 1 with gh-keyword stderr.
-# Point PATH at a minimal shadow that excludes gh; assert rc=1 plus
-# 'requires gh' in stderr. The PATH is /usr/bin:/bin (common commands
-# available, no project bin/, no gh) — jq is NOT required any more
-# since the skill parses config via bash-regex.
+# Build a narrow shadow bin that explicitly excludes gh. /usr/bin/gh is
+# preinstalled on GitHub Actions runners, so PATH="/usr/bin:/bin" does
+# NOT hide it there. Instead, construct a PATH that contains only the
+# commands the preflight needs, found at their actual locations via
+# `command -v`, and NO gh. Assert rc=1 plus 'requires gh' in stderr.
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c16)
 ERR=$(mktemp)
-(cd "$FIX" && PATH="/usr/bin:/bin" bash "$PREFLIGHT_SCRIPT" "fix something" >/dev/null 2>"$ERR")
+SHADOW_BIN=$(mktemp -d)
+for cmd in bash cat grep sed awk date mkdir head basename git printf env tr cut; do
+  src=$(command -v "$cmd" 2>/dev/null) || continue
+  ln -s "$src" "$SHADOW_BIN/$cmd"
+done
+(cd "$FIX" && PATH="$SHADOW_BIN" bash "$PREFLIGHT_SCRIPT" "fix something" >/dev/null 2>"$ERR")
 RC=$?
+rm -rf -- "$SHADOW_BIN"
 if [ "$RC" -eq 1 ] && grep -q 'requires gh' "$ERR"; then
   pass "16 gh missing: rc=1 + 'requires gh' stderr"
 else


### PR DESCRIPTION
## Summary

Fixes `tests/test-quickfix.sh` Case 16 ("gh missing") to work on GitHub Actions ubuntu-latest. The previous PATH setup (`PATH="/usr/bin:/bin"`) assumed `gh` wasn't in either directory — true on dev containers where `gh` is at `/usr/local/bin/gh`, but false on Actions runners where `gh` is preinstalled at `/usr/bin/gh`. Result: CI saw `rc=0` from the skill (it found gh via /usr/bin) instead of the expected `rc=1` from the gh-missing gate.

Exposed by PR #52's full-test-gate landing — the test only started running in CI once `test.yml` switched to `tests/run-all.sh`. Pre-existing environment assumption, not a new regression.

## Fix

Replace the fragile PATH-subset approach with a narrow shadow-bin directory:

- `mktemp -d` a fresh tmp dir
- Symlink the commands the preflight actually uses (bash, cat, grep, sed, awk, date, mkdir, head, basename, git, printf, env, tr, cut) from wherever they live on the host
- Set `PATH=$SHADOW_BIN` (just that, no /usr/bin, no /bin)
- `gh` is unreachable regardless of where the host has it installed
- Clean up the shadow dir after the case runs

## Scope audit

Only Case 16 used the `PATH="/usr/bin:/bin"` idiom (grep confirmed). Other tests use `PATH="$FIX/bin:$PATH"` which doesn't hide real-system gh. No other fix needed.

## Test plan

- [x] `bash tests/run-all.sh` locally: 733/733
- [x] Grep "PASS 16" in test-quickfix.sh run: confirmed
- [ ] CI on this PR will confirm the fix works on ubuntu-latest — the whole point of this PR

🤖 Generated with /quickfix