### PR TITLE
Add Codex support planning review artifacts

### DIFF
--- a/docs/compat/codex-support-review/CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_PLAN.md
+++ b/docs/compat/codex-support-review/CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_PLAN.md
@@ -1,0 +1,487 @@
+# Z Skills Claude/Codex Support Plan
+
+## Summary
+
+Add first-class Codex support to Z Skills without regressing Claude Code support.
+The implementation target is the active development repository,
+`github.com/zeveck/zskills-dev`, not the currently published mirror at
+`github.com/zeveck/zskills`.
+
+This plan is intentionally pattern-level. The public mirror is behind the dev
+repo, and a newer polished Z Skills release may land before this work is
+applied. Implementers must refresh against latest `zskills-dev` before editing
+and preserve the compatibility patterns here rather than hardcoding today’s
+exact file list or skill count.
+
+Core decision: keep one canonical source of skill intent, then use
+provider-specific progressive disclosure modules for Claude and Codex behavior.
+Do not maintain separate hand-edited Claude and Codex forks.
+
+## Current State
+
+- Public `zskills` was inspected at commit `14dea81da487`.
+- `zskills-dev` was inspected at commit `15642f8eeef`.
+- `zskills-dev` is ahead of public `zskills` and currently includes newer skills
+  such as `cleanup-merged`, `create-worktree`, and `quickfix`.
+- Existing Codex installation used a shallow `Codex Port Notes` adapter in each
+  installed skill. That makes many skills usable as playbooks, but it does not
+  fully convert orchestration behavior.
+- The strongest Codex fits are procedural/review skills such as `commit`,
+  `verify-changes`, `investigate`, `review-feedback`, `manual-testing`, and
+  `model-design`.
+- The weakest Codex fits are orchestration and installer skills such as
+  `run-plan`, `fix-issues`, `research-and-go`, and `update-zskills`, because
+  they depend on Claude cron tools, hooks, agent semantics, `.claude` state, and
+  release/install conventions.
+
+## Design Principles
+
+1. **Shared intent, provider-specific runtime.** Keep workflow intent in a
+   canonical skill source, but isolate runtime-specific behavior into provider
+   modules.
+2. **Provider support is a contract, not prose.** Do not rely on general adapter
+   notes to override contradictory instructions later in the file.
+3. **Progressive disclosure must be deterministic.** Every skill must load
+   provider behavior before mode behavior.
+4. **Generate and test outputs.** Claude and Codex rendered skill trees should be
+   generated from shared source and validated in CI.
+5. **Prefer neutral shared state.** Cross-provider pipeline state should live
+   under `.zskills/` where possible; provider runtime files should live under
+   `.claude/` or `.codex/` only when the provider requires it.
+6. **Do not weaken Claude behavior.** Existing Claude tests and safety contracts
+   remain authoritative for Claude output.
+
+## Architecture
+
+### Provider Model
+
+Add a provider layer with at least these providers:
+
+- `claude`
+- `codex`
+
+Each provider defines capabilities for:
+
+- scheduler
+- delegation
+- hook/enforcement model
+- config paths
+- install target
+- log/session state
+- command surface
+- rules/instructions output
+
+The provider contract should be represented in a manifest file, not inferred
+from prose. A suggested shape:
+
+```yaml
+providers:
+  claude:
+    skills_dir: ".claude/skills"
+    rules_dir: ".claude/rules/zskills"
+    config_path: ".claude/zskills-config.json"
+    scheduler: "claude-cron"
+    delegation: "claude-agent"
+    hooks: "claude-pretooluse"
+  codex:
+    skills_dir: "~/.codex/skills"
+    rules_dir: ".codex/zskills"
+    config_path: ".codex/zskills-config.json"
+    scheduler: "external-queue"
+    delegation: "codex-spawn-agent-or-inline"
+    hooks: "explicit-checks"
+```
+
+Exact format can be JSON, YAML, or TOML, but it must be machine-readable and
+validated by tests.
+
+### Progressive Disclosure Load Order
+
+Every skill entrypoint must use the same load order:
+
+```text
+SKILL.md bootstrap
+  -> provider/<provider>.md
+  -> modes/<mode>.md
+  -> references/*.md as needed
+```
+
+Rules:
+
+- `SKILL.md` owns frontmatter, trigger summary, argument parsing overview, and
+  the instruction to load the provider module first.
+- Provider modules define runtime/tool behavior and provider-specific
+  substitutions.
+- Mode modules define workflow-specific steps.
+- Reference modules contain large examples, templates, schemas, or repeated
+  checklists.
+- Mode files must not silently assume Claude-only or Codex-only capabilities
+  unless they explicitly load a provider-specific submodule.
+
+This avoids brittle “load a mode, then override it later” behavior.
+
+### Provider Modules
+
+Add provider modules at a consistent path, for example:
+
+```text
+skills/<skill>/providers/claude.md
+skills/<skill>/providers/codex.md
+```
+
+For common behavior, use shared provider references:
+
+```text
+providers/claude/common.md
+providers/codex/common.md
+providers/codex/scheduler.md
+providers/codex/delegation.md
+providers/codex/git-safety.md
+```
+
+Skill-local provider modules may be short and link to common provider
+references. This keeps behavior centralized while still allowing skill-specific
+exceptions.
+
+### Rendered Outputs
+
+Support two generated outputs:
+
+- Claude output: current `.claude/skills` behavior plus existing Claude rules,
+  hooks, and `.claude/rules/zskills/managed.md`.
+- Codex output: Codex-compatible skills with no raw Claude cron/hook/log
+  assumptions, installed to `~/.codex/skills` or a configured Codex skill
+  destination.
+
+Generated outputs should include metadata recording:
+
+- source repo URL
+- source commit
+- provider
+- render timestamp
+- skill manifest version
+- generator version
+
+Do not rely on the shallow “Codex Port Notes” header as the long-term porting
+strategy.
+
+## Codex Runtime Contract
+
+### Delegation
+
+Codex delegation must follow Codex rules:
+
+- Use `spawn_agent` only when the user explicitly requests delegation or
+  parallel agent work.
+- Otherwise run inline and report the reduced freshness/isolation guarantee.
+- Verification reports must state which mode was achieved:
+  - `multi-agent`
+  - `inline`
+  - `external reviewer unavailable`
+
+Codex provider modules must not instruct the agent to inspect for Claude
+`Agent` or `Task` tools.
+
+### Scheduler
+
+Implement Codex autonomy through an external queue and runner, not through
+Claude `CronCreate`, `CronList`, or `CronDelete`.
+
+Suggested files:
+
+```text
+.codex/zskills/jobs.jsonl
+.codex/zskills/locks/
+.codex/zskills/runs/
+```
+
+Each queued job must be structured data, not raw shell:
+
+```json
+{
+  "id": "run-plan.FEATURE.phase-3",
+  "provider": "codex",
+  "skill": "run-plan",
+  "mode": "phase",
+  "args": {
+    "plan": "plans/FEATURE.md",
+    "phase": "3",
+    "landing": "cherry-pick"
+  },
+  "status": "queued",
+  "attempt": 0,
+  "max_attempts": 3,
+  "not_before": "2026-04-26T13:00:00Z",
+  "created_at": "2026-04-26T12:55:00Z"
+}
+```
+
+Required scheduler semantics:
+
+- idempotency key prevents duplicate queued work
+- lock file prevents concurrent execution of the same job
+- runner refuses dirty working trees unless the job explicitly allows them
+- runner records `queued`, `running`, `succeeded`, `failed`, `retrying`, and
+  `cancelled`
+- retry policy is explicit and bounded
+- interrupted jobs can be recovered
+- only allow known skill/mode pairs and structured arguments
+- every autonomous phase also prints a human-runnable continuation command
+
+### Hooks And Enforcement
+
+Codex does not automatically enforce Claude PreToolUse hooks.
+
+Codex provider behavior should:
+
+- perform explicit preflight checks in the current turn
+- optionally provide a Git hook or wrapper script for teams that want local
+  enforcement
+- not claim `.claude/settings.json` hook enforcement exists in Codex
+- keep `.zskills/tracking` marker semantics where they are provider-neutral
+
+### Paths And State
+
+Use this lookup order for config:
+
+1. `.codex/zskills-config.json`
+2. `.claude/zskills-config.json` as compatibility fallback
+
+Use `.zskills/` for shared pipeline state where practical:
+
+```text
+.zskills/tracking/
+.zskills/manifests/
+.zskills/reports/
+```
+
+Use `.codex/zskills/` only for Codex runtime details:
+
+```text
+.codex/zskills/jobs.jsonl
+.codex/zskills/locks/
+.codex/zskills/managed.md
+```
+
+Codex output must not require `.claude/logs`.
+
+## Claude Runtime Contract
+
+Claude output must preserve existing behavior:
+
+- `.claude/skills`
+- `.claude/rules/zskills/managed.md`
+- `.claude/zskills-config.json`
+- Claude hook installation and settings merge
+- Claude cron tools where currently used
+- Claude `Agent`/`Task` semantics where the skill relies on them
+
+Provider work must not weaken existing Claude tests. If a provider abstraction
+forces a behavior change in Claude, add an explicit compatibility test and make
+the change intentional.
+
+## Skill Migration Strategy
+
+### Phase 1 — Framework And Tests
+
+Start with infrastructure rather than rewriting every skill.
+
+Implement:
+
+- provider manifest
+- provider common modules
+- renderer scaffolding
+- leakage tests
+- load-graph tests
+- Codex scheduler schema tests
+- generated-output manifest
+
+No skill should be considered migrated until its provider behavior is covered by
+tests.
+
+### Phase 2 — Installer And Renderer
+
+Migrate `update-zskills` first.
+
+Required behavior:
+
+- preserve current Claude install/update/rerender behavior
+- add Codex install/update/rerender behavior
+- install or update provider modules
+- render Claude and Codex outputs
+- write provider-specific managed rules/instructions
+- verify generated output matches committed/generated artifacts
+- report source commit and provider compatibility status
+
+`update-zskills --rerender` should become the release gate for provider output.
+
+### Phase 3 — Core Orchestration
+
+Migrate `run-plan` next.
+
+Required behavior:
+
+- shared plan parsing and phase selection
+- provider-specific delegation
+- provider-specific scheduling
+- provider-specific hook/enforcement assumptions
+- provider-neutral `.zskills/tracking` semantics where possible
+- Codex continuation queue support for `finish auto`
+- human-runnable continuation output after each phase
+
+Then migrate:
+
+- `fix-issues`
+- `research-and-go`
+- `do`
+- `qe-audit`
+- `briefing`
+
+### Phase 4 — Lower-Risk Skills
+
+Migrate low-runtime-dependency skills after the framework is stable:
+
+- `commit`
+- `verify-changes`
+- `investigate`
+- `draft-plan`
+- `refine-plan`
+- `review-feedback`
+- `manual-testing`
+- `model-design`
+- `doc`
+- block-diagram add-ons
+
+These mostly need provider path/config/delegation cleanup, not new architecture.
+
+## Testing Plan
+
+### Provider Leakage Tests
+
+Codex-rendered output must not contain active instructions to use:
+
+- `CronCreate`
+- `CronList`
+- `CronDelete`
+- `.claude/settings.json`
+- `.claude/logs`
+- Claude `Agent`/`Task` tool checks
+- claims that Claude hooks enforce Codex actions
+
+Claude-rendered output must not contain active instructions requiring:
+
+- `.codex/zskills-config.json`
+- `.codex/zskills/jobs.jsonl`
+- Codex `spawn_agent`
+- Codex-only scheduler commands
+
+Cross-provider explanatory documentation is allowed only in designated
+architecture docs, not active skill instructions.
+
+### Progressive Disclosure Tests
+
+Add load-graph tests:
+
+- every `SKILL.md` references exactly one provider-loading step
+- provider module resolves before mode module
+- all referenced files exist
+- no cycles
+- no provider conflicts
+- mode files do not bypass provider contract for scheduler/delegation/hooks
+
+### Scheduler Tests
+
+Add Codex scheduler tests for:
+
+- duplicate job prevention
+- lock acquisition and release
+- stale lock recovery
+- interrupted job recovery
+- dirty tree refusal
+- structured argument validation
+- allowed skill/mode whitelist
+- bounded retries
+- cancelled job handling
+- human continuation command generation
+
+### Release And Drift Tests
+
+Add release tests for:
+
+- manifest skill count equals actual skills
+- add-on manifest equals actual add-ons
+- dev-only skills are stripped from prod when marked
+- generated Claude artifacts match committed output
+- generated Codex artifacts match committed output
+- public mirror drift is detected before release
+- changelog/release metadata includes provider compatibility status
+
+Existing recursive conformance tests should continue to grep whole skill
+directories, not only `SKILL.md`, so contracts can live in provider/mode files.
+
+## Documentation Updates
+
+Update Z Skills docs to explain:
+
+- Claude remains the default/primary supported provider until Codex output is
+  fully validated.
+- Codex support uses generated provider-specific output.
+- Autonomous Codex continuation requires an external queue runner.
+- Scheduled behavior differs by provider.
+- Provider compatibility is tracked per skill.
+- A future public mirror may lag behind dev, so issue reports should include
+  source commit and provider.
+
+Add a short compatibility table:
+
+```text
+Skill              Claude  Codex  Notes
+commit             full    full   low provider dependency
+verify-changes     full    full   delegation differs
+run-plan           full    beta   scheduler/delegation differs
+fix-issues         full    beta   scheduler/GitHub orchestration differs
+update-zskills     full    beta   provider renderer required
+```
+
+The exact table should be generated from the manifest once the manifest exists.
+
+## Agent Review Notes
+
+A review agent evaluated the plan direction and found the approach sound with
+these conditions:
+
+- Provider behavior must be isolated as a real contract, not a prose patch.
+- Load order must be deterministic: `SKILL.md` bootstrap, provider module, mode
+  module, references.
+- Codex scheduler support must define a queue API with schema, locking,
+  idempotency, status transitions, recovery, retry policy, and command
+  validation.
+- Release drift between `zskills-dev` and public `zskills` must be tested, not
+  left as documentation.
+- Provider modules, progressive disclosure, scheduler state, and release
+  rendering should all be treated as testable interfaces.
+
+## Acceptance Criteria
+
+The implementation is complete when:
+
+- Claude behavior still passes all existing upstream tests.
+- Codex-rendered skills install cleanly into a Codex skill directory.
+- Provider leakage tests pass for Claude and Codex output.
+- Load-graph tests pass for all skills.
+- Codex scheduler tests pass.
+- `update-zskills --rerender` or its provider-aware replacement validates both
+  Claude and Codex outputs.
+- Release workflow detects manifest/public mirror drift before publishing.
+- At least `update-zskills` and `run-plan` have provider-aware implementations.
+- Documentation clearly states provider support status and scheduler differences.
+
+## Implementation Defaults
+
+- Target latest `zskills-dev` at implementation time.
+- Use shared canonical source with generated provider-specific outputs.
+- Prefer `.zskills/` for provider-neutral state.
+- Prefer `.codex/zskills/` for Codex runtime state.
+- Keep `.claude/rules/zskills/managed.md` for Claude rules.
+- Treat public `zskills` as a release artifact, not the development source.
+- Do not hand-maintain separate Claude and Codex skill forks.

