### PR TITLE
docs: revise QUEUED_QUICKFIXES QF2 + QF4 per Opus re-review

### DIFF
--- a/QUEUED_QUICKFIXES.md
+++ b/QUEUED_QUICKFIXES.md
@@ -1,8 +1,8 @@
 # Queued /quickfix Prompts
 
-Three `/quickfix` invocations to run when ready. Prompts 1 and 2 address recurring failure modes in `/draft-plan` and `/refine-plan`; Prompt 3 fixes `/update-zskills` source-asset discovery. Run in any order — they are independent.
+Four `/quickfix` invocations to run when ready. Prompts 1 and 2 address recurring failure modes in `/draft-plan` and `/refine-plan`; Prompt 3 fixes `/update-zskills` source-asset discovery; Prompt 4 adds positional-tail guidance to `/refine-plan`. Prompts 1, 2, and 4 are independent of each other (no line-range overlap, but 1 and 2 both edit `skills/draft-plan/SKILL.md` so let one PR land before kicking off the other). Prompt 3 must wait for SCRIPTS_INTO_SKILLS_PLAN, SKILL_FILE_DRIFT_FIX, and DEFAULT_PORT_CONFIG to land first.
 
-Source context: produced 2026-04-26 from a session where both bugs surfaced (file collision in `/tmp/draft-plan-review-round-1.md` exposed the convergence-by-refiner-self-declaration pattern). Reviewed by an independent agent before queueing; review found three issues, all incorporated below (full verbatim bullet, explicit two-edit-sites, /research-and-plan acknowledged as follow-up).
+Source context: produced 2026-04-26 from a session where both bugs surfaced (file collision in `/tmp/draft-plan-review-round-1.md` exposed the convergence-by-refiner-self-declaration pattern). Re-reviewed 2026-04-27 by three independent Opus agents; revisions to Prompts 2 and 4 incorporated below (Edit-replace clarification on QF2, prose-mirror clarification on QF4, in-scope spaces-in-paths fix added to QF4 Sub-edit 5).
 
 ---
 
@@ -27,7 +27,7 @@ Use the same <slug> Phase 1 already constructs for `/tmp/draft-plan-research-<sl
 ## Prompt 2 — Convergence rule fix across `/draft-plan` and `/refine-plan`
 
 ```
-/quickfix Fix /draft-plan and /refine-plan: make convergence the orchestrating skill's judgment, not the refiner agent's self-declaration. Same fix applies symmetrically to both skills. (/research-and-plan Step 3 has the same bug class with different wording — out of scope here, file as a follow-up issue at the end.)
+/quickfix Fix /draft-plan and /refine-plan: make convergence the orchestrating skill's judgment, not the refiner agent's self-declaration. The bug is missing-guardrail (current text describes WHAT convergence means but is silent on WHO judges it, leaving the orchestrator to drift into rubber-stamping refiner output). Same fix applies symmetrically to both skills. (/research-and-plan Step 3 has a related — but distinct — pair of issues, out of scope here; file as a follow-up issue at the end.)
 
 Two edit sites per skill — four total source edits, plus mirrors:
 
@@ -42,7 +42,8 @@ For Edits 1 and 3 (the Convergence-Check phase bodies): add this paragraph at th
 
 > Convergence is the **orchestrator's judgment**, not the refiner's self-call. Do NOT accept "CONVERGED" from the refiner agent as authoritative — the refiner just refined; it is biased toward declaring its own work done. This is a recurring failure mode in practice.
 
-Then restate the rule so the orchestrator's job is clear:
+Then **replace the existing numbered "Check convergence" list (steps 1-2) with** this expanded version (preserve step 3 "Track round history" as-is):
+
   - Count remaining substantive issues from the refiner's disposition table (Justified-not-fixed entries plus any gaps the refinement introduced).
   - 0 substantive issues → converged → next phase.
   - >0 substantive issues AND rounds < max → another review+refine cycle. Honor the user's rounds budget; don't stop early.
