### PR TITLE
feat(drift-arch): runtime config read + drift-warn (DRIFT_ARCH_FIX)

### DIFF
--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -2,8 +2,9 @@
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
-# This file is a template. Replace {{PLACEHOLDER}} values and remove
-# sections that don't apply to your project.
+# This file is a template. Most behavior is now driven at runtime from
+# .claude/zskills-config.json (unit_cmd, full_cmd, ui.file_patterns,
+# main_protected, etc.). Remove sections that don't apply to your project.
 #
 # Register BOTH this file and block-unsafe-generic.sh in .claude/settings.json
 # on the PreToolUse event, Bash matcher. The generic layer runs first.
@@ -221,38 +222,97 @@ fi
 
 # ─── CONFIGURE: set your test command patterns ────────────────────────
 # Piping test output (loses failures, forces re-runs -- capture to file instead)
-# Replace the placeholder values with your actual test command patterns.
-UNIT_TEST_CMD="bash tests/test-hooks.sh"
-FULL_TEST_CMD="bash tests/test-hooks.sh"
-
-# Build regex pattern from configured test commands (fall back to generic if unconfigured)
-if [[ "$UNIT_TEST_CMD" == *'{{'* ]] || [[ "$FULL_TEST_CMD" == *'{{'* ]]; then
-  # Placeholders not replaced -- use a generic pattern that catches common test runners
-  TEST_PIPE_PATTERN='npm[[:space:]]+test([[:space:]]|$)|npm[[:space:]]+run[[:space:]]+test(:[^[:space:]]+)?([[:space:]]|$)|node[[:space:]]+--test[[:space:]]'
-else
-  # Escape dots and special chars for bash regex
-  ESCAPED_UNIT="${UNIT_TEST_CMD//./\\.}"
-  ESCAPED_FULL="${FULL_TEST_CMD//./\\.}"
-  # Replace spaces with flexible whitespace
-  ESCAPED_UNIT="${ESCAPED_UNIT// /[[:space:]]+}"
-  ESCAPED_FULL="${ESCAPED_FULL// /[[:space:]]+}"
-  TEST_PIPE_PATTERN="(${ESCAPED_UNIT}|${ESCAPED_FULL})"
-fi
-
-# Split on &&, ||, ; so the pipe check only fires when the pipe is in
-# the SAME segment as the test command (otherwise an unrelated `ls | head`
-# earlier in the command falsely trips the block).
-_TEST_SEP=$'\x01'
-_TEST_NORM="${INPUT//&&/$_TEST_SEP}"
-_TEST_NORM="${_TEST_NORM//||/$_TEST_SEP}"
-_TEST_NORM="${_TEST_NORM//;/$_TEST_SEP}"
-IFS=$'\x01' read -ra _TEST_SEGMENTS <<< "$_TEST_NORM"
-for _seg in "${_TEST_SEGMENTS[@]}"; do
-  if [[ "$_seg" =~ $TEST_PIPE_PATTERN ]] && [[ "$_seg" == *'|'* ]]; then
-    block_with_reason "Don't pipe test output -- it loses failure details. Instead: TEST_OUT=\"/tmp/zskills-tests/\$(basename \"\$(pwd)\")\"; mkdir -p \"\$TEST_OUT\"; ${FULL_TEST_CMD:-npm run test:all} > \"\$TEST_OUT/.test-results.txt\" 2>&1 then read \"\$TEST_OUT/.test-results.txt\" to inspect failures."
+#
+# ─── Runtime config read (eliminates install-time drift) ───
+# Config location: .claude/zskills-config.json in the checked-out tree.
+# --show-toplevel matches the existing is_main_protected() pattern at
+# line 146; in a worktree, this returns the worktree root, which is
+# correct — the config is git-tracked, so each worktree reads its own
+# branch-current version.
+_ZSK_REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+_ZSK_CFG="$_ZSK_REPO_ROOT/.claude/zskills-config.json"
+UNIT_TEST_CMD=""
+FULL_TEST_CMD=""
+UI_FILE_PATTERNS=""
+if [ -f "$_ZSK_CFG" ]; then
+  _ZSK_CFG_BODY=$(cat "$_ZSK_CFG" 2>/dev/null) || _ZSK_CFG_BODY=""
+  if [[ "$_ZSK_CFG_BODY" =~ \"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    UNIT_TEST_CMD="${BASH_REMATCH[1]}"
   fi
-done
-unset _TEST_SEP _TEST_NORM _TEST_SEGMENTS _seg
+  if [[ "$_ZSK_CFG_BODY" =~ \"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    FULL_TEST_CMD="${BASH_REMATCH[1]}"
+  fi
+  # ui.file_patterns: scope via enclosing "ui" object to disambiguate
+  # from testing.file_patterns (array, doesn't match the string regex
+  # anyway, but prefix scoping is defensive against future schema change).
+  if [[ "$_ZSK_CFG_BODY" =~ \"ui\"[[:space:]]*:[[:space:]]*\{[^}]*\"file_patterns\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    UI_FILE_PATTERNS="${BASH_REMATCH[1]}"
+  fi
+  unset _ZSK_CFG_BODY
+fi
+unset _ZSK_REPO_ROOT _ZSK_CFG
+
+# Escape every bash-regex metacharacter that might appear in a config
+# test-command string (parens, brackets, pipe, asterisk, plus, etc.).
+# Then re-space spaces to [[:space:]]+ so "bash  tests/run-all.sh"
+# (multiple spaces) still matches.
+#
+# Bash parameter-expansion quoting note: inside ${var//pat/replace}, `pat`
+# is a glob pattern. `?` matches any single char, `[...]` is a class,
+# `}` closes the expansion early. We use `[?]` (literal-? class) for the
+# `?` rule and `\\\}` (escaped closer) for the `}` rule to work around these.
+_zsk_regex_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//./\\.}"
+  s="${s//\(/\\(}"
+  s="${s//\)/\\)}"
+  s="${s//\[/\\[}"
+  s="${s//\]/\\]}"
+  s="${s//|/\\|}"
+  s="${s//\*/\\*}"
+  s="${s//+/\\+}"
+  s="${s//[?]/\\?}"
+  s="${s//\$/\\\$}"
+  s="${s//^/\\^}"
+  s="${s//\{/\\{}"
+  s="${s//\}/\\\}}"
+  s="${s// /[[:space:]]+}"
+  printf '%s' "$s"
+}
+
+# Guard: without both vars set, TEST_PIPE_PATTERN="(|)" matches empty
+# string and blocks every piped command. Skip the pipe check entirely
+# if both are empty (config missing or test fields unset).
+if [ -n "$UNIT_TEST_CMD" ] || [ -n "$FULL_TEST_CMD" ]; then
+  ESCAPED_UNIT=""
+  ESCAPED_FULL=""
+  [ -n "$UNIT_TEST_CMD" ] && ESCAPED_UNIT="$(_zsk_regex_escape "$UNIT_TEST_CMD")"
+  [ -n "$FULL_TEST_CMD" ] && ESCAPED_FULL="$(_zsk_regex_escape "$FULL_TEST_CMD")"
+  # Only alternate non-empty vars to avoid "(|cmd)" degenerate case.
+  if [ -n "$ESCAPED_UNIT" ] && [ -n "$ESCAPED_FULL" ]; then
+    TEST_PIPE_PATTERN="(${ESCAPED_UNIT}|${ESCAPED_FULL})"
+  elif [ -n "$ESCAPED_UNIT" ]; then
+    TEST_PIPE_PATTERN="${ESCAPED_UNIT}"
+  else
+    TEST_PIPE_PATTERN="${ESCAPED_FULL}"
+  fi
+
+  # Split on &&, ||, ; so the pipe check only fires when the pipe is in
+  # the SAME segment as the test command (otherwise an unrelated `ls | head`
+  # earlier in the command falsely trips the block).
+  _TEST_SEP=$'\x01'
+  _TEST_NORM="${INPUT//&&/$_TEST_SEP}"
+  _TEST_NORM="${_TEST_NORM//||/$_TEST_SEP}"
+  _TEST_NORM="${_TEST_NORM//;/$_TEST_SEP}"
+  IFS=$'\x01' read -ra _TEST_SEGMENTS <<< "$_TEST_NORM"
+  for _seg in "${_TEST_SEGMENTS[@]}"; do
+    if [[ "$_seg" =~ $TEST_PIPE_PATTERN ]] && [[ "$_seg" == *'|'* ]]; then
+      block_with_reason "Don't pipe test output -- it loses failure details. Instead: TEST_OUT=\"/tmp/zskills-tests/\$(basename \"\$(pwd)\")\"; mkdir -p \"\$TEST_OUT\"; ${FULL_TEST_CMD:-npm run test:all} > \"\$TEST_OUT/.test-results.txt\" 2>&1 then read \"\$TEST_OUT/.test-results.txt\" to inspect failures."
+    fi
+  done
+  unset _TEST_SEP _TEST_NORM _TEST_SEGMENTS _seg
+fi
 
 # --- main_protected: block git commit on main ---
 if [[ "$COMMAND" =~ git[[:space:]]+commit ]] && is_main_protected && is_on_main; then
@@ -266,49 +326,26 @@ if [[ "$COMMAND" =~ git[[:space:]]+commit ]]; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
-    if [[ "$FULL_TEST_CHECK" == *'{{'* ]]; then
-      # Placeholder not replaced -- warn only if project has test infrastructure
-      REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-      HAS_TESTS=false
-      if [ -f "$REPO_ROOT/package.json" ]; then
-        PACKAGE_CONTENT=$(<"$REPO_ROOT/package.json")
-        if [[ "$PACKAGE_CONTENT" == *'"test"'* ]]; then
-          HAS_TESTS=true
+    # Check if full test command was run in this session
+    TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
+    if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
+      # Check if any code files are being committed (skip check for content-only)
+      DIFF_OUTPUT=$(git diff --cached --name-only 2>/dev/null)
+      CODE_FILES=""
+      while IFS= read -r line; do
+        if [[ "$line" =~ \.(js|ts|json|css|html|rs|py|go|rb)$ ]]; then
+          CODE_FILES+="$line"$'\n'
         fi
-      fi
-      if ! $HAS_TESTS; then
-        for f in "$REPO_ROOT"/pytest.ini "$REPO_ROOT"/jest.config.* "$REPO_ROOT"/vitest.config.* "$REPO_ROOT"/.mocharc.* "$REPO_ROOT"/Makefile; do
-          if [[ -f "$f" ]]; then
-            HAS_TESTS=true
-            break
-          fi
-        done
-      fi
-      if $HAS_TESTS; then
-        block_with_reason "BLOCKED: Test infrastructure detected but FULL_TEST_CMD not configured in block-unsafe-project.sh. Configure it so the pre-commit test check works."
-      fi
-    else
-      # Check if full test command was run in this session
-      TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
-      if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
-        # Check if any code files are being committed (skip check for content-only)
-        DIFF_OUTPUT=$(git diff --cached --name-only 2>/dev/null)
-        CODE_FILES=""
-        while IFS= read -r line; do
-          if [[ "$line" =~ \.(js|ts|json|css|html|rs|py|go|rb)$ ]]; then
-            CODE_FILES+="$line"$'\n'
-          fi
-        done <<< "$DIFF_OUTPUT"
-        if [ -n "$CODE_FILES" ]; then
-          block_with_reason "BLOCKED: Committing code but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before committing. (Content-only commits are exempt.)"
-        fi
+      done <<< "$DIFF_OUTPUT"
+      if [ -n "$CODE_FILES" ]; then
+        block_with_reason "BLOCKED: Committing code but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before committing. (Content-only commits are exempt.)"
       fi
     fi
 
     # ─── CONFIGURE: set your UI source paths, or remove this section if not applicable ───
-    # Check if UI files changed but no playwright-cli verification
-    UI_FILE_PATTERNS="{{UI_FILE_PATTERNS}}"
-    if [[ "$UI_FILE_PATTERNS" != '{{UI_FILE_PATTERNS}}' ]]; then
+    # Check if UI files changed but no playwright-cli verification.
+    # UI_FILE_PATTERNS is initialized at the top from .claude/zskills-config.json (ui.file_patterns).
+    if [ -n "$UI_FILE_PATTERNS" ]; then
       UI_DIFF_OUTPUT=$(git diff --cached --name-only 2>/dev/null)
       UI_FILES=""
       while IFS= read -r line; do
@@ -424,32 +461,9 @@ if [[ "$COMMAND" =~ git[[:space:]]+cherry-pick ]]; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
-    if [[ "$FULL_TEST_CHECK" == *'{{'* ]]; then
-      # Placeholder not replaced -- warn only if project has test infrastructure
-      REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-      HAS_TESTS=false
-      if [ -f "$REPO_ROOT/package.json" ]; then
-        PACKAGE_CONTENT=$(<"$REPO_ROOT/package.json")
-        if [[ "$PACKAGE_CONTENT" == *'"test"'* ]]; then
-          HAS_TESTS=true
-        fi
-      fi
-      if ! $HAS_TESTS; then
-        for f in "$REPO_ROOT"/pytest.ini "$REPO_ROOT"/jest.config.* "$REPO_ROOT"/vitest.config.* "$REPO_ROOT"/.mocharc.* "$REPO_ROOT"/Makefile; do
-          if [[ -f "$f" ]]; then
-            HAS_TESTS=true
-            break
-          fi
-        done
-      fi
-      if $HAS_TESTS; then
-        block_with_reason "BLOCKED: Test infrastructure detected but FULL_TEST_CMD not configured in block-unsafe-project.sh. Configure it so the pre-commit test check works."
-      fi
-    else
-      TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
-      if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
-        block_with_reason "BLOCKED: git cherry-pick but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before landing code on main."
-      fi
+    TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
+    if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
+      block_with_reason "BLOCKED: git cherry-pick but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before landing code on main."
     fi
   fi
 

--- a/.claude/hooks/warn-config-drift.sh
+++ b/.claude/hooks/warn-config-drift.sh
@@ -3,8 +3,8 @@
 #
 # Fires after an Edit or Write tool whose target path ends with
 # .claude/zskills-config.json. Emits a note on stderr reminding the
-# user that CLAUDE.md is a render-time snapshot and may now be stale;
-# `/update-zskills --rerender` regenerates the template-managed portion.
+# user that .claude/rules/zskills/managed.md is a render-time snapshot
+# and may now be stale; `/update-zskills --rerender` regenerates it.
 #
 # Non-blocking by contract: always exits 0, even on malformed input.
 # A PostToolUse warn hook must never halt the user.
@@ -37,7 +37,7 @@ if [[ "$FILE_PATH" == *".claude/zskills-config.json" ]]; then
 NOTE: You just edited `.claude/zskills-config.json`.
 
 - Hooks and helper scripts read config at runtime — they are already current.
-- CLAUDE.md is a render-time snapshot — it may now be stale. Run `/update-zskills --rerender` to regenerate the template-managed portion (user-added content below `## Agent Rules` is preserved; conflicts write `CLAUDE.md.new` for manual merge).
+- `.claude/rules/zskills/managed.md` is a render-time snapshot — it may now be stale. Run `/update-zskills --rerender` to regenerate it (full-file rewrite; the file is zskills-owned, no user content lives there).
 WARN
 fi
 

--- a/.claude/hooks/warn-config-drift.sh
+++ b/.claude/hooks/warn-config-drift.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# warn-config-drift.sh — PostToolUse hook, non-blocking warn.
+#
+# Fires after an Edit or Write tool whose target path ends with
+# .claude/zskills-config.json. Emits a note on stderr reminding the
+# user that CLAUDE.md is a render-time snapshot and may now be stale;
+# `/update-zskills --rerender` regenerates the template-managed portion.
+#
+# Non-blocking by contract: always exits 0, even on malformed input.
+# A PostToolUse warn hook must never halt the user.
+
+set -u
+
+INPUT=$(cat 2>/dev/null) || exit 0
+[ -z "$INPUT" ] && exit 0
+
+# Extract tool_name. Handles `"tool_name":"Edit"` and `"tool_name": "Edit"`.
+TOOL_NAME=""
+if [[ "$INPUT" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  TOOL_NAME="${BASH_REMATCH[1]}"
+fi
+
+# Only Edit and Write are wired to this hook; bail on anything else.
+if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then
+  exit 0
+fi
+
+# Extract tool_input.file_path. Same whitespace-tolerant idiom.
+FILE_PATH=""
+if [[ "$INPUT" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  FILE_PATH="${BASH_REMATCH[1]}"
+fi
+
+# Suffix-match: handles absolute, repo-relative, cwd-relative paths.
+if [[ "$FILE_PATH" == *".claude/zskills-config.json" ]]; then
+  cat >&2 <<'WARN'
+NOTE: You just edited `.claude/zskills-config.json`.
+
+- Hooks and helper scripts read config at runtime — they are already current.
+- CLAUDE.md is a render-time snapshot — it may now be stale. Run `/update-zskills --rerender` to regenerate the template-managed portion (user-added content below `## Agent Rules` is preserved; conflicts write `CLAUDE.md.new` for manual merge).
+WARN
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,28 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -758,6 +758,18 @@ subagent dispatches that specify a model below the configured minimum
 surfaces `/update-zskills --rerender` guidance after edits to
 `.claude/zskills-config.json`.
 
+**Install-integrity check (applies to every row).** Before writing a
+settings.json entry for a triple, verify the referenced hook file is
+present in `$PORTABLE/hooks/` (source) — and therefore copyable to
+`.claude/hooks/`. If the source file is missing (e.g. a zskills release
+cut before the hook landed), warn the user and **skip that row's
+wiring**; do not write a settings.json entry pointing at a script that
+won't exist on disk. Report as `skip: <basename> — source missing` in
+the Step 6 preview. Same pattern as the other hook copies in Step C:
+"Copy missing hooks from `$PORTABLE/hooks/`" already fails soft if the
+source file isn't there; this just extends that convention into the
+settings.json merge.
+
 #### Step C.9 — Hook renames
 
 Rename migrations run BEFORE the main Step C merge loop (step 3 above),

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-zskills
-argument-hint: "[install] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
+argument-hint: "[install | --rerender] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 ---
 
@@ -13,7 +13,7 @@ dependencies.
 **Invocation:**
 
 ```
-/update-zskills [install] [cherry-pick | locked-main-pr | direct]
+/update-zskills [install | --rerender] [cherry-pick | locked-main-pr | direct]
                 [--with-addons | --with-block-diagram-addons]
 ```
 
@@ -25,6 +25,10 @@ was found and what was done about it.
 **Explicit mode:**
 - `install` — force a full first-time setup (same as what the default
   mode does when nothing is installed, but skips the detection step)
+- `--rerender` — regenerate the template-managed portion of `CLAUDE.md`
+  against the current `.claude/zskills-config.json`. Preserves every
+  line below `## Agent Rules`. No audit, no preset, no hooks/scripts
+  touched. See `### Step D — --rerender` for the full algorithm.
 
 **Preset keywords (bare word, anywhere in the args):**
 
@@ -317,13 +321,11 @@ for each field F in schema:
 
 | Placeholder | Config path | Example |
 |-------------|-------------|---------|
-| `{{UNIT_TEST_CMD}}` | `testing.unit_cmd` | `npm run test` |
-| `{{FULL_TEST_CMD}}` | `testing.full_cmd` | `npm run test:all` |
-| `{{UI_FILE_PATTERNS}}` | `ui.file_patterns` | `src/(components\|ui)/.*\\.tsx?$` |
 | `{{DEV_SERVER_CMD}}` | `dev_server.cmd` | `npm start` |
 | `{{PORT_SCRIPT}}` | `dev_server.port_script` | `scripts/port.sh` |
-| `{{MAIN_REPO_PATH}}` | `dev_server.main_repo_path` | `/workspaces/my-app` |
 | `{{AUTH_BYPASS}}` | `ui.auth_bypass` | `localStorage.setItem(...)` |
+
+Runtime-read fields (not install-filled): `testing.unit_cmd`, `testing.full_cmd`, `ui.file_patterns`, `dev_server.main_repo_path`. Hooks and helper scripts read these directly from `.claude/zskills-config.json` at every invocation — see Phase 1 of `plans/DRIFT_ARCH_FIX.md`.
 
 **Empty value handling:** When a config field is empty string `""`, the
 corresponding template section is commented out with a TODO marker:
@@ -620,9 +622,25 @@ a duplicate section header.
 Copy missing hooks from `$PORTABLE/hooks/` to `.claude/hooks/`.
 
 - For `block-unsafe-project.sh.template`: copy to
-  `.claude/hooks/block-unsafe-project.sh`, then fill in the
-  `# CONFIGURE:` values from project detection (test commands, UI file
-  patterns). Use placeholders/fallbacks for anything undetectable.
+  `.claude/hooks/block-unsafe-project.sh`. No install-time placeholder
+  fill needed — the hook reads `testing.unit_cmd`, `testing.full_cmd`,
+  and `ui.file_patterns` from `.claude/zskills-config.json` at runtime
+  via bash regex (same idiom as `is_main_protected()`). Just copy the
+  source template.
+- For `scripts/port.sh` and `scripts/test-all.sh`: copy as-is from
+  `$PORTABLE/scripts/`. These also read `dev_server.main_repo_path` and
+  `testing.unit_cmd` from `.claude/zskills-config.json` at runtime — no
+  install-time fill.
+- For any remaining templates that do still contain placeholders
+  (`{{E2E_TEST_CMD}}`, `{{BUILD_TEST_CMD}}`): these have no config
+  source, so fill from project detection or leave as a `# TODO`
+  comment. Only these two placeholders — all others listed in the
+  Step 0.5 mapping table go through the template-render path (Step B),
+  not the hook path.
+
+Note: hooks and helper scripts read `testing.*`, `ui.file_patterns`,
+and `dev_server.main_repo_path` from `.claude/zskills-config.json` at
+runtime. No install-time fill needed. Only copy the source template.
 
 **Explain what each hook does** so the user understands what's being added:
 
@@ -655,48 +673,127 @@ Tracking files are ephemeral session state and should never be committed.
 project's dev server launcher); PID files are per-worktree runtime state
 and must never be committed.
 
-Then register the hooks in `.claude/settings.json`. The format is:
+Then register the hooks in `.claude/settings.json` via a **surgical
+agent-driven merge** — `Read` + `Edit` only, never `Write`-from-template.
+This preserves every other top-level key (`permissions`, `env`,
+`statusLine`, `model`, ...) and every non-zskills-owned hook entry that
+a user or another tool may have added.
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh\"",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  }
-}
+**Canonical zskills-owned triples** (single source of truth — anything
+not in this table is foreign and preserved untouched):
+
+| Event        | Matcher | Command literal                                                              |
+|--------------|---------|------------------------------------------------------------------------------|
+| PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh"`           |
+| PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh"`           |
+| PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`                   |
+| PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
+| PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
+
+All 5 rows carry `"type": "command"` and `"timeout": 5`. The
+`warn-config-drift.sh` hook lands in Phase 3 of
+`plans/DRIFT_ARCH_FIX.md`; the two PostToolUse rows become live once
+that hook is installed.
+
+**Step C algorithm** (never overwrite; never reorder top-level keys;
+never strip whitespace from untouched regions; never re-emit the file
+from a template):
+
+1. **`Read` `.claude/settings.json`.** If the file does not exist,
+   `Write` a minimal file containing only the zskills `hooks` block
+   populated from the table above. Nothing to preserve on a fresh
+   install — stop.
+2. If the top-level `hooks` key is absent, `Edit` to insert a
+   `"hooks": { "PreToolUse": [], "PostToolUse": [] }` skeleton adjacent
+   to the existing top-level keys.
+   Do not touch `permissions`, `env`, `statusLine`, `model`, or any other existing top-level key.
+3. **Run Step C.9 renames first** (see below): for each
+   `old_command → new_command` row in the migration table, search the
+   entire `hooks.PreToolUse` and `hooks.PostToolUse` arrays for an
+   entry whose `command` equals `old_command`. If found, `Edit` to
+   replace the exact `old_command` string with `new_command` in place.
+   The surrounding structure (matcher, timeout, siblings) is preserved.
+   Renames first ensures later steps don't see orphan entries.
+4. For each `(event, matcher, command)` triple in the canonical table:
+   a. Search the ENTIRE `hooks.<event>` array (all matcher blocks) for
+      an object whose `hooks[*].command` equals `command` exactly. If
+      found anywhere — even under a different matcher — treat as
+      "already present" and skip (do not duplicate).
+   b. Otherwise, locate the matcher block whose `matcher` field equals
+      the triple's matcher. If present, `Edit` to append the zskills
+      hook object to that block's `hooks` array.
+      Do not touch sibling hook objects (user-added customizations in the same matcher survive).
+   c. If no matcher block with that matcher exists, `Edit` to append a
+      new `{ "matcher": "<matcher>", "hooks": [ <zskills entry> ] }`
+      object to `hooks.<event>`.
+5. Never reorder top-level keys, never strip whitespace from untouched
+   regions, never re-emit the file from a template, never remove
+   entries not listed in the rename table (Step C.9) or already-present
+   check (step 4a).
+6. **Preview and confirm before any `Edit`.** Display a diff-style
+   summary to the user — one line per planned action (`+ add
+   block-agents.sh under Agent matcher`, `skip: block-unsafe-generic.sh
+   already present`, `rename: block-unsafe-project.sh → deny-unsafe.sh`
+   ) — and ASK for confirmation.
+   Mirrors the Step B CLAUDE.md append convention (preview + ask).
+   On confirmation, perform the Edits; on rejection, report which
+   entries were missing and exit without changes.
+7. **Report:** `"Step C: registered N hook entries, skipped M already
+   present, renamed R, preserved F foreign entries."`
+
+**Why agent-driven, not scripted.** Three prior adversarial reviews of
+bash-splice approaches (append-if-missing, overwrite-if-stock,
+partition-by-ownership) all concluded that bash + nested-JSON is
+high-cost / high-risk. The `Edit` tool's exact-string match + LLM
+reasoning about JSON structure makes this operation natural. Precedents
+in this same skill: Step B's CLAUDE.md append, the `zskills-config.json`
+backfill (Step 0.5 step 3.5), and `scripts/apply-preset.sh`'s line
+splice — all surgical, all agent-driven, all preserve-by-default. Step
+C aligns with the house style.
+
+**Matcher semantics:** `PreToolUse`+`Bash` enforces command safety and
+tracking. `PreToolUse`+`Agent` enforces `agents.min_model` — blocking
+subagent dispatches that specify a model below the configured minimum
+(haiku=1 < sonnet=2 < opus=3). `PostToolUse`+`Edit`/`Write` (Phase 3)
+surfaces `/update-zskills --rerender` guidance after edits to
+`.claude/zskills-config.json`.
+
+#### Step C.9 — Hook renames
+
+Rename migrations run BEFORE the main Step C merge loop (step 3 above),
+so each row rewrites an existing entry in place. The surrounding
+structure (matcher, timeout, siblings) is preserved byte-for-byte.
+
+**When to add a row:** when a zskills release renames a hook file
+(e.g. `block-unsafe.sh` → `block-unsafe-generic.sh`), the PR that
+ships the rename MUST add a row here. Without a row, the old command
+lingers in every downstream install's `settings.json` alongside the
+new one — two copies of the same hook registered under the same
+matcher.
+
+**Format:** one row per rename, `old_command` and `new_command` as
+full exact strings (same form as the canonical table's `Command
+literal` column). Rows are append-only and idempotent — if
+`old_command` is absent from a given install, the row is a no-op.
+
+**Migration table** (initially empty):
+
+```
+# old_command → new_command
+
+# (none yet)
+#
+# Template for future rows:
+# old_command: bash "$CLAUDE_PROJECT_DIR/.claude/hooks/<old-name>.sh"
+# new_command: bash "$CLAUDE_PROJECT_DIR/.claude/hooks/<new-name>.sh"
+#
+# Committed in the same PR that ships the rename. Rows accumulate; the
+# table is append-only. Step C.9 runs each row against every install;
+# rows are idempotent (if old_command absent, the row is a no-op).
 ```
 
-Note: both `Bash` and `Agent` matchers are used for PreToolUse hooks. The `Bash`
-matcher hooks enforce command safety and tracking. The `Agent` matcher hook
-enforces `agents.min_model` — blocking subagent dispatches that specify a model
-below the configured minimum (haiku=1 < sonnet=2 < opus=3).
-
-Report: "Installed N hooks: [list]"
+When a row is added, include it in the preview displayed to the user in
+Step C step 6 (`rename: <basename> → <basename>`).
 
 #### Step C.5 — Statusline (optional)
 
@@ -839,6 +936,103 @@ Run /update-zskills to check for updates later.
 
    Source: $ZSKILLS_PATH (pulled from origin)
    ```
+
+---
+
+### Step D — --rerender
+
+**Trigger:** user runs `/update-zskills --rerender`.
+
+**Scope:** regenerates `CLAUDE.md` only. Hooks and helper scripts are
+runtime-read; they auto-reflect config changes with no action from
+this flag. Does not touch `.claude/settings.json`, skills, or source
+templates. No audit, no preset, no config backfill — this is a pure
+CLAUDE.md re-render against the current `.claude/zskills-config.json`.
+
+**Use case:** after a post-install edit to
+`.claude/zskills-config.json` changes a render-time-filled field
+(`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`, `{{PORT_SCRIPT}}`,
+`{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`, `{{BUILD_TEST_CMD}}`,
+`{{TIMEZONE}}`), the frozen `CLAUDE.md` snapshot has drifted. This
+flag brings it back in sync without an audit round-trip.
+
+**Boundary-detection algorithm:**
+
+1. **Locate the `## Agent Rules` demarcation** in the existing
+   `CLAUDE.md`:
+
+   ```bash
+   HEADING_LINE=$(grep -n '^## Agent Rules[[:space:]]*$' CLAUDE.md | head -1 | cut -d: -f1)
+   ```
+
+   Tolerant of trailing whitespace, strict on leading `##` and — by
+   convention — a surrounding blank line (Step B appends with blank
+   lines around the heading). If no match → **exit 2** with error:
+
+   > `CLAUDE.md missing '## Agent Rules' demarcation; cannot rerender safely. Add the heading or re-run /update-zskills (without --rerender) for initial install.`
+
+2. **Split the existing file** on the heading line:
+   - `existing_above` = lines `1 .. heading_line - 1`
+   - `existing_below` = lines `heading_line .. end` (heading itself
+     stays in the below region)
+
+3. **Render `CLAUDE_TEMPLATE.md` against current config.** For each
+   placeholder (`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`,
+   `{{PORT_SCRIPT}}`, `{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`,
+   `{{BUILD_TEST_CMD}}`, `{{TIMEZONE}}`), substitute the current
+   config value (per Step B's existing fill logic, unchanged). Locate
+   the `## Agent Rules` heading in the rendered output; extract
+   `fresh_above`.
+
+4. **Byte-compare `existing_above` to `fresh_above`.**
+   Right-trim trailing whitespace on each line before comparing, to
+   tolerate editor-induced churn. No "normalize by substituting prior
+   values" — if they differ, the differences are either user edits OR
+   config-change-since-last-render. Both cases mean the user reviews
+   before overwriting.
+
+   - **Identical:** write `fresh_above + existing_below` to
+     `CLAUDE.md`. **Exit 0.** If the resulting bytes equal the
+     existing `CLAUDE.md` content, skip the write entirely so the file
+     mtime stays stable — ensures idempotency (second consecutive
+     `--rerender` is a true no-op).
+   - **Different:** write `fresh_above + existing_below` to
+     `CLAUDE.md.new`. Do NOT overwrite `CLAUDE.md`. Print to stderr
+     verbatim:
+
+     ```
+     CLAUDE.md differs above '## Agent Rules' (user edits, config drift, or both).
+     New rendered content written to CLAUDE.md.new. Review with:
+         diff CLAUDE.md CLAUDE.md.new
+     To accept the new version:  mv CLAUDE.md.new CLAUDE.md
+     To discard it:              rm CLAUDE.md.new
+     ```
+
+     **Exit 2.**
+
+**Missing `CLAUDE.md`:** **exit 1** with error `no existing CLAUDE.md;
+run /update-zskills (without --rerender) for initial install`. Do not
+create one silently — `--rerender` is explicitly a re-render of an
+existing install, not an initial install.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Clean re-render (or idempotent no-op). |
+| 1 | No existing `CLAUDE.md` — not a valid `--rerender` target. |
+| 2 | Conflict (user edits above `## Agent Rules`, or missing demarcation heading). |
+
+**Why no interactive prompt on conflict:** `--rerender` is routinely
+invoked from headless automation (e.g., the Phase 3
+`warn-config-drift.sh` hook suggests it after a config edit). The
+diff-command + merge-instructions on stderr keep the agent's path
+deterministic while preserving user intent.
+
+**What `--rerender` does NOT do:** re-run the audit, backfill config
+fields, apply a preset, update skills, copy hooks/scripts, or touch
+`.claude/settings.json`. Any of those require a full
+`/update-zskills` invocation.
 
 ---
 

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -25,10 +25,11 @@ was found and what was done about it.
 **Explicit mode:**
 - `install` — force a full first-time setup (same as what the default
   mode does when nothing is installed, but skips the detection step)
-- `--rerender` — regenerate the template-managed portion of `CLAUDE.md`
-  against the current `.claude/zskills-config.json`. Preserves every
-  line below `## Agent Rules`. No audit, no preset, no hooks/scripts
-  touched. See `### Step D — --rerender` for the full algorithm.
+- `--rerender` — regenerate `.claude/rules/zskills/managed.md` against
+  the current `.claude/zskills-config.json`. Simple full-file rewrite
+  of the zskills-owned rules file; root `./CLAUDE.md` is never touched.
+  No audit, no preset, no hooks/scripts touched. See
+  `### Step D — --rerender` for the algorithm.
 
 **Preset keywords (bare word, anywhere in the args):**
 
@@ -413,10 +414,12 @@ List all `.claude/skills/*/SKILL.md` files. For each skill:
   - Script references (`scripts/port.sh`, `scripts/test-all.sh`) — check if
     the script file exists.
 
-### Step 2 — Check CLAUDE.md for 13 generic rules
+### Step 2 — Check zskills rules file for 13 generic rules
 
-Read the project's `CLAUDE.md` (if it exists). For each of the 13 generic
-rules, search for a distinctive key phrase that identifies the rule
+Read `.claude/rules/zskills/managed.md` (the zskills-owned rules
+file); if absent, fall back to reading root `./CLAUDE.md` (pre-Phase-4
+installs rendered rules there). For each of the 13 generic rules,
+search for a distinctive key phrase that identifies the rule
 (**case-insensitive**). Mark the rule as present if the key phrase is
 found, missing otherwise.
 
@@ -438,10 +441,12 @@ found, missing otherwise.
 
 ### Step 2.5 — Documentation presence audit (execution modes)
 
-Search the project's `CLAUDE.md` for these documentation-presence signals.
-Mark each present/missing based on **case-insensitive substring match**:
+Search the zskills rules file (`.claude/rules/zskills/managed.md`,
+falling back to root `./CLAUDE.md`) for these documentation-presence
+signals. Mark each present/missing based on **case-insensitive
+substring match**:
 
-| Check | Key phrase(s) to search in CLAUDE.md |
+| Check | Key phrase(s) to search in zskills rules file |
 |-------|--------------------------------------|
 | Execution Modes section | `## Execution Modes` (heading) |
 | Landing mode keywords documented | `cherry-pick` AND `pr` AND `direct` |
@@ -499,7 +504,7 @@ Skill Dependencies: all satisfied | K missing
   - /run-plan requires /verify-changes — NOT INSTALLED
   ...
 
-CLAUDE.md Rules: M/13 present (K missing)
+Agent Rules: M/13 present (K missing)
   Missing:
   - [rule name]: [key phrase not found]
   ...
@@ -562,14 +567,23 @@ Run Step 0 (locate portable assets). If the path cannot be resolved, stop
 with an error: "Cannot locate zskills-portable/ directory. Please provide
 the path to the Z Skills source repo."
 
-#### Step B — Fill CLAUDE.md gaps
+#### Step B — Render zskills-managed rules file
 
-**If CLAUDE.md does NOT exist:**
+**Target path:** `.claude/rules/zskills/managed.md` in the project.
+Create the `.claude/rules/zskills/` subdirectory if absent. Claude Code
+auto-loads everything under `.claude/rules/` recursively at session
+start, so no `@`-import from root `./CLAUDE.md` is needed.
 
-Copy `$PORTABLE/CLAUDE_TEMPLATE.md` to `CLAUDE.md`. Then **auto-detect
-placeholder values** and fill them in — do not prompt or block:
+**Ownership rule:** zskills owns `.claude/rules/zskills/` in full. The
+user's root `./CLAUDE.md` is theirs exclusively. No cross-writes:
+Step B never reads or modifies root `./CLAUDE.md` content (the
+migration sub-step below is the sole, deterministic exception, and it
+only removes zskills-rendered lines — never user content).
 
-1. **Scan project files** for detection signals:
+**Render algorithm (every install, first-run and subsequent — idempotent):**
+
+1. **Scan project files for auto-detected placeholder defaults** (only
+   used when the corresponding config field is empty):
    - `package.json` — `name`, `scripts.start`, `scripts.dev`, `scripts.test`,
      `scripts["test:all"]`, `scripts["test:ci"]`
    - `Cargo.toml` — `[package] name`
@@ -580,42 +594,102 @@ placeholder values** and fill them in — do not prompt or block:
    - `pytest.ini` / `jest.config.*` / `.mocharc.*` — test framework detection
    - Git remote URL or directory name — fallback for project name
 
-2. **Fill in values automatically.** Do not prompt. Do not block.
-   - **Detected values** -> replace the placeholder directly
-   - **Undetectable values** -> use sensible defaults:
-     - `{{PROJECT_NAME}}` -> directory name (always available)
-     - `{{DEV_SERVER_CMD}}` -> `npm start` if package.json exists,
-       otherwise comment out the section
-     - `{{UNIT_TEST_CMD}}` -> `npm test` if package.json exists,
-       otherwise comment out
-     - `{{FULL_TEST_CMD}}` -> same as unit test command, or comment out
-   - **Truly unknown values** -> comment out with a TODO marker:
-     `<!-- TODO: fill in when known -->`
+2. **Substitute placeholders** in `$PORTABLE/CLAUDE_TEMPLATE.md` using
+   current `.claude/zskills-config.json` values (fall back to
+   auto-detected defaults for empty fields; for truly unknown values,
+   comment out with a TODO marker `<!-- TODO: fill in when known -->`).
+   Placeholder mapping is documented in Step 0.5.
 
-3. **Report what was filled and what needs review:**
+3. **Write the rendered content** to
+   `.claude/rules/zskills/managed.md`. Full overwrite is safe by
+   ownership rule — zskills owns this file in full; no user content
+   ever lives here. The file is regenerated from template + config on
+   every install and every `--rerender`. Never leaves broken
+   `{{PLACEHOLDER}}` strings.
+
+4. **Run the root-CLAUDE.md migration sub-step** (below) to detect and
+   relocate any pre-Phase-4 zskills content from root `./CLAUDE.md`.
+
+5. **Report:**
    ```
-   CLAUDE.md created. Values filled:
+   .claude/rules/zskills/managed.md rendered. Values filled:
      Project name: my-app (from package.json)
      Dev server: npm start (detected)
      Test command: npm test (detected)
      Full test: commented out (no test:all script found — update when ready)
 
-   Review CLAUDE.md and adjust any values that need changing.
+   Review .claude/rules/zskills/managed.md and adjust config values if needed
+   (edit .claude/zskills-config.json, then rerun /update-zskills --rerender).
    ```
 
-The CLAUDE.md should be functional immediately — the 13 agent rules
-work regardless of project-specific values. Unfilled placeholders should
-never leave broken `{{PLACEHOLDER}}` strings in the file.
+**Migration sub-step — relocate pre-Phase-4 zskills content from root `./CLAUDE.md`:**
 
-**If CLAUDE.md EXISTS but is missing rules:**
+Earlier zskills installs rendered into root `./CLAUDE.md`; Phase 4
+moved the target to `.claude/rules/zskills/managed.md`. On every
+install (first-run and subsequent), detect any zskills-rendered lines
+still sitting in root `./CLAUDE.md` and remove them — carefully, so
+user-authored content that merely mentions a zskills value is
+preserved. Idempotent: on a clean install or after a previous
+migration, nothing matches and nothing changes.
 
-Show the user which rules are missing, show the exact text that will be
-appended, and ASK before modifying. Append to a `## Agent Rules` section at
-the end of the existing CLAUDE.md. If `## Agent Rules` already exists in
-CLAUDE.md, append the missing rules to the existing section — do NOT create
-a duplicate section header.
+Algorithm:
 
-**NEVER overwrite or modify existing CLAUDE.md content.**
+1. If root `./CLAUDE.md` does not exist, the migration is a no-op.
+   Skip and continue.
+
+2. **Render the current template against current config** (same
+   substitution used in Step B step 2 above) to produce a
+   `$RENDERED_TEMPLATE` string. This is the set of lines zskills would
+   write today.
+
+3. For each placeholder `P` in `CLAUDE_TEMPLATE.md` whose current
+   rendered value `V` is non-empty, identify the set of lines in
+   `$RENDERED_TEMPLATE` that contain `V`. For each such "template
+   line," record its ±2-line neighbourhood in the template (2 lines
+   before, 2 lines after). The neighbourhood is the **context
+   signature** for that template line.
+
+4. Walk root `./CLAUDE.md` line by line. A root line is a **migration
+   candidate** iff:
+   - it contains at least one placeholder's current rendered value `V`, AND
+   - its ±2-line neighbourhood in root `./CLAUDE.md` matches the
+     corresponding template line's context signature (line-for-line,
+     ignoring trailing whitespace).
+
+   The context match restricts removal to lines that were genuinely
+   rendered by zskills. Prose that merely mentions a zskills value in
+   non-template context (e.g., "I remember we used to have
+   `bash tests/run-all.sh`…") fails the context check and is preserved.
+
+5. **If zero candidates**, migration is a no-op. Do not create a
+   backup, do not emit a NOTICE. Stop.
+
+6. **Otherwise**: back up root `./CLAUDE.md` to
+   `./CLAUDE.md.pre-zskills-migration` — **only if that backup does
+   NOT already exist.** Never overwrite a prior backup. This preserves
+   the user's pre-migration state across repeated `/update-zskills`
+   invocations.
+
+7. Remove the matched candidate lines from root `./CLAUDE.md`.
+   Everything else is left byte-identical. If the result is an empty
+   file, leave it as an empty file (do not delete) — an existing
+   `./CLAUDE.md` with no content signals "user chose zskills-only
+   rules and has no other project notes yet"; recreating it on next
+   invocation is cheaper than guessing intent.
+
+8. Emit to stderr:
+
+   ```
+   NOTICE: Migrated zskills content from root ./CLAUDE.md to .claude/rules/zskills/managed.md.
+   Backup: ./CLAUDE.md.pre-zskills-migration.
+   If your Claude Code settings exclude .claude/** from context (e.g. claudeMdExcludes),
+   the new rules file will not auto-load — adjust your excludes or @-import it from root CLAUDE.md.
+   ```
+
+**NEVER modify user-authored content in root `./CLAUDE.md`** — the
+migration removes only lines matching both value AND ±2-line template
+context. Anything the user added (their own sections, notes,
+references) is untouched.
 
 #### Step C — Fill hook gaps
 
@@ -887,7 +961,8 @@ formatting variance and legacy hook versions. Delegate to the script.
 Installation complete.
 
 Installed:
-- CLAUDE.md: [created | N rules appended | already complete]
+- .claude/rules/zskills/managed.md: [rendered | already current]
+- Root ./CLAUDE.md migration: [none | N lines relocated, backup at ./CLAUDE.md.pre-zskills-migration]
 - Hooks: N hooks installed
 - Scripts: N scripts installed
 - Add-ons: N add-on skills installed (omit this line if no add-on flag was used)
@@ -920,8 +995,8 @@ Run /update-zskills to check for updates later.
    are installed (e.g., `.claude/skills/add-block/SKILL.md` exists). If so,
    diff against `$ZSKILLS_PATH/block-diagram/` and update the same way.
 
-5. **Fill new gaps.** For any NEW items (skills, hooks, scripts, CLAUDE.md
-   rules) that don't exist yet, install them using the same steps as the
+5. **Fill new gaps.** For any NEW items (skills, hooks, scripts, zskills
+   rules file) that don't exist yet, install them using the same steps as the
    install path above (Steps B-E). In particular, if
    `scripts/apply-preset.sh` is missing from the target, copy it — Step F
    relies on it.
@@ -955,96 +1030,38 @@ Run /update-zskills to check for updates later.
 
 **Trigger:** user runs `/update-zskills --rerender`.
 
-**Scope:** regenerates `CLAUDE.md` only. Hooks and helper scripts are
-runtime-read; they auto-reflect config changes with no action from
-this flag. Does not touch `.claude/settings.json`, skills, or source
-templates. No audit, no preset, no config backfill — this is a pure
-CLAUDE.md re-render against the current `.claude/zskills-config.json`.
+**Scope:** full-file rewrite of `.claude/rules/zskills/managed.md`
+against the current `.claude/zskills-config.json`.
+Root `./CLAUDE.md` is never touched by `--rerender`.
+Hooks and helper scripts are runtime-read; they
+auto-reflect config changes with no action from this flag. Does not
+touch `.claude/settings.json`, skills, or source templates. No audit,
+no preset, no config backfill, no migration. Pure re-render.
 
-**Use case:** after a post-install edit to
-`.claude/zskills-config.json` changes a render-time-filled field
-(`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`, `{{PORT_SCRIPT}}`,
-`{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`, `{{BUILD_TEST_CMD}}`,
-`{{TIMEZONE}}`), the frozen `CLAUDE.md` snapshot has drifted. This
-flag brings it back in sync without an audit round-trip.
+**Algorithm:**
 
-**Boundary-detection algorithm:**
-
-1. **Locate the `## Agent Rules` demarcation** in the existing
-   `CLAUDE.md`:
-
-   ```bash
-   HEADING_LINE=$(grep -n '^## Agent Rules[[:space:]]*$' CLAUDE.md | head -1 | cut -d: -f1)
-   ```
-
-   Tolerant of trailing whitespace, strict on leading `##` and — by
-   convention — a surrounding blank line (Step B appends with blank
-   lines around the heading). If no match → **exit 2** with error:
-
-   > `CLAUDE.md missing '## Agent Rules' demarcation; cannot rerender safely. Add the heading or re-run /update-zskills (without --rerender) for initial install.`
-
-2. **Split the existing file** on the heading line:
-   - `existing_above` = lines `1 .. heading_line - 1`
-   - `existing_below` = lines `heading_line .. end` (heading itself
-     stays in the below region)
-
-3. **Render `CLAUDE_TEMPLATE.md` against current config.** For each
-   placeholder (`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`,
-   `{{PORT_SCRIPT}}`, `{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`,
-   `{{BUILD_TEST_CMD}}`, `{{TIMEZONE}}`), substitute the current
-   config value (per Step B's existing fill logic, unchanged). Locate
-   the `## Agent Rules` heading in the rendered output; extract
-   `fresh_above`.
-
-4. **Byte-compare `existing_above` to `fresh_above`.**
-   Right-trim trailing whitespace on each line before comparing, to
-   tolerate editor-induced churn. No "normalize by substituting prior
-   values" — if they differ, the differences are either user edits OR
-   config-change-since-last-render. Both cases mean the user reviews
-   before overwriting.
-
-   - **Identical:** write `fresh_above + existing_below` to
-     `CLAUDE.md`. **Exit 0.** If the resulting bytes equal the
-     existing `CLAUDE.md` content, skip the write entirely so the file
-     mtime stays stable — ensures idempotency (second consecutive
-     `--rerender` is a true no-op).
-   - **Different:** write `fresh_above + existing_below` to
-     `CLAUDE.md.new`. Do NOT overwrite `CLAUDE.md`. Print to stderr
-     verbatim:
-
-     ```
-     CLAUDE.md differs above '## Agent Rules' (user edits, config drift, or both).
-     New rendered content written to CLAUDE.md.new. Review with:
-         diff CLAUDE.md CLAUDE.md.new
-     To accept the new version:  mv CLAUDE.md.new CLAUDE.md
-     To discard it:              rm CLAUDE.md.new
-     ```
-
-     **Exit 2.**
-
-**Missing `CLAUDE.md`:** **exit 1** with error `no existing CLAUDE.md;
-run /update-zskills (without --rerender) for initial install`. Do not
-create one silently — `--rerender` is explicitly a re-render of an
-existing install, not an initial install.
+1. If `$PORTABLE/CLAUDE_TEMPLATE.md` is missing or unreadable, **exit
+   1** with error `CLAUDE_TEMPLATE.md missing or unreadable; cannot
+   rerender`.
+2. Render the template against current config (same substitution
+   logic as Step B step 2).
+3. Create `.claude/rules/zskills/` if absent.
+4. Write the rendered content to `.claude/rules/zskills/managed.md`
+   (full overwrite — the file is zskills-owned, no user content lives
+   here).
+5. **Exit 0.**
 
 **Exit codes:**
 
 | Code | Meaning |
 |------|---------|
-| 0 | Clean re-render (or idempotent no-op). |
-| 1 | No existing `CLAUDE.md` — not a valid `--rerender` target. |
-| 2 | Conflict (user edits above `## Agent Rules`, or missing demarcation heading). |
-
-**Why no interactive prompt on conflict:** `--rerender` is routinely
-invoked from headless automation (e.g., the Phase 3
-`warn-config-drift.sh` hook suggests it after a config edit). The
-diff-command + merge-instructions on stderr keep the agent's path
-deterministic while preserving user intent.
+| 0 | Re-render complete. |
+| 1 | `CLAUDE_TEMPLATE.md` missing or invalid. |
 
 **What `--rerender` does NOT do:** re-run the audit, backfill config
-fields, apply a preset, update skills, copy hooks/scripts, or touch
-`.claude/settings.json`. Any of those require a full
-`/update-zskills` invocation.
+fields, apply a preset, update skills, copy hooks/scripts, touch
+`.claude/settings.json`, or run the root-CLAUDE.md migration. Any of
+those require a full `/update-zskills` invocation.
 
 ---
 
@@ -1052,9 +1069,13 @@ fields, apply a preset, update skills, copy hooks/scripts, or touch
 
 These rules are inviolable. They apply to all modes:
 
-1. **NEVER overwrite existing CLAUDE.md content** — append only. New rules
-   go into `## Agent Rules` at the end. Never modify or delete existing
-   sections.
+1. **zskills owns `.claude/rules/zskills/` in full; root `./CLAUDE.md`
+   is the user's exclusively.** zskills renders, overwrites, and
+   rerenders its own `managed.md` freely. It never writes to root
+   `./CLAUDE.md` except for the one-time migration sub-step in
+   Step B, which removes only lines matching both a rendered value
+   AND the template's ±2-line context around that value. No other
+   cross-writes.
 2. **NEVER overwrite existing hooks or scripts** — if a file already
    exists, skip it. The user may have customized it.
    (Exception: `scripts/apply-preset.sh` performs targeted in-place

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -2,8 +2,9 @@
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
-# This file is a template. Replace {{PLACEHOLDER}} values and remove
-# sections that don't apply to your project.
+# This file is a template. Most behavior is now driven at runtime from
+# .claude/zskills-config.json (unit_cmd, full_cmd, ui.file_patterns,
+# main_protected, etc.). Remove sections that don't apply to your project.
 #
 # Register BOTH this file and block-unsafe-generic.sh in .claude/settings.json
 # on the PreToolUse event, Bash matcher. The generic layer runs first.
@@ -221,38 +222,97 @@ fi
 
 # ─── CONFIGURE: set your test command patterns ────────────────────────
 # Piping test output (loses failures, forces re-runs -- capture to file instead)
-# Replace the placeholder values with your actual test command patterns.
-UNIT_TEST_CMD="{{UNIT_TEST_CMD}}"
-FULL_TEST_CMD="{{FULL_TEST_CMD}}"
-
-# Build regex pattern from configured test commands (fall back to generic if unconfigured)
-if [[ "$UNIT_TEST_CMD" == *'{{'* ]] || [[ "$FULL_TEST_CMD" == *'{{'* ]]; then
-  # Placeholders not replaced -- use a generic pattern that catches common test runners
-  TEST_PIPE_PATTERN='npm[[:space:]]+test([[:space:]]|$)|npm[[:space:]]+run[[:space:]]+test(:[^[:space:]]+)?([[:space:]]|$)|node[[:space:]]+--test[[:space:]]'
-else
-  # Escape dots and special chars for bash regex
-  ESCAPED_UNIT="${UNIT_TEST_CMD//./\\.}"
-  ESCAPED_FULL="${FULL_TEST_CMD//./\\.}"
-  # Replace spaces with flexible whitespace
-  ESCAPED_UNIT="${ESCAPED_UNIT// /[[:space:]]+}"
-  ESCAPED_FULL="${ESCAPED_FULL// /[[:space:]]+}"
-  TEST_PIPE_PATTERN="(${ESCAPED_UNIT}|${ESCAPED_FULL})"
-fi
-
-# Split on &&, ||, ; so the pipe check only fires when the pipe is in
-# the SAME segment as the test command (otherwise an unrelated `ls | head`
-# earlier in the command falsely trips the block).
-_TEST_SEP=$'\x01'
-_TEST_NORM="${INPUT//&&/$_TEST_SEP}"
-_TEST_NORM="${_TEST_NORM//||/$_TEST_SEP}"
-_TEST_NORM="${_TEST_NORM//;/$_TEST_SEP}"
-IFS=$'\x01' read -ra _TEST_SEGMENTS <<< "$_TEST_NORM"
-for _seg in "${_TEST_SEGMENTS[@]}"; do
-  if [[ "$_seg" =~ $TEST_PIPE_PATTERN ]] && [[ "$_seg" == *'|'* ]]; then
-    block_with_reason "Don't pipe test output -- it loses failure details. Instead: TEST_OUT=\"/tmp/zskills-tests/\$(basename \"\$(pwd)\")\"; mkdir -p \"\$TEST_OUT\"; ${FULL_TEST_CMD:-npm run test:all} > \"\$TEST_OUT/.test-results.txt\" 2>&1 then read \"\$TEST_OUT/.test-results.txt\" to inspect failures."
+#
+# ─── Runtime config read (eliminates install-time drift) ───
+# Config location: .claude/zskills-config.json in the checked-out tree.
+# --show-toplevel matches the existing is_main_protected() pattern at
+# line 146; in a worktree, this returns the worktree root, which is
+# correct — the config is git-tracked, so each worktree reads its own
+# branch-current version.
+_ZSK_REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+_ZSK_CFG="$_ZSK_REPO_ROOT/.claude/zskills-config.json"
+UNIT_TEST_CMD=""
+FULL_TEST_CMD=""
+UI_FILE_PATTERNS=""
+if [ -f "$_ZSK_CFG" ]; then
+  _ZSK_CFG_BODY=$(cat "$_ZSK_CFG" 2>/dev/null) || _ZSK_CFG_BODY=""
+  if [[ "$_ZSK_CFG_BODY" =~ \"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    UNIT_TEST_CMD="${BASH_REMATCH[1]}"
   fi
-done
-unset _TEST_SEP _TEST_NORM _TEST_SEGMENTS _seg
+  if [[ "$_ZSK_CFG_BODY" =~ \"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    FULL_TEST_CMD="${BASH_REMATCH[1]}"
+  fi
+  # ui.file_patterns: scope via enclosing "ui" object to disambiguate
+  # from testing.file_patterns (array, doesn't match the string regex
+  # anyway, but prefix scoping is defensive against future schema change).
+  if [[ "$_ZSK_CFG_BODY" =~ \"ui\"[[:space:]]*:[[:space:]]*\{[^}]*\"file_patterns\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    UI_FILE_PATTERNS="${BASH_REMATCH[1]}"
+  fi
+  unset _ZSK_CFG_BODY
+fi
+unset _ZSK_REPO_ROOT _ZSK_CFG
+
+# Escape every bash-regex metacharacter that might appear in a config
+# test-command string (parens, brackets, pipe, asterisk, plus, etc.).
+# Then re-space spaces to [[:space:]]+ so "bash  tests/run-all.sh"
+# (multiple spaces) still matches.
+#
+# Bash parameter-expansion quoting note: inside ${var//pat/replace}, `pat`
+# is a glob pattern. `?` matches any single char, `[...]` is a class,
+# `}` closes the expansion early. We use `[?]` (literal-? class) for the
+# `?` rule and `\\\}` (escaped closer) for the `}` rule to work around these.
+_zsk_regex_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//./\\.}"
+  s="${s//\(/\\(}"
+  s="${s//\)/\\)}"
+  s="${s//\[/\\[}"
+  s="${s//\]/\\]}"
+  s="${s//|/\\|}"
+  s="${s//\*/\\*}"
+  s="${s//+/\\+}"
+  s="${s//[?]/\\?}"
+  s="${s//\$/\\\$}"
+  s="${s//^/\\^}"
+  s="${s//\{/\\{}"
+  s="${s//\}/\\\}}"
+  s="${s// /[[:space:]]+}"
+  printf '%s' "$s"
+}
+
+# Guard: without both vars set, TEST_PIPE_PATTERN="(|)" matches empty
+# string and blocks every piped command. Skip the pipe check entirely
+# if both are empty (config missing or test fields unset).
+if [ -n "$UNIT_TEST_CMD" ] || [ -n "$FULL_TEST_CMD" ]; then
+  ESCAPED_UNIT=""
+  ESCAPED_FULL=""
+  [ -n "$UNIT_TEST_CMD" ] && ESCAPED_UNIT="$(_zsk_regex_escape "$UNIT_TEST_CMD")"
+  [ -n "$FULL_TEST_CMD" ] && ESCAPED_FULL="$(_zsk_regex_escape "$FULL_TEST_CMD")"
+  # Only alternate non-empty vars to avoid "(|cmd)" degenerate case.
+  if [ -n "$ESCAPED_UNIT" ] && [ -n "$ESCAPED_FULL" ]; then
+    TEST_PIPE_PATTERN="(${ESCAPED_UNIT}|${ESCAPED_FULL})"
+  elif [ -n "$ESCAPED_UNIT" ]; then
+    TEST_PIPE_PATTERN="${ESCAPED_UNIT}"
+  else
+    TEST_PIPE_PATTERN="${ESCAPED_FULL}"
+  fi
+
+  # Split on &&, ||, ; so the pipe check only fires when the pipe is in
+  # the SAME segment as the test command (otherwise an unrelated `ls | head`
+  # earlier in the command falsely trips the block).
+  _TEST_SEP=$'\x01'
+  _TEST_NORM="${INPUT//&&/$_TEST_SEP}"
+  _TEST_NORM="${_TEST_NORM//||/$_TEST_SEP}"
+  _TEST_NORM="${_TEST_NORM//;/$_TEST_SEP}"
+  IFS=$'\x01' read -ra _TEST_SEGMENTS <<< "$_TEST_NORM"
+  for _seg in "${_TEST_SEGMENTS[@]}"; do
+    if [[ "$_seg" =~ $TEST_PIPE_PATTERN ]] && [[ "$_seg" == *'|'* ]]; then
+      block_with_reason "Don't pipe test output -- it loses failure details. Instead: TEST_OUT=\"/tmp/zskills-tests/\$(basename \"\$(pwd)\")\"; mkdir -p \"\$TEST_OUT\"; ${FULL_TEST_CMD:-npm run test:all} > \"\$TEST_OUT/.test-results.txt\" 2>&1 then read \"\$TEST_OUT/.test-results.txt\" to inspect failures."
+    fi
+  done
+  unset _TEST_SEP _TEST_NORM _TEST_SEGMENTS _seg
+fi
 
 # --- main_protected: block git commit on main ---
 if [[ "$COMMAND" =~ git[[:space:]]+commit ]] && is_main_protected && is_on_main; then
@@ -266,49 +326,26 @@ if [[ "$COMMAND" =~ git[[:space:]]+commit ]]; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
-    if [[ "$FULL_TEST_CHECK" == *'{{'* ]]; then
-      # Placeholder not replaced -- warn only if project has test infrastructure
-      REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-      HAS_TESTS=false
-      if [ -f "$REPO_ROOT/package.json" ]; then
-        PACKAGE_CONTENT=$(<"$REPO_ROOT/package.json")
-        if [[ "$PACKAGE_CONTENT" == *'"test"'* ]]; then
-          HAS_TESTS=true
+    # Check if full test command was run in this session
+    TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
+    if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
+      # Check if any code files are being committed (skip check for content-only)
+      DIFF_OUTPUT=$(git diff --cached --name-only 2>/dev/null)
+      CODE_FILES=""
+      while IFS= read -r line; do
+        if [[ "$line" =~ \.(js|ts|json|css|html|rs|py|go|rb)$ ]]; then
+          CODE_FILES+="$line"$'\n'
         fi
-      fi
-      if ! $HAS_TESTS; then
-        for f in "$REPO_ROOT"/pytest.ini "$REPO_ROOT"/jest.config.* "$REPO_ROOT"/vitest.config.* "$REPO_ROOT"/.mocharc.* "$REPO_ROOT"/Makefile; do
-          if [[ -f "$f" ]]; then
-            HAS_TESTS=true
-            break
-          fi
-        done
-      fi
-      if $HAS_TESTS; then
-        block_with_reason "BLOCKED: Test infrastructure detected but FULL_TEST_CMD not configured in block-unsafe-project.sh. Configure it so the pre-commit test check works."
-      fi
-    else
-      # Check if full test command was run in this session
-      TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
-      if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
-        # Check if any code files are being committed (skip check for content-only)
-        DIFF_OUTPUT=$(git diff --cached --name-only 2>/dev/null)
-        CODE_FILES=""
-        while IFS= read -r line; do
-          if [[ "$line" =~ \.(js|ts|json|css|html|rs|py|go|rb)$ ]]; then
-            CODE_FILES+="$line"$'\n'
-          fi
-        done <<< "$DIFF_OUTPUT"
-        if [ -n "$CODE_FILES" ]; then
-          block_with_reason "BLOCKED: Committing code but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before committing. (Content-only commits are exempt.)"
-        fi
+      done <<< "$DIFF_OUTPUT"
+      if [ -n "$CODE_FILES" ]; then
+        block_with_reason "BLOCKED: Committing code but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before committing. (Content-only commits are exempt.)"
       fi
     fi
 
     # ─── CONFIGURE: set your UI source paths, or remove this section if not applicable ───
-    # Check if UI files changed but no playwright-cli verification
-    UI_FILE_PATTERNS="{{UI_FILE_PATTERNS}}"
-    if [[ "$UI_FILE_PATTERNS" != '{{UI_FILE_PATTERNS}}' ]]; then
+    # Check if UI files changed but no playwright-cli verification.
+    # UI_FILE_PATTERNS is initialized at the top from .claude/zskills-config.json (ui.file_patterns).
+    if [ -n "$UI_FILE_PATTERNS" ]; then
       UI_DIFF_OUTPUT=$(git diff --cached --name-only 2>/dev/null)
       UI_FILES=""
       while IFS= read -r line; do
@@ -424,32 +461,9 @@ if [[ "$COMMAND" =~ git[[:space:]]+cherry-pick ]]; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
-    if [[ "$FULL_TEST_CHECK" == *'{{'* ]]; then
-      # Placeholder not replaced -- warn only if project has test infrastructure
-      REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-      HAS_TESTS=false
-      if [ -f "$REPO_ROOT/package.json" ]; then
-        PACKAGE_CONTENT=$(<"$REPO_ROOT/package.json")
-        if [[ "$PACKAGE_CONTENT" == *'"test"'* ]]; then
-          HAS_TESTS=true
-        fi
-      fi
-      if ! $HAS_TESTS; then
-        for f in "$REPO_ROOT"/pytest.ini "$REPO_ROOT"/jest.config.* "$REPO_ROOT"/vitest.config.* "$REPO_ROOT"/.mocharc.* "$REPO_ROOT"/Makefile; do
-          if [[ -f "$f" ]]; then
-            HAS_TESTS=true
-            break
-          fi
-        done
-      fi
-      if $HAS_TESTS; then
-        block_with_reason "BLOCKED: Test infrastructure detected but FULL_TEST_CMD not configured in block-unsafe-project.sh. Configure it so the pre-commit test check works."
-      fi
-    else
-      TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
-      if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
-        block_with_reason "BLOCKED: git cherry-pick but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before landing code on main."
-      fi
+    TRANSCRIPT_CONTENT=$(cat "$TRANSCRIPT" 2>/dev/null) || TRANSCRIPT_CONTENT=""
+    if [[ "$TRANSCRIPT_CONTENT" != *"$FULL_TEST_CHECK"* ]]; then
+      block_with_reason "BLOCKED: git cherry-pick but '${FULL_TEST_CHECK}' was not found in the session transcript. Run tests before landing code on main."
     fi
   fi
 

--- a/hooks/warn-config-drift.sh
+++ b/hooks/warn-config-drift.sh
@@ -3,8 +3,8 @@
 #
 # Fires after an Edit or Write tool whose target path ends with
 # .claude/zskills-config.json. Emits a note on stderr reminding the
-# user that CLAUDE.md is a render-time snapshot and may now be stale;
-# `/update-zskills --rerender` regenerates the template-managed portion.
+# user that .claude/rules/zskills/managed.md is a render-time snapshot
+# and may now be stale; `/update-zskills --rerender` regenerates it.
 #
 # Non-blocking by contract: always exits 0, even on malformed input.
 # A PostToolUse warn hook must never halt the user.
@@ -37,7 +37,7 @@ if [[ "$FILE_PATH" == *".claude/zskills-config.json" ]]; then
 NOTE: You just edited `.claude/zskills-config.json`.
 
 - Hooks and helper scripts read config at runtime — they are already current.
-- CLAUDE.md is a render-time snapshot — it may now be stale. Run `/update-zskills --rerender` to regenerate the template-managed portion (user-added content below `## Agent Rules` is preserved; conflicts write `CLAUDE.md.new` for manual merge).
+- `.claude/rules/zskills/managed.md` is a render-time snapshot — it may now be stale. Run `/update-zskills --rerender` to regenerate it (full-file rewrite; the file is zskills-owned, no user content lives there).
 WARN
 fi
 

--- a/hooks/warn-config-drift.sh
+++ b/hooks/warn-config-drift.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# warn-config-drift.sh — PostToolUse hook, non-blocking warn.
+#
+# Fires after an Edit or Write tool whose target path ends with
+# .claude/zskills-config.json. Emits a note on stderr reminding the
+# user that CLAUDE.md is a render-time snapshot and may now be stale;
+# `/update-zskills --rerender` regenerates the template-managed portion.
+#
+# Non-blocking by contract: always exits 0, even on malformed input.
+# A PostToolUse warn hook must never halt the user.
+
+set -u
+
+INPUT=$(cat 2>/dev/null) || exit 0
+[ -z "$INPUT" ] && exit 0
+
+# Extract tool_name. Handles `"tool_name":"Edit"` and `"tool_name": "Edit"`.
+TOOL_NAME=""
+if [[ "$INPUT" =~ \"tool_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  TOOL_NAME="${BASH_REMATCH[1]}"
+fi
+
+# Only Edit and Write are wired to this hook; bail on anything else.
+if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then
+  exit 0
+fi
+
+# Extract tool_input.file_path. Same whitespace-tolerant idiom.
+FILE_PATH=""
+if [[ "$INPUT" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  FILE_PATH="${BASH_REMATCH[1]}"
+fi
+
+# Suffix-match: handles absolute, repo-relative, cwd-relative paths.
+if [[ "$FILE_PATH" == *".claude/zskills-config.json" ]]; then
+  cat >&2 <<'WARN'
+NOTE: You just edited `.claude/zskills-config.json`.
+
+- Hooks and helper scripts read config at runtime — they are already current.
+- CLAUDE.md is a render-time snapshot — it may now be stale. Run `/update-zskills --rerender` to regenerate the template-managed portion (user-added content below `## Agent Rules` is preserved; conflicts write `CLAUDE.md.new` for manual merge).
+WARN
+fi
+
+exit 0

--- a/plans/DRIFT_ARCH_FIX.md
+++ b/plans/DRIFT_ARCH_FIX.md
@@ -26,7 +26,7 @@ Ship-blocker for 2026.04.1: yes. Shipping now propagates the render-time-snapsho
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Migrate CODE consumers to runtime config read | 🟡 In Progress | `3b3fc88` | 5 files; +14 tests; 733→747 |
+| 1 — Migrate CODE consumers to runtime config read | ✅ Done | `3b3fc88` | 5 files; +14 tests; 733→747 |
 | 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ⬚ | | |
 | 3 — Add PostToolUse drift-warn hook + wire settings.json | ⬚ | | |
 

--- a/plans/DRIFT_ARCH_FIX.md
+++ b/plans/DRIFT_ARCH_FIX.md
@@ -30,7 +30,7 @@ Ship-blocker for 2026.04.1: yes. Shipping now propagates the render-time-snapsho
 | 1 — Migrate CODE consumers to runtime config read | ✅ Done | `3b3fc88` | 5 files; +14 tests; 733→747 |
 | 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ✅ Done | `8ce91de` | Step C agent-driven merge + Step D --rerender + 48 new test assertions; 747→801 |
 | 3 — Add PostToolUse drift-warn hook + wire settings.json | ✅ Done | `e3e6b3c` | New hook + settings.json wiring + install-integrity note; +5 tests; 801→806 |
-| 4 — Move zskills-managed content to `.claude/rules/zskills/managed.md` (supersedes Phase 2's Step D) | ⬚ | | |
+| 4 — Move zskills-managed content to `.claude/rules/zskills/managed.md` (supersedes Phase 2's Step D) | ✅ Done | `2cac108` | Namespaced subdir + simple rewrite + auto-migration + drift-warn path update; 806→815 |
 
 ## Phase 1 — Migrate CODE consumers to runtime config read
 

--- a/plans/DRIFT_ARCH_FIX.md
+++ b/plans/DRIFT_ARCH_FIX.md
@@ -26,7 +26,7 @@ Ship-blocker for 2026.04.1: yes. Shipping now propagates the render-time-snapsho
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Migrate CODE consumers to runtime config read | ⬚ | | |
+| 1 — Migrate CODE consumers to runtime config read | 🟡 In Progress | `3b3fc88` | 5 files; +14 tests; 733→747 |
 | 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ⬚ | | |
 | 3 — Add PostToolUse drift-warn hook + wire settings.json | ⬚ | | |
 

--- a/plans/DRIFT_ARCH_FIX.md
+++ b/plans/DRIFT_ARCH_FIX.md
@@ -1,7 +1,8 @@
 ---
 title: Drift-Arch Fix — Runtime Config Read + Drift-Warn
 created: 2026-04-23
-status: active
+status: complete
+completed: 2026-04-24
 ---
 
 # Plan: Drift-Arch Fix
@@ -28,7 +29,7 @@ Ship-blocker for 2026.04.1: yes. Shipping now propagates the render-time-snapsho
 |-------|--------|--------|-------|
 | 1 — Migrate CODE consumers to runtime config read | ✅ Done | `3b3fc88` | 5 files; +14 tests; 733→747 |
 | 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ✅ Done | `8ce91de` | Step C agent-driven merge + Step D --rerender + 48 new test assertions; 747→801 |
-| 3 — Add PostToolUse drift-warn hook + wire settings.json | ⬚ | | |
+| 3 — Add PostToolUse drift-warn hook + wire settings.json | ✅ Done | `e3e6b3c` | New hook + settings.json wiring + install-integrity note; +5 tests; 801→806 |
 
 ## Phase 1 — Migrate CODE consumers to runtime config read
 

--- a/plans/DRIFT_ARCH_FIX.md
+++ b/plans/DRIFT_ARCH_FIX.md
@@ -27,7 +27,7 @@ Ship-blocker for 2026.04.1: yes. Shipping now propagates the render-time-snapsho
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Migrate CODE consumers to runtime config read | ✅ Done | `3b3fc88` | 5 files; +14 tests; 733→747 |
-| 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ⬚ | | |
+| 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ✅ Done | `8ce91de` | Step C agent-driven merge + Step D --rerender + 48 new test assertions; 747→801 |
 | 3 — Add PostToolUse drift-warn hook + wire settings.json | ⬚ | | |
 
 ## Phase 1 — Migrate CODE consumers to runtime config read

--- a/plans/DRIFT_ARCH_FIX.md
+++ b/plans/DRIFT_ARCH_FIX.md
@@ -30,6 +30,7 @@ Ship-blocker for 2026.04.1: yes. Shipping now propagates the render-time-snapsho
 | 1 — Migrate CODE consumers to runtime config read | ✅ Done | `3b3fc88` | 5 files; +14 tests; 733→747 |
 | 2 — Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber | ✅ Done | `8ce91de` | Step C agent-driven merge + Step D --rerender + 48 new test assertions; 747→801 |
 | 3 — Add PostToolUse drift-warn hook + wire settings.json | ✅ Done | `e3e6b3c` | New hook + settings.json wiring + install-integrity note; +5 tests; 801→806 |
+| 4 — Move zskills-managed content to `.claude/rules/zskills/managed.md` (supersedes Phase 2's Step D) | ⬚ | | |
 
 ## Phase 1 — Migrate CODE consumers to runtime config read
 
@@ -443,6 +444,68 @@ All round-1 findings addressed (fixed or justified with evidence-anchored reason
 | R2-DA — Edit outside Claude Code tools | DA | Verified limitation | **Justified** — documented in Out-of-Scope |
 
 All round-2 findings dispositioned. No substantive issues remain; the plan converges.
+
+## Phase 4 — Move zskills-managed content to `.claude/rules/zskills/managed.md`
+
+### Goal
+
+Give zskills its own namespaced, auto-loaded location that it fully owns. Root `./CLAUDE.md` becomes user-exclusive. Supersedes Phase 2's `--rerender` byte-compare design with a simple full-rewrite that can never clobber user content (because no user content lives in `.claude/rules/zskills/`).
+
+### Work Items
+
+- [ ] 4.1 — Edit `skills/update-zskills/SKILL.md` Step B: render template into `.claude/rules/zskills/managed.md` (create the `.claude/rules/zskills/` subdirectory if absent). Stop writing to root `./CLAUDE.md` entirely. Drop the "NEVER overwrite existing CLAUDE.md content" rule; replace with: "zskills owns `.claude/rules/zskills/` in full. User's root `./CLAUDE.md` is theirs exclusively. No cross-writes."
+
+- [ ] 4.2 — Rewrite `### Step D — --rerender` as a simple full-file rewrite of `.claude/rules/zskills/managed.md`. Single success exit code (rc=0); rc=1 only if the template is missing/invalid. No byte-compare, no `.new` file, no boundary algorithm.
+
+- [ ] 4.3 — Mirror SKILL.md changes to `.claude/skills/update-zskills/SKILL.md` (byte-identical).
+
+- [ ] 4.4 — Migration logic in Step B: on every install (first-run and subsequent), detect zskills-rendered content in root `./CLAUDE.md`. For each placeholder in `CLAUDE_TEMPLATE.md`, render its current-config value; grep root `./CLAUDE.md` for lines containing that value within the template's ±2-line context. Lines matching both content AND context are candidates for removal. If any found:
+  - Back up root `./CLAUDE.md` to `./CLAUDE.md.pre-zskills-migration` (only if the backup does NOT already exist — never overwrite a prior backup).
+  - Remove matched lines from root `./CLAUDE.md`. Everything else untouched.
+  - Emit stderr NOTICE: "Migrated zskills content from root ./CLAUDE.md to .claude/rules/zskills/managed.md. Backup: ./CLAUDE.md.pre-zskills-migration."
+  - Idempotent: re-running on an already-migrated project is a no-op (nothing to remove, no new backup).
+
+- [ ] 4.5 — Update `hooks/warn-config-drift.sh` + `.claude/hooks/warn-config-drift.sh`: stderr wording references `.claude/rules/zskills/managed.md` specifically (was generic "CLAUDE.md" in Phase 3). Mirror byte-identical.
+
+- [ ] 4.6 — Replace `tests/test-update-zskills-rerender.sh` (459-line byte-compare oracle → ~150 lines). Test cases:
+  - Fresh install: `.claude/rules/zskills/managed.md` created, contains current-config values; root `./CLAUDE.md` absent or untouched.
+  - `--rerender` after config edit: file reflects new values; no `.new`; rc=0.
+  - Migration happy path: fixture with zskills-rendered content in root `./CLAUDE.md` → lines removed, backup at `./CLAUDE.md.pre-zskills-migration`, rules file contains fresh values.
+  - Migration no-op: fixture with user-only root `./CLAUDE.md` (no zskills lines) → untouched, no backup.
+  - Migration idempotent: run install twice on same fixture; backup still exists only once, root `./CLAUDE.md` unchanged on second run.
+
+- [ ] 4.7 — Update WI 2.7-style structural assertions in `tests/test-skill-conformance.sh`: new Step B wording, new Step D wording, presence of migration block, drift-warn hook references new path. Remove byte-compare and `.new`-file assertions.
+
+### Design & Constraints
+
+**Location choice: `.claude/rules/zskills/managed.md`.** Per Claude Code docs, `.claude/rules/` is auto-loaded recursively at session start, same priority as `.claude/CLAUDE.md`. Files without `paths` frontmatter load unconditionally. Namespaced subdirectory `zskills/` prevents collision with user files or other tools (anyone else uses their own name or the top level of `.claude/rules/`).
+
+**Why NOT `.claude/CLAUDE.md`**: that's a Claude Code documented user-intended project-CLAUDE.md location, co-equal with root `./CLAUDE.md`. Claiming it = squatting on shared address space. Users or other tools could legitimately expect to own it.
+
+**Why NOT `@.claude/…` import from root CLAUDE.md**: requires editing the user's root CLAUDE.md once (to add the `@` line); bootstrap issue if root CLAUDE.md doesn't exist.
+
+**Why a single `managed.md`, not multiple topic files**: Claude Code doesn't document load order for multiple `.md` files in a subdirectory. Single file removes ordering concerns. Can split later.
+
+**Migration detection precision**: content-match alone would false-positive on prose that mentions a value (e.g., "…note we previously used `bash tests/old.sh`…"). Matching content + ±2-line context against the rendered template restricts removal to lines that were genuinely rendered by zskills.
+
+**Backup policy**: `.pre-zskills-migration` created at most once. Prior backups are never overwritten. Users who re-run migration retain their pre-migration state.
+
+**Known caveat**: if a user has `claudeMdExcludes: ["**/.claude/**"]` or similarly broad exclusions in their settings, the rules file will be excluded. Migration NOTICE mentions this for awareness.
+
+### Acceptance Criteria
+
+- [ ] Fresh install on clean project: `.claude/rules/zskills/managed.md` created with rendered content. Root `./CLAUDE.md` untouched.
+- [ ] `--rerender` after config edit: `.claude/rules/zskills/managed.md` reflects new values; no `.new` file created; rc=0.
+- [ ] Migration happy path: zskills-rendered lines removed from root `./CLAUDE.md`, backup at `./CLAUDE.md.pre-zskills-migration`, rules file contains fresh values, stderr NOTICE emitted.
+- [ ] Migration no-op: root `./CLAUDE.md` with no zskills content unchanged; no backup created.
+- [ ] Migration idempotent: re-running install does not create a second backup; root `./CLAUDE.md` unchanged.
+- [ ] Drift-warn hook: editing `.claude/zskills-config.json` produces stderr containing `.claude/rules/zskills/managed.md` verbatim.
+- [ ] `skills/update-zskills/SKILL.md` and `.claude/skills/update-zskills/SKILL.md` byte-identical.
+- [ ] All tests pass. 806/806 baseline maintained or improved.
+
+### Dependencies
+
+Phases 1, 2, 3 already landed on `feat/drift-arch-fix`. Phase 4 supersedes Phase 2's Step D (the byte-compare algorithm and its test file are replaced).
 
 ## Disposition Table (Round 3 — post-convergence expansion)
 

--- a/reports/plan-drift-arch-fix.md
+++ b/reports/plan-drift-arch-fix.md
@@ -1,0 +1,35 @@
+# Plan Report — Drift-Arch Fix
+
+## Phase — 1 Migrate CODE consumers to runtime config read
+
+**Plan:** plans/DRIFT_ARCH_FIX.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-drift-arch-fix (feat/drift-arch-fix)
+**Commit:** 3b3fc88
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1.1 | Migrate `hooks/block-unsafe-project.sh.template` (runtime-read block, empty-pattern guard, dead-code cleanup) | Done | 3b3fc88 |
+| 1.2 | Mirror into `.claude/hooks/block-unsafe-project.sh` (byte-identical) | Done | 3b3fc88 |
+| 1.3 | Migrate `scripts/port.sh` (runtime read of `dev_server.main_repo_path`) | Done | 3b3fc88 |
+| 1.4 | Migrate `scripts/test-all.sh` (runtime reads, keep E2E/BUILD placeholders) | Done | 3b3fc88 |
+| 1.5 | 7 runtime-config-read tests in `tests/test-hooks.sh` | Done | 3b3fc88 |
+| 1.6 | Drift-regression grep test (deny-list + allow-list + template cleanliness) | Done | 3b3fc88 |
+
+### Verification
+- Test suite: PASSED (747/747; baseline was 733/733; +14 new, zero regressions)
+- Drift-regression grep: zero matches for migrated placeholders in installed hook / `scripts/port.sh` / `scripts/test-all.sh`; `{{E2E_TEST_CMD}}` and `{{BUILD_TEST_CMD}}` correctly preserved in `test-all.sh`
+- Mirror parity: `diff -q` between source template and installed hook reports no differences
+- `_zsk_regex_escape` correctness: traced `test(abc)` → `test\(abc\)`; implementer's fixes for `?`, `{`, `}`, `[`, `]` verified correct
+- Acceptance criteria: all 5 present and passing
+
+### Notes
+- Plan text contained a genuine spec bug in the `_zsk_regex_escape` idiom: `${s//?/\\?}` used the `?` glob-wildcard (which matches every character, not the literal `?`), and `${s//\}/\\}}` closed the parameter expansion early. Implementer fixed with `${s//[?]/\\?}` and `${s//\}/\\\}}` (plus bracket-class escape fixes), inline-documented. Commit message flags this explicitly.
+- Test-fixture setups in `test-hooks.sh` updated from sed-placeholder to config-file-write approach (since placeholders are now runtime-read). Uses `python3` merge for partial-config cases — python3 is already assumed available by other tests in the suite.
+
+### Risks
+None identified. Phase delivers architectural guarantee: drift is impossible for the migrated CODE consumers going forward.
+
+### Next
+Phase 2 — Update `/update-zskills` (drop migrated fills, add `--rerender`, fix settings.json clobber). Scheduled via one-shot cron after this phase's PR push.

--- a/reports/plan-drift-arch-fix.md
+++ b/reports/plan-drift-arch-fix.md
@@ -1,5 +1,39 @@
 # Plan Report — Drift-Arch Fix
 
+**Plan status:** ✅ Complete (all 3 phases landed on `feat/drift-arch-fix`; PR #59 ready to squash-merge).
+
+## Phase — 3 Add PostToolUse drift-warn hook + wire settings.json
+
+**Plan:** plans/DRIFT_ARCH_FIX.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-drift-arch-fix (feat/drift-arch-fix)
+**Commit:** e3e6b3c
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 3.1 | Create `hooks/warn-config-drift.sh` (source) | Done | e3e6b3c |
+| 3.2 | Mirror to `.claude/hooks/warn-config-drift.sh` (byte-identical, +x) | Done | e3e6b3c |
+| 3.3 | Add PostToolUse entries to `.claude/settings.json` (Edit + Write matchers) | Done | e3e6b3c |
+| 3.4 | PostToolUse rows in canonical triples table (already landed in Phase 2) | Done | 8ce91de |
+| 3.5 | 5 test cases under `=== PostToolUse: config drift warn ===` | Done | e3e6b3c |
+
+### Verification
+- Test suite: PASSED (806/806; baseline 801/801; +5 new, zero regressions).
+- Byte-identical mirrors: `hooks/warn-config-drift.sh` ≡ `.claude/hooks/warn-config-drift.sh`; skill source ≡ mirror.
+- Settings.json: valid JSON; existing PreToolUse preserved byte-identical; new PostToolUse block has exactly 2 entries (Edit, Write) per plan.
+- Hook correctness: always `exit 0`; suffix-matches `.claude/zskills-config.json`; warn text verbatim.
+- All 5 WI 3.5 test cases pass (Edit/Write on config, Edit on unrelated file, malformed stdin).
+
+### Notes
+- WI 3.4 was effectively a no-op — Phase 2 pre-landed both PostToolUse rows (Edit, Write) in the canonical triples table when drafting Step C. Phase 3 only needed the hook file + settings.json wiring.
+- Install-integrity addition (WI 3.x "use judgment"): implementer added a specific "source missing → skip row" note in `skills/update-zskills/SKILL.md` Step C. Mirrored to `.claude/skills/update-zskills/SKILL.md`.
+
+### Risks
+None identified. Phase completes the drift-arch fix: users who edit `.claude/zskills-config.json` now get a stderr warn reminding them to `/update-zskills --rerender` if CLAUDE.md matters.
+
+---
+
 ## Phase — 2 Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber
 
 **Plan:** plans/DRIFT_ARCH_FIX.md

--- a/reports/plan-drift-arch-fix.md
+++ b/reports/plan-drift-arch-fix.md
@@ -1,6 +1,50 @@
 # Plan Report — Drift-Arch Fix
 
-**Plan status:** ✅ Complete (all 3 phases landed on `feat/drift-arch-fix`; PR #59 ready to squash-merge).
+**Plan status:** ✅ Complete (all 4 phases landed on `feat/drift-arch-fix`; PR #59 ready to squash-merge).
+
+## Phase — 4 Move zskills-managed content to `.claude/rules/zskills/managed.md`
+
+**Plan:** plans/DRIFT_ARCH_FIX.md
+**Status:** Completed (verified). **Supersedes** Phase 2's Step D byte-compare design.
+**Worktree:** /tmp/zskills-pr-drift-arch-fix (feat/drift-arch-fix)
+**Commit:** 2cac108
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 4.1 | Step B renders into `.claude/rules/zskills/managed.md`; "NEVER overwrite" rule replaced with explicit file ownership | Done | 2cac108 |
+| 4.2 | Step D rewritten as simple full-file rewrite; rc=0/rc=1 only; no `.new`, no byte-compare | Done | 2cac108 |
+| 4.3 | SKILL.md mirror to `.claude/skills/update-zskills/SKILL.md` (byte-identical) | Done | 2cac108 |
+| 4.4 | Auto-migration in Step B: detects zskills-rendered lines via ±2-line context match; backs up root CLAUDE.md; idempotent | Done | 2cac108 |
+| 4.5 | Drift-warn hook stderr references new path; byte-identical mirror | Done | 2cac108 |
+| 4.6 | `tests/test-update-zskills-rerender.sh` replaced (byte-compare oracle → 21 assertions across 5 cases including prose-preservation) | Done | 2cac108 |
+| 4.7 | `tests/test-skill-conformance.sh` Step B/D assertions updated; byte-compare residue negatively asserted | Done | 2cac108 |
+
+### Verification
+- Test suite: PASSED (**815/815**; baseline 806/806; +9 new; zero regressions).
+- Byte-identical mirrors: SKILL.md pair + warn-config-drift.sh pair both verified.
+- Step B: "NEVER overwrite" rule gone; replaced with ownership language.
+- Step D: no byte-compare, no `.new` file, no boundary detection — simple full-rewrite.
+- Migration precision: ±2-line context match verified via test case 3d (prose mention "I remember we used to have `npm start`" is preserved while template-context lines are removed).
+- Drift-warn hook: stderr references `.claude/rules/zskills/managed.md` verbatim.
+- All 8 Phase 4 acceptance criteria met.
+
+### Architectural wins
+- **File-level ownership**: zskills owns `.claude/rules/zskills/` in full; user owns root `./CLAUDE.md` exclusively. No cross-writes.
+- **Namespaced location**: `.claude/rules/zskills/managed.md` uses a subdirectory namespace that avoids collision with user files, other tools, or standard Claude Code locations (`./CLAUDE.md`, `./.claude/CLAUDE.md`).
+- **Auto-loaded**: Claude Code auto-discovers `.claude/rules/**/*.md` at session start — no `@-import` needed, no root CLAUDE.md prerequisite.
+- **Auto-migration**: existing consumers with zskills content in root `./CLAUDE.md` get seamless migration on next `/update-zskills` run (backup + clean + re-render in new location).
+- **Step B bug closed**: the "NEVER overwrite existing CLAUDE.md content" rule was a symptom of writing into user-owned territory. Eliminated by moving zskills out of user territory entirely.
+
+### Notes
+- Adversarially reviewed before implementation (namespace-collision risk, Claude Code feature maturity, migration correctness).
+- Implementer surfaced and handled edge case: if migration leaves root `./CLAUDE.md` empty, it's preserved rather than deleted (explicit user presence signal).
+- CLAUDE_TEMPLATE.md prose unchanged (didn't claim "this is your CLAUDE.md"; renders identically in both target locations).
+
+### Risks
+None identified. Phase 4 closes both the originally-spec'd drift-bug scope AND the Step B "never overwrite" bug that the user surfaced during execution.
+
+---
 
 ## Phase — 3 Add PostToolUse drift-warn hook + wire settings.json
 

--- a/reports/plan-drift-arch-fix.md
+++ b/reports/plan-drift-arch-fix.md
@@ -1,5 +1,43 @@
 # Plan Report — Drift-Arch Fix
 
+## Phase — 2 Update /update-zskills: drop migrated fills, add --rerender, fix settings.json clobber
+
+**Plan:** plans/DRIFT_ARCH_FIX.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-drift-arch-fix (feat/drift-arch-fix)
+**Commit:** 8ce91de
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 2.1 | Remove placeholder-fill for migrated keys in Step C; keep E2E/BUILD fills | Done | 8ce91de |
+| 2.2 | Update placeholder-mapping table (remove migrated rows, annotate runtime-read fields) | Done | 8ce91de |
+| 2.3 | Add `### Step D — --rerender` with boundary algorithm + exit codes | Done | 8ce91de |
+| 2.4 | Integration tests for `--rerender` (6 blocks, 16 assertions) | Done | 8ce91de |
+| 2.5 | Rewrite Step C as agent-driven Read+Edit merge with canonical triples table | Done | 8ce91de |
+| 2.6 | `### Step C.9 — Hook renames` subsection with initially-empty migration table | Done | 8ce91de |
+| 2.7 | 32 structural conformance assertions for Step C / C.9 / D contracts | Done | 8ce91de |
+
+### Verification
+- Test suite: PASSED (801/801; baseline 747/747; +54 new assertions, zero regressions).
+- Byte-identical mirror: `diff -q skills/update-zskills/SKILL.md .claude/skills/update-zskills/SKILL.md` clean.
+- Canonical triples table: 5 rows (3 PreToolUse Bash/Bash/Agent + 2 PostToolUse Edit/Write) verified.
+- Step D boundary algorithm: 6 concrete steps with exit codes 0/1/2 + verbatim stderr prompt + idempotency via byte-compare-skip-write.
+- Step C.9 migration table: initially empty, row format documented, runs before main merge loop.
+- All Phase 2 acceptance criteria met.
+
+### Notes
+- **Plan-prose inconsistency flagged (non-blocking)**: WI 2.4 Test 1 says "Happy path: stale CLAUDE.md + updated config → new CLAUDE.md contains current config values (rc=0)", but the Design & Constraints' simplified byte-compare algorithm (intentional round-2 change removing the hand-wavy "normalize" step) makes rc=2 + `CLAUDE.md.new` the correct behavior on any drift. Tests correctly follow the algorithm; plan prose worth a small doc-only tidy — filed as non-blocking.
+- **`## Agent Rules` anchor absent from `CLAUDE_TEMPLATE.md`**: it's added by Step B's rules-append path when merging rules into an existing CLAUDE.md. Users who never went through that path get rc=2 "missing demarcation" on first `--rerender` invocation — correct per spec (user must add the heading or re-run `/update-zskills` non-`--rerender` first).
+
+### Risks
+None identified. Phase closes the `/update-zskills` Step C full-overwrite bug that was silently clobbering user-added PreToolUse entries on every install.
+
+### Next
+Phase 3 — PostToolUse drift-warn hook (`warn-config-drift.sh`) + wire via Phase 2's Step C merge (which already knows the two new triples from Phase 2's canonical table).
+
+---
+
 ## Phase — 1 Migrate CODE consumers to runtime config read
 
 **Plan:** plans/DRIFT_ARCH_FIX.md

--- a/scripts/port.sh
+++ b/scripts/port.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # port.sh -- deterministic dev-server port for the current project root.
 #
-# Main repo ({{MAIN_REPO_PATH}}) -> 8080 (backward compatible).
+# Main repo (dev_server.main_repo_path, read at runtime from
+# .claude/zskills-config.json) -> 8080 (backward compatible).
 # Worktrees -> stable port in 9000-60000 derived from the project root path.
 # DEV_PORT env var overrides everything.
 #
@@ -10,7 +11,21 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-MAIN_REPO='{{MAIN_REPO_PATH}}'
+# ─── Runtime config read (eliminates install-time drift) ───
+# Read dev_server.main_repo_path from the checked-out config.
+_ZSK_REPO_ROOT="${REPO_ROOT:-$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || echo "$PROJECT_ROOT")}"
+_ZSK_CFG="$_ZSK_REPO_ROOT/.claude/zskills-config.json"
+MAIN_REPO=""
+if [ -f "$_ZSK_CFG" ]; then
+  _ZSK_CFG_BODY=$(cat "$_ZSK_CFG" 2>/dev/null) || _ZSK_CFG_BODY=""
+  # Scope to dev_server.main_repo_path via enclosing "dev_server" object.
+  if [[ "$_ZSK_CFG_BODY" =~ \"dev_server\"[[:space:]]*:[[:space:]]*\{[^}]*\"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    MAIN_REPO="${BASH_REMATCH[1]}"
+  fi
+  unset _ZSK_CFG_BODY
+fi
+unset _ZSK_REPO_ROOT _ZSK_CFG
+
 DEFAULT_PORT=8080
 RANGE_START=9000
 RANGE_SIZE=51000  # 9000-60000
@@ -22,7 +37,7 @@ if [[ -n "$DEV_PORT" ]]; then
 fi
 
 # Main repo gets the default port
-if [[ "$MAIN_REPO" != '{{MAIN_REPO_PATH}}' ]] && [[ "$PROJECT_ROOT" == "$MAIN_REPO" ]]; then
+if [[ -n "$MAIN_REPO" ]] && [[ "$PROJECT_ROOT" == "$MAIN_REPO" ]]; then
   echo "$DEFAULT_PORT"
   exit 0
 fi

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -11,8 +11,23 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# ─── Runtime config read (eliminates install-time drift) ───
+# Read testing.unit_cmd from the checked-out .claude/zskills-config.json.
+_ZSK_REPO_ROOT="${REPO_ROOT:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || cd "$SCRIPT_DIR/.." && pwd)}"
+_ZSK_CFG="$_ZSK_REPO_ROOT/.claude/zskills-config.json"
+UNIT_TEST_CMD=""
+if [ -f "$_ZSK_CFG" ]; then
+  _ZSK_CFG_BODY=$(cat "$_ZSK_CFG" 2>/dev/null) || _ZSK_CFG_BODY=""
+  if [[ "$_ZSK_CFG_BODY" =~ \"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    UNIT_TEST_CMD="${BASH_REMATCH[1]}"
+  fi
+  unset _ZSK_CFG_BODY
+fi
+unset _ZSK_REPO_ROOT _ZSK_CFG
+
 # ─── CONFIGURE ──────────────────────────────────────────────────────
-UNIT_TEST_CMD='{{UNIT_TEST_CMD}}'
+# E2E_TEST_CMD / BUILD_TEST_CMD have no config source; install-filled by
+# /update-zskills. See plan DRIFT_ARCH_FIX.md Out-of-Scope.
 E2E_TEST_CMD='{{E2E_TEST_CMD}}'
 BUILD_TEST_CMD='{{BUILD_TEST_CMD}}'
 # ────────────────────────────────────────────────────────────────────
@@ -46,8 +61,18 @@ get_port() {
   fi
   local project_root
   project_root="$(cd "$SCRIPT_DIR/.." && pwd)"
-  local main_repo='{{MAIN_REPO_PATH}}'
-  if [[ "$main_repo" != '{{MAIN_REPO_PATH}}' ]] && [[ "$project_root" == "$main_repo" ]]; then
+  # Runtime config read: dev_server.main_repo_path
+  local _cfg_root="${REPO_ROOT:-$(git -C "$project_root" rev-parse --show-toplevel 2>/dev/null || echo "$project_root")}"
+  local _cfg="$_cfg_root/.claude/zskills-config.json"
+  local main_repo=""
+  if [ -f "$_cfg" ]; then
+    local _body
+    _body=$(cat "$_cfg" 2>/dev/null) || _body=""
+    if [[ "$_body" =~ \"dev_server\"[[:space:]]*:[[:space:]]*\{[^}]*\"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+      main_repo="${BASH_REMATCH[1]}"
+    fi
+  fi
+  if [[ -n "$main_repo" ]] && [[ "$project_root" == "$main_repo" ]]; then
     echo 8080
     return
   fi

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -758,6 +758,18 @@ subagent dispatches that specify a model below the configured minimum
 surfaces `/update-zskills --rerender` guidance after edits to
 `.claude/zskills-config.json`.
 
+**Install-integrity check (applies to every row).** Before writing a
+settings.json entry for a triple, verify the referenced hook file is
+present in `$PORTABLE/hooks/` (source) — and therefore copyable to
+`.claude/hooks/`. If the source file is missing (e.g. a zskills release
+cut before the hook landed), warn the user and **skip that row's
+wiring**; do not write a settings.json entry pointing at a script that
+won't exist on disk. Report as `skip: <basename> — source missing` in
+the Step 6 preview. Same pattern as the other hook copies in Step C:
+"Copy missing hooks from `$PORTABLE/hooks/`" already fails soft if the
+source file isn't there; this just extends that convention into the
+settings.json merge.
+
 #### Step C.9 — Hook renames
 
 Rename migrations run BEFORE the main Step C merge loop (step 3 above),

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-zskills
-argument-hint: "[install] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
+argument-hint: "[install | --rerender] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 ---
 
@@ -13,7 +13,7 @@ dependencies.
 **Invocation:**
 
 ```
-/update-zskills [install] [cherry-pick | locked-main-pr | direct]
+/update-zskills [install | --rerender] [cherry-pick | locked-main-pr | direct]
                 [--with-addons | --with-block-diagram-addons]
 ```
 
@@ -25,6 +25,10 @@ was found and what was done about it.
 **Explicit mode:**
 - `install` — force a full first-time setup (same as what the default
   mode does when nothing is installed, but skips the detection step)
+- `--rerender` — regenerate the template-managed portion of `CLAUDE.md`
+  against the current `.claude/zskills-config.json`. Preserves every
+  line below `## Agent Rules`. No audit, no preset, no hooks/scripts
+  touched. See `### Step D — --rerender` for the full algorithm.
 
 **Preset keywords (bare word, anywhere in the args):**
 
@@ -317,13 +321,11 @@ for each field F in schema:
 
 | Placeholder | Config path | Example |
 |-------------|-------------|---------|
-| `{{UNIT_TEST_CMD}}` | `testing.unit_cmd` | `npm run test` |
-| `{{FULL_TEST_CMD}}` | `testing.full_cmd` | `npm run test:all` |
-| `{{UI_FILE_PATTERNS}}` | `ui.file_patterns` | `src/(components\|ui)/.*\\.tsx?$` |
 | `{{DEV_SERVER_CMD}}` | `dev_server.cmd` | `npm start` |
 | `{{PORT_SCRIPT}}` | `dev_server.port_script` | `scripts/port.sh` |
-| `{{MAIN_REPO_PATH}}` | `dev_server.main_repo_path` | `/workspaces/my-app` |
 | `{{AUTH_BYPASS}}` | `ui.auth_bypass` | `localStorage.setItem(...)` |
+
+Runtime-read fields (not install-filled): `testing.unit_cmd`, `testing.full_cmd`, `ui.file_patterns`, `dev_server.main_repo_path`. Hooks and helper scripts read these directly from `.claude/zskills-config.json` at every invocation — see Phase 1 of `plans/DRIFT_ARCH_FIX.md`.
 
 **Empty value handling:** When a config field is empty string `""`, the
 corresponding template section is commented out with a TODO marker:
@@ -620,9 +622,25 @@ a duplicate section header.
 Copy missing hooks from `$PORTABLE/hooks/` to `.claude/hooks/`.
 
 - For `block-unsafe-project.sh.template`: copy to
-  `.claude/hooks/block-unsafe-project.sh`, then fill in the
-  `# CONFIGURE:` values from project detection (test commands, UI file
-  patterns). Use placeholders/fallbacks for anything undetectable.
+  `.claude/hooks/block-unsafe-project.sh`. No install-time placeholder
+  fill needed — the hook reads `testing.unit_cmd`, `testing.full_cmd`,
+  and `ui.file_patterns` from `.claude/zskills-config.json` at runtime
+  via bash regex (same idiom as `is_main_protected()`). Just copy the
+  source template.
+- For `scripts/port.sh` and `scripts/test-all.sh`: copy as-is from
+  `$PORTABLE/scripts/`. These also read `dev_server.main_repo_path` and
+  `testing.unit_cmd` from `.claude/zskills-config.json` at runtime — no
+  install-time fill.
+- For any remaining templates that do still contain placeholders
+  (`{{E2E_TEST_CMD}}`, `{{BUILD_TEST_CMD}}`): these have no config
+  source, so fill from project detection or leave as a `# TODO`
+  comment. Only these two placeholders — all others listed in the
+  Step 0.5 mapping table go through the template-render path (Step B),
+  not the hook path.
+
+Note: hooks and helper scripts read `testing.*`, `ui.file_patterns`,
+and `dev_server.main_repo_path` from `.claude/zskills-config.json` at
+runtime. No install-time fill needed. Only copy the source template.
 
 **Explain what each hook does** so the user understands what's being added:
 
@@ -655,48 +673,127 @@ Tracking files are ephemeral session state and should never be committed.
 project's dev server launcher); PID files are per-worktree runtime state
 and must never be committed.
 
-Then register the hooks in `.claude/settings.json`. The format is:
+Then register the hooks in `.claude/settings.json` via a **surgical
+agent-driven merge** — `Read` + `Edit` only, never `Write`-from-template.
+This preserves every other top-level key (`permissions`, `env`,
+`statusLine`, `model`, ...) and every non-zskills-owned hook entry that
+a user or another tool may have added.
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh\"",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  }
-}
+**Canonical zskills-owned triples** (single source of truth — anything
+not in this table is foreign and preserved untouched):
+
+| Event        | Matcher | Command literal                                                              |
+|--------------|---------|------------------------------------------------------------------------------|
+| PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh"`           |
+| PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh"`           |
+| PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`                   |
+| PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
+| PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
+
+All 5 rows carry `"type": "command"` and `"timeout": 5`. The
+`warn-config-drift.sh` hook lands in Phase 3 of
+`plans/DRIFT_ARCH_FIX.md`; the two PostToolUse rows become live once
+that hook is installed.
+
+**Step C algorithm** (never overwrite; never reorder top-level keys;
+never strip whitespace from untouched regions; never re-emit the file
+from a template):
+
+1. **`Read` `.claude/settings.json`.** If the file does not exist,
+   `Write` a minimal file containing only the zskills `hooks` block
+   populated from the table above. Nothing to preserve on a fresh
+   install — stop.
+2. If the top-level `hooks` key is absent, `Edit` to insert a
+   `"hooks": { "PreToolUse": [], "PostToolUse": [] }` skeleton adjacent
+   to the existing top-level keys.
+   Do not touch `permissions`, `env`, `statusLine`, `model`, or any other existing top-level key.
+3. **Run Step C.9 renames first** (see below): for each
+   `old_command → new_command` row in the migration table, search the
+   entire `hooks.PreToolUse` and `hooks.PostToolUse` arrays for an
+   entry whose `command` equals `old_command`. If found, `Edit` to
+   replace the exact `old_command` string with `new_command` in place.
+   The surrounding structure (matcher, timeout, siblings) is preserved.
+   Renames first ensures later steps don't see orphan entries.
+4. For each `(event, matcher, command)` triple in the canonical table:
+   a. Search the ENTIRE `hooks.<event>` array (all matcher blocks) for
+      an object whose `hooks[*].command` equals `command` exactly. If
+      found anywhere — even under a different matcher — treat as
+      "already present" and skip (do not duplicate).
+   b. Otherwise, locate the matcher block whose `matcher` field equals
+      the triple's matcher. If present, `Edit` to append the zskills
+      hook object to that block's `hooks` array.
+      Do not touch sibling hook objects (user-added customizations in the same matcher survive).
+   c. If no matcher block with that matcher exists, `Edit` to append a
+      new `{ "matcher": "<matcher>", "hooks": [ <zskills entry> ] }`
+      object to `hooks.<event>`.
+5. Never reorder top-level keys, never strip whitespace from untouched
+   regions, never re-emit the file from a template, never remove
+   entries not listed in the rename table (Step C.9) or already-present
+   check (step 4a).
+6. **Preview and confirm before any `Edit`.** Display a diff-style
+   summary to the user — one line per planned action (`+ add
+   block-agents.sh under Agent matcher`, `skip: block-unsafe-generic.sh
+   already present`, `rename: block-unsafe-project.sh → deny-unsafe.sh`
+   ) — and ASK for confirmation.
+   Mirrors the Step B CLAUDE.md append convention (preview + ask).
+   On confirmation, perform the Edits; on rejection, report which
+   entries were missing and exit without changes.
+7. **Report:** `"Step C: registered N hook entries, skipped M already
+   present, renamed R, preserved F foreign entries."`
+
+**Why agent-driven, not scripted.** Three prior adversarial reviews of
+bash-splice approaches (append-if-missing, overwrite-if-stock,
+partition-by-ownership) all concluded that bash + nested-JSON is
+high-cost / high-risk. The `Edit` tool's exact-string match + LLM
+reasoning about JSON structure makes this operation natural. Precedents
+in this same skill: Step B's CLAUDE.md append, the `zskills-config.json`
+backfill (Step 0.5 step 3.5), and `scripts/apply-preset.sh`'s line
+splice — all surgical, all agent-driven, all preserve-by-default. Step
+C aligns with the house style.
+
+**Matcher semantics:** `PreToolUse`+`Bash` enforces command safety and
+tracking. `PreToolUse`+`Agent` enforces `agents.min_model` — blocking
+subagent dispatches that specify a model below the configured minimum
+(haiku=1 < sonnet=2 < opus=3). `PostToolUse`+`Edit`/`Write` (Phase 3)
+surfaces `/update-zskills --rerender` guidance after edits to
+`.claude/zskills-config.json`.
+
+#### Step C.9 — Hook renames
+
+Rename migrations run BEFORE the main Step C merge loop (step 3 above),
+so each row rewrites an existing entry in place. The surrounding
+structure (matcher, timeout, siblings) is preserved byte-for-byte.
+
+**When to add a row:** when a zskills release renames a hook file
+(e.g. `block-unsafe.sh` → `block-unsafe-generic.sh`), the PR that
+ships the rename MUST add a row here. Without a row, the old command
+lingers in every downstream install's `settings.json` alongside the
+new one — two copies of the same hook registered under the same
+matcher.
+
+**Format:** one row per rename, `old_command` and `new_command` as
+full exact strings (same form as the canonical table's `Command
+literal` column). Rows are append-only and idempotent — if
+`old_command` is absent from a given install, the row is a no-op.
+
+**Migration table** (initially empty):
+
+```
+# old_command → new_command
+
+# (none yet)
+#
+# Template for future rows:
+# old_command: bash "$CLAUDE_PROJECT_DIR/.claude/hooks/<old-name>.sh"
+# new_command: bash "$CLAUDE_PROJECT_DIR/.claude/hooks/<new-name>.sh"
+#
+# Committed in the same PR that ships the rename. Rows accumulate; the
+# table is append-only. Step C.9 runs each row against every install;
+# rows are idempotent (if old_command absent, the row is a no-op).
 ```
 
-Note: both `Bash` and `Agent` matchers are used for PreToolUse hooks. The `Bash`
-matcher hooks enforce command safety and tracking. The `Agent` matcher hook
-enforces `agents.min_model` — blocking subagent dispatches that specify a model
-below the configured minimum (haiku=1 < sonnet=2 < opus=3).
-
-Report: "Installed N hooks: [list]"
+When a row is added, include it in the preview displayed to the user in
+Step C step 6 (`rename: <basename> → <basename>`).
 
 #### Step C.5 — Statusline (optional)
 
@@ -839,6 +936,103 @@ Run /update-zskills to check for updates later.
 
    Source: $ZSKILLS_PATH (pulled from origin)
    ```
+
+---
+
+### Step D — --rerender
+
+**Trigger:** user runs `/update-zskills --rerender`.
+
+**Scope:** regenerates `CLAUDE.md` only. Hooks and helper scripts are
+runtime-read; they auto-reflect config changes with no action from
+this flag. Does not touch `.claude/settings.json`, skills, or source
+templates. No audit, no preset, no config backfill — this is a pure
+CLAUDE.md re-render against the current `.claude/zskills-config.json`.
+
+**Use case:** after a post-install edit to
+`.claude/zskills-config.json` changes a render-time-filled field
+(`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`, `{{PORT_SCRIPT}}`,
+`{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`, `{{BUILD_TEST_CMD}}`,
+`{{TIMEZONE}}`), the frozen `CLAUDE.md` snapshot has drifted. This
+flag brings it back in sync without an audit round-trip.
+
+**Boundary-detection algorithm:**
+
+1. **Locate the `## Agent Rules` demarcation** in the existing
+   `CLAUDE.md`:
+
+   ```bash
+   HEADING_LINE=$(grep -n '^## Agent Rules[[:space:]]*$' CLAUDE.md | head -1 | cut -d: -f1)
+   ```
+
+   Tolerant of trailing whitespace, strict on leading `##` and — by
+   convention — a surrounding blank line (Step B appends with blank
+   lines around the heading). If no match → **exit 2** with error:
+
+   > `CLAUDE.md missing '## Agent Rules' demarcation; cannot rerender safely. Add the heading or re-run /update-zskills (without --rerender) for initial install.`
+
+2. **Split the existing file** on the heading line:
+   - `existing_above` = lines `1 .. heading_line - 1`
+   - `existing_below` = lines `heading_line .. end` (heading itself
+     stays in the below region)
+
+3. **Render `CLAUDE_TEMPLATE.md` against current config.** For each
+   placeholder (`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`,
+   `{{PORT_SCRIPT}}`, `{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`,
+   `{{BUILD_TEST_CMD}}`, `{{TIMEZONE}}`), substitute the current
+   config value (per Step B's existing fill logic, unchanged). Locate
+   the `## Agent Rules` heading in the rendered output; extract
+   `fresh_above`.
+
+4. **Byte-compare `existing_above` to `fresh_above`.**
+   Right-trim trailing whitespace on each line before comparing, to
+   tolerate editor-induced churn. No "normalize by substituting prior
+   values" — if they differ, the differences are either user edits OR
+   config-change-since-last-render. Both cases mean the user reviews
+   before overwriting.
+
+   - **Identical:** write `fresh_above + existing_below` to
+     `CLAUDE.md`. **Exit 0.** If the resulting bytes equal the
+     existing `CLAUDE.md` content, skip the write entirely so the file
+     mtime stays stable — ensures idempotency (second consecutive
+     `--rerender` is a true no-op).
+   - **Different:** write `fresh_above + existing_below` to
+     `CLAUDE.md.new`. Do NOT overwrite `CLAUDE.md`. Print to stderr
+     verbatim:
+
+     ```
+     CLAUDE.md differs above '## Agent Rules' (user edits, config drift, or both).
+     New rendered content written to CLAUDE.md.new. Review with:
+         diff CLAUDE.md CLAUDE.md.new
+     To accept the new version:  mv CLAUDE.md.new CLAUDE.md
+     To discard it:              rm CLAUDE.md.new
+     ```
+
+     **Exit 2.**
+
+**Missing `CLAUDE.md`:** **exit 1** with error `no existing CLAUDE.md;
+run /update-zskills (without --rerender) for initial install`. Do not
+create one silently — `--rerender` is explicitly a re-render of an
+existing install, not an initial install.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Clean re-render (or idempotent no-op). |
+| 1 | No existing `CLAUDE.md` — not a valid `--rerender` target. |
+| 2 | Conflict (user edits above `## Agent Rules`, or missing demarcation heading). |
+
+**Why no interactive prompt on conflict:** `--rerender` is routinely
+invoked from headless automation (e.g., the Phase 3
+`warn-config-drift.sh` hook suggests it after a config edit). The
+diff-command + merge-instructions on stderr keep the agent's path
+deterministic while preserving user intent.
+
+**What `--rerender` does NOT do:** re-run the audit, backfill config
+fields, apply a preset, update skills, copy hooks/scripts, or touch
+`.claude/settings.json`. Any of those require a full
+`/update-zskills` invocation.
 
 ---
 

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -25,10 +25,11 @@ was found and what was done about it.
 **Explicit mode:**
 - `install` — force a full first-time setup (same as what the default
   mode does when nothing is installed, but skips the detection step)
-- `--rerender` — regenerate the template-managed portion of `CLAUDE.md`
-  against the current `.claude/zskills-config.json`. Preserves every
-  line below `## Agent Rules`. No audit, no preset, no hooks/scripts
-  touched. See `### Step D — --rerender` for the full algorithm.
+- `--rerender` — regenerate `.claude/rules/zskills/managed.md` against
+  the current `.claude/zskills-config.json`. Simple full-file rewrite
+  of the zskills-owned rules file; root `./CLAUDE.md` is never touched.
+  No audit, no preset, no hooks/scripts touched. See
+  `### Step D — --rerender` for the algorithm.
 
 **Preset keywords (bare word, anywhere in the args):**
 
@@ -413,10 +414,12 @@ List all `.claude/skills/*/SKILL.md` files. For each skill:
   - Script references (`scripts/port.sh`, `scripts/test-all.sh`) — check if
     the script file exists.
 
-### Step 2 — Check CLAUDE.md for 13 generic rules
+### Step 2 — Check zskills rules file for 13 generic rules
 
-Read the project's `CLAUDE.md` (if it exists). For each of the 13 generic
-rules, search for a distinctive key phrase that identifies the rule
+Read `.claude/rules/zskills/managed.md` (the zskills-owned rules
+file); if absent, fall back to reading root `./CLAUDE.md` (pre-Phase-4
+installs rendered rules there). For each of the 13 generic rules,
+search for a distinctive key phrase that identifies the rule
 (**case-insensitive**). Mark the rule as present if the key phrase is
 found, missing otherwise.
 
@@ -438,10 +441,12 @@ found, missing otherwise.
 
 ### Step 2.5 — Documentation presence audit (execution modes)
 
-Search the project's `CLAUDE.md` for these documentation-presence signals.
-Mark each present/missing based on **case-insensitive substring match**:
+Search the zskills rules file (`.claude/rules/zskills/managed.md`,
+falling back to root `./CLAUDE.md`) for these documentation-presence
+signals. Mark each present/missing based on **case-insensitive
+substring match**:
 
-| Check | Key phrase(s) to search in CLAUDE.md |
+| Check | Key phrase(s) to search in zskills rules file |
 |-------|--------------------------------------|
 | Execution Modes section | `## Execution Modes` (heading) |
 | Landing mode keywords documented | `cherry-pick` AND `pr` AND `direct` |
@@ -499,7 +504,7 @@ Skill Dependencies: all satisfied | K missing
   - /run-plan requires /verify-changes — NOT INSTALLED
   ...
 
-CLAUDE.md Rules: M/13 present (K missing)
+Agent Rules: M/13 present (K missing)
   Missing:
   - [rule name]: [key phrase not found]
   ...
@@ -562,14 +567,23 @@ Run Step 0 (locate portable assets). If the path cannot be resolved, stop
 with an error: "Cannot locate zskills-portable/ directory. Please provide
 the path to the Z Skills source repo."
 
-#### Step B — Fill CLAUDE.md gaps
+#### Step B — Render zskills-managed rules file
 
-**If CLAUDE.md does NOT exist:**
+**Target path:** `.claude/rules/zskills/managed.md` in the project.
+Create the `.claude/rules/zskills/` subdirectory if absent. Claude Code
+auto-loads everything under `.claude/rules/` recursively at session
+start, so no `@`-import from root `./CLAUDE.md` is needed.
 
-Copy `$PORTABLE/CLAUDE_TEMPLATE.md` to `CLAUDE.md`. Then **auto-detect
-placeholder values** and fill them in — do not prompt or block:
+**Ownership rule:** zskills owns `.claude/rules/zskills/` in full. The
+user's root `./CLAUDE.md` is theirs exclusively. No cross-writes:
+Step B never reads or modifies root `./CLAUDE.md` content (the
+migration sub-step below is the sole, deterministic exception, and it
+only removes zskills-rendered lines — never user content).
 
-1. **Scan project files** for detection signals:
+**Render algorithm (every install, first-run and subsequent — idempotent):**
+
+1. **Scan project files for auto-detected placeholder defaults** (only
+   used when the corresponding config field is empty):
    - `package.json` — `name`, `scripts.start`, `scripts.dev`, `scripts.test`,
      `scripts["test:all"]`, `scripts["test:ci"]`
    - `Cargo.toml` — `[package] name`
@@ -580,42 +594,102 @@ placeholder values** and fill them in — do not prompt or block:
    - `pytest.ini` / `jest.config.*` / `.mocharc.*` — test framework detection
    - Git remote URL or directory name — fallback for project name
 
-2. **Fill in values automatically.** Do not prompt. Do not block.
-   - **Detected values** -> replace the placeholder directly
-   - **Undetectable values** -> use sensible defaults:
-     - `{{PROJECT_NAME}}` -> directory name (always available)
-     - `{{DEV_SERVER_CMD}}` -> `npm start` if package.json exists,
-       otherwise comment out the section
-     - `{{UNIT_TEST_CMD}}` -> `npm test` if package.json exists,
-       otherwise comment out
-     - `{{FULL_TEST_CMD}}` -> same as unit test command, or comment out
-   - **Truly unknown values** -> comment out with a TODO marker:
-     `<!-- TODO: fill in when known -->`
+2. **Substitute placeholders** in `$PORTABLE/CLAUDE_TEMPLATE.md` using
+   current `.claude/zskills-config.json` values (fall back to
+   auto-detected defaults for empty fields; for truly unknown values,
+   comment out with a TODO marker `<!-- TODO: fill in when known -->`).
+   Placeholder mapping is documented in Step 0.5.
 
-3. **Report what was filled and what needs review:**
+3. **Write the rendered content** to
+   `.claude/rules/zskills/managed.md`. Full overwrite is safe by
+   ownership rule — zskills owns this file in full; no user content
+   ever lives here. The file is regenerated from template + config on
+   every install and every `--rerender`. Never leaves broken
+   `{{PLACEHOLDER}}` strings.
+
+4. **Run the root-CLAUDE.md migration sub-step** (below) to detect and
+   relocate any pre-Phase-4 zskills content from root `./CLAUDE.md`.
+
+5. **Report:**
    ```
-   CLAUDE.md created. Values filled:
+   .claude/rules/zskills/managed.md rendered. Values filled:
      Project name: my-app (from package.json)
      Dev server: npm start (detected)
      Test command: npm test (detected)
      Full test: commented out (no test:all script found — update when ready)
 
-   Review CLAUDE.md and adjust any values that need changing.
+   Review .claude/rules/zskills/managed.md and adjust config values if needed
+   (edit .claude/zskills-config.json, then rerun /update-zskills --rerender).
    ```
 
-The CLAUDE.md should be functional immediately — the 13 agent rules
-work regardless of project-specific values. Unfilled placeholders should
-never leave broken `{{PLACEHOLDER}}` strings in the file.
+**Migration sub-step — relocate pre-Phase-4 zskills content from root `./CLAUDE.md`:**
 
-**If CLAUDE.md EXISTS but is missing rules:**
+Earlier zskills installs rendered into root `./CLAUDE.md`; Phase 4
+moved the target to `.claude/rules/zskills/managed.md`. On every
+install (first-run and subsequent), detect any zskills-rendered lines
+still sitting in root `./CLAUDE.md` and remove them — carefully, so
+user-authored content that merely mentions a zskills value is
+preserved. Idempotent: on a clean install or after a previous
+migration, nothing matches and nothing changes.
 
-Show the user which rules are missing, show the exact text that will be
-appended, and ASK before modifying. Append to a `## Agent Rules` section at
-the end of the existing CLAUDE.md. If `## Agent Rules` already exists in
-CLAUDE.md, append the missing rules to the existing section — do NOT create
-a duplicate section header.
+Algorithm:
 
-**NEVER overwrite or modify existing CLAUDE.md content.**
+1. If root `./CLAUDE.md` does not exist, the migration is a no-op.
+   Skip and continue.
+
+2. **Render the current template against current config** (same
+   substitution used in Step B step 2 above) to produce a
+   `$RENDERED_TEMPLATE` string. This is the set of lines zskills would
+   write today.
+
+3. For each placeholder `P` in `CLAUDE_TEMPLATE.md` whose current
+   rendered value `V` is non-empty, identify the set of lines in
+   `$RENDERED_TEMPLATE` that contain `V`. For each such "template
+   line," record its ±2-line neighbourhood in the template (2 lines
+   before, 2 lines after). The neighbourhood is the **context
+   signature** for that template line.
+
+4. Walk root `./CLAUDE.md` line by line. A root line is a **migration
+   candidate** iff:
+   - it contains at least one placeholder's current rendered value `V`, AND
+   - its ±2-line neighbourhood in root `./CLAUDE.md` matches the
+     corresponding template line's context signature (line-for-line,
+     ignoring trailing whitespace).
+
+   The context match restricts removal to lines that were genuinely
+   rendered by zskills. Prose that merely mentions a zskills value in
+   non-template context (e.g., "I remember we used to have
+   `bash tests/run-all.sh`…") fails the context check and is preserved.
+
+5. **If zero candidates**, migration is a no-op. Do not create a
+   backup, do not emit a NOTICE. Stop.
+
+6. **Otherwise**: back up root `./CLAUDE.md` to
+   `./CLAUDE.md.pre-zskills-migration` — **only if that backup does
+   NOT already exist.** Never overwrite a prior backup. This preserves
+   the user's pre-migration state across repeated `/update-zskills`
+   invocations.
+
+7. Remove the matched candidate lines from root `./CLAUDE.md`.
+   Everything else is left byte-identical. If the result is an empty
+   file, leave it as an empty file (do not delete) — an existing
+   `./CLAUDE.md` with no content signals "user chose zskills-only
+   rules and has no other project notes yet"; recreating it on next
+   invocation is cheaper than guessing intent.
+
+8. Emit to stderr:
+
+   ```
+   NOTICE: Migrated zskills content from root ./CLAUDE.md to .claude/rules/zskills/managed.md.
+   Backup: ./CLAUDE.md.pre-zskills-migration.
+   If your Claude Code settings exclude .claude/** from context (e.g. claudeMdExcludes),
+   the new rules file will not auto-load — adjust your excludes or @-import it from root CLAUDE.md.
+   ```
+
+**NEVER modify user-authored content in root `./CLAUDE.md`** — the
+migration removes only lines matching both value AND ±2-line template
+context. Anything the user added (their own sections, notes,
+references) is untouched.
 
 #### Step C — Fill hook gaps
 
@@ -887,7 +961,8 @@ formatting variance and legacy hook versions. Delegate to the script.
 Installation complete.
 
 Installed:
-- CLAUDE.md: [created | N rules appended | already complete]
+- .claude/rules/zskills/managed.md: [rendered | already current]
+- Root ./CLAUDE.md migration: [none | N lines relocated, backup at ./CLAUDE.md.pre-zskills-migration]
 - Hooks: N hooks installed
 - Scripts: N scripts installed
 - Add-ons: N add-on skills installed (omit this line if no add-on flag was used)
@@ -920,8 +995,8 @@ Run /update-zskills to check for updates later.
    are installed (e.g., `.claude/skills/add-block/SKILL.md` exists). If so,
    diff against `$ZSKILLS_PATH/block-diagram/` and update the same way.
 
-5. **Fill new gaps.** For any NEW items (skills, hooks, scripts, CLAUDE.md
-   rules) that don't exist yet, install them using the same steps as the
+5. **Fill new gaps.** For any NEW items (skills, hooks, scripts, zskills
+   rules file) that don't exist yet, install them using the same steps as the
    install path above (Steps B-E). In particular, if
    `scripts/apply-preset.sh` is missing from the target, copy it — Step F
    relies on it.
@@ -955,96 +1030,38 @@ Run /update-zskills to check for updates later.
 
 **Trigger:** user runs `/update-zskills --rerender`.
 
-**Scope:** regenerates `CLAUDE.md` only. Hooks and helper scripts are
-runtime-read; they auto-reflect config changes with no action from
-this flag. Does not touch `.claude/settings.json`, skills, or source
-templates. No audit, no preset, no config backfill — this is a pure
-CLAUDE.md re-render against the current `.claude/zskills-config.json`.
+**Scope:** full-file rewrite of `.claude/rules/zskills/managed.md`
+against the current `.claude/zskills-config.json`.
+Root `./CLAUDE.md` is never touched by `--rerender`.
+Hooks and helper scripts are runtime-read; they
+auto-reflect config changes with no action from this flag. Does not
+touch `.claude/settings.json`, skills, or source templates. No audit,
+no preset, no config backfill, no migration. Pure re-render.
 
-**Use case:** after a post-install edit to
-`.claude/zskills-config.json` changes a render-time-filled field
-(`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`, `{{PORT_SCRIPT}}`,
-`{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`, `{{BUILD_TEST_CMD}}`,
-`{{TIMEZONE}}`), the frozen `CLAUDE.md` snapshot has drifted. This
-flag brings it back in sync without an audit round-trip.
+**Algorithm:**
 
-**Boundary-detection algorithm:**
-
-1. **Locate the `## Agent Rules` demarcation** in the existing
-   `CLAUDE.md`:
-
-   ```bash
-   HEADING_LINE=$(grep -n '^## Agent Rules[[:space:]]*$' CLAUDE.md | head -1 | cut -d: -f1)
-   ```
-
-   Tolerant of trailing whitespace, strict on leading `##` and — by
-   convention — a surrounding blank line (Step B appends with blank
-   lines around the heading). If no match → **exit 2** with error:
-
-   > `CLAUDE.md missing '## Agent Rules' demarcation; cannot rerender safely. Add the heading or re-run /update-zskills (without --rerender) for initial install.`
-
-2. **Split the existing file** on the heading line:
-   - `existing_above` = lines `1 .. heading_line - 1`
-   - `existing_below` = lines `heading_line .. end` (heading itself
-     stays in the below region)
-
-3. **Render `CLAUDE_TEMPLATE.md` against current config.** For each
-   placeholder (`{{PROJECT_NAME}}`, `{{DEV_SERVER_CMD}}`,
-   `{{PORT_SCRIPT}}`, `{{AUTH_BYPASS}}`, `{{E2E_TEST_CMD}}`,
-   `{{BUILD_TEST_CMD}}`, `{{TIMEZONE}}`), substitute the current
-   config value (per Step B's existing fill logic, unchanged). Locate
-   the `## Agent Rules` heading in the rendered output; extract
-   `fresh_above`.
-
-4. **Byte-compare `existing_above` to `fresh_above`.**
-   Right-trim trailing whitespace on each line before comparing, to
-   tolerate editor-induced churn. No "normalize by substituting prior
-   values" — if they differ, the differences are either user edits OR
-   config-change-since-last-render. Both cases mean the user reviews
-   before overwriting.
-
-   - **Identical:** write `fresh_above + existing_below` to
-     `CLAUDE.md`. **Exit 0.** If the resulting bytes equal the
-     existing `CLAUDE.md` content, skip the write entirely so the file
-     mtime stays stable — ensures idempotency (second consecutive
-     `--rerender` is a true no-op).
-   - **Different:** write `fresh_above + existing_below` to
-     `CLAUDE.md.new`. Do NOT overwrite `CLAUDE.md`. Print to stderr
-     verbatim:
-
-     ```
-     CLAUDE.md differs above '## Agent Rules' (user edits, config drift, or both).
-     New rendered content written to CLAUDE.md.new. Review with:
-         diff CLAUDE.md CLAUDE.md.new
-     To accept the new version:  mv CLAUDE.md.new CLAUDE.md
-     To discard it:              rm CLAUDE.md.new
-     ```
-
-     **Exit 2.**
-
-**Missing `CLAUDE.md`:** **exit 1** with error `no existing CLAUDE.md;
-run /update-zskills (without --rerender) for initial install`. Do not
-create one silently — `--rerender` is explicitly a re-render of an
-existing install, not an initial install.
+1. If `$PORTABLE/CLAUDE_TEMPLATE.md` is missing or unreadable, **exit
+   1** with error `CLAUDE_TEMPLATE.md missing or unreadable; cannot
+   rerender`.
+2. Render the template against current config (same substitution
+   logic as Step B step 2).
+3. Create `.claude/rules/zskills/` if absent.
+4. Write the rendered content to `.claude/rules/zskills/managed.md`
+   (full overwrite — the file is zskills-owned, no user content lives
+   here).
+5. **Exit 0.**
 
 **Exit codes:**
 
 | Code | Meaning |
 |------|---------|
-| 0 | Clean re-render (or idempotent no-op). |
-| 1 | No existing `CLAUDE.md` — not a valid `--rerender` target. |
-| 2 | Conflict (user edits above `## Agent Rules`, or missing demarcation heading). |
-
-**Why no interactive prompt on conflict:** `--rerender` is routinely
-invoked from headless automation (e.g., the Phase 3
-`warn-config-drift.sh` hook suggests it after a config edit). The
-diff-command + merge-instructions on stderr keep the agent's path
-deterministic while preserving user intent.
+| 0 | Re-render complete. |
+| 1 | `CLAUDE_TEMPLATE.md` missing or invalid. |
 
 **What `--rerender` does NOT do:** re-run the audit, backfill config
-fields, apply a preset, update skills, copy hooks/scripts, or touch
-`.claude/settings.json`. Any of those require a full
-`/update-zskills` invocation.
+fields, apply a preset, update skills, copy hooks/scripts, touch
+`.claude/settings.json`, or run the root-CLAUDE.md migration. Any of
+those require a full `/update-zskills` invocation.
 
 ---
 
@@ -1052,9 +1069,13 @@ fields, apply a preset, update skills, copy hooks/scripts, or touch
 
 These rules are inviolable. They apply to all modes:
 
-1. **NEVER overwrite existing CLAUDE.md content** — append only. New rules
-   go into `## Agent Rules` at the end. Never modify or delete existing
-   sections.
+1. **zskills owns `.claude/rules/zskills/` in full; root `./CLAUDE.md`
+   is the user's exclusively.** zskills renders, overwrites, and
+   rerenders its own `managed.md` freely. It never writes to root
+   `./CLAUDE.md` except for the one-time migration sub-step in
+   Step B, which removes only lines matching both a rendered value
+   AND the template's ±2-line context around that value. No other
+   cross-writes.
 2. **NEVER overwrite existing hooks or scripts** — if a file already
    exists, skip it. The user may have customized it.
    (Exception: `scripts/apply-preset.sh` performs targeted in-place

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -48,6 +48,7 @@ run_suite "test-canary-failures.sh" "tests/test-canary-failures.sh"
 run_suite "test-tracking-integration.sh" "tests/test-tracking-integration.sh"
 run_suite "test-stop-dev.sh" "tests/test-stop-dev.sh"
 run_suite "test-quickfix.sh" "tests/test-quickfix.sh"
+run_suite "test-update-zskills-rerender.sh" "tests/test-update-zskills-rerender.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2603,7 +2603,7 @@ _run_warn_hook() {
 # Case 1: Edit on repo-relative .claude/zskills-config.json → warn fires.
 _run_warn_hook '{"tool_name":"Edit","tool_input":{"file_path":".claude/zskills-config.json"}}'
 if [[ "$_WARN_RC" -eq 0 ]] \
-  && [[ "$_WARN_ERR" == *"CLAUDE.md"* ]] \
+  && [[ "$_WARN_ERR" == *".claude/rules/zskills/managed.md"* ]] \
   && [[ "$_WARN_ERR" == *"/update-zskills --rerender"* ]]; then
   pass "warn-config-drift: Edit on .claude/zskills-config.json — stderr warns, rc=0"
 else
@@ -2613,7 +2613,7 @@ fi
 # Case 2: Edit with absolute path → same warn (suffix matcher).
 _run_warn_hook '{"tool_name":"Edit","tool_input":{"file_path":"/workspaces/zskills/.claude/zskills-config.json"}}'
 if [[ "$_WARN_RC" -eq 0 ]] \
-  && [[ "$_WARN_ERR" == *"CLAUDE.md"* ]] \
+  && [[ "$_WARN_ERR" == *".claude/rules/zskills/managed.md"* ]] \
   && [[ "$_WARN_ERR" == *"/update-zskills --rerender"* ]]; then
   pass "warn-config-drift: Edit absolute path — suffix-match fires warn, rc=0"
 else
@@ -2631,7 +2631,7 @@ fi
 # Case 4: Write on .claude/zskills-config.json → same warn.
 _run_warn_hook '{"tool_name":"Write","tool_input":{"file_path":".claude/zskills-config.json"}}'
 if [[ "$_WARN_RC" -eq 0 ]] \
-  && [[ "$_WARN_ERR" == *"CLAUDE.md"* ]] \
+  && [[ "$_WARN_ERR" == *".claude/rules/zskills/managed.md"* ]] \
   && [[ "$_WARN_ERR" == *"/update-zskills --rerender"* ]]; then
   pass "warn-config-drift: Write on .claude/zskills-config.json — stderr warns, rc=0"
 else

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2582,6 +2582,70 @@ else
   pass "drift-regression: installed hook — dead '{{' placeholder-detection branches removed"
 fi
 
+# ─── Phase 3: PostToolUse drift-warn hook ─────────────────────────────
+echo ""
+echo "=== PostToolUse: config drift warn ==="
+
+WARN_HOOK="$REPO_ROOT/hooks/warn-config-drift.sh"
+
+# Helper: run warn hook, capture stderr (fd2) and rc. stdout is discarded
+# — the hook only speaks on stderr.
+_run_warn_hook() {
+  local _input="$1"
+  local _err_file
+  _err_file=$(mktemp)
+  printf '%s' "$_input" | bash "$WARN_HOOK" 2>"$_err_file" >/dev/null
+  _WARN_RC=$?
+  _WARN_ERR=$(cat "$_err_file")
+  rm -f "$_err_file"
+}
+
+# Case 1: Edit on repo-relative .claude/zskills-config.json → warn fires.
+_run_warn_hook '{"tool_name":"Edit","tool_input":{"file_path":".claude/zskills-config.json"}}'
+if [[ "$_WARN_RC" -eq 0 ]] \
+  && [[ "$_WARN_ERR" == *"CLAUDE.md"* ]] \
+  && [[ "$_WARN_ERR" == *"/update-zskills --rerender"* ]]; then
+  pass "warn-config-drift: Edit on .claude/zskills-config.json — stderr warns, rc=0"
+else
+  fail "warn-config-drift: Edit relative — rc=$_WARN_RC, stderr=$_WARN_ERR"
+fi
+
+# Case 2: Edit with absolute path → same warn (suffix matcher).
+_run_warn_hook '{"tool_name":"Edit","tool_input":{"file_path":"/workspaces/zskills/.claude/zskills-config.json"}}'
+if [[ "$_WARN_RC" -eq 0 ]] \
+  && [[ "$_WARN_ERR" == *"CLAUDE.md"* ]] \
+  && [[ "$_WARN_ERR" == *"/update-zskills --rerender"* ]]; then
+  pass "warn-config-drift: Edit absolute path — suffix-match fires warn, rc=0"
+else
+  fail "warn-config-drift: Edit absolute — rc=$_WARN_RC, stderr=$_WARN_ERR"
+fi
+
+# Case 3: Edit on an unrelated file → stderr empty.
+_run_warn_hook '{"tool_name":"Edit","tool_input":{"file_path":"package.json"}}'
+if [[ "$_WARN_RC" -eq 0 ]] && [[ -z "$_WARN_ERR" ]]; then
+  pass "warn-config-drift: Edit on package.json — no warn, rc=0"
+else
+  fail "warn-config-drift: Edit unrelated — rc=$_WARN_RC, stderr=$_WARN_ERR"
+fi
+
+# Case 4: Write on .claude/zskills-config.json → same warn.
+_run_warn_hook '{"tool_name":"Write","tool_input":{"file_path":".claude/zskills-config.json"}}'
+if [[ "$_WARN_RC" -eq 0 ]] \
+  && [[ "$_WARN_ERR" == *"CLAUDE.md"* ]] \
+  && [[ "$_WARN_ERR" == *"/update-zskills --rerender"* ]]; then
+  pass "warn-config-drift: Write on .claude/zskills-config.json — stderr warns, rc=0"
+else
+  fail "warn-config-drift: Write — rc=$_WARN_RC, stderr=$_WARN_ERR"
+fi
+
+# Case 5: Malformed stdin → non-blocking exit, stderr empty.
+_run_warn_hook 'not json garbage at all'
+if [[ "$_WARN_RC" -eq 0 ]] && [[ -z "$_WARN_ERR" ]]; then
+  pass "warn-config-drift: malformed stdin — rc=0, stderr empty (non-blocking)"
+else
+  fail "warn-config-drift: malformed — rc=$_WARN_RC, stderr=$_WARN_ERR"
+fi
+
 echo ""
 echo "---"
 printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$((PASS_COUNT + FAIL_COUNT))"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -397,11 +397,22 @@ setup_project_test() {
   mkdir -p "$TEST_TMPDIR/.claude/hooks"
   mkdir -p "$TEST_TMPDIR/.zskills/tracking"
 
-  # Copy and configure the hook template
+  # Copy the hook template. Post-Phase-1, test-cmd / UI-pattern values are
+  # NOT install-filled — they are read at runtime from .claude/zskills-config.json.
   cp "$PROJECT_HOOK" "$TEST_TMPDIR/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{UNIT_TEST_CMD}}|npm test|g' "$TEST_TMPDIR/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{FULL_TEST_CMD}}|npm run test:all|g' "$TEST_TMPDIR/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{UI_FILE_PATTERNS}}|src/ui/|g' "$TEST_TMPDIR/.claude/hooks/block-unsafe-project.sh"
+
+  # Write the runtime config the hook expects.
+  cat > "$TEST_TMPDIR/.claude/zskills-config.json" <<'EOF'
+{
+  "testing": {
+    "unit_cmd": "npm test",
+    "full_cmd": "npm run test:all"
+  },
+  "ui": {
+    "file_patterns": "src/ui/"
+  }
+}
+EOF
 
   # Create mock package.json with test script
   printf '{"scripts":{"test":"vitest","test:all":"vitest run"}}\n' > "$TEST_TMPDIR/package.json"
@@ -946,11 +957,9 @@ run_main_protected_test() {
   mkdir -p "$test_tmpdir/.claude/hooks"
   mkdir -p "$test_tmpdir/.zskills/tracking"
 
-  # Copy and configure the hook template
+  # Copy the hook template. Post-Phase-1 the hook reads test-cmd / UI values
+  # at runtime from .claude/zskills-config.json.
   cp "$PROJECT_HOOK" "$test_tmpdir/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{UNIT_TEST_CMD}}|npm test|g' "$test_tmpdir/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{FULL_TEST_CMD}}|npm run test:all|g' "$test_tmpdir/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{UI_FILE_PATTERNS}}|src/ui/|g' "$test_tmpdir/.claude/hooks/block-unsafe-project.sh"
 
   # Create mock package.json and transcript
   printf '{"scripts":{"test":"vitest","test:all":"vitest run"}}\n' > "$test_tmpdir/package.json"
@@ -959,10 +968,32 @@ run_main_protected_test() {
   # Initialize git repo on specified branch
   (cd "$test_tmpdir" && git init -q && git checkout -b "$branch" 2>/dev/null && git add -A && git commit -q -m "init" 2>/dev/null)
 
-  # Write config if provided
+  # Write config: always include test-cmd fields so runtime read populates
+  # FULL_TEST_CMD (used by the commit transcript gate). The caller-supplied
+  # config_content may override (e.g., to add execution.main_protected).
   if [ -n "$config_content" ]; then
-    cat > "$test_tmpdir/.claude/zskills-config.json" <<EOF
-$config_content
+    # Caller supplied partial config (e.g. just {"execution": {...}}). Merge
+    # default testing/ui fields so the runtime-read block populates the
+    # hook's test-cmd / UI-pattern vars. python3 is available on CI.
+    CALLER_CFG="$config_content" python3 -c '
+import json, os
+caller = json.loads(os.environ["CALLER_CFG"])
+defaults = {"testing": {"unit_cmd": "npm test", "full_cmd": "npm run test:all"}, "ui": {"file_patterns": "src/ui/"}}
+for k, v in defaults.items():
+    caller.setdefault(k, v)
+print(json.dumps(caller))
+' > "$test_tmpdir/.claude/zskills-config.json"
+  else
+    cat > "$test_tmpdir/.claude/zskills-config.json" <<'EOF'
+{
+  "testing": {
+    "unit_cmd": "npm test",
+    "full_cmd": "npm run test:all"
+  },
+  "ui": {
+    "file_patterns": "src/ui/"
+  }
+}
 EOF
   fi
 
@@ -1138,15 +1169,19 @@ run_worktree_cd_test() {
   # Setup main repo on main with main_protected=true
   mkdir -p "$main_tmpdir/.claude/hooks"
   cp "$PROJECT_HOOK" "$main_tmpdir/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{UNIT_TEST_CMD}}|npm test|g' "$main_tmpdir/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{FULL_TEST_CMD}}|npm run test:all|g' "$main_tmpdir/.claude/hooks/block-unsafe-project.sh"
-  sed -i 's|{{UI_FILE_PATTERNS}}|src/ui/|g' "$main_tmpdir/.claude/hooks/block-unsafe-project.sh"
   printf '{"scripts":{"test":"vitest","test:all":"vitest run"}}\n' > "$main_tmpdir/package.json"
   printf 'npm run test:all\n' > "$main_tmpdir/.transcript"
   (cd "$main_tmpdir" && git init -q && git checkout -b main 2>/dev/null && git add -A && git commit -q -m "init" 2>/dev/null)
-  cat > "$main_tmpdir/.claude/zskills-config.json" <<EOF
-$config_content
-EOF
+  # Merge caller's partial config with default test-cmd / UI fields so runtime
+  # read populates all hook vars.
+  CALLER_CFG="$config_content" python3 -c '
+import json, os
+caller = json.loads(os.environ["CALLER_CFG"])
+defaults = {"testing": {"unit_cmd": "npm test", "full_cmd": "npm run test:all"}, "ui": {"file_patterns": "src/ui/"}}
+for k, v in defaults.items():
+    caller.setdefault(k, v)
+print(json.dumps(caller))
+' > "$main_tmpdir/.claude/zskills-config.json"
 
   # Setup separate "worktree" on the requested branch (a fresh repo is
   # equivalent for the predicate's purpose — git -C reports its own branch).
@@ -1201,9 +1236,12 @@ push_tracking_tmpdir=$(mktemp -d)
 mkdir -p "$push_tracking_tmpdir/.claude/hooks"
 mkdir -p "$push_tracking_tmpdir/.zskills/tracking"
 cp "$PROJECT_HOOK" "$push_tracking_tmpdir/.claude/hooks/block-unsafe-project.sh"
-sed -i 's|{{UNIT_TEST_CMD}}|npm test|g' "$push_tracking_tmpdir/.claude/hooks/block-unsafe-project.sh"
-sed -i 's|{{FULL_TEST_CMD}}|npm run test:all|g' "$push_tracking_tmpdir/.claude/hooks/block-unsafe-project.sh"
-sed -i 's|{{UI_FILE_PATTERNS}}|src/ui/|g' "$push_tracking_tmpdir/.claude/hooks/block-unsafe-project.sh"
+cat > "$push_tracking_tmpdir/.claude/zskills-config.json" <<'EOF'
+{
+  "testing": {"unit_cmd": "npm test", "full_cmd": "npm run test:all"},
+  "ui": {"file_patterns": "src/ui/"}
+}
+EOF
 printf '{"scripts":{"test":"vitest","test:all":"vitest run"}}\n' > "$push_tracking_tmpdir/package.json"
 printf 'npm run test:all\n' > "$push_tracking_tmpdir/.transcript"
 (cd "$push_tracking_tmpdir" && git init -q && git checkout -b main 2>/dev/null && git add -A && git commit -q -m "init" 2>/dev/null)
@@ -2370,6 +2408,179 @@ test_verify_changes_arg_parser() {
   fi
 }
 test_verify_changes_arg_parser
+
+echo ""
+echo "=== Runtime config read ==="
+# These tests validate Phase 1 of DRIFT_ARCH_FIX: block-unsafe-project.sh reads
+# testing.unit_cmd / testing.full_cmd / ui.file_patterns at RUNTIME from
+# .claude/zskills-config.json instead of install-filled placeholders. Each
+# test synthesizes a fixture tree and invokes the hook with REPO_ROOT override.
+
+_rcr_setup_fixture() {
+  # Args: $1 = dir, $2 = config JSON body (written verbatim to .claude/zskills-config.json).
+  local dir="$1"
+  local config="$2"
+  mkdir -p "$dir/.claude/hooks"
+  mkdir -p "$dir/.zskills/tracking"
+  cp "$PROJECT_HOOK" "$dir/.claude/hooks/block-unsafe-project.sh"
+  if [ -n "$config" ]; then
+    printf '%s\n' "$config" > "$dir/.claude/zskills-config.json"
+  fi
+  (cd "$dir" && git init -q && git add -A && git commit -q -m "init" 2>/dev/null) || true
+}
+
+_rcr_run_hook() {
+  # Args: $1 = fixture dir, $2 = Bash command, $3 = transcript body (optional).
+  local dir="$1"
+  local cmd="$2"
+  local transcript_body="${3:-FIXTURE_FULL_CMD}"
+  printf '%s\n' "$transcript_body" > "$dir/.transcript"
+  local json="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$cmd\"},\"transcript_path\":\"$dir/.transcript\"}"
+  echo "$json" | REPO_ROOT="$dir" TRACKING_ROOT="$dir" LOCAL_ROOT="$dir" \
+    bash -c "cd '$dir' && bash '$dir/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null
+}
+
+# 1. full_cmd read honored (allow path): transcript contains configured full_cmd.
+_rcr_tmp=$(mktemp -d)
+_rcr_setup_fixture "$_rcr_tmp" '{"testing":{"full_cmd":"FIXTURE_FULL_CMD"}}'
+# Stage a code file so the commit gate is non-exempt.
+(cd "$_rcr_tmp" && echo "var x=1;" > app.js && git add app.js)
+_rcr_result=$(_rcr_run_hook "$_rcr_tmp" "git commit -m test" "FIXTURE_FULL_CMD was run here")
+if [[ "$_rcr_result" != *"deny"* ]]; then
+  pass "runtime-read: full_cmd honored — transcript match allows commit"
+else
+  fail "runtime-read: full_cmd — expected allow, got: $_rcr_result"
+fi
+rm -rf "$_rcr_tmp"
+
+# 2. full_cmd read honored (deny path): transcript lacks configured full_cmd.
+_rcr_tmp=$(mktemp -d)
+_rcr_setup_fixture "$_rcr_tmp" '{"testing":{"full_cmd":"FIXTURE_FULL_CMD"}}'
+(cd "$_rcr_tmp" && echo "var x=1;" > app.js && git add app.js)
+_rcr_result=$(_rcr_run_hook "$_rcr_tmp" "git commit -m test" "some other output, no test marker here")
+if [[ "$_rcr_result" == *"FIXTURE_FULL_CMD"* ]] && [[ "$_rcr_result" == *"deny"* ]]; then
+  pass "runtime-read: full_cmd honored — missing transcript match blocks commit with verbatim cmd in reason"
+else
+  fail "runtime-read: full_cmd missing — expected block referencing FIXTURE_FULL_CMD, got: $_rcr_result"
+fi
+rm -rf "$_rcr_tmp"
+
+# 3. unit_cmd read honored: piped invocation of configured unit_cmd blocks.
+_rcr_tmp=$(mktemp -d)
+_rcr_setup_fixture "$_rcr_tmp" '{"testing":{"unit_cmd":"FIXTURE_UNIT","full_cmd":"FIXTURE_FULL"}}'
+_rcr_result=$(_rcr_run_hook "$_rcr_tmp" "FIXTURE_UNIT | head")
+if [[ "$_rcr_result" == *"Don't pipe test output"* ]]; then
+  pass "runtime-read: unit_cmd honored — pipe-block fires on configured cmd"
+else
+  fail "runtime-read: unit_cmd pipe — expected pipe-block, got: $_rcr_result"
+fi
+rm -rf "$_rcr_tmp"
+
+# 4. ui.file_patterns read honored: downstream UI-touch detection uses configured pattern.
+_rcr_tmp=$(mktemp -d)
+_rcr_setup_fixture "$_rcr_tmp" '{"testing":{"full_cmd":"FIXTURE_FULL"},"ui":{"file_patterns":"src/ui/"}}'
+mkdir -p "$_rcr_tmp/src/ui"
+(cd "$_rcr_tmp" && echo "var x=1;" > src/ui/widget.js && git add src/ui/widget.js)
+# Transcript contains FIXTURE_FULL (so test-cmd gate passes) but NO playwright-cli.
+_rcr_result=$(_rcr_run_hook "$_rcr_tmp" "git commit -m test" "FIXTURE_FULL ran")
+if [[ "$_rcr_result" == *"UI files changed but no playwright-cli"* ]]; then
+  pass "runtime-read: ui.file_patterns honored — UI commit blocked without playwright-cli"
+else
+  fail "runtime-read: ui.file_patterns — expected UI-block, got: $_rcr_result"
+fi
+rm -rf "$_rcr_tmp"
+
+# 5. Fallback: no config file → empty vars → empty-pattern guard skips pipe check.
+_rcr_tmp=$(mktemp -d)
+_rcr_setup_fixture "$_rcr_tmp" ""   # no config written
+_rcr_result=$(_rcr_run_hook "$_rcr_tmp" "ls | head -5")
+if [[ -z "$_rcr_result" ]] || [[ "$_rcr_result" != *"deny"* ]]; then
+  pass "runtime-read: no-config fallback — empty-pattern guard skips pipe check on unrelated piped cmds"
+else
+  fail "runtime-read: no-config — expected allow on 'ls | head', got: $_rcr_result"
+fi
+rm -rf "$_rcr_tmp"
+
+# 6. Subdir invocation: cwd is $FIXTURE/src/ but config is at root — hook resolves via --show-toplevel.
+_rcr_tmp=$(mktemp -d)
+_rcr_setup_fixture "$_rcr_tmp" '{"testing":{"unit_cmd":"FIXTURE_SUBDIR_UNIT","full_cmd":"FIXTURE_SUBDIR_FULL"}}'
+mkdir -p "$_rcr_tmp/src"
+printf 'FIXTURE_SUBDIR_FULL ran\n' > "$_rcr_tmp/.transcript"
+_rcr_json="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"FIXTURE_SUBDIR_UNIT | head\"},\"transcript_path\":\"$_rcr_tmp/.transcript\"}"
+# Do NOT pass REPO_ROOT so the hook must derive it via git rev-parse --show-toplevel from src/.
+_rcr_result=$(echo "$_rcr_json" | bash -c "cd '$_rcr_tmp/src' && bash '$_rcr_tmp/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null)
+if [[ "$_rcr_result" == *"Don't pipe test output"* ]]; then
+  pass "runtime-read: subdir invocation — --show-toplevel resolves config correctly"
+else
+  fail "runtime-read: subdir — expected pipe-block from subdir cwd, got: $_rcr_result"
+fi
+rm -rf "$_rcr_tmp"
+
+# 7. Worktree invocation: config in worktree checkout resolves correctly.
+_rcr_tmp=$(mktemp -d)
+_rcr_wt=$(mktemp -d -u)   # worktree path (not yet created)
+_rcr_setup_fixture "$_rcr_tmp" '{"testing":{"unit_cmd":"FIXTURE_WT_UNIT","full_cmd":"FIXTURE_WT_FULL"}}'
+# Commit the config + hook into the main repo so they land in the worktree checkout.
+(cd "$_rcr_tmp" && git add -A && git commit -q --allow-empty -m "seed config" 2>/dev/null)
+(cd "$_rcr_tmp" && git worktree add -q -b feat/wt-test "$_rcr_wt" 2>/dev/null) || _rcr_wt=""
+if [ -n "$_rcr_wt" ] && [ -f "$_rcr_wt/.claude/zskills-config.json" ]; then
+  printf 'FIXTURE_WT_FULL ran\n' > "$_rcr_wt/.transcript"
+  _rcr_json="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"FIXTURE_WT_UNIT | head\"},\"transcript_path\":\"$_rcr_wt/.transcript\"}"
+  _rcr_result=$(echo "$_rcr_json" | bash -c "cd '$_rcr_wt' && bash '$_rcr_wt/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null)
+  if [[ "$_rcr_result" == *"Don't pipe test output"* ]]; then
+    pass "runtime-read: worktree invocation — config resolves from worktree checkout"
+  else
+    fail "runtime-read: worktree — expected pipe-block in worktree, got: $_rcr_result"
+  fi
+  (cd "$_rcr_tmp" && git worktree remove -f "$_rcr_wt" 2>/dev/null) || rm -rf "$_rcr_wt"
+else
+  fail "runtime-read: worktree — fixture setup failed (worktree not created or config not present)"
+fi
+rm -rf "$_rcr_tmp"
+
+# ─── WI 1.6: drift-regression — placeholder deny-list + allow-list ───
+echo ""
+echo "=== Drift regression: placeholder deny-list / allow-list ==="
+
+# Deny-list: migrated placeholders must be absent from installed hook + scripts.
+_drift_fail=0
+for tok in '{{UNIT_TEST_CMD}}' '{{FULL_TEST_CMD}}' '{{UI_FILE_PATTERNS}}' '{{MAIN_REPO_PATH}}'; do
+  if grep -Fq "$tok" \
+    "$REPO_ROOT/.claude/hooks/block-unsafe-project.sh" \
+    "$REPO_ROOT/scripts/port.sh" \
+    "$REPO_ROOT/scripts/test-all.sh"; then
+    fail "drift-regression: migrated placeholder $tok still present in installed hook/scripts"
+    _drift_fail=1
+  fi
+done
+if [ "$_drift_fail" -eq 0 ]; then
+  pass "drift-regression: deny-list — no migrated placeholders in installed hook or scripts"
+fi
+
+# Allow-list: install-time placeholders must remain in test-all.sh.
+for tok in '{{E2E_TEST_CMD}}' '{{BUILD_TEST_CMD}}'; do
+  if grep -Fq "$tok" "$REPO_ROOT/scripts/test-all.sh"; then
+    pass "drift-regression: allow-list — $tok present in test-all.sh"
+  else
+    fail "drift-regression: install-time placeholder $tok missing from test-all.sh"
+  fi
+done
+
+# Additional: template must also be placeholder-free for migrated vars.
+for tok in '{{UNIT_TEST_CMD}}' '{{FULL_TEST_CMD}}' '{{UI_FILE_PATTERNS}}'; do
+  if grep -Fq "$tok" "$REPO_ROOT/hooks/block-unsafe-project.sh.template"; then
+    fail "drift-regression: template still contains migrated placeholder $tok"
+  else
+    pass "drift-regression: template — $tok removed from source template"
+  fi
+done
+
+# Installed hook no longer contains the dead `'{{'` detection branches.
+if grep -F "'{{'" "$REPO_ROOT/.claude/hooks/block-unsafe-project.sh" > /dev/null; then
+  fail "drift-regression: installed hook still contains dead '{{' detection branches"
+else
+  pass "drift-regression: installed hook — dead '{{' placeholder-detection branches removed"
+fi
 
 echo ""
 echo "---"

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -246,20 +246,47 @@ check_fixed update-zskills "Step C.9 runs before main merge"          'run BEFOR
 check_fixed update-zskills "Step C.9 row format documented"           'old_command: bash'
 check_fixed update-zskills "Step C.9 contribution instructions"       'ships the rename'
 
-# WI 2.4 — Step D --rerender section exists with all documented behaviors.
+# WI 4.x — Step B renders into .claude/rules/zskills/managed.md (zskills-owned).
+check       update-zskills "Step B header: render rules file" \
+  '^#### Step B — Render zskills-managed rules file'
+check_fixed update-zskills "Step B: target path managed.md" \
+  '.claude/rules/zskills/managed.md'
+check_fixed update-zskills "Step B: ownership rule" \
+  'zskills owns `.claude/rules/zskills/` in full'
+check_fixed update-zskills "Step B: root CLAUDE.md is user's" \
+  'root `./CLAUDE.md` is theirs exclusively'
+# WI 4.4 — Migration sub-step: root CLAUDE.md detection + backup + NOTICE.
+check       update-zskills "Step B: migration sub-step header" \
+  '^\*\*Migration sub-step'
+check_fixed update-zskills "Step B: migration ±2 line context" \
+  '±2-line'
+check_fixed update-zskills "Step B: migration backup path" \
+  './CLAUDE.md.pre-zskills-migration'
+check_fixed update-zskills "Step B: migration NOTICE stderr" \
+  'NOTICE: Migrated zskills content'
+check_fixed update-zskills "Step B: migration idempotent no backup overwrite" \
+  'Never overwrite a prior backup'
+
+# WI 4.2 — Step D --rerender section: simple full-file rewrite, rc=0/rc=1 only.
 check       update-zskills "Step D header" \
   '^### Step D — --rerender'
 check_fixed update-zskills "Step D: --rerender trigger"               '`/update-zskills --rerender`'
-check_fixed update-zskills "Step D: CLAUDE.md only scope"             'regenerates `CLAUDE.md` only'
-check_fixed update-zskills "Step D: Agent Rules demarcation grep"     'grep -n '\''^## Agent Rules'
-check_fixed update-zskills "Step D: exit 0 clean rerender"            'Clean re-render'
-check_fixed update-zskills "Step D: exit 1 missing CLAUDE.md"         'no existing CLAUDE.md'
-check_fixed update-zskills "Step D: exit 2 conflict"                  'CLAUDE.md.new'
-check_fixed update-zskills "Step D: mv accept instruction"            'mv CLAUDE.md.new CLAUDE.md'
-check_fixed update-zskills "Step D: rm discard instruction"           'rm CLAUDE.md.new'
-check_fixed update-zskills "Step D: idempotency"                      'mtime stays stable'
-check_fixed update-zskills "Step D: no interactive prompt"            'Why no interactive prompt'
-check       update-zskills "Step D: byte-compare with right-trim"     '[Rr]ight-trim trailing whitespace'
+check_fixed update-zskills "Step D: full-file rewrite scope" \
+  'full-file rewrite of `.claude/rules/zskills/managed.md`'
+check_fixed update-zskills "Step D: root CLAUDE.md never touched" \
+  'Root `./CLAUDE.md` is never touched by `--rerender`'
+check_fixed update-zskills "Step D: exit 0 success" \
+  'Re-render complete'
+check_fixed update-zskills "Step D: exit 1 template missing" \
+  'CLAUDE_TEMPLATE.md missing or unreadable'
+# Negative assertion — the byte-compare / .new artifacts MUST be gone.
+if grep -nE 'CLAUDE\.md\.new|byte-compare|Agent Rules.*demarcation|boundary-detection' \
+  "$REPO_ROOT/skills/update-zskills/SKILL.md" > /dev/null 2>&1; then
+  fail "[update-zskills] WI4.2: Step D still references byte-compare / .new / boundary" \
+    "CLAUDE.md.new or byte-compare language still present"
+else
+  pass "[update-zskills] WI4.2: no byte-compare / .new / boundary references in SKILL.md"
+fi
 
 # WI 2.1 — Step C hook-gap block no longer fills migrated placeholders.
 # (block-unsafe-project.sh should say "No install-time placeholder fill needed".)

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -199,6 +199,98 @@ check_fixed verify-changes "flag glyph literal"       '⚠️ Flag'
 check_fixed verify-changes "faab84b regression anchor" 'faab84b'
 
 echo ""
+echo "=== /update-zskills — Step C / C.9 / D contract (DRIFT_ARCH_FIX Phase 2) ==="
+# Step C is the agent-driven settings.json merge — Read+Edit, never Write-from-template.
+# Step C.9 is the hook-rename migration table (initially empty, append-only).
+# Step D is the --rerender subcommand for CLAUDE.md regeneration.
+# These assertions guard the SKILL.md contract; they do NOT execute the skill.
+
+# WI 2.7.1 — Step C says "Read + Edit", never "Write the whole file".
+check_fixed update-zskills "Step C: Read + Edit (agent-driven)" \
+  'surgical'
+check       update-zskills "Step C: Read + Edit terms appear" \
+  '`Read`.*`Edit`|Read. .*Edit.'
+check_fixed update-zskills "Step C: never Write-from-template"      'never `Write`-from-template'
+
+# WI 2.7.2 — Canonical zskills-owned triples for all 5 rows (3 PreToolUse + 2 PostToolUse).
+check_fixed update-zskills "Step C triples: PreToolUse Bash block-unsafe-generic" \
+  'PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh"`'
+check_fixed update-zskills "Step C triples: PreToolUse Bash block-unsafe-project" \
+  'PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh"`'
+check_fixed update-zskills "Step C triples: PreToolUse Agent block-agents" \
+  'PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`'
+check_fixed update-zskills "Step C triples: PostToolUse Edit warn-config-drift" \
+  'PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`'
+check_fixed update-zskills "Step C triples: PostToolUse Write warn-config-drift" \
+  'PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`'
+
+# WI 2.7.3 — Preserve rule: never overwrite, never reorder top-level keys.
+check_fixed update-zskills "Step C preserve: never overwrite"         'never overwrite'
+check_fixed update-zskills "Step C preserve: never reorder top-level" 'never reorder top-level keys'
+check_fixed update-zskills "Step C preserve: foreign entries preserved" \
+  'preserved untouched'
+
+# WI 2.7.4 — Preview-and-confirm convention (mirrors Step B).
+check_fixed update-zskills "Step C preview-and-confirm"               'Preview and confirm before any `Edit`'
+check       update-zskills "Step C preview mentions Step B parity" \
+  'Mirrors the Step B CLAUDE.md append convention'
+check_fixed update-zskills "Step C report line"                       'registered N hook entries'
+
+# WI 2.7.5 — Step C.9 rename subsection exists, is initially empty, documents format.
+check       update-zskills "Step C.9 subsection header" \
+  '^#### Step C\.9 — Hook renames'
+check_fixed update-zskills "Step C.9 initially empty"                 '# (none yet)'
+check_fixed update-zskills "Step C.9 append-only"                     'append-only'
+check_fixed update-zskills "Step C.9 idempotent"                      'idempotent'
+check_fixed update-zskills "Step C.9 runs before main merge"          'run BEFORE the main Step C merge'
+check_fixed update-zskills "Step C.9 row format documented"           'old_command: bash'
+check_fixed update-zskills "Step C.9 contribution instructions"       'ships the rename'
+
+# WI 2.4 — Step D --rerender section exists with all documented behaviors.
+check       update-zskills "Step D header" \
+  '^### Step D — --rerender'
+check_fixed update-zskills "Step D: --rerender trigger"               '`/update-zskills --rerender`'
+check_fixed update-zskills "Step D: CLAUDE.md only scope"             'regenerates `CLAUDE.md` only'
+check_fixed update-zskills "Step D: Agent Rules demarcation grep"     'grep -n '\''^## Agent Rules'
+check_fixed update-zskills "Step D: exit 0 clean rerender"            'Clean re-render'
+check_fixed update-zskills "Step D: exit 1 missing CLAUDE.md"         'no existing CLAUDE.md'
+check_fixed update-zskills "Step D: exit 2 conflict"                  'CLAUDE.md.new'
+check_fixed update-zskills "Step D: mv accept instruction"            'mv CLAUDE.md.new CLAUDE.md'
+check_fixed update-zskills "Step D: rm discard instruction"           'rm CLAUDE.md.new'
+check_fixed update-zskills "Step D: idempotency"                      'mtime stays stable'
+check_fixed update-zskills "Step D: no interactive prompt"            'Why no interactive prompt'
+check       update-zskills "Step D: byte-compare with right-trim"     '[Rr]ight-trim trailing whitespace'
+
+# WI 2.1 — Step C hook-gap block no longer fills migrated placeholders.
+# (block-unsafe-project.sh should say "No install-time placeholder fill needed".)
+check_fixed update-zskills "WI2.1: block-unsafe-project runtime-read" \
+  'reads `testing.unit_cmd`, `testing.full_cmd`,'
+check_fixed update-zskills "WI2.1: E2E/BUILD still allowed" \
+  '{{E2E_TEST_CMD}}'
+# Negative assertion — the four migrated placeholders must not appear as
+# "fill" instructions anywhere in Step C's hook-gap section.
+# (We allow them in migration-mapping tables, just not as "fill in X from Y".)
+if grep -nE 'fill in.*\{\{UNIT_TEST_CMD\}\}|fill in.*\{\{FULL_TEST_CMD\}\}|fill in.*\{\{UI_FILE_PATTERNS\}\}|fill in.*\{\{MAIN_REPO_PATH\}\}' \
+  "$REPO_ROOT/skills/update-zskills/SKILL.md" > /dev/null 2>&1; then
+  fail "[update-zskills] WI2.1: migrated placeholders still have fill-in instructions" \
+    "fill in {{UNIT_TEST_CMD|FULL_TEST_CMD|UI_FILE_PATTERNS|MAIN_REPO_PATH}}"
+else
+  pass "[update-zskills] WI2.1: no fill-in instructions for migrated placeholders"
+fi
+
+# WI 2.2 — Placeholder-mapping table no longer lists the 4 migrated rows;
+# has the "Runtime-read fields" note.
+if grep -nE '^\| `\{\{(UNIT_TEST_CMD|FULL_TEST_CMD|UI_FILE_PATTERNS|MAIN_REPO_PATH)\}\}`' \
+  "$REPO_ROOT/skills/update-zskills/SKILL.md" > /dev/null 2>&1; then
+  fail "[update-zskills] WI2.2: placeholder table still contains migrated rows" \
+    "table rows for migrated keys"
+else
+  pass "[update-zskills] WI2.2: placeholder table has no migrated rows"
+fi
+check_fixed update-zskills "WI2.2: runtime-read note" \
+  'Runtime-read fields (not install-filled)'
+
+echo ""
 echo "=== create-worktree.sh caller contract ==="
 # Every multi-line `bash ".../scripts/create-worktree.sh" \` invocation in
 # skills/ must include `--pipeline-id` within the next 12 lines. Doc-prose

--- a/tests/test-update-zskills-rerender.sh
+++ b/tests/test-update-zskills-rerender.sh
@@ -1,20 +1,28 @@
 #!/bin/bash
-# Integration test for /update-zskills --rerender (DRIFT_ARCH_FIX Phase 2, WI 2.4).
+# Integration test for /update-zskills Step B (render) + Step D (--rerender)
+# and the root-CLAUDE.md migration sub-step (DRIFT_ARCH_FIX Phase 4).
 #
-# --rerender is an agent-executed command. We cannot literally invoke the
-# skill from a shell test. Instead, we encode the algorithm documented in
-# `skills/update-zskills/SKILL.md` "### Step D — --rerender" as a bash
-# function `run_rerender` below, and run it against fixture directories.
-# The function is the executable oracle — if SKILL.md's spec changes
-# meaning, the oracle must be updated in lockstep. Any meaningful drift
-# between spec and oracle that affects a test case will fail.
+# /update-zskills is an agent-executed command. We cannot literally invoke
+# the skill from a shell test. Instead, we encode the algorithm documented
+# in `skills/update-zskills/SKILL.md` "Step B" (render + migration) and
+# "Step D — --rerender" as bash functions below, and run them against
+# fixture directories. The functions are executable oracles — if SKILL.md's
+# spec changes meaning, the oracles must be updated in lockstep.
 #
-# Coverage (matches WI 2.4 exactly):
-#   1. Happy path:  stale CLAUDE.md + updated config → new CLAUDE.md has current config values.
-#   2. Preservation: user content below `## Agent Rules` preserved verbatim.
-#   3. Conflict:     user edit above `## Agent Rules` → CLAUDE.md.new written, rc=2, stderr prompt.
-#   4. Missing file: no CLAUDE.md → rc=1 with specific error.
-#   5. Idempotency:  two back-to-back rerenders → second is a true no-op (mtime stable).
+# Coverage (matches WI 4.6 exactly):
+#   1. Fresh install:       .claude/rules/zskills/managed.md created,
+#                           contains current-config values; root CLAUDE.md
+#                           absent or untouched.
+#   2. --rerender after     managed.md reflects new values; no .new file;
+#      config edit:         rc=0.
+#   3. Migration happy:     fixture with zskills-rendered content in root
+#                           CLAUDE.md → lines removed, backup at
+#                           ./CLAUDE.md.pre-zskills-migration, managed.md
+#                           has fresh values, stderr NOTICE emitted.
+#   4. Migration no-op:     fixture with user-only root CLAUDE.md (no
+#                           zskills lines) → untouched, no backup.
+#   5. Migration idempotent: run install twice; backup exists only once,
+#                           root CLAUDE.md unchanged on second run.
 
 set -o pipefail
 
@@ -27,44 +35,44 @@ FAIL_COUNT=0
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
-# --- Oracle implementation of Step D ---------------------------------------
-# Args: $1 = working directory (must contain CLAUDE.md — optional — plus
-# .claude/zskills-config.json and CLAUDE_TEMPLATE.md in its root).
-# Writes CLAUDE.md or CLAUDE.md.new per spec. Prints stderr message verbatim
-# on conflict. Exit codes match Step D: 0 clean, 1 missing, 2 conflict.
-run_rerender() {
+# --- Oracle: render template against config ---------------------------------
+# Args: $1 = template content, $2..$N = KEY=VALUE pairs (placeholder substitutions).
+# Prints the rendered content to stdout.
+render_template() {
+  local out="$1"; shift
+  local kv key val
+  for kv in "$@"; do
+    key="${kv%%=*}"
+    val="${kv#*=}"
+    out="${out//\{\{${key}\}\}/$val}"
+  done
+  printf '%s' "$out"
+}
+
+# --- Oracle: Step B (render + migration) ------------------------------------
+# Args: $1 = working directory containing CLAUDE_TEMPLATE.md and
+#             .claude/zskills-config.json.
+# Writes .claude/rules/zskills/managed.md. Performs root-CLAUDE.md migration.
+# Prints stderr NOTICE on migration with non-zero candidates.
+# Returns 0 always (on success). 1 if template missing.
+run_step_b() {
   local dir="$1"
-  local claude="$dir/CLAUDE.md"
   local template="$dir/CLAUDE_TEMPLATE.md"
   local config="$dir/.claude/zskills-config.json"
+  local rules_dir="$dir/.claude/rules/zskills"
+  local rules_file="$rules_dir/managed.md"
 
-  # Missing CLAUDE.md → rc 1.
-  if [ ! -f "$claude" ]; then
-    echo "no existing CLAUDE.md; run /update-zskills (without --rerender) for initial install" >&2
+  if [ ! -f "$template" ]; then
+    echo "CLAUDE_TEMPLATE.md missing or unreadable; cannot render" >&2
     return 1
   fi
 
-  # Locate `## Agent Rules` demarcation.
-  local heading_line
-  heading_line=$(grep -n '^## Agent Rules[[:space:]]*$' "$claude" | head -1 | cut -d: -f1)
-  if [ -z "$heading_line" ]; then
-    echo "CLAUDE.md missing '## Agent Rules' demarcation; cannot rerender safely. Add the heading or re-run /update-zskills (without --rerender) for initial install." >&2
-    return 2
-  fi
-
-  # Split existing file.
-  local existing_above existing_below
-  existing_above=$(sed -n "1,$((heading_line - 1))p" "$claude")
-  existing_below=$(sed -n "${heading_line},\$p" "$claude")
-
-  # Render template against current config. Extract placeholder values from
-  # config via bash regex (mirrors Step 0.5's approach). Only the fields
-  # that appear in the test template are substituted; unknown placeholders
-  # pass through verbatim (same as Step B's "empty → comment out" is not
-  # what Step D promises — Step D re-substitutes current values).
-  local config_content
+  # Extract simple placeholder values from config (bash regex; same idiom as
+  # Step 0.5 of SKILL.md). Only the three fields the test fixtures use are
+  # substituted.
+  local config_content project_name dev_cmd timezone
   config_content=$(cat "$config" 2>/dev/null || echo "")
-  local project_name="" dev_cmd="" timezone=""
+  project_name=""; dev_cmd=""; timezone=""
   if [[ "$config_content" =~ \"project_name\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
     project_name="${BASH_REMATCH[1]}"
   fi
@@ -75,60 +83,193 @@ run_rerender() {
     timezone="${BASH_REMATCH[1]}"
   fi
 
-  local rendered
-  rendered=$(cat "$template")
-  rendered="${rendered//\{\{PROJECT_NAME\}\}/$project_name}"
-  rendered="${rendered//\{\{DEV_SERVER_CMD\}\}/$dev_cmd}"
-  rendered="${rendered//\{\{TIMEZONE\}\}/$timezone}"
+  local template_content rendered
+  template_content=$(cat "$template")
+  rendered=$(render_template "$template_content" \
+    "PROJECT_NAME=$project_name" \
+    "DEV_SERVER_CMD=$dev_cmd" \
+    "TIMEZONE=$timezone")
 
-  # Extract fresh_above: everything before `## Agent Rules` in the rendered
-  # output. If the template lacks the heading, synthesize one — the test
-  # fixtures guarantee a heading is present.
-  local fresh_heading_line
-  fresh_heading_line=$(echo "$rendered" | grep -n '^## Agent Rules[[:space:]]*$' | head -1 | cut -d: -f1)
-  if [ -z "$fresh_heading_line" ]; then
-    # The rendered template must carry the demarcation; if absent, the
-    # caller's template is malformed — treat as a conflict.
-    echo "rendered template lacks '## Agent Rules' heading; cannot merge" >&2
-    return 2
-  fi
-  local fresh_above
-  fresh_above=$(echo "$rendered" | sed -n "1,$((fresh_heading_line - 1))p")
+  # Write rules file (full overwrite).
+  mkdir -p "$rules_dir"
+  printf '%s' "$rendered" > "$rules_file"
 
-  # Right-trim trailing whitespace on each line before comparing.
-  local existing_trim fresh_trim
-  existing_trim=$(echo "$existing_above" | sed -E 's/[[:space:]]+$//')
-  fresh_trim=$(echo "$fresh_above" | sed -E 's/[[:space:]]+$//')
-
-  local merged
-  merged="$fresh_above"$'\n'"$existing_below"
-
-  if [ "$existing_trim" = "$fresh_trim" ]; then
-    # Idempotency: skip write if resulting bytes equal current file bytes.
-    local current
-    current=$(cat "$claude")
-    if [ "$current" = "$merged" ]; then
-      return 0
-    fi
-    printf '%s' "$merged" > "$claude"
+  # Migration sub-step: if root ./CLAUDE.md exists, detect zskills-rendered
+  # lines and remove them with ±2-line context match.
+  local root_claude="$dir/CLAUDE.md"
+  if [ ! -f "$root_claude" ]; then
     return 0
   fi
 
-  # Conflict: write .new, leave CLAUDE.md untouched, stderr verbatim.
-  printf '%s' "$merged" > "$claude.new"
-  cat >&2 <<'CONFLICT_MSG'
-CLAUDE.md differs above '## Agent Rules' (user edits, config drift, or both).
-New rendered content written to CLAUDE.md.new. Review with:
-    diff CLAUDE.md CLAUDE.md.new
-To accept the new version:  mv CLAUDE.md.new CLAUDE.md
-To discard it:              rm CLAUDE.md.new
-CONFLICT_MSG
-  return 2
+  local backup="$dir/CLAUDE.md.pre-zskills-migration"
+
+  # Build the set of (value, template-line-number, template ±2 context) tuples.
+  # For each non-empty placeholder value V, find template lines containing V
+  # and record the context signature (5-line window, trailing-ws-trimmed).
+  local tmp_candidates
+  tmp_candidates=$(mktemp)
+
+  # We'll use awk to scan the rendered template and produce context signatures.
+  # Values we look for (non-empty only).
+  local -a values=()
+  [ -n "$project_name" ] && values+=("$project_name")
+  [ -n "$dev_cmd" ]      && values+=("$dev_cmd")
+  [ -n "$timezone" ]     && values+=("$timezone")
+
+  if [ "${#values[@]}" -eq 0 ]; then
+    rm -f "$tmp_candidates"
+    return 0
+  fi
+
+  # Write the rendered template to a temp file so we can index it by line.
+  local tmp_rendered
+  tmp_rendered=$(mktemp)
+  printf '%s' "$rendered" > "$tmp_rendered"
+
+  # right-trim utility (bash):
+  rtrim() { local s="$1"; printf '%s' "${s%"${s##*[![:space:]]}"}"; }
+
+  # Read the root CLAUDE.md into an array (preserve trailing-newline behaviour
+  # by using mapfile).
+  local -a root_lines=() tmpl_lines=()
+  mapfile -t root_lines < "$root_claude"
+  mapfile -t tmpl_lines < "$tmp_rendered"
+
+  # For each value V, for each template line i that contains V, build the
+  # template ±2 signature and scan the root for a matching root line j
+  # containing V whose ±2 signature matches.
+  local i j v n_root n_tmpl
+  n_root=${#root_lines[@]}
+  n_tmpl=${#tmpl_lines[@]}
+  local -A remove_root=()  # keys: root line indices to remove
+
+  # Compute the trimmed 5-line signature at given index into a given array.
+  # Args: $1 = "root"|"tmpl", $2 = center index, $3 = array length.
+  # Echoes signature joined by \x1f.
+  signature() {
+    local arr="$1" idx="$2" n="$3"
+    local k line
+    local sig=""
+    for k in $((idx - 2)) $((idx - 1)) "$idx" $((idx + 1)) $((idx + 2)); do
+      if [ "$k" -lt 0 ] || [ "$k" -ge "$n" ]; then
+        sig+=$'\x1e'  # sentinel: out-of-bounds
+      else
+        if [ "$arr" = "root" ]; then line="${root_lines[$k]}"; else line="${tmpl_lines[$k]}"; fi
+        sig+=$(rtrim "$line")
+      fi
+      sig+=$'\x1f'
+    done
+    printf '%s' "$sig"
+  }
+
+  for v in "${values[@]}"; do
+    # Find template line indices containing v.
+    local -a tmpl_hits=()
+    for ((i = 0; i < n_tmpl; i++)); do
+      if [[ "${tmpl_lines[$i]}" == *"$v"* ]]; then
+        tmpl_hits+=("$i")
+      fi
+    done
+    [ "${#tmpl_hits[@]}" -eq 0 ] && continue
+    # For each tmpl hit, compute its signature.
+    local -a tmpl_sigs=()
+    for i in "${tmpl_hits[@]}"; do
+      tmpl_sigs+=("$(signature tmpl "$i" "$n_tmpl")")
+    done
+    # Scan root for lines containing v; compute signature; compare to any tmpl_sig.
+    for ((j = 0; j < n_root; j++)); do
+      [ -n "${remove_root[$j]:-}" ] && continue
+      if [[ "${root_lines[$j]}" == *"$v"* ]]; then
+        local root_sig
+        root_sig=$(signature root "$j" "$n_root")
+        local ts
+        for ts in "${tmpl_sigs[@]}"; do
+          if [ "$root_sig" = "$ts" ]; then
+            remove_root[$j]=1
+            break
+          fi
+        done
+      fi
+    done
+  done
+
+  rm -f "$tmp_candidates" "$tmp_rendered"
+
+  # If no candidates, no-op (no backup, no notice).
+  if [ "${#remove_root[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  # Backup root CLAUDE.md only if the backup doesn't already exist.
+  if [ ! -e "$backup" ]; then
+    cp "$root_claude" "$backup"
+  fi
+
+  # Rewrite root CLAUDE.md, dropping the removed lines.
+  local new_root
+  new_root=$(mktemp)
+  for ((i = 0; i < n_root; i++)); do
+    if [ -z "${remove_root[$i]:-}" ]; then
+      printf '%s\n' "${root_lines[$i]}" >> "$new_root"
+    fi
+  done
+  # Preserve behaviour: if the original file ended without a trailing newline
+  # and we wrote nothing, leave an empty file. mapfile + printf \n inherently
+  # produces trailing newline per line kept.
+  mv "$new_root" "$root_claude"
+
+  cat >&2 <<'NOTICE'
+NOTICE: Migrated zskills content from root ./CLAUDE.md to .claude/rules/zskills/managed.md.
+Backup: ./CLAUDE.md.pre-zskills-migration.
+If your Claude Code settings exclude .claude/** from context (e.g. claudeMdExcludes),
+the new rules file will not auto-load — adjust your excludes or @-import it from root CLAUDE.md.
+NOTICE
+
+  return 0
+}
+
+# --- Oracle: Step D (--rerender) --------------------------------------------
+# Args: $1 = working directory.
+# Full-file rewrite of .claude/rules/zskills/managed.md against current config.
+# Exit codes: 0 on success, 1 if template missing.
+run_rerender() {
+  local dir="$1"
+  local template="$dir/CLAUDE_TEMPLATE.md"
+  local config="$dir/.claude/zskills-config.json"
+  local rules_dir="$dir/.claude/rules/zskills"
+  local rules_file="$rules_dir/managed.md"
+
+  if [ ! -f "$template" ]; then
+    echo "CLAUDE_TEMPLATE.md missing or unreadable; cannot rerender" >&2
+    return 1
+  fi
+
+  local config_content project_name dev_cmd timezone
+  config_content=$(cat "$config" 2>/dev/null || echo "")
+  project_name=""; dev_cmd=""; timezone=""
+  if [[ "$config_content" =~ \"project_name\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    project_name="${BASH_REMATCH[1]}"
+  fi
+  if [[ "$config_content" =~ \"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    dev_cmd="${BASH_REMATCH[1]}"
+  fi
+  if [[ "$config_content" =~ \"timezone\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    timezone="${BASH_REMATCH[1]}"
+  fi
+
+  local template_content rendered
+  template_content=$(cat "$template")
+  rendered=$(render_template "$template_content" \
+    "PROJECT_NAME=$project_name" \
+    "DEV_SERVER_CMD=$dev_cmd" \
+    "TIMEZONE=$timezone")
+
+  mkdir -p "$rules_dir"
+  printf '%s' "$rendered" > "$rules_file"
+  return 0
 }
 
 # --- Fixture builder --------------------------------------------------------
-# Creates a fresh sandbox: <tmp>/CLAUDE_TEMPLATE.md, <tmp>/.claude/zskills-config.json,
-# <tmp>/CLAUDE.md (optional).
 make_fixture() {
   local dir="$1"
   local project_name="$2"
@@ -146,7 +287,7 @@ make_fixture() {
 
 ## Agent Rules
 
-Rendered-in-template rules go here.
+Generic rules rendered by zskills.
 TEMPLATE
   cat > "$dir/.claude/zskills-config.json" <<CONFIG
 {
@@ -159,292 +300,238 @@ TEMPLATE
 CONFIG
 }
 
-# --- Test 1: happy path -----------------------------------------------------
-# NOTE: The plan's WI 2.4 describes this as "stale CLAUDE.md + updated
-# config → new CLAUDE.md contains current config values". Under the
-# simplified algorithm (no "normalize by substituting prior values"), any
-# byte difference above '## Agent Rules' — including pure config drift —
-# triggers the conflict path: rc=2, CLAUDE.md untouched, CLAUDE.md.new
-# written with the fresh render. We assert that outcome here; the new
-# config values land in CLAUDE.md.new (which the user accepts via
-# `mv CLAUDE.md.new CLAUDE.md`). This matches the algorithm verbatim.
-echo "=== Test 1: happy path — stale config → CLAUDE.md.new carries new values ==="
+# --- Test 1: fresh install --------------------------------------------------
+echo "=== Test 1: fresh install — managed.md rendered, root CLAUDE.md untouched ==="
 T1="$(mktemp -d)"
-make_fixture "$T1" "acme-new" "npm run serve"
-# Seed CLAUDE.md with OLD config values.
-cat > "$T1/CLAUDE.md" <<'STALE'
-# acme-old — Agent Reference
-
-## Dev Server
-
-```bash
-npm start
-```
-
-## Agent Rules
-
-Rendered-in-template rules go here.
-STALE
-run_rerender "$T1" 2>/tmp/rerender-stderr-t1
+make_fixture "$T1" "acme" "npm start"
+# No root CLAUDE.md on a fresh project.
+run_step_b "$T1" 2>/tmp/rerender-stderr-t1
 rc=$?
-if [ "$rc" -eq 2 ]; then
-  pass "Test 1a: rc=2 when stale config differs from current (conflict path)"
+if [ "$rc" -eq 0 ]; then
+  pass "Test 1a: rc=0 on fresh install"
 else
-  fail "Test 1a: rc should be 2 (conflict)" "got rc=$rc"
+  fail "Test 1a: rc should be 0" "got rc=$rc"
 fi
-if [ -f "$T1/CLAUDE.md.new" ] \
-   && grep -q '^# acme-new — Agent Reference' "$T1/CLAUDE.md.new" \
-   && grep -q '^npm run serve$' "$T1/CLAUDE.md.new"; then
-  pass "Test 1b: CLAUDE.md.new contains current config values"
+if [ -f "$T1/.claude/rules/zskills/managed.md" ] \
+   && grep -q '^# acme — Agent Reference' "$T1/.claude/rules/zskills/managed.md" \
+   && grep -q '^npm start$' "$T1/.claude/rules/zskills/managed.md"; then
+  pass "Test 1b: managed.md contains rendered values"
 else
-  fail "Test 1b: CLAUDE.md.new missing new values" \
-    "$([ -f "$T1/CLAUDE.md.new" ] && head -5 "$T1/CLAUDE.md.new" || echo 'file missing')"
+  fail "Test 1b: managed.md missing or malformed" \
+    "$([ -f "$T1/.claude/rules/zskills/managed.md" ] && head -3 "$T1/.claude/rules/zskills/managed.md" || echo 'file missing')"
 fi
-if grep -q '^# acme-old — Agent Reference' "$T1/CLAUDE.md" \
-   && grep -q '^npm start$' "$T1/CLAUDE.md"; then
-  pass "Test 1c: CLAUDE.md untouched on conflict"
+if [ ! -f "$T1/CLAUDE.md" ]; then
+  pass "Test 1c: root CLAUDE.md absent (never created)"
 else
-  fail "Test 1c: CLAUDE.md was modified" "spec says leave existing alone"
+  fail "Test 1c: root CLAUDE.md was silently created" "file exists"
 fi
 rm -rf "$T1" /tmp/rerender-stderr-t1
 
-# --- Test 2: preservation below Agent Rules --------------------------------
-# Same semantics as Test 1: under the simplified algorithm, a stale config
-# produces rc=2 and CLAUDE.md.new. We assert that CLAUDE.md.new preserves
-# the user's below-heading content verbatim in the merged output — the
-# below-region is always carried over (never regenerated from template)
-# regardless of whether the above-region is identical or conflicting.
+# --- Test 2: --rerender after config edit -----------------------------------
 echo ""
-echo "=== Test 2: user content below '## Agent Rules' preserved verbatim ==="
+echo "=== Test 2: --rerender after config edit — managed.md reflects new values, rc=0 ==="
 T2="$(mktemp -d)"
-make_fixture "$T2" "acme-new" "npm run serve"
-cat > "$T2/CLAUDE.md" <<'STALE2'
-# acme-old — Agent Reference
-
-## Dev Server
-
-```bash
-npm start
-```
-
-## Agent Rules
-
-Rendered-in-template rules go here.
-
-## User Section
-
-This paragraph is user-authored. Do not modify.
-
-- bullet 1
-- bullet 2
-STALE2
-run_rerender "$T2" 2>/tmp/rerender-stderr-t2
+make_fixture "$T2" "acme-old" "npm start"
+run_step_b "$T2" 2>/tmp/rerender-stderr-t2-a
+# Simulate a config edit: rewrite config with new values.
+cat > "$T2/.claude/zskills-config.json" <<CONFIG
+{
+  "project_name": "acme-new",
+  "timezone": "America/New_York",
+  "dev_server": {
+    "cmd": "npm run serve"
+  }
+}
+CONFIG
+run_rerender "$T2" 2>/tmp/rerender-stderr-t2-b
 rc=$?
-# The merged output must be in CLAUDE.md.new (conflict path); user content
-# must be preserved verbatim.
-target="$T2/CLAUDE.md.new"
-[ -f "$target" ] || target="$T2/CLAUDE.md"  # tolerate either path in the assertion
-if grep -q 'This paragraph is user-authored. Do not modify.' "$target" \
-   && grep -q '^- bullet 1$' "$target" \
-   && grep -q '^- bullet 2$' "$target" \
-   && grep -q '^## User Section$' "$target"; then
-  pass "Test 2: user content below demarcation preserved (in $(basename "$target"))"
+if [ "$rc" -eq 0 ]; then
+  pass "Test 2a: rc=0 on --rerender"
 else
-  fail "Test 2: user content lost" "see $target"
+  fail "Test 2a: rc should be 0" "got rc=$rc"
 fi
-rm -rf "$T2" /tmp/rerender-stderr-t2
+if grep -q '^# acme-new — Agent Reference' "$T2/.claude/rules/zskills/managed.md" \
+   && grep -q '^npm run serve$' "$T2/.claude/rules/zskills/managed.md"; then
+  pass "Test 2b: managed.md contains new config values"
+else
+  fail "Test 2b: managed.md not rerendered" "$(head -3 "$T2/.claude/rules/zskills/managed.md")"
+fi
+if [ ! -f "$T2/.claude/rules/zskills/managed.md.new" ]; then
+  pass "Test 2c: no .new file created (byte-compare gone)"
+else
+  fail "Test 2c: unexpected .new file" "managed.md.new exists"
+fi
+rm -rf "$T2" /tmp/rerender-stderr-t2-a /tmp/rerender-stderr-t2-b
 
-# --- Test 3: conflict — edit above `## Agent Rules` ------------------------
+# --- Test 3: migration happy path -------------------------------------------
 echo ""
-echo "=== Test 3: edit above Agent Rules → CLAUDE.md.new, rc=2, stderr prompt ==="
+echo "=== Test 3: migration happy path — zskills lines removed, backup created ==="
 T3="$(mktemp -d)"
-make_fixture "$T3" "acme-new" "npm run serve"
-cat > "$T3/CLAUDE.md" <<'STALE3'
-# acme-old — Agent Reference
-
-## Dev Server
-
-```bash
-npm start
-```
-
-## Custom User Section
-
-This section was inserted by the user between Dev Server and Agent Rules.
-It must trigger the conflict path.
-
-## Agent Rules
-
-Rendered-in-template rules go here.
-STALE3
-PRE_CLAUDE=$(cat "$T3/CLAUDE.md")
-run_rerender "$T3" 2>/tmp/rerender-stderr-t3
-rc=$?
-if [ "$rc" -eq 2 ]; then
-  pass "Test 3a: rc=2 on conflict"
-else
-  fail "Test 3a: rc should be 2" "got rc=$rc"
-fi
-if [ -f "$T3/CLAUDE.md.new" ]; then
-  pass "Test 3b: CLAUDE.md.new written"
-else
-  fail "Test 3b: CLAUDE.md.new missing" "no file"
-fi
-POST_CLAUDE=$(cat "$T3/CLAUDE.md")
-if [ "$PRE_CLAUDE" = "$POST_CLAUDE" ]; then
-  pass "Test 3c: CLAUDE.md untouched on conflict"
-else
-  fail "Test 3c: CLAUDE.md was modified" "expected unchanged"
-fi
-if grep -q "CLAUDE.md differs above '## Agent Rules'" /tmp/rerender-stderr-t3 \
-   && grep -q 'diff CLAUDE.md CLAUDE.md.new' /tmp/rerender-stderr-t3 \
-   && grep -q 'mv CLAUDE.md.new CLAUDE.md' /tmp/rerender-stderr-t3 \
-   && grep -q 'rm CLAUDE.md.new' /tmp/rerender-stderr-t3; then
-  pass "Test 3d: stderr prompt verbatim"
-else
-  fail "Test 3d: stderr prompt missing expected lines" "$(cat /tmp/rerender-stderr-t3)"
-fi
-rm -rf "$T3" /tmp/rerender-stderr-t3
-
-# --- Test 4: missing CLAUDE.md ---------------------------------------------
-echo ""
-echo "=== Test 4: no CLAUDE.md → rc=1 with specific error ==="
-T4="$(mktemp -d)"
-make_fixture "$T4" "acme-new" "npm run serve"
-rm -f "$T4/CLAUDE.md"  # explicitly ensure missing
-run_rerender "$T4" 2>/tmp/rerender-stderr-t4
-rc=$?
-if [ "$rc" -eq 1 ]; then
-  pass "Test 4a: rc=1 on missing CLAUDE.md"
-else
-  fail "Test 4a: rc should be 1" "got rc=$rc"
-fi
-if grep -q 'no existing CLAUDE.md' /tmp/rerender-stderr-t4 \
-   && grep -q 'run /update-zskills (without --rerender) for initial install' /tmp/rerender-stderr-t4; then
-  pass "Test 4b: stderr has expected message"
-else
-  fail "Test 4b: stderr missing expected text" "$(cat /tmp/rerender-stderr-t4)"
-fi
-if [ ! -f "$T4/CLAUDE.md" ]; then
-  pass "Test 4c: CLAUDE.md not silently created"
-else
-  fail "Test 4c: CLAUDE.md was silently created" "file exists"
-fi
-rm -rf "$T4" /tmp/rerender-stderr-t4
-
-# --- Test 5: idempotency ---------------------------------------------------
-echo ""
-echo "=== Test 5: back-to-back rerender → second run is a true no-op ==="
-T5="$(mktemp -d)"
-make_fixture "$T5" "acme" "npm run dev"
-# Seed a CLAUDE.md whose "above" region already matches the current template.
-cat > "$T5/CLAUDE.md" <<'CURRENT'
+make_fixture "$T3" "acme" "npm start"
+# Seed root CLAUDE.md with zskills-rendered content AND user content.
+cat > "$T3/CLAUDE.md" <<'ROOT'
 # acme — Agent Reference
 
 ## Dev Server
 
 ```bash
-npm run dev
+npm start
 ```
 
 ## Agent Rules
 
-Rendered-in-template rules go here.
+Generic rules rendered by zskills.
+
+## My Personal Notes
+
+I remember we used to have `npm start` but now we use something different.
+Other personal notes go here.
+ROOT
+run_step_b "$T3" 2>/tmp/rerender-stderr-t3
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Test 3a: rc=0 on migration"
+else
+  fail "Test 3a: rc should be 0" "got rc=$rc"
+fi
+if [ -f "$T3/CLAUDE.md.pre-zskills-migration" ]; then
+  pass "Test 3b: backup created at ./CLAUDE.md.pre-zskills-migration"
+else
+  fail "Test 3b: backup missing" "no backup file"
+fi
+if grep -q 'NOTICE: Migrated zskills content' /tmp/rerender-stderr-t3 \
+   && grep -q '.claude/rules/zskills/managed.md' /tmp/rerender-stderr-t3 \
+   && grep -q '.pre-zskills-migration' /tmp/rerender-stderr-t3; then
+  pass "Test 3c: stderr NOTICE emitted"
+else
+  fail "Test 3c: NOTICE missing or malformed" "$(cat /tmp/rerender-stderr-t3)"
+fi
+# The template line `# acme — Agent Reference` (line 1 of root) should match
+# (it occurs at line 1 of the rendered template too). Same for the dev-cmd
+# block. The "I remember we used to have `npm start`" line is in a different
+# context (no matching ±2 signature) and must be preserved.
+if ! grep -q '^# acme — Agent Reference' "$T3/CLAUDE.md" \
+   && grep -q 'I remember we used to have' "$T3/CLAUDE.md" \
+   && grep -q '^## My Personal Notes' "$T3/CLAUDE.md"; then
+  pass "Test 3d: zskills lines removed, user content + prose-mention preserved"
+else
+  fail "Test 3d: migration removed wrong lines or preserved too much" "$(cat "$T3/CLAUDE.md")"
+fi
+if [ -f "$T3/.claude/rules/zskills/managed.md" ] \
+   && grep -q '^# acme — Agent Reference' "$T3/.claude/rules/zskills/managed.md"; then
+  pass "Test 3e: managed.md rendered with fresh values"
+else
+  fail "Test 3e: managed.md missing" "file missing or malformed"
+fi
+rm -rf "$T3" /tmp/rerender-stderr-t3
+
+# --- Test 4: migration no-op ------------------------------------------------
+echo ""
+echo "=== Test 4: migration no-op — user-only CLAUDE.md untouched, no backup ==="
+T4="$(mktemp -d)"
+make_fixture "$T4" "acme" "npm start"
+cat > "$T4/CLAUDE.md" <<'USER_ONLY'
+# My Project Notes
+
+This is entirely my own content. I never used zskills rendering here.
+
+- Some bullet
+- Another bullet
+
+## Random heading
+
+Some paragraph.
+USER_ONLY
+PRE=$(cat "$T4/CLAUDE.md")
+run_step_b "$T4" 2>/tmp/rerender-stderr-t4
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Test 4a: rc=0 on no-op migration"
+else
+  fail "Test 4a: rc should be 0" "got rc=$rc"
+fi
+POST=$(cat "$T4/CLAUDE.md")
+if [ "$PRE" = "$POST" ]; then
+  pass "Test 4b: root CLAUDE.md untouched (byte-identical)"
+else
+  fail "Test 4b: root CLAUDE.md was modified" "diff observed"
+fi
+if [ ! -e "$T4/CLAUDE.md.pre-zskills-migration" ]; then
+  pass "Test 4c: no backup created (nothing to migrate)"
+else
+  fail "Test 4c: unexpected backup" "backup file exists"
+fi
+if ! grep -q 'NOTICE: Migrated zskills content' /tmp/rerender-stderr-t4; then
+  pass "Test 4d: no NOTICE emitted"
+else
+  fail "Test 4d: unexpected NOTICE" "$(cat /tmp/rerender-stderr-t4)"
+fi
+rm -rf "$T4" /tmp/rerender-stderr-t4
+
+# --- Test 5: migration idempotency ------------------------------------------
+echo ""
+echo "=== Test 5: migration idempotent — second run no-ops, backup not duplicated ==="
+T5="$(mktemp -d)"
+make_fixture "$T5" "acme" "npm start"
+cat > "$T5/CLAUDE.md" <<'ROOT2'
+# acme — Agent Reference
+
+## Dev Server
+
+```bash
+npm start
+```
+
+## Agent Rules
+
+Generic rules rendered by zskills.
 
 ## User Appendix
 
-Custom user notes.
-CURRENT
-# First rerender: should be rc=0 and either no-op or identical write.
-run_rerender "$T5" 2>/tmp/rerender-stderr-t5-a
+User's own content.
+ROOT2
+# First run: performs migration.
+run_step_b "$T5" 2>/tmp/rerender-stderr-t5-a
 rc=$?
 if [ "$rc" -eq 0 ]; then
-  pass "Test 5a: first rerender rc=0"
+  pass "Test 5a: first run rc=0"
 else
-  fail "Test 5a: first rc should be 0" "got $rc"
+  fail "Test 5a: first rc should be 0" "got rc=$rc"
 fi
-FIRST_MTIME=$(stat -c %Y "$T5/CLAUDE.md")
-FIRST_CONTENT=$(cat "$T5/CLAUDE.md")
-sleep 1  # ensure mtime resolution would register a change
-# Second rerender.
-run_rerender "$T5" 2>/tmp/rerender-stderr-t5-b
+if [ -f "$T5/CLAUDE.md.pre-zskills-migration" ]; then
+  pass "Test 5b: backup exists after first run"
+else
+  fail "Test 5b: backup missing after first run" "no backup"
+fi
+POST_FIRST=$(cat "$T5/CLAUDE.md")
+BACKUP_MTIME=$(stat -c %Y "$T5/CLAUDE.md.pre-zskills-migration")
+sleep 1  # ensure any later write would have a different mtime
+# Second run: should be a no-op.
+run_step_b "$T5" 2>/tmp/rerender-stderr-t5-b
 rc=$?
 if [ "$rc" -eq 0 ]; then
-  pass "Test 5b: second rerender rc=0"
+  pass "Test 5c: second run rc=0"
 else
-  fail "Test 5b: second rc should be 0" "got $rc"
+  fail "Test 5c: second rc should be 0" "got rc=$rc"
 fi
-SECOND_MTIME=$(stat -c %Y "$T5/CLAUDE.md")
-SECOND_CONTENT=$(cat "$T5/CLAUDE.md")
-if [ "$FIRST_CONTENT" = "$SECOND_CONTENT" ]; then
-  pass "Test 5c: content identical across runs"
+POST_SECOND=$(cat "$T5/CLAUDE.md")
+BACKUP_MTIME2=$(stat -c %Y "$T5/CLAUDE.md.pre-zskills-migration")
+if [ "$POST_FIRST" = "$POST_SECOND" ]; then
+  pass "Test 5d: root CLAUDE.md unchanged on second run"
 else
-  fail "Test 5c: content differs across runs" "diff observed"
+  fail "Test 5d: root CLAUDE.md modified on second run" "diff observed"
 fi
-if [ "$FIRST_MTIME" = "$SECOND_MTIME" ]; then
-  pass "Test 5d: mtime unchanged (idempotent no-op)"
+if [ "$BACKUP_MTIME" = "$BACKUP_MTIME2" ]; then
+  pass "Test 5e: backup not overwritten (mtime stable)"
 else
-  fail "Test 5d: mtime changed on no-op rerender" "$FIRST_MTIME vs $SECOND_MTIME"
+  fail "Test 5e: backup was overwritten" "$BACKUP_MTIME vs $BACKUP_MTIME2"
+fi
+if ! grep -q 'NOTICE: Migrated zskills content' /tmp/rerender-stderr-t5-b; then
+  pass "Test 5f: no NOTICE on second run"
+else
+  fail "Test 5f: second run emitted NOTICE" "$(cat /tmp/rerender-stderr-t5-b)"
 fi
 rm -rf "$T5" /tmp/rerender-stderr-t5-a /tmp/rerender-stderr-t5-b
-
-# --- Test 6: Step C spec accommodates user-added hook (doc-check) ---------
-# WI 2.7 also asks for a separate "integration" test: write a synthetic
-# settings.json fixture with a user-added custom Bash hook, write a doc
-# asserting the Step C spec would preserve that hook (doc-check, not
-# execution). We model this as a structural check: Step C's SKILL.md text
-# explicitly says "Do not touch sibling hook objects (user-added
-# customizations in the same matcher survive)", which the earlier
-# test-skill-conformance check already asserts. Here we additionally
-# verify that a synthetic settings.json fixture with a user-hook is
-# LEFT UNCHANGED by a dry-run parse — we do NOT execute the merge
-# (agent-driven), only confirm the fixture's structure is preserved on
-# read.
-echo ""
-echo "=== Test 6: synthetic settings.json fixture preserves user-added hook ==="
-T6="$(mktemp -d)"
-cat > "$T6/settings.json" <<'FIXTURE'
-{
-  "permissions": {
-    "allow": ["Bash(ls)"]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-custom.sh\"",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  },
-  "model": "opus"
-}
-FIXTURE
-# The doc-check: Step C's spec promises foreign entries and non-hooks
-# top-level keys are preserved. We confirm the fixture is parseable and
-# contains the user-custom.sh reference — then assert Step C's SKILL.md
-# documents preservation. (The execution itself is the agent's job at
-# runtime.)
-if grep -q 'user-custom.sh' "$T6/settings.json" \
-   && grep -q '"model": "opus"' "$T6/settings.json" \
-   && grep -q '"permissions"' "$T6/settings.json"; then
-  # Confirm SKILL.md documents preservation for exactly this shape.
-  if grep -q 'Do not touch sibling hook objects' "$REPO_ROOT/skills/update-zskills/SKILL.md" \
-     && grep -q 'user-added customizations in the same matcher survive' "$REPO_ROOT/skills/update-zskills/SKILL.md" \
-     && grep -q 'Do not touch `permissions`, `env`, `statusLine`, `model`' "$REPO_ROOT/skills/update-zskills/SKILL.md"; then
-    pass "Test 6: Step C spec documents preservation of user hook + other top-level keys"
-  else
-    fail "Test 6: SKILL.md missing preservation-of-foreign-entries guarantees" "see Step C"
-  fi
-else
-  fail "Test 6: fixture malformed" "see $T6/settings.json"
-fi
-rm -rf "$T6"
 
 # --- Summary ---------------------------------------------------------------
 echo ""

--- a/tests/test-update-zskills-rerender.sh
+++ b/tests/test-update-zskills-rerender.sh
@@ -1,0 +1,459 @@
+#!/bin/bash
+# Integration test for /update-zskills --rerender (DRIFT_ARCH_FIX Phase 2, WI 2.4).
+#
+# --rerender is an agent-executed command. We cannot literally invoke the
+# skill from a shell test. Instead, we encode the algorithm documented in
+# `skills/update-zskills/SKILL.md` "### Step D — --rerender" as a bash
+# function `run_rerender` below, and run it against fixture directories.
+# The function is the executable oracle — if SKILL.md's spec changes
+# meaning, the oracle must be updated in lockstep. Any meaningful drift
+# between spec and oracle that affects a test case will fail.
+#
+# Coverage (matches WI 2.4 exactly):
+#   1. Happy path:  stale CLAUDE.md + updated config → new CLAUDE.md has current config values.
+#   2. Preservation: user content below `## Agent Rules` preserved verbatim.
+#   3. Conflict:     user edit above `## Agent Rules` → CLAUDE.md.new written, rc=2, stderr prompt.
+#   4. Missing file: no CLAUDE.md → rc=1 with specific error.
+#   5. Idempotency:  two back-to-back rerenders → second is a true no-op (mtime stable).
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# --- Oracle implementation of Step D ---------------------------------------
+# Args: $1 = working directory (must contain CLAUDE.md — optional — plus
+# .claude/zskills-config.json and CLAUDE_TEMPLATE.md in its root).
+# Writes CLAUDE.md or CLAUDE.md.new per spec. Prints stderr message verbatim
+# on conflict. Exit codes match Step D: 0 clean, 1 missing, 2 conflict.
+run_rerender() {
+  local dir="$1"
+  local claude="$dir/CLAUDE.md"
+  local template="$dir/CLAUDE_TEMPLATE.md"
+  local config="$dir/.claude/zskills-config.json"
+
+  # Missing CLAUDE.md → rc 1.
+  if [ ! -f "$claude" ]; then
+    echo "no existing CLAUDE.md; run /update-zskills (without --rerender) for initial install" >&2
+    return 1
+  fi
+
+  # Locate `## Agent Rules` demarcation.
+  local heading_line
+  heading_line=$(grep -n '^## Agent Rules[[:space:]]*$' "$claude" | head -1 | cut -d: -f1)
+  if [ -z "$heading_line" ]; then
+    echo "CLAUDE.md missing '## Agent Rules' demarcation; cannot rerender safely. Add the heading or re-run /update-zskills (without --rerender) for initial install." >&2
+    return 2
+  fi
+
+  # Split existing file.
+  local existing_above existing_below
+  existing_above=$(sed -n "1,$((heading_line - 1))p" "$claude")
+  existing_below=$(sed -n "${heading_line},\$p" "$claude")
+
+  # Render template against current config. Extract placeholder values from
+  # config via bash regex (mirrors Step 0.5's approach). Only the fields
+  # that appear in the test template are substituted; unknown placeholders
+  # pass through verbatim (same as Step B's "empty → comment out" is not
+  # what Step D promises — Step D re-substitutes current values).
+  local config_content
+  config_content=$(cat "$config" 2>/dev/null || echo "")
+  local project_name="" dev_cmd="" timezone=""
+  if [[ "$config_content" =~ \"project_name\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    project_name="${BASH_REMATCH[1]}"
+  fi
+  if [[ "$config_content" =~ \"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    dev_cmd="${BASH_REMATCH[1]}"
+  fi
+  if [[ "$config_content" =~ \"timezone\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+    timezone="${BASH_REMATCH[1]}"
+  fi
+
+  local rendered
+  rendered=$(cat "$template")
+  rendered="${rendered//\{\{PROJECT_NAME\}\}/$project_name}"
+  rendered="${rendered//\{\{DEV_SERVER_CMD\}\}/$dev_cmd}"
+  rendered="${rendered//\{\{TIMEZONE\}\}/$timezone}"
+
+  # Extract fresh_above: everything before `## Agent Rules` in the rendered
+  # output. If the template lacks the heading, synthesize one — the test
+  # fixtures guarantee a heading is present.
+  local fresh_heading_line
+  fresh_heading_line=$(echo "$rendered" | grep -n '^## Agent Rules[[:space:]]*$' | head -1 | cut -d: -f1)
+  if [ -z "$fresh_heading_line" ]; then
+    # The rendered template must carry the demarcation; if absent, the
+    # caller's template is malformed — treat as a conflict.
+    echo "rendered template lacks '## Agent Rules' heading; cannot merge" >&2
+    return 2
+  fi
+  local fresh_above
+  fresh_above=$(echo "$rendered" | sed -n "1,$((fresh_heading_line - 1))p")
+
+  # Right-trim trailing whitespace on each line before comparing.
+  local existing_trim fresh_trim
+  existing_trim=$(echo "$existing_above" | sed -E 's/[[:space:]]+$//')
+  fresh_trim=$(echo "$fresh_above" | sed -E 's/[[:space:]]+$//')
+
+  local merged
+  merged="$fresh_above"$'\n'"$existing_below"
+
+  if [ "$existing_trim" = "$fresh_trim" ]; then
+    # Idempotency: skip write if resulting bytes equal current file bytes.
+    local current
+    current=$(cat "$claude")
+    if [ "$current" = "$merged" ]; then
+      return 0
+    fi
+    printf '%s' "$merged" > "$claude"
+    return 0
+  fi
+
+  # Conflict: write .new, leave CLAUDE.md untouched, stderr verbatim.
+  printf '%s' "$merged" > "$claude.new"
+  cat >&2 <<'CONFLICT_MSG'
+CLAUDE.md differs above '## Agent Rules' (user edits, config drift, or both).
+New rendered content written to CLAUDE.md.new. Review with:
+    diff CLAUDE.md CLAUDE.md.new
+To accept the new version:  mv CLAUDE.md.new CLAUDE.md
+To discard it:              rm CLAUDE.md.new
+CONFLICT_MSG
+  return 2
+}
+
+# --- Fixture builder --------------------------------------------------------
+# Creates a fresh sandbox: <tmp>/CLAUDE_TEMPLATE.md, <tmp>/.claude/zskills-config.json,
+# <tmp>/CLAUDE.md (optional).
+make_fixture() {
+  local dir="$1"
+  local project_name="$2"
+  local dev_cmd="$3"
+  rm -rf "$dir"
+  mkdir -p "$dir/.claude"
+  cat > "$dir/CLAUDE_TEMPLATE.md" <<TEMPLATE
+# {{PROJECT_NAME}} — Agent Reference
+
+## Dev Server
+
+\`\`\`bash
+{{DEV_SERVER_CMD}}
+\`\`\`
+
+## Agent Rules
+
+Rendered-in-template rules go here.
+TEMPLATE
+  cat > "$dir/.claude/zskills-config.json" <<CONFIG
+{
+  "project_name": "$project_name",
+  "timezone": "America/New_York",
+  "dev_server": {
+    "cmd": "$dev_cmd"
+  }
+}
+CONFIG
+}
+
+# --- Test 1: happy path -----------------------------------------------------
+# NOTE: The plan's WI 2.4 describes this as "stale CLAUDE.md + updated
+# config → new CLAUDE.md contains current config values". Under the
+# simplified algorithm (no "normalize by substituting prior values"), any
+# byte difference above '## Agent Rules' — including pure config drift —
+# triggers the conflict path: rc=2, CLAUDE.md untouched, CLAUDE.md.new
+# written with the fresh render. We assert that outcome here; the new
+# config values land in CLAUDE.md.new (which the user accepts via
+# `mv CLAUDE.md.new CLAUDE.md`). This matches the algorithm verbatim.
+echo "=== Test 1: happy path — stale config → CLAUDE.md.new carries new values ==="
+T1="$(mktemp -d)"
+make_fixture "$T1" "acme-new" "npm run serve"
+# Seed CLAUDE.md with OLD config values.
+cat > "$T1/CLAUDE.md" <<'STALE'
+# acme-old — Agent Reference
+
+## Dev Server
+
+```bash
+npm start
+```
+
+## Agent Rules
+
+Rendered-in-template rules go here.
+STALE
+run_rerender "$T1" 2>/tmp/rerender-stderr-t1
+rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "Test 1a: rc=2 when stale config differs from current (conflict path)"
+else
+  fail "Test 1a: rc should be 2 (conflict)" "got rc=$rc"
+fi
+if [ -f "$T1/CLAUDE.md.new" ] \
+   && grep -q '^# acme-new — Agent Reference' "$T1/CLAUDE.md.new" \
+   && grep -q '^npm run serve$' "$T1/CLAUDE.md.new"; then
+  pass "Test 1b: CLAUDE.md.new contains current config values"
+else
+  fail "Test 1b: CLAUDE.md.new missing new values" \
+    "$([ -f "$T1/CLAUDE.md.new" ] && head -5 "$T1/CLAUDE.md.new" || echo 'file missing')"
+fi
+if grep -q '^# acme-old — Agent Reference' "$T1/CLAUDE.md" \
+   && grep -q '^npm start$' "$T1/CLAUDE.md"; then
+  pass "Test 1c: CLAUDE.md untouched on conflict"
+else
+  fail "Test 1c: CLAUDE.md was modified" "spec says leave existing alone"
+fi
+rm -rf "$T1" /tmp/rerender-stderr-t1
+
+# --- Test 2: preservation below Agent Rules --------------------------------
+# Same semantics as Test 1: under the simplified algorithm, a stale config
+# produces rc=2 and CLAUDE.md.new. We assert that CLAUDE.md.new preserves
+# the user's below-heading content verbatim in the merged output — the
+# below-region is always carried over (never regenerated from template)
+# regardless of whether the above-region is identical or conflicting.
+echo ""
+echo "=== Test 2: user content below '## Agent Rules' preserved verbatim ==="
+T2="$(mktemp -d)"
+make_fixture "$T2" "acme-new" "npm run serve"
+cat > "$T2/CLAUDE.md" <<'STALE2'
+# acme-old — Agent Reference
+
+## Dev Server
+
+```bash
+npm start
+```
+
+## Agent Rules
+
+Rendered-in-template rules go here.
+
+## User Section
+
+This paragraph is user-authored. Do not modify.
+
+- bullet 1
+- bullet 2
+STALE2
+run_rerender "$T2" 2>/tmp/rerender-stderr-t2
+rc=$?
+# The merged output must be in CLAUDE.md.new (conflict path); user content
+# must be preserved verbatim.
+target="$T2/CLAUDE.md.new"
+[ -f "$target" ] || target="$T2/CLAUDE.md"  # tolerate either path in the assertion
+if grep -q 'This paragraph is user-authored. Do not modify.' "$target" \
+   && grep -q '^- bullet 1$' "$target" \
+   && grep -q '^- bullet 2$' "$target" \
+   && grep -q '^## User Section$' "$target"; then
+  pass "Test 2: user content below demarcation preserved (in $(basename "$target"))"
+else
+  fail "Test 2: user content lost" "see $target"
+fi
+rm -rf "$T2" /tmp/rerender-stderr-t2
+
+# --- Test 3: conflict — edit above `## Agent Rules` ------------------------
+echo ""
+echo "=== Test 3: edit above Agent Rules → CLAUDE.md.new, rc=2, stderr prompt ==="
+T3="$(mktemp -d)"
+make_fixture "$T3" "acme-new" "npm run serve"
+cat > "$T3/CLAUDE.md" <<'STALE3'
+# acme-old — Agent Reference
+
+## Dev Server
+
+```bash
+npm start
+```
+
+## Custom User Section
+
+This section was inserted by the user between Dev Server and Agent Rules.
+It must trigger the conflict path.
+
+## Agent Rules
+
+Rendered-in-template rules go here.
+STALE3
+PRE_CLAUDE=$(cat "$T3/CLAUDE.md")
+run_rerender "$T3" 2>/tmp/rerender-stderr-t3
+rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "Test 3a: rc=2 on conflict"
+else
+  fail "Test 3a: rc should be 2" "got rc=$rc"
+fi
+if [ -f "$T3/CLAUDE.md.new" ]; then
+  pass "Test 3b: CLAUDE.md.new written"
+else
+  fail "Test 3b: CLAUDE.md.new missing" "no file"
+fi
+POST_CLAUDE=$(cat "$T3/CLAUDE.md")
+if [ "$PRE_CLAUDE" = "$POST_CLAUDE" ]; then
+  pass "Test 3c: CLAUDE.md untouched on conflict"
+else
+  fail "Test 3c: CLAUDE.md was modified" "expected unchanged"
+fi
+if grep -q "CLAUDE.md differs above '## Agent Rules'" /tmp/rerender-stderr-t3 \
+   && grep -q 'diff CLAUDE.md CLAUDE.md.new' /tmp/rerender-stderr-t3 \
+   && grep -q 'mv CLAUDE.md.new CLAUDE.md' /tmp/rerender-stderr-t3 \
+   && grep -q 'rm CLAUDE.md.new' /tmp/rerender-stderr-t3; then
+  pass "Test 3d: stderr prompt verbatim"
+else
+  fail "Test 3d: stderr prompt missing expected lines" "$(cat /tmp/rerender-stderr-t3)"
+fi
+rm -rf "$T3" /tmp/rerender-stderr-t3
+
+# --- Test 4: missing CLAUDE.md ---------------------------------------------
+echo ""
+echo "=== Test 4: no CLAUDE.md → rc=1 with specific error ==="
+T4="$(mktemp -d)"
+make_fixture "$T4" "acme-new" "npm run serve"
+rm -f "$T4/CLAUDE.md"  # explicitly ensure missing
+run_rerender "$T4" 2>/tmp/rerender-stderr-t4
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "Test 4a: rc=1 on missing CLAUDE.md"
+else
+  fail "Test 4a: rc should be 1" "got rc=$rc"
+fi
+if grep -q 'no existing CLAUDE.md' /tmp/rerender-stderr-t4 \
+   && grep -q 'run /update-zskills (without --rerender) for initial install' /tmp/rerender-stderr-t4; then
+  pass "Test 4b: stderr has expected message"
+else
+  fail "Test 4b: stderr missing expected text" "$(cat /tmp/rerender-stderr-t4)"
+fi
+if [ ! -f "$T4/CLAUDE.md" ]; then
+  pass "Test 4c: CLAUDE.md not silently created"
+else
+  fail "Test 4c: CLAUDE.md was silently created" "file exists"
+fi
+rm -rf "$T4" /tmp/rerender-stderr-t4
+
+# --- Test 5: idempotency ---------------------------------------------------
+echo ""
+echo "=== Test 5: back-to-back rerender → second run is a true no-op ==="
+T5="$(mktemp -d)"
+make_fixture "$T5" "acme" "npm run dev"
+# Seed a CLAUDE.md whose "above" region already matches the current template.
+cat > "$T5/CLAUDE.md" <<'CURRENT'
+# acme — Agent Reference
+
+## Dev Server
+
+```bash
+npm run dev
+```
+
+## Agent Rules
+
+Rendered-in-template rules go here.
+
+## User Appendix
+
+Custom user notes.
+CURRENT
+# First rerender: should be rc=0 and either no-op or identical write.
+run_rerender "$T5" 2>/tmp/rerender-stderr-t5-a
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Test 5a: first rerender rc=0"
+else
+  fail "Test 5a: first rc should be 0" "got $rc"
+fi
+FIRST_MTIME=$(stat -c %Y "$T5/CLAUDE.md")
+FIRST_CONTENT=$(cat "$T5/CLAUDE.md")
+sleep 1  # ensure mtime resolution would register a change
+# Second rerender.
+run_rerender "$T5" 2>/tmp/rerender-stderr-t5-b
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "Test 5b: second rerender rc=0"
+else
+  fail "Test 5b: second rc should be 0" "got $rc"
+fi
+SECOND_MTIME=$(stat -c %Y "$T5/CLAUDE.md")
+SECOND_CONTENT=$(cat "$T5/CLAUDE.md")
+if [ "$FIRST_CONTENT" = "$SECOND_CONTENT" ]; then
+  pass "Test 5c: content identical across runs"
+else
+  fail "Test 5c: content differs across runs" "diff observed"
+fi
+if [ "$FIRST_MTIME" = "$SECOND_MTIME" ]; then
+  pass "Test 5d: mtime unchanged (idempotent no-op)"
+else
+  fail "Test 5d: mtime changed on no-op rerender" "$FIRST_MTIME vs $SECOND_MTIME"
+fi
+rm -rf "$T5" /tmp/rerender-stderr-t5-a /tmp/rerender-stderr-t5-b
+
+# --- Test 6: Step C spec accommodates user-added hook (doc-check) ---------
+# WI 2.7 also asks for a separate "integration" test: write a synthetic
+# settings.json fixture with a user-added custom Bash hook, write a doc
+# asserting the Step C spec would preserve that hook (doc-check, not
+# execution). We model this as a structural check: Step C's SKILL.md text
+# explicitly says "Do not touch sibling hook objects (user-added
+# customizations in the same matcher survive)", which the earlier
+# test-skill-conformance check already asserts. Here we additionally
+# verify that a synthetic settings.json fixture with a user-hook is
+# LEFT UNCHANGED by a dry-run parse — we do NOT execute the merge
+# (agent-driven), only confirm the fixture's structure is preserved on
+# read.
+echo ""
+echo "=== Test 6: synthetic settings.json fixture preserves user-added hook ==="
+T6="$(mktemp -d)"
+cat > "$T6/settings.json" <<'FIXTURE'
+{
+  "permissions": {
+    "allow": ["Bash(ls)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-custom.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  },
+  "model": "opus"
+}
+FIXTURE
+# The doc-check: Step C's spec promises foreign entries and non-hooks
+# top-level keys are preserved. We confirm the fixture is parseable and
+# contains the user-custom.sh reference — then assert Step C's SKILL.md
+# documents preservation. (The execution itself is the agent's job at
+# runtime.)
+if grep -q 'user-custom.sh' "$T6/settings.json" \
+   && grep -q '"model": "opus"' "$T6/settings.json" \
+   && grep -q '"permissions"' "$T6/settings.json"; then
+  # Confirm SKILL.md documents preservation for exactly this shape.
+  if grep -q 'Do not touch sibling hook objects' "$REPO_ROOT/skills/update-zskills/SKILL.md" \
+     && grep -q 'user-added customizations in the same matcher survive' "$REPO_ROOT/skills/update-zskills/SKILL.md" \
+     && grep -q 'Do not touch `permissions`, `env`, `statusLine`, `model`' "$REPO_ROOT/skills/update-zskills/SKILL.md"; then
+    pass "Test 6: Step C spec documents preservation of user hook + other top-level keys"
+  else
+    fail "Test 6: SKILL.md missing preservation-of-foreign-entries guarantees" "see Step C"
+  fi
+else
+  fail "Test 6: fixture malformed" "see $T6/settings.json"
+fi
+rm -rf "$T6"
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "---"
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Implements `plans/DRIFT_ARCH_FIX.md` — closes the drift-class bugs where hooks, helper scripts, and `/update-zskills`-managed content snapshot `.claude/zskills-config.json` values at install time and go stale silently on post-install config edits.

Landing via PR mode (`execution.landing: "pr"`). All 4 phases accumulate on this branch; squash-merge lands the whole drift-arch fix as one unit.

## Progress — all phases complete ✅

- [x] **Phase 1** — Migrate CODE consumers to runtime config read (commit `3b3fc88`)
- [x] **Phase 2** — `/update-zskills` Step C agent-driven settings.json merge + `--rerender` initial spec + drop migrated fills (commit `8ce91de`)
- [x] **Phase 3** — PostToolUse `warn-config-drift` hook + settings.json wiring (commit `e3e6b3c`)
- [x] **Phase 4** — Move zskills-managed content to `.claude/rules/zskills/managed.md` — namespaced, zskills-owned, simple `--rerender` full-rewrite, auto-migration for existing consumers (commit `2cac108`). **Supersedes Phase 2's byte-compare `--rerender` design.**

## What's fixed

- **Original task**: hook hardcoded test-command drift — hooks + helper scripts now read config at runtime (Phase 1).
- **Pre-existing bug #1**: `/update-zskills` Step C full-overwrite of settings.json `hooks` object (silently clobbered user-added PreToolUse entries) — rewritten as agent-driven Read+Edit merge with canonical zskills-owned triples table (Phase 2).
- **Pre-existing bug #2**: Step B `"NEVER overwrite existing CLAUDE.md content"` rule was itself a bug — meant config changes never propagated to downstream CLAUDE.md. Eliminated by moving zskills content out of user territory entirely (Phase 4).
- **Documentation drift awareness**: PostToolUse hook nudges user on `.claude/zskills-config.json` edits (Phase 3).

## Architecture after merge

Clean file-level ownership:
- **zskills-owned**: `.claude/hooks/`, `scripts/` (install-filled only for fields without config source), `.claude/rules/zskills/managed.md`, zskills-rendered entries in `.claude/settings.json`.
- **User-owned**: root `./CLAUDE.md` (exclusively), any custom PreToolUse/PostToolUse entries in `.claude/settings.json`, anything outside `.claude/rules/zskills/`.
- No overlap, no clobber risk, no markers, no byte-compare dance.

## Stats

- **Tests**: 733 → **815 passing** (+82 new; zero regressions)
- **Files changed**: 15 (+2192/-404)
- **Adversarial review rounds**: 3 formal + 1 post-convergence scope expansion + 1 Phase 4 redesign. All findings dispositioned in plan.

## Migration for existing consumers (downstream)

First `/update-zskills` run after this merges:
- Detects zskills-rendered content in root `./CLAUDE.md` via ±2-line context match against current-config-rendered template.
- Backs up to `./CLAUDE.md.pre-zskills-migration` (only if no prior backup exists).
- Removes matched lines; everything else untouched.
- Writes fresh content to `.claude/rules/zskills/managed.md`.
- Emits stderr NOTICE.
- Idempotent on re-run.

## Verification

Independent `/verify-changes branch` dispatched a fresh multi-agent review: CLEAN.
- Mirror parity: all 3 pairs byte-identical.
- Placeholder deny-list + allow-list: as specified.
- Phase 4 supersede: zero byte-compare/`.new` residue in SKILL.md.
- Step B migration: 6/6 required elements present.
- Step D full-rewrite: rc=0/rc=1, no `.new` file.
- Drift-warn hook: references new path verbatim.
- No UI changes; no user sign-off items needed.

## Known follow-ups (filed; not blocking)

- #56 — `/commit` should respect `execution.landing` for default mode.
- #58 — push-guard regex false-positives on `origin main` in fetch-before-push blocks.

🤖 Drafted via `/draft-plan`; executed via `/run-plan ... finish auto` with user-driven design corrections mid-pipeline.