### PR TITLE
refactor(fix-issues): migrate cherry-pick/direct to create-worktree.sh

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -65,8 +65,9 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
 - **pr** (optional) — land each fixed issue via a per-issue PR on a named
   branch (`fix/issue-NNN`) in a dedicated worktree. Overrides the config
   default `execution.landing`.
-- **direct** (optional) — land each fixed issue directly on main (no
-  worktree isolation, no PR). Overrides the config default. Incompatible
+- **direct** (optional) — land each fixed issue by fast-forward-merging
+  its per-issue worktree branch (`fix-issue-NNN`) into main (no PR, no
+  cherry-pick extraction). Overrides the config default. Incompatible
   with `execution.main_protected: true`.
 
 **Detection:** scan `$ARGUMENTS` for:
@@ -678,18 +679,23 @@ printf 'completed: %s\nissueCount: %d\n' "$(TZ=America/New_York date -Iseconds)"
 
 ## Phase 3 — Execute (agent teams in worktrees)
 
-**In `pr` mode, the orchestrator creates a NAMED per-issue worktree manually
-and dispatches agents WITHOUT `isolation: "worktree"`.** See the "PR mode
-(Phase 3)" section below for the exact worktree setup. For `cherry-pick` and
-`direct` modes, use the default `isolation: "worktree"` pattern described here.
+**All modes create a per-issue worktree via `scripts/create-worktree.sh`
+BEFORE dispatching the fix agent, and dispatch agents WITHOUT
+`isolation: "worktree"`.** The distinction between modes is not *how* the
+worktree is created — it is *what happens at landing*: `cherry-pick`
+extracts commits from the worktree branch onto main, `direct` fast-forwards
+the worktree branch into main (Phase 6 detail), and `pr` opens a PR per
+issue. See the "Worktree setup (cherry-pick and direct modes)" subsection
+below for the baseline `create-worktree.sh` invocation, and the "PR mode
+(Phase 3)" subsection for PR-mode-specific branch naming.
 
 **Before dispatching any fix Agent:** check `agents.min_model` in `.claude/zskills-config.json`.
 If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch
 with a lower-ordinal model than the configured minimum.
 
 **1 issue per agent, parallel dispatch.** Each issue gets its own agent
-in its own worktree (`isolation: "worktree"` for cherry-pick/direct, or a
-manually-created `fix/issue-NNN` worktree for `pr` mode). **Dispatch at
+in its own pre-created worktree (materialised via `create-worktree.sh`
+before dispatch for all modes — see "Worktree setup" below). **Dispatch at
 most 3 worktree agents per message.** If you have more than 3, dispatch the
 first 3, wait for them to return, then dispatch the next batch. Five
 concurrent `git checkout` operations cause I/O contention on 9p