@@ -58,7 +59,7 @@ Replace the entire three-line bullet with this single-line bullet:
 
   - **Convergence is the orchestrator's call** based on the refiner's disposition table, not the refiner's self-declaration. Run all budgeted rounds unless issues drop to 0.
 
-After landing, file a follow-up GitHub issue: `gh issue create --title "Apply orchestrator-convergence fix to /research-and-plan Step 3 (follow-up)" --body "Step 3 (L217-253) has the same self-declaration bug class with CRITICAL/MAJOR-severity wording. Same fix applies; out of scope of the /draft-plan + /refine-plan symmetric /quickfix."`
+After landing, file a follow-up GitHub issue: `gh issue create --title "Apply orchestrator-convergence fix to /research-and-plan Step 3 (follow-up)" --body "Step 3 (L217-253) has TWO related issues: (a) the same orchestrator-judgment gap as /draft-plan and /refine-plan (silent on WHO judges convergence), AND (b) a separate severity-thresholding concern (the rule is "no CRITICAL or MAJOR issues" rather than 'no substantive issues at all'). Both should be evaluated together; the fix is not a literal copy of the /draft-plan + /refine-plan symmetric quickfix because Step 3 dispatches reviewer + DA in parallel and applies fixes inline (no single named refiner agent)."`
 ```
 
 ---
@@ -92,7 +93,7 @@ Feedback context: Simon Greenwold cloned to a non-/tmp path and /update-zskills 
 ## Prompt 4 — Add positional-tail guidance arg to /refine-plan
 
 ```
-/quickfix Add optional positional-tail guidance arg to /refine-plan, mirroring /draft-plan's description pattern.
+/quickfix Add optional positional-tail guidance arg to /refine-plan AND tighten the Detection rule to fix a paths-with-spaces bug. Mirror /draft-plan's description-detection pattern (which is prose-level, not bash regex — no new shell variable required; remaining unrecognized tokens, joined with spaces, are the guidance).
 
 Edit skills/refine-plan/SKILL.md (then mirror to .claude/skills/refine-plan/ via `rm -rf` + `cp -r` + `diff -rq`):
 