--- a/docs/compat/codex-support-review/CODEX_ZSKILLS_REPORT.md
+++ b/docs/compat/codex-support-review/CODEX_ZSKILLS_REPORT.md
@@ -1,0 +1,262 @@
+# Codex Z Skills Evaluation Report
+
+## Summary
+
+Z Skills installed successfully as a Codex skill library, with 21 skills under
+`~/.codex/skills` and upstream helper assets vendored under
+`~/.codex/zskills-portable`.
+
+The result is useful, but it is not a fully native Codex automation stack. The
+best-converted skills work as strong engineering playbooks for commits,
+verification, debugging, planning, and manual testing. The weakest fit is the
+autonomous orchestration layer, because upstream Z Skills relies heavily on
+Claude Code features that are not available here: cron tools, Claude hooks,
+Claude agent semantics, `.claude` logs, and `.claude/settings.json`.
+
+Upstream validation looked healthy: the upstream test suite passed with
+`504/504` tests passing from the cloned source repo.
+
+## Executive Assessment
+
+```text
+┌───────────────────┬───────────────────┬────────────┬──────────────────────────────────┐
+│ Tier              │ Skill             │ Fit        │ Note                             │
+├───────────────────┼───────────────────┼────────────┼──────────────────────────────────┤
+│ Best native fit   │ commit            │ High       │ Safe commit workflow             │
+│                   │ verify-changes    │ High       │ Strong verification flow         │
+│                   │ investigate       │ High       │ Root-cause debugging             │
+│                   │ review-feedback   │ High       │ JSON and GitHub triage           │
+│                   │ manual-testing    │ High       │ Browser testing recipes          │
+│                   │ model-design      │ High       │ Reference guidance               │
+├───────────────────┼───────────────────┼────────────┼──────────────────────────────────┤
+│ Strong w/caveats  │ draft-plan        │ Med-High   │ Delegation caveat                │
+│                   │ refine-plan       │ Med-High   │ Plan drift review                │
+│                   │ doc               │ Med-High   │ Assumes docs structure           │
+│                   │ add-example       │ Med-High   │ Domain-specific                  │
+├───────────────────┼───────────────────┼────────────┼──────────────────────────────────┤
+│ Supervised use    │ briefing          │ Medium     │ Assumes .claude paths            │
+│                   │ plans             │ Medium     │ Z Skills plan format             │
+│                   │ do                │ Medium     │ Scheduling not native            │
+│                   │ qe-audit          │ Medium     │ Manual scheduled flows           │
+│                   │ research-and-plan │ Medium     │ Claude agent language            │
+│                   │ fix-report        │ Medium     │ Sprint artifacts required        │
+│                   │ add-block         │ Medium     │ Domain/worktree heavy            │
+├───────────────────┼───────────────────┼────────────┼──────────────────────────────────┤
+│ Needs rewrite     │ run-plan          │ Low-Med    │ Cron/hooks/agents/.claude        │
+│                   │ fix-issues        │ Low-Med    │ Claude orchestration heavy       │
+│                   │ research-and-go   │ Low-Med    │ Depends on cron continuation     │
+├───────────────────┼───────────────────┼────────────┼──────────────────────────────────┤
+│ Weakest fit       │ update-zskills    │ Low        │ Claude installer                 │
+└───────────────────┴───────────────────┴────────────┴──────────────────────────────────┘
+```
+
+## Detailed Skill Evaluation
+
+```text
+┌───────────────────┬──────────────┬────────────┬────────────────────────────────────────────────────────────────────────────────┐
+│ Skill             │ Agentic Use  │ Codex Fit  │ Evaluation                                                                     │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ commit            │ High         │ High       │ Excellent agentic guardrail for turning messy working-tree state into a clean  │
+│                   │              │            │ commit. It forces inventory, dependency tracing, unrelated-change protection,  │
+│                   │              │            │ and review before commit.                                                      │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ verify-changes    │ High         │ High       │ Strong verification operator. It pushes the agent to inspect diffs, assess     │
+│                   │              │            │ test coverage, run tests, manually verify UI when needed, and fix issues       │
+│                   │              │            │ recursively.                                                                   │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ investigate       │ High         │ High       │ Strong debugging skill. It requires reproduction, trace-based root cause,      │
+│                   │              │            │ proof before patching, and verification after the fix, which maps well to      │
+│                   │              │            │ autonomous coding.                                                             │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ review-feedback   │ Medium       │ High       │ Good triage workflow for feedback exports. Agentic value is bounded because    │
+│                   │              │            │ filing issues needs judgment and sometimes user approval, but the steps are    │
+│                   │              │            │ concrete.                                                                      │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ manual-testing    │ Medium       │ High       │ Useful operational checklist for browser verification. It improves agent       │
+│                   │              │            │ behavior by requiring real mouse and keyboard events instead of synthetic      │
+│                   │              │            │ shortcuts.                                                                     │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ model-design      │ Low          │ High       │ Mostly reference guidance rather than an autonomous workflow. Very reliable    │
+│                   │              │            │ because it has few runtime dependencies and gives clear layout heuristics.     │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ draft-plan        │ High         │ Med-High   │ High-value planning workflow. It is agentically strong when delegation is      │
+│                   │              │            │ allowed, but in Codex the adversarial multi-agent loop often has to be run     │
+│                   │              │            │ inline.                                                                        │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ refine-plan       │ High         │ Med-High   │ Good for long-running work where plans drift. It focuses the agent on          │
+│                   │              │            │ completed-vs-remaining scope and prevents stale assumptions from leaking       │
+│                   │              │            │ forward.                                                                       │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ doc               │ Medium       │ Med-High   │ Good documentation audit workflow, especially in the source project. General   │
+│                   │              │            │ usefulness drops when the repo does not match its assumed docs and block-      │
+│                   │              │            │ library structure.                                                             │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ add-example       │ Medium       │ Med-High   │ Good domain workflow for adding examples with tests and screenshots. Agentic   │
+│                   │              │            │ quality is strong inside block-diagram projects, weaker outside them.          │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ briefing          │ Medium       │ Medium     │ Useful status-gathering skill, especially with helper scripts. Codex efficacy  │
+│                   │              │            │ is reduced by assumptions about .claude worktrees, logs, and scheduled         │
+│                   │              │            │ briefings.                                                                     │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ plans             │ Medium       │ Medium     │ Good plan dashboard concept. It helps agents choose next work, but only if the │
+│                   │              │            │ repo follows Z Skills plan formatting and progress conventions.                │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ do                │ High         │ Medium     │ Good lightweight task dispatcher in concept. Codex can use the direct          │
+│                   │              │            │ workflow, but scheduled runs, PR automation, and some delegation behavior need │
+│                   │              │            │ manual adaptation.                                                             │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ qe-audit          │ High         │ Medium     │ Strong quality-engineering mindset: coverage gaps, stress paths, and recent-   │
+│                   │              │            │ change audits. Scheduled and parallel audit pieces are not native in Codex.    │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ research-and-plan │ High         │ Medium     │ Good decomposition workflow for broad goals. The core thinking ports well, but │
+│                   │              │            │ the skill still contains Claude-specific Skill-vs-Agent orchestration          │
+│                   │              │            │ guidance.                                                                      │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ fix-report        │ Medium       │ Medium     │ Useful for reviewing sprint outputs and deciding what to land or close.        │
+│                   │              │            │ Depends heavily on Z Skills reports, worktrees, and landing markers.           │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ add-block         │ High         │ Medium     │ Detailed, disciplined workflow for adding block types. Good agentic checklist, │
+│                   │              │            │ but domain-specific and still tied to Claude worktree/verification             │
+│                   │              │            │ assumptions.                                                                   │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ run-plan          │ Very High    │ Low-Med    │ The strongest upstream orchestration skill, but the least clean Codex fit. It  │
+│                   │              │            │ depends on Claude agents, cron continuation, hooks, .claude logs, and Z Skills │
+│                   │              │            │ markers.                                                                       │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ fix-issues        │ Very High    │ Low-Med    │ Powerful bug-sprint orchestrator. Agentic design is strong, but native Codex   │
+│                   │              │            │ use is limited by scheduling, GitHub orchestration, hooks, and multi-agent     │
+│                   │              │            │ assumptions.                                                                   │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ research-and-go   │ Very High    │ Low-Med    │ Ambitious end-to-end autonomous pipeline. Most value is architectural; Codex   │
+│                   │              │            │ cannot currently reproduce the unattended cron-driven continuation model.      │
+├───────────────────┼──────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────┤
+│ update-zskills    │ Medium       │ Low        │ Important upstream maintenance skill, but mostly installs Claude               │
+│                   │              │            │ infrastructure. For Codex it is reference material until rewritten for .codex  │
+│                   │              │            │ paths and semantics.                                                           │
+└───────────────────┴──────────────┴────────────┴────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## What Converted Well
+
+- Prompt-only workflows converted well.
+- Engineering discipline skills converted best: `commit`, `verify-changes`,
+  `investigate`, `draft-plan`, and `refine-plan`.
+- Reference and checklist-style skills converted cleanly: `manual-testing`,
+  `model-design`, and `review-feedback`.
+- The installed skill frontmatter is Codex-compatible. Claude-only fields such
+  as `disable-model-invocation` and `argument-hint` were removed.
+- Upstream helper scripts were preserved for reference and optional manual use.
+
+## What Does Not Quite Work
+
+### Native Scheduling
+
+Upstream Z Skills depends on `CronList`, `CronCreate`, and `CronDelete` for
+commands such as:
+
+- `/run-plan ... every ...`
+- `/run-plan ... finish auto`
+- `/fix-issues ... every ...`
+- `/qe-audit ... every ...`
+- `/briefing ... every ...`
+
+Those tools are not available in this Codex environment. The installed adapter
+marks scheduled continuation as unsupported unless an external scheduler is
+provided.
+
+Potential improvement:
+
+- Add a Codex-native scheduler shim that writes continuation jobs to a local
+  queue file such as `.codex/zskills-jobs.json`.
+- Provide a small shell runner that can be called by `cron`, `systemd`, or a
+  user-triggered command.
+- Rewrite scheduled skill sections to emit explicit next-step commands instead
+  of calling unavailable Claude cron tools.
+
+### Claude Hooks
+
+The upstream safety model relies on `.claude/settings.json` and hook scripts.
+The hook scripts themselves test well, but Codex does not automatically enforce
+Claude hooks.
+
+Potential improvement:
+
+- Port the hook configuration to a Codex-compatible project policy document.
+- Add optional Git hooks under `.git/hooks` or a repo-local `scripts/safe-git`
+  wrapper for teams that want enforcement.
+- Rewrite safety-critical skill sections so they perform explicit checks in the
+  current turn instead of assuming hooks will block unsafe operations.
+
+### Agent And Worktree Semantics
+
+Many upstream skills refer to Claude `Agent` or `Task` tools, `isolation:
+"worktree"`, and Claude-specific subagent behavior. Codex has `spawn_agent`,
+but the active Codex instructions only allow spawning agents when the user
+explicitly requests delegation or parallel agent work.
+
+Potential improvement:
+
+- Replace Claude agent instructions with Codex delegation rules.
+- Add two execution modes to orchestration skills:
+  - `inline`: no subagents; lower independence, simpler operation.
+  - `delegated`: uses Codex `spawn_agent` only when explicitly authorized.
+- Rewrite verification sections to state the achieved freshness mode rather
+  than assuming sibling subagents are always available.
+
+### `.claude` State And Logs
+
+Several skills assume `.claude/worktrees`, `.claude/logs`, and
+`.claude/zskills-config.json`. Codex does not maintain `.claude/logs`, and
+Codex-native configuration should prefer `.codex/zskills-config.json`.
+
+Potential improvement:
+
+- Normalize all config lookup examples to:
+  1. `.codex/zskills-config.json`
+  2. `.claude/zskills-config.json` as a compatibility fallback
+- Remove `.claude/logs` commit requirements from Codex-specific copies.
+- Update helper scripts such as `briefing.cjs` and `briefing.py` to detect
+  both `.codex` and `.claude` layouts.
+
+### `update-zskills`
+
+`update-zskills` is the weakest Codex fit because it mostly installs Claude
+Code infrastructure.
+
+Potential improvement:
+
+- Split it into two skills:
+  - `update-zskills-upstream`: update the upstream vendored source.
+  - `update-zskills-codex`: regenerate Codex-converted skills and validate them.
+- Make the Codex updater idempotently install to `~/.codex/skills`.
+- Add a conversion script that patches known Claude-only sections rather than
+  relying on a general adapter header.
+
+### Autonomous Pipelines
+
+`research-and-go`, `run-plan finish auto`, and `fix-issues auto` are valuable
+designs, but they are not fully autonomous in Codex as installed. They assume
+cron-fired continuation, automatic hook enforcement, and flexible subagent
+dispatch.
+
+Potential improvement:
+
+- Treat these as supervised workflows for now.
+- Rebuild autonomy around explicit resumable state files in `.codex/zskills/`.
+- Make each phase executable as a single top-level Codex request.
+- Produce a final command at the end of each phase, such as:
+  `Continue run-plan for plans/FEATURE.md phase 3`.
+
+## Recommended Next Steps
+
+1. Keep using the high-fit skills immediately: `commit`, `verify-changes`,
+   `investigate`, `draft-plan`, `refine-plan`, `review-feedback`,
+   `manual-testing`, and `model-design`.
+2. Treat `run-plan`, `fix-issues`, and `research-and-go` as supervised
+   playbooks until rewritten.
+3. Build a small conversion script so the Codex port can be regenerated from
+   upstream Z Skills without manual patch drift.
+4. Rewrite `update-zskills` first, because it should become the maintainable
+   entry point for future Codex-native updates.
+5. Rewrite `run-plan` second, because it is the core orchestration engine and
+   the highest-value target for a real Codex-native port.

--- a/docs/compat/codex-support-review/DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md
+++ b/docs/compat/codex-support-review/DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md
@@ -1,0 +1,508 @@
+---
+title: Codex Support for Z Skills Shared Source
+created: 2026-04-26
+status: active
+---
+
+# Plan: Codex Support for Z Skills Shared Source
+
+## Overview
+
+Update Z Skills so the same upstream source can support both Claude Code and
+Codex without maintaining a hand-edited Codex fork. The plan targets
+`github.com/zeveck/zskills-dev` as the implementation repo, but it is
+deliberately pattern-driven because upstream is active and a newer, more
+polished version with additional skills may land before execution.
+
+The intended end state is a shared-source distribution model:
+
+- Canonical skill content stays in upstream `skills/` and helper assets stay in
+  upstream `scripts/`, `hooks/`, `config/`, and templates.
+- Agent-specific behavior is expressed through a small compatibility contract,
+  adapter snippets, generated install targets, and conformance tests.
+- Claude remains supported through `.claude/skills`, `.claude/settings.json`,
+  Claude hooks, Claude `Agent`/`Task`, and Claude `Cron*` tools.
+- Codex is supported through `.codex/skills`, `AGENTS.md` or Codex-oriented
+  project guidance, explicit in-turn checks, Codex delegation only when the
+  runtime exposes a delegation tool and the user permits delegation, and an
+  external scheduler bridge for unattended continuation.
+
+Research inputs:
+
+- `CODEX_ZSKILLS_REPORT.md` found 21 installed Codex skills and identified the
+  strongest fits as prompt/checklist workflows such as `commit`,
+  `verify-changes`, `investigate`, `draft-plan`, and `refine-plan`.
+- The same report identified weak Codex fit around native scheduling, Claude
+  hook enforcement, Claude `Agent`/`Task` semantics, `.claude` logs/state, and
+  `update-zskills`.
+- Local installed Codex skills currently rely on repeated "Codex Port Notes"
+  headers instead of a native shared-source generation path.
+- As of the upstream snapshot inspected on 2026-04-26, `zskills-dev` had 21
+  core skills and newer additions such as `create-worktree`, `cleanup-merged`,
+  and `quickfix`; its README still describes Claude-first installation into
+  `.claude/skills` and `.claude/zskills-config.json`.
+
+Out of scope:
+
+- Do not rewrite every skill line-by-line against today's upstream text.
+- Do not remove Claude behavior or weaken Claude hook/session assumptions.
+- Do not implement a Codex-native hidden scheduler inside Codex. Codex
+  scheduled/autonomous workflows use an external scheduler bridge.
+- Do not make product-specific changes to downstream repos consuming Z Skills.
+
+## Progress Tracker
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| 1 -- Compatibility Contract and Inventory | ⬚ | | |
+| 2 -- Shared Source Markers and Generator | ⬚ | | |
+| 3 -- Runtime Paths, Config, and Scheduler Bridge | ⬚ | | |
+| 4 -- Convert Orchestration Guidance by Capability | ⬚ | | |
+| 5 -- Installer and Distribution Flow | ⬚ | | |
+| 6 -- Cross-Agent Test Matrix and Documentation | ⬚ | | |
+
+## Phase 1 -- Compatibility Contract and Inventory
+
+### Goal
+
+Define the Claude/Codex compatibility contract and build an inventory that
+drives later conversion work from patterns rather than brittle per-skill edits.
+
+### Work Items
+
+- [ ] Create `docs/compat/agent-capabilities.md` documenting the supported
+  capability matrix for Claude and Codex.
+- [ ] Create `docs/compat/codex-porting-patterns.md` with canonical rules for
+  paths, config lookup, instruction files, agents, scheduling, hooks, logs,
+  reports, and destructive-operation safeguards.
+- [ ] Add a script such as `scripts/audit-agent-specifics.sh` that scans
+  `skills/`, `scripts/`, `hooks/`, templates, and README docs for agent-specific
+  anchors: `.claude`, `CLAUDE.md`, `settings.json`, `Agent`, `Task`, `CronList`,
+  `CronCreate`, `CronDelete`, `.claude/logs`, hook enforcement claims, and
+  hardcoded install paths.
+- [ ] Classify every finding into one of four actions:
+  `shared` (valid for both agents), `claude-only`, `codex-adapted`, or
+  `unsupported-with-external-bridge`.
+- [ ] Add a generated report path, for example
+  `reports/agent-compat-inventory.md`, summarizing findings by skill and
+  helper asset.
+- [ ] Record the upstream commit hash used for the inventory and run the
+  upstream test suite available at that commit. If tests are too expensive or
+  environment-specific, record the exact skipped command and reason.
+- [ ] Add the inventory script to the upstream test runner if the repo already
+  has a script aggregation point, or document it as a required manual check if
+  the current runner structure changes before execution.
+
+### Design & Constraints
+
+The compatibility contract must treat this as a shared-source project, not as
+two forks. The inventory should produce guidance like:
+
+| Upstream concept | Claude target | Codex target |
+|---|---|---|
+| Skill install path | `.claude/skills/<name>/SKILL.md` | `.codex/skills/<name>/SKILL.md` or user-level `$CODEX_HOME/skills/<name>/SKILL.md` |
+| Project instructions | `CLAUDE.md` | `AGENTS.md` plus active Codex developer/user instructions |
+| Config lookup | target-aware: explicit override, then `.claude/zskills-config.json`, then compatibility fallback | target-aware: explicit override, then `.codex/zskills-config.json`, then `.claude/zskills-config.json` fallback |
+| Hooks | Claude PreToolUse hooks in `.claude/settings.json` | explicit checks in skills; optional Git hooks or wrappers only when installed by user choice |
+| Agents | Claude `Agent`/`Task` | Codex delegation tool if available and explicitly authorized; otherwise inline freshness mode |
+| Scheduling | Claude `Cron*` tools | external scheduler bridge invoking top-level Codex requests |
+| Logs | `.claude/logs` | no required Codex session-log commit path |
+
+The inventory should avoid asserting exact line numbers as durable facts. It
+may include current anchors as evidence, but the durable output is the
+classification and conversion rule.
+
+### Acceptance Criteria
+
+- [ ] `docs/compat/agent-capabilities.md` explicitly covers config, skill
+  install paths, instruction files, hooks, scheduling, delegation, logs,
+  reports, worktrees, and tests.
+- [ ] `docs/compat/codex-porting-patterns.md` says Codex scheduled/autonomous
+  behavior requires an external scheduler bridge.
+- [ ] `scripts/audit-agent-specifics.sh` exits nonzero when it finds an
+  unclassified Claude-only anchor in shared content.
+- [ ] `reports/agent-compat-inventory.md` is generated from the script and
+  covers all current `skills/*/SKILL.md` files, including any newer skills that
+  landed before implementation.
+- [ ] The report records the upstream commit hash and the result of the
+  upstream test command used as the baseline.
+- [ ] New skills or helper assets fail inventory until classified.
+- [ ] The inventory distinguishes weak-fit orchestration skills from high-fit
+  prompt/checklist skills using the categories from `CODEX_ZSKILLS_REPORT.md`
+  without freezing the exact local installed skill count.
+
+### Dependencies
+
+None.
+
+## Phase 2 -- Shared Source Markers and Generator
+
+### Goal
+
+Create a small generation layer that emits Claude and Codex install artifacts
+from the same upstream skill source.
+
+### Work Items
+
+- [ ] Add a source convention for agent-specific fragments. Prefer progressive
+  disclosure blocks that are easy for humans to maintain, for example:
+  `<!-- zskills:agent claude -->...<!-- /zskills:agent -->`,
+  `<!-- zskills:agent codex -->...<!-- /zskills:agent -->`, and
+  `<!-- zskills:agent shared -->...<!-- /zskills:agent -->`.
+- [ ] Define the rule that shared prose is the default; agent-specific blocks
+  are used only where capability semantics differ.
+- [ ] Implement `scripts/render-skills.sh` or extend the existing release/build
+  script to render two outputs:
+  `dist/claude/skills/<name>/SKILL.md` and
+  `dist/codex/skills/<name>/SKILL.md`.
+- [ ] Ensure the Codex renderer removes or rewrites Claude-only frontmatter
+  fields that Codex does not use, while preserving `name` and `description`.
+- [ ] Replace the repeated installed "Codex Port Notes" header with generated
+  Codex adaptation sections sourced from the compatibility contract.
+- [ ] Add renderer tests with fixture skills covering shared-only content,
+  Claude-only blocks, Codex-only blocks, nested-looking text that must not be
+  parsed as a block, and malformed block boundaries.
+- [ ] Add a nonblocking inventory warning mode for unconverted upstream skills,
+  so Phase 2 can prove rendering mechanics before Phase 4 has converted all
+  Claude-only operational sections.
+
+### Design & Constraints
+
+Progressive disclosure should make the common path readable. A skill should
+not become a maze of conditionals. Use agent-specific blocks around narrow
+sections such as scheduling commands, hook installation, and delegation
+instructions.
+
+Renderer behavior should be deterministic:
+
+```text
+Input:  skills/<skill>/SKILL.md
+Output: dist/claude/skills/<skill>/SKILL.md
+        dist/codex/skills/<skill>/SKILL.md
+Rule:   shared content included in both; target block included only in target;
+        other target blocks omitted; malformed markers fail the build.
+```
+
+Do not use ad hoc global substitutions for semantics like replacing every
+`CLAUDE.md` with `AGENTS.md`. Some mentions are historical or Claude-specific
+and should stay in Claude output only. The renderer should apply explicit block
+selection and small frontmatter transforms, not broad text mutation.
+
+### Acceptance Criteria
+
+- [ ] Rendering all current upstream skills succeeds for both Claude and Codex.
+- [ ] Fixture-rendered Codex output omits Claude-only fixture blocks and keeps
+  Codex/shared blocks.
+- [ ] Fixture-rendered Claude output omits Codex-only fixture blocks and keeps
+  Claude/shared blocks.
+- [ ] Generated upstream output may still contain unconverted findings from the
+  Phase 1 inventory, but they are reported as classified warnings rather than
+  hidden or silently rewritten.
+- [ ] Claude output preserves existing Claude visible content except for
+  documented stripping of marker comments and frontmatter normalization.
+- [ ] Renderer fixture tests cover success and failure paths.
+- [ ] Golden fixture tests prove marker comments are stripped from generated
+  target output.
+
+### Dependencies
+
+Phase 1.
+
+## Phase 3 -- Runtime Paths, Config, and Scheduler Bridge
+
+### Goal
+
+Make helper scripts and config resolution work under both `.claude` and
+`.codex`, and introduce a Codex-compatible external scheduler bridge for
+skills that currently rely on Claude `Cron*` tools.
+
+### Work Items
+
+- [ ] Add a target-aware config resolver script or documented shell snippet,
+  for example `scripts/zskills-config-path.sh`, that accepts a target
+  (`claude`, `codex`, or `auto`) and resolves config in this order: explicit
+  env override, target-native config, then compatibility fallback.
+- [ ] Update scripts that read config directly, such as `port.sh`,
+  `apply-preset.sh`, `briefing.cjs`, `briefing.py`, and worktree/landing
+  helpers, to use the resolver or the same tested lookup contract.
+- [ ] Extend `config/zskills-config.schema.json` with agent-neutral fields
+  where needed, such as `agent.target`, `scheduler.backend`,
+  `scheduler.command_template`, and any existing `execution.*` fields required
+  by newer upstream skills.
+- [ ] Add `scripts/zskills-scheduler.sh` as an external bridge. It should
+  manage a repo-local queue file such as `.zskills/scheduler/jobs.json` or
+  `.codex/zskills-jobs.json`, and support at least `add`, `list`, `run-due`,
+  `run-now`, and `remove`.
+- [ ] Add `docs/compat/codex-scheduler-contract.md` specifying the bridge
+  contract: job schema, prompt payload, working directory, environment, runner
+  command template, lock file, retry policy, job state transitions, last exit
+  status, and dry-run behavior.
+- [ ] Add a fake-runner test harness so `run-due` can prove exact request
+  rendering, locking, status updates, and retry behavior without invoking
+  Codex itself.
+- [ ] Define how Codex skills report scheduled work: emit the exact next
+  top-level request for the external runner rather than claiming native Codex
+  cron support.
+- [ ] Add tests for config precedence, missing config fallback, malformed config
+  handling, scheduler job creation, deduplication, cancellation, and due-job
+  selection.
+
+### Design & Constraints
+
+External scheduler means the skill writes enough durable state for a separate
+process to invoke Codex later. It does not mean Codex silently schedules itself.
+Codex output should say what was registered and how to run it, for example:
+
+```text
+bash scripts/zskills-scheduler.sh run-due
+```
+
+The bridge should be useful from cron, systemd timers, GitHub Actions, or a
+manual shell loop. It should not depend on a proprietary Codex cron tool.
+
+Config lookup must not break either target. Claude runs prefer `.claude` when
+both config files exist. Codex runs prefer `.codex` when both exist. Each target
+may fall back to the other only for compatibility and only when its native file
+is absent.
+
+### Acceptance Criteria
+
+- [ ] Helper scripts that read Z Skills config use the shared resolver or have
+  tests proving equivalent target-aware behavior.
+- [ ] Resolver tests cover both-config-present cases: Claude reads `.claude`;
+  Codex reads `.codex`.
+- [ ] Codex-rendered scheduling sections for `run-plan`, `fix-issues`,
+  `research-and-go`, `do`, `qe-audit`, and `briefing` describe the external
+  bridge and contain no direct Claude `Cron*` calls.
+- [ ] Claude-rendered scheduling sections still describe Claude cron behavior
+  if upstream retains it.
+- [ ] Scheduler tests pass without network access and without invoking Codex by
+  using a fake runner.
+- [ ] `run-due --dry-run` prints the exact command/request that would be sent
+  to the configured Codex runner.
+- [ ] Scheduler locking prevents two `run-due` processes from executing the
+  same job concurrently.
+- [ ] Queue files and tracking markers are documented as durable state, not
+  session logs.
+
+### Dependencies
+
+Phases 1 and 2.
+
+## Phase 4 -- Convert Orchestration Guidance by Capability
+
+### Goal
+
+Update skill workflows so agent-specific behavior is selected by capability:
+inline, delegated, scheduled, hook-enforced, or explicitly checked.
+
+### Work Items
+
+- [ ] Convert high-fit skills first: `commit`, `verify-changes`,
+  `investigate`, `review-feedback`, `manual-testing`, `model-design`,
+  `draft-plan`, and `refine-plan`.
+- [ ] Convert medium-fit dispatcher and status skills next: `do`, `plans`,
+  `briefing`, `doc`, `qe-audit`, `fix-report`, plus any newer upstream utility
+  skills such as `cleanup-merged`, `quickfix`, or `create-worktree` if present.
+- [ ] Convert low-fit orchestration skills last: `run-plan`, `fix-issues`, and
+  `research-and-go`.
+- [ ] For every place a skill asks for Claude `Agent` or `Task`, add a Codex
+  branch that states:
+  "Use a Codex delegation tool only when the runtime exposes one and the user
+  explicitly requested delegation or parallel agent work; otherwise run inline
+  and record the freshness mode."
+- [ ] For every place a skill relies on Claude hooks, add a Codex branch that
+  performs the check explicitly in the current turn or labels the check as an
+  optional external enforcement mechanism.
+- [ ] Remove Codex requirements to commit `.claude/logs`; preserve any
+  user-facing reports and durable Z Skills tracking markers that are still
+  meaningful.
+- [ ] Update plan/report templates so they can say "Verification freshness:
+  delegated", "inline", or "external/manual" rather than assuming a fresh
+  Claude subagent exists.
+
+### Design & Constraints
+
+The conversion should be capability-based, not brand-string-based whenever
+possible. For example, the plan should not say "Codex cannot verify"; it should
+say "when no delegated reviewer is permitted, run inline verification and label
+the freshness mode as inline."
+
+Use progressive disclosure to keep skill bodies readable:
+
+- Common workflow steps remain shared.
+- Claude-only automation details live in Claude blocks.
+- Codex-specific fallback and external scheduler details live in Codex blocks.
+- Long examples or mode-specific mechanics move into `skills/<name>/modes/` or
+  `skills/<name>/references/` when the upstream skill already uses that style.
+
+### Acceptance Criteria
+
+- [ ] No Codex-rendered skill claims Claude hooks or `.claude/settings.json`
+  will enforce safety.
+- [ ] No Codex-rendered skill names a concrete delegation tool as universally
+  available; delegation is described as capability-detected and explicitly
+  user-authorized.
+- [ ] Verification/report templates include a freshness mode field where
+  relevant.
+- [ ] `run-plan`, `fix-issues`, and `research-and-go` have supervised Codex
+  paths and external-scheduler paths, with clear stop/next/status behavior.
+- [ ] Existing Claude tests and canaries that are not inherently
+  Claude-environment-only still pass.
+
+### Dependencies
+
+Phases 1 through 3.
+
+## Phase 5 -- Installer and Distribution Flow
+
+### Goal
+
+Make `/update-zskills` the maintainable entry point for both Claude and Codex
+without turning it into a Claude-only installer.
+
+### Work Items
+
+- [ ] Split installer responsibilities into shared discovery, Claude target
+  installation, Codex target installation, and validation.
+- [ ] Add a concrete script surface, for example
+  `scripts/install-zskills.sh --target <claude|codex|both>`, and keep
+  `/update-zskills` as the skill/documentation wrapper that invokes or explains
+  the script.
+- [ ] Add an install target argument or auto-detection contract, for example
+  `--target claude`, `--target codex`, and `--target both`.
+- [ ] For Claude target, preserve `.claude/skills`, `.claude/settings.json`,
+  hook registration, and `.claude/zskills-config.json` behavior.
+- [ ] For Codex target, install generated skills to a defined location:
+  project-local `.codex/skills/<name>/SKILL.md` for repo installs, or
+  `$CODEX_HOME/skills/<name>/SKILL.md` only when a global install flag is
+  explicitly selected.
+- [ ] For Codex target, write or update `.codex/zskills-config.json`, and
+  create or update Codex-compatible project guidance without claiming hook
+  enforcement.
+- [ ] Ensure add-on flags work for both targets and discover add-ons from the
+  current upstream tree rather than from a hardcoded list.
+- [ ] Update release/build docs so `zskills-dev` can render and test both
+  targets before publishing to the public mirror.
+- [ ] Add dry-run output that shows which files would be installed or changed
+  for each target.
+
+### Design & Constraints
+
+The installer should preserve project-specific config fields when applying
+presets. Existing upstream behavior says preset application owns only landing
+mode, main protection, and the generic hook's main-push toggle. Codex target
+support should keep that preservation principle, even if the Codex target does
+not use the hook toggle directly.
+
+Codex installation should not write `.claude/settings.json` unless the user
+also selected the Claude target. Claude installation should not require
+`.codex` files. Tests should exercise the script surface, not only the skill
+prose.
+
+### Acceptance Criteria
+
+- [ ] `scripts/install-zskills.sh --target claude` preserves current Claude
+  install/update behavior.
+- [ ] `scripts/install-zskills.sh --target codex` installs generated Codex
+  skills and config without writing Claude hook settings.
+- [ ] `scripts/install-zskills.sh --target both` installs both generated
+  targets and reports both validation results.
+- [ ] `/update-zskills` documents or delegates to the script surface for the
+  same three target modes.
+- [ ] Re-running the installer is idempotent for unchanged generated output.
+- [ ] Dry-run tests prove target-specific file lists are correct.
+- [ ] Codex project-local and explicit global install locations are both
+  covered by tests.
+- [ ] Add-on installation tests cover at least core-only and block-diagram or
+  equivalent current upstream add-on packs.
+
+### Dependencies
+
+Phases 1 through 4.
+
+## Phase 6 -- Cross-Agent Test Matrix and Documentation
+
+### Goal
+
+Lock in the shared-source support model with tests, generated docs, and an
+upgrade checklist that can handle a newer upstream landing before execution.
+
+### Work Items
+
+- [ ] Add a cross-agent conformance test that renders both targets and greps
+  for forbidden unguarded target-specific anchors in the opposite output.
+- [ ] Add smoke tests that install Claude target into a temporary project and
+  Codex target into a temporary project.
+- [ ] Add scheduler bridge tests to the main test runner.
+- [ ] Add a "moving upstream" checklist to the plan or docs: refresh from
+  `zskills-dev`, rerun inventory, classify new skills/assets, render both
+  targets, run conformance, then update docs.
+- [ ] Update README installation docs with separate Claude, Codex, and both
+  target instructions.
+- [ ] Update release docs so public mirror publication includes generated
+  artifacts or a documented generation step.
+- [ ] Add a short maintainer guide explaining when to use agent-specific blocks
+  and when to keep prose shared.
+
+### Design & Constraints
+
+Tests should protect behavior contracts, not incidental wording. Current
+upstream already has conformance-style tests that grep for critical invariants
+across skill directories. Extend that pattern for cross-agent rendering rather
+than asserting exact prose.
+
+The moving-upstream checklist is required because this plan intentionally does
+not freeze today's exact skill list. If upstream adds or removes skills before
+execution, the implementer must update the inventory first and then apply the
+same compatibility categories.
+
+### Acceptance Criteria
+
+- [ ] Cross-agent conformance fails when Claude-only operational requirements
+  leak into Codex output.
+- [ ] Cross-agent conformance fails when Codex-only warnings or external
+  scheduler instructions leak into Claude output.
+- [ ] Temporary-project install tests pass for Claude target, Codex target, and
+  both target where environment prerequisites are available.
+- [ ] README clearly says `zskills-dev` is pre-release and public users install
+  from the public mirror, while maintainers implement this plan in
+  `zskills-dev`.
+- [ ] Release docs include a required render/test step before publishing.
+- [ ] The final verification report includes the current upstream commit hash
+  used for implementation, so reviewers can distinguish durable patterns from
+  snapshot-specific facts.
+
+### Dependencies
+
+Phases 1 through 5.
+
+## Plan Quality
+
+**Drafting process:** `/draft-plan` with 1 planned adversarial review round
+
+**Convergence:** Converged after round 1
+
+**Remaining concerns:** The biggest residual risk is upstream drift. This plan
+mitigates it by requiring an inventory refresh and classification before
+implementation, and by specifying behavior contracts rather than exact edits
+against today's skill text.
+
+### Round History
+
+| Round | Reviewer Findings | Devil's Advocate Findings | Resolved |
+|-------|-------------------|---------------------------|----------|
+| 1 | 8 findings | 0 separate DA findings | 8/8 |
+
+### Round 1 Disposition
+
+| Finding | Evidence | Disposition |
+|---|---|---|
+| Phase 2 acceptance required full Codex cleanup before conversion | Verified | Fixed: Phase 2 now validates renderer mechanics and classified warnings; forbidden-anchor checks moved to Phases 4/6. |
+| Scheduler bridge lacked executable runner contract | Verified | Fixed: Phase 3 now requires a scheduler contract doc, fake runner, dry-run output, locking, state, and retries. |
+| Codex delegation named `spawn_agent` too concretely | Verified | Fixed: plan now uses capability-detected Codex delegation instead of assuming one tool name. |
+| `.codex`-first lookup would break Claude in both-target installs | Verified | Fixed: config lookup is target-aware with explicit Claude and Codex precedence tests. |
+| Marker/generator diff acceptance conflicted with marked source | Verified | Fixed: Phase 2 now relies on golden fixtures and documented marker stripping. |
+| Upstream drift gate was too late | Verified | Fixed: Phase 1 now records upstream commit/test baseline and fails unclassified new assets. |
+| Installer target surface was only slash-command prose | Verified | Fixed: Phase 5 now requires a concrete installer script plus `/update-zskills` wrapper. |
+| Codex install location was vague | Verified | Fixed: Phase 5 defines project-local and explicit global install targets with tests. |

--- a/docs/compat/codex-support-review/DRAFT_PLAN_VS_CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_CASE_STUDY.md
+++ b/docs/compat/codex-support-review/DRAFT_PLAN_VS_CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_CASE_STUDY.md
@@ -1,0 +1,369 @@
+# Case Study: Draft Plan vs. CODEX Plan for Z Skills Codex Support
+
+## Summary
+
+This case study compares two plans for adding first-class Codex support to
+Z Skills while preserving Claude Code support:
+
+- `CODEX_ZSKILLS_REPORT.md`
+- `CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_PLAN.md`
+- `DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md`
+
+## Methodology
+
+Both plans were produced in Codex 5.5, but with different planning workflows:
+
+- `CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_PLAN.md` was created using Codex planning
+  mode.
+- `DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md` was created using the
+  Z Skills `draft-plan` skill loaded into Codex 5.5.
+
+That distinction matters for interpretation. The comparison is not only between
+two plan documents; it is also a small methodology case study comparing native
+Codex planning mode against a Z Skills planning workflow running in the same
+model family.
+
+`CODEX_ZSKILLS_REPORT.md` should be treated as a shared evidence base for both
+plans. It records the observed state of installed Codex skills, identifies the
+strongest and weakest Codex fits, and surfaces the Claude-specific assumptions
+that the plans attempt to address.
+
+The stronger execution plan is
+`DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md`.
+
+The draft plan is more likely to produce a solid and correct outcome because it
+turns the goal into an implementable sequence: inventory, renderer, runtime
+paths, scheduler bridge, skill conversion, installer flow, conformance tests,
+and documentation. It also carries explicit acceptance criteria and a recorded
+review disposition.
+
+The CODEX plan is still valuable. It is architecturally sharper in several
+places, especially around provider contracts, deterministic load order,
+scheduler semantics, and leakage testing. The best path is to use the draft
+plan as the execution base and merge in the strongest contracts from the CODEX
+plan before implementation.
+
+## Recommendation
+
+Use `DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md` as the working plan.
+
+Before executing it, amend it with four concepts from
+`CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_PLAN.md`:
+
+1. A machine-readable provider manifest.
+2. Deterministic provider/module load-order rules and load-graph tests.
+3. A settled Codex scheduler state layout with jobs, locks, and run records.
+4. An earlier proof point for the hard paths: `update-zskills` and `run-plan`.
+
+This combines the draft plan's operational structure with the CODEX plan's
+stronger architectural guardrails.
+
+## Why The Draft Plan Is More Likely To Succeed
+
+### It Has A Real Execution Sequence
+
+The draft plan is organized into six dependent phases:
+
+- Compatibility contract and inventory.
+- Shared-source markers and generator.
+- Runtime paths, config, and scheduler bridge.
+- Capability-based orchestration conversion.
+- Installer and distribution flow.
+- Cross-agent test matrix and documentation.
+
+That sequencing matters. The plan starts by discovering and classifying the
+actual Claude-specific anchors before attempting broad conversion. It then
+builds rendering mechanics, runtime support, and tests before completing the
+installer and documentation flow.
+
+The CODEX plan has phases, but they are broader and less directly taskable. It
+is better as an architecture note than as a sprint-ready implementation plan.
+
+### It Defines Concrete Script Surfaces
+
+The draft plan names specific scripts or script classes:
+
+- `scripts/audit-agent-specifics.sh`
+- `scripts/render-skills.sh`
+- `scripts/zskills-config-path.sh`
+- `scripts/zskills-scheduler.sh`
+- `scripts/install-zskills.sh --target <claude|codex|both>`
+
+This improves executability. A future implementer can work through tangible
+artifacts and tests instead of translating architecture prose into tool surfaces
+from scratch.
+
+The CODEX plan identifies important capabilities, but it does not consistently
+turn them into concrete file paths, command surfaces, and per-phase acceptance
+criteria.
+
+### It Has Better Acceptance Criteria
+
+Each phase in the draft plan includes acceptance criteria. These criteria are
+specific enough to drive review:
+
+- New skills or helper assets fail inventory until classified.
+- Renderer fixture tests cover target blocks and malformed markers.
+- Config resolver tests cover both-config-present cases.
+- Scheduler tests use a fake runner and do not invoke Codex.
+- Installer dry-run tests prove target-specific file lists.
+- Cross-agent conformance fails when operational requirements leak into the
+  wrong output.
+
+The CODEX plan includes a strong final acceptance list and good test categories,
+but it does not break completion down as rigorously by phase.
+
+### It Fixes Review-Identified Problems
+
+The draft plan includes a "Plan Quality" section showing issues found and fixed
+during review. Important fixes include:
+
+- Moving full forbidden-anchor cleanup out of the renderer-only phase.
+- Adding a scheduler runner contract.
+- Avoiding a hard assumption that Codex delegation is always named
+  `spawn_agent`.
+- Making config lookup target-aware.
+- Adding a concrete installer target surface.
+- Defining Codex install locations.
+
+Those fixes are not cosmetic. They directly address likely failure modes in a
+Claude-to-Codex support plan.
+
+## Where The CODEX Plan Is Stronger
+
+### Provider Contract As A First-Class Object
+
+The CODEX plan explicitly says provider support should be represented in a
+machine-readable manifest instead of inferred from prose. It lists capabilities
+such as:
+
+- scheduler
+- delegation
+- hook/enforcement model
+- config paths
+- install target
+- log/session state
+- command surface
+- rules/instructions output
+
+The draft plan has compatibility docs and generated artifacts, but it should
+make this provider manifest a formal deliverable. Without that, the system could
+drift back toward scattered conditionals and adapter prose.
+
+### Deterministic Progressive Disclosure Load Order
+
+The CODEX plan specifies a clear load order:
+
+```text
+SKILL.md bootstrap
+  -> provider/<provider>.md
+  -> modes/<mode>.md
+  -> references/*.md as needed
+```
+
+This is stronger than relying only on inline source markers. The draft plan's
+marker-based approach is easier to land, but it risks becoming noisy in complex
+skills unless a load contract or equivalent conformance check exists.
+
+The best synthesis is to allow narrow source markers where they keep shared
+prose readable, while still requiring provider contracts and load-graph tests
+for complex runtime behavior.
+
+### Scheduler Semantics Are Clearer
+
+The CODEX plan gives a stronger scheduler model:
+
+- structured job data
+- idempotency keys
+- lock files
+- status transitions
+- bounded retries
+- interrupted job recovery
+- allowed skill/mode validation
+- human-runnable continuation commands
+
+The draft plan includes most of these ideas, but leaves the queue location
+somewhat open. It should settle the durable state layout before implementation,
+preferably with separate locations for shared state and Codex runtime state.
+
+### Earlier Hard-Path Validation
+
+The CODEX plan proposes migrating `update-zskills` first and `run-plan` next.
+That is a useful architectural proof because those are among the hardest pieces:
+
+- `update-zskills` validates installer, renderer, distribution, and managed
+  guidance behavior.
+- `run-plan` validates scheduler, delegation, tracking, continuation, and
+  verification behavior.
+
+The draft plan converts high-fit skills first and low-fit orchestration skills
+last. That lowers early implementation risk, but it may delay discovering that
+the architecture is insufficient for the core orchestration workflows.
+
+A better order would preserve the draft plan's phases, but introduce an early
+thin-slice proof for `update-zskills` and `run-plan` before broad conversion.
+
+## Risks In The Draft Plan
+
+### Marker Sprawl
+
+The draft plan prefers source markers such as:
+
+```text
+<!-- zskills:agent claude -->
+<!-- zskills:agent codex -->
+<!-- zskills:agent shared -->
+```
+
+This is practical, but it can become hard to maintain if large portions of
+skills diverge by provider. The plan should set a threshold: narrow differences
+can use markers, while larger runtime differences should move to provider or
+mode modules.
+
+### "Adapter Snippets" Could Be Too Weak
+
+The draft plan describes agent-specific behavior through "a small compatibility
+contract, adapter snippets, generated install targets, and conformance tests."
+That is mostly sound, but "adapter snippets" risks preserving the existing
+shallow "Codex Port Notes" pattern unless the compatibility contract is
+enforceable.
+
+The plan should explicitly say that adapter snippets are generated artifacts or
+bounded source fragments, not a free-form prose layer that tries to override
+contradictory instructions later in a skill.
+
+### Delayed Validation Of Orchestration
+
+The draft plan converts low-fit orchestration skills last. That is reasonable
+for incremental delivery, but it delays the most important correctness test.
+Codex support for Z Skills is not proven until orchestration skills work under
+Codex constraints.
+
+The plan should include an early vertical slice through `update-zskills` and
+`run-plan`, even if full conversion remains later.
+
+## Risks In The CODEX Plan
+
+### Less Executable
+
+The CODEX plan has strong principles and contracts, but fewer concrete
+implementation steps. It does not provide the same level of phase-by-phase work
+items, dependencies, and acceptance criteria as the draft plan.
+
+That makes it more likely that two implementers would interpret it differently.
+For a cross-provider migration, that ambiguity is risky.
+
+### Codex Delegation Is Too Concrete
+
+The CODEX plan specifically names `spawn_agent` in its Codex delegation
+contract. That is less future-proof than the draft plan's capability-detected
+language:
+
+- use a Codex delegation tool only when the runtime exposes one
+- require explicit user permission for delegation or parallel agent work
+- otherwise run inline and report freshness mode
+
+The draft language is better because it describes the behavioral contract
+rather than one runtime's current tool name.
+
+### Config Lookup Is Not Target-Aware Enough
+
+The CODEX plan gives Codex config precedence as:
+
+1. `.codex/zskills-config.json`
+2. `.claude/zskills-config.json`
+
+That is correct for Codex, but incomplete for a dual-target installer. Claude
+must prefer `.claude` when both files exist, and Codex must prefer `.codex`.
+The draft plan explicitly fixes this with target-aware config lookup.
+
+### Provider Modules May Be Too Heavy Everywhere
+
+The CODEX plan suggests skill-local provider modules for each provider. That is
+appropriate for complex runtime behavior, but may be too much ceremony for
+skills that only need small path or wording differences.
+
+The draft plan's marker approach is likely easier to land. The final design
+should support both:
+
+- source markers for narrow conditional fragments
+- provider modules for substantial runtime behavior
+
+## What Each Plan Missed
+
+### Additional Detail The Draft Plan Should Add
+
+- Define the provider manifest schema and make it a generated/tested artifact.
+- Define when to use inline markers versus provider modules.
+- Settle queue and runtime-state paths before implementation.
+- Add an early vertical slice for `update-zskills` and `run-plan`.
+- Explicitly say adapter snippets cannot override contradictory shared
+  instructions by prose alone.
+- Add a provider compatibility status field per skill, generated from the
+  manifest or inventory.
+
+### Additional Detail The CODEX Plan Should Add
+
+- Convert its architecture into phase-level work items.
+- Add dependencies for each phase.
+- Add per-phase acceptance criteria.
+- Generalize Codex delegation away from a specific tool name.
+- Make config precedence target-aware.
+- Specify installer command surfaces and dry-run behavior.
+- Define how source markers and provider modules can coexist.
+
+## Combined Plan Shape
+
+A stronger merged plan would look like this:
+
+1. Inventory all Claude-specific and Codex-specific anchors.
+2. Define a machine-readable provider manifest.
+3. Define source markers for narrow differences and provider modules for large
+   runtime differences.
+4. Build the renderer and fixture tests.
+5. Add target-aware config resolution.
+6. Add the Codex external scheduler bridge with settled state paths.
+7. Prove the architecture with a thin slice of `update-zskills` and `run-plan`.
+8. Convert high-fit and medium-fit skills.
+9. Complete orchestration skills.
+10. Finish installer, conformance tests, release docs, and public mirror drift
+    checks.
+
+This keeps the draft plan's manageable execution flow while forcing the hardest
+architecture assumptions to be proven early.
+
+## Second-Agent Review
+
+A second agent independently reviewed both plans and the preliminary assessment.
+It agreed with the main conclusion:
+
+- The draft plan is more likely to produce a solid implementation because it is
+  operationally stronger.
+- The CODEX plan should not be dismissed as merely less actionable because it
+  contains concrete contracts the draft should absorb.
+
+The second review specifically highlighted these CODEX plan strengths:
+
+- machine-readable provider manifest
+- deterministic load order
+- load-graph tests
+- clearer scheduler state model
+- early focus on `update-zskills` and `run-plan`
+
+It also agreed that the CODEX plan has weaker execution detail, over-specifies
+Codex delegation by naming `spawn_agent`, and lacks target-aware config lookup.
+
+## Final Judgment
+
+The draft plan should be the base. It is more complete as an executable plan
+and has already incorporated review feedback on several important failure
+modes.
+
+The CODEX plan should be treated as an architectural supplement. Its best ideas
+should be patched into the draft before implementation, especially the provider
+manifest, deterministic load graph, stricter scheduler state model, and early
+hard-path validation.
+
+Taken together, the two plans point to a clear answer: do not choose between
+execution quality and architectural rigor. Use the draft plan to drive the work,
+but strengthen it with the CODEX plan's enforceable contracts.

--- a/docs/compat/codex-support-review/README.md
+++ b/docs/compat/codex-support-review/README.md
@@ -1,0 +1,20 @@
+# Codex Support Planning Review
+
+This folder preserves planning and review artifacts for future Codex support in
+Z Skills. These files are review inputs, not the authoritative implementation
+plan for `main`.
+
+Artifacts:
+
+- `CODEX_ZSKILLS_REPORT.md`: evidence report on existing Codex skill behavior,
+  strong and weak fit areas, and Claude-specific assumptions.
+- `CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_PLAN.md`: plan produced using Codex
+  planning mode in Codex 5.5.
+- `DRAFT_PLAN_CODEX_ZSKILLS_CODEX_SUPPORT_PLAN.md`: plan produced using the
+  Z Skills `draft-plan` skill loaded into Codex 5.5.
+- `DRAFT_PLAN_VS_CODEX_PLAN_ZSKILLS_CODEX_SUPPORT_CASE_STUDY.md`: comparison
+  and recommendation, including a second-agent review.
+
+Suggested next step before implementation: synthesize these inputs into one
+canonical `docs/compat/codex-support-plan.md` and keep this folder as
+methodology/background evidence.


### PR DESCRIPTION
This draft PR preserves Codex support planning artifacts for review and future synthesis. It is not intended as an implementation PR yet.

Includes:
- Codex skill compatibility report
- Codex planning-mode plan
- Z Skills draft-plan output
- Comparative case study
- Review README

Expected next step:
Review and synthesize these inputs into a canonical Codex support plan before any implementation work.