### PR TITLE
docs: never dispatch agents on Haiku — Subagent Dispatch rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,17 @@ file a GitHub issue with the error output and mark the test `it.skip('name
 
 **Optimize for correctness, not speed.** Follow instructions exactly, including every intermediate verification step. Never skip verification to "save time" -- skipped steps mean the user has to re-verify, which saves nothing. Never stub methods, return bogus values, or simplify implementations to get something working faster. Never reframe the task to make it easier. Review agents will find shortcuts, so cutting corners gains nothing. When the user says "after each step, verify" -- verify after each step, not once at the end.
 
+## Subagent Dispatch
+
+**NEVER dispatch agents on Haiku.** Haiku produces over-literal pattern matches and misses framing -- it greps for an exact string, doesn't find it, and concludes "no bug" when the actual problem is the absence of a guardrail. It is consistently wrong on judgment-class tasks. We do not use Haiku anywhere, period.
+
+When using the Agent tool:
+
+- **Default: omit the `model` parameter** so the subagent inherits the parent's model (typically Opus). This is the safe default.
+- **`subagent_type: "Explore"` pins its own model frontmatter to Haiku 4.5 in this environment.** Do NOT use `Explore` without explicitly passing `model: "opus"` (or whichever model the parent is currently using). Prefer `subagent_type: "general-purpose"` -- it inherits the parent model with no override needed.
+- Treat any subagent type as Haiku-by-default until you have read its agent definition and confirmed otherwise. When in doubt, pass `model: "opus"` explicitly, or use `general-purpose`.
+- **Sonnet** is acceptable only for rare simple+mechanical work (bulk renames, find-replace, format conversion). Never for analysis, review, verification, or judgment.
+
 ## Playwright CLI (Browser Automation)
 
 This environment uses `playwright-cli` for browser automation. Run `playwright-cli --help` for available commands.

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -4,6 +4,17 @@
 
 {{SOURCE_LAYOUT}}
 
+## Subagent Dispatch
+
+**NEVER dispatch agents on Haiku.** Haiku produces over-literal pattern matches and misses framing -- it greps for an exact string, doesn't find it, and concludes "no bug" when the actual problem is the absence of a guardrail. It is consistently wrong on judgment-class tasks. We do not use Haiku anywhere, period.
+
+When using the Agent tool:
+
+- **Default: omit the `model` parameter** so the subagent inherits the parent's model (typically Opus). This is the safe default.
+- **`subagent_type: "Explore"` pins its own model frontmatter to Haiku 4.5 in this environment.** Do NOT use `Explore` without explicitly passing `model: "opus"` (or whichever model the parent is currently using). Prefer `subagent_type: "general-purpose"` -- it inherits the parent model with no override needed.
+- Treat any subagent type as Haiku-by-default until you have read its agent definition and confirmed otherwise. When in doubt, pass `model: "opus"` explicitly, or use `general-purpose`.
+- **Sonnet** is acceptable only for rare simple+mechanical work (bulk renames, find-replace, format conversion). Never for analysis, review, verification, or judgment.
+
 ## Dev Server
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a `## Subagent Dispatch` section to `CLAUDE.md` and `CLAUDE_TEMPLATE.md` codifying the project rule: never dispatch agents on Haiku.

## Why

Haiku produces over-literal pattern matches and misses framing on judgment-class tasks. Surfaced today during a `/quickfix` review where an `Explore`-dispatched reviewer flagged QF2 as "FUNDAMENTALLY WRONG" because the literal string `CONVERGED` wasn't present in the skill source — missing that the QF2 prompt was *adding* a missing guardrail, not fixing a broken instruction. That's a comprehension miss Opus would not have made.

The `Explore` subagent type pins its frontmatter `model:` to Haiku 4.5, so `subagent_type: "Explore"` silently downgrades to Haiku unless the caller passes `model: "opus"` explicitly.

## Rule

- **Default:** omit `model` parameter — subagent inherits parent (Opus).
- **`Explore`:** never use without explicit `model: "opus"`. Prefer `general-purpose` (inherits parent, no override needed).
- Treat all subagent types as Haiku-by-default until verified.
- **Sonnet** only for rare simple+mechanical work; never analysis, review, or judgment.

The template version propagates to consumer projects via `/update-zskills`.

## Test plan

- [x] Markdown-only change; no skill code, hooks, or scripts touched
- [x] Section placed after "Optimize for correctness" in CLAUDE.md and after Architecture in CLAUDE_TEMPLATE.md (consistent with surrounding rule prose)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)