### PR TITLE
do: model-compose slug/title/scope derivations

### DIFF
--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -8,16 +8,22 @@ Selected when the user passes `pr` explicitly, or when
 
 **This path replaces the normal Phase 2–5 flow entirely. After the PR is created, skip to Phase 5 Report.**
 
-**Step A1 — Compute task slug:**
+**Step A1 — Compose task slug (model-layer).** Set shell variable
+`TASK_SLUG` to a kebab-case identifier matching
+`^[a-z0-9]+(-[a-z0-9]+)*$`, ≤30 chars, a 3–5 word summary of the task.
+Compose from `$TASK_DESCRIPTION`'s essential verbs/nouns — not a verbatim
+prefix of the input. Multi-line descriptions compose the same way as
+single-line ones: distill the intent, don't splice lines.
+
 ```bash
-# N = min(4, word_count) words from TASK_DESCRIPTION
-WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
-N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
-TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
-  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
-  | tr '[:upper:]' '[:lower:]' \
-  | cut -c1-30 \
-  | sed 's/-$//')
+if [ -z "${TASK_SLUG:-}" ]; then
+  echo "ERROR: TASK_SLUG not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$TASK_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#TASK_SLUG} -gt 30 ]; then
+  echo "ERROR: TASK_SLUG must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤30 chars (got '$TASK_SLUG')." >&2
+  exit 2
+fi
 ```
 
 **Step A2 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
@@ -125,7 +131,22 @@ git rebase origin/main || { echo "ERROR: Rebase conflict. Resolve manually in $W
 git push -u origin "$BRANCH_NAME"
 
 # PR body: explicit title and body, not --fill
-PR_TITLE="do: $(echo "$TASK_DESCRIPTION" | cut -c1-60)"
+#
+# Compose $PR_TITLE (model-layer). Set shell variable PR_TITLE to a
+# single-line title, ≤60 chars, that MUST begin with the literal prefix
+# `do: ` (four characters: d, o, colon, space — preserving /do's existing
+# convention). After the prefix, summarize what the task actually did —
+# compose from the completed work, not a verbatim prefix of
+# $TASK_DESCRIPTION.
+if [ -z "${PR_TITLE:-}" ]; then
+  echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 60 ] || [[ "$PR_TITLE" != do:\ * ]]; then
+  echo "ERROR: PR_TITLE must be a single line ≤60 chars starting with 'do: ' (got '$PR_TITLE')." >&2
+  exit 2
+fi
+
 PR_BODY="Task: ${TASK_DESCRIPTION}
 
 Worktree: ${WORKTREE_PATH}

--- a/.claude/skills/do/modes/worktree.md
+++ b/.claude/skills/do/modes/worktree.md
@@ -6,17 +6,24 @@ Create a named worktree and do the work there; the verification agent commits af
 Selected when the user passes `worktree` explicitly, or when
 `execution.landing` in `.claude/zskills-config.json` is `"cherry-pick"`.
 
-Create a named worktree at `/tmp/<project>-do-<slug>/` via `scripts/create-worktree.sh` (same path convention as `/do pr`, `/fix-issues pr`, and `/run-plan`; `WORKTREE_ROOT` in config overrides `/tmp`):
+Create a named worktree at `/tmp/<project>-do-<slug>/` via `scripts/create-worktree.sh` (same path convention as `/do pr`, `/fix-issues pr`, and `/run-plan`; `WORKTREE_ROOT` in config overrides `/tmp`).
+
+**Compose $TASK_SLUG (model-layer).** Set shell variable `TASK_SLUG` to a
+kebab-case identifier matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤30 chars, a
+3–5 word summary of the task. Compose from `$TASK_DESCRIPTION`'s essential
+verbs/nouns — not a verbatim prefix of the input. Multi-line descriptions
+compose the same way as single-line ones: distill the intent, don't
+splice lines.
 
 ```bash
-# Compute slug from task description
-WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
-N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
-TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
-  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
-  | tr '[:upper:]' '[:lower:]' \
-  | cut -c1-30 \
-  | sed 's/-$//')
+if [ -z "${TASK_SLUG:-}" ]; then
+  echo "ERROR: TASK_SLUG not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$TASK_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#TASK_SLUG} -gt 30 ]; then
+  echo "ERROR: TASK_SLUG must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤30 chars (got '$TASK_SLUG')." >&2
+  exit 2
+fi
 
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 ATTEMPT_SLUG="${TASK_SLUG}"

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -290,37 +290,32 @@ exists only as a fallback for the literal-script execution path used by
 
 ### WI 1.6 — Slug derivation
 
-Pipeline: lowercase → collapse non-alphanumerics to `-` → trim leading
-and trailing `-` → `cut -c1-40` → **trim trailing `-` again** (the second
-trim is load-bearing: when the cut boundary lands on a `-`, otherwise the
-branch would end in `quickfix/fix-foo-`).
+**Compose $SLUG (model-layer).** Set shell variable `SLUG` to a kebab-case
+identifier matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤40 chars, a 3–6 word
+summary of the task. Compose from the description's essential verbs/nouns
+— not a verbatim prefix of the input. Multi-line descriptions compose the
+same way as single-line ones: distill the intent, don't splice lines.
 
 ```bash
