### PR TITLE
fix(hooks): scope main-protected rules a/b to push segment

### DIFF
--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -631,16 +631,33 @@ fi
 # legitimate worktree-scoped pushes without closing a realistic attack
 # vector.
 if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected; then
-  # (a) Explicit origin main/master (optionally force-prefixed with +):
-  if [[ "$COMMAND" =~ origin[[:space:]]+\+?(main|master)([[:space:]]|$|\") ]]; then
+  # Scope rules (a) and (b) to JUST the `git push` command segment, not the
+  # whole $COMMAND buffer. Without this, multi-statement commands like
+  # `git fetch origin main && git push -u origin feat/foo` false-positive
+  # because "origin main" appears in the fetch portion. Mirrors the bounded
+  # extraction in block-unsafe-generic.sh:266-280.
+  PUSH_CMD="$COMMAND"
+  PUSH_CMD="${PUSH_CMD##*git push}"
+  PUSH_ARGS=""
+  for word in $PUSH_CMD; do
+    case "$word" in
+      "&&"*|";"*|"|"*) break ;;  # stop at command chaining
+      -*) continue ;;            # skip flags (-u, --force, etc.)
+      *) PUSH_ARGS="$PUSH_ARGS $word" ;;
+    esac
+  done
+  # (a) Explicit origin main/master (optionally prefixed with + for
+  # force-push or : for delete-refspec):
+  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (b) HEAD:main or HEAD:master refspec:
-  if [[ "$COMMAND" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
+  if [[ "$PUSH_ARGS" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — defaults to pushing
-  # the current branch, which is main:
+  # the current branch, which is main. Tested against full $COMMAND
+  # because seeing `origin` ANYWHERE means a non-naked push is present.
   if ! [[ "$COMMAND" =~ origin[[:space:]] ]] && is_on_main; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -631,16 +631,33 @@ fi
 # legitimate worktree-scoped pushes without closing a realistic attack
 # vector.
 if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected; then
-  # (a) Explicit origin main/master (optionally force-prefixed with +):
-  if [[ "$COMMAND" =~ origin[[:space:]]+\+?(main|master)([[:space:]]|$|\") ]]; then
+  # Scope rules (a) and (b) to JUST the `git push` command segment, not the
+  # whole $COMMAND buffer. Without this, multi-statement commands like
+  # `git fetch origin main && git push -u origin feat/foo` false-positive
+  # because "origin main" appears in the fetch portion. Mirrors the bounded
+  # extraction in block-unsafe-generic.sh:266-280.
+  PUSH_CMD="$COMMAND"
+  PUSH_CMD="${PUSH_CMD##*git push}"
+  PUSH_ARGS=""
+  for word in $PUSH_CMD; do
+    case "$word" in
+      "&&"*|";"*|"|"*) break ;;  # stop at command chaining
+      -*) continue ;;            # skip flags (-u, --force, etc.)
+      *) PUSH_ARGS="$PUSH_ARGS $word" ;;
+    esac
+  done
+  # (a) Explicit origin main/master (optionally prefixed with + for
+  # force-push or : for delete-refspec):
+  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (b) HEAD:main or HEAD:master refspec:
-  if [[ "$COMMAND" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
+  if [[ "$PUSH_ARGS" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — defaults to pushing
-  # the current branch, which is main:
+  # the current branch, which is main. Tested against full $COMMAND
+  # because seeing `origin` ANYWHERE means a non-naked push is present.
   if ! [[ "$COMMAND" =~ origin[[:space:]] ]] && is_on_main; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1146,6 +1146,89 @@ else
 fi
 
 echo ""
+echo "=== Project hook: push-segment scoping (rules a/b) ==="
+
+# Background: rules (a) and (b) used to scan the entire $COMMAND buffer, which
+# false-positived on multi-statement commands like
+# `git fetch origin main && git push -u origin feat/foo` — "origin main" in
+# the fetch portion tripped rule (a). The fix scopes the regex to PUSH_ARGS
+# (the bounded post-`git push` segment, mirroring block-unsafe-generic.sh).
+# These tests pin both the regression cases (must ALLOW) and the BLOCK cases
+# the fix must keep working.
+
+# Regression case (this bug): fetch-then-push on a feature branch.
+RESULT=$(run_main_protected_test "feat/foo" '{"execution": {"main_protected": true}}' "git fetch origin main && git push -u origin feat/foo")
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "push-scope: fetch origin main && push -u origin feat/foo allowed"
+else
+  fail "push-scope: fetch origin main && push -u origin feat/foo should be allowed, got: $RESULT"
+fi
+
+# Regression case (semicolon variant of the same chain).
+RESULT=$(run_main_protected_test "chore/foo" '{"execution": {"main_protected": true}}' "git fetch origin main; git push -u origin chore/foo")
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "push-scope: fetch origin main; push -u origin chore/foo allowed"
+else
+  fail "push-scope: fetch origin main; push -u origin chore/foo should be allowed, got: $RESULT"
+fi
+
+# BLOCK: explicit `git push origin main` (rule a).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push origin main blocked"
+else
+  fail "push-scope: git push origin main should be blocked, got: $RESULT"
+fi
+
+# BLOCK: master variant of rule (a).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin master")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push origin master blocked"
+else
+  fail "push-scope: git push origin master should be blocked, got: $RESULT"
+fi
+
+# BLOCK: rule (a) with -u flag (flags must be skipped, target still detected).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push -u origin main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push -u origin main blocked"
+else
+  fail "push-scope: git push -u origin main should be blocked, got: $RESULT"
+fi
+
+# BLOCK: force-prefix form `+main`.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin +main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push origin +main blocked"
+else
+  fail "push-scope: git push origin +main should be blocked, got: $RESULT"
+fi
+
+# BLOCK: delete-refspec form `:main`.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin :main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push origin :main (delete-refspec) blocked"
+else
+  fail "push-scope: git push origin :main should be blocked, got: $RESULT"
+fi
+
+# BLOCK: bare HEAD:main (rule b — no `origin` token).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push HEAD:main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push HEAD:main blocked"
+else
+  fail "push-scope: git push HEAD:main should be blocked, got: $RESULT"
+fi
+
+# BLOCK: bare HEAD:master (rule b — master variant).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push HEAD:master")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "push-scope: git push HEAD:master blocked"
+else
+  fail "push-scope: git push HEAD:master should be blocked, got: $RESULT"
+fi
+
+echo ""
 echo "=== Project hook: main_protected — worktree-cd awareness ==="
 
 # Background: hooks run in a separate process whose cwd is the main repo on


### PR DESCRIPTION
## Summary

Fixes a false-positive in `hooks/block-unsafe-project.sh.template`'s push-protection block.

Rules (a) and (b) ran their regexes against the entire `$COMMAND` buffer rather than just the `git push` segment. A multi-statement command like `git fetch origin main && git push -u origin feat/foo` triggered BLOCKED because `"origin main"` appeared in the fetch portion.

Surfaced earlier in the session when running:
```
git fetch origin main 2>&1 | tail -2; git rebase origin/main 2>&1 | tail -3; git push -u origin chore/plans-index-rebuild
```
The legitimate feature-branch push was blocked.

## Fix

Adopts the same bounded extraction pattern that `block-unsafe-generic.sh` already uses (lines 261–290) — that hook was the reference implementation:

1. Strip everything before `git push` via `${PUSH_CMD##*git push}`
2. Walk word-by-word, breaking at `&&` / `;` / `|` chaining boundaries
3. Skip flag tokens (`-u`, `--force`, etc.)
4. Collect positionals into `PUSH_ARGS`
5. Apply rules (a) and (b) regexes to `PUSH_ARGS` instead of `$COMMAND`

Rule (c) (naked push while on main) is **unchanged** — it correctly scans full `$COMMAND` (`origin` anywhere means a non-naked push is present).

Rule (a) regex tightened from `\+?` to `[+:]?` so it catches both force-prefix (`+main`) and delete-refspec (`:main`) forms, as required by the new test table.

`block-unsafe-generic.sh` is **not changed** — it already scopes correctly.

## Test plan

Added 9 regression tests under `=== Project hook: push-segment scoping (rules a/b) ===` in `tests/test-hooks.sh`:

- ALLOW: `git fetch origin main && git push -u origin feat/foo` (regression)
- ALLOW: `git fetch origin main; git push -u origin chore/foo` (regression, semicolon variant)
- BLOCK: `git push origin main` (rule a)
- BLOCK: `git push origin master`
- BLOCK: `git push -u origin main`
- BLOCK: `git push origin +main` (force prefix)
- BLOCK: `git push origin :main` (delete refspec)
- BLOCK: `git push HEAD:main` (rule b)
- BLOCK: `git push HEAD:master`

Suite total: **827 → 836 (0 failed)**.

🤖 Generated with /quickfix