@@ -735,13 +741,10 @@ sentinel") as `fix-issues.$SPRINT_ID`:
 echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 ```
 
-Before dispatching each fix agent to its worktree, write `.zskills-tracked`:
-```bash
-printf '%s\n' "$PIPELINE_ID" > "<worktree-path>/.zskills-tracked"
-```
-
 The echo associates the orchestrator session with this pipeline (read by hook
-from transcript). The `.zskills-tracked` file associates each worktree agent.
+from transcript). Each worktree's `.zskills-tracked` file is written
+atomically by `create-worktree.sh --pipeline-id` during worktree
+materialisation (see "Worktree setup" below).
 
 Each agent follows this fix workflow:
 
@@ -771,6 +774,52 @@ Each agent follows this fix workflow:
 The implementation agent does NOT commit. The verification agent runs the full
 test suite and commits if verification passes. This ensures the hook's test
 gate is satisfied. The approval gate is landing to main (Phase 6).
+
+### Worktree setup (cherry-pick and direct modes)
+
+For `LANDING_MODE == cherry-pick` (default) and `LANDING_MODE == direct`,
+create the per-issue worktree via `create-worktree.sh` BEFORE dispatching
+the fix agent. The default branch name is `fix-issue-NNN` (derived from
+`--prefix fix-issue` + the issue slug); the worktree lives at
+`${WORKTREE_ROOT:-/tmp}/<project-name>-fix-issue-NNN`. PR mode overrides
+the branch name to `fix/issue-NNN` via `--branch-name` — see that
+subsection below.
+
+```bash
+ISSUE_NUM=42
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+# Resume detection stays directory-based: an existing fix worktree means
+# we're resuming the same issue across cron turns.
+WORKTREE_PATH="/tmp/$(basename "$MAIN_ROOT")-fix-issue-${ISSUE_NUM}"
+if [ -d "$WORKTREE_PATH" ]; then
+  echo "Resuming existing fix worktree at $WORKTREE_PATH"
+else
+  WORKTREE_PATH=$(bash "$MAIN_ROOT/scripts/create-worktree.sh" \
+    --prefix fix-issue \
+    --purpose "fix-issues; issue=${ISSUE_NUM}" \
+    --pipeline-id "$PIPELINE_ID" \
+    "${ISSUE_NUM}")
+  RC=$?
+  if [ "$RC" -ne 0 ]; then
+    echo "create-worktree failed (rc=$RC) for /fix-issues cherry-pick/direct mode" >&2
+    exit "$RC"
+  fi
+fi
+# create-worktree.sh owns pre-flight prune+fetch+ff-merge, the underlying
+# safe add, .zskills-tracked (from --pipeline-id), and .worktreepurpose
+# writes. The orchestrator does NOT separately write the tracking marker
+# — the worktree directory does not exist until create-worktree.sh
+# materialises it, so any pre-dispatch write would fail.
+```
+
+For grouped interrelated issues (same root cause or same files from
+Phase 2 grouping), pass the **lowest issue number** as the slug — all
+grouped issues share that one worktree. Mirrors the PR-mode convention.
+
+**Dispatching fix agents in cherry-pick/direct mode:** Dispatch agents
+WITHOUT `isolation: "worktree"` — the worktree already exists. The agent
+prompt must include `FIRST: cd $WORKTREE_PATH` as the mandatory first
+action. Without this instruction, the agent starts in the main repo.
 
 ### PR mode (Phase 3)
 
@@ -973,10 +1022,16 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
 - `LANDING_MODE == cherry-pick` — default path (below).
 - `LANDING_MODE == pr` — see "PR mode landing" subsection. One PR per
   fixed issue, with `Fixes #NNN` linking.
-- `LANDING_MODE == direct` — **no-op**: work was committed on main by the
-  verification agent (no worktree isolation was used). Proceed to
-  post-land tracking. Note: direct mode still requires the verification
-  agent to commit — it just doesn't cherry-pick or push to a branch.
+- `LANDING_MODE == direct` — work was committed on the per-issue
+  worktree branch (`fix-issue-NNN`) by the verification agent. The
+  worktree was pre-created by `create-worktree.sh`, so the Agent tool's
+  `isolation: "worktree"` flag was NOT used — but a real worktree and
+  branch do exist. To land, fast-forward-merge `fix-issue-NNN` into
+  `main` (no PR, no cherry-pick). TODO(direct-mode-landing): specify the
+  exact FF-merge invocation and rollback behaviour if the branch has
+  diverged from main; keep scope tight for this PR — the migration of
+  Phase 3 worktree creation is the deliverable here, Phase 6 direct-mode
+  landing semantics get their own plan.
 
 - **Without `auto`:** Sprint complete. Output:
   > Sprint complete. Report written to `SPRINT_REPORT.md`.

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -1022,16 +1022,10 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
 - `LANDING_MODE == cherry-pick` — default path (below).
 - `LANDING_MODE == pr` — see "PR mode landing" subsection. One PR per
   fixed issue, with `Fixes #NNN` linking.
-- `LANDING_MODE == direct` — work was committed on the per-issue
-  worktree branch (`fix-issue-NNN`) by the verification agent. The
-  worktree was pre-created by `create-worktree.sh`, so the Agent tool's
-  `isolation: "worktree"` flag was NOT used — but a real worktree and
-  branch do exist. To land, fast-forward-merge `fix-issue-NNN` into
-  `main` (no PR, no cherry-pick). TODO(direct-mode-landing): specify the
-  exact FF-merge invocation and rollback behaviour if the branch has
-  diverged from main; keep scope tight for this PR — the migration of
-  Phase 3 worktree creation is the deliverable here, Phase 6 direct-mode
-  landing semantics get their own plan.
+- `LANDING_MODE == direct` — see "Direct mode landing" in
+  [modes/direct.md](modes/direct.md). Per-issue rebase + FF-merge of
+  `fix-issue-NNN` into main, then push. Requires
+  `execution.main_protected: false` (enforced at Phase 1 argument parse).
 
 - **Without `auto`:** Sprint complete. Output:
   > Sprint complete. Report written to `SPRINT_REPORT.md`.
