### PR TITLE
Fix #56: /commit respects execution.landing config for default mode

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -25,6 +25,9 @@ Commit current work without picking up or harming unrelated changes.
 **Parsing:** `pr` is recognized ONLY when it is the **FIRST token** in
 `$ARGUMENTS`. This prevents false-triggering on scope hints that contain
 "pr" mid-string. `push` and `land` are reserved keywords for non-PR mode.
+When no explicit mode token is supplied, the skill consults
+`execution.landing` in `.claude/zskills-config.json` to pick the default
+(see the config-driven default-mode block below).
 
 ```bash
 FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
@@ -35,10 +38,88 @@ if [[ "$FIRST_TOKEN" == "pr" ]]; then
 fi
 ```
 
+**Config-driven default mode (when no explicit mode token is given):**
+
+If `$ARGUMENTS` contains no explicit mode token (`pr` as first token, or
+`push`/`land` anywhere), read `execution.landing` from
+`.claude/zskills-config.json` to pick the default. This mirrors the
+landing-mode resolution in `/run-plan`, `/fix-issues`, and `/do` so
+projects with `execution.landing: "pr"` (the default preset, which also
+sets `main_protected: true`) get PR mode for `/commit` without users
+needing to retype `pr` every time. Bash regex only — no jq, matching the
+co-author read in Phase 5.
+
+```bash
+# Detect any explicit mode signal in the arguments. `pr` is first-token-only
+# (to avoid false-triggering on scope hints); `push` and `land` are
+# recognized anywhere (matching their parsing throughout the rest of this
+# skill, e.g., `/commit skill updates push`).
+HAS_EXPLICIT_MODE=0
+if [[ "$FIRST_TOKEN" == "pr" ]]; then
+  HAS_EXPLICIT_MODE=1
+elif [[ "$ARGUMENTS" =~ (^|[[:space:]])(push|land)($|[[:space:]]) ]]; then
+  HAS_EXPLICIT_MODE=1
+fi
+
+if [ "$HAS_EXPLICIT_MODE" -eq 0 ]; then
+  # No explicit mode — consult execution.landing from config.
+  CONFIG_FILE=".claude/zskills-config.json"
+  if [ -f "$CONFIG_FILE" ]; then
+    CONFIG_CONTENT=$(cat "$CONFIG_FILE")
+    if [[ "$CONFIG_CONTENT" =~ \"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+      CFG_LANDING="${BASH_REMATCH[1]}"
+      case "$CFG_LANDING" in
+        pr)
+          # Treat as `/commit pr` — drop into PR subcommand mode below.
+          # SCOPE_HINT keeps any scope words from $ARGUMENTS (no `pr` prefix
+          # to strip, since the user didn't type it).
+          SCOPE_HINT="$ARGUMENTS"
+          DEFAULT_MODE="pr"
+          ;;
+        direct|"")
+          # Commit-only default — current behavior preserved.
+          DEFAULT_MODE="commit"
+          ;;
+        cherry-pick)
+          # `/commit land` is the cherry-pick subcommand for landing
+          # worktree commits onto main, NOT a default-mode selector. A
+          # config of `cherry-pick` here is almost certainly a misconfig
+          # (the user probably wanted `pr` or `direct`). Surface loudly
+          # rather than silently picking a behavior.
+          echo "ERROR: execution.landing=\"cherry-pick\" is not a valid default for /commit." >&2
+          echo "  /commit land is the cherry-pick subcommand for landing worktree" >&2
+          echo "  commits onto main; it is NOT a default-mode selector. Set" >&2
+          echo "  execution.landing to \"pr\" or \"direct\" in" >&2
+          echo "  .claude/zskills-config.json, or invoke /commit land explicitly." >&2
+          exit 1
+          ;;
+        *)
+          # Unknown value — fall back to commit-only.
+          DEFAULT_MODE="commit"
+          ;;
+      esac
+    else
+      DEFAULT_MODE="commit"
+    fi
+  else
+    DEFAULT_MODE="commit"
+  fi
+
+  # If config says `pr`, behave exactly as `/commit pr` from here on:
+  # skip Phases 1–5 and run modes/pr.md end-to-end.
+  if [ "$DEFAULT_MODE" = "pr" ]; then
+    FIRST_TOKEN="pr"  # so downstream "is FIRST_TOKEN pr?" branches engage
+  fi
+fi
+```
+
 Disambiguation:
 - `/commit pr` → PR mode (first token is `pr`)
 - `/commit pr comments fix` → PR mode (first token is `pr`), scope hint: "comments fix"
 - `/commit fix pr format` → scope hint "fix pr format", regular commit (first token is "fix")