-SLUG=$(printf '%s' "$DESCRIPTION" \
-       | tr '[:upper:]' '[:lower:]' \
-       | sed -E 's/[^a-z0-9]+/-/g' \
-       | sed -E 's/^-+//; s/-+$//' \
-       | cut -c1-40 \
-       | sed -E 's/-+$//')
-
-if [ -z "$SLUG" ]; then
-  echo "ERROR: description produced an empty slug (no alphanumerics)." >&2
+if [ -z "${SLUG:-}" ]; then
+  echo "ERROR: SLUG not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#SLUG} -gt 40 ]; then
+  echo "ERROR: SLUG must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤40 chars (got '$SLUG')." >&2
   exit 2
 fi
-case "$SLUG" in
-  */*) echo "ERROR: slug must not contain '/' (got '$SLUG')." >&2; exit 2 ;;
-esac
 ```
 
 Examples:
 
-| Input | Slug |
-|-------|------|
+| Input | Composed SLUG |
+|-------|---------------|
 | `Fix README typo!` | `fix-readme-typo` |
-| `Fix the broken link in docs/intro.md` | `fix-the-broken-link-in-docs-intro-md` |
+| `Fix the broken link in docs/intro.md` | `fix-broken-docs-link` |
 | `  Update CHANGELOG  ` | `update-changelog` |
-| `---Fix---foo---` | `fix-foo` |
-| `!!!` | `""` → exit 2 |
+| Multi-line: `"Refactor the worker pool\n\nIt's currently unbounded..."` | `refactor-worker-pool` |
+| `!!!` | (model cannot compose a slug from punctuation → validator exit 2 after any attempt) |
 
 ### WI 1.7 — Branch naming
 
@@ -697,12 +692,27 @@ fi
 
 ## Phase 7 — PR creation (WI 1.15)
 
-Title is the description truncated to 70 characters. Body is built via a
-`<<-EOF` heredoc with **tab-indented** body lines (tabs are stripped by
-`<<-`; using spaces would render the body as a code block on GitHub).
+**Compose $PR_TITLE (model-layer).** Set shell variable `PR_TITLE` to a
+single-line conventional-commit style title of the form
+`type(scope): summary` (type ∈ {feat, fix, docs, refactor, chore, test,
+build, ci, style, perf, revert}; scope is the primary module/file being
+changed; summary describes what's actually changing). ≤70 chars, no
+newlines. Compose from what the PR actually does — not a verbatim prefix
+of the description.
+
+Body is built via a `<<-EOF` heredoc with **tab-indented** body lines
+(tabs are stripped by `<<-`; using spaces would render the body as a code
+block on GitHub).
 
 ```bash
-PR_TITLE=$(printf '%s' "$DESCRIPTION" | cut -c1-70)
+if [ -z "${PR_TITLE:-}" ]; then
+  echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 70 ]; then
+  echo "ERROR: PR_TITLE must be a single line ≤70 chars (got '$PR_TITLE')." >&2
+  exit 2
+fi
 
 PR_BODY=$(cat <<-EOF
 	## Summary

--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -53,18 +53,36 @@ DIFFERENT scopes are fine — they run in parallel without conflict.
 
 **Create the scoped sentinel:**
 
+**Compose $SCOPE (model-layer).** Set shell variable `SCOPE` to a
+kebab-case identifier matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤30 chars, a
+3–5 word summary of the goal. Compose from `$DESCRIPTION`'s essential
+verbs/nouns — not a verbatim prefix of the input. Multi-line
+descriptions compose the same way as single-line ones: distill the
+intent, don't splice lines.
+
 ```bash
-SCOPE=$(echo "$DESCRIPTION" | tr '[:upper:] ' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | cut -c1-30)
+if [ -z "${SCOPE:-}" ]; then
+  echo "ERROR: SCOPE not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$SCOPE" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#SCOPE} -gt 30 ]; then
+  echo "ERROR: SCOPE must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤30 chars (got '$SCOPE')." >&2
+  exit 2
+fi
+
 PIPELINE_ID="research-and-go.$SCOPE"
 PIPELINE_ID=$(bash scripts/sanitize-pipeline-id.sh "$PIPELINE_ID")
 # Recover SCOPE after sanitization (strip the "research-and-go." prefix).
+# Sanitization is idempotent on a validator-passing $SCOPE, but keep the
+# recovery so any future change to the sanitizer cannot silently skew
+# $SCOPE away from what $PIPELINE_ID encodes.
 SCOPE="${PIPELINE_ID#research-and-go.}"
 mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 printf 'skill=research-and-go\ngoal=%s\nstartedAt=%s\n' "$DESCRIPTION" "$(date -Iseconds)" > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.research-and-go.$SCOPE"
 ```
 
 Where `$DESCRIPTION` is the broad goal passed to this command and `$SCOPE` is a
-slugified version for scoping.
+model-composed short identifier used for tracking-dir scoping.
 
 **Declare pipeline ID for hook scoping:**
 

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -8,16 +8,22 @@ Selected when the user passes `pr` explicitly, or when
 
 **This path replaces the normal Phase 2–5 flow entirely. After the PR is created, skip to Phase 5 Report.**
 
-**Step A1 — Compute task slug:**
+**Step A1 — Compose task slug (model-layer).** Set shell variable
+`TASK_SLUG` to a kebab-case identifier matching
+`^[a-z0-9]+(-[a-z0-9]+)*$`, ≤30 chars, a 3–5 word summary of the task.
+Compose from `$TASK_DESCRIPTION`'s essential verbs/nouns — not a verbatim
+prefix of the input. Multi-line descriptions compose the same way as
+single-line ones: distill the intent, don't splice lines.
+
 ```bash
-# N = min(4, word_count) words from TASK_DESCRIPTION
-WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
-N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
-TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
-  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
-  | tr '[:upper:]' '[:lower:]' \
-  | cut -c1-30 \
-  | sed 's/-$//')
+if [ -z "${TASK_SLUG:-}" ]; then
+  echo "ERROR: TASK_SLUG not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$TASK_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#TASK_SLUG} -gt 30 ]; then
+  echo "ERROR: TASK_SLUG must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤30 chars (got '$TASK_SLUG')." >&2
+  exit 2
+fi
 ```
 
 **Step A2 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
@@ -125,7 +131,22 @@ git rebase origin/main || { echo "ERROR: Rebase conflict. Resolve manually in $W
 git push -u origin "$BRANCH_NAME"
 
 # PR body: explicit title and body, not --fill
-PR_TITLE="do: $(echo "$TASK_DESCRIPTION" | cut -c1-60)"
+#
+# Compose $PR_TITLE (model-layer). Set shell variable PR_TITLE to a
+# single-line title, ≤60 chars, that MUST begin with the literal prefix
+# `do: ` (four characters: d, o, colon, space — preserving /do's existing
+# convention). After the prefix, summarize what the task actually did —
+# compose from the completed work, not a verbatim prefix of
+# $TASK_DESCRIPTION.
+if [ -z "${PR_TITLE:-}" ]; then
+  echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 60 ] || [[ "$PR_TITLE" != do:\ * ]]; then
+  echo "ERROR: PR_TITLE must be a single line ≤60 chars starting with 'do: ' (got '$PR_TITLE')." >&2
+  exit 2
+fi
+
 PR_BODY="Task: ${TASK_DESCRIPTION}
 
 Worktree: ${WORKTREE_PATH}

--- a/skills/do/modes/worktree.md
+++ b/skills/do/modes/worktree.md
@@ -6,17 +6,24 @@ Create a named worktree and do the work there; the verification agent commits af
 Selected when the user passes `worktree` explicitly, or when
 `execution.landing` in `.claude/zskills-config.json` is `"cherry-pick"`.
 
-Create a named worktree at `/tmp/<project>-do-<slug>/` via `scripts/create-worktree.sh` (same path convention as `/do pr`, `/fix-issues pr`, and `/run-plan`; `WORKTREE_ROOT` in config overrides `/tmp`):
+Create a named worktree at `/tmp/<project>-do-<slug>/` via `scripts/create-worktree.sh` (same path convention as `/do pr`, `/fix-issues pr`, and `/run-plan`; `WORKTREE_ROOT` in config overrides `/tmp`).
+
+**Compose $TASK_SLUG (model-layer).** Set shell variable `TASK_SLUG` to a
+kebab-case identifier matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤30 chars, a
+3–5 word summary of the task. Compose from `$TASK_DESCRIPTION`'s essential
+verbs/nouns — not a verbatim prefix of the input. Multi-line descriptions
+compose the same way as single-line ones: distill the intent, don't
+splice lines.
 
 ```bash
-# Compute slug from task description
-WORD_COUNT=$(echo "$TASK_DESCRIPTION" | wc -w)
-N=$(( WORD_COUNT < 4 ? WORD_COUNT : 4 ))
-TASK_SLUG=$(echo "$TASK_DESCRIPTION" | awk "{for(i=1;i<=$N;i++) printf \$i\"-\"; print \"\"}" \
-  | sed -E 's/[^a-zA-Z0-9]+/-/g; s/-+/-/g; s/^-//; s/-$//' \
-  | tr '[:upper:]' '[:lower:]' \
-  | cut -c1-30 \
-  | sed 's/-$//')
+if [ -z "${TASK_SLUG:-}" ]; then
+  echo "ERROR: TASK_SLUG not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$TASK_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#TASK_SLUG} -gt 30 ]; then
+  echo "ERROR: TASK_SLUG must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤30 chars (got '$TASK_SLUG')." >&2
+  exit 2
+fi
 
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 ATTEMPT_SLUG="${TASK_SLUG}"

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -290,37 +290,32 @@ exists only as a fallback for the literal-script execution path used by
 
 ### WI 1.6 — Slug derivation
 
-Pipeline: lowercase → collapse non-alphanumerics to `-` → trim leading
-and trailing `-` → `cut -c1-40` → **trim trailing `-` again** (the second
-trim is load-bearing: when the cut boundary lands on a `-`, otherwise the
-branch would end in `quickfix/fix-foo-`).
+**Compose $SLUG (model-layer).** Set shell variable `SLUG` to a kebab-case
+identifier matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤40 chars, a 3–6 word
+summary of the task. Compose from the description's essential verbs/nouns
+— not a verbatim prefix of the input. Multi-line descriptions compose the
+same way as single-line ones: distill the intent, don't splice lines.
 
 ```bash
-SLUG=$(printf '%s' "$DESCRIPTION" \
-       | tr '[:upper:]' '[:lower:]' \
-       | sed -E 's/[^a-z0-9]+/-/g' \
-       | sed -E 's/^-+//; s/-+$//' \
-       | cut -c1-40 \
-       | sed -E 's/-+$//')
-
-if [ -z "$SLUG" ]; then
-  echo "ERROR: description produced an empty slug (no alphanumerics)." >&2
+if [ -z "${SLUG:-}" ]; then
+  echo "ERROR: SLUG not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#SLUG} -gt 40 ]; then
+  echo "ERROR: SLUG must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤40 chars (got '$SLUG')." >&2
   exit 2
 fi
-case "$SLUG" in
-  */*) echo "ERROR: slug must not contain '/' (got '$SLUG')." >&2; exit 2 ;;
-esac
 ```
 
 Examples:
 
-| Input | Slug |
-|-------|------|
+| Input | Composed SLUG |
+|-------|---------------|
 | `Fix README typo!` | `fix-readme-typo` |
-| `Fix the broken link in docs/intro.md` | `fix-the-broken-link-in-docs-intro-md` |
+| `Fix the broken link in docs/intro.md` | `fix-broken-docs-link` |
 | `  Update CHANGELOG  ` | `update-changelog` |
-| `---Fix---foo---` | `fix-foo` |
-| `!!!` | `""` → exit 2 |
+| Multi-line: `"Refactor the worker pool\n\nIt's currently unbounded..."` | `refactor-worker-pool` |
+| `!!!` | (model cannot compose a slug from punctuation → validator exit 2 after any attempt) |
 
 ### WI 1.7 — Branch naming
 
@@ -697,12 +692,27 @@ fi
 
 ## Phase 7 — PR creation (WI 1.15)
 
-Title is the description truncated to 70 characters. Body is built via a
-`<<-EOF` heredoc with **tab-indented** body lines (tabs are stripped by
-`<<-`; using spaces would render the body as a code block on GitHub).
+**Compose $PR_TITLE (model-layer).** Set shell variable `PR_TITLE` to a
+single-line conventional-commit style title of the form
+`type(scope): summary` (type ∈ {feat, fix, docs, refactor, chore, test,
+build, ci, style, perf, revert}; scope is the primary module/file being
+changed; summary describes what's actually changing). ≤70 chars, no
+newlines. Compose from what the PR actually does — not a verbatim prefix
+of the description.
+
+Body is built via a `<<-EOF` heredoc with **tab-indented** body lines
+(tabs are stripped by `<<-`; using spaces would render the body as a code
+block on GitHub).
 
 ```bash
