### PR TITLE
fix(tests): test-create-worktree cases 10/11/12/19 assume local 'main' ref

### DIFF
--- a/tests/test-create-worktree.sh
+++ b/tests/test-create-worktree.sh
@@ -31,6 +31,19 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # paths on MAIN_ROOT, so the test must too (else default paths mismatch).
 MAIN_ROOT="$(cd "$(git -C "$REPO_ROOT" rev-parse --git-common-dir)/.." && pwd)"
 PROJECT_NAME="$(basename "$MAIN_ROOT")"
+
+# Fixture anchors for cases 10, 11, 19. These cases construct synthetic
+# branches via plumbing (commit-tree) rooted on the current main-equivalent
+# commit. On a main-branch checkout (local dev, push-to-main CI) `main`
+# exists as a local ref; on a GitHub Actions PR checkout HEAD is detached
+# at the PR merge commit and local `main` does NOT exist. Fall back to
+# HEAD so fixture construction succeeds in both environments.
+# --verify --quiet ensures rev-parse prints NOTHING on failure (without
+# --verify it prints the unresolved name to stdout, polluting the var).
+MAIN_SHA=$(git -C "$MAIN_ROOT" rev-parse --verify --quiet main 2>/dev/null \
+        || git -C "$MAIN_ROOT" rev-parse --verify HEAD)
+MAIN_TREE_SHA=$(git -C "$MAIN_ROOT" rev-parse --verify --quiet main^{tree} 2>/dev/null \
+             || git -C "$MAIN_ROOT" rev-parse --verify HEAD^{tree})
 # Prefer the worktree copy of the script so in-flight edits (this phase's
 # Phase 1a-gap fixes, for example) are exercised rather than the landed
 # main-repo copy. Fall back to the main-repo script only if the worktree
@@ -352,12 +365,11 @@ BR_10="${PREFIX_10}-${SLUG_10}"
 BASE_10="cw-testbase-${SLUG_BASE}-c10"
 register_branch "$BR_10"; register_branch "$BASE_10"
 
-MAIN_SHA=$(git -C "$MAIN_ROOT" rev-parse main)
 # Stale branch at main SHA.
 git -C "$MAIN_ROOT" branch "$BR_10" "$MAIN_SHA" 2>/dev/null || true
 # Synthetic base, one empty commit ahead of main.
 BASE_COMMIT_10=$(GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test \
-  git -C "$MAIN_ROOT" commit-tree "$(git -C "$MAIN_ROOT" rev-parse main^{tree})" -p "$MAIN_SHA" -m "cw-test: base advance c10")
+  git -C "$MAIN_ROOT" commit-tree "$MAIN_TREE_SHA" -p "$MAIN_SHA" -m "cw-test: base advance c10")
 git -C "$MAIN_ROOT" branch "$BASE_10" "$BASE_COMMIT_10" 2>/dev/null || true
 
 ERR_10=$(mktemp)
@@ -385,7 +397,7 @@ BR_11="${PREFIX_11}-${SLUG_11}"
 register_branch "$BR_11"
 
 AHEAD_COMMIT_11=$(GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test \
-  git -C "$MAIN_ROOT" commit-tree "$(git -C "$MAIN_ROOT" rev-parse main^{tree})" -p "$MAIN_SHA" -m "cw-test: ahead c11")
+  git -C "$MAIN_ROOT" commit-tree "$MAIN_TREE_SHA" -p "$MAIN_SHA" -m "cw-test: ahead c11")
 git -C "$MAIN_ROOT" branch "$BR_11" "$AHEAD_COMMIT_11" 2>/dev/null || true
 
 ERR_11=$(mktemp)
@@ -687,7 +699,6 @@ register_wt "$WT_19"; register_branch "$BR_19"; register_branch "$ROLLBACK_BRANC
 
 # Build the rollback base via plumbing: take main's tree, splice in
 # .zskills-tracked/keep, commit on top of main.
-MAIN_TREE_SHA=$(git -C "$MAIN_ROOT" rev-parse main^{tree})
 KEEP_BLOB=$(echo "rollback fixture for case 19" | git -C "$MAIN_ROOT" hash-object -w --stdin)
 SUB_TREE=$(printf '100644 blob %s\tkeep\n' "$KEEP_BLOB" | git -C "$MAIN_ROOT" mktree)
 # Extract all existing entries from main's tree, append our new entry.


### PR DESCRIPTION
## Summary

Fixes `tests/test-create-worktree.sh` Cases 10, 11, 12 (cascade from 11), and 19 which fail on GitHub Actions PR CI. These cases construct synthetic branches via `git commit-tree` rooted on the current main-equivalent commit. The fixture setup read `$(git rev-parse main)` and `$(git rev-parse main^{tree})` directly — but `actions/checkout@v4` on a PR event leaves HEAD detached at the PR merge commit and does NOT create a local `main` ref, so both calls fail.

Exposed by PR #52's full-test-gate landing. Before #52, `test.yml` ran only a hook subset; `test-create-worktree.sh` never ran in CI.

## Failure shape observed on PR #53's CI

```
FAIL 10 poisoned: rc=128, stdout=''
    fatal: ambiguous argument 'main^{tree}': unknown revision or path not in the working tree.
    fatal: not a valid object name main
FAIL 11 resume-denied: rc=0, stdout='/tmp/...'   ← fixture branch never created, so fresh create
FAIL 12 resume-allowed: rc=2                      ← cascade from 11 (path already exists)
FAIL 19 rollback: rc=128, stdout=''
    fatal: invalid reference: test-rollback-base-...
```

## Fix

- Hoist `MAIN_SHA` and `MAIN_TREE_SHA` to the top of the test with `--verify --quiet` and HEAD fallback.
- `--verify` is load-bearing: without it, `git rev-parse` prints the unresolved name to stdout on failure, polluting the capture (confirmed in CI-sim: `MAIN_SHA='main\n<sha>'` broke `commit-tree`).
- Remove the redundant inline `rev-parse main^{tree}` in cases 10/11 and the redundant assignments in cases 10/19.

## Validation

Reproduced in a depth-1 clone with detached HEAD and no local `main`:
- Before fix (even with basic `|| HEAD` fallback): 4/22 fail same as CI
- With `--verify --quiet` fallback: **22/22 pass**
- Full `bash tests/run-all.sh` locally: 733/733 pass

## Test plan

- [x] Full suite green locally (733/733)
- [x] CI-sim (detached HEAD, no `main`): 22/22
- [ ] CI on this PR will confirm (the whole point of this PR)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>