+- `/commit` with `execution.landing: "pr"` in config → PR mode (config default)
+- `/commit` with `execution.landing: "direct"` or no config → commit-only (preserved default)
+- `/commit push` or `/commit land` always overrides config — explicit wins
 
 Examples:
 - `/commit` → scope: *(none)*, action: commit

--- a/SPRINT_REPORT.md
+++ b/SPRINT_REPORT.md
@@ -15,3 +15,22 @@
 | #1 | zskills assumes bash/node is installed | Cross-platform hook strategy requires architectural decisions (rewrite hooks without bash/node/jq dependency, or document requirements, or add runtime detection with fallbacks). Not a batch-fix item. Consider `/draft-plan` for #1. |
 
 No actionable issues found (1 open, 1 skipped as too complex). Sprint complete with no fixes.
+
+## Sprint — 2026-04-27 13:51 [UNFINALIZED]
+
+**Mode:** interactive | **Focus:** default
+
+User invoked `/fix-issues 56 and 58`. During Phase 1 preflight, detected that #58 was already closed by PR #73 (merged earlier the same day). Closed #58 with a credit comment per the sync workflow; sprint proceeded with #56 only.
+
+### Fixed
+
+| # | Title | Worktree | Commit | Tests | Agent Verify | User Verify |
+|---|-------|----------|--------|-------|-------------|-------------|
+| #56 | bug: /commit doesn't respect execution.landing config for default mode | `/tmp/zskills-fix-issue-56` | `c8bc8f0` | +8 contract assertions in `tests/test-skill-conformance.sh`; suite 836→844 | PASS (full suite green, 0 failed) | N/A (skill markdown + bash test assertions only) |
+
+### Closed via sync (during this sprint)
+
+| # | Title | Verdict | Evidence |
+|---|-------|---------|----------|
+| #58 | bug: main_protected push-guard regex false-positives on 'git fetch origin main' in multi-command blocks | FIXED | PR #73 merged 2026-04-27 12:38Z; segment-scoping fix at `hooks/block-unsafe-project.sh.template:639-655`; 9 regression tests in `tests/test-hooks.sh`. Closed via `/fix-issues sync` verdict during preflight. |
+

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -25,6 +25,9 @@ Commit current work without picking up or harming unrelated changes.
 **Parsing:** `pr` is recognized ONLY when it is the **FIRST token** in
 `$ARGUMENTS`. This prevents false-triggering on scope hints that contain
 "pr" mid-string. `push` and `land` are reserved keywords for non-PR mode.
+When no explicit mode token is supplied, the skill consults
+`execution.landing` in `.claude/zskills-config.json` to pick the default
+(see the config-driven default-mode block below).
 
 ```bash
 FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
@@ -35,10 +38,88 @@ if [[ "$FIRST_TOKEN" == "pr" ]]; then
 fi
 ```
 