@@ -101,16 +102,22 @@ Edit skills/refine-plan/SKILL.md (then mirror to .claude/skills/refine-plan/ via
    to:
      /refine-plan <plan-file> [rounds N] [guidance...]
 
-2. Update the Detection block (currently in the Arguments section) so any tokens not matched as the plan file (.md / path token) or `rounds N` keyword join into a `$GUIDANCE` shell variable (mirror /draft-plan's positional-tail logic). Empty guidance is the current default behavior.
+2. Update the Detection block (currently in the Arguments section) so any tokens not matched as the plan file or `rounds N` keyword (note: `rounds` requires a numeric argument, so guidance text starting with the word "rounds" not followed by a number is NOT misclassified) join (space-separated) into the guidance, which gets prepended to agent prompts in step 3. Empty guidance is the current default behavior. Mirror /draft-plan's prose-level detection — no new bash variable required.
 
-3. Update Phase 2 — Adversarial Review (parallel agents). When dispatching the reviewer and devil's advocate agents, if `$GUIDANCE` is non-empty, prepend it to each agent's prompt as an explicit "User-driven scope/focus directive" section. Agents treat it as priming context that shapes WHAT they pressure-test, NOT as factual claims to act on without verification (verify-before-fix discipline still applies).
+3. Update Phase 2 — Adversarial Review (parallel agents). When dispatching the reviewer and devil's advocate agents, if guidance is non-empty, prepend it to each agent's prompt as an explicit "User-driven scope/focus directive" section. Agents treat it as priming context that shapes WHAT they pressure-test, NOT as factual claims to act on without verification (verify-before-fix discipline still applies).
 
 4. Add an Examples bullet to Arguments showing usage:
    - `/refine-plan plans/FOO.md anti-deferral focus`
    - `/refine-plan plans/FOO.md rounds 3 expand audit to all config fields`
 
-Why: in a recent session, /refine-plan needed user-driven priming to surface deferred work. Without this arg, the orchestrator manually injected priming into agent prompts — workable but error-prone (forgotten across invocations, no audit trail). Mirroring /draft-plan's positional-tail keeps the convention consistent with the /refine-plan SKILL's existing arg style (no --flags today; bareword + keyword + positional). Multi-word guidance natural without quoting.
+5. Tighten the Detection rule for the plan file: the current rule reads (in skills/refine-plan/SKILL.md L48-49):
+     "The **first token** ending in `.md` or containing `/` is the plan file."
+   Drop the "or containing `/`" clause so the rule becomes:
+     "The **first token** ending in `.md` is the plan file. If the token contains `/`, use as-is; otherwise prepend `plans/`."
+   This mirrors /draft-plan's first-token-ending-in-.md rule exactly. Closes a bug where a path with embedded spaces (e.g., `/refine-plan plans/My Phase.md`) tokenizes into `plans/My` + `Phase.md`; the partial path matched the "containing /" clause and produced a misleading "plan file `plans/My` not found" error. After this fix, `plans/My` doesn't end in `.md` so it falls through, and the user gets the existing clear "No plan file specified. Usage: ..." error instead.
 
-NO behavior change to existing invocations: omitting guidance is the current default. The Detection block must handle "no guidance" cleanly (empty $GUIDANCE → reviewer/DA prompts unchanged from today's output).
+Why: in a recent session, /refine-plan needed user-driven priming to surface deferred work. Without this arg, the orchestrator manually injected priming into agent prompts — workable but error-prone (forgotten across invocations, no audit trail). Mirroring /draft-plan's positional-tail keeps the convention consistent with the /refine-plan SKILL's existing arg style (no --flags today; bareword + keyword + positional). Multi-word guidance natural without quoting. Sub-edit 5 closes a previously deferred hole rather than filing a follow-up issue, since we're already in the Detection block.
+
+NO behavior change to existing valid invocations: omitting guidance is the current default; every previously-correct path-with-or-without-slash still works (`plans/X.md` still matches; `X.md` still gets `plans/` prepended). Sub-edit 5 only changes behavior for the previously-broken paths-with-spaces case (now fails fast with a clearer message). Empty guidance → reviewer/DA prompts unchanged from today's output.
 ```
 


### PR DESCRIPTION
## Summary

Revises Prompt 2 and Prompt 4 in `QUEUED_QUICKFIXES.md` based on a fresh Opus re-review (the original Haiku-class review of QF2 was demonstrably wrong, which prompted the no-Haiku CLAUDE.md rule in PR #76).

## QF2 changes

- **Tighten Edit 1/3 instruction** — change "Then restate the rule" to "Then **replace the existing numbered Check convergence list (steps 1-2) with**" so the executing agent replaces rather than appends. Step 3 (Track round history) preserved.
- **Reframe the bug** in the prompt's preamble as a missing-guardrail (silence on WHO judges convergence) rather than a broken-text bug, so the implementing agent doesn't go hunting for non-existent text and conclude "no bug."
- **Rewrite the /research-and-plan follow-up clause** to acknowledge Step 3 has TWO related but distinct issues (orchestrator-judgment gap + severity-thresholding), not "the same bug class."

## QF4 changes

- **Clarify "/draft-plan's positional-tail logic"** as prose-level detection — no new shell variable required; remaining unrecognized tokens, joined with spaces, are the guidance.
- **Add Sub-edit 5** closing the paths-with-spaces hole that was previously deferred to a follow-up issue: drop the "or containing /" clause from the first-token Detection rule so /refine-plan mirrors /draft-plan's stricter pattern. We're already in the Detection block, so closing the hole is in-scope per CLAUDE.md "don't defer hole closure."

## Header fix

- "Three" → "Four" prompts (Prompt 4 was added post-initial-batch but the header count was never updated).
- Provenance note updated to reflect Opus re-review.

## Test plan

- [x] Markdown-only change; no skill source, hooks, scripts, or code touched
- [x] QF1 and QF3 prompts left unchanged (QF1 was "READY no edits"; QF3 stays deferred-by-design pending plan landings)
- [x] CI green

After merge, the user can invoke each /quickfix with the revised body verbatim from the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)