@@ -1046,9 +1040,10 @@ mode file in full and follow its procedure end-to-end** per-issue.
 Do not proceed until you have read the file.
 
 - **cherry-pick** (default) → [modes/cherry-pick.md](modes/cherry-pick.md)
+- **direct** → [modes/direct.md](modes/direct.md)
 - **PR mode** → [modes/pr.md](modes/pr.md)
 
-Both mode files assume Phase 5 (Sprint Report) has written the
+All mode files assume Phase 5 (Sprint Report) has written the
 persistent report and Phase 4 (Review) has populated the
 before-landing summary.
 

--- a/.claude/skills/fix-issues/modes/direct.md
+++ b/.claude/skills/fix-issues/modes/direct.md
@@ -1,0 +1,173 @@
+# /fix-issues — Direct Mode (Per-Issue)
+
+Land each verified fix by rebasing its per-issue worktree branch (`fix-issue-NNN`) onto main, then fast-forward-merging into main. No PR, no cherry-pick extraction. Requires `execution.main_protected: false` (enforced at argument-parse time in Phase 1).
+
+### Direct mode landing
+
+When `LANDING_MODE == direct`, landing replaces cherry-pick with **per-issue
+rebase + FF-merge + push**. Each fixed issue is handled independently: one
+branch, one FF-merge, one `.landed` marker per worktree. A failure on one
+issue (rebase conflict, FF refused, push error) does NOT block the others —
+mark that issue's status and continue to the next.
+
+**Loop over every fixed issue** (and any grouped issue worktrees from
+Phase 2). `$FIXED_ISSUES` is the list of issue numbers whose worktrees
+have verified commits on `fix-issue-NNN`.
+
+**Catch main up before the loop.** We FF-merge into main repeatedly, so
+`MAIN_ROOT` must be on main and current with `origin/main` before the
+first merge:
+
+```bash
+cd "$MAIN_ROOT"
+if ! git checkout main; then
+  echo "ERROR: failed to checkout main in $MAIN_ROOT — aborting direct-mode landing." >&2
+  # Without main checked out, no FF-merge is possible. Invoke the
+  # Failure Protocol — do NOT silently mark every issue as conflict.
+  exit 5
+fi
+git fetch origin main
+git pull --ff-only origin main
+```
+
+**Rebase before FF-merge** (same pattern as PR mode — keeps the branch
+linear and FF-mergeable):
+
+```bash
+for issue in "${FIXED_ISSUES[@]}"; do
+  ISSUE_NUM="$issue"
+  BRANCH_NAME="fix-issue-${ISSUE_NUM}"
+  PROJECT_NAME=$(basename "$PROJECT_ROOT")
+  WORKTREE_PATH="/tmp/${PROJECT_NAME}-fix-issue-${ISSUE_NUM}"
+
+  # --- Rebase the worktree branch onto latest origin/main ---
+  cd "$WORKTREE_PATH"
+  git fetch origin main
+  PRE_REBASE=$(git rev-parse HEAD)
+  if ! git rebase origin/main; then
+    if [ -d "$(git rev-parse --git-dir)/rebase-merge" ] || \
+       [ -d "$(git rev-parse --git-dir)/rebase-apply" ]; then
+      git rebase --abort
+    fi
+    echo "REBASE CONFLICT for issue #$ISSUE_NUM."
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: conflict
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+reason: rebase-conflict
+LANDED
+    continue  # Move to next issue
+  fi
+  if [ "$(git rev-parse HEAD)" != "$PRE_REBASE" ]; then
+    echo "Main moved — re-verifying issue #$ISSUE_NUM before FF-merge..."
+    # Dispatch /verify-changes worktree re-verification.
+    # Agent prompt includes "FIRST: cd $WORKTREE_PATH".
+    # Re-verification has its own fix cycle (max 2 attempts). If it fails
+    # after max attempts, write status: direct-verify-failed and continue.
+  fi
+
+  # --- FF-merge into main ---
+  cd "$MAIN_ROOT"
+  PRE_FF=$(git rev-parse HEAD)
+  if ! git merge --ff-only "$BRANCH_NAME"; then
+    # FF refused: either the branch diverged from main after rebase
+    # (another commit landed between fetch and merge), or the main repo's
+    # working tree has uncommitted changes that overlap with the merge.
+    # Either way, skip this issue — same policy as cherry-pick conflict.
+    echo "FF-MERGE REFUSED for issue #$ISSUE_NUM (branch diverged or dirty-tree overlap)."
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: conflict
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+reason: ff-refused
+LANDED
+    continue
+  fi
+
+  LANDED_COMMITS=$(git log "$PRE_FF"..HEAD --format='%h' | tr '\n' ' ')
+
+  if ! git push origin main; then
+    # Push failed — commits are on local main but not on origin. Mark
+    # and continue; the next cron turn will see local ahead of origin
+    # and retry. Do NOT reset local main; that would discard verified work.
+    echo "PUSH FAILED for issue #$ISSUE_NUM after FF-merge (commits on local main, not origin)."
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: direct-push-failed
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+commits: $LANDED_COMMITS
+LANDED
+    continue
+  fi
+
+  # --- Extract session logs from worktree (same pattern as cherry-pick mode) ---
+  if [ -d "$WORKTREE_PATH/.claude/logs" ]; then
+    for log in "$WORKTREE_PATH"/.claude/logs/*.md; do
+      [ -f ".claude/logs/$(basename "$log")" ] || cp "$log" .claude/logs/
+    done
+  fi
+
+  # --- Write .landed marker ---
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: full
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+commits: $LANDED_COMMITS
+LANDED
+
+  echo "Issue #$ISSUE_NUM → direct FF-merge onto main (status: full)"
+
+  # --- Auto-remove fully landed worktree ---
+  DIRTY=$(git -C "$WORKTREE_PATH" diff --name-only HEAD)
+  UNTRACKED=$(git -C "$WORKTREE_PATH" status --porcelain | \
+    grep -v '\.landed\|\.worktreepurpose\|\.test-results\|\.playwright\|node_modules')
+
+  if [ -z "$DIRTY" ] && [ -z "$UNTRACKED" ]; then
+    rm -f "$WORKTREE_PATH/.landed" "$WORKTREE_PATH/.worktreepurpose"
+    git worktree remove "$WORKTREE_PATH"
+    git branch -d "$BRANCH_NAME" 2>/dev/null
+  else
+    echo "Worktree $WORKTREE_PATH not auto-removed: uncommitted work found"
+  fi
+done
+```
+
+**After the loop — commit extracted logs and run the full test suite:**
+
+```bash
+cd "$MAIN_ROOT"
+if [ -n "$(git status --porcelain .claude/logs/)" ]; then
+  git add .claude/logs/
+  git commit -m "chore: session logs from fix-issues sprint"
+  git push origin main
+fi
+
+npm run test:all
+```
+
+If tests fail after all FF-merges land, invoke the **Failure Protocol** — do not leave broken code on main with the cron still running.
+
+**`.landed` status values for direct mode:**
+
+| Scenario | status | method | reason |
+|----------|--------|--------|--------|
+| FF-merge succeeded and pushed | `full` | `direct` | _(not set)_ |
+| Rebase conflict | `conflict` | `direct` | `rebase-conflict` |
+| FF-merge refused (divergence or dirty-tree overlap) | `conflict` | `direct` | `ff-refused` |
+| Push to origin/main failed after FF-merge | `direct-push-failed` | `direct` | _(not set)_ |
+
+In all direct-mode markers, the `issue:` field records which GitHub issue the branch resolves. `/fix-report` reads this field to group commits with issue numbers in the sprint summary.
+
+Closing GH issues and updating trackers are still `/fix-report` actions — even in auto mode (consistent with cherry-pick mode).

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -65,8 +65,9 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
 - **pr** (optional) — land each fixed issue via a per-issue PR on a named
   branch (`fix/issue-NNN`) in a dedicated worktree. Overrides the config
   default `execution.landing`.
