### PR TITLE
feat(run-plan): sync PR body progress across phases (closes #60)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1185,6 +1185,85 @@ commits on the feature branch.
    feature branch *before* push so it's captured in the squash). If
    landing fails in either mode, tracker correctly reads In Progress.
 
+5. **(PR mode only) Sync the GitHub PR body's progress section.** The PR
+   body was snapshotted at PR-open time in Phase 6 (Step 5, Create PR) and
+   wrapped with HTML-comment markers (`<!-- run-plan:progress:start -->`
+   and `<!-- run-plan:progress:end -->`). As subsequent phases land on the
+   feature branch, the PR body must be updated so readers see current
+   progress — not the stale Phase 1 snapshot. Splice ONLY the
+   marker-enclosed region; preserve user-authored prose outside the
+   markers verbatim.
+
+   Skip this step entirely in cherry-pick / direct modes — there is no PR.
+   Skip this step in PR mode if no PR exists yet (Phase 6 hasn't opened
+   one), e.g. when Phase 4 runs between phases in finish mode before any
+   push has happened. Phase 6's Create PR step is authoritative for the
+   initial body.
+
+   ```bash
+   # Only run in PR mode, and only if a PR already exists for this branch.
+   if [ "$LANDING_MODE" = "pr" ]; then
+     PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null)
+     if [ -n "$PR_NUMBER" ]; then
+       # Capture current PR body to a temp file (per-PR path avoids cross-run
+       # collisions). Use gh's --jq to extract the JSON string cleanly; this
+       # yields raw markdown with real newlines (no JSON escaping).
+       PR_BODY_FILE="/tmp/pr-body-${PLAN_SLUG}-${PR_NUMBER}.md"
+       if ! gh pr view "$PR_NUMBER" --json body --jq '.body' > "$PR_BODY_FILE" 2>/dev/null; then
+         echo "NOTICE: skipping PR body sync: gh pr view #$PR_NUMBER failed" >&2
+       else
+         CURRENT_BODY=$(cat "$PR_BODY_FILE")
+         START_MARKER='<!-- run-plan:progress:start -->'
+         END_MARKER='<!-- run-plan:progress:end -->'
+
+         # Regenerate the progress section from the plan tracker — SAME
+         # format as Phase 6 (Step 5) writes at PR-open time. Keep this in
+         # sync with that template.
+         COMPLETED_PHASES=$(grep -E '^\| .* \| ✅' "$PLAN_FILE" | sed 's/|//g' | awk '{$1=$1};1' || echo "See plan file")
+         NEW_PROGRESS="**Phases completed:**
+$COMPLETED_PHASES"
+
+         # Splice with bash regex (NO jq — zskills avoids jq in skills).
+         # The regex captures: (prefix-up-to-and-including-start-marker)
+         # (anything-in-between) (end-marker-and-rest). We keep groups 1
+         # and 3 and replace group 2 with the new progress content.
+         # Graceful on missing markers: emit NOTICE and skip the update.
+         if [[ "$CURRENT_BODY" =~ (.*$START_MARKER)(.*)($END_MARKER.*) ]]; then
+           PREFIX="${BASH_REMATCH[1]}"
+           SUFFIX="${BASH_REMATCH[3]}"
+           UPDATED_BODY="${PREFIX}
+${NEW_PROGRESS}
+${SUFFIX}"
+           if ! gh pr edit "$PR_NUMBER" --body "$UPDATED_BODY" >/dev/null 2>&1; then
+             echo "WARNING: gh pr edit #$PR_NUMBER failed — PR body not synced (auth/network?)" >&2
+           else
+             echo "Synced PR #$PR_NUMBER body progress section."
+           fi
+         else
+           echo "NOTICE: skipping PR body sync: markers not found; this is expected for PRs not opened by /run-plan PR mode" >&2
+         fi
+         rm -f "$PR_BODY_FILE"
+       fi
+     fi
+   fi
+   ```
+
+   **Design properties:**
+   - **Idempotent:** the splice only rewrites the marker-enclosed region;
+     safe to run multiple times per phase.
+   - **Headless-safe:** no interactive prompts; operates via `gh pr view`
+     + `gh pr edit`.
+   - **Preserves user edits outside markers:** user-authored prose
+     (additional sections, links, review notes) outside the marker pair
+     survives the splice.
+   - **Graceful on missing markers:** emit a NOTICE to stderr and skip
+     the update. Do NOT fail Phase 4 — the plan-tracker commit on the
+     feature branch is the source of truth; the PR body is a convenience
+     surface.
+   - **No jq:** splice is pure bash regex (`BASH_REMATCH`). `gh pr view
+     --json body --jq '.body'` is used only to extract the JSON string
+     cleanly (`.jq` is a flag on `gh`, not a separate binary dep).
+
 ## Phase 5 — Write Report
 
 **PREPEND** new phase sections after the H1 in `reports/plan-{slug}.md`

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -211,10 +211,17 @@ fi
 # Collect completed phases for the body
 COMPLETED_PHASES=$(grep -E '^\| .* \| ✅' "$PLAN_FILE" | sed 's/|//g' | awk '{$1=$1};1' || echo "See plan file")
 
+# The progress section is wrapped with HTML-comment markers so that Phase 4
+# (Update Progress Tracking) can splice in updated progress as later phases
+# land, without clobbering user-authored prose outside the markers. The
+# markers are literal sentinels — do not rename them without updating the
+# Phase 4 splice logic in skills/run-plan/SKILL.md.
 PR_BODY="## Plan: ${PLAN_TITLE}
 
+<!-- run-plan:progress:start -->
 **Phases completed:**
 ${COMPLETED_PHASES}
+<!-- run-plan:progress:end -->
 
 **Report:** See \`reports/plan-${PLAN_SLUG}.md\` for details.
 

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1185,6 +1185,85 @@ commits on the feature branch.
    feature branch *before* push so it's captured in the squash). If
    landing fails in either mode, tracker correctly reads In Progress.
 
+5. **(PR mode only) Sync the GitHub PR body's progress section.** The PR
+   body was snapshotted at PR-open time in Phase 6 (Step 5, Create PR) and
+   wrapped with HTML-comment markers (`<!-- run-plan:progress:start -->`
+   and `<!-- run-plan:progress:end -->`). As subsequent phases land on the
+   feature branch, the PR body must be updated so readers see current
+   progress — not the stale Phase 1 snapshot. Splice ONLY the
+   marker-enclosed region; preserve user-authored prose outside the
+   markers verbatim.
+
+   Skip this step entirely in cherry-pick / direct modes — there is no PR.
+   Skip this step in PR mode if no PR exists yet (Phase 6 hasn't opened
+   one), e.g. when Phase 4 runs between phases in finish mode before any
+   push has happened. Phase 6's Create PR step is authoritative for the
+   initial body.
+
+   ```bash
+   # Only run in PR mode, and only if a PR already exists for this branch.
+   if [ "$LANDING_MODE" = "pr" ]; then
+     PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' 2>/dev/null)
+     if [ -n "$PR_NUMBER" ]; then
+       # Capture current PR body to a temp file (per-PR path avoids cross-run
+       # collisions). Use gh's --jq to extract the JSON string cleanly; this
+       # yields raw markdown with real newlines (no JSON escaping).
+       PR_BODY_FILE="/tmp/pr-body-${PLAN_SLUG}-${PR_NUMBER}.md"
+       if ! gh pr view "$PR_NUMBER" --json body --jq '.body' > "$PR_BODY_FILE" 2>/dev/null; then
+         echo "NOTICE: skipping PR body sync: gh pr view #$PR_NUMBER failed" >&2
+       else
+         CURRENT_BODY=$(cat "$PR_BODY_FILE")
+         START_MARKER='<!-- run-plan:progress:start -->'
+         END_MARKER='<!-- run-plan:progress:end -->'
+
+         # Regenerate the progress section from the plan tracker — SAME
+         # format as Phase 6 (Step 5) writes at PR-open time. Keep this in
+         # sync with that template.
+         COMPLETED_PHASES=$(grep -E '^\| .* \| ✅' "$PLAN_FILE" | sed 's/|//g' | awk '{$1=$1};1' || echo "See plan file")
+         NEW_PROGRESS="**Phases completed:**
+$COMPLETED_PHASES"
+
+         # Splice with bash regex (NO jq — zskills avoids jq in skills).
+         # The regex captures: (prefix-up-to-and-including-start-marker)
+         # (anything-in-between) (end-marker-and-rest). We keep groups 1
+         # and 3 and replace group 2 with the new progress content.
+         # Graceful on missing markers: emit NOTICE and skip the update.
+         if [[ "$CURRENT_BODY" =~ (.*$START_MARKER)(.*)($END_MARKER.*) ]]; then
+           PREFIX="${BASH_REMATCH[1]}"
+           SUFFIX="${BASH_REMATCH[3]}"
+           UPDATED_BODY="${PREFIX}
+${NEW_PROGRESS}
+${SUFFIX}"
+           if ! gh pr edit "$PR_NUMBER" --body "$UPDATED_BODY" >/dev/null 2>&1; then
+             echo "WARNING: gh pr edit #$PR_NUMBER failed — PR body not synced (auth/network?)" >&2
+           else
+             echo "Synced PR #$PR_NUMBER body progress section."
+           fi
+         else
+           echo "NOTICE: skipping PR body sync: markers not found; this is expected for PRs not opened by /run-plan PR mode" >&2
+         fi
+         rm -f "$PR_BODY_FILE"
+       fi
+     fi
+   fi
+   ```
+
+   **Design properties:**
+   - **Idempotent:** the splice only rewrites the marker-enclosed region;
+     safe to run multiple times per phase.
+   - **Headless-safe:** no interactive prompts; operates via `gh pr view`
+     + `gh pr edit`.
+   - **Preserves user edits outside markers:** user-authored prose
+     (additional sections, links, review notes) outside the marker pair
+     survives the splice.
+   - **Graceful on missing markers:** emit a NOTICE to stderr and skip
+     the update. Do NOT fail Phase 4 — the plan-tracker commit on the
+     feature branch is the source of truth; the PR body is a convenience
+     surface.
+   - **No jq:** splice is pure bash regex (`BASH_REMATCH`). `gh pr view
+     --json body --jq '.body'` is used only to extract the JSON string
+     cleanly (`.jq` is a flag on `gh`, not a separate binary dep).
+
 ## Phase 5 — Write Report
 
 **PREPEND** new phase sections after the H1 in `reports/plan-{slug}.md`

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -211,10 +211,17 @@ fi
 # Collect completed phases for the body
 COMPLETED_PHASES=$(grep -E '^\| .* \| ✅' "$PLAN_FILE" | sed 's/|//g' | awk '{$1=$1};1' || echo "See plan file")
 
+# The progress section is wrapped with HTML-comment markers so that Phase 4
+# (Update Progress Tracking) can splice in updated progress as later phases
+# land, without clobbering user-authored prose outside the markers. The
+# markers are literal sentinels — do not rename them without updating the
+# Phase 4 splice logic in skills/run-plan/SKILL.md.
 PR_BODY="## Plan: ${PLAN_TITLE}
 
+<!-- run-plan:progress:start -->
 **Phases completed:**
 ${COMPLETED_PHASES}
+<!-- run-plan:progress:end -->
 
 **Report:** See \`reports/plan-${PLAN_SLUG}.md\` for details.
 

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -84,6 +84,23 @@ check_fixed run-plan "final-verify marker glob"     'requires.verify-changes.fin
 check_fixed run-plan "read-auth: PR worktree path"  'PR_WORKTREE_PATH="/tmp/${PROJECT_NAME}-pr-${PLAN_SLUG}"'
 check_fixed run-plan "read-auth: feature-branch branch" 'PLAN_FILE_FOR_READ="$PR_WORKTREE_PATH/$PLAN_FILE"'
 check_fixed run-plan "read-auth: main fallback"     'PLAN_FILE_FOR_READ="$MAIN_ROOT/$PLAN_FILE"'
+# PR-body progress sync (issue #60): PR mode opens the PR once in Phase 6
+# and used to never revisit the body, leaving the progress checklist frozen
+# at Phase 1. The fix wraps the PR body's progress section in HTML-comment
+# markers at open time (modes/pr.md) and adds a Phase 4 splice step
+# (SKILL.md) that rewrites only the marker-enclosed region, preserving
+# user-authored prose outside. Conformance assertions:
+#   1. Both markers exist in the PR body template.
+#   2. Phase 4 invokes gh pr edit for the body sync.
+#   3. Phase 4 splices between the same two markers.
+#   4. Phase 4 emits the NOTICE-on-missing-markers fallback text (skipping
+#      rather than erroring), preserving graceful behavior for PRs not
+#      opened by /run-plan.
+check_fixed run-plan "pr body: start marker"          '<!-- run-plan:progress:start -->'
+check_fixed run-plan "pr body: end marker"            '<!-- run-plan:progress:end -->'
+check_fixed run-plan "phase4: gh pr edit body sync"   'gh pr edit "$PR_NUMBER" --body'
+check_fixed run-plan "phase4: splice between markers" '(.*$START_MARKER)(.*)($END_MARKER.*)'
+check       run-plan "phase4: NOTICE on missing markers" 'markers not found.*expected for PRs not opened by /run-plan'
 # Test-command resolution (caught by CANARY10 re-run — verifier defaulted to
 # a template file because no skill resolved testing.full_cmd). Both /run-plan
 # and /verify-changes MUST have the three-case decision tree: config → use,


### PR DESCRIPTION
## Summary

Closes #60.

In PR mode, `/run-plan` accumulates commits across multiple phases but the PR body is written once (when Phase 6 opens the PR) and never updated as subsequent phases land. Surfaced on PR #59 (DRIFT_ARCH_FIX): body showed only Phase 1 checked even after all 4 phases committed.

## Fix

- Wrap the progress checklist in `<!-- run-plan:progress:start -->` / `<!-- run-plan:progress:end -->` HTML-comment markers when the PR is opened (Phase 6 Create PR step in `modes/pr.md`).
- Add a Phase 4 sub-step (PR mode only) that reads the current PR body via `gh pr view --json body --jq '.body'`, regenerates the progress section from the plan's Progress Tracker, splices between markers using bash `BASH_REMATCH`, and writes back via `gh pr edit --body`.
- Scope-gated: only runs when `LANDING_MODE=pr` **and** a PR exists for the branch (no-op during Phase 1 before Phase 6 opens the PR; no-op entirely in cherry-pick/direct modes).
- Graceful on missing markers: stderr NOTICE + skip (for PRs opened outside `/run-plan`, or cases where a user removed the markers).
- No `jq` used for the splice — only `gh --jq` for the single JSON field read. Splice is pure bash.

## Properties

- **Idempotent**: re-running the sync produces the same result.
- **Preserves user edits**: anything outside the markers survives verbatim.
- **Headless-safe**: no interactive prompts.
- **Non-fatal on network/auth failure**: warns and proceeds rather than failing Phase 4.

## Test plan

- [x] Full suite: 820/820 passing (baseline 815 → 820, +5 from new structural assertions).
- [x] Byte-identical mirrors for `skills/run-plan/SKILL.md` and `skills/run-plan/modes/pr.md` (CI drift-check will enforce).
- [x] 5 new structural assertions in `tests/test-skill-conformance.sh`: start marker, end marker, `gh pr edit` call, splice regex, NOTICE fallback text.
- [ ] CI on this PR to confirm green.

🤖 Generated with /quickfix (agent-dispatched)