-PR_TITLE=$(printf '%s' "$DESCRIPTION" | cut -c1-70)
+if [ -z "${PR_TITLE:-}" ]; then
+  echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 70 ]; then
+  echo "ERROR: PR_TITLE must be a single line ≤70 chars (got '$PR_TITLE')." >&2
+  exit 2
+fi
 
 PR_BODY=$(cat <<-EOF
 	## Summary

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -53,18 +53,36 @@ DIFFERENT scopes are fine — they run in parallel without conflict.
 
 **Create the scoped sentinel:**
 
+**Compose $SCOPE (model-layer).** Set shell variable `SCOPE` to a
+kebab-case identifier matching `^[a-z0-9]+(-[a-z0-9]+)*$`, ≤30 chars, a
+3–5 word summary of the goal. Compose from `$DESCRIPTION`'s essential
+verbs/nouns — not a verbatim prefix of the input. Multi-line
+descriptions compose the same way as single-line ones: distill the
+intent, don't splice lines.
+
 ```bash
-SCOPE=$(echo "$DESCRIPTION" | tr '[:upper:] ' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | cut -c1-30)
+if [ -z "${SCOPE:-}" ]; then
+  echo "ERROR: SCOPE not set — model-layer composition step skipped." >&2
+  exit 5
+fi
+if ! [[ "$SCOPE" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#SCOPE} -gt 30 ]; then
+  echo "ERROR: SCOPE must match ^[a-z0-9]+(-[a-z0-9]+)*\$ and be ≤30 chars (got '$SCOPE')." >&2
+  exit 2
+fi
+
 PIPELINE_ID="research-and-go.$SCOPE"
 PIPELINE_ID=$(bash scripts/sanitize-pipeline-id.sh "$PIPELINE_ID")
 # Recover SCOPE after sanitization (strip the "research-and-go." prefix).
+# Sanitization is idempotent on a validator-passing $SCOPE, but keep the
+# recovery so any future change to the sanitizer cannot silently skew
+# $SCOPE away from what $PIPELINE_ID encodes.
 SCOPE="${PIPELINE_ID#research-and-go.}"
 mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 printf 'skill=research-and-go\ngoal=%s\nstartedAt=%s\n' "$DESCRIPTION" "$(date -Iseconds)" > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.research-and-go.$SCOPE"
 ```
 
 Where `$DESCRIPTION` is the broad goal passed to this command and `$SCOPE` is a
-slugified version for scoping.
+model-composed short identifier used for tracking-dir scoping.
 
 **Declare pipeline ID for hook scoping:**
 

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -47,16 +47,14 @@ fail() {
 }
 
 # --- Helpers ------------------------------------------------------------
-# Slug derivation, extracted verbatim from skills/quickfix/SKILL.md WI 1.6.
-# Keeping this in a helper lets us table-drive WI 1.6's contract.
-derive_slug() {
-  printf '%s' "$1" \
-    | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9]+/-/g' \
-    | sed -E 's/^-+//; s/-+$//' \
-    | cut -c1-40 \
-    | sed -E 's/-+$//'
-}
+#
+# WI 1.6 is now model-composed: the model sets $SLUG before any bash
+# fence runs, and a bash validator enforces shape. Tests that drive the
+# preflight slice set $SLUG explicitly in the environment (via the
+# `SLUG=…` prefix on the `bash "$PREFLIGHT_SCRIPT" …` invocation). A
+# harness-wide default is also injected into the extracted preflight /
+# full-flow scripts below so cases that only exercise pre-slug gates
+# (e.g. landing-gate, gh-gate, test-cmd gate) still proceed.
 
 # Per-run scratch directory; never under $REPO_ROOT so `git status` stays clean.
 TEST_TMPDIR="/tmp/zskills-quickfix-test-$$"