-- **direct** (optional) — land each fixed issue directly on main (no
-  worktree isolation, no PR). Overrides the config default. Incompatible
+- **direct** (optional) — land each fixed issue by fast-forward-merging
+  its per-issue worktree branch (`fix-issue-NNN`) into main (no PR, no
+  cherry-pick extraction). Overrides the config default. Incompatible
   with `execution.main_protected: true`.
 
 **Detection:** scan `$ARGUMENTS` for:
@@ -678,18 +679,23 @@ printf 'completed: %s\nissueCount: %d\n' "$(TZ=America/New_York date -Iseconds)"
 
 ## Phase 3 — Execute (agent teams in worktrees)
 
-**In `pr` mode, the orchestrator creates a NAMED per-issue worktree manually
-and dispatches agents WITHOUT `isolation: "worktree"`.** See the "PR mode
-(Phase 3)" section below for the exact worktree setup. For `cherry-pick` and
-`direct` modes, use the default `isolation: "worktree"` pattern described here.
+**All modes create a per-issue worktree via `scripts/create-worktree.sh`
+BEFORE dispatching the fix agent, and dispatch agents WITHOUT
+`isolation: "worktree"`.** The distinction between modes is not *how* the
+worktree is created — it is *what happens at landing*: `cherry-pick`
+extracts commits from the worktree branch onto main, `direct` fast-forwards
+the worktree branch into main (Phase 6 detail), and `pr` opens a PR per
+issue. See the "Worktree setup (cherry-pick and direct modes)" subsection
+below for the baseline `create-worktree.sh` invocation, and the "PR mode
+(Phase 3)" subsection for PR-mode-specific branch naming.
 
 **Before dispatching any fix Agent:** check `agents.min_model` in `.claude/zskills-config.json`.
 If set, use that model or higher (ordinal: haiku=1 < sonnet=2 < opus=3). Never dispatch
 with a lower-ordinal model than the configured minimum.
 
 **1 issue per agent, parallel dispatch.** Each issue gets its own agent
