### PR TITLE
refactor(block-diagram): migrate add-block, fix add-example tracking

### DIFF
--- a/block-diagram/add-block/SKILL.md
+++ b/block-diagram/add-block/SKILL.md
@@ -22,6 +22,11 @@ WORKTREE_PATH=$(bash "$MAIN_ROOT/scripts/create-worktree.sh" \
   --purpose "add-block; block=${BLOCK_NAME}" \
   --pipeline-id "add-block.${BLOCK_NAME}" \
   "${BLOCK_NAME}")
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  echo "create-worktree failed (rc=$RC) for /add-block" >&2
+  exit "$RC"
+fi
 ```
 
 `create-worktree.sh` handles pre-flight (`prune`/`fetch`/`ff-merge` against
@@ -712,9 +717,12 @@ verification is single-context self-review — flag this clearly in the
 verification report so the user knows what kind of verification they got.
 
 Dispatch a verification agent (or run inline per the dispatch protocol
-above) targeting the worktree. The agent that implemented the blocks must
-NOT verify them — either dispatch a fresh subagent or, if running inline,
-ensure your current context is distinct from the implementer's.
+above) targeting the worktree, the same way as the implementation agent
+in the preamble: **without** `isolation: "worktree"`, with
+`FIRST: cd $WORKTREE_PATH` as the mandatory first action. The agent that
+implemented the blocks must NOT verify them — either dispatch a fresh
+subagent or, if running inline, ensure your current context is distinct
+from the implementer's.
 
 Give the verification agent:
 - The **worktree path** and **branch name**

--- a/block-diagram/add-block/SKILL.md
+++ b/block-diagram/add-block/SKILL.md
@@ -11,8 +11,28 @@ description: >-
 Every new block must complete all steps (0–12). Steps 0–10 are the
 implementation workflow. Steps 11–12 are verification and landing.
 
-**All implementation happens in a worktree.** Dispatch the implementation
-agent with `isolation: "worktree"`. Include the verbatim plan text and the
+**All implementation happens in a pre-created worktree.** Before dispatching
+the implementation agent, the orchestrator creates the worktree via
+`scripts/create-worktree.sh`:
+
+```bash
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+WORKTREE_PATH=$(bash "$MAIN_ROOT/scripts/create-worktree.sh" \
+  --prefix add-block \
+  --purpose "add-block; block=${BLOCK_NAME}" \
+  --pipeline-id "add-block.${BLOCK_NAME}" \
+  "${BLOCK_NAME}")
+```
+
+`create-worktree.sh` handles pre-flight (`prune`/`fetch`/`ff-merge` against
+`main`), the underlying safe `git worktree add`, and an atomic
+`.zskills-tracked` write from `--pipeline-id`. No manual `.zskills-tracked`
+write is needed.
+
+Then dispatch the implementation agent **WITHOUT** `isolation: "worktree"`
+— the worktree already exists. The agent prompt MUST start with
+`FIRST: cd $WORKTREE_PATH` as a mandatory first action; without that, the
+agent starts in the main repo. Include the verbatim plan text and the
 worktree test recipe in the agent prompt:
 
 > **Worktree test recipe:**
@@ -35,6 +55,11 @@ When adding **multiple blocks at once**, change the step ordering:
 5. **Once:** Steps 10–12 (report, verification, landing)
 
 Do NOT do step 7 per-block when batching. Defer it until all blocks are implemented and tested.
+
+**Worktree pipeline-id in batch mode:** All grouped blocks share one worktree.
+Use the **first** block name from the user's invocation as the `${BLOCK_NAME}`
+slug for the orchestrator's `create-worktree.sh` call (mirrors fix-issues's
+"lowest issue number" convention for grouped issues).
 
 ---
 
@@ -370,13 +395,6 @@ mkdir -p "$MAIN_ROOT/.zskills/tracking"
 printf 'skill: add-example\nparent: add-block\nblock: %s\ndate: %s\n' \
   "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/requires.add-example.${BLOCK_NAME}"
-```
-
-Before dispatching any agent to a worktree, write the pipeline ID:
-
-```bash
-printf '%s\n' "add-block.${BLOCK_NAME}" > "<worktree-path>/.zskills-tracked"
-printf '%s\n' "add-block.${BLOCK_NAME}" > "$MAIN_ROOT/.zskills-tracked"
 ```
 
 Use the `/add-example` skill to create an example model for this block