@@ -193,10 +191,17 @@ extract_preflight() {
 }
 
 # Extract to a shared helper script for the cases that run it.
+#
+# WI 1.6 is model-composed: the model sets $SLUG before the validator
+# fence runs. The test harness simulates that by injecting a default
+# `SLUG` from the environment (or falling back to a harness default) at
+# the top of the extracted script. Individual cases that care about a
+# specific slug export `SLUG=…` before invoking.
 PREFLIGHT_SCRIPT="$TEST_TMPDIR/preflight.sh"
 {
   echo '#!/bin/bash'
   echo 'set -u'
+  echo ': "${SLUG:=fix-stub}"'
   extract_preflight
 } > "$PREFLIGHT_SCRIPT"
 chmod +x "$PREFLIGHT_SCRIPT"
@@ -225,12 +230,17 @@ FULL_FLOW_SCRIPT="$TEST_TMPDIR/full-flow.sh"
 {
   echo '#!/bin/bash'
   echo 'set -u'
-  # WI 1.13 expects the model to set COMMIT_SUBJECT (conventional-commit
-  # form) before the commit fence runs. The fixture simulates that
-  # model-layer composition step with a synthetic subject so the bash
-  # extraction can test the rest of the flow (compose body, commit,
-  # push, PR) end-to-end.
+  # WI 1.6, 1.13, and 1.15 all expect the model to set shell variables
+  # (SLUG, COMMIT_SUBJECT, PR_TITLE) before the corresponding bash
+  # validator/commit/PR fences run. The fixture simulates those model-
+  # layer composition steps so the bash extraction can test the rest of
+  # the flow (branch creation, compose body, commit, push, PR) end-to-
+  # end. Individual cases that care about a specific slug export
+  # `SLUG=…` before invoking; the default below makes cases that don't
+  # care "just work".
+  echo ': "${SLUG:=fix-stub}"'
   echo 'COMMIT_SUBJECT="test(case43): synthetic conventional-commit subject"'
+  echo 'PR_TITLE="test: synthetic PR title"'
   extract_full_flow
 } > "$FULL_FLOW_SCRIPT"
 chmod +x "$FULL_FLOW_SCRIPT"