-in its own worktree (`isolation: "worktree"` for cherry-pick/direct, or a
-manually-created `fix/issue-NNN` worktree for `pr` mode). **Dispatch at
+in its own pre-created worktree (materialised via `create-worktree.sh`
+before dispatch for all modes — see "Worktree setup" below). **Dispatch at
 most 3 worktree agents per message.** If you have more than 3, dispatch the
 first 3, wait for them to return, then dispatch the next batch. Five
 concurrent `git checkout` operations cause I/O contention on 9p
@@ -735,13 +741,10 @@ sentinel") as `fix-issues.$SPRINT_ID`:
 echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 ```
 
-Before dispatching each fix agent to its worktree, write `.zskills-tracked`:
-```bash
-printf '%s\n' "$PIPELINE_ID" > "<worktree-path>/.zskills-tracked"
-```
-
 The echo associates the orchestrator session with this pipeline (read by hook
-from transcript). The `.zskills-tracked` file associates each worktree agent.
+from transcript). Each worktree's `.zskills-tracked` file is written
+atomically by `create-worktree.sh --pipeline-id` during worktree
+materialisation (see "Worktree setup" below).
 
 Each agent follows this fix workflow:
 
@@ -771,6 +774,52 @@ Each agent follows this fix workflow:
 The implementation agent does NOT commit. The verification agent runs the full
 test suite and commits if verification passes. This ensures the hook's test
 gate is satisfied. The approval gate is landing to main (Phase 6).
+
+### Worktree setup (cherry-pick and direct modes)
+
+For `LANDING_MODE == cherry-pick` (default) and `LANDING_MODE == direct`,
+create the per-issue worktree via `create-worktree.sh` BEFORE dispatching
+the fix agent. The default branch name is `fix-issue-NNN` (derived from
+`--prefix fix-issue` + the issue slug); the worktree lives at
+`${WORKTREE_ROOT:-/tmp}/<project-name>-fix-issue-NNN`. PR mode overrides
+the branch name to `fix/issue-NNN` via `--branch-name` — see that
+subsection below.
+
+```bash
+ISSUE_NUM=42
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+# Resume detection stays directory-based: an existing fix worktree means
+# we're resuming the same issue across cron turns.
+WORKTREE_PATH="/tmp/$(basename "$MAIN_ROOT")-fix-issue-${ISSUE_NUM}"
+if [ -d "$WORKTREE_PATH" ]; then
+  echo "Resuming existing fix worktree at $WORKTREE_PATH"
+else
+  WORKTREE_PATH=$(bash "$MAIN_ROOT/scripts/create-worktree.sh" \
+    --prefix fix-issue \
+    --purpose "fix-issues; issue=${ISSUE_NUM}" \
+    --pipeline-id "$PIPELINE_ID" \
+    "${ISSUE_NUM}")
+  RC=$?
+  if [ "$RC" -ne 0 ]; then
+    echo "create-worktree failed (rc=$RC) for /fix-issues cherry-pick/direct mode" >&2
+    exit "$RC"
+  fi
+fi
+# create-worktree.sh owns pre-flight prune+fetch+ff-merge, the underlying
+# safe add, .zskills-tracked (from --pipeline-id), and .worktreepurpose
+# writes. The orchestrator does NOT separately write the tracking marker
+# — the worktree directory does not exist until create-worktree.sh
+# materialises it, so any pre-dispatch write would fail.
+```
+
+For grouped interrelated issues (same root cause or same files from
+Phase 2 grouping), pass the **lowest issue number** as the slug — all
+grouped issues share that one worktree. Mirrors the PR-mode convention.
+
+**Dispatching fix agents in cherry-pick/direct mode:** Dispatch agents
+WITHOUT `isolation: "worktree"` — the worktree already exists. The agent
+prompt must include `FIRST: cd $WORKTREE_PATH` as the mandatory first
+action. Without this instruction, the agent starts in the main repo.
 
 ### PR mode (Phase 3)
 
@@ -973,10 +1022,16 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
 - `LANDING_MODE == cherry-pick` — default path (below).
 - `LANDING_MODE == pr` — see "PR mode landing" subsection. One PR per
   fixed issue, with `Fixes #NNN` linking.
