### PR TITLE
fix(readme): portable cp glob for BSD cp (macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ project.
 2. **Copy skills** from the clone into your project:
    ```bash
    mkdir -p .claude/skills
-   cp -r /tmp/zskills/skills/*/ .claude/skills/
+   cp -r /tmp/zskills/skills/* .claude/skills/
    ```
 
 3. **Run `/update-zskills`** to complete setup. This is the important


### PR DESCRIPTION
## Summary

README.md line 70 used `cp -r /tmp/zskills/skills/*/ .claude/skills/`. On BSD cp (macOS), the trailing slash on the glob causes each skill directory's *contents* to be copied loose into `.claude/skills/` instead of creating `.claude/skills/<skill-name>/` subdirectories, leaving the install unusable. Dropping the trailing slash (`cp -r /tmp/zskills/skills/* .claude/skills/`) makes the glob portable across BSD cp and GNU cp.

Reported by Simon Greenwold after a fresh macOS install. Grep-verified as the only occurrence in active docs; `plans/` and `reports/` references (historical) left alone.

Mode: `agent-dispatched`
Base: `main`
Slug: `fix-readme-cp-command-for-bsd-macos`

## Test plan

- [x] `bash tests/run-all.sh` — 820/820 passed (no regressions from the docs edit)

A GNU-cp smoke test isn't included because both the old and new forms work on GNU cp; the bug is BSD-specific and the evidence is Simon's reproduction + documented BSD cp trailing-slash semantics.

🤖 Generated with /quickfix