### PR TITLE
feat(scripts): mirror-skill.sh — hook-compatible mirror regen (#84)

### DIFF
--- a/scripts/mirror-skill.sh
+++ b/scripts/mirror-skill.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# scripts/mirror-skill.sh — Regenerate .claude/skills/<name>/ mirror from
+# skills/<name>/. Hook-compatible: uses per-file rm (no -r flag) for
+# orphan removal instead of `rm -rf`, avoiding block-unsafe-generic.sh's
+# recursive-rm gate.
+#
+# Usage: bash scripts/mirror-skill.sh <skill-name>
+# Exit:
+#   0 — mirror updated, diff -rq clean.
+#   1 — usage error, source path missing, or post-regen diff non-clean.
+
+set -u
+
+NAME="${1:-}"
+if [ -z "$NAME" ]; then
+  echo "Usage: bash scripts/mirror-skill.sh <skill-name>" >&2
+  exit 1
+fi
+
+# Resolve repo root (allow caller to be in any subdir).
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+SRC="$REPO_ROOT/skills/$NAME"
+DST="$REPO_ROOT/.claude/skills/$NAME"
+
+if [ ! -d "$SRC" ]; then
+  echo "ERROR: source dir not found: $SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$DST"
+
+# Copy source contents over destination — handles file updates and adds.
+# `cp -a src/. dst/` is the dot-source idiom that copies CONTENTS into
+# dst (not src as a subdir of dst).
+cp -a "$SRC/." "$DST/"
+
+# Find files in mirror that don't exist in source, remove them per-file.
+# `diff -rq` output line for orphans: "Only in <dir>[/<subdir>]: <basename>"
+# We pass `dst` to awk as a variable to handle paths with regex metachars.
+diff -rq "$SRC/" "$DST/" 2>/dev/null | awk -v dst="$DST" '
+  index($0, "Only in " dst) == 1 {
+    # Strip the leading "Only in " prefix.
+    line = substr($0, length("Only in ") + 1)
+    # Split on ": " — left side is the directory, right is the basename.
+    sep = index(line, ": ")
+    if (sep == 0) next
+    dir = substr(line, 1, sep - 1)
+    base = substr(line, sep + 2)
+    print dir "/" base
+  }
+' | while IFS= read -r orphan; do
+  if [ -f "$orphan" ]; then
+    rm -- "$orphan"
+  elif [ -d "$orphan" ]; then
+    # Empty directory: rmdir (no -r). If non-empty, recurse via find +
+    # per-file rm so we never invoke `rm -r`.
+    find "$orphan" -type f -print0 | while IFS= read -r -d '' f; do
+      rm -- "$f"
+    done
+    # Now remove now-empty subdirs depth-first.
+    find "$orphan" -depth -type d -empty -exec rmdir {} \;
+  fi
+done
+
+# Verify clean.
+DIFF_OUT=$(diff -rq "$SRC/" "$DST/" 2>&1)
+if [ -n "$DIFF_OUT" ]; then
+  echo "ERROR: mirror not clean after regen:" >&2
+  echo "$DIFF_OUT" >&2
+  exit 1
+fi
+
+echo "Mirror clean: skills/$NAME/ -> .claude/skills/$NAME/"
+exit 0

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -49,6 +49,7 @@ run_suite "test-tracking-integration.sh" "tests/test-tracking-integration.sh"
 run_suite "test-stop-dev.sh" "tests/test-stop-dev.sh"
 run_suite "test-quickfix.sh" "tests/test-quickfix.sh"
 run_suite "test-update-zskills-rerender.sh" "tests/test-update-zskills-rerender.sh"
+run_suite "test-mirror-skill.sh" "tests/test-mirror-skill.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test-mirror-skill.sh
+++ b/tests/test-mirror-skill.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Tests for scripts/mirror-skill.sh
+# Run from repo root: bash tests/test-mirror-skill.sh
+#
+# Each test builds a synthetic fixture under /tmp/zskills-mirror-test-<n>/
+# with its own `skills/<name>/` and `.claude/skills/<name>/` trees, then
+# runs the helper inside the fixture (via a `cd` + isolated git init so
+# `git rev-parse --show-toplevel` picks up the fixture root, not the
+# real zskills repo).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/mirror-skill.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  printf '\033[32m  PASS\033[0m %s\n' "$1"
+  ((PASS_COUNT++))
+}
+
+fail() {
+  printf '\033[31m  FAIL\033[0m %s\n' "$1"
+  ((FAIL_COUNT++))
+}
+
+# Build a fresh fixture root: a /tmp dir containing a `skills/<name>/`
+# tree, an empty `.claude/skills/` parent, and an isolated git repo so
+# the helper resolves repo root to the fixture (not the real zskills
+# checkout). Echoes the fixture path on stdout.
+make_fixture() {
+  local label="$1"
+  local fixture="/tmp/zskills-mirror-test-$label-$$"
+  rm -rf -- "$fixture" 2>/dev/null
+  mkdir -p "$fixture/skills" "$fixture/.claude/skills"
+  ( cd "$fixture" && git init -q && git config user.email t@t && git config user.name t )
+  echo "$fixture"
+}
+
+cleanup_fixture() {
+  local fixture="$1"
+  # Per CLAUDE.md: only `rm -rf` literal /tmp/<name> paths.
+  case "$fixture" in
+    /tmp/zskills-mirror-test-*)
+      rm -rf -- "$fixture"
+      ;;
+    *)
+      echo "REFUSING to clean non-/tmp path: $fixture" >&2
+      ;;
+  esac
+}
+
+echo "=== mirror-skill.sh tests ==="
+
+# --- Test 1: single-file source, fresh mirror -------------------------
+F=$(make_fixture t1)
+mkdir -p "$F/skills/alpha"
+echo "alpha content" > "$F/skills/alpha/SKILL.md"
+out=$( cd "$F" && bash "$HELPER" alpha 2>&1 )
+ec=$?
+if [ "$ec" -eq 0 ] \
+   && [ -f "$F/.claude/skills/alpha/SKILL.md" ] \
+   && [ "$(cat "$F/.claude/skills/alpha/SKILL.md")" = "alpha content" ] \
+   && diff -rq "$F/skills/alpha/" "$F/.claude/skills/alpha/" >/dev/null 2>&1; then
+  pass "single-file source -> fresh mirror"
+else
+  fail "single-file fresh mirror (exit=$ec, out=$out)"
+fi
+cleanup_fixture "$F"
+
+# --- Test 2: multi-file source, fresh mirror --------------------------
+F=$(make_fixture t2)
+mkdir -p "$F/skills/beta/references" "$F/skills/beta/modes"
+echo "main"  > "$F/skills/beta/SKILL.md"
+echo "ref-x" > "$F/skills/beta/references/x.md"
+echo "pr"    > "$F/skills/beta/modes/pr.md"
+out=$( cd "$F" && bash "$HELPER" beta 2>&1 )
+ec=$?
+if [ "$ec" -eq 0 ] \
+   && [ -f "$F/.claude/skills/beta/SKILL.md" ] \
+   && [ -f "$F/.claude/skills/beta/references/x.md" ] \
+   && [ -f "$F/.claude/skills/beta/modes/pr.md" ] \
+   && diff -rq "$F/skills/beta/" "$F/.claude/skills/beta/" >/dev/null 2>&1; then
+  pass "multi-file source -> fresh mirror"
+else
+  fail "multi-file fresh mirror (exit=$ec, out=$out)"
+fi
+cleanup_fixture "$F"
+
+# --- Test 3: existing mirror with orphan ------------------------------
+F=$(make_fixture t3)
+mkdir -p "$F/skills/gamma"
+echo "new content" > "$F/skills/gamma/SKILL.md"
+mkdir -p "$F/.claude/skills/gamma"
+echo "stale content" > "$F/.claude/skills/gamma/SKILL.md"
+echo "orphan"        > "$F/.claude/skills/gamma/OLD_FILE.md"
+out=$( cd "$F" && bash "$HELPER" gamma 2>&1 )
+ec=$?
+if [ "$ec" -eq 0 ] \
+   && [ "$(cat "$F/.claude/skills/gamma/SKILL.md")" = "new content" ] \
+   && [ ! -e "$F/.claude/skills/gamma/OLD_FILE.md" ] \
+   && diff -rq "$F/skills/gamma/" "$F/.claude/skills/gamma/" >/dev/null 2>&1; then
+  pass "existing mirror with orphan: orphan removed, content updated"
+else
+  fail "orphan removal (exit=$ec, out=$out, orphan-exists=$( [ -e "$F/.claude/skills/gamma/OLD_FILE.md" ] && echo yes || echo no ))"
+fi
+cleanup_fixture "$F"
+
+# --- Test 4: source doesn't exist -> exit 1 ---------------------------
+F=$(make_fixture t4)
+out=$( cd "$F" && bash "$HELPER" does-not-exist 2>&1 )
+ec=$?
+if [ "$ec" -eq 1 ] && echo "$out" | grep -qi "source dir not found"; then
+  pass "missing source: exit 1 with clear error"
+else
+  fail "missing source (exit=$ec, out=$out)"
+fi
+cleanup_fixture "$F"
+
+# --- Test 5: no arg -> exit 1 with usage -----------------------------
+F=$(make_fixture t5)
+out=$( cd "$F" && bash "$HELPER" 2>&1 )
+ec=$?
+if [ "$ec" -eq 1 ] && echo "$out" | grep -qi "usage"; then
+  pass "no arg: exit 1 with usage message"
+else
+  fail "no-arg usage (exit=$ec, out=$out)"
+fi
+cleanup_fixture "$F"
+
+# --- Test 6: update-only (no orphans, no adds) ------------------------
+F=$(make_fixture t6)
+mkdir -p "$F/skills/delta"
+echo "v2 content" > "$F/skills/delta/SKILL.md"
+mkdir -p "$F/.claude/skills/delta"
+echo "v1 content" > "$F/.claude/skills/delta/SKILL.md"
+out=$( cd "$F" && bash "$HELPER" delta 2>&1 )
+ec=$?
+if [ "$ec" -eq 0 ] \
+   && [ "$(cat "$F/.claude/skills/delta/SKILL.md")" = "v2 content" ] \
+   && diff -rq "$F/skills/delta/" "$F/.claude/skills/delta/" >/dev/null 2>&1; then
+  pass "update-only: stale mirror file is refreshed to source content"
+else
+  fail "update-only (exit=$ec, out=$out)"
+fi
+cleanup_fixture "$F"
+
+echo ""
+echo "---"
+printf 'Results: %d passed, %d failed (of %d)\n' \
+  "$PASS_COUNT" "$FAIL_COUNT" "$((PASS_COUNT + FAIL_COUNT))"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #84. **Option 2** per the issue's decision comment.