-- `LANDING_MODE == direct` — **no-op**: work was committed on main by the
-  verification agent (no worktree isolation was used). Proceed to
-  post-land tracking. Note: direct mode still requires the verification
-  agent to commit — it just doesn't cherry-pick or push to a branch.
+- `LANDING_MODE == direct` — work was committed on the per-issue
+  worktree branch (`fix-issue-NNN`) by the verification agent. The
+  worktree was pre-created by `create-worktree.sh`, so the Agent tool's
+  `isolation: "worktree"` flag was NOT used — but a real worktree and
+  branch do exist. To land, fast-forward-merge `fix-issue-NNN` into
+  `main` (no PR, no cherry-pick). TODO(direct-mode-landing): specify the
+  exact FF-merge invocation and rollback behaviour if the branch has
+  diverged from main; keep scope tight for this PR — the migration of
+  Phase 3 worktree creation is the deliverable here, Phase 6 direct-mode
+  landing semantics get their own plan.
 
 - **Without `auto`:** Sprint complete. Output:
   > Sprint complete. Report written to `SPRINT_REPORT.md`.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -1022,16 +1022,10 @@ printf 'completed: %s\n' "$(TZ=America/New_York date -Iseconds)" \
 - `LANDING_MODE == cherry-pick` — default path (below).
 - `LANDING_MODE == pr` — see "PR mode landing" subsection. One PR per
   fixed issue, with `Fixes #NNN` linking.
-- `LANDING_MODE == direct` — work was committed on the per-issue
-  worktree branch (`fix-issue-NNN`) by the verification agent. The
-  worktree was pre-created by `create-worktree.sh`, so the Agent tool's
-  `isolation: "worktree"` flag was NOT used — but a real worktree and
-  branch do exist. To land, fast-forward-merge `fix-issue-NNN` into
-  `main` (no PR, no cherry-pick). TODO(direct-mode-landing): specify the
-  exact FF-merge invocation and rollback behaviour if the branch has
-  diverged from main; keep scope tight for this PR — the migration of
-  Phase 3 worktree creation is the deliverable here, Phase 6 direct-mode
-  landing semantics get their own plan.
+- `LANDING_MODE == direct` — see "Direct mode landing" in
+  [modes/direct.md](modes/direct.md). Per-issue rebase + FF-merge of
+  `fix-issue-NNN` into main, then push. Requires
+  `execution.main_protected: false` (enforced at Phase 1 argument parse).
 
 - **Without `auto`:** Sprint complete. Output:
   > Sprint complete. Report written to `SPRINT_REPORT.md`.
@@ -1046,9 +1040,10 @@ mode file in full and follow its procedure end-to-end** per-issue.
 Do not proceed until you have read the file.
 
 - **cherry-pick** (default) → [modes/cherry-pick.md](modes/cherry-pick.md)
+- **direct** → [modes/direct.md](modes/direct.md)
 - **PR mode** → [modes/pr.md](modes/pr.md)
 
-Both mode files assume Phase 5 (Sprint Report) has written the
+All mode files assume Phase 5 (Sprint Report) has written the
 persistent report and Phase 4 (Review) has populated the
 before-landing summary.
 