+**Config-driven default mode (when no explicit mode token is given):**
+
+If `$ARGUMENTS` contains no explicit mode token (`pr` as first token, or
+`push`/`land` anywhere), read `execution.landing` from
+`.claude/zskills-config.json` to pick the default. This mirrors the
+landing-mode resolution in `/run-plan`, `/fix-issues`, and `/do` so
+projects with `execution.landing: "pr"` (the default preset, which also
+sets `main_protected: true`) get PR mode for `/commit` without users
+needing to retype `pr` every time. Bash regex only — no jq, matching the
+co-author read in Phase 5.
+
+```bash
+# Detect any explicit mode signal in the arguments. `pr` is first-token-only
+# (to avoid false-triggering on scope hints); `push` and `land` are
+# recognized anywhere (matching their parsing throughout the rest of this
+# skill, e.g., `/commit skill updates push`).
+HAS_EXPLICIT_MODE=0
+if [[ "$FIRST_TOKEN" == "pr" ]]; then
+  HAS_EXPLICIT_MODE=1
+elif [[ "$ARGUMENTS" =~ (^|[[:space:]])(push|land)($|[[:space:]]) ]]; then
+  HAS_EXPLICIT_MODE=1
+fi
+
+if [ "$HAS_EXPLICIT_MODE" -eq 0 ]; then
+  # No explicit mode — consult execution.landing from config.
+  CONFIG_FILE=".claude/zskills-config.json"
+  if [ -f "$CONFIG_FILE" ]; then
+    CONFIG_CONTENT=$(cat "$CONFIG_FILE")
+    if [[ "$CONFIG_CONTENT" =~ \"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+      CFG_LANDING="${BASH_REMATCH[1]}"
+      case "$CFG_LANDING" in
+        pr)
+          # Treat as `/commit pr` — drop into PR subcommand mode below.
+          # SCOPE_HINT keeps any scope words from $ARGUMENTS (no `pr` prefix
+          # to strip, since the user didn't type it).
+          SCOPE_HINT="$ARGUMENTS"
+          DEFAULT_MODE="pr"
+          ;;
+        direct|"")
+          # Commit-only default — current behavior preserved.
+          DEFAULT_MODE="commit"
+          ;;
+        cherry-pick)
+          # `/commit land` is the cherry-pick subcommand for landing
+          # worktree commits onto main, NOT a default-mode selector. A
+          # config of `cherry-pick` here is almost certainly a misconfig
+          # (the user probably wanted `pr` or `direct`). Surface loudly
+          # rather than silently picking a behavior.
+          echo "ERROR: execution.landing=\"cherry-pick\" is not a valid default for /commit." >&2
+          echo "  /commit land is the cherry-pick subcommand for landing worktree" >&2
+          echo "  commits onto main; it is NOT a default-mode selector. Set" >&2
+          echo "  execution.landing to \"pr\" or \"direct\" in" >&2
+          echo "  .claude/zskills-config.json, or invoke /commit land explicitly." >&2
+          exit 1
+          ;;
+        *)
+          # Unknown value — fall back to commit-only.
+          DEFAULT_MODE="commit"
+          ;;
+      esac
+    else
+      DEFAULT_MODE="commit"
+    fi
+  else
+    DEFAULT_MODE="commit"
+  fi
+
+  # If config says `pr`, behave exactly as `/commit pr` from here on:
+  # skip Phases 1–5 and run modes/pr.md end-to-end.
+  if [ "$DEFAULT_MODE" = "pr" ]; then
+    FIRST_TOKEN="pr"  # so downstream "is FIRST_TOKEN pr?" branches engage
+  fi
+fi
+```
+
 Disambiguation:
 - `/commit pr` → PR mode (first token is `pr`)
 - `/commit pr comments fix` → PR mode (first token is `pr`), scope hint: "comments fix"
 - `/commit fix pr format` → scope hint "fix pr format", regular commit (first token is "fix")
+- `/commit` with `execution.landing: "pr"` in config → PR mode (config default)
+- `/commit` with `execution.landing: "direct"` or no config → commit-only (preserved default)
+- `/commit push` or `/commit land` always overrides config — explicit wins
 
 Examples:
 - `/commit` → scope: *(none)*, action: commit

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -144,6 +144,20 @@ check       commit "origin/main for log"      'git log origin/main\.\.HEAD'
 check       commit "--watch unreliable"       '--watch.*(exit code is unreliable|UNRELIABLE)'
 check_fixed commit "write-landed"             'bash scripts/write-landed.sh'
 check       commit "read-only reviewer"       'You are read-only|you are read-only'
