### PR TITLE
fix(draft-plan): slug-namespace round review file paths

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -123,7 +123,7 @@ The summary should cover:
 - Open questions or uncertainties
 
 **Similarly, write each round's review findings to files:**
-- `/tmp/draft-plan-review-round-N.md` — reviewer + devil's advocate findings
+- `/tmp/draft-plan-review-<slug>-round-N.md` — reviewer + devil's advocate findings
 - Pass these file paths to the refiner agent so it has the full context
 
 **Scope check — is this too big for one plan?** After consolidating

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -123,7 +123,7 @@ The summary should cover:
 - Open questions or uncertainties
 
 **Similarly, write each round's review findings to files:**
-- `/tmp/draft-plan-review-round-N.md` — reviewer + devil's advocate findings
+- `/tmp/draft-plan-review-<slug>-round-N.md` — reviewer + devil's advocate findings
 - Pass these file paths to the refiner agent so it has the full context
 
 **Scope check — is this too big for one plan?** After consolidating


### PR DESCRIPTION
## Summary

QF1 from `QUEUED_QUICKFIXES.md`. The unnamespaced `/tmp/draft-plan-review-round-N.md` path collides when two `/draft-plan` invocations run sequentially or in parallel — the very collision that surfaced this whole queue (the convergence-orchestrator-judgment session was triggered by an actual `/tmp/draft-plan-review-round-1.md` collision).

Switch L126 of `skills/draft-plan/SKILL.md` from:

```
- `/tmp/draft-plan-review-round-N.md` — reviewer + devil's advocate findings
```

to:

```
- `/tmp/draft-plan-review-<slug>-round-N.md` — reviewer + devil's advocate findings
```

This uses the same `<slug>` Phase 1 already constructs for `/tmp/draft-plan-research-<slug>.md` (consistent with L111, L113, L161, L181). Mirror at `.claude/skills/draft-plan/SKILL.md` regenerated to match.

Slug source is the output-filename basename (e.g. `FEATURE_EXPORT` for `plans/FEATURE_EXPORT.md`); ASCII alnum + underscore are POSIX-portable in `/tmp/`.

Mode: `agent-dispatched`
Base: `main`
Slug: `slug-namespace-draft-plan-reviews`

## Note for follow-up

The QF1 prompt in `QUEUED_QUICKFIXES.md` and other `/quickfix` prompts use `rm -rf .claude/skills/X/ && cp -r ...` for mirror regeneration. The implementing agent reported that `block-unsafe-generic.sh` blocks recursive deletes outside `/tmp/<name>`. For this single-file mirror, byte-equivalent direct `cp` worked, but the canonical recipe will fail for any future multi-file mirror. Worth filing as a separate issue or adjusting the spec.

## Test plan

- [x] `bash tests/run-all.sh` — 851/851 passed
- [x] Mirror parity: `diff -rq skills/draft-plan/ .claude/skills/draft-plan/` empty
- [x] No other unnamespaced `/tmp/draft-plan-*` paths in the source (verified by Opus reviewer pre-execution)
- [x] CI green

🤖 Generated with /quickfix