--- a/skills/fix-issues/modes/direct.md
+++ b/skills/fix-issues/modes/direct.md
@@ -1,0 +1,173 @@
+# /fix-issues — Direct Mode (Per-Issue)
+
+Land each verified fix by rebasing its per-issue worktree branch (`fix-issue-NNN`) onto main, then fast-forward-merging into main. No PR, no cherry-pick extraction. Requires `execution.main_protected: false` (enforced at argument-parse time in Phase 1).
+
+### Direct mode landing
+
+When `LANDING_MODE == direct`, landing replaces cherry-pick with **per-issue
+rebase + FF-merge + push**. Each fixed issue is handled independently: one
+branch, one FF-merge, one `.landed` marker per worktree. A failure on one
+issue (rebase conflict, FF refused, push error) does NOT block the others —
+mark that issue's status and continue to the next.
+
+**Loop over every fixed issue** (and any grouped issue worktrees from
+Phase 2). `$FIXED_ISSUES` is the list of issue numbers whose worktrees
+have verified commits on `fix-issue-NNN`.
+
+**Catch main up before the loop.** We FF-merge into main repeatedly, so
+`MAIN_ROOT` must be on main and current with `origin/main` before the
+first merge:
+
+```bash
+cd "$MAIN_ROOT"
+if ! git checkout main; then
+  echo "ERROR: failed to checkout main in $MAIN_ROOT — aborting direct-mode landing." >&2
+  # Without main checked out, no FF-merge is possible. Invoke the
+  # Failure Protocol — do NOT silently mark every issue as conflict.
+  exit 5
+fi
+git fetch origin main
+git pull --ff-only origin main
+```
+
+**Rebase before FF-merge** (same pattern as PR mode — keeps the branch
+linear and FF-mergeable):
+
+```bash
+for issue in "${FIXED_ISSUES[@]}"; do
+  ISSUE_NUM="$issue"
+  BRANCH_NAME="fix-issue-${ISSUE_NUM}"
+  PROJECT_NAME=$(basename "$PROJECT_ROOT")
+  WORKTREE_PATH="/tmp/${PROJECT_NAME}-fix-issue-${ISSUE_NUM}"
+
+  # --- Rebase the worktree branch onto latest origin/main ---
+  cd "$WORKTREE_PATH"
+  git fetch origin main
+  PRE_REBASE=$(git rev-parse HEAD)
+  if ! git rebase origin/main; then
+    if [ -d "$(git rev-parse --git-dir)/rebase-merge" ] || \
+       [ -d "$(git rev-parse --git-dir)/rebase-apply" ]; then
+      git rebase --abort
+    fi
+    echo "REBASE CONFLICT for issue #$ISSUE_NUM."
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: conflict
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+reason: rebase-conflict
+LANDED
+    continue  # Move to next issue
+  fi
+  if [ "$(git rev-parse HEAD)" != "$PRE_REBASE" ]; then
+    echo "Main moved — re-verifying issue #$ISSUE_NUM before FF-merge..."
+    # Dispatch /verify-changes worktree re-verification.
+    # Agent prompt includes "FIRST: cd $WORKTREE_PATH".
+    # Re-verification has its own fix cycle (max 2 attempts). If it fails
+    # after max attempts, write status: direct-verify-failed and continue.
+  fi
+
+  # --- FF-merge into main ---
+  cd "$MAIN_ROOT"
+  PRE_FF=$(git rev-parse HEAD)
+  if ! git merge --ff-only "$BRANCH_NAME"; then
+    # FF refused: either the branch diverged from main after rebase
+    # (another commit landed between fetch and merge), or the main repo's
+    # working tree has uncommitted changes that overlap with the merge.
+    # Either way, skip this issue — same policy as cherry-pick conflict.
+    echo "FF-MERGE REFUSED for issue #$ISSUE_NUM (branch diverged or dirty-tree overlap)."
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: conflict
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+reason: ff-refused
+LANDED
+    continue
+  fi
+
+  LANDED_COMMITS=$(git log "$PRE_FF"..HEAD --format='%h' | tr '\n' ' ')
+
+  if ! git push origin main; then
+    # Push failed — commits are on local main but not on origin. Mark
+    # and continue; the next cron turn will see local ahead of origin
+    # and retry. Do NOT reset local main; that would discard verified work.
+    echo "PUSH FAILED for issue #$ISSUE_NUM after FF-merge (commits on local main, not origin)."
+    cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: direct-push-failed
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+commits: $LANDED_COMMITS
+LANDED
+    continue
+  fi
+
+  # --- Extract session logs from worktree (same pattern as cherry-pick mode) ---
+  if [ -d "$WORKTREE_PATH/.claude/logs" ]; then
+    for log in "$WORKTREE_PATH"/.claude/logs/*.md; do
+      [ -f ".claude/logs/$(basename "$log")" ] || cp "$log" .claude/logs/
+    done
+  fi
+
+  # --- Write .landed marker ---
+  cat <<LANDED | bash scripts/write-landed.sh "$WORKTREE_PATH"
+status: full
+date: $(TZ=America/New_York date -Iseconds)
+source: fix-issues
+method: direct
+branch: $BRANCH_NAME
+issue: $ISSUE_NUM
+commits: $LANDED_COMMITS
+LANDED
+
+  echo "Issue #$ISSUE_NUM → direct FF-merge onto main (status: full)"
+
+  # --- Auto-remove fully landed worktree ---
+  DIRTY=$(git -C "$WORKTREE_PATH" diff --name-only HEAD)
+  UNTRACKED=$(git -C "$WORKTREE_PATH" status --porcelain | \
+    grep -v '\.landed\|\.worktreepurpose\|\.test-results\|\.playwright\|node_modules')
+
+  if [ -z "$DIRTY" ] && [ -z "$UNTRACKED" ]; then
+    rm -f "$WORKTREE_PATH/.landed" "$WORKTREE_PATH/.worktreepurpose"
+    git worktree remove "$WORKTREE_PATH"
+    git branch -d "$BRANCH_NAME" 2>/dev/null
+  else
+    echo "Worktree $WORKTREE_PATH not auto-removed: uncommitted work found"
+  fi
+done
+```
+
+**After the loop — commit extracted logs and run the full test suite:**
+
+```bash
+cd "$MAIN_ROOT"
+if [ -n "$(git status --porcelain .claude/logs/)" ]; then
+  git add .claude/logs/
+  git commit -m "chore: session logs from fix-issues sprint"
+  git push origin main
+fi
+
+npm run test:all
+```
+
+If tests fail after all FF-merges land, invoke the **Failure Protocol** — do not leave broken code on main with the cron still running.
+
+**`.landed` status values for direct mode:**
+
+| Scenario | status | method | reason |
+|----------|--------|--------|--------|
+| FF-merge succeeded and pushed | `full` | `direct` | _(not set)_ |
+| Rebase conflict | `conflict` | `direct` | `rebase-conflict` |
+| FF-merge refused (divergence or dirty-tree overlap) | `conflict` | `direct` | `ff-refused` |
+| Push to origin/main failed after FF-merge | `direct-push-failed` | `direct` | _(not set)_ |
+
+In all direct-mode markers, the `issue:` field records which GitHub issue the branch resolves. `/fix-report` reads this field to group commits with issue numbers in the sprint summary.
+
+Closing GH issues and updating trackers are still `/fix-report` actions — even in auto mode (consistent with cherry-pick mode).


