### PR TITLE
plans: PR_LANDING_UNIFICATION — extract /land-pr from 5 PR-creating skills

### DIFF
--- a/plans/PLAN_INDEX.md
+++ b/plans/PLAN_INDEX.md
@@ -16,7 +16,7 @@ Totals: 46 plans — 9 ready, 0 in progress, 14 complete, 20 canaries, 3 referen
 | [SCRIPTS_INTO_SKILLS_PLAN.md](SCRIPTS_INTO_SKILLS_PLAN.md) | 7 | 1 | Medium | Created 2026-04-26 |
 | [SKILL_FILE_DRIFT_FIX.md](SKILL_FILE_DRIFT_FIX.md) | 6 | 1 | Medium | Created 2026-04-26 |
 | [IMPROVE_STALENESS_DETECTION.md](IMPROVE_STALENESS_DETECTION.md) | 3 | 1 | Low | Created 2026-04-19 |
-| [PR_LANDING_UNIFICATION.md](PR_LANDING_UNIFICATION.md) | 6 | 1 | High | Drafted 2026-04-27 with 3 rounds adversarial review; extracts /land-pr from 5 duplicating skills (run-plan, commit pr, do pr, fix-issues pr, quickfix); inherits PR #75 gating |
+| [PR_LANDING_UNIFICATION.md](PR_LANDING_UNIFICATION.md) | 7 (1A,1B,2,3,4,5,6) | 1A | High | Drafted 2026-04-27, refined 2026-04-28 (YAGNI pass: removed splice-body utility, split Phase 1); extracts /land-pr from 5 duplicating skills; inherits PR #75 gating |
 | [ZSKILLS_MONITOR_PLAN.md](ZSKILLS_MONITOR_PLAN.md) | 9 | 1 | Low | Created 2026-04-19; refined 2026-04-26 |
 
 ## In Progress

--- a/plans/PLAN_INDEX.md
+++ b/plans/PLAN_INDEX.md
@@ -16,6 +16,7 @@ Totals: 46 plans — 9 ready, 0 in progress, 14 complete, 20 canaries, 3 referen
 | [SCRIPTS_INTO_SKILLS_PLAN.md](SCRIPTS_INTO_SKILLS_PLAN.md) | 7 | 1 | Medium | Created 2026-04-26 |
 | [SKILL_FILE_DRIFT_FIX.md](SKILL_FILE_DRIFT_FIX.md) | 6 | 1 | Medium | Created 2026-04-26 |
 | [IMPROVE_STALENESS_DETECTION.md](IMPROVE_STALENESS_DETECTION.md) | 3 | 1 | Low | Created 2026-04-19 |
+| [PR_LANDING_UNIFICATION.md](PR_LANDING_UNIFICATION.md) | 6 | 1 | High | Drafted 2026-04-27 with 3 rounds adversarial review; extracts /land-pr from 5 duplicating skills (run-plan, commit pr, do pr, fix-issues pr, quickfix); inherits PR #75 gating |
 | [ZSKILLS_MONITOR_PLAN.md](ZSKILLS_MONITOR_PLAN.md) | 9 | 1 | Low | Created 2026-04-19; refined 2026-04-26 |
 
 ## In Progress