+# Config-driven default mode (issue #56): /commit with no explicit mode
+# token must consult execution.landing in .claude/zskills-config.json
+# instead of always defaulting to commit-only. Explicit `pr` (first
+# token), `push` (anywhere), or `land` (anywhere) override the config.
+# A config of `cherry-pick` is rejected as misuse (the `land` subcommand
+# is the cherry-pick flow, not a default-mode selector).
+check_fixed commit "default-mode: landing config read"   'execution.landing'
+check_fixed commit "default-mode: bash-regex landing"    '\"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"'
+check_fixed commit "default-mode: explicit-mode guard"   'HAS_EXPLICIT_MODE'
+check_fixed commit "default-mode: push|land anywhere"    '(push|land)'
+check_fixed commit "default-mode: pr → PR mode"          'DEFAULT_MODE="pr"'
+check_fixed commit "default-mode: direct → commit-only"  'direct|"")'
+check       commit "default-mode: cherry-pick rejected"  'cherry-pick.*not a valid default|cherry-pick.*NOT a default-mode'
+check       commit "default-mode: no jq dependency"      'Bash regex only|no jq|no external JSON'
 
 echo ""
 echo "=== /commit — structural landmarks ==="


### PR DESCRIPTION
Fixes #56

## Summary

`/commit` invoked with no explicit mode token now reads `execution.landing` from `.claude/zskills-config.json` and defaults to that mode. Previously it always defaulted to commit-only, requiring users on `landing: "pr"` projects (like this one) to remember `/commit pr` every time.

Behavior:

- `landing: "pr"` → default to PR mode (same as `/commit pr`)
- `landing: "direct"` or unset/missing → commit-only (current behavior preserved)
- `landing: "cherry-pick"` → hard error pointing at `/commit land` as the cherry-pick subcommand

Explicit mode tokens still override the config default — first-token `pr` and anywhere-in-args `push`/`land` continue to engage their respective modes regardless of config. Uses the canonical bash-regex idiom from `skills/run-plan/SKILL.md:98` (no jq, per repo convention).

## Changes

- `skills/commit/SKILL.md` — added a "Config-driven default mode" block after the existing FIRST_TOKEN parsing; updated the parsing-intro paragraph and Disambiguation list with three new bullets covering the config-driven cases.
- `.claude/skills/commit/SKILL.md` — full mirror regenerated via `rm -rf` + `cp -r` (`diff -rq` empty).
- `tests/test-skill-conformance.sh` — 8 new contract assertions in the `=== /commit — behavior contracts ===` section, mapping to issue cases A/B/C plus the cherry-pick rejection and no-jq convention.
- `SPRINT_REPORT.md` — appended a 2026-04-27 sprint section recording this work.

## Test plan

- [x] Full suite green: 836 → 844 passing, 0 failed (`bash tests/run-all.sh`)
- [x] Mirror identical: `diff -rq skills/commit .claude/skills/commit` empty
- [x] Regex idiom matches `skills/run-plan/SKILL.md:98` byte-for-byte
- [x] All four config cases handled: `pr`, `direct`, unset, `cherry-pick`
- [x] Explicit-mode guard preserved: `pr` first-token + `push`/`land` anywhere still override config
- [x] Cherry-pick error explains how to fix the misconfig
- [x] Disambiguation prose updated to reflect new behavior
- [ ] Real `/commit` invocation in a session against a `landing: "pr"` config — the test harness greps skill markdown contracts; behavioral validation requires running it. (Easy to verify after merge: try `/commit foo bar` here; should default to PR mode.)

## Notes

- Verified by a fresh /verify-changes agent (separate context from the implementer); verdict PASS, commit `c8bc8f0`.
- Implementer flagged three judgment calls — all validated by the verifier:
  1. First-token-only `pr` vs anywhere-in-args `push`/`land` — matches existing skill semantics (e.g., `/commit fix pr format` is a regular commit per existing Disambiguation table).
  2. Hard `exit 1` on `landing: "cherry-pick"` rather than soft warning — surfaces misconfigs loudly per the repo's "surface bugs, don't patch" rule.
  3. Reused canonical run-plan regex pattern verbatim — correct.

🤖 Generated via /fix-issues sprint