The canonical mirror-regen recipe documented across skill prompts uses `rm -rf .claude/skills/<name>/` + `cp -r`, blocked by `block-unsafe-generic.sh`'s recursive-rm gate. Single-file mirrors get a clean `cp source target` workaround from the implementing agent, but multi-file mirrors would silently leak deletions.

This adds `scripts/mirror-skill.sh <skill-name>` as the canonical entrypoint.

## Helper behavior

1. Resolve repo root + validate source `skills/<name>/`.
2. `cp -a src/. dst/` — copies contents into mirror (handles updates and adds for any layout).
3. Find orphans via `diff -rq`, remove per-file:
   - Files: `rm <file>` (no `-r` flag → not hook-blocked).
   - Empty directories: `find -type f` rm of contents, then `rmdir` depth-first.
4. Verify clean: post-regen `diff -rq` must be empty; non-clean exits 1 with the diff.

## Tests

`tests/test-mirror-skill.sh` — 6 cases:

| Case | Coverage |
|---|---|
| 1. Single-file source → fresh mirror | Baseline (matches today's only-mirror-shape) |
| 2. Multi-file (`references/` + `modes/`) → fresh mirror | The case the helper is built for |
| 3. Existing mirror with orphan → orphan removed | Deletion-leak prevention |
| 4. Missing source → exit 1 with clear error | Error path |
| 5. No arg → exit 1 with usage | Error path |
| 6. Update-only (no orphans, no adds) | Refresh case |

Wired into `tests/run-all.sh`.

## Out of scope

Per the issue's decision comment: did NOT retroactively edit `QUEUED_QUICKFIXES.md` or any existing skill prompt. Future skill prompts should reference `bash scripts/mirror-skill.sh <name>` directly; existing prompts have either executed already or have agent-applied workarounds.

## Test plan

- [x] `bash tests/run-all.sh` — 857/857 passed locally (851 existing + 6 new)
- [x] Manual smoke: `bash scripts/mirror-skill.sh draft-plan` on a real mirror → clean
- [x] Hook-compatible: never invokes `rm -r`, `find ... -delete`, `rsync ... --delete`, or `xargs rm`
- [ ] CI green

🤖 Generated via issue-driven /quickfix-equivalent flow