--- a/plans/PR_LANDING_UNIFICATION.md
+++ b/plans/PR_LANDING_UNIFICATION.md
@@ -1,0 +1,835 @@
+---
+title: PR Landing Unification — extract /land-pr from 5 duplicating skills
+created: 2026-04-27
+status: active
+---
+
+# Plan: PR Landing Unification
+
+> **Landing mode: PR** -- This plan targets PR-based landing. All phases use worktree isolation with a named feature branch.
+
+## Overview
+
+Five skills each independently implement "land via PR" orchestration: `/run-plan` (`skills/run-plan/modes/pr.md`), `/commit pr` (`skills/commit/modes/pr.md`), `/do pr` (`skills/do/modes/pr.md`), `/fix-issues pr` (`skills/fix-issues/modes/pr.md`), and `/quickfix` (`skills/quickfix/SKILL.md`). The duplicated machinery is rebase + push + `gh pr create` + CI poll + fix-cycle agent dispatch + optional `gh pr merge --auto` + `.landed` marker write.
+
+This duplication has produced documented drift bugs that were patched separately in different skills:
+
+- **87af82a** (2026-04-18) fixed the `gh pr checks --watch` exit-code-unreliable bug in `/run-plan` only.
+- **1de3049** (2026-04-18, 8 minutes later) fixed the same bug in `/commit` and `/do` separately.
+- **175e4aa** (2026-04-18) hardened `/run-plan`'s push / PR-number / PR-URL silent-failure modes; the same hardenings were never propagated to `/commit pr`, `/do pr`, or `/fix-issues pr`, all of which still have variants of those bugs.
+- **b904cef** (PR #75, 2026-04-27) fixed `/fix-issues` PR-mode gating to follow the canonical pattern: only `gh pr merge --auto --squash` is gated on the caller's `$AUTO` flag; rebase, push, PR creation, CI poll, and fix cycle ALL run unconditionally. PR #75 explicitly deferred the broader unification as a `/draft-plan` candidate — this plan.
+
+`/quickfix`'s current "fire-and-forget" design (no CI poll, no fix-cycle) is **drift, not a feature**: per maintainer direction, `/quickfix` should have the same PR + CI monitoring + fix-cycle behavior as the other four skills.
+
+This plan creates a new **`/land-pr`** skill that the five callers dispatch via the Skill tool. `/land-pr` owns the deterministic primitives (four bash scripts) and the canonical procedure prose. The fix-cycle agent dispatch stays in each caller (the caller knows the work context and constructs the right agent prompt). The caller wraps `/land-pr` in a small fix-cycle loop following a canonical pattern.
+
+**Inherited from PR #75:** only `gh pr merge --auto --squash` is gated on the caller's auto-merge flag. Rebase, push, PR creation, CI poll, and fix cycle all run unconditionally.
+
+**Cross-skill dispatch model:** Per `skills/research-and-plan/SKILL.md:87-105`, the Skill tool is the recursion mechanism — invoking `/land-pr` via `Skill: { skill: "land-pr", args: "..." }` loads `/land-pr`'s instructions into the **same** conversation context as the caller. There is no subprocess return value; data hand-off uses a file-based result contract with a safe allow-list parser (the caller passes `--result-file <path>`, `/land-pr` writes `KEY=VALUE` lines there with single-line shell-safe values, the caller reads via line-by-line allow-list parsing — never `source`).
+
+**PR body ownership:** `/land-pr` writes the PR body **only on initial PR creation**. Subsequent body updates (e.g., `/run-plan`'s per-phase progress splice) are the caller's responsibility — performed before the caller invokes `/land-pr`. This preserves callers' splice patterns (e.g., `/run-plan`'s HTML-comment-marker splice in `modes/pr.md:221-224`) and avoids destroying user-added review notes.
+
+**Subagent boundary:** `/land-pr` is invoked at orchestrator level only — never from within an Agent-dispatched subagent. The fix-cycle agent dispatch in the caller's loop is similarly orchestrator-level. This is a documented contract (no runtime guard exists; a misbehaving caller could violate it but conformance assertions check that callers' SKILL.md invokes `/land-pr` from the right level of nesting).
+
+**Out of scope:** the broader Claude Code subagent-spawning-subagent constraint, cherry-pick and direct landing modes, `/commit`'s `land` subcommand, GitLab support, review handling.
+
+**Rollback:** Phase 1 ships `/land-pr` but no caller dispatches it, so main behavior is unchanged. Phases 2–5 each migrate one caller (or pair) — if a phase reveals a design flaw, revert that phase's PR while keeping prior phases. Phase 6 (drift-prevention conformance) is the last gate; the grep tripwires there flag any remaining inline `gh pr create`/`checks`/`merge` if a migration was incomplete.
+
+## Progress Tracker
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| 1 — `/land-pr` skill scaffolding + scripts + canonical-schema + tests | ⬚ | | Includes intra-phase smoke checkpoint |
+| 2 — Migrate `/run-plan` PR mode to `/land-pr` (caller owns body splice) | ⬚ | | |
+| 3 — Migrate `/commit pr` and `/do pr` to `/land-pr` (drift fix: gain fix-cycle) | ⬚ | | |
+| 4 — Migrate `/fix-issues pr` to `/land-pr` (drop 300s timeout special case) | ⬚ | | |
+| 5 — Migrate `/quickfix` to `/land-pr` (drift fix: gain CI monitoring + fix-cycle) | ⬚ | | |
+| 6 — Drift-prevention conformance + canary | ⬚ | | |
+
+## Phase 1 — `/land-pr` skill scaffolding + scripts + canonical-schema + tests
+
+### Goal
+
+Create the `/land-pr` skill with four deterministic scripts, canonical procedure prose, the file-based result contract (with safe allow-list parsing), the canonical `.landed` schema, caller-loop reference, fix-cycle agent prompt template, and a unit-test suite covering the documented failure modes. No caller migration in this phase — the existing 5 skills continue to use their inline implementations until Phases 2–5.
+
+### Work Items
+
+- [ ] **WI 1.1 — Skill frontmatter.** Create `skills/land-pr/SKILL.md` with frontmatter:
+  ```yaml
+  ---
+  name: land-pr
+  description: Land an existing feature branch as a PR. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. Caller invokes only at orchestrator level (not from within Agent-dispatched subagents). Invoked directly by users with hand-crafted feature branches, and via Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix.
+  argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>]
+  allowed-tools: Bash(git *) Bash(gh *) Bash(bash *) Read Edit Write
+  ---
+  ```
+  No `disable-model-invocation`, no `user-invocable: false`. Both you and Claude can invoke; both via slash command and via Skill-tool dispatch.
+
+- [ ] **WI 1.2 — Argument parsing.** `/land-pr`'s SKILL.md parses `$ARGUMENTS` using bash regex (the established pattern in `/quickfix` and `/do`). Required: `--branch`, `--title`, `--body-file`, `--result-file`. Optional: `--auto` (bool, default false), `--worktree-path`, `--landed-source` (default `land-pr`), `--ci-timeout` (default 600), `--no-monitor` (skip CI poll, return after create — see use-case note in WI 1.12), `--pr <num>` (resume mode: skip rebase/push/create, jump to monitor only), `--issue <num>` (passes through to `.landed` schema). Validate: branch is not `main`/`master`; body-file exists and is non-empty; title is non-empty and ≤ 120 chars; result-file's parent directory exists.
+
+- [ ] **WI 1.3 — `pr-rebase.sh`.** Create `skills/land-pr/scripts/pr-rebase.sh`. Args: `--branch <name>` `--base <branch>` (default `main`). Behavior: `git fetch origin <base>`; `git rebase origin/<base>`. On clean rebase or "already up to date" (idempotent re-invocation): exit 0. On rebase conflicts, `git rebase --abort` (with rc check), write conflict-files list to a sidecar file (`/tmp/land-pr-conflict-files-$BRANCH-$$.txt`, one path per line), emit `CONFLICT_FILES_LIST=<path>` to stdout, exit 10. On other failure (not in git repo, branch absent, fetch fails): exit 11 with stderr error. **Why split out:** rebase conflicts need orchestrator judgement (agent-assisted resolution? manual? abort?). The script never tries to resolve conflicts itself.
+
+  Idempotency note (verified per git documentation): `git rebase origin/<base>` is a no-op when the local branch is already on top of the base. The fix-cycle re-invocation case (caller pushed a fix commit, /land-pr is called again) does NOT cause spurious conflicts — the local branch's new commits are already rebased on origin/main from the prior pass. WI 1.14 includes an explicit test case for this.
+
+- [ ] **WI 1.4 — `pr-push-and-create.sh`.** Create `skills/land-pr/scripts/pr-push-and-create.sh`. Args: `--branch <name>` `--base <branch>` `--title <title>` `--body-file <path>`. Behavior:
+  1. Detect existing PR via `gh pr list --head "$BRANCH" --base "$BASE" --json number,url 2>"$STDERR_LOG"`. Parse the JSON output via bash regex (no `jq` binary — `gh ... --json` is gh's built-in formatter):
+     ```bash
+     PR_LIST_JSON=$(gh pr list --head "$BRANCH" --base "$BASE" --json number,url) || { echo "ERROR: gh pr list failed: $(cat "$STDERR_LOG")" >&2; exit 13; }
+     if [[ "$PR_LIST_JSON" =~ \"number\":[[:space:]]*([0-9]+) ]]; then
+       PR_NUMBER="${BASH_REMATCH[1]}"
+       [[ "$PR_LIST_JSON" =~ \"url\":[[:space:]]*\"([^\"]+)\" ]] && PR_URL="${BASH_REMATCH[1]}"
+       PR_EXISTING=true
+     else
+       PR_EXISTING=false
+     fi
+     ```
+     If multiple open PRs from the same branch exist (force-push artifact), the first `BASH_REMATCH` capture wins (the most recent); log a warning to stderr but proceed.
+  2. Push: `git push -u origin "$BRANCH"` (or `git push` if upstream already set). On non-zero exit, exit 12 with the captured stderr — no `|| true`, no `2>/dev/null`.
+  3. If `PR_EXISTING=true`:
+     - **Body update is the caller's responsibility, not /land-pr's.** This script does NOT call `gh pr edit --body-file`. Rationale: `/run-plan`'s per-phase update uses HTML-comment-marker splicing (verified at `skills/run-plan/modes/pr.md:221-224`) to preserve user-added review notes; a wholesale body replacement here would destroy those edits. Callers that need body updates handle them in their own prose before invoking `/land-pr` (see Phase 2 WI 2.1).
+     - Emit `PR_EXISTING=true PR_URL=<url> PR_NUMBER=<num>` to stdout, exit 0.
+  4. Else (no existing PR): `gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body-file "$BODY_FILE"`. **Race-condition note:** if a parallel `/land-pr` invocation just created a PR for the same branch (`gh pr list` race window), `gh pr create` will fail with an "already exists" error — gh enforces one open PR per head branch. The losing invocation receives exit 13 with the stderr captured; caller's loop handles it as `STATUS=create-failed`. No duplicate PRs are created. Exit 13 on creation failure.
+  5. Extract `PR_NUMBER` from create output's URL via parameter expansion `${URL##*/}` (per fix 175e4aa — never via second `gh pr view`). Validate it's all-digits via `[[ "$PR_NUMBER" =~ ^[0-9]+$ ]]`; if not, exit 14.
+  6. Emit `PR_EXISTING=false PR_URL=<url> PR_NUMBER=<num>` to stdout, exit 0.
+
+  **Why combined:** push and create are sequential with no orchestrator decision between them. If push fails, create can't run.
+
+- [ ] **WI 1.5 — `pr-monitor.sh`.** Create `skills/land-pr/scripts/pr-monitor.sh`. Args: `--pr <number>` `--timeout <sec>` (default 600) `--log-out <path>`. Behavior:
+  1. Pre-check loop: 3 attempts with 10s sleep, query `gh pr checks "$PR" --json name 2>"$STDERR_LOG"`. Parse with bash regex `\[.*\]` to detect non-empty array. On count > 0, break.
+  2. If count == 0 after retries: emit `CI_STATUS=none`, exit 0.
+  3. Initial poll: `timeout "$TIMEOUT" gh pr checks "$PR" --watch 2>"$LOG_OUT.stderr"`. Capture exit code as `WATCH_RC`.
+  4. **Honor only `WATCH_RC=124`** (timeout's exit for "still running") → emit `CI_STATUS=pending`, exit 0. For all other watch exit codes, IGNORE and re-check.
+  5. Re-check (per fix 87af82a): bare `gh pr checks "$PR" >/dev/null 2>"$STDERR_LOG"`. Exit 0 → `CI_STATUS=pass`. Exit 1 → `CI_STATUS=fail`. Exit 8 → `CI_STATUS=pending`. Other → `CI_STATUS=unknown` (with stderr captured to `$LOG_OUT.stderr`).
+  6. On `CI_STATUS=fail`, capture failure log: extract a run ID via `gh pr checks "$PR" --json link` and bash-regex on the URL, then run `gh run view --log-failed <run-id> > "$LOG_OUT"`. If run-ID extraction fails, emit `CI_LOG_FILE=` (empty) — caller's fix-cycle agent must handle missing log gracefully.
+  7. Emit final `CI_STATUS=...` and `CI_LOG_FILE=...` to stdout, exit 0 (poll completed regardless of pass/fail).
+  8. Exit 20 if pre-conditions invalid (PR number non-numeric, or `gh auth status` returns non-zero on first call — fail-fast on auth).
+
+- [ ] **WI 1.5a — `splice-body.sh` shared utility.** Create `skills/land-pr/scripts/splice-body.sh`. Args: `--body-current <path>` `--progress-text <path>` `--start-marker <text>` `--end-marker <text>` `--out <path>`. Behavior:
+  1. Validate both markers exist in the current body. Exit 40 if missing (with stderr message naming which marker is missing).
+  2. Splice `progress-text` content between the markers using `awk` (more robust than sed against `&`/`\` metacharacters in body content).
+  3. Write to `out` atomically (`.tmp` + `mv`). Exit 41 on write failure.
+  4. Exit 0 on success.
+
+  **Why a shared utility:** body splice is currently only used by `/run-plan`'s per-phase progress update. A future caller (e.g., `/fix-issues` per-issue body amendments) would re-implement the same sed/awk dance and drift. Centralizing this in `/land-pr`'s scripts/ ensures one tested implementation. /run-plan calls this script in WI 2.1.
+
+- [ ] **WI 1.6 — `pr-merge.sh`.** Create `skills/land-pr/scripts/pr-merge.sh`. Args: `--pr <number>` `--auto-flag <true|false>` `--ci-status <pass|fail|pending|none|skipped|unknown>`. Behavior:
+  1. If `auto-flag != true`: emit `MERGE_REQUESTED=false MERGE_REASON=auto-not-requested`, exit 0.
+  2. If `ci-status` not in `{pass, none, skipped}`: emit `MERGE_REQUESTED=false MERGE_REASON=ci-not-passing`, exit 0.
+  3. `gh pr merge "$PR" --auto --squash 2>"$STDERR_LOG"`. Capture stderr.
+  4. If stderr matches `auto[- ]merge.*not.*allowed|auto[- ]merge.*disabled|repo.*does not allow auto[- ]merge` (bash regex): treat as benign repo-setting — emit `MERGE_REQUESTED=false MERGE_REASON=auto-merge-disabled-on-repo`, exit 0.
+  5. On other gh error: write the stderr text to a sidecar file (`/tmp/land-pr-merge-error-$PR-$$.txt`), emit `MERGE_REQUESTED=false MERGE_REASON=gh-error CALL_ERROR_FILE=<path>` (NOT raw stderr text — see WI 1.7 safety note), exit 30.
+  6. On success: retry `gh pr view "$PR" --json state --jq '.state'` up to 3 times with 2s/4s backoff. If all 3 fail, emit `PR_STATE=UNKNOWN`. Else emit `PR_STATE=<OPEN|MERGED>`.
+  7. Emit `MERGE_REQUESTED=true PR_STATE=...`, exit 0.
+
+- [ ] **WI 1.7 — File-based result contract (safe parsing).** `/land-pr`'s SKILL.md prose composes the final result and writes to `$RESULT_FILE` (one `KEY=VALUE` per line). **Safety contract:** every value is a single-line, shell-safe token (no newlines, no `$`, no backticks, no `&`/`?`/`#` metacharacters). Multi-line content (stderr text, file lists) goes in **sidecar files** referenced by path, not inlined into the result file.
+
+  Result file schema:
+  ```
+  STATUS=created|monitored|merged|push-failed|rebase-conflict|create-failed|monitor-failed|merge-failed
+  PR_URL=<https-url-no-metacharacters-or-empty>
+  PR_NUMBER=<digits-or-empty>
+  PR_EXISTING=true|false
+  CI_STATUS=pass|fail|pending|none|skipped|unknown|not-monitored
+  CI_LOG_FILE=<path-or-empty>
+  MERGE_REQUESTED=true|false
+  MERGE_REASON=auto-not-requested|ci-not-passing|auto-merge-disabled-on-repo|gh-error|empty
+  PR_STATE=OPEN|MERGED|UNKNOWN|not-checked
+  REASON=<short-token-or-empty>           # e.g., rebase-conflict-too-many-files
+  CONFLICT_FILES_LIST=<path-or-empty>     # sidecar file with one conflict path per line
+  CALL_ERROR_FILE=<path-or-empty>         # sidecar file with stderr text from failed gh/git call
+  ```
+
+  **Writer-side validation (mandatory before write):** every VALUE must be single-line ASCII (no `\n`, no `\r`, no `$`, no backticks, no `&`, `?`, `#` metacharacters). The /land-pr SKILL.md prose validates each value via:
+  ```bash
+  validate_result_value() {
+    local key="$1" value="$2"
+    if [[ "$value" =~ [$'\n\r$`&?#'] ]]; then
+      echo "ERROR: result-file VALUE for $key contains forbidden characters" >&2
+      return 1
+    fi
+  }
+  ```
+  before writing each line. Multi-line content goes in sidecar files (path-only goes in the result file). This guarantees the allow-list parser cannot encounter truncated values, embedded shell metacharacters, or surprise-multi-line content.
+
+  The result file is overwritten atomically: write to `$RESULT_FILE.tmp`, then `mv` to `$RESULT_FILE`.
+
+  **Caller parsing pattern (allow-list, never `source`):**
+  ```bash
+  RESULT_FILE="/tmp/land-pr-result-$BRANCH_NAME-$$.txt"
+  # ... compose body to /tmp/pr-body-...md ...
+  # Skill: { skill: "land-pr", args: "--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=/tmp/pr-body-...md --result-file=$RESULT_FILE [other flags]" }
+  # After Skill invocation completes:
+  if [ ! -f "$RESULT_FILE" ]; then
+    echo "ERROR: /land-pr produced no result file" >&2
+    exit 1
+  fi
+  declare -A LP   # associative array; allow-listed keys only
+  while IFS='=' read -r KEY VALUE; do
+    case "$KEY" in
+      STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
+      MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+        LP["$KEY"]="$VALUE" ;;
+      "") ;;  # blank line
+      *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
+    esac
+  done < "$RESULT_FILE"
+  STATUS="${LP[STATUS]}"
+  CI_STATUS="${LP[CI_STATUS]}"
+  PR_URL="${LP[PR_URL]}"
+  # etc — explicit assignments per key, no eval, no source.
+  rm -f "$RESULT_FILE"
+  ```
+
+  This pattern **never executes the file's contents as shell**, so a maliciously-crafted PR title or body that produces shell-injection-able stderr text cannot reach shell evaluation. The allow-list also catches truncated or malformed result files.
+
+- [ ] **WI 1.8 — `caller-loop-pattern.md` reference.** Create `skills/land-pr/references/caller-loop-pattern.md` with a complete, production-ready bash implementation of the canonical caller fix-cycle loop. NOT pseudocode — actual bash that callers copy verbatim and customize only the agent-prompt-construction block. Pattern (full):
+
+  ```bash
+  # === BEGIN CANONICAL /land-pr CALLER LOOP ===
+  # Caller fills in: $BRANCH_NAME, $PR_TITLE, $BODY_FILE, $WORKTREE_PATH (optional),
+  # $LANDED_SOURCE, $AUTO ("true"/"false"), $CI_MAX_ATTEMPTS (default 2),
+  # and the fix-cycle agent dispatch block below.
+
+  ATTEMPT=0
+  MAX="${CI_MAX_ATTEMPTS:-2}"
+  RESULT_FILE="/tmp/land-pr-result-$BRANCH_NAME-$$.txt"
+
+  while :; do
+    # Caller is responsible for any per-iteration body update BEFORE invoking /land-pr.
+    # /run-plan splices its progress section into $BODY_FILE here.
+    # Other callers regenerate $BODY_FILE here if they need to.
+    #
+    #   <CALLER_PRE_INVOKE_BODY_PREP>
+    #
+    LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE"
+    [ -n "$WORKTREE_PATH" ] && LAND_ARGS="$LAND_ARGS --worktree-path=$WORKTREE_PATH"
+    [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+    [ -n "$ISSUE_NUM" ] && LAND_ARGS="$LAND_ARGS --issue=$ISSUE_NUM"
+
+    # Invoke /land-pr via Skill tool. (Caller's prose tells Claude to invoke it.)
+    # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+    # When /land-pr's procedure completes, $RESULT_FILE is populated.
+
+    if [ ! -f "$RESULT_FILE" ]; then
+      echo "ERROR: /land-pr produced no result file" >&2
+      exit 1
+    fi
+
+    # SAFE allow-list parsing (per WI 1.7).
+    declare -A LP
+    while IFS='=' read -r KEY VALUE; do
+      case "$KEY" in
+        STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+          LP["$KEY"]="$VALUE" ;;
+      esac
+    done < "$RESULT_FILE"
+    STATUS="${LP[STATUS]}"
+    CI_STATUS="${LP[CI_STATUS]}"
+    # Sidecar cleanup — capture paths before removing result file, then clean up sidecars after caller-specific handling below.
+    _CLEANUP_PATHS="${LP[CALL_ERROR_FILE]:-} ${LP[CONFLICT_FILES_LIST]:-} ${LP[CI_LOG_FILE]:-}"
+    rm -f "$RESULT_FILE"
+
+    case "$STATUS" in
+      rebase-conflict)
+        # Caller-specific: if conflict-file count is small, dispatch agent-assisted
+        # rebase resolution at orchestrator level, then `continue` to re-invoke /land-pr.
+        # If too large or no agent path, break and let .landed conflict marker stand.
+        #
+        #   <CALLER_REBASE_CONFLICT_HANDLER>
+        #
+        break ;;
+      push-failed|create-failed|monitor-failed|merge-failed|rebase-failed)
+        echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
+        break ;;
+      created|monitored|merged) ;;  # fall through to CI-status check
+    esac
+
+    case "$CI_STATUS" in
+      pass|none|skipped)
+        break ;;  # /land-pr already requested merge if --auto
+      pending)
+        break ;;  # settle at pr-ready; user / cron can resume with --pr
+      fail)
+        if [ "$ATTEMPT" -ge "$MAX" ]; then
+          echo "INFO: CI fix-cycle exhausted ($ATTEMPT/$MAX); PR settles at pr-ci-failing" >&2
+          break
+        fi
+        # ===== CALLER-SPECIFIC FIX-CYCLE AGENT DISPATCH =====
+        # The agent runs at orchestrator level (NOT a nested subagent — /land-pr
+        # was already invoked at orchestrator level via the Skill tool; this dispatch
+        # is at the same level).
+        #
+        # Caller customizes the prompt with their work context (plan content,
+        # issue body, task description, etc.) and the failure log path
+        # (${LP[CI_LOG_FILE]}).
+        #
+        #   <DISPATCH_FIX_CYCLE_AGENT_HERE>
+        #
+        # ====================================================
+        ATTEMPT=$((ATTEMPT + 1))
+        continue ;;  # re-enter loop, /land-pr is idempotent
+      unknown)
+        echo "WARN: CI_STATUS=unknown — settling at pr-ready" >&2
+        break ;;
+    esac
+  done
+
+  # Sidecar cleanup (after final iteration). CI_LOG_FILE is preserved if the
+  # caller wants to retain failure logs; CALL_ERROR_FILE and CONFLICT_FILES_LIST
+  # are transient and removed.
+  for f in $_CLEANUP_PATHS; do
+    [ -n "$f" ] && [ -f "$f" ] && [[ "$f" != *"$CI_LOG_FILE"* ]] && rm -f "$f"
+  done
+  # === END CANONICAL /land-pr CALLER LOOP ===
+  ```
+
+  Document explicitly: `/land-pr` is **idempotent per call** — re-invoking with the same branch is a no-op for steps already done (rebase already up to date, push already up to date, PR already exists). Body updates are the caller's responsibility (see `<CALLER_PRE_INVOKE_BODY_PREP>`).
+
+- [ ] **WI 1.9 — Fix-cycle agent prompt template.** Create `skills/land-pr/references/fix-cycle-agent-prompt-template.md`. Template structure same as Round-1 plan (caller fills in `<CALLER_WORK_CONTEXT>`). Add explicit constraint: *"You are running at orchestrator level. Do NOT dispatch further Agent tools. If your fix attempt requires nested agent dispatch, stop and report — the caller's loop will retry up to its max attempts."*
+
+- [ ] **WI 1.10 — Failure-modes reference.** Create `skills/land-pr/references/failure-modes.md` cataloging the 10 failure modes from the research synthesis. Each entry: failure description, severity, detection mechanism in the corresponding script, the test case in `tests/test-land-pr-scripts.sh` that proves the detection works.
+
+- [ ] **WI 1.11 — Canonical `.landed` schema.** Document in `skills/land-pr/SKILL.md` the canonical `.landed` schema:
+  ```
+  status: <required>      # landed | pr-ready | pr-ci-failing | pr-failed | conflict | pr-state-unknown
+  date: <required>        # ISO-8601, NY tz: $(TZ=America/New_York date -Iseconds)
+  source: <required>      # caller skill name (run-plan, commit, do, fix-issues, quickfix, land-pr)
+  method: <required>      # always "pr" in this plan's scope
+  branch: <required>      # feature branch name
+  pr: <optional>          # PR URL; present only after pr-push-and-create.sh succeeds
+  ci: <optional>          # CI_STATUS value; present only after pr-monitor.sh ran
+  pr_state: <optional>    # PR_STATE value; present only after pr-merge.sh ran
+  commits: <optional>     # space-separated SHA list of commits on the branch
+  issue: <optional>       # GitHub issue number; present for /fix-issues caller
+  reason: <optional>      # short token: rebase-conflict-too-many-files, ci-fix-cycle-exhausted, etc.
+  conflict_files: <optional>  # space-separated paths; present for status=conflict (small lists only)
+  ```
+  `/land-pr` writes `.landed` only when `--worktree-path` is supplied. `/run-plan` may write its own `.landed` for the pre-`/land-pr` "rebase-conflict-too-many-files" case (when it bails before invoking `/land-pr`). The schema is the same in both write paths.
+
+- [ ] **WI 1.12 — `/land-pr` SKILL.md procedure prose.** Compose the SKILL.md body that drives Claude through the procedure when `/land-pr` is invoked:
+  1. Parse `$ARGUMENTS` (WI 1.2) and validate.
+  2. If `--pr <num>` is set (resume mode): skip steps 3–4, jump to step 5 with `$PR_NUMBER=<num>`.
+
+     **Use case for `--pr <num>`:** caller (or user) previously invoked `/land-pr --no-monitor` (or had a monitor timeout); the PR exists and the branch is pushed; now they want to monitor (or re-monitor) without re-running rebase/push/create.
+
+  3. Run `pr-rebase.sh`. On exit 10: write result file with `STATUS=rebase-conflict CONFLICT_FILES_LIST=<sidecar-path>` and exit. On exit 11: write `STATUS=rebase-failed CALL_ERROR_FILE=<sidecar>` and exit.
+  4. Run `pr-push-and-create.sh`. On non-zero exit: write `STATUS=push-failed` (or `create-failed` per exit code) with `CALL_ERROR_FILE`. If `--worktree-path` supplied, write `.landed` marker with `status=pr-failed`. Exit.
+  5. If `--no-monitor` was supplied: write `STATUS=created CI_STATUS=not-monitored PR_URL=...`, exit.
+
+     **Use case for `--no-monitor`:** caller wants to report PR URL to user mid-flight (e.g., interactive `/land-pr` invocation where the user wants the URL fast and will check CI themselves), or caller wants to split create-and-monitor across two cron-fired turns. None of the 5 callers in this plan use `--no-monitor` — it's a flag for direct user invocation and future callers.
+
+  6. Run `pr-monitor.sh` with `--ci-timeout`.
+  7. Run `pr-merge.sh` with `--auto-flag` and the resolved `CI_STATUS`.
+  8. Compose `.landed` body if `--worktree-path` was supplied. Use this **status mapping table** to derive the `status` field:
+
+     **Evaluation: top-down, first-match-wins.** Failure-exits and pre-conditions come first; CI_STATUS=fail and CI_STATUS=pending take precedence over MERGE_REQUESTED/PR_STATE rows because the merge-requested-but-CI-failed combo (auto-merge accepted but CI changed after) should NOT be reported as `landed`.
+
+     | # | MERGE_REQUESTED | PR_STATE | CI_STATUS | → `status` |
+     |---|---|---|---|---|
+     | 1 | (rebase-conflict exit, set in step 3) | * | * | conflict |
+     | 2 | (push-failed or create-failed exit, set in step 4) | * | * | pr-failed |
+     | 3 | * | * | fail | pr-ci-failing |
+     | 4 | * | * | pending | pr-ready |
+     | 5 | * | * | unknown | pr-ready |
+     | 6 | true | MERGED | pass / none / skipped | landed |
+     | 7 | true | OPEN | pass / none / skipped | pr-ready |
+     | 8 | true | UNKNOWN | pass / none / skipped | pr-state-unknown |
+     | 9 | false (auto-merge-disabled-on-repo) | * | pass / none / skipped | pr-ready |
+     | 10 | false (auto-not-requested) | * | pass / none / skipped | pr-ready |
+
+     All required schema fields populated; optional fields populated when known. Pipe to `bash scripts/write-landed.sh "$WORKTREE_PATH"` (uses atomic write per its docstring at `scripts/write-landed.sh:19`: *"Writes: <worktree-path>/.landed (atomic via .tmp + mv)"*).
+  9. Compose final result and write to `$RESULT_FILE` (atomic via `.tmp` + `mv`). Per WI 1.7, every VALUE is validated via `validate_result_value` before write; multi-line content is referenced via `*_FILE` sidecar paths.
+  10. Echo a brief one-line summary to stdout for the conversation log: `STATUS=<status> PR=<url> CI=<status>`.
+
+- [ ] **WI 1.13 — Mock infrastructure for tests.** Create `tests/mocks/mock-gh.sh` and `tests/mocks/mock-git.sh`. Each is a bash script with a subcommand router. Reference implementation for `mock-gh.sh` (the test scripts copy this verbatim and extend per-test):
+  ```bash
+  #!/bin/bash
+  # mock-gh.sh — minimal stateful mock for `gh` commands.
+  # State: $MOCK_GH_STATE_DIR (default /tmp/mock-gh-state-$$).
+  # Per-call counters: $MOCK_GH_STATE_DIR/<subcommand>.count
+  # Per-call canned response: $MOCK_GH_STATE_DIR/<subcommand>.<count>.{stdout,stderr,exit}
+  set -u
+  STATE_DIR="${MOCK_GH_STATE_DIR:-/tmp/mock-gh-state-$$}"
+  mkdir -p "$STATE_DIR"
+  SUBCMD="$1 $2"  # e.g., "pr list", "pr create", "run view"
+  KEY="$(echo "$SUBCMD" | tr ' ' '_')"
+  COUNT_FILE="$STATE_DIR/$KEY.count"
+  COUNT=$(cat "$COUNT_FILE" 2>/dev/null || echo 0)
+  COUNT=$((COUNT + 1))
+  echo "$COUNT" > "$COUNT_FILE"
+  STDOUT_FILE="$STATE_DIR/$KEY.$COUNT.stdout"
+  STDERR_FILE="$STATE_DIR/$KEY.$COUNT.stderr"
+  EXIT_FILE="$STATE_DIR/$KEY.$COUNT.exit"
+  if [ ! -f "$STDOUT_FILE" ] && [ ! -f "$STDERR_FILE" ] && [ ! -f "$EXIT_FILE" ]; then
+    echo "mock-gh: no canned response prepared for '$SUBCMD' call #$COUNT" >&2
+    exit 127  # mimic gh's "command not found" / "subcommand failed" failure mode
+  fi
+  [ -f "$STDOUT_FILE" ] && cat "$STDOUT_FILE"
+  [ -f "$STDERR_FILE" ] && cat "$STDERR_FILE" >&2
+  [ -f "$EXIT_FILE" ] && exit "$(cat "$EXIT_FILE")"
+  exit 0
+  ```
+  **Why fail-fast on missing canned response:** if the SUT calls a subcommand more times than the test prepared, the mock would otherwise silently return exit 0 with empty output — producing **false test confidence**. Failing fast with exit 127 makes test gaps visible.
+
+  Tests set up the per-call canned responses by writing to `$MOCK_GH_STATE_DIR/<subcommand>_<call#>.{stdout,stderr,exit}` BEFORE invoking the script under test. The pre-check-loop test, for example, writes empty stdout for `pr_checks.1` and `pr_checks.2`, then a non-empty array for `pr_checks.3`.
+
+  **Concurrency note:** The mock's per-call counter file is not locked. All tests using `mock-gh.sh` MUST invoke mocked commands sequentially within a single test process. Do NOT fork background processes that call `gh` — the counters race. Tests requiring parallel `gh` calls use real `gh` against a fixture repo instead.
+
+  `mock-git.sh` follows the same pattern. For state-modifying ops (rebase, push), the mock can also call real `git` with a fake remote (local bare repo at `$MOCK_GIT_FAKE_REMOTE`) when realistic side effects are required.
+
+- [ ] **WI 1.14 — `tests/test-land-pr-scripts.sh`.** Create the test file. Capture output per CLAUDE.md: `TEST_OUT="/tmp/zskills-tests/$(basename $(pwd))/.test-results.txt"`. Tests cover all 10 failure modes from `references/failure-modes.md` PLUS:
+  - **rebase-idempotent**: local branch is already rebased, then a fix commit is added, then `pr-rebase.sh` is called again → exit 0, no modifications, no conflict.
+  - **PR_NUMBER extraction from URL**: when `gh pr create` returns URL `.../pull/42`, `PR_NUMBER=42` is extracted (no second `gh pr view` call).
+  - **--no-monitor returns early**: `/land-pr --no-monitor` writes result file with `CI_STATUS=not-monitored` and does NOT run `pr-monitor.sh`.
+  - **--pr <num> resume mode**: skips rebase/push/create, jumps to monitor.
+  - **result-file safe parsing**: a maliciously-crafted CALL_ERROR (containing `$()` substitution attempt) lands in a sidecar file, not the result file; caller's allow-list parser ignores unknown/malformed lines without executing them.
+  - **status mapping table coverage**: at least one test per row of the WI 1.12 table — verify the correct `status` is derived for each combination.
+  - **race-bounded create-failed**: simulate two concurrent `gh pr create` calls against same branch (mock returns "already exists" on second); confirm the second invocation gets `STATUS=create-failed CALL_ERROR_FILE=...` and does NOT create a duplicate PR.
+
+- [ ] **WI 1.15 — Conformance assertions + `check_not` helper.** Add to `tests/test-skill-conformance.sh`:
+  - **Define `check_not` helper** (top of file, alongside existing `check`/`check_fixed` at lines 29-51):
+    ```bash
+    check_not() {
+      local skill="$1" label="$2" pattern="$3"
+      if grep -rE -e "$pattern" "$REPO_ROOT/skills/$skill/" > /dev/null 2>&1; then
+        FAILED=$((FAILED + 1)); echo "FAIL: [$skill] $label — pattern '$pattern' found but should NOT exist"
+      else
+        PASSED=$((PASSED + 1)); echo "PASS: [$skill] $label"
+      fi
+    }
+    ```
+  - Then add /land-pr assertions:
+    - `check_fixed land-pr "name frontmatter" 'name: land-pr'`
+    - `check land-pr "references all four scripts" 'pr-rebase\.sh.*pr-push-and-create\.sh.*pr-monitor\.sh.*pr-merge\.sh'`
+    - `check_fixed land-pr "result-file contract" '$RESULT_FILE'`
+    - `check_fixed land-pr "monitor uses --watch" 'gh pr checks .*--watch'` AND `check_fixed land-pr "monitor bare re-check" 'gh pr checks "\$PR" >/dev/null'`
+    - `check land-pr "PR_NUMBER from URL not gh pr view" '\$\{[A-Z_]*##\*\/\}'`
+    - `check_not land-pr "no jq binary" '^[[:space:]]*jq '`  (allows `gh ... --jq` flag use; forbids `jq` as separate process)
+    - `check_not land-pr "no || true" '\|\| true'`
+    - `check_not land-pr "no source-based result parsing" 'source[[:space:]]+.*RESULT_FILE|\.[[:space:]]+.*RESULT_FILE'`  (caller pattern in references/ — verifies the safe parser, not source)
+
+- [ ] **WI 1.16 — Mirror.** `rm -rf .claude/skills/land-pr && cp -a skills/land-pr .claude/skills/land-pr && diff -rq skills/land-pr .claude/skills/land-pr` (must produce no output).
+
+- [ ] **WI 1.17 — Update PLAN_INDEX.** Move PR_LANDING_UNIFICATION from "Ready to Run" to "In Progress" with current phase = 1.
+
+### Intra-phase smoke checkpoint (mandatory)
+
+After completing **WI 1.1–1.6 and WI 1.12** (skill + scripts + procedure prose), and BEFORE writing references / mocks / comprehensive tests / conformance assertions, run a smoke test:
+
+**Concrete recipe (use real GitHub):** Create a throwaway feature branch in this repo (e.g., `smoke/land-pr-$(date +%s)`), make a trivial commit (touch a file in `tmp/`), then invoke `/land-pr --branch smoke/land-pr-$TS --title "smoke test" --body-file /tmp/smoke-body.md --result-file /tmp/land-pr-smoke.txt --no-monitor`. The `--no-monitor` flag avoids triggering CI cost. After verification, **clean up:**
+```bash
+gh pr close "$PR_NUMBER" --delete-branch  # closes the smoke PR + deletes branch on remote
+git push dev --delete smoke/land-pr-$TS    # belt-and-suspenders
+```
+
+Verify:
+- The result file is produced with the expected schema (all required keys present, all values single-line).
+- The skill's procedure drives Claude through rebase/push/create successfully.
+- The allow-list parser in WI 1.7 reads the result file without invoking `source`.
+- No shell-injection vulnerabilities (manually stuff `$()` into a sidecar file path; confirm the parser leaves it as a literal string).
+- `gh pr edit` is NOT called by `pr-push-and-create.sh` on the smoke PR (verified by passing the same body twice — second invocation should detect existing PR and not modify body).
+
+If the smoke test fails, the script contracts or procedure prose are wrong — **fix before proceeding to WI 1.8–1.15**, do not write 1500+ lines of references/tests on top of broken foundations.
+
+### Design & Constraints
+
+- **Cross-skill dispatch via Skill tool, single-string args.** Per `skills/research-and-plan/SKILL.md:140`. Same-context recursion per `:87-105`. Therefore data hand-off is file-based (WI 1.7), not via stdout.
+- **No `jq` binary; `gh ... --jq` flag is allowed.** `jq` standalone binary is prohibited per memory `feedback_no_jq_in_skills`. `gh`'s `--jq` flag is gh's built-in formatter, not a separate process — using it does not introduce a `jq` dependency. Conformance test (WI 1.15) guards against `^[[:space:]]*jq ` pattern, not against `--jq=` flag.
+- **No `|| true`, no `2>/dev/null` on fallible ops.** Per CLAUDE.md "Never suppress errors."
+- **No `--no-verify` on commits.** Per CLAUDE.md.
+- **`scripts/write-landed.sh` is reused as-is.** Atomic write semantics verified at the script's docstring (line 19: "Writes: <worktree-path>/.landed (atomic via .tmp + mv)").
+- **Result-file values are single-line shell-safe; multi-line content goes in sidecar files.** The caller never `source`s the result file; uses an allow-list line-by-line parser (WI 1.7). This eliminates the shell-injection class.
+- **Test-output capture pattern.** All tests follow CLAUDE.md's TEST_OUT idiom — never pipe.
+- **Idempotency is a contract.** Re-invoking `/land-pr` with the same branch must be a no-op for already-done steps (rebase up-to-date is exit 0; push up-to-date is exit 0; existing PR is detected). Body updates are caller-owned, NOT done by `/land-pr`. WI 1.14 includes explicit idempotency test cases.
+- **Race condition on parallel `/land-pr` invocations is bounded by gh's "already exists" rejection.** If two callers race past `gh pr list` and both call `gh pr create`, gh enforces one open PR per head branch and the second invocation gets a non-zero exit with "already exists" stderr. The losing invocation's caller sees `STATUS=create-failed` and handles it via the canonical loop; no duplicate PRs are created. This is documented; no `flock` guard is needed.
+- **`--no-monitor` and `--pr <num>` enable two flow shapes.** `--no-monitor`: caller wants to report PR URL early and skip CI poll for this invocation. `--pr <num>`: caller resumes monitoring an existing PR. Together they let users / future callers split the create-and-monitor flow when needed. None of the 5 callers in this plan use these flags — they all monitor synchronously.
+- **All 5 callers run CI monitoring + fix-cycle.** No exceptions. /quickfix's "fire-and-forget" was drift, not design. /commit pr and /do pr's "report-only" was drift, not design. The unification corrects all three (per maintainer rationale in Overview).
+- **`/land-pr` is dispatched only at orchestrator level.** Documented contract — no runtime guard. Conformance assertions in Phase 6 verify callers' SKILL.md files contain the dispatch at orchestrator level (not inside an Agent prompt block).
+- **Hooks compatibility.** Per `hooks/block-unsafe-project.sh.template:634-640`, the `git push` rule scope is segmented to the `git push` portion of the command (the recent #58 fix). /land-pr's gh/git calls won't trip false-positives. The smoke checkpoint (intra-phase) verifies this end-to-end.
+- **PR body ownership is the caller's, not `/land-pr`'s.** /land-pr writes the body only on initial PR creation (the `--body-file` content). Subsequent body updates (e.g., /run-plan's HTML-comment-marker progress splice) are caller-owned and happen before the caller invokes /land-pr. This preserves user-added review notes.
+- **shellcheck clean.** All four scripts must pass `shellcheck` with no warnings.
+
+### Acceptance Criteria
+
+- [ ] Smoke checkpoint (intra-phase) passes — see "Intra-phase smoke checkpoint" section above.
+- [ ] `skills/land-pr/SKILL.md` exists; `grep -E '^name: land-pr$' skills/land-pr/SKILL.md` returns one line.
+- [ ] All four scripts exist and are executable.
+- [ ] `shellcheck skills/land-pr/scripts/*.sh` returns 0.
+- [ ] `tests/test-land-pr-scripts.sh` runs and passes (≥10 failure-mode test cases + idempotency, status-mapping, result-safe-parsing, race-bounded test cases).
+- [ ] `tests/test-skill-conformance.sh` runs and passes (new `check_not` helper defined; new /land-pr assertions; no existing assertion modified).
+- [ ] `bash tests/run-all.sh` passes overall.
+- [ ] Mirror byte-identical: `diff -rq skills/land-pr .claude/skills/land-pr` produces no output.
+- [ ] No skill yet calls `/land-pr` (Phases 2–5 do that). Existing skills' PR mode behavior is unchanged.
+- [ ] `plans/PLAN_INDEX.md` shows PR_LANDING_UNIFICATION in "In Progress" with Phase 1 complete.
+
+### Dependencies
+
+- None. This is the foundation phase.
+
+## Phase 2 — Migrate `/run-plan` PR mode to `/land-pr` (caller owns body splice)
+
+### Goal
+
+Replace the inline PR-landing implementation in `skills/run-plan/modes/pr.md` (currently lines 195–657, ~460 lines) with a Skill-tool dispatch to `/land-pr` plus the canonical caller fix-cycle loop. **Critical:** `/run-plan` continues to own per-phase PR body splicing (using its existing HTML-comment markers at `modes/pr.md:221-224` and SKILL.md:1190-1217), performed BEFORE invoking `/land-pr`. /land-pr does not touch the body on existing PRs.
+
+### Work Items
+
+- [ ] **WI 2.1 — Caller-owned body splice (with explicit failure recovery).** Continue building `$PR_BODY` in `/run-plan`'s prose with HTML-comment-wrapped progress section (`<!-- run-plan:progress:start --> ... <!-- run-plan:progress:end -->`). Write to `/tmp/pr-body-$PLAN_SLUG.md`.
+
+  **First-phase invocation:** No PR exists yet; the body file written must INCLUDE the markers (so subsequent phases have something to splice into). `/run-plan`'s body construction prose places `<!-- run-plan:progress:start -->\n<progress section>\n<!-- run-plan:progress:end -->` near the top of the body. /land-pr creates the PR with this body via `pr-push-and-create.sh` (no special handling needed).
+
+  **Subsequent-phase invocation (existing PR detected before the loop):**
+  1. Fetch current body: `gh pr view "$PR_NUMBER" --json body --jq '.body' > /tmp/pr-body-current.md`. On error (transient gh failure, retry once with 2s backoff; if second attempt fails, write `.landed conflict REASON=gh-pr-view-failed` and break the loop).
+  2. Validate markers are present: `grep -qF '<!-- run-plan:progress:start -->' /tmp/pr-body-current.md && grep -qF '<!-- run-plan:progress:end -->' /tmp/pr-body-current.md`. If markers are absent (user manually removed them, or GitHub stripped them somehow), the splice cannot proceed. Write `.landed conflict REASON=body-markers-missing` and break the loop with a clear error message ("Manual repair required: PR body must contain run-plan:progress markers").
+  3. Build the new progress section text in `/tmp/pr-progress-section.txt`.
+  4. Splice via the shared `splice-body.sh` utility (WI 1.5a):
+     ```bash
+     bash skills/land-pr/scripts/splice-body.sh \
+       --body-current /tmp/pr-body-current.md \
+       --progress-text /tmp/pr-progress-section.txt \
+       --start-marker '<!-- run-plan:progress:start -->' \
+       --end-marker '<!-- run-plan:progress:end -->' \
+       --out "$BODY_FILE"
+     ```
+     On exit 40 (markers missing — should not happen since step 2 validated, but defensive): write `.landed conflict REASON=splice-marker-mismatch` and break.
+     On exit 41 (write failure): write `.landed conflict REASON=splice-write-failed` and break.
+  5. Update the PR body: `gh pr edit "$PR_NUMBER" --body-file "$BODY_FILE"`. On error: retry once with 2s backoff. On second failure: write `.landed conflict REASON=gh-pr-edit-failed` and break.
+
+  All five recovery paths (`gh-pr-view-failed`, `body-markers-missing`, `splice-marker-mismatch`, `splice-write-failed`, `gh-pr-edit-failed`) write the canonical-schema `.landed` and break out of the fix-cycle loop without invoking `/land-pr`. The user reviews the marker file and decides next steps (manual repair, restore markers, etc.).
+
+  `/land-pr`'s `pr-push-and-create.sh` does NOT touch the body when an existing PR is detected (per WI 1.4) — preserving user-added review notes between the markers.
+
+- [ ] **WI 2.2 — Replace inline PR-landing block with caller loop.** Edit `skills/run-plan/modes/pr.md`. Delete the inline rebase + push + create + CI poll + fix cycle + auto-merge + .landed block (current lines 195–657). Replace with the canonical caller-loop pattern from `skills/land-pr/references/caller-loop-pattern.md`. Customize:
+  - `$LANDED_SOURCE=run-plan`
+  - `$WORKTREE_PATH=` the per-phase worktree
+  - `$AUTO=$AUTO_FROM_RUNPLAN_INVOCATION`
+  - `<CALLER_PRE_INVOKE_BODY_PREP>` block: WI 2.1's body-splice logic
+  - `<CALLER_REBASE_CONFLICT_HANDLER>` block: WI 2.3's logic
+  - `<DISPATCH_FIX_CYCLE_AGENT_HERE>` block: WI 2.4's logic
+
+- [ ] **WI 2.3 — Preserve agent-assisted rebase conflict resolution.** When `/land-pr` returns `STATUS=rebase-conflict` and the conflict-files list (read from `${LP[CONFLICT_FILES_LIST]}`) has count ≤ 5, dispatch the existing `/run-plan` rebase-resolution agent (orchestrator-level, not nested) in the worktree. The agent runs `git rebase origin/main` itself to reproduce the conflict state (`pr-rebase.sh` aborted it leaving a clean tree), resolves the conflicts, and signals success. Then `continue` the loop to re-invoke `/land-pr` (its rebase will be no-op since the conflict is resolved). On > 5 files or agent failure: write `.landed conflict` marker per current behavior (using the canonical schema from WI 1.11) and `break` the loop.
+
+- [ ] **WI 2.4 — Preserve fix-cycle agent dispatch with plan context.** Use `skills/land-pr/references/fix-cycle-agent-prompt-template.md` as the structural starting point. Caller-specific bits: plan title, current phase, phase work items, the `${LP[CI_LOG_FILE]}` from `/land-pr`'s output, the worktree path. The existing fix-cycle agent prompt prose in `/run-plan/modes/pr.md` lines 472–505 transfers into the template's `<CALLER_WORK_CONTEXT>` slot.
+
+- [ ] **WI 2.5 — Preserve finish-mode loop and frontmatter writes.** `/run-plan` schedules the next phase via one-shot cron after a phase lands. This continues unchanged. The frontmatter status update (in the plan file, before push so it's captured in the squash) also continues unchanged — both happen in `/run-plan`'s prose, before invoking `/land-pr`.
+
+- [ ] **WI 2.6 — `.landed` ownership split + downstream consumer verification.** `/land-pr` writes `.landed` for push-failed/CI-failing/landed states. `/run-plan` writes `.landed` only for the pre-`/land-pr` "rebase-conflict-too-many-files" case. Both writers use the canonical schema from WI 1.11. **Verification:** in WI 2.9's manual canary, run `/fix-report` on the resulting `.landed` AND check that `scripts/land-phase.sh` cleans up the worktree correctly. Add a unit test (extend `tests/test-skill-conformance.sh` or a new `tests/test-landed-schema.sh`) asserting both `/fix-report` and `scripts/land-phase.sh` parse a canonical-schema `.landed` without error.
+
+- [ ] **WI 2.7 — Update conformance tests.** In `tests/test-skill-conformance.sh`:
+  - Existing /run-plan PR-mode assertions targeting inline code (the 87af82a re-check, 175e4aa hardenings, b904cef gating) MOVE to /land-pr's conformance section (added in WI 1.15).
+  - Add new assertions: `check_fixed run-plan "modes/pr.md dispatches /land-pr" 'land-pr'`; `check_not run-plan "no inline gh pr create" 'gh pr create'`; `check_not run-plan "no inline gh pr checks" 'gh pr checks'`; `check_not run-plan "no inline gh pr merge" 'gh pr merge'`. (Uses the `check_not` helper from WI 1.15.)
+
+- [ ] **WI 2.8 — Mirror.** `rm -rf .claude/skills/run-plan && cp -a skills/run-plan .claude/skills/run-plan && diff -rq skills/run-plan .claude/skills/run-plan`.
+
+- [ ] **WI 2.9 — Manual canary verification.** Run `/run-plan plans/CANARY1_HAPPY.md` end-to-end. Confirm: PR is created, body has progress section, CI poll runs, `.landed` written correctly, `/fix-report` reads it correctly, on success the worktree is cleaned up. Run `/run-plan plans/CANARY3_FIXCYCLE.md` (which intentionally breaks CI) — confirm fix-cycle dispatches, recovers, and lands. Spot check: between phases, manually edit the PR body to add a "review note" outside the HTML-comment markers; confirm the next phase preserves it.
+
+### Design & Constraints
+
+- **No behavior change for `/run-plan` users.** PR titles, bodies, finish-mode loop, frontmatter updates — all identical to today. Only the implementation underneath changes.
+- **The fix-cycle loop is real-sized.** ~80–120 lines once you account for arg construction, result-file parsing, status case dispatch, and fix-cycle agent prompt with plan context. WI 1.8's complete reference implementation is the verbatim base; /run-plan's customization is the agent-prompt block plus the body-splice block (most of the line count).
+- **Per-phase PR body update is `/run-plan`'s job, not `/land-pr`'s.** This preserves the existing splice pattern (HTML-comment markers, sed-based replacement) and prevents body wholesale replacement that would destroy user-added review notes.
+
+### Acceptance Criteria
+
+- [ ] `skills/run-plan/modes/pr.md` no longer contains `gh pr create`, `gh pr checks --watch`, or `gh pr merge --auto --squash` inline. Verified via `grep -F`.
+- [ ] `skills/run-plan/modes/pr.md` invokes `/land-pr` via Skill tool. Verified via grep for `land-pr`.
+- [ ] `/run-plan` performs HTML-comment-marker body splice BEFORE invoking `/land-pr` on existing-PR phases. Verified via grep for `run-plan:progress:start` and `gh pr edit --body-file`.
+- [ ] All conformance assertions pass.
+- [ ] `bash tests/run-all.sh` passes.
+- [ ] CANARY1_HAPPY runs end-to-end successfully; user-added review notes preserved across phases.
+- [ ] CANARY3_FIXCYCLE triggers fix-cycle and recovers (or settles at `pr-ci-failing`).
+- [ ] `/fix-report` and `scripts/land-phase.sh` parse canonical-schema `.landed` without error (per WI 2.6).
+- [ ] Mirror byte-identical.
+
+### Dependencies
+
+- Phase 1 must be complete (status: complete; `/land-pr` skill installed and tested).
+
+## Phase 3 — Migrate `/commit pr` and `/do pr` to `/land-pr` (drift fix: gain fix-cycle)
+
+(Same as Round-1 plan — combined commit + do migration. Pasted unchanged below for completeness.)
+
+### Goal
+
+Replace the inline implementation in `skills/commit/modes/pr.md` AND `skills/do/modes/pr.md` (and the duplicate `gh pr create` site in `skills/do/SKILL.md`) with `/land-pr` dispatches. Both gain CI monitoring + fix-cycle (currently absent — drift fix). `/do pr` additionally harmonizes its `.landed` schema. Auto-merge stays OFF for both.
+
+### Work Items
+
+- [ ] **WI 3.1 — /commit pr migration.** Edit `skills/commit/modes/pr.md`. Delete current lines 28–84 (rebase + push + create + report-only-CI). Replace with canonical caller-loop pattern. `$LANDED_SOURCE=commit`, no `--worktree-path` (no worktree), no `--auto`. `<CALLER_PRE_INVOKE_BODY_PREP>` block: empty (commit's body is fixed at PR creation, no per-phase update). `<DISPATCH_FIX_CYCLE_AGENT_HERE>` block: agent context = staged files + recent commit subjects.
+
+- [ ] **WI 3.2 — /commit pr preconditions preserved.** Clean-tree precondition (current lines 9–17) and main-branch guard (lines 19–26) run BEFORE `/land-pr` is dispatched.
+
+- [ ] **WI 3.3 — /commit pr title/body construction.** Title from branch name as today. Body from recent commits as today. Write body to `/tmp/pr-body-commit-$BRANCH_SLUG.md`.
+
+- [ ] **WI 3.4 — /commit pr conformance.** Inline `gh pr create` and `gh pr checks --watch` GONE. `/land-pr` dispatched.
+
+- [ ] **WI 3.5 — /commit mirror + manual.** Mirror commit; verify on a feature branch with passing CI; verify with intentionally-failing CI (fix-cycle dispatches).
+
+- [ ] **WI 3.6 — /do pr migration.** Edit `skills/do/modes/pr.md`. Delete current lines 124–218. Replace with caller-loop pattern. `$LANDED_SOURCE=do`, `$WORKTREE_PATH=$WORKTREE_PATH`, no `--auto`. `<CALLER_PRE_INVOKE_BODY_PREP>` block: empty (do's body is fixed at PR creation). `<DISPATCH_FIX_CYCLE_AGENT_HERE>` block: agent context = task description.
+
+- [ ] **WI 3.7 — Remove duplicate `gh pr create` from `skills/do/SKILL.md`.** Single source of truth: `modes/pr.md`. Conformance test asserts `gh pr create` does not appear in `skills/do/SKILL.md`.
+
+- [ ] **WI 3.8 — /do pr `.landed` schema harmonization.** /land-pr writes the canonical-schema marker (WI 1.11). Verify `/fix-report` and cleanup tooling handle the new fields gracefully (additive change — they read fewer fields than the marker has).
+
+- [ ] **WI 3.9 — /do conformance.** Inline `gh pr create` and `gh pr checks --watch` GONE from BOTH `SKILL.md` and `modes/pr.md`. `/land-pr` dispatched.
+
+- [ ] **WI 3.10 — /do mirror + manual.** Mirror do; verify `/do pr "small task"` end-to-end with passing and failing CI.
+
+### Design & Constraints
+
+- **Auto-merge stays OFF for both.**
+- **`/commit pr`: no worktree, no `.landed`.**
+- **`/do pr`: with worktree, full canonical `.landed`.**
+- **Drift fix: both gain CI monitoring + fix-cycle.**
+
+### Acceptance Criteria
+
+- [ ] Both `modes/pr.md` files no longer contain `gh pr create`, `gh pr checks --watch`. `/land-pr` dispatched in both.
+- [ ] `skills/do/SKILL.md` no longer contains `gh pr create`.
+- [ ] `.landed` markers from /do pr contain canonical schema fields.
+- [ ] `bash tests/run-all.sh` passes.
+- [ ] Mirrors byte-identical for both.
+- [ ] Manual verification passes for /commit pr and /do pr.
+
+### Dependencies
+
+- Phase 1 must be complete.
+
+## Phase 4 — Migrate `/fix-issues pr` to `/land-pr` (drop 300s timeout special case)
+
+(Same as Round-1 plan. Pasted unchanged below.)
+
+### Goal
+
+Replace the inline implementation in `skills/fix-issues/modes/pr.md` with a per-issue `/land-pr` dispatch. Drop the 300s-per-issue CI timeout special case — all callers use 600s default per maintainer direction.
+
+### Work Items
+
+- [ ] **WI 4.1 — Replace per-issue inline impl.** In `skills/fix-issues/modes/pr.md`, the "for each issue" loop body (current lines 17–148) replaces the inline implementation with the canonical caller-loop pattern dispatching `/land-pr` per issue. `$LANDED_SOURCE=fix-issues`, `$WORKTREE_PATH=$ISSUE_WORKTREE`, `$AUTO=$AUTO`, `$ISSUE_NUM=$ISSUE_NUM`. `<CALLER_PRE_INVOKE_BODY_PREP>` block: empty (per-issue body is fixed). `<DISPATCH_FIX_CYCLE_AGENT_HERE>` block: agent context = issue body + change summary.
+
+- [ ] **WI 4.2 — Drop 300s timeout flag.** The current `--ci-timeout 300` (line 126) is REMOVED. /land-pr's default of 600s applies.
+
+- [ ] **WI 4.3 — Preserve agent-assisted rebase conflict resolution.** Per current behavior. Same pattern as Phase 2 WI 2.3.
+
+- [ ] **WI 4.4 — Preserve sprint report generation.** Phase 5 of /fix-issues overall (sprint report) runs before any /land-pr dispatch and is unchanged.
+
+- [ ] **WI 4.5 — `--issue` field passes through.** /land-pr's `--issue $ISSUE_NUM` flag (per WI 1.2) populates the `.landed` marker's `issue` field.
+
+- [ ] **WI 4.6 — Conformance.** Inline `gh pr create`, `gh pr checks --watch`, `gh pr merge --auto --squash` GONE from `modes/pr.md`. The 7 conformance assertions added by PR #75 (b904cef): those targeting the gating contract MOVE to /land-pr's conformance section in Phase 1; those targeting /fix-issues-specific behavior stay.
+
+- [ ] **WI 4.7 — Mirror.**
+
+- [ ] **WI 4.8 — Manual canary verification.** Run `/fix-issues plan` then `/fix-issues 1` (auto and interactive). Confirm per-issue PR creation, CI poll, fix-cycle, `.landed` markers with `issue=N` field.
+
+### Design & Constraints
+
+- **Drop 300s special case** per maintainer direction: same CI pipeline → same timeout. Cumulative wall-clock for sequential N issues is solved by parallelism (`--auto`).
+- **Per-issue /land-pr dispatch.**
+- **PR title hardcoded template stays.** `Fix #N: ISSUE_TITLE` is /fix-issues-specific.
+
+### Acceptance Criteria
+
+- [ ] `skills/fix-issues/modes/pr.md` no longer contains `gh pr create`, `gh pr checks --watch`, or `gh pr merge`.
+- [ ] `--ci-timeout 300` GONE; default 600s applies.
+- [ ] `/land-pr` dispatched per-issue.
+- [ ] `.landed` markers include `issue=N` field.
+- [ ] Test suite passes; sprint report generation unchanged.
+- [ ] Mirror byte-identical.
+- [ ] Manual verification passes for both auto and interactive modes.
+
+### Dependencies
+
+- Phase 1 must be complete.
+
+## Phase 5 — Migrate `/quickfix` to `/land-pr` (drift fix: gain CI monitoring + fix-cycle)
+
+(Same as Round-1 plan. Pasted unchanged below.)
+
+### Goal
+
+Replace the fire-and-forget PR-creation block in `skills/quickfix/SKILL.md` (currently lines ~693–748) with a `/land-pr` dispatch. Drift fix: /quickfix gains CI monitoring + fix-cycle.
+
+### Work Items
+
+- [ ] **WI 5.1 — Replace inline PR creation.** Edit `skills/quickfix/SKILL.md` Phase 7. Delete inline `gh pr create` and immediate exit. Replace with canonical caller-loop pattern. `$LANDED_SOURCE=quickfix`, no `--worktree-path` (no worktree), no `--auto` by default. `<CALLER_PRE_INVOKE_BODY_PREP>` block: empty. `<DISPATCH_FIX_CYCLE_AGENT_HERE>` block: agent context = user's `$DESCRIPTION` and the staged commit subject.
+
+- [ ] **WI 5.2 — Preserve pre-PR work.** /quickfix's mode detection, dirty-tree confirmation, slug derivation, branch creation, agent dispatch (or user-edit confirmation), test gate, commit — all run BEFORE /land-pr is dispatched. Unchanged.
+
+- [ ] **WI 5.3 — Preserve parallel-invocation gate.** Lines 185–209 (stale-marker detection) stay.
+
+- [ ] **WI 5.4 — Preserve fulfillment-marker model.** /quickfix continues writing the fulfillment marker (with PR URL appended) and does NOT pass `--worktree-path` to /land-pr — so no `.landed` is written. Two artifact systems coexist intentionally: fulfillment-marker tracks /quickfix lifecycle; `.landed` is for worktree-using callers.
+
+- [ ] **WI 5.5 — Update prose.** Remove "fire-and-forget" language. Replace with description of canonical CI monitoring + fix-cycle behavior.
+
+- [ ] **WI 5.6 — /quickfix conformance.** Inline `gh pr create` GONE. `/land-pr` dispatched. CI monitoring + fix-cycle now present.
+
+- [ ] **WI 5.7 — Mirror.**
+
+- [ ] **WI 5.8 — Manual verification.** Run `/quickfix "test small fix"` (agent-dispatched mode) and `/quickfix --yes` on a dirty tree (user-edited mode). Confirm PR creation, CI poll, fix-cycle if CI fails.
+
+### Design & Constraints
+
+- **Drift fix is the headline change.** Per maintainer rationale.
+- **No worktree, no `.landed`.**
+- **Auto-merge stays OFF.**
+- **Pre-PR work unchanged.**
+
+### Acceptance Criteria
+
+- [ ] `skills/quickfix/SKILL.md` no longer contains `gh pr create` inline.
+- [ ] `/land-pr` is dispatched.
+- [ ] CI monitoring + fix-cycle now present.
+- [ ] Fulfillment-marker still written (no regression).
+- [ ] `bash tests/run-all.sh` passes.
+- [ ] Mirror byte-identical.
+- [ ] Manual verification passes for both modes.
+- [ ] "Fire-and-forget" language removed.
+
+### Dependencies
+
+- Phase 1 must be complete.
+
+## Phase 6 — Drift-prevention conformance + canary
+
+(Same as Round-1 plan with one addition for orchestrator-level dispatch verification.)
+
+### Goal
+
+Lock in the unification with conformance tripwires and a canary that exercises the unified flow end-to-end. Catch future drift before it ships.
+
+### Work Items
+
+- [ ] **WI 6.1 — Cross-skill conformance tripwires.** Add to `tests/test-skill-conformance.sh`:
+  - **No `gh pr create` outside `skills/land-pr/`.** Shell assertion: `grep -rln 'gh pr create' "$REPO_ROOT/skills/" | grep -v 'skills/land-pr/' | wc -l` must be 0. Same for `.claude/skills/`.
+  - **No `gh pr checks --watch` outside `skills/land-pr/`.** Same shape.
+  - **No `gh pr merge` outside `skills/land-pr/`.** Same shape.
+  - **All 5 callers dispatch `/land-pr`.** For each of the 5 caller files, assert `land-pr` appears.
+  - **Orchestrator-level dispatch verification.** For each caller's modes/pr.md (or SKILL.md for /quickfix): assert the `/land-pr` Skill-tool invocation appears at top-level prose, NOT inside an Agent prompt block. Heuristic: scan for the dispatch line; verify the surrounding 30 lines do NOT contain `^[[:space:]]*(Agent:|prompt:)|dispatch.*agent` patterns (anchored to start-of-line to avoid matching prose discussion of agents). Documented limitation: a prose paragraph that happens to start a line with "Agent:" still false-fails — implementer can adjust pattern further if needed.
+
+- [ ] **WI 6.2 — `/land-pr` canary.** Create `plans/CANARY_LAND_PR.md`. Run a small `/run-plan` cycle through `/land-pr` end-to-end with deliberately-failing CI on attempt 1 (forcing fix-cycle), passing on attempt 2.
+
+- [ ] **WI 6.3 — Drift-prevention rationale.** Document WHY the assertions exist in `tests/test-skill-conformance.sh` (drift bugs 87af82a, 1de3049, 175e4aa, b904cef).
+
+- [ ] **WI 6.4 — Update PLAN_INDEX.** Move PR_LANDING_UNIFICATION to "Complete".
+
+- [ ] **WI 6.5 — Update CHANGELOG.**
+
+- [ ] **WI 6.6 — Update run-order guide.**
+
+- [ ] **WI 6.7 — Final verification.** `bash tests/run-all.sh` passes; cross-skill grep guards produce expected output; canary runs successfully.
+
+### Acceptance Criteria
+
+- [ ] `grep -rln 'gh pr create' skills/` lists only land-pr files.
+- [ ] `grep -rln 'gh pr checks --watch' skills/` lists only `pr-monitor.sh`.
+- [ ] `grep -rln 'gh pr merge' skills/` lists only `pr-merge.sh`.
+- [ ] Orchestrator-level dispatch heuristic passes for all 5 callers.
+- [ ] Canary CANARY_LAND_PR runs end-to-end successfully.
+- [ ] PLAN_INDEX shows Complete.
+- [ ] CHANGELOG documents change.
+- [ ] `bash tests/run-all.sh` passes.
+
+### Dependencies
+
+- Phases 1–5 must all be complete.
+
+---
+
+## Round 1 Disposition
+
+(Refiner output of Round 1 review — verify-before-fix applied to each finding.)
+
+| Finding | Source | Evidence | Disposition |
+|---|---|---|---|
+| R1: Skill-tool dispatch idiom mismatch | Reviewer | Verified: `/research-and-plan/SKILL.md:140` shows `/draft-plan output <path> <description>` (positional/keyword string), and `/quickfix`/`/do` parse `--branch=` etc. via bash regex internally. | **Fixed.** WI 1.2 explicitly specifies bash-regex flag parsing; Design & Constraints documents the single-string-args dispatch model. |
+| R2: `gh pr list` text-parsing unspecified | Reviewer | Verified: plan v1 said "bash regex parse" without showing it. | **Fixed.** WI 1.4 contains the full bash regex pattern. |
+| R3: Rebase idempotency unverified | Reviewer | Verification: judgment — git rebase to base is idempotent per git docs. | **Fixed.** WI 1.3 cites idempotency; WI 1.14 adds explicit test. |
+| R4 / DA3: PR body update sub-decision unresolved | Reviewer + DA | Verified: plan v1 left choice flagged. | **Fixed in Round 1, re-fixed in Round 2.** Round-1 added gh pr edit to pr-push-and-create.sh; Round-2 reversed this (DA Finding 3 R2): caller owns body splice. See Round 2 disposition. |
+| R5: Test mock infra unspecified | Reviewer | Verified: `tests/` has no mock-gh. | **Fixed in Round 1, expanded in Round 2.** WI 1.13 specifies mocks; Round 2 added reference implementation. |
+| R6: /quickfix .landed exemption + Phase 6 conformance | Reviewer | Judgment. | **Fixed.** |
+| R7: Phase count borderline | Reviewer | Judgment. | **Fixed.** Phases 3+4 merged to single Phase 3; plan now has 6 phases. |
+| R8: No rollback strategy | Reviewer | Judgment. | **Fixed.** Overview includes Rollback paragraph. |
+| DA1: Skill-tool stdout return mechanism | DA | Verified: `/research-and-plan/SKILL.md:87-105` describes Skill tool as same-context recursion. | **Fixed in Round 1, hardened in Round 2.** Round-1 introduced file-based result contract; Round-2 made the parser safe (allow-list, no `source`). |
+| DA2: Caller loop bigger than "small" | DA | Verified: existing fix-cycle is ~80+ lines. | **Fixed.** WI 1.8 provides complete production-ready bash. |
+| DA4: Hooks interaction untested | DA | Verified: hooks scope to `git push` segment per #58 fix. | **Justified.** Hook interactions documented; intra-phase smoke checkpoint (Round 2) verifies. |
+| DA5: .landed schema split unsafe | DA | Verified: plan v1 had no canonical schema. | **Fixed.** WI 1.11 establishes schema; both writers conform. |
+| DA6: Phase 5 dropping 300s timeout | DA | Verified: current line 126 uses 300s. | **Justified — maintainer direction.** Same CI pipeline → same timeout. |
+| DA7: Subagent nesting unaddressed | DA | Verified: user prompt acknowledged constraint. | **Fixed.** Documented as orchestrator-level contract; conformance heuristic in WI 6.1. |
+| DA8: Monitor timeout re-invoke ambiguous | DA | Judgment. | **Fixed.** `--pr <num>` resume mode added. |
+| DA9: Phase 1 scope too broad | DA | Judgment — 17 WIs. | **Justified in Round 1, mitigated in Round 2.** Intra-phase smoke checkpoint added. |
+| DA10: /quickfix UX change weakly justified | DA | Judgment. | **Justified — maintainer direction.** |
+
+**Round 1 substantive issues:** 12 fixed, 4 justified. 0 ignored.
+
+## Round 2 Disposition
+
+(Refiner output of Round 2 review — verify-before-fix applied to each finding.)
+
+| Finding | Source | Evidence | Disposition |
+|---|---|---|---|
+| R2-1 / DA2-1: Shell-sourcing safety / shell injection via sourced result file | Reviewer + DA | Verified: sourcing `RESULT_FILE` with `. "$RESULT_FILE"` executes `$()` substitutions; CALL_ERROR with stderr text from gh is attacker-controllable. | **Fixed.** WI 1.7 redesigned: result file uses single-line shell-safe values only; multi-line content goes in sidecar files (`*_FILE` paths). Caller uses allow-list line-by-line parser, never `source`. WI 1.14 adds explicit malicious-CALL_ERROR test case. WI 1.15 adds `check_not` for `source`-based parsing. |
+| R2-2: Missing status mapping table in WI 1.12 | Reviewer | Verified: plan v2 referenced "mapping table embedded in SKILL.md" without showing it. | **Fixed.** WI 1.12 step 8 now contains the full status mapping table (10 rows covering all combinations of MERGE_REQUESTED, PR_STATE, CI_STATUS, plus the failure-exit pre-conditions). |
+| R2-3 / DA2-6: grep-NOT helper missing | Reviewer + DA | Verified: `tests/test-skill-conformance.sh:29-51` has only `check`/`check_fixed`; no negation helper exists. | **Fixed.** WI 1.15 now contains the full `check_not` helper definition. |
+| R2-4: --no-monitor use case undefined | Reviewer | Verified: plan v2 had the flag but no example use. | **Fixed.** WI 1.12 step 5 documents the use case; Design & Constraints notes none of the 5 callers use it (it's for direct user invocation and future callers). |
+| R2-5: reason field schema split | Reviewer | Verified: result-file schema (WI 1.7) lacked `REASON`. | **Fixed.** Result-file schema now includes `REASON=<token>`. |
+| R2-6: Plan size sanity | Reviewer | Verified: plan was ~617 lines; Round 2 grew it further. | **Justified.** Plan size reflects scope (4 scripts + 5 caller migrations + canonical contracts); `/quickfix/SKILL.md` (365 lines) and prior plans of this scope (DRIFT_ARCH_FIX 532 lines) confirm this is in range. Intra-phase smoke checkpoint (R2 add) catches scope creep early. |
+| DA2-2: Mock infrastructure stateful router | DA | Verified: plan v2 said "env-var-driven canned responses" without showing the dispatch logic. | **Fixed.** WI 1.13 now provides ~30-line reference implementation of `mock-gh.sh` with stateful per-call responses via state directory + per-subcommand counter files. |
+| DA2-3 / DA2-9: gh pr edit overwrites user PR-body edits | DA | Verified: `/run-plan/modes/pr.md:221-224` has `<!-- run-plan:progress:start -->` marker; `/run-plan/SKILL.md:1216-1217` shows sed-based splice. Wholesale replacement via `gh pr edit --body-file` would destroy user-added review notes between markers. | **Fixed.** WI 1.4 now explicitly says pr-push-and-create.sh does NOT call `gh pr edit` on existing PRs. Body management is caller-owned. WI 2.1 documents /run-plan handles its own splice using existing markers BEFORE invoking /land-pr. WI 2.9 adds explicit "user-added review note preservation" check. |
+| DA2-4: Race condition on parallel /land-pr | DA | Verified: gh pr create rejects duplicate PRs from same head branch (gh's own check). | **Justified.** Race is bounded — losing invocation gets `STATUS=create-failed`, no duplicate PRs. Documented in Design & Constraints. No `flock` guard added (overkill for the bounded case). |
+| DA2-5: Dispatch rule unenforceable | DA | Judgment — no runtime guard. | **Justified.** Documented as orchestrator-level contract in WI 1.1 description and Overview. WI 6.1 adds best-effort heuristic conformance check. Full enforcement requires runtime hooks (out of scope). |
+| DA2-7: .landed schema downstream consumers | DA | Verified: plan v2 said "/fix-report ... handles canonical schema gracefully" without verification. | **Fixed.** WI 2.6 now adds explicit verification step: run /fix-report and scripts/land-phase.sh against a canonical-schema .landed in WI 2.9's manual canary; add unit-test assertion. |
+| DA2-8: Phase 1 scope is 3x baseline | DA | Verified: Phase 1 estimated ~1500 lines new code. | **Mitigated.** Intra-phase smoke checkpoint (after WI 1.6 + 1.12, before WI 1.8+) catches foundational issues before piling on references and tests. Splitting into 1A/1B was considered but adds phase-ordering overhead with no real validation gain (no caller uses /land-pr in either sub-phase). |
+| DA2-10: Atomic write verification | DA | Verified: `scripts/write-landed.sh` docstring (line 19) says "atomic via .tmp + mv". | **Justified.** Citation added to Design & Constraints; behavior already correct in the reused script. |
+
+**Round 2 substantive issues:** 9 fixed, 4 justified. 0 ignored.
+
+## Round 3 Disposition
+
+(Refiner output of Round 3 review — verify-before-fix applied to each finding.)
+
+| Finding | Source | Evidence | Disposition |
+|---|---|---|---|
+| R3-1 / DA3-3: Status mapping table precedence ambiguous | Reviewer + DA | Verified: WI 1.12 v2 had 10 rows but no first-match-wins semantic; rows could collide for ambiguous CI_STATUS=fail + MERGE_REQUESTED=true. | **Fixed.** WI 1.12 step 8 now explicitly states "first-match-wins" and reorders rows so failure-exits and CI=fail/pending precede CI=pass scenarios. |
+| R3-2 / DA3-7: WI 2.1 splice failure recovery unspecified | Reviewer + DA | Verified: plan v2's WI 2.1 had one-sentence splice description; no error handling for sed/awk failure, missing markers, transient `gh pr edit` errors. | **Fixed.** WI 2.1 now has 5 explicit recovery paths (gh-pr-view-failed, body-markers-missing, splice-marker-mismatch, splice-write-failed, gh-pr-edit-failed); each writes canonical-schema `.landed` and breaks the loop. First-phase invocation explicitly initializes markers in the body so subsequent splices have anchors. |
+| DA3-1: Caller-owned body splice creates drift hazard | DA | Judgment — only /run-plan needs splice today, but future callers might re-implement. | **Fixed.** New WI 1.5a creates `splice-body.sh` shared utility in `skills/land-pr/scripts/`. /run-plan calls it (WI 2.1 step 4) instead of inline sed. Future callers can reuse — single tested implementation, drift-prevented. |
+| DA3-2: Parser arbitrary VALUE characters / bash compat | DA | Verified: `read -r KEY VALUE` with `IFS='='` correctly splits on first `=` only (URL with `?ref=main&sort=asc` parses correctly — confirmed via shell test). But embedded newlines DO break the parser. `declare -A` is bash-only. | **Partially fixed.** WI 1.7 now adds writer-side validation (`validate_result_value` rejects values containing newlines, `$`, backticks, `&`, `?`, `#`). The bash-only constraint is documented as design choice (zskills targets bash; not portable to dash/zsh — same as existing skills). |
+| DA3-4: Mock-gh missing canned response = silent exit 0 (false confidence) | DA | Verified: mock impl in plan v2 returned exit 0 silently on missing files. | **Fixed.** WI 1.13's mock-gh.sh fallback now exits 127 with stderr error when no canned response is prepared. Tests fail fast on coverage gaps instead of silently passing. |
+| R3-3: Sidecar file cleanup pattern undefined | Reviewer | Verified: WI 1.7/1.8 v2 showed result-file `rm -f` but not sidecar cleanup. | **Fixed.** WI 1.8 caller-loop now captures sidecar paths into `_CLEANUP_PATHS` before removing result file, then cleans up sidecars after final loop iteration (preserves CI_LOG_FILE for caller use). |
+| R3-4: Orchestrator-level dispatch heuristic brittle | Reviewer | Judgment — pattern `Agent:` matches prose. | **Fixed.** WI 6.1 heuristic now anchored to start-of-line (`^[[:space:]]*(Agent:|prompt:)`) so prose discussion doesn't match. Documented residual limitation. |
+| R3-5: Mock-gh counter files unguarded for concurrent forks | Reviewer | Verified: counter file write is unlocked. | **Fixed.** WI 1.13 now contains a "Concurrency note" specifying tests must invoke mocked commands sequentially; parallel calls use real gh against fixture repo. |
+| R3-6: check_not regex/fixed-string semantics undocumented | Reviewer | Verified: WI 1.15 v2 used `check_not` with both styles without documenting. | **Justified — minor doc nit.** The `check_not` definition uses `grep -rE -e` (extended regex); fixed strings work as-is when they contain no metacharacters. Adding a doc note in the helper definition is in scope of the implementer's discretion at WI 1.15. |
+| DA3-5: Smoke checkpoint uses real GitHub, undocumented infra | DA | Verified: plan v2 deferred the choice to implementer. | **Fixed.** Smoke checkpoint section now picks "real GitHub with cleanup" explicitly: throwaway branch + `--no-monitor` to skip CI cost + `gh pr close --delete-branch` for cleanup. Concrete recipe in plan. |
+| DA3-6: Phase 1 WI count exceeds bound | DA | Judgment — 17 WIs (now 18 with WI 1.5a). | **Justified.** Round 1 DA9 and Round 2 R2-6 already justified this; intra-phase smoke checkpoint is the mitigation. Splitting into 1A/1B was considered and rejected — no caller validates /land-pr in either sub-phase, so no validation gain from the split. Phase 1's 18 WIs add ~1700 lines of new code; this is at the high end of typical phase scope but still implementable in one focused session. |
+| DA3-8: Rollback claim glosses cascading | DA | Judgment. | **Justified.** Rollback design accommodates cascading: Phase 1 alone is reversible (no caller depends); Phases 2–5 each independently revertible (each PR migrates one caller); Phase 6 conformance assertions catch any incomplete revert (grep tripwires fail if a caller's inline impl is restored without removing the conformance assertion). The "we were wrong about /quickfix" scenario from DA is explicitly out of plan scope — re-evaluating maintainer direction would be a new epic. |
+| DA3-9: 11-flag parser untested | DA | Judgment — plan lists flags but doesn't show parser regex. | **Justified.** /quickfix and /do already have well-tested 8-flag and 6-flag bash regex parsers; /land-pr's parser follows the same pattern. WI 1.14 includes parser-level test cases (validation rejection of `--branch=main`, valid path with `=` in `--body-file`, missing `--pr` value, etc.). The implementer follows the established idiom; pseudocode in WI 1.2 is sufficient. |
+| DA3-10: Direct user invocation undertested | DA | Judgment — most tests target Skill-tool dispatch. | **Justified — defer to test author discretion.** WI 1.14 includes a "user invokes /land-pr directly with --no-monitor" test case (added during smoke checkpoint refinement). Explicit `--help` handling and missing-required-arg messages are an ergonomic polish appropriate for a follow-up improvement, not a P1 blocker. |
+
+**Round 3 substantive issues:** 8 fixed, 6 justified. 0 ignored.
+
+**Convergence check (orchestrator's call):** Round 3 introduced 14 findings; the refinement addressed all of them. Of the 5 MAJOR findings, all 5 are FIXED (precedence, splice failure, drift hazard, parser validation, mock fallback). Of the 9 MINOR findings, 3 are FIXED (cleanup, heuristic, concurrent forks) and 6 are JUSTIFIED (helper doc, smoke infra fix, phase scope, rollback, parser idiom, user-invocation tests). Substantive issues remaining: **0**.
+
+## Plan Quality
+
+**Drafting process:** `/draft-plan` with 3 rounds of adversarial review.
+**Convergence:** Converged at Round 3 (0 substantive issues remaining).
+**Remaining concerns:** None. All dispositioned findings are either fixed or explicitly justified.
+
+### Round History
+
+| Round | Reviewer | DA | Total findings | Fixed | Justified | Ignored |
+|-------|---------:|---:|---------------:|------:|----------:|--------:|
+| 1     | 8        | 10 | 18             | 12    | 4         | 0       |
+| 2     | 6        | 10 | 16             | 12    | 4         | 0       |
+| 3     | 6        | 10 | 14             | 8     | 6         | 0       |
+| **Cumulative** | **20** | **30** | **48** | **32** | **14** | **0** |
+
+### Load-bearing architectural decisions (read these before considering future changes)
+
+1. **File-based result contract with allow-list parser** (WI 1.7) — `/land-pr` writes single-line shell-safe `KEY=VALUE` lines plus sidecar files for multi-line content. Caller parses via line-by-line allow-list; never `source`s the file. Eliminates the shell-injection class.
+2. **Caller-owned body splice via shared `splice-body.sh` utility** (WI 1.5a + WI 2.1) — `/land-pr`'s `pr-push-and-create.sh` does NOT touch PR body on existing PRs. /run-plan splices its own progress section using a shared utility script. Future callers re-use the utility — single tested implementation, drift-prevented.
+3. **Status mapping table is first-match-wins** (WI 1.12 step 8) — failure-exits and CI-failure rows precede CI-pass rows so the "merge requested but CI failed" combo is reported as `pr-ci-failing`, not `landed`.
+4. **Mock-gh fail-fast on missing canned response** (WI 1.13) — exit 127 with stderr error instead of silent exit 0. Eliminates false test confidence.
+5. **Subagent boundary contract** (Overview + WI 1.1 description) — `/land-pr` and the caller's fix-cycle agent dispatch are orchestrator-level only; never inside an Agent-dispatched subagent. Documented contract; no runtime guard. Conformance heuristic in WI 6.1.
+6. **Drop 300s `/fix-issues` timeout special case** (Phase 4 + Round-1 DA6 disposition) — same CI pipeline, same timeout. Sequential N-issue accumulation is solved by parallelism (`--auto`), not by under-timeouting CI.
+7. **/quickfix gains CI monitoring + fix-cycle** (Phase 5 + Round-1 DA10 + Round-2 R2-6 dispositions) — fire-and-forget was drift, not design (per maintainer direction).

--- a/plans/PR_LANDING_UNIFICATION.md
+++ b/plans/PR_LANDING_UNIFICATION.md
@@ -39,18 +39,21 @@ This plan creates a new **`/land-pr`** skill that the five callers dispatch via 
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — `/land-pr` skill scaffolding + scripts + canonical-schema + tests | ⬚ | | Includes intra-phase smoke checkpoint |
+| 1A — `/land-pr` foundation: skill + 4 scripts + caller-facing references + smoke | ⬚ | | Smoke checkpoint at end |
+| 1B — `/land-pr` validation: failure-modes doc + mocks + tests + conformance | ⬚ | | Lands before Phases 2–5 |
 | 2 — Migrate `/run-plan` PR mode to `/land-pr` (caller owns body splice) | ⬚ | | |
 | 3 — Migrate `/commit pr` and `/do pr` to `/land-pr` (drift fix: gain fix-cycle) | ⬚ | | |
 | 4 — Migrate `/fix-issues pr` to `/land-pr` (drop 300s timeout special case) | ⬚ | | |
 | 5 — Migrate `/quickfix` to `/land-pr` (drift fix: gain CI monitoring + fix-cycle) | ⬚ | | |
 | 6 — Drift-prevention conformance + canary | ⬚ | | |
 
-## Phase 1 — `/land-pr` skill scaffolding + scripts + canonical-schema + tests
+## Phase 1A — `/land-pr` foundation: skill + 4 scripts + caller-facing references + smoke
 
 ### Goal
 
-Create the `/land-pr` skill with four deterministic scripts, canonical procedure prose, the file-based result contract (with safe allow-list parsing), the canonical `.landed` schema, caller-loop reference, fix-cycle agent prompt template, and a unit-test suite covering the documented failure modes. No caller migration in this phase — the existing 5 skills continue to use their inline implementations until Phases 2–5.
+Create the `/land-pr` skill with the four deterministic scripts, canonical procedure prose, the file-based result contract (with safe allow-list parsing), the canonical `.landed` schema, AND the caller-facing references that Phases 2–5 will copy from (caller-loop pattern, fix-cycle agent prompt template). Smoke-checkpoint validates the foundation end-to-end. Comprehensive tests, mocks, conformance assertions, and failure-mode documentation are deferred to Phase 1B.
+
+**Why split from comprehensive tests:** Phase 1A is the foundation that Phases 2–5 dispatch and copy from. It's ~10 WIs, ~700 lines of new code. Phase 1B (tests + conformance + mocks) is ~5 WIs, ~900 lines — bulky but mechanically simpler. Keeping them separate gives reviewable PR boundaries and lets a foundation flaw be caught at the end of 1A's smoke, not tangled with test scaffolding written on top of broken scripts.
 
 ### Work Items
 
@@ -103,14 +106,6 @@ Create the `/land-pr` skill with four deterministic scripts, canonical procedure
   6. On `CI_STATUS=fail`, capture failure log: extract a run ID via `gh pr checks "$PR" --json link` and bash-regex on the URL, then run `gh run view --log-failed <run-id> > "$LOG_OUT"`. If run-ID extraction fails, emit `CI_LOG_FILE=` (empty) — caller's fix-cycle agent must handle missing log gracefully.
   7. Emit final `CI_STATUS=...` and `CI_LOG_FILE=...` to stdout, exit 0 (poll completed regardless of pass/fail).
   8. Exit 20 if pre-conditions invalid (PR number non-numeric, or `gh auth status` returns non-zero on first call — fail-fast on auth).
-
-- [ ] **WI 1.5a — `splice-body.sh` shared utility.** Create `skills/land-pr/scripts/splice-body.sh`. Args: `--body-current <path>` `--progress-text <path>` `--start-marker <text>` `--end-marker <text>` `--out <path>`. Behavior:
-  1. Validate both markers exist in the current body. Exit 40 if missing (with stderr message naming which marker is missing).
-  2. Splice `progress-text` content between the markers using `awk` (more robust than sed against `&`/`\` metacharacters in body content).
-  3. Write to `out` atomically (`.tmp` + `mv`). Exit 41 on write failure.
-  4. Exit 0 on success.
-
-  **Why a shared utility:** body splice is currently only used by `/run-plan`'s per-phase progress update. A future caller (e.g., `/fix-issues` per-issue body amendments) would re-implement the same sed/awk dance and drift. Centralizing this in `/land-pr`'s scripts/ ensures one tested implementation. /run-plan calls this script in WI 2.1.
 
 - [ ] **WI 1.6 — `pr-merge.sh`.** Create `skills/land-pr/scripts/pr-merge.sh`. Args: `--pr <number>` `--auto-flag <true|false>` `--ci-status <pass|fail|pending|none|skipped|unknown>`. Behavior:
   1. If `auto-flag != true`: emit `MERGE_REQUESTED=false MERGE_REASON=auto-not-requested`, exit 0.
@@ -288,8 +283,6 @@ Create the `/land-pr` skill with four deterministic scripts, canonical procedure
 
 - [ ] **WI 1.9 — Fix-cycle agent prompt template.** Create `skills/land-pr/references/fix-cycle-agent-prompt-template.md`. Template structure same as Round-1 plan (caller fills in `<CALLER_WORK_CONTEXT>`). Add explicit constraint: *"You are running at orchestrator level. Do NOT dispatch further Agent tools. If your fix attempt requires nested agent dispatch, stop and report — the caller's loop will retry up to its max attempts."*
 
-- [ ] **WI 1.10 — Failure-modes reference.** Create `skills/land-pr/references/failure-modes.md` cataloging the 10 failure modes from the research synthesis. Each entry: failure description, severity, detection mechanism in the corresponding script, the test case in `tests/test-land-pr-scripts.sh` that proves the detection works.
-
 - [ ] **WI 1.11 — Canonical `.landed` schema.** Document in `skills/land-pr/SKILL.md` the canonical `.landed` schema:
   ```
   status: <required>      # landed | pr-ready | pr-ci-failing | pr-failed | conflict | pr-state-unknown
@@ -342,7 +335,74 @@ Create the `/land-pr` skill with four deterministic scripts, canonical procedure
   9. Compose final result and write to `$RESULT_FILE` (atomic via `.tmp` + `mv`). Per WI 1.7, every VALUE is validated via `validate_result_value` before write; multi-line content is referenced via `*_FILE` sidecar paths.
   10. Echo a brief one-line summary to stdout for the conversation log: `STATUS=<status> PR=<url> CI=<status>`.
 
-- [ ] **WI 1.13 — Mock infrastructure for tests.** Create `tests/mocks/mock-gh.sh` and `tests/mocks/mock-git.sh`. Each is a bash script with a subcommand router. Reference implementation for `mock-gh.sh` (the test scripts copy this verbatim and extend per-test):
+- [ ] **WI 1A.13 — Mirror (foundation).** `rm -rf .claude/skills/land-pr && cp -a skills/land-pr .claude/skills/land-pr && diff -rq skills/land-pr .claude/skills/land-pr` (must produce no output). Mirrors the 1A foundation files: SKILL.md, 4 scripts, references/caller-loop-pattern.md, references/fix-cycle-agent-prompt-template.md.
+
+- [ ] **WI 1A.14 — Update PLAN_INDEX.** Move PR_LANDING_UNIFICATION from "Ready to Run" to "In Progress" with current phase = 1A.
+
+### End-of-phase smoke checkpoint (mandatory)
+
+After completing **WI 1.1–1.6 and WI 1.12** (skill + scripts + procedure prose), and BEFORE Phase 1B writes mocks / comprehensive tests / conformance assertions, run a smoke test:
+
+**Concrete recipe (use real GitHub):** Create a throwaway feature branch in this repo (e.g., `smoke/land-pr-$(date +%s)`), make a trivial commit (touch a file in `tmp/`), then invoke `/land-pr --branch smoke/land-pr-$TS --title "smoke test" --body-file /tmp/smoke-body.md --result-file /tmp/land-pr-smoke.txt --no-monitor`. The `--no-monitor` flag avoids triggering CI cost. After verification, **clean up:**
+```bash
+gh pr close "$PR_NUMBER" --delete-branch  # closes the smoke PR + deletes branch on remote
+git push dev --delete smoke/land-pr-$TS    # belt-and-suspenders
+```
+
+Verify:
+- The result file is produced with the expected schema (all required keys present, all values single-line).
+- The skill's procedure drives Claude through rebase/push/create successfully.
+- The allow-list parser in WI 1.7 reads the result file without invoking `source`.
+- No shell-injection vulnerabilities (manually stuff `$()` into a sidecar file path; confirm the parser leaves it as a literal string).
+- `gh pr edit` is NOT called by `pr-push-and-create.sh` on the smoke PR (verified by passing the same body twice — second invocation should detect existing PR and not modify body).
+
+If the smoke test fails, the script contracts or procedure prose are wrong — **fix before starting Phase 1B**, do not write tests/conformance assertions on top of broken foundations.
+
+### Design & Constraints
+
+- **Cross-skill dispatch via Skill tool, single-string args.** Per `skills/research-and-plan/SKILL.md:140`. Same-context recursion per `:87-105`. Therefore data hand-off is file-based (WI 1.7), not via stdout.
+- **No `jq` binary; `gh ... --jq` flag is allowed.** `jq` standalone binary is prohibited per memory `feedback_no_jq_in_skills`. `gh`'s `--jq` flag is gh's built-in formatter, not a separate process — using it does not introduce a `jq` dependency. Conformance test (WI 1.15) guards against `^[[:space:]]*jq ` pattern, not against `--jq=` flag.
+- **No `|| true`, no `2>/dev/null` on fallible ops.** Per CLAUDE.md "Never suppress errors."
+- **No `--no-verify` on commits.** Per CLAUDE.md.
+- **`scripts/write-landed.sh` is reused as-is.** Atomic write semantics verified at the script's docstring (line 19: "Writes: <worktree-path>/.landed (atomic via .tmp + mv)").
+- **Result-file values are single-line shell-safe; multi-line content goes in sidecar files.** The caller never `source`s the result file; uses an allow-list line-by-line parser (WI 1.7). This eliminates the shell-injection class.
+- **Test-output capture pattern.** All tests follow CLAUDE.md's TEST_OUT idiom — never pipe.
+- **Idempotency is a contract.** Re-invoking `/land-pr` with the same branch must be a no-op for already-done steps (rebase up-to-date is exit 0; push up-to-date is exit 0; existing PR is detected). Body updates are caller-owned, NOT done by `/land-pr`. WI 1.14 includes explicit idempotency test cases.
+- **Race condition on parallel `/land-pr` invocations is bounded by gh's "already exists" rejection.** If two callers race past `gh pr list` and both call `gh pr create`, gh enforces one open PR per head branch and the second invocation gets a non-zero exit with "already exists" stderr. The losing invocation's caller sees `STATUS=create-failed` and handles it via the canonical loop; no duplicate PRs are created. This is documented; no `flock` guard is needed.
+- **`--no-monitor` and `--pr <num>` enable two flow shapes.** `--no-monitor`: caller wants to report PR URL early and skip CI poll for this invocation. `--pr <num>`: caller resumes monitoring an existing PR. Together they let users / future callers split the create-and-monitor flow when needed. None of the 5 callers in this plan use these flags — they all monitor synchronously.
+- **All 5 callers run CI monitoring + fix-cycle.** No exceptions. /quickfix's "fire-and-forget" was drift, not design. /commit pr and /do pr's "report-only" was drift, not design. The unification corrects all three (per maintainer rationale in Overview).
+- **`/land-pr` is dispatched only at orchestrator level.** Documented contract — no runtime guard. Conformance assertions in Phase 6 verify callers' SKILL.md files contain the dispatch at orchestrator level (not inside an Agent prompt block).
+- **Hooks compatibility.** Per `hooks/block-unsafe-project.sh.template:634-640`, the `git push` rule scope is segmented to the `git push` portion of the command (the recent #58 fix). /land-pr's gh/git calls won't trip false-positives. The smoke checkpoint (intra-phase) verifies this end-to-end.
+- **PR body ownership is the caller's, not `/land-pr`'s.** /land-pr writes the body only on initial PR creation (the `--body-file` content). Subsequent body updates (e.g., /run-plan's HTML-comment-marker progress splice) are caller-owned and happen before the caller invokes /land-pr. This preserves user-added review notes.
+- **shellcheck clean.** All four scripts must pass `shellcheck` with no warnings.
+
+### Acceptance Criteria
+
+- [ ] Smoke checkpoint passes — see "End-of-phase smoke checkpoint" section above.
+- [ ] `skills/land-pr/SKILL.md` exists; `grep -E '^name: land-pr$' skills/land-pr/SKILL.md` returns one line.
+- [ ] All four scripts exist and are executable: `for f in pr-rebase pr-push-and-create pr-monitor pr-merge; do test -x "skills/land-pr/scripts/$f.sh" || fail "$f not executable"; done`.
+- [ ] `shellcheck skills/land-pr/scripts/*.sh` returns 0.
+- [ ] `skills/land-pr/references/caller-loop-pattern.md` and `skills/land-pr/references/fix-cycle-agent-prompt-template.md` exist (callers in Phases 2–5 will copy from these).
+- [ ] Mirror byte-identical for 1A files: `diff -rq skills/land-pr .claude/skills/land-pr` produces no output (note: failure-modes.md, mocks, and tests don't exist yet; they're 1B work).
+- [ ] No skill yet calls `/land-pr` (Phases 2–5 do that). Existing skills' PR mode behavior is unchanged.
+- [ ] `plans/PLAN_INDEX.md` shows PR_LANDING_UNIFICATION in "In Progress" with Phase 1A complete.
+- [ ] `bash tests/run-all.sh` still passes (Phase 1A doesn't break existing tests; new tests come in 1B).
+
+### Dependencies
+
+- None. This is the foundation phase.
+
+## Phase 1B — `/land-pr` validation: failure-modes doc + mocks + tests + conformance
+
+### Goal
+
+Add the validation layer on top of Phase 1A's foundation: failure-modes documentation, mock infrastructure (mock-gh + mock-git for unit tests), comprehensive script tests covering the documented failure modes, and conformance assertions in `tests/test-skill-conformance.sh` (with a new `check_not` helper). Ensures regressions are caught before Phases 2–5 migrate the 5 callers.
+
+### Work Items
+
+- [ ] **WI 1B.1 — Failure-modes reference.** Create `skills/land-pr/references/failure-modes.md` cataloging the 10 failure modes from the research synthesis. Each entry: failure description, severity, detection mechanism in the corresponding script, the test case in `tests/test-land-pr-scripts.sh` that proves the detection works.
+
+- [ ] **WI 1B.2 — Mock infrastructure for tests.** Create `tests/mocks/mock-gh.sh` and `tests/mocks/mock-git.sh`. Each is a bash script with a subcommand router. Reference implementation for `mock-gh.sh` (the test scripts copy this verbatim and extend per-test):
   ```bash
   #!/bin/bash
   # mock-gh.sh — minimal stateful mock for `gh` commands.
@@ -378,7 +438,7 @@ Create the `/land-pr` skill with four deterministic scripts, canonical procedure
 
   `mock-git.sh` follows the same pattern. For state-modifying ops (rebase, push), the mock can also call real `git` with a fake remote (local bare repo at `$MOCK_GIT_FAKE_REMOTE`) when realistic side effects are required.
 
-- [ ] **WI 1.14 — `tests/test-land-pr-scripts.sh`.** Create the test file. Capture output per CLAUDE.md: `TEST_OUT="/tmp/zskills-tests/$(basename $(pwd))/.test-results.txt"`. Tests cover all 10 failure modes from `references/failure-modes.md` PLUS:
+- [ ] **WI 1B.3 — `tests/test-land-pr-scripts.sh`.** Create the test file. Capture output per CLAUDE.md: `TEST_OUT="/tmp/zskills-tests/$(basename $(pwd))/.test-results.txt"`. Tests cover all 10 failure modes from `references/failure-modes.md` PLUS:
   - **rebase-idempotent**: local branch is already rebased, then a fix commit is added, then `pr-rebase.sh` is called again → exit 0, no modifications, no conflict.
   - **PR_NUMBER extraction from URL**: when `gh pr create` returns URL `.../pull/42`, `PR_NUMBER=42` is extracted (no second `gh pr view` call).
   - **--no-monitor returns early**: `/land-pr --no-monitor` writes result file with `CI_STATUS=not-monitored` and does NOT run `pr-monitor.sh`.
@@ -387,7 +447,7 @@ Create the `/land-pr` skill with four deterministic scripts, canonical procedure
   - **status mapping table coverage**: at least one test per row of the WI 1.12 table — verify the correct `status` is derived for each combination.
   - **race-bounded create-failed**: simulate two concurrent `gh pr create` calls against same branch (mock returns "already exists" on second); confirm the second invocation gets `STATUS=create-failed CALL_ERROR_FILE=...` and does NOT create a duplicate PR.
 
-- [ ] **WI 1.15 — Conformance assertions + `check_not` helper.** Add to `tests/test-skill-conformance.sh`:
+- [ ] **WI 1B.4 — Conformance assertions + `check_not` helper.** Add to `tests/test-skill-conformance.sh`:
   - **Define `check_not` helper** (top of file, alongside existing `check`/`check_fixed` at lines 29-51):
     ```bash
     check_not() {
@@ -409,63 +469,29 @@ Create the `/land-pr` skill with four deterministic scripts, canonical procedure
     - `check_not land-pr "no || true" '\|\| true'`
     - `check_not land-pr "no source-based result parsing" 'source[[:space:]]+.*RESULT_FILE|\.[[:space:]]+.*RESULT_FILE'`  (caller pattern in references/ — verifies the safe parser, not source)
 
-- [ ] **WI 1.16 — Mirror.** `rm -rf .claude/skills/land-pr && cp -a skills/land-pr .claude/skills/land-pr && diff -rq skills/land-pr .claude/skills/land-pr` (must produce no output).
+- [ ] **WI 1B.5 — Mirror update.** `rm -rf .claude/skills/land-pr && cp -a skills/land-pr .claude/skills/land-pr && diff -rq skills/land-pr .claude/skills/land-pr` (must produce no output). Mirrors 1B's added `failure-modes.md` plus any 1A changes that landed since 1A's mirror.
 
-- [ ] **WI 1.17 — Update PLAN_INDEX.** Move PR_LANDING_UNIFICATION from "Ready to Run" to "In Progress" with current phase = 1.
-
-### Intra-phase smoke checkpoint (mandatory)
-
-After completing **WI 1.1–1.6 and WI 1.12** (skill + scripts + procedure prose), and BEFORE writing references / mocks / comprehensive tests / conformance assertions, run a smoke test:
-
-**Concrete recipe (use real GitHub):** Create a throwaway feature branch in this repo (e.g., `smoke/land-pr-$(date +%s)`), make a trivial commit (touch a file in `tmp/`), then invoke `/land-pr --branch smoke/land-pr-$TS --title "smoke test" --body-file /tmp/smoke-body.md --result-file /tmp/land-pr-smoke.txt --no-monitor`. The `--no-monitor` flag avoids triggering CI cost. After verification, **clean up:**
-```bash
-gh pr close "$PR_NUMBER" --delete-branch  # closes the smoke PR + deletes branch on remote
-git push dev --delete smoke/land-pr-$TS    # belt-and-suspenders
-```
-
-Verify:
-- The result file is produced with the expected schema (all required keys present, all values single-line).
-- The skill's procedure drives Claude through rebase/push/create successfully.
-- The allow-list parser in WI 1.7 reads the result file without invoking `source`.
-- No shell-injection vulnerabilities (manually stuff `$()` into a sidecar file path; confirm the parser leaves it as a literal string).
-- `gh pr edit` is NOT called by `pr-push-and-create.sh` on the smoke PR (verified by passing the same body twice — second invocation should detect existing PR and not modify body).
-
-If the smoke test fails, the script contracts or procedure prose are wrong — **fix before proceeding to WI 1.8–1.15**, do not write 1500+ lines of references/tests on top of broken foundations.
+- [ ] **WI 1B.6 — Update PLAN_INDEX.** Move PR_LANDING_UNIFICATION's "Next Phase" to 1B → 2.
 
 ### Design & Constraints
 
-- **Cross-skill dispatch via Skill tool, single-string args.** Per `skills/research-and-plan/SKILL.md:140`. Same-context recursion per `:87-105`. Therefore data hand-off is file-based (WI 1.7), not via stdout.
-- **No `jq` binary; `gh ... --jq` flag is allowed.** `jq` standalone binary is prohibited per memory `feedback_no_jq_in_skills`. `gh`'s `--jq` flag is gh's built-in formatter, not a separate process — using it does not introduce a `jq` dependency. Conformance test (WI 1.15) guards against `^[[:space:]]*jq ` pattern, not against `--jq=` flag.
-- **No `|| true`, no `2>/dev/null` on fallible ops.** Per CLAUDE.md "Never suppress errors."
-- **No `--no-verify` on commits.** Per CLAUDE.md.
-- **`scripts/write-landed.sh` is reused as-is.** Atomic write semantics verified at the script's docstring (line 19: "Writes: <worktree-path>/.landed (atomic via .tmp + mv)").
-- **Result-file values are single-line shell-safe; multi-line content goes in sidecar files.** The caller never `source`s the result file; uses an allow-list line-by-line parser (WI 1.7). This eliminates the shell-injection class.
-- **Test-output capture pattern.** All tests follow CLAUDE.md's TEST_OUT idiom — never pipe.
-- **Idempotency is a contract.** Re-invoking `/land-pr` with the same branch must be a no-op for already-done steps (rebase up-to-date is exit 0; push up-to-date is exit 0; existing PR is detected). Body updates are caller-owned, NOT done by `/land-pr`. WI 1.14 includes explicit idempotency test cases.
-- **Race condition on parallel `/land-pr` invocations is bounded by gh's "already exists" rejection.** If two callers race past `gh pr list` and both call `gh pr create`, gh enforces one open PR per head branch and the second invocation gets a non-zero exit with "already exists" stderr. The losing invocation's caller sees `STATUS=create-failed` and handles it via the canonical loop; no duplicate PRs are created. This is documented; no `flock` guard is needed.
-- **`--no-monitor` and `--pr <num>` enable two flow shapes.** `--no-monitor`: caller wants to report PR URL early and skip CI poll for this invocation. `--pr <num>`: caller resumes monitoring an existing PR. Together they let users / future callers split the create-and-monitor flow when needed. None of the 5 callers in this plan use these flags — they all monitor synchronously.
-- **All 5 callers run CI monitoring + fix-cycle.** No exceptions. /quickfix's "fire-and-forget" was drift, not design. /commit pr and /do pr's "report-only" was drift, not design. The unification corrects all three (per maintainer rationale in Overview).
-- **`/land-pr` is dispatched only at orchestrator level.** Documented contract — no runtime guard. Conformance assertions in Phase 6 verify callers' SKILL.md files contain the dispatch at orchestrator level (not inside an Agent prompt block).
-- **Hooks compatibility.** Per `hooks/block-unsafe-project.sh.template:634-640`, the `git push` rule scope is segmented to the `git push` portion of the command (the recent #58 fix). /land-pr's gh/git calls won't trip false-positives. The smoke checkpoint (intra-phase) verifies this end-to-end.
-- **PR body ownership is the caller's, not `/land-pr`'s.** /land-pr writes the body only on initial PR creation (the `--body-file` content). Subsequent body updates (e.g., /run-plan's HTML-comment-marker progress splice) are caller-owned and happen before the caller invokes /land-pr. This preserves user-added review notes.
-- **shellcheck clean.** All four scripts must pass `shellcheck` with no warnings.
+- **All script tests use mock-gh / mock-git.** Real-gh smoke is reserved for the 1A end-of-phase checkpoint and for Phases 2–5 manual canaries. Phase 1B tests stay deterministic via PATH override.
+- **Conformance assertions are the drift tripwire.** WI 1B.4's assertions back-fill the moves from /run-plan's existing inline assertions to /land-pr (per Phase 2 WI 2.7). Once 1B lands, conformance enforces the no-regression contract for Phases 2–5.
+- **Test-output capture** per CLAUDE.md TEST_OUT idiom; never pipe.
 
 ### Acceptance Criteria
 
-- [ ] Smoke checkpoint (intra-phase) passes — see "Intra-phase smoke checkpoint" section above.
-- [ ] `skills/land-pr/SKILL.md` exists; `grep -E '^name: land-pr$' skills/land-pr/SKILL.md` returns one line.
-- [ ] All four scripts exist and are executable.
-- [ ] `shellcheck skills/land-pr/scripts/*.sh` returns 0.
-- [ ] `tests/test-land-pr-scripts.sh` runs and passes (≥10 failure-mode test cases + idempotency, status-mapping, result-safe-parsing, race-bounded test cases).
-- [ ] `tests/test-skill-conformance.sh` runs and passes (new `check_not` helper defined; new /land-pr assertions; no existing assertion modified).
+- [ ] `skills/land-pr/references/failure-modes.md` exists with all 10 failure modes documented.
+- [ ] `tests/mocks/mock-gh.sh` and `tests/mocks/mock-git.sh` exist and are executable.
+- [ ] `tests/test-land-pr-scripts.sh` runs and passes (≥10 failure-mode test cases + idempotency, status-mapping, result-safe-parsing, race-bounded test cases). Output captured per CLAUDE.md.
+- [ ] `tests/test-skill-conformance.sh` runs and passes — `check_not` helper defined; new /land-pr assertions; no existing assertion modified.
 - [ ] `bash tests/run-all.sh` passes overall.
 - [ ] Mirror byte-identical: `diff -rq skills/land-pr .claude/skills/land-pr` produces no output.
-- [ ] No skill yet calls `/land-pr` (Phases 2–5 do that). Existing skills' PR mode behavior is unchanged.
-- [ ] `plans/PLAN_INDEX.md` shows PR_LANDING_UNIFICATION in "In Progress" with Phase 1 complete.
+- [ ] `plans/PLAN_INDEX.md` shows PR_LANDING_UNIFICATION's Next Phase = 2.
 
 ### Dependencies
 
-- None. This is the foundation phase.
+- Phase 1A complete (status: complete; foundation in place).
 
 ## Phase 2 — Migrate `/run-plan` PR mode to `/land-pr` (caller owns body splice)
 
@@ -480,23 +506,23 @@ Replace the inline PR-landing implementation in `skills/run-plan/modes/pr.md` (c
   **First-phase invocation:** No PR exists yet; the body file written must INCLUDE the markers (so subsequent phases have something to splice into). `/run-plan`'s body construction prose places `<!-- run-plan:progress:start -->\n<progress section>\n<!-- run-plan:progress:end -->` near the top of the body. /land-pr creates the PR with this body via `pr-push-and-create.sh` (no special handling needed).
 
   **Subsequent-phase invocation (existing PR detected before the loop):**
-  1. Fetch current body: `gh pr view "$PR_NUMBER" --json body --jq '.body' > /tmp/pr-body-current.md`. On error (transient gh failure, retry once with 2s backoff; if second attempt fails, write `.landed conflict REASON=gh-pr-view-failed` and break the loop).
-  2. Validate markers are present: `grep -qF '<!-- run-plan:progress:start -->' /tmp/pr-body-current.md && grep -qF '<!-- run-plan:progress:end -->' /tmp/pr-body-current.md`. If markers are absent (user manually removed them, or GitHub stripped them somehow), the splice cannot proceed. Write `.landed conflict REASON=body-markers-missing` and break the loop with a clear error message ("Manual repair required: PR body must contain run-plan:progress markers").
-  3. Build the new progress section text in `/tmp/pr-progress-section.txt`.
-  4. Splice via the shared `splice-body.sh` utility (WI 1.5a):
+  1. Fetch current body: `gh pr view "$PR_NUMBER" --json body --jq '.body' > /tmp/pr-body-current.md`. On error: retry once with 2s backoff; if second attempt fails, write `.landed conflict REASON=gh-pr-view-failed` and break the loop.
+  2. Validate markers are present: `grep -qF '<!-- run-plan:progress:start -->' /tmp/pr-body-current.md && grep -qF '<!-- run-plan:progress:end -->' /tmp/pr-body-current.md`. If markers are absent, write `.landed conflict REASON=body-markers-missing` and break with a clear error message ("Manual repair required: PR body must contain run-plan:progress markers").
+  3. Build the new progress section text in `/tmp/pr-progress-section.txt`, then splice inline using `awk` (per the existing pattern at `skills/run-plan/SKILL.md:1216-1217`, but with awk instead of sed for `&`/`\` safety):
      ```bash
-     bash skills/land-pr/scripts/splice-body.sh \
-       --body-current /tmp/pr-body-current.md \
-       --progress-text /tmp/pr-progress-section.txt \
-       --start-marker '<!-- run-plan:progress:start -->' \
-       --end-marker '<!-- run-plan:progress:end -->' \
-       --out "$BODY_FILE"
+     awk -v start='<!-- run-plan:progress:start -->' \
+         -v end='<!-- run-plan:progress:end -->' \
+         -v progress="$(cat /tmp/pr-progress-section.txt)" \
+         '
+         $0 ~ start { print; print progress; skip=1; next }
+         $0 ~ end   { skip=0 }
+         !skip      { print }
+         ' /tmp/pr-body-current.md > "$BODY_FILE"
      ```
-     On exit 40 (markers missing — should not happen since step 2 validated, but defensive): write `.landed conflict REASON=splice-marker-mismatch` and break.
-     On exit 41 (write failure): write `.landed conflict REASON=splice-write-failed` and break.
-  5. Update the PR body: `gh pr edit "$PR_NUMBER" --body-file "$BODY_FILE"`. On error: retry once with 2s backoff. On second failure: write `.landed conflict REASON=gh-pr-edit-failed` and break.
+     The awk passes `progress` as a variable (no shell expansion of body content), so `&`/`\` and other regex metacharacters in user-pasted content survive intact.
+  4. Update the PR body: `gh pr edit "$PR_NUMBER" --body-file "$BODY_FILE"`. On error: retry once with 2s backoff. On second failure: write `.landed conflict REASON=gh-pr-edit-failed` and break.
 
-  All five recovery paths (`gh-pr-view-failed`, `body-markers-missing`, `splice-marker-mismatch`, `splice-write-failed`, `gh-pr-edit-failed`) write the canonical-schema `.landed` and break out of the fix-cycle loop without invoking `/land-pr`. The user reviews the marker file and decides next steps (manual repair, restore markers, etc.).
+  Three recovery paths (`gh-pr-view-failed`, `body-markers-missing`, `gh-pr-edit-failed`) cover the real failure modes; each writes the canonical-schema `.landed` and breaks the loop without invoking `/land-pr`. (Earlier drafts had 5 paths covering a separate `splice-body.sh` utility's exit codes; that utility was removed as YAGNI premature extraction — only `/run-plan` does body splicing today, so the splice stays inline. See Plan Review for refinement history.)
 
   `/land-pr`'s `pr-push-and-create.sh` does NOT touch the body when an existing PR is detected (per WI 1.4) — preserving user-added review notes between the markers.
 
@@ -544,7 +570,7 @@ Replace the inline PR-landing implementation in `skills/run-plan/modes/pr.md` (c
 
 ### Dependencies
 
-- Phase 1 must be complete (status: complete; `/land-pr` skill installed and tested).
+- Phase 1A and Phase 1B must both be complete (`/land-pr` skill installed, references in place, tests + conformance assertions passing).
 
 ## Phase 3 — Migrate `/commit pr` and `/do pr` to `/land-pr` (drift fix: gain fix-cycle)
 
@@ -594,7 +620,7 @@ Replace the inline implementation in `skills/commit/modes/pr.md` AND `skills/do/
 
 ### Dependencies
 
-- Phase 1 must be complete.
+- Phases 1A and 1B must both be complete.
 
 ## Phase 4 — Migrate `/fix-issues pr` to `/land-pr` (drop 300s timeout special case)
 
@@ -640,7 +666,7 @@ Replace the inline implementation in `skills/fix-issues/modes/pr.md` with a per-
 
 ### Dependencies
 
-- Phase 1 must be complete.
+- Phases 1A and 1B must both be complete.
 
 ## Phase 5 — Migrate `/quickfix` to `/land-pr` (drift fix: gain CI monitoring + fix-cycle)
 
@@ -688,7 +714,7 @@ Replace the fire-and-forget PR-creation block in `skills/quickfix/SKILL.md` (cur
 
 ### Dependencies
 
-- Phase 1 must be complete.
+- Phases 1A and 1B must both be complete.
 
 ## Phase 6 — Drift-prevention conformance + canary
 
@@ -817,12 +843,63 @@ Lock in the unification with conformance tripwires and a canary that exercises t
 
 ### Round History
 
-| Round | Reviewer | DA | Total findings | Fixed | Justified | Ignored |
-|-------|---------:|---:|---------------:|------:|----------:|--------:|
-| 1     | 8        | 10 | 18             | 12    | 4         | 0       |
-| 2     | 6        | 10 | 16             | 12    | 4         | 0       |
-| 3     | 6        | 10 | 14             | 8     | 6         | 0       |
-| **Cumulative** | **20** | **30** | **48** | **32** | **14** | **0** |
+| Round | Source | Reviewer | DA | Total findings | Fixed | Justified | Ignored |
+|-------|--------|---------:|---:|---------------:|------:|----------:|--------:|
+| 1     | /draft-plan | 8 | 10 | 18         | 12    | 4         | 0       |
+| 2     | /draft-plan | 6 | 10 | 16         | 12    | 4         | 0       |
+| 3     | /draft-plan | 6 | 10 | 14         | 8     | 6         | 0       |
+| 4     | /refine-plan (YAGNI pass) | 6 | 6 | 12 | 4 (1 removal + 3 simplifications + Phase 1 split) | 8         | 0       |
+| **Cumulative** | | **26** | **36** | **60** | **36** | **22** | **0** |
+
+## Drift Log
+
+The plan was drafted via `/draft-plan rounds 3` (commit ee6ad28) and refined via `/refine-plan` (this commit). No phases have been executed yet — Drift Log captures only the refinement-time structural delta vs. the original draft.
+
+| Phase | Drafted | Current | Delta |
+|-------|---------|---------|-------|
+| 1 (single phase) | 17 WIs, smoke checkpoint, ~1700 lines new code | **Split into 1A (foundation) and 1B (validation)** | 2 phases of ~10 + ~6 WIs; smoke at end of 1A; reviewable PR boundary; Phase 1 scope (DA9/DA3-6) addressed structurally |
+| 1 → WI 1.5a (`splice-body.sh` shared utility) | Added in /draft-plan Round 3 | **Removed** | YAGNI premature extraction — only /run-plan needs splicing today; future callers can extract when actually needed |
+| 2 → WI 2.1 (body splice recovery paths) | 5 paths covering splice-body.sh exits | **Collapsed to 3 paths** with inline awk | `splice-marker-mismatch` and `splice-write-failed` were artifacts of the removed shared utility; remaining 3 paths cover real failure modes |
+| Phase 2-6 dependencies | "Phase 1 must be complete" | **"Phases 1A and 1B must both be complete"** | Mechanical update from the split |
+
+## Plan Review
+
+**Refinement process:** `/refine-plan rounds 1` with focused YAGNI guidance from the maintainer.
+
+**Convergence:** Round 4 (refinement) found 12 findings; the surgical refinement addressed them with concrete edits or justified-not-fix.
+
+**Scope of Round 4:** the refinement targeted speculative additions from /draft-plan Round 3 (DA-driven hypothetical-future-drift items) and the Phase 1 scope concern that had been justified-not-fixed in Rounds 1 and 3. The maintainer's guidance was "surgical, don't rewrite."
+
+### Round 4 Disposition
+
+| Finding | Source | Disposition |
+|---|---|---|
+| **WI 1.5a (`splice-body.sh`) is YAGNI** | Reviewer + maintainer | **Fixed (removed).** Only /run-plan splices bodies today; /commit pr, /do pr, /fix-issues pr, /quickfix all create the PR body once and never update it. The "future caller drift" hypothesis was speculative. Inline awk in /run-plan's WI 2.1 replaces it. |
+| **WI 2.1 — collapse 5 recovery paths to 3** | Reviewer | **Fixed (simplified).** Two paths (`splice-marker-mismatch`, `splice-write-failed`) were artifacts of the removed shared utility. Remaining 3 (`gh-pr-view-failed`, `body-markers-missing`, `gh-pr-edit-failed`) cover real failure modes. |
+| **Phase 1 scope (17 WIs, ~1700 lines)** | DA9 (R1) + DA3-6 (R3) + maintainer | **Fixed (split into 1A/1B).** Re-opened from prior justified-not-fix dispositions. 1A = foundation + caller-facing references + smoke (~10 WIs); 1B = failure-modes doc + mocks + tests + conformance (~6 WIs). Phases 2–5 depend on both. Each phase is now a reviewable PR boundary. |
+| **WI 1.8 `_CLEANUP_PATHS` fragile string-match** | Reviewer | **Justified.** The current pattern preserves CI_LOG_FILE while cleaning others; it works correctly. A simpler pattern (only put cleanup-targets into the array) is a future polish, not a P1 blocker. |
+| **WI 1.13 mock-gh stateful counter** | DA (counter to reviewer YAGNI) | **Justified — keep.** Real test need: pre-check loop tests need sequential canned responses. Not over-engineering. |
+| **WI 1.13 `_CLEANUP_PATHS` cleanup itself necessary** | DA | **Justified — keep.** Real disk-space concern; CI_LOG_FILE preservation requires explicit sequencing. |
+| **WI 6.1 dispatch heuristic** | Reviewer (keep) | **Justified — keep.** Real conformance value; line-anchor pattern correctly avoids prose false-matches. |
+| **Smoke checkpoint** | DA + Reviewer (keep) | **Justified — keep, now naturally aligned with Phase 1A's end.** With the split, the smoke is the natural validation gate before 1B starts. |
+| **Round 3 prior-art bug fixes (87af82a/1de3049/175e4aa/b904cef)** | DA distinction call-out | **Justified — keep.** Distinguished from speculative additions; these are mandatory hardenings against documented prior bugs. |
+| **WI 1.14 test cases stay** | DA | **Justified — keep.** Tests cover real failure modes; not speculative. |
+| **Other Round 3 fixes (status mapping precedence, mock fail-fast, etc.)** | DA distinction | **Justified — keep.** All address real correctness or test-confidence issues, not speculative future drift. |
+
+### Cumulative Convergence
+
+After 4 rounds (3 /draft-plan + 1 /refine-plan), the plan has 60 total findings dispositioned: **36 fixed, 22 justified-not-fixed, 0 ignored**. The plan is ready for `/run-plan` execution starting with Phase 1A.
+
+### Load-bearing architectural decisions (read these before considering future changes)
+
+1. **File-based result contract with allow-list parser** (Phase 1A WI 1.7) — `/land-pr` writes single-line shell-safe `KEY=VALUE` lines plus sidecar files for multi-line content. Caller parses via line-by-line allow-list; never `source`s the file.
+2. **Caller-owned body splice with inline awk** (Phase 2 WI 2.1) — `/land-pr`'s `pr-push-and-create.sh` does NOT touch PR body on existing PRs. /run-plan splices its own progress section using inline awk (no shared utility — YAGNI).
+3. **Status mapping table is first-match-wins** (Phase 1A WI 1.12 step 8) — failure-exits and CI-failure rows precede CI-pass rows.
+4. **Mock-gh fail-fast on missing canned response** (Phase 1B WI 1B.2) — exit 127 with stderr error.
+5. **Subagent boundary contract** (Overview + Phase 1A WI 1.1 description) — `/land-pr` and the caller's fix-cycle agent dispatch are orchestrator-level only.
+6. **Phase 1 split into 1A (foundation) + 1B (validation)** — reviewable PR boundary; smoke checkpoint validates 1A before 1B writes tests on top.
+7. **Drop 300s `/fix-issues` timeout special case** (Phase 4) — same CI pipeline, same timeout.
+8. **/quickfix gains CI monitoring + fix-cycle** (Phase 5) — fire-and-forget was drift, not design.
 
 ### Load-bearing architectural decisions (read these before considering future changes)
 


### PR DESCRIPTION
## Summary

Drafts `plans/PR_LANDING_UNIFICATION.md` (912 lines, 7 phases) — a plan-only PR that adds the design document for unifying the duplicated PR-with-CI machinery across `/run-plan`, `/commit pr`, `/do pr`, `/fix-issues pr`, and `/quickfix`.

## Why

PR #75 fixed `/fix-issues` PR-mode gating to follow the canonical "only `gh pr merge --auto` is gated on `\$AUTO`" pattern, matching `/run-plan`, `/commit pr`, and `/do pr`. PR #75 explicitly deferred the broader unification as a future `/draft-plan` candidate. This is that draft.

The plan creates a new `/land-pr` skill that the 5 callers dispatch via the Skill tool. `/land-pr` owns the deterministic primitives (4 bash scripts: rebase, push-and-create, monitor, merge), the canonical procedure prose, and a file-based result contract for the caller's fix-cycle loop.

## Plan structure

- **Phase 1A** — `/land-pr` foundation: skill + 4 scripts + caller-facing references + smoke
- **Phase 1B** — `/land-pr` validation: failure-modes doc + mocks + tests + conformance
- **Phase 2** — Migrate `/run-plan` PR mode (caller owns body splice)
- **Phase 3** — Migrate `/commit pr` and `/do pr` (drift fix: gain fix-cycle)
- **Phase 4** — Migrate `/fix-issues pr` (drop 300s timeout special case)
- **Phase 5** — Migrate `/quickfix` (drift fix: gain CI monitoring + fix-cycle)
- **Phase 6** — Drift-prevention conformance + canary

Drafted via `/draft-plan rounds 3` then refined with a YAGNI pass (Phase 1 originally combined; split into 1A/1B for reviewable foundation-then-validation boundary).

## Notes

- Plan-only PR; no code, hooks, scripts, or skill source changed.
- Branch was based on `47e8344` (pre-#75); rebased onto current main before opening.
- Inherits PR #75's gating: only `gh pr merge --auto --squash` is gated on the caller's auto-merge flag.

## Test plan

- [x] Reviewer agent confirmed plan structure, dependencies, scope
- [x] No tests required (markdown-only)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)