### PR TITLE
fix(hooks): scope rule (c) to PUSH_ARGS + match git push at EOL (#81)

### DIFF
--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -630,7 +630,7 @@ fi
 # variable-bearing push-target forms) produces false-positives on
 # legitimate worktree-scoped pushes without closing a realistic attack
 # vector.
-if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected; then
+if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\"|$) ]] && is_main_protected; then
   # Scope rules (a) and (b) to JUST the `git push` command segment, not the
   # whole $COMMAND buffer. Without this, multi-statement commands like
   # `git fetch origin main && git push -u origin feat/foo` false-positive
@@ -655,10 +655,13 @@ if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected;
   if [[ "$PUSH_ARGS" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
-  # (c) Naked push (no origin arg) while on main — defaults to pushing
-  # the current branch, which is main. Tested against full $COMMAND
-  # because seeing `origin` ANYWHERE means a non-naked push is present.
-  if ! [[ "$COMMAND" =~ origin[[:space:]] ]] && is_on_main; then
+  # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,
+  # not full $COMMAND. An empty PUSH_ARGS means we extracted no
+  # positional args from the push segment, which matches a naked
+  # `git push`. Quoted-argument false-positives (e.g. grep "git push"
+  # in some-file) no longer trip because the extraction loop only
+  # sees tokens after the actual `git push` invocation.
+  if [ -z "${PUSH_ARGS// /}" ] && is_on_main; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
 fi

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -630,7 +630,7 @@ fi
 # variable-bearing push-target forms) produces false-positives on
 # legitimate worktree-scoped pushes without closing a realistic attack
 # vector.
-if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected; then
+if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\"|$) ]] && is_main_protected; then
   # Scope rules (a) and (b) to JUST the `git push` command segment, not the
   # whole $COMMAND buffer. Without this, multi-statement commands like
   # `git fetch origin main && git push -u origin feat/foo` false-positive
@@ -655,10 +655,13 @@ if [[ "$COMMAND" =~ git[[:space:]]+push([[:space:]]|\") ]] && is_main_protected;
   if [[ "$PUSH_ARGS" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
-  # (c) Naked push (no origin arg) while on main — defaults to pushing
-  # the current branch, which is main. Tested against full $COMMAND
-  # because seeing `origin` ANYWHERE means a non-naked push is present.
-  if ! [[ "$COMMAND" =~ origin[[:space:]] ]] && is_on_main; then
+  # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,
+  # not full $COMMAND. An empty PUSH_ARGS means we extracted no
+  # positional args from the push segment, which matches a naked
+  # `git push`. Quoted-argument false-positives (e.g. grep "git push"
+  # in some-file) no longer trip because the extraction loop only
+  # sees tokens after the actual `git push` invocation.
+  if [ -z "${PUSH_ARGS// /}" ] && is_on_main; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
 fi

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -997,7 +997,14 @@ print(json.dumps(caller))
 EOF
   fi
 
-  local json="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$cmd\"},\"transcript_path\":\"$test_tmpdir/.transcript\"}"
+  # JSON shape: "command" is the LAST field so the hook's greedy sed
+  # extraction (`.*"command":"\(.*\)".*`) doesn't bleed envelope tokens
+  # like `transcript_path` into COMMAND. Single-line JSON is required by
+  # the helper; reordering to put `command` last is the simplest way to
+  # match production (where Claude Code's JSON is multi-line, also clean).
+  # Issue #81: rule (c)'s PUSH_ARGS-based check needs a clean COMMAND so
+  # the post-`git push` segment doesn't get JSON envelope words spliced in.
+  local json="{\"tool_name\":\"Bash\",\"transcript_path\":\"$test_tmpdir/.transcript\",\"tool_input\":{\"command\":\"$cmd\"}}"
   # Override LOCAL_ROOT and TRACKING_ROOT so the hook resolves to the fixture,
   # not the caller's worktree. Without these, the hook's push-path tracking
   # block reads .zskills-tracked + tracking markers from wherever the test was
@@ -1226,6 +1233,82 @@ if [[ "$RESULT" == *"Cannot push to main"* ]]; then
   pass "push-scope: git push HEAD:master blocked"
 else
   fail "push-scope: git push HEAD:master should be blocked, got: $RESULT"
+fi
+
+echo ""
+echo "=== Project hook: rule (c) push-segment scoping (issue #81) ==="
+
+# Background: rule (c) ("naked push while on main") used to scan the entire
+# $COMMAND for `origin[[:space:]]`. That false-positived whenever the literal
+# string `git push` appeared inside a quoted argument (grep/sed/echo/awk
+# scanning a file or message that mentions "git push") AND there was no
+# `origin ` substring elsewhere in the command AND the agent was on main.
+# The fix scopes rule (c) to PUSH_ARGS — the bounded post-`git push` segment.
+# These tests pin the BLOCK cases that must keep working AND the ALLOW cases
+# the fix is supposed to unblock.
+
+# BLOCK (true naked push, the case rule c was designed for): on main, bare
+# `git push` defaults to pushing the current branch (main). Must still block.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "git push")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "rule-c: naked git push on main blocked"
+else
+  fail "rule-c: naked git push on main should be blocked, got: $RESULT"
+fi
+
+# BLOCK (flag-only push on main): `git push -u` has no positional args, so
+# PUSH_ARGS extraction yields empty. Must still block.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "git push -u")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "rule-c: git push -u (flag only) on main blocked"
+else
+  fail "rule-c: git push -u (flag only) on main should be blocked, got: $RESULT"
+fi
+
+# ALLOW (the false-positive from issue #81): on main, grep for the literal
+# string "git push" inside a file. The hook's outer gate matches `git push"`
+# (where the trailing `"` closes a quoted shell arg). Pre-fix, rule (c) then
+# scanned $COMMAND, saw no `origin ` substring, and blocked. PUSH_ARGS scoping
+# fixes this — PUSH_ARGS contains the trailing tokens after `git push`, which
+# is non-empty (`" some-file.sh"`), so rule (c) skips. Note: JSON encoding of
+# the embedded double-quote requires `\"` here so the test fixture's bash-to-
+# JSON interpolation produces a literal `"` in the extracted command.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' 'grep -n \"git push\" some-file.sh')
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "rule-c: grep \"git push\" some-file.sh on main allowed (issue #81)"
+else
+  fail "rule-c: grep \"git push\" some-file.sh on main should be allowed, got: $RESULT"
+fi
+
+# ALLOW (echo with literal substring): on main, echo a string that mentions
+# "git push". Same shape as the grep case — quoted-argument false-positive.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' 'echo \"remember to git push\" >> notes.md')
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "rule-c: echo \"remember to git push\" on main allowed"
+else
+  fail "rule-c: echo \"remember to git push\" on main should be allowed, got: $RESULT"
+fi
+
+# ALLOW (feature-branch push while branch is main): rule (c) keys off
+# is_on_main, but PUSH_ARGS contains positional args (`origin feat/foo`), so
+# rule (c) must skip. Rules (a)/(b) inspect PUSH_ARGS and find no main/master,
+# so they also pass. End result: allowed.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "git push -u origin feat/foo")
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "rule-c: git push -u origin feat/foo (while on main) allowed"
+else
+  fail "rule-c: git push -u origin feat/foo (while on main) should be allowed, got: $RESULT"
+fi
+
+# ALLOW (the original #58 case, plus #81 scoping check): fetch-then-push of
+# a feature branch while on main. The fetch portion contains `origin main`,
+# but rule (a) is scoped to PUSH_ARGS so it doesn't fire; rule (c) sees
+# PUSH_ARGS=`origin feat/foo` (non-empty) so it doesn't fire either.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "git fetch origin main && git push -u origin feat/foo")
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "rule-c: git fetch origin main && git push -u origin feat/foo (while on main) allowed"
+else
+  fail "rule-c: git fetch origin main && git push -u origin feat/foo (while on main) should be allowed, got: $RESULT"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #81.

Two related fixes to the main_protected push-guard in `hooks/block-unsafe-project.sh.template`:

### 1. Rule (c) scoped to `PUSH_ARGS` (the original #81 bug)

Rule (c) — naked-push-while-on-main — was testing `$COMMAND` directly. PR #73 (Issue #58 fix) already segment-scoped rules (a) and (b) to `PUSH_ARGS`; rule (c) was left because of an assumption ("if `origin` appears anywhere, a non-naked push is present") that breaks whenever `git push` appears in a quoted arg without `origin` nearby. Switched to `[ -z "${PUSH_ARGS// /}" ]` — the actual signature of a naked push.

### 2. Outer gate regex matches `git push` at end-of-line

Discovered while fixing #1: the outer regex `git[[:space:]]+push([[:space:]]|\")` doesn't match a clean COMMAND of `git push` with no trailing chars. Pre-fix, the test fixture's mid-envelope `command` field caused JSON-bleed that left a `"` after push (matching `\"`). Once the fixture was reordered to put `command` last (matching production's multi-line JSON extraction), the outer regex stopped matching naked `git push` and rules a/b/c never executed. Extended alternation to `[[:space:]]|\"|$`.

## Test fixture reorder

Moved `command` to the LAST JSON field in `tests/test-hooks.sh:1007` so the hook's greedy sed extraction yields a clean COMMAND (matches production behavior).

## Tests added

6 new cases under "Project hook: rule (c) push-segment scoping (issue #81)":

| Case | Expected |
|---|---|
| Naked `git push` on main | BLOCK (true rule-c case) |
| `git push -u` on main | BLOCK (flags only) |
| `grep "git push" some-file.sh` on main | ALLOW (#81 case) |
| `echo "remember to git push"` on main | ALLOW (#81 case) |
| `git push -u origin feat/foo` on main | ALLOW (#58 regression) |
| `git fetch origin main && git push -u origin feat/foo` | ALLOW (PR #73 regression) |

## Test plan

- [x] `bash tests/run-all.sh` — 857/857 passed locally (851 existing + 6 new)
- [x] Both source `.template` and installed `.claude/hooks/` versions updated identically
- [x] CI green

🤖 Generated via issue-driven /quickfix-equivalent flow