### PR TITLE
docs(readme): add Tests CI badge (dev-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <!-- prod-strip:start -->
 [![🚀 Ship to Prod](https://img.shields.io/badge/%F0%9F%9A%80%20Ship%20to%20Prod-click%20to%20release-ea580c?style=for-the-badge)](https://github.com/zeveck/zskills-dev/actions/workflows/ship-to-prod.yml)
+[![Tests](https://github.com/zeveck/zskills-dev/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/zeveck/zskills-dev/actions/workflows/test.yml)
 
 > ⚠️ **This is `zskills-dev`, the development repository.** End users should
 > install from the public mirror at **[`github.com/zeveck/zskills`](https://github.com/zeveck/zskills)**.


### PR DESCRIPTION
## Summary

Adds the Tests workflow badge next to the Ship to Prod badge. Lives inside the existing `<!-- prod-strip:start --> ... <!-- prod-strip:end -->` block so `scripts/build-prod.sh` keeps it out of the public mirror — dev-repo-specific signal only.

## Test plan

- [x] Badge markup renders (uses standard GitHub Actions SVG endpoint)
- [ ] Confirm badge is stripped by build-prod.sh on next ship

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>