--- a/block-diagram/add-example/SKILL.md
+++ b/block-diagram/add-example/SKILL.md
@@ -34,12 +34,12 @@ printf 'skill: add-example\nname: %s\nstatus: started\ndate: %s\n' \
 Where `$NAME` is derived from the block type(s) or model name (e.g.,
 `Gain`, `math-batch`).
 
-Before dispatching any agent to a worktree, write the pipeline ID:
-
-```bash
-printf '%s\n' "add-example.${NAME}" > "<worktree-path>/.zskills-tracked"
-printf '%s\n' "add-example.${NAME}" > "$MAIN_ROOT/.zskills-tracked"
-```
+`/add-example` runs as a sub-skill inside its parent's worktree (Claude
+Code subagents cannot dispatch their own subagents). Do **not** write
+`.zskills-tracked` here — the worktree's existing file (written by the
+parent's `create-worktree.sh --pipeline-id` call) defines the active
+pipeline ID, and overwriting it would corrupt the parent's tracking
+scope.
 
 ## Before You Start
 

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -125,6 +125,14 @@ if [ -d ".claude/skills/cleanup-merged" ]; then
     "diff -q 'skills/cleanup-merged/SKILL.md' '.claude/skills/cleanup-merged/SKILL.md' >/dev/null"
 fi
 
+# Cross-skill invariant: no skill statically prescribes `isolation: "worktree"`.
+# All worktree work must go through scripts/create-worktree.sh (manual creation)
+# per plans/EXECUTION_MODES.md. Word-boundary on "with" distinguishes prescriptions
+# ("Dispatch ... with `isolation: "worktree"`") from negative warnings ("WITHOUT
+# `isolation: "worktree"`"), so existing migrated skills don't false-positive.
+check 'no skill prescribes isolation: worktree (use scripts/create-worktree.sh)' \
+  '! grep -rEn '"'"'\bwith[[:space:]]+`?isolation: *"worktree"'"'"' skills/ block-diagram/ 2>/dev/null'
+
 # Emit format expected by tests/run-all.sh
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Migrates `block-diagram/add-block/SKILL.md` off `isolation: "worktree"`, mirroring the cherry-pick/direct migration in PR #64. Orchestrator now pre-creates the per-block worktree via `scripts/create-worktree.sh --pipeline-id "add-block.${BLOCK_NAME}"`, then dispatches the implementation agent **without** `isolation: "worktree"` with a mandatory `FIRST: cd $WORKTREE_PATH`. Adds rc-check on the script invocation and a Batch Mode pipeline-id rule (first block name in the user's invocation, mirroring fix-issues's "lowest issue number wins" for grouped issues).
- Fixes `block-diagram/add-example/SKILL.md`: removes the block that wrote `add-example.${NAME}` to the worktree's and `$MAIN_ROOT`'s `.zskills-tracked`. The hook (`hooks/block-unsafe-project.sh.template:388-393`) re-reads `$LOCAL_ROOT/.zskills-tracked` on every fire, so the overwrite silently miscoped the parent's post-delegation commits. Sub-skills must inherit the parent's pipeline ID via the worktree's existing `.zskills-tracked`.
- Adds a regression-guard `check` to `tests/test-skill-invariants.sh` that fails CI if any skill statically prescribes `isolation: "worktree"`. Word-boundary anchor on `with` distinguishes prescriptions from the `WITHOUT` warnings in migrated skills — verified zero false positives across `skills/` and `block-diagram/`.

**Out of scope, filed as #65:** catch-up tracking-naming migration for `block-diagram/` skills (~20 marker write sites still on the flat `.zskills/tracking/` layout). Phase 6 of `plans/UNIFY_TRACKING_NAMES.md` removed the hook's dual-read fallback, so those markers are now invisible to enforcement gates. Same systemic miss as this PR's `isolation: "worktree"` cleanup — `block-diagram/` was excluded from both framework-wide migrations.

## Test plan

- [x] `bash tests/run-all.sh` — 827/827 passed (baseline 826 + the new lint check)
- [x] Lint regex tested both directions: matches `Dispatch ... with \`isolation: "worktree"\``, does not match any of the existing `WITHOUT \`isolation: "worktree"\`` warning lines in `skills/run-plan/`, `skills/fix-issues/`, `skills/do/`
- [x] `/verify-changes branch` A+ after fixing two issues caught in round 1 (commit `b7b3055`): missing exit-code check on `create-worktree.sh` invocation, and Step 11 verifier-dispatch prose not restating the dispatch convention
- [x] Manual verification — N/A (markdown + bash test only, no UI files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)