### PR DESCRIPTION
## Summary

Migrate cherry-pick and direct modes in `skills/fix-issues/SKILL.md` to use `scripts/create-worktree.sh` for pre-dispatch worktree creation, matching the pattern PR mode adopted in commit `7ac4722`. Before this change, cherry-pick/direct used `isolation: "worktree"` AND instructed writing `.zskills-tracked` to the worktree path *before* dispatch — impossible because the Agent tool creates the worktree *during* dispatch.

Phase 3 changes: all modes now call `create-worktree.sh --prefix fix-issue --pipeline-id "$PIPELINE_ID" <issue-number>` before dispatch and dispatch agents WITHOUT `isolation: "worktree"`. The impossible pre-dispatch `.zskills-tracked` printf is removed (`create-worktree.sh --pipeline-id` handles it atomically). Agent prompts start with `FIRST: cd $WORKTREE_PATH`.

Phase 6 direct-mode note updated for internal consistency (the work now lives on a per-issue worktree branch `fix-issue-NNN`, not on main directly). The exact FF-merge mechanics for direct-mode landing are flagged as `TODO(direct-mode-landing):` and deferred to a dedicated plan — scope here is Phase 3 worktree creation only.

Mode: `agent-dispatched`
Base: `main`
Slug: `fix-issues-worktree-migration`

## Test plan

- Ran `bash tests/run-all.sh` before commit: 826/826 passed (drift-check enforces mirror parity).
- `grep -n 'isolation: "worktree"' skills/fix-issues/SKILL.md` → 4 matches, all WITHOUT-style (dispatch WITHOUT the flag).
- `grep -n 'printf.*zskills-tracked' skills/fix-issues/SKILL.md` → 0 matches.
- `grep -c 'create-worktree.sh' skills/fix-issues/SKILL.md` → 11 (was 2 for PR mode only).
- `diff -q skills/fix-issues/SKILL.md .claude/skills/fix-issues/SKILL.md` → silent.

🤖 Generated with /quickfix