### PR TITLE
fix(quickfix): return user to base branch after PR creation

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 
 `/quickfix` turns the current main checkout (with or without dirty edits)
 into a one-commit PR without leaving main. No worktree. No cherry-pick.
-Fire-and-forget: commit, push, open PR, print URL, exit.
+Fire-and-forget: commit, push, open PR, print URL, return to base branch, exit.
 
 **Ultrathink throughout.**
 
@@ -746,10 +746,22 @@ if [ -f "$MARKER" ]; then
 fi
 
 echo "$PR_URL"
+
+# WI 1.17 — return to base branch on success.
+# The PR exists on GitHub; locally we leave the user where they started
+# (on $BASE_BRANCH) so subsequent commands don't accidentally pile onto
+# the feature branch. Forgiving: if the checkout fails, warn but do not
+# fail the run — the PR is already created.
+if ! git checkout "$BASE_BRANCH"; then
+  echo "WARN: PR created at $PR_URL but failed to checkout back to $BASE_BRANCH. Run 'git checkout $BASE_BRANCH' manually." >&2
+fi
 ```
 
 No `--watch`, no polling. CI runs on GitHub's side; the user follows the
-URL. The EXIT trap finalizes the marker to `complete` on success.
+URL. The success path returns the working tree to `$BASE_BRANCH` so
+subsequent commands don't accidentally pile onto the feature branch —
+forgiving on failure (warn, do not fail the run, since the PR is already
+created). The EXIT trap finalizes the marker to `complete` on success.
 
 ### Terminal marker states
 
@@ -784,4 +796,4 @@ to attest to.
 - **No error suppression on fallible operations.** Distinguish network failure from branch-exists; check each cleanup step.
 - **Bare-branch push only.** `git push -u origin "$BRANCH"` — never a refspec pointed at a protected ref.
 - **No `.landed` marker.** `/quickfix` has no worktree; PR state is authoritative via `gh pr view`.
-- **Fire-and-forget.** End at `gh pr create`; print URL; exit. No polling, no `--watch`.
+- **Fire-and-forget.** End at `gh pr create`; print URL; return user to `$BASE_BRANCH`; exit. No polling, no `--watch`.

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 
 `/quickfix` turns the current main checkout (with or without dirty edits)
 into a one-commit PR without leaving main. No worktree. No cherry-pick.
-Fire-and-forget: commit, push, open PR, print URL, exit.
+Fire-and-forget: commit, push, open PR, print URL, return to base branch, exit.
 
 **Ultrathink throughout.**
 
@@ -746,10 +746,22 @@ if [ -f "$MARKER" ]; then
 fi
 
 echo "$PR_URL"
+
+# WI 1.17 — return to base branch on success.
+# The PR exists on GitHub; locally we leave the user where they started
+# (on $BASE_BRANCH) so subsequent commands don't accidentally pile onto
+# the feature branch. Forgiving: if the checkout fails, warn but do not
+# fail the run — the PR is already created.
+if ! git checkout "$BASE_BRANCH"; then
+  echo "WARN: PR created at $PR_URL but failed to checkout back to $BASE_BRANCH. Run 'git checkout $BASE_BRANCH' manually." >&2
+fi
 ```
 
 No `--watch`, no polling. CI runs on GitHub's side; the user follows the
-URL. The EXIT trap finalizes the marker to `complete` on success.
+URL. The success path returns the working tree to `$BASE_BRANCH` so
+subsequent commands don't accidentally pile onto the feature branch —
+forgiving on failure (warn, do not fail the run, since the PR is already
+created). The EXIT trap finalizes the marker to `complete` on success.
 
 ### Terminal marker states
 
@@ -784,4 +796,4 @@ to attest to.
 - **No error suppression on fallible operations.** Distinguish network failure from branch-exists; check each cleanup step.
 - **Bare-branch push only.** `git push -u origin "$BRANCH"` — never a refspec pointed at a protected ref.
 - **No `.landed` marker.** `/quickfix` has no worktree; PR state is authoritative via `gh pr view`.
-- **Fire-and-forget.** End at `gh pr create`; print URL; exit. No polling, no `--watch`.
+- **Fire-and-forget.** End at `gh pr create`; print URL; return user to `$BASE_BRANCH`; exit. No polling, no `--watch`.

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -1009,8 +1009,9 @@ if [ "$RC" -eq 0 ] \
    && [ "$MARKER_STATUS_COMPLETE" = "yes" ] \
    && [ "$MARKER_PR_FIELD" = "yes" ] \
    && [ "$STDOUT_HAS_PR_URL" = "yes" ] \
-   && [ "$COMMIT_TRAILER" -ge 1 ]; then
-  pass "43 true end-to-end (user-edited): branch pushed, PR URL printed, marker complete with pr: field, mode-aware trailer"
+   && [ "$COMMIT_TRAILER" -ge 1 ] \
+   && [ "$CURRENT" = "main" ]; then
+  pass "43 true end-to-end (user-edited): branch pushed, PR URL printed, marker complete with pr: field, mode-aware trailer, returned to base"
 else
   fail "43 end-to-end: rc=$RC current='$CURRENT' local=$BRANCH_EXISTS_LOCAL remote=$BRANCH_EXISTS_REMOTE marker-complete=$MARKER_STATUS_COMPLETE marker-pr=$MARKER_PR_FIELD stdout-url=$STDOUT_HAS_PR_URL trailer-count=$COMMIT_TRAILER"
   echo "  --- stdout ---"; sed 's/^/    /' "$OUT"


### PR DESCRIPTION
## Summary

`/quickfix`'s overview claims it "turns the current main checkout ... into a one-commit PR without leaving main" — but the implementation left the user on the feature branch after a successful PR, contradicting the prose. Subsequent commands in the user's session would accidentally pile onto the feature branch unless they manually ran `git checkout main`.

Surfaced as a usability friction during today's QF1 run — the user finished the /quickfix and was unexpectedly on `feat/slug-namespace-draft-plan-reviews`.

## Fix

Add WI 1.17 (Phase 7, after WI 1.16 marker URL append): `git checkout "$BASE_BRANCH"`.

Forgiving on failure: if the checkout fails, warn but do not fail the run. The PR is already created on GitHub; we don't want a transient local-state hiccup to flip the marker from `complete` → `failed`.

## Failure paths unchanged

The push-failure (WI 1.14) and PR-create-failure (WI 1.15) paths still leave the user on the feature branch deliberately, so they can retry `git push` or `gh pr create` manually without re-staging. Only the success path returns the user to base.

## Tests

- Case 43 (full end-to-end, user-edited mode) extended to assert `CURRENT == "main"` after the run.
- Cases 40-42, 47 (preflight-only) unchanged — they only exercise the script up through branch creation, which still leaves the working tree on the feature branch (correct for that test-script's scope).
- Local: 851/851 passed.

## Files

- `skills/quickfix/SKILL.md` — WI 1.17 bash block + prose paragraph + Fire-and-forget Key Rule + overview line.
- `.claude/skills/quickfix/SKILL.md` — byte-for-byte mirror.
- `tests/test-quickfix.sh` — Case 43 assertion extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)