@@ -261,25 +271,68 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Case 3 — Slug derivation contract (WI 1.6)
+# Case 3 — SLUG validator-shape contract (WI 1.6)
+#
+# WI 1.6 is now model-composed: the model sets $SLUG, a bash validator
+# enforces shape. This case table-drives the validator regex + length
+# cap by running the actual fence block from the skill and asserting
+# that valid SLUGs pass and malformed ones fail with the expected exit
+# code. Regex: `^[a-z0-9]+(-[a-z0-9]+)*$`; max length 40.
 # ────────────────────────────────────────────────────────────────────
-slug_case() {
-  local label="$1" input="$2" expected="$3" got
-  got=$(derive_slug "$input")
-  if [ "$got" = "$expected" ]; then
-    pass "3  slug: $label"
+slug_validator() {
+  local slug="$1"
+  # Exact fence copy of WI 1.6's validator — kept in sync with the
+  # skill source. If this block drifts from skills/quickfix/SKILL.md
+  # WI 1.6, the test suite falsely passes; a targeted grep below
+  # asserts the fence is still present in source.
+  if [ -z "${slug:-}" ]; then
+    return 5
+  fi
+  if ! [[ "$slug" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#slug} -gt 40 ]; then
+    return 2
+  fi
+  return 0
+}
+slug_accept() {
+  local label="$1" input="$2"
+  slug_validator "$input"
+  local rc=$?
+  if [ "$rc" -eq 0 ]; then
+    pass "3  slug accept: $label ('$input')"
   else
-    fail "3  slug: $label — input='$input' expected='$expected' got='$got'"
+    fail "3  slug accept: $label ('$input') — got rc=$rc, expected 0"
   fi
 }
-slug_case "ASCII punctuation → kebab"          "Fix README typo!"                        "fix-readme-typo"
-slug_case "embedded slash → dash"              "Fix the broken link in docs/intro.md"    "fix-the-broken-link-in-docs-intro-md"
-slug_case "leading/trailing whitespace trim"   "  Update CHANGELOG  "                    "update-changelog"
-slug_case "collapsed leading/trailing dashes"  "---Fix---foo---"                         "fix-foo"
-# 41-char input chosen so cut -c1-40 lands on a dash; final sed must strip it.
-slug_case "boundary-at-cut trailing dash"      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx FOO" \
-                                               "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-slug_case "no alphanumerics → empty"           "!!!"                                     ""
+slug_reject() {
+  local label="$1" input="$2" expected_rc="$3"
+  slug_validator "$input"
+  local rc=$?
+  if [ "$rc" -eq "$expected_rc" ]; then
+    pass "3  slug reject: $label ('$input') → rc=$rc"
+  else
+    fail "3  slug reject: $label ('$input') — got rc=$rc, expected $expected_rc"
+  fi
+}
+slug_accept "single char"                "a"
+slug_accept "two segments"               "a-b"
+slug_accept "alphanumeric segments"      "ab-cd"
+slug_accept "typical 3-word"             "fix-readme-typo"
+slug_reject "uppercase"                  "Foo"                                             2
+slug_reject "leading dash"               "-foo"                                            2
+slug_reject "trailing dash"              "foo-"                                            2
+slug_reject "double dash"                "a--b"                                            2
+slug_reject "empty"                      ""                                                5
+slug_reject "slash"                      "a/b"                                             2
+slug_reject "41-char overflow"           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"       2
+
+# Also assert the validator fence itself is still literally present
+# in the skill source (guards against drift between test and skill).
+if grep -qE '^\s*echo "ERROR: SLUG not set — model-layer composition step skipped\."' "$SKILL" \
+   && grep -qE '^\s*if \! \[\[ "\$SLUG" =~ \^\[a-z0-9\]\+\(-\[a-z0-9\]\+\)\*\$ \]\] \|\| \[ \$\{#SLUG\} -gt 40 \]; then' "$SKILL"; then
+  pass "3  slug validator fence: present in skill source"
+else
+  fail "3  slug validator fence: NOT present in skill source — test harness and skill have drifted"
+fi
 
 # ────────────────────────────────────────────────────────────────────
 # Case 4 — Branch-name contract (WI 1.7)
@@ -604,7 +657,10 @@ rm -f -- "$ERR"
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c25 "true" "true" "pr" "")
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix foo" >/dev/null 2>"$ERR")
+# Model-composed SLUG injected explicitly (simulates WI 1.6's model-layer
+# composition step). The test specifically exercises empty-prefix
+# branch-name assembly, not slug derivation.
+(cd "$FIX" && SLUG=fix-foo PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix foo" >/dev/null 2>"$ERR")
 RC=$?
 MARKER="$FIX/.zskills/tracking/quickfix.fix-foo/fulfilled.quickfix.fix-foo"
 if [ -f "$MARKER" ] && grep -q '^branch: fix-foo$' "$MARKER"; then
@@ -680,7 +736,7 @@ git -C "$FIX" push --quiet origin quickfix/fix-remote-collision
 git -C "$FIX" checkout --quiet main
 git -C "$FIX" branch -D quickfix/fix-remote-collision >/dev/null 2>&1
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix remote collision" >/dev/null 2>"$ERR")
+(cd "$FIX" && SLUG=fix-remote-collision PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix remote collision" >/dev/null 2>"$ERR")
 RC=$?
 if [ "$RC" -eq 2 ] && grep -q 'already exists on origin' "$ERR"; then
   pass "28 remote branch collision: rc=2 + 'already exists on origin' stderr"
@@ -696,7 +752,7 @@ FIX=$(make_fixture c29)
 # Pre-create a LOCAL branch with the target slug name.
 git -C "$FIX" branch quickfix/fix-local-collision
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix local collision" >/dev/null 2>"$ERR")
+(cd "$FIX" && SLUG=fix-local-collision PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix local collision" >/dev/null 2>"$ERR")
 RC=$?
 if [ "$RC" -eq 2 ] && grep -q "'quickfix/fix-local-collision' already exists locally" "$ERR"; then
   pass "29 local branch collision: rc=2 + 'already exists locally' stderr"
@@ -725,20 +781,20 @@ fi
 rm -f -- "$ERR"
 
 # ────────────────────────────────────────────────────────────────────
-# Case 31 — Slash in slug (description with only specials) exits 2.
-# Description that derives to empty slug: '!!!' — already covered by
-# case 3, but assert the full preflight exits 2 with 'empty slug'
-# stderr.
+# Case 31 — Malformed SLUG (slash) is rejected by the WI 1.6 validator
+# at rc=2 with a 'SLUG must match' discriminator. Exercises the new
+# model-composed contract: the model sets $SLUG, the bash validator
+# enforces kebab-shape. A slash is outside the validator regex.
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c31)
 echo "dirty" >> "$FIX/README.md"
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "!!!" >/dev/null 2>"$ERR")
+(cd "$FIX" && SLUG="a/b" PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix something" >/dev/null 2>"$ERR")
 RC=$?
-if [ "$RC" -eq 2 ] && grep -q 'empty slug' "$ERR"; then
-  pass "31 empty-slug description: rc=2 + 'empty slug' stderr"
+if [ "$RC" -eq 2 ] && grep -q 'SLUG must match' "$ERR"; then
+  pass "31 malformed SLUG (slash): rc=2 + 'SLUG must match' stderr"
 else
-  fail "31 empty-slug: rc=$RC stderr='$(cat "$ERR")'"
+  fail "31 malformed SLUG: rc=$RC stderr='$(cat "$ERR")'"
 fi
 rm -f -- "$ERR"
 
@@ -748,7 +804,7 @@ rm -f -- "$ERR"
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c32)
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix tracking path" >/dev/null 2>"$ERR")
+(cd "$FIX" && SLUG=fix-tracking-path PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix tracking path" >/dev/null 2>"$ERR")
 MARKER="$FIX/.zskills/tracking/quickfix.fix-tracking-path/fulfilled.quickfix.fix-tracking-path"
 if [ -f "$MARKER" ] && grep -q '^skill: quickfix$' "$MARKER" && grep -q '^slug: fix-tracking-path$' "$MARKER"; then
   pass "32 tracking path: pipeline-scoped subdir + marker basename + fields"
@@ -861,7 +917,7 @@ fi
 FIX=$(make_fixture c40)
 echo "edit" >> "$FIX/README.md"
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix readme typo" >/dev/null 2>"$ERR")
+(cd "$FIX" && SLUG=fix-readme-typo PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix readme typo" >/dev/null 2>"$ERR")
 RC=$?
 CURRENT=$(git -C "$FIX" branch --show-current)
 MARKER="$FIX/.zskills/tracking/quickfix.fix-readme-typo/fulfilled.quickfix.fix-readme-typo"
@@ -884,7 +940,9 @@ rm -f -- "$ERR"
 FIX=$(make_fixture c41)
 echo "edit" >> "$FIX/README.md"
 ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "a description with spaces" >/dev/null 2>"$ERR")
+# Explicit SLUG stub — the model-composed identifier is what drives
+# branch assembly now; the description isn't re-derived in bash.
+(cd "$FIX" && SLUG=a-description-with-spaces PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "a description with spaces" >/dev/null 2>"$ERR")
 RC=$?
 CURRENT=$(git -C "$FIX" branch --show-current)
 if [ "$RC" -eq 0 ] && [ "$CURRENT" = "quickfix/a-description-with-spaces" ]; then
@@ -932,7 +990,7 @@ FIX=$(make_fixture c43)
 echo "edit for fix" >> "$FIX/README.md"
 ERR=$(mktemp)
 OUT=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$FULL_FLOW_SCRIPT" --yes "fix readme typo" >"$OUT" 2>"$ERR")
+(cd "$FIX" && SLUG=fix-readme-typo PATH="$FIX/bin:$PATH" bash "$FULL_FLOW_SCRIPT" --yes "fix readme typo" >"$OUT" 2>"$ERR")
 RC=$?
 
 # Assertions


### PR DESCRIPTION
Migrates mechanical bash pipelines (`cut -c1-N` line-by-line on user descriptions) to a model-composed + bash-validator pattern across **six sites in four skills**, mirroring `/quickfix` WI 1.13's existing `COMMIT_SUBJECT` pattern.

## Bug

Pipelines like `printf '%s' "$DESC" | ... | cut -c1-40 | ...` operate line-by-line on multi-line descriptions, producing multi-line slugs/titles that break `git checkout -b`, `gh pr create --title`, etc. On single-line inputs they produce mid-word truncations (past PRs: `feat/add-an-empty-nojekyll-file-at-the-repo-r`, `feat/restore-the-proper-full-test-gate-curren`). The intent was always a short human summary, not a verbatim prefix.

## Sites migrated

| File | Site | Variable | Shape |
|---|---|---|---|
| `skills/quickfix/SKILL.md` | WI 1.6 | `SLUG` | kebab ≤40 chars |
| `skills/quickfix/SKILL.md` | WI 1.15 | `PR_TITLE` | single-line ≤70, conventional-commit |
| `skills/do/modes/pr.md` | Step A1 | `TASK_SLUG` | kebab ≤30 |
| `skills/do/modes/pr.md` | Step A7 | `PR_TITLE` | single-line ≤60, `do: ` prefix |
| `skills/do/modes/worktree.md` | Step A1 | `TASK_SLUG` | kebab ≤30 |
| `skills/research-and-go/SKILL.md` | scoped sentinel | `SCOPE` | kebab ≤30 |

Mirrors under `.claude/skills/` synced for all four skills.

## Fix pattern

For each site, the bash pipeline is replaced with a validator-only fence that enforces shape on a model-composed value:

```bash
if [ -z "${VAR:-}" ]; then
  echo "ERROR: VAR not set — model-layer composition step skipped." >&2
  exit 5
fi
if ! [[ "$VAR" =~ <regex> ]] || [ ${#VAR} -gt <cap> ]; then
  echo "ERROR: VAR must match <regex> and be ≤<cap> chars (got '$VAR')." >&2
  exit 2
fi
```

Kebab sites use `^[a-z0-9]+(-[a-z0-9]+)*$`. PR_TITLE sites use "no newline" + length cap instead of a strict regex, plus a `do: ` prefix check where applicable.

## Tests

- `tests/test-quickfix.sh`: dropped `derive_slug()` helper + `slug_case` assertions (lines tested the pipeline that no longer exists). Added validator-shape cases under Case 3 (accept: `a`, `a-b`, `ab-cd`, `fix-readme-typo`; reject: uppercase, leading/trailing dash, double-dash, empty, slash, overlength). E2E cases that previously asserted specific expected slugs (25, 28, 29, 31, 32, 40, 41, 43) now drive the flow with explicit `SLUG` stubs.
- Full suite: **826/826 passing**.

## Validation

- `grep -RnE 'cut -c1-(30|40|60|70)' skills/` → zero matches
- `grep -nE 'derive_slug|slug_case' tests/test-quickfix.sh` → zero matches
- `diff -q` on each source/mirror pair → silent

## Pattern summary

Model composes, bash validator enforces, hard error if unset or malformed. No fallback pipelines anywhere — the intent is that the model always produces a good short identifier. Symmetric across all four skills and uniform with `/quickfix`'s existing `COMMIT_SUBJECT` pattern at WI 1.13.

---

🤖 Generated via `/do pr` (worktree: `/tmp/zskills-do-model-compose-derivations`)
