### PR TITLE
[improve-staleness-detection] Improve /run-plan Staleness Detection (Arithmetic Drift) — Phase 1

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -679,6 +679,26 @@ Use cases:
 - `### Execution: delegate /run-plan plans/SUB_PLAN.md finish auto` — meta-plans
 - `### Execution: delegate /draft-plan plans/FOO.md <description>` — plan generation
 
+### Plan-text drift signals
+
+Include this VERBATIM in the dispatch prompt (delegate mode) so the
+delegated skill's implementing agent surfaces stale numeric acceptance
+criteria during its work:
+
+> If during your work you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+Tokens are parsed by `scripts/plan-drift-correct.sh --parse <report-file>`
+in Phase 3.5. Format is single-line, space-delimited; `<field>` MUST NOT
+contain `:` or `=`.
+
 ### Direct mode
 
 When `LANDING_MODE` is `direct`:
@@ -868,6 +888,28 @@ agent hasn't returned after 2 hours, declare it **failed**:
    those exact tests. Do not stop after the easy items and declare the hard
    ones "future work."
 
+### Plan-text drift signals
+
+Include this VERBATIM in every implementation-agent prompt (worktree
+mode) so the agent flags numeric acceptance bands that don't match
+reality at execution time:
+
+> If during your work you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+Tokens are parsed by `scripts/plan-drift-correct.sh --parse <report-file>`
+in Phase 3.5. Format is single-line, space-delimited; `<field>` MUST NOT
+contain `:` or `=`. Phase format: `phase=1`, `phase=4A`, etc.; bullet is
+the 1-indexed ordinal of a numeric-bearing bullet within the phase's
+`### Acceptance Criteria` section.
+
 ### PR mode (Phase 2)
 
 When `LANDING_MODE == pr`, the orchestrator creates a persistent worktree with
@@ -1038,6 +1080,26 @@ If this phase used delegate execution, verification runs on **main**:
 4. Dispatch a verification agent if needed (same rules as worktree mode
    below, but targeting main instead of a worktree path).
 
+#### Plan-text drift signals (delegate mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> If during your verification you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+**Verifiers MUST re-detect drift independently.** Do not forward the
+implementation agent's tokens — re-measure each numeric acceptance
+criterion against current reality. If implementation skipped the check
+OR implementation IS the source of drift, the verifier catches it.
+Phase 3.5 processes the UNION of both reports' tokens.
+
 ### Worktree mode verification
 
 1. **Dispatch verification agent** targeting the worktree's changes. The
@@ -1137,6 +1199,26 @@ If this phase used delegate execution, verification runs on **main**:
      After the fix agent finishes, re-verify (max 2 rounds). If still
      failing after 2 fix+verify cycles, **STOP** — needs human judgment.
      Invoke the Failure Protocol.
+
+#### Plan-text drift signals (worktree mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> If during your verification you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+**Verifiers MUST re-detect drift independently.** Do not forward the
+implementation agent's tokens — re-measure each numeric acceptance
+criterion against current reality. If implementation skipped the check
+OR implementation IS the source of drift, the verifier catches it.
+Phase 3.5 processes the UNION of both reports' tokens.
 
 ### Post-verification tracking
 
@@ -1704,6 +1786,11 @@ template is in the same file.
   with DATA: (1) current phase and when it started, (2) agent duration and
   tool call count, (3) errors or retries. Do not say "everything is fine"
   if an agent has been running >30 minutes or retried 2+ times.
+- **Plan-text drift signals.** Implementation and verification
+  agents MUST emit a `PLAN-TEXT-DRIFT:` token (format above) for
+  each numeric acceptance criterion that doesn't match reality.
+  Phase 3.5 parses these to decide whether to auto-correct the
+  plan. Token format forbids `:` and `=` inside `<field>`.
 
 ## Edge Cases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-04-28
+
+### Added
+- feat(run-plan): add `PLAN-TEXT-DRIFT:` structured token for
+  acceptance-band drift flags; see `skills/run-plan/SKILL.md` Key Rules
+  and `scripts/plan-drift-correct.sh`. Implementation and verification
+  agents emit one token per stale numeric acceptance criterion;
+  `scripts/plan-drift-correct.sh` provides `--parse` / `--drift` /
+  `--correct` modes consumed by `/run-plan` Phase 3.5
+  (`plans/IMPROVE_STALENESS_DETECTION.md`).
+
 ## 2026-04-21
 
 ### Major

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plans/IMPROVE_STALENESS_DETECTION.md](plans/IMPROVE_STALENESS_DETECTION.md) | 0/3 | **Ready to run** — /draft-plan converged round 1 (15/15 findings addressed); structural fix for stale-acceptance-band class of bug |
+| [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 1/3 | **In progress** — Phase 1 done (PLAN-TEXT-DRIFT token + scripts/plan-drift-correct.sh, 34 tests); Phase 2 (post-implement auto-correct gate) and Phase 3 (pre-dispatch arithmetic gate + --eval) remaining |
 | [plan-restructure-run-plan.md](reports/plan-restructure-run-plan.md) | 5/5 | **Complete** — all phases landed; 531/531 tests PASS; mirror parity clean; real-GitHub canaries deferred to user |
 | [plan-ci-fix-cycle-canary.md](reports/plan-ci-fix-cycle-canary.md) | 1/1 | **Complete** — CI-fix-cycle canary (pending this PR) |
 | [plan-parallel-canarya.md](reports/plan-parallel-canarya.md) | 1/1 | **Complete** — concurrent-pipeline in-vivo canary |

--- a/docs/tracking/TRACKING_NAMING.md
+++ b/docs/tracking/TRACKING_NAMING.md
@@ -399,6 +399,28 @@ only — the orchestrator itself never commits code):
 The isolation is structural — two concurrent pipelines cannot see
 each other's markers because they live in disjoint subdirectories.
 
+### Informational marker prefixes (allow-list)
+
+The hook enforces `requires.*`, `fulfilled.*`, and `step.*` only. Any
+basename outside that set is silently ignored — pipelines can write
+human-readable progress markers without affecting commit gating.
+
+Currently defined informational prefixes:
+
+- `phasestep.<skill>.<id>.<phase>.<event>` — per-phase progress notes
+  emitted by `/run-plan` and friends. Examples:
+  - `phasestep.run-plan.<id>.<phase>.drift-detect` — emitted by Phase 3.5
+    (introduced in `plans/IMPROVE_STALENESS_DETECTION.md` Phase 2) when
+    the orchestrator runs `scripts/plan-drift-correct.sh --parse` over
+    the implementation + verification reports. Informational only; the
+    hook ignores `phasestep.*`.
+- `meta.<skill>.<index>` — metadata-only markers used by
+  `research-and-go` for dispatcher-time bookkeeping (see OQ1).
+
+If a future design needs enforcement of one of these, promote it into
+`requires.*`/`fulfilled.*`/`step.*` rather than extending the hook's
+prefix set.
+
 ## References
 
 - `plans/UNIFY_TRACKING_NAMES.md` — the plan that commissions this doc

--- a/plans/IMPROVE_STALENESS_DETECTION.md
+++ b/plans/IMPROVE_STALENESS_DETECTION.md
@@ -23,7 +23,7 @@ Combined with `/refine-plan` Dimension 7, these form a defense-in-depth chain: *
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Standardize `PLAN-TEXT-DRIFT:` token + `scripts/plan-drift-correct.sh`        | ⬚ | | |
+| 1 — Standardize `PLAN-TEXT-DRIFT:` token + `scripts/plan-drift-correct.sh`        | 🟡 | `33fa174` | impl + tests; verifier committed |
 | 2 — Post-implement auto-correct gate (Phase 3.5)                                  | ⬚ | | |
 | 3 — Pre-dispatch arithmetic gate (Phase 1 step 6 extension) + tests + docs        | ⬚ | | |
 

--- a/plans/IMPROVE_STALENESS_DETECTION.md
+++ b/plans/IMPROVE_STALENESS_DETECTION.md
@@ -23,7 +23,7 @@ Combined with `/refine-plan` Dimension 7, these form a defense-in-depth chain: *
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Standardize `PLAN-TEXT-DRIFT:` token + `scripts/plan-drift-correct.sh`        | 🟡 | `33fa174` | impl + tests; verifier committed |
+| 1 — Standardize `PLAN-TEXT-DRIFT:` token + `scripts/plan-drift-correct.sh`        | ✅ Done | `33fa174` | landed via PR squash; 897/897 tests |
 | 2 — Post-implement auto-correct gate (Phase 3.5)                                  | ⬚ | | |
 | 3 — Pre-dispatch arithmetic gate (Phase 1 step 6 extension) + tests + docs        | ⬚ | | |
 

--- a/reports/plan-improve-staleness-detection.md
+++ b/reports/plan-improve-staleness-detection.md
@@ -1,0 +1,53 @@
+# Plan Report — Improve /run-plan Staleness Detection (Arithmetic Drift)
+
+## Phase — 1 Standardize PLAN-TEXT-DRIFT token + scripts/plan-drift-correct.sh [UNFINALIZED]
+
+**Plan:** plans/IMPROVE_STALENESS_DETECTION.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-improve-staleness-detection
+**Branch:** feat/improve-staleness-detection
+**Commits:** 33fa174 (impl + tests), 07a3cf6 (tracker mark in-progress)
+
+### Work Items
+
+| # | Item | Status | Source |
+|---|------|--------|--------|
+| 1.1 | Token format documented in SKILL.md | Done | 33fa174 |
+| 1.2 | `scripts/plan-drift-correct.sh` (501 lines, --parse / --drift / --correct, set -eu, no eval) | Done | 33fa174 |
+| 1.3 | `tests/test-plan-drift-correct.sh` (34 cases, ≥20 required) | Done | 33fa174 |
+| 1.4 | Registered in `tests/run-all.sh` | Done | 33fa174 |
+| 1.5 | `### Plan-text drift signals` H3 in 4 dispatch sections | Done | 33fa174 |
+| 1.6 | Key Rules bullet | Done | 33fa174 |
+| 1.7 | `docs/tracking/TRACKING_NAMING.md` allow-list update | Done | 33fa174 |
+| 1.8 | CHANGELOG entry | Done | 33fa174 |
+| 1.9 | Mirror parity (per-file cp) | Done | 33fa174 |
+| 1.10 | Commit | Done | 33fa174 |
+
+### Verification
+
+- Test suite: PASSED (897/897, +34 from baseline 863)
+- All 11 acceptance criteria verified by independent verification agent
+- Mirror clean: `diff -r skills/run-plan .claude/skills/run-plan` empty
+- Byte-preservation (lines 1-285) holds
+- No `eval`, no `$(( ))` over user input, no `jq` in script
+- All 5 `<stated>` forms supported (range, ≤, ≥, ~/literal, exactly); "any other form" exits 2
+
+### PLAN-TEXT-DRIFT findings (informational; Phase 3.5 doesn't exist yet)
+
+Both implementer and verifier independently flagged drift in Phase 1 acceptance bullets. Binding criteria all pass; drifts are in parenthetical/documentation references:
+
+```
+PLAN-TEXT-DRIFT: phase=1 bullet=10 field=test-count plan=~551 actual=897
+PLAN-TEXT-DRIFT: phase=1 bullet=11 field=parse-plan-line plan=286 actual=349
+```
+
+- bullet=10: parenthetical "(existing 531 + new 20 ≈ 551)" is stale; baseline was 863 + 34 = 897. Binding "100% pass rate" criterion holds.
+- bullet=11: prose says "Phase 1 Parse Plan at line 286 in the current source" — actual is line 349. The 285-line slice still operates correctly (everything in lines 1-285 is pre-Phase-1 and untouched), so byte-preservation passes; the 286 reference is stale documentation only.
+
+These tokens are recorded for posterity. Once Phase 2 lands (Phase 3.5 gate), a future `/run-plan` invocation on this plan would auto-correct them within the ≤10% / 10–20% bands. For now they are documented and bypass-able.
+
+### Notes
+
+- Phase 1 is a foundation-only phase: ships the token spec, the helper script, and tests. No `/run-plan` SKILL.md flow change yet (the new H3 subsections are content additions, not behavioral changes).
+- Phase 2 will add `## Phase 3.5` (post-implement auto-correct gate) wrapping `scripts/plan-drift-correct.sh`.
+- Phase 3 will extend Phase 1 step 6 with a pre-dispatch arithmetic gate plus `--eval` mode for integer +/- evaluation.

--- a/scripts/plan-drift-correct.sh
+++ b/scripts/plan-drift-correct.sh
@@ -1,0 +1,501 @@
+#!/bin/bash
+# Parse, compute, and apply numeric "acceptance-band drift" corrections
+# emitted by /run-plan implementation and verification agents.
+#
+# Pure bash — no jq, no eval, no $(( )) over user-controlled input.
+# Stated-form parsing uses awk + case + integer arithmetic only. Same
+# pattern as scripts/compute-cron-fire.sh: keep parse/compute/edit logic
+# in a testable script rather than skill-prose.
+#
+# Token format (single-line, space-delimited key=value):
+#
+#   PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+#
+# - phase=<N>      1-indexed phase number (e.g., phase=1, phase=4A)
+# - bullet=<M>     1-indexed ordinal within `### Acceptance Criteria`
+# - field=<str>    short identifier, free-form but MUST NOT contain ':'
+#                  or '=' (forbids parse ambiguity)
+# - plan=<stated>  exact literal from the acceptance criterion
+# - actual=<int>   measured value (integer; leading sign + digits)
+#
+# Modes:
+#   --parse <report-file>
+#     Reads file, extracts every PLAN-TEXT-DRIFT: token. For each token,
+#     emits one line on stdout: <phase>|<bullet>|<field>|<stated>|<actual>
+#     Exit 0 on success; 1 if any malformed token (stderr explains).
+#
+#   --drift <stated> <actual>
+#     Computes drift-percent (integer, rounded UP) for the given stated
+#     form and integer actual. Supported stated forms:
+#       N-M / N–M       range, drift = |actual - midpoint| / midpoint * 100
+#       <=N / ≤N / "at most N"
+#                       0 if actual ≤ N, else (actual - N)/N * 100
+#       >=N / ≥N / "at least N"
+#                       0 if actual ≥ N, else (N - actual)/N * 100
+#       ~N / "approximately N" / "expected N" / literal N
+#                       drift = |actual - N| / N * 100
+#       exactly N       0 if actual == N, else 999
+#     Any other form: exit 2 with stderr 'unsupported stated form: ...'.
+#
+#   --correct <plan-file> <phase> <bullet> <new-band> [--audit "original band"]
+#     Edits <plan-file>: locates the <phase> ### Acceptance Criteria
+#     section, finds the <bullet>th numeric-bearing bullet, replaces its
+#     stated band with <new-band>, and appends an audit comment of the
+#     form `<!-- Auto-corrected YYYY-MM-DD: was X, arithmetic says Y -->`.
+#     Exit 0 on success; 1 if the target bullet can't be uniquely located.
+#
+# Exits:
+#   0  success
+#   1  malformed token (parse) / unlocatable bullet (correct)
+#   2  unsupported stated form (drift) / usage error / unknown mode
+
+set -eu
+
+usage() {
+  sed -n '/^# Token format/,/^#   2 /p' "$0" | sed 's/^# \?//'
+}
+
+# ---------- helpers ----------
+
+# Print an error to stderr.
+err() { printf '%s\n' "$*" >&2; }
+
+# Validate <field> rejects ':' or '='.
+field_ok() {
+  case "$1" in
+    *:*|*=*) return 1 ;;
+  esac
+  return 0
+}
+
+# Parse an integer "actual" — leading optional sign, then digits, anything
+# trailing is discarded. Sets $ACTUAL_INT (positive integers only allowed
+# downstream — drift-percent treats negatives as 0-band overshoot).
+parse_actual_int() {
+  local raw="$1" sign='' digits
+  case "$raw" in
+    -*) sign='-'; raw="${raw#-}" ;;
+    +*) raw="${raw#+}" ;;
+  esac
+  # Extract leading digits via shell parameter expansion (no eval, no awk).
+  digits=''
+  while [ -n "$raw" ]; do
+    case "$raw" in
+      [0-9]*) digits="${digits}${raw:0:1}"; raw="${raw:1}" ;;
+      *) break ;;
+    esac
+  done
+  if [ -z "$digits" ]; then
+    return 1
+  fi
+  # Strip leading zeros but keep "0".
+  while [ "${#digits}" -gt 1 ] && [ "${digits:0:1}" = "0" ]; do
+    digits="${digits:1}"
+  done
+  ACTUAL_INT="${sign}${digits}"
+  return 0
+}
+
+# Integer absolute value into stdout.
+abs_int() {
+  local n="$1"
+  case "$n" in
+    -*) printf '%s\n' "${n#-}" ;;
+    *)  printf '%s\n' "$n" ;;
+  esac
+}
+
+# Ceiling division of |num| by denom (denom > 0). Both must be integers.
+ceil_div_abs() {
+  local n d a
+  n="$1"; d="$2"
+  a=$(abs_int "$n")
+  # ceil(a/d) = (a + d - 1) / d for non-negative a, positive d
+  printf '%s\n' "$(( (a + d - 1) / d ))"
+}
+
+# Compute |actual - target| / target * 100, rounded up. target must be > 0.
+drift_relative() {
+  local target="$1" actual="$2" diff
+  if [ "$target" -le 0 ]; then
+    err "drift_relative: target must be positive (got $target)"
+    return 2
+  fi
+  diff=$(( actual - target ))
+  diff=$(abs_int "$diff")
+  # ceil(diff*100/target)
+  printf '%s\n' "$(( (diff * 100 + target - 1) / target ))"
+}
+
+# Normalise a stated form for case-matching: strip surrounding whitespace,
+# replace en-dash with hyphen, replace ≤/≥ with <=/>=.
+normalise_stated() {
+  local s="$1"
+  # Trim leading/trailing whitespace.
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  # En-dash → hyphen.
+  s="${s//–/-}"
+  # ≤ → <= , ≥ → >= (multibyte-safe via bash string ops).
+  s="${s//≤/<=}"
+  s="${s//≥/>=}"
+  printf '%s' "$s"
+}
+
+# ---------- mode: --parse ----------
+
+mode_parse() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    err "plan-drift-correct --parse: file not found: $file"
+    return 2
+  fi
+
+  local rc=0 line_no=0 line
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$(( line_no + 1 ))
+    case "$line" in
+      *PLAN-TEXT-DRIFT:*) ;;
+      *) continue ;;
+    esac
+
+    # Extract the substring starting at the token marker.
+    local rest="${line#*PLAN-TEXT-DRIFT:}"
+    # Strip leading spaces.
+    rest="${rest#"${rest%%[![:space:]]*}"}"
+
+    # Token must be exactly 5 space-delimited key=value pairs.
+    # Grammar: phase=<v> bullet=<v> field=<v> plan=<v> actual=<v>
+    # We cannot use shell word-split because <stated> may contain spaces
+    # (e.g. "at most 50"). Anchor on the literal keys instead.
+    local phase bullet field plan_v actual_v
+
+    # Each value runs up to the next ' KEY=' boundary or EOL.
+    if ! [[ "$rest" =~ ^phase=([^[:space:]]+)[[:space:]]+bullet=([^[:space:]]+)[[:space:]]+field=([^[:space:]]+)[[:space:]]+plan=(.+)[[:space:]]+actual=(.+)$ ]]; then
+      err "plan-drift-correct --parse: malformed token at line $line_no: $line"
+      err "  expected: PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>"
+      rc=1
+      continue
+    fi
+    phase="${BASH_REMATCH[1]}"
+    bullet="${BASH_REMATCH[2]}"
+    field="${BASH_REMATCH[3]}"
+    plan_v="${BASH_REMATCH[4]}"
+    actual_v="${BASH_REMATCH[5]}"
+
+    # Validate field has no ':' or '='.
+    if ! field_ok "$field"; then
+      err "plan-drift-correct --parse: field contains ':' or '=' at line $line_no: $field"
+      rc=1
+      continue
+    fi
+
+    # phase must be alphanumeric (digits + optional trailing letter, e.g. 4A).
+    if ! [[ "$phase" =~ ^[0-9]+[A-Za-z]?$ ]]; then
+      err "plan-drift-correct --parse: invalid phase '$phase' at line $line_no"
+      rc=1
+      continue
+    fi
+
+    # bullet must be a positive integer.
+    if ! [[ "$bullet" =~ ^[1-9][0-9]*$ ]]; then
+      err "plan-drift-correct --parse: invalid bullet '$bullet' at line $line_no (must be positive integer)"
+      rc=1
+      continue
+    fi
+
+    # plan_v must not be empty (already guaranteed by regex .+).
+    # actual_v must contain leading digits (with optional sign).
+    if ! parse_actual_int "$actual_v"; then
+      err "plan-drift-correct --parse: actual='$actual_v' has no leading integer at line $line_no"
+      rc=1
+      continue
+    fi
+
+    printf '%s|%s|%s|%s|%s\n' "$phase" "$bullet" "$field" "$plan_v" "$ACTUAL_INT"
+  done < "$file"
+
+  return $rc
+}
+
+# ---------- mode: --drift ----------
+
+mode_drift() {
+  local stated_raw="$1" actual_raw="$2"
+
+  if ! parse_actual_int "$actual_raw"; then
+    err "plan-drift-correct --drift: actual must be an integer, got '$actual_raw'"
+    return 2
+  fi
+  local actual="$ACTUAL_INT"
+
+  local stated
+  stated=$(normalise_stated "$stated_raw")
+
+  # Try each supported form in turn. Order matters: more specific patterns
+  # (range "N-M") before bare-N forms.
+
+  # exactly N
+  if [[ "$stated" =~ ^exactly[[:space:]]+([+-]?[0-9]+)$ ]]; then
+    local n="${BASH_REMATCH[1]}"
+    if [ "$actual" -eq "$n" ]; then
+      printf '0\n'
+    else
+      printf '999\n'
+    fi
+    return 0
+  fi
+
+  # range: N-M (after en-dash normalisation; allow leading sign on first num)
+  if [[ "$stated" =~ ^([+-]?[0-9]+)-([+-]?[0-9]+)$ ]]; then
+    local lo="${BASH_REMATCH[1]}" hi="${BASH_REMATCH[2]}"
+    if [ "$lo" -gt "$hi" ]; then
+      err "plan-drift-correct --drift: range lo > hi in '$stated_raw'"
+      return 2
+    fi
+    # midpoint (integer; truncating toward zero is fine — drift is small either way)
+    local mid=$(( (lo + hi) / 2 ))
+    if [ "$mid" -le 0 ]; then
+      err "plan-drift-correct --drift: range midpoint must be positive in '$stated_raw'"
+      return 2
+    fi
+    drift_relative "$mid" "$actual"
+    return 0
+  fi
+
+  # ≤N / <=N / "at most N"
+  if [[ "$stated" =~ ^(\<=|at[[:space:]]+most[[:space:]]+)([+-]?[0-9]+)$ ]]; then
+    local n="${BASH_REMATCH[2]}"
+    if [ "$n" -le 0 ]; then
+      err "plan-drift-correct --drift: bound must be positive in '$stated_raw'"
+      return 2
+    fi
+    if [ "$actual" -le "$n" ]; then
+      printf '0\n'
+    else
+      local diff=$(( actual - n ))
+      printf '%s\n' "$(( (diff * 100 + n - 1) / n ))"
+    fi
+    return 0
+  fi
+
+  # ≥N / >=N / "at least N"
+  if [[ "$stated" =~ ^(\>=|at[[:space:]]+least[[:space:]]+)([+-]?[0-9]+)$ ]]; then
+    local n="${BASH_REMATCH[2]}"
+    if [ "$n" -le 0 ]; then
+      err "plan-drift-correct --drift: bound must be positive in '$stated_raw'"
+      return 2
+    fi
+    if [ "$actual" -ge "$n" ]; then
+      printf '0\n'
+    else
+      local diff=$(( n - actual ))
+      printf '%s\n' "$(( (diff * 100 + n - 1) / n ))"
+    fi
+    return 0
+  fi
+
+  # ~N / approximately N / expected N / literal N
+  if [[ "$stated" =~ ^(~|approximately[[:space:]]+|expected[[:space:]]+)?([+-]?[0-9]+)$ ]]; then
+    local n="${BASH_REMATCH[2]}"
+    if [ "$n" -le 0 ]; then
+      err "plan-drift-correct --drift: target must be positive in '$stated_raw'"
+      return 2
+    fi
+    drift_relative "$n" "$actual"
+    return 0
+  fi
+
+  err "unsupported stated form: $stated_raw"
+  return 2
+}
+
+# ---------- mode: --correct ----------
+
+mode_correct() {
+  local plan_file="$1" target_phase="$2" target_bullet="$3" new_band="$4"
+  local audit_was=""
+
+  shift 4
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --audit)
+        shift
+        audit_was="${1:-}"
+        if [ -z "$audit_was" ]; then
+          err "plan-drift-correct --correct: --audit requires a value"
+          return 2
+        fi
+        shift
+        ;;
+      *)
+        err "plan-drift-correct --correct: unknown arg '$1'"
+        return 2
+        ;;
+    esac
+  done
+
+  if [ ! -f "$plan_file" ]; then
+    err "plan-drift-correct --correct: plan file not found: $plan_file"
+    return 2
+  fi
+  if ! [[ "$target_phase" =~ ^[0-9]+[A-Za-z]?$ ]]; then
+    err "plan-drift-correct --correct: invalid phase '$target_phase'"
+    return 2
+  fi
+  if ! [[ "$target_bullet" =~ ^[1-9][0-9]*$ ]]; then
+    err "plan-drift-correct --correct: invalid bullet '$target_bullet'"
+    return 2
+  fi
+
+  # Locate the phase header. We anchor on '## Phase <N>' (allowing trailing
+  # text such as "— Foo"). Use grep -nE with anchored pattern; the awk
+  # walk that follows uses NR comparisons, not unanchored substring greps.
+  local phase_re='^## Phase '"$target_phase"'( |\b|—|-|$)'
+  local start_line
+  start_line=$(grep -nE "$phase_re" "$plan_file" | head -1 | cut -d: -f1 || true)
+  if [ -z "$start_line" ]; then
+    err "plan-drift-correct --correct: phase '$target_phase' header not found in $plan_file"
+    return 1
+  fi
+
+  # Find the next phase header (any) after start_line, to bound the search.
+  local end_line
+  end_line=$(awk -v s="$start_line" 'NR > s && /^## Phase / { print NR; exit }' "$plan_file")
+  if [ -z "$end_line" ]; then
+    end_line=$(wc -l < "$plan_file")
+    end_line=$(( end_line + 1 ))
+  fi
+
+  # Within [start_line, end_line), find '### Acceptance Criteria'.
+  local accept_line
+  accept_line=$(awk -v s="$start_line" -v e="$end_line" \
+    'NR >= s && NR < e && /^### Acceptance Criteria[[:space:]]*$/ { print NR; exit }' \
+    "$plan_file")
+  if [ -z "$accept_line" ]; then
+    err "plan-drift-correct --correct: phase '$target_phase' has no '### Acceptance Criteria' section"
+    return 1
+  fi
+
+  # Find end of acceptance section: next '### ' or '## ' header.
+  local accept_end
+  accept_end=$(awk -v s="$accept_line" 'NR > s && /^(##|###) / { print NR; exit }' "$plan_file")
+  if [ -z "$accept_end" ]; then
+    accept_end=$(wc -l < "$plan_file")
+    accept_end=$(( accept_end + 1 ))
+  fi
+
+  # Walk bullets in (accept_line, accept_end). A bullet starts with '- [ ]'
+  # or '- [x]' optionally indented, OR '- ' (no checkbox). Numeric-bearing
+  # bullets are those that contain at least one digit. We index 1-based.
+  # Multi-line bullets (continuation indented further) belong to the
+  # previous bullet.
+  local target_bullet_line=""
+  local idx=0
+  local current_line=""
+  local i=$(( accept_line + 1 ))
+  while [ "$i" -lt "$accept_end" ]; do
+    local row
+    row=$(sed -n "${i}p" "$plan_file")
+    # Detect new bullet (top-level '- ' with no leading non-empty spaces > 2).
+    if [[ "$row" =~ ^-[[:space:]] ]] || [[ "$row" =~ ^[[:space:]]{0,3}-[[:space:]] ]]; then
+      # New bullet: count it if it contains a digit.
+      if [[ "$row" =~ [0-9] ]]; then
+        idx=$(( idx + 1 ))
+        if [ "$idx" -eq "$target_bullet" ]; then
+          target_bullet_line="$i"
+          break
+        fi
+      fi
+    fi
+    i=$(( i + 1 ))
+  done
+
+  if [ -z "$target_bullet_line" ]; then
+    err "plan-drift-correct --correct: phase '$target_phase' has fewer than $target_bullet numeric-bearing acceptance bullets"
+    return 1
+  fi
+
+  # Apply the rewrite.
+  local original
+  original=$(sed -n "${target_bullet_line}p" "$plan_file")
+
+  # Locate the band literal to replace. We prefer the user-supplied
+  # `--audit "<original band>"` because it's the explicit, unambiguous
+  # match. Without --audit, we fall back to a heuristic: replace the FIRST
+  # parenthesised or backticked numeric-looking token. To stay safe we
+  # require --audit unless the line contains exactly one numeric token.
+  local rewritten
+  if [ -n "$audit_was" ]; then
+    # Literal substring replacement, first occurrence only.
+    if [[ "$original" != *"$audit_was"* ]]; then
+      err "plan-drift-correct --correct: --audit literal '$audit_was' not found on bullet line $target_bullet_line"
+      return 1
+    fi
+    rewritten="${original/"$audit_was"/$new_band}"
+  else
+    err "plan-drift-correct --correct: --audit \"<original band>\" is required (heuristic substitution refused)"
+    return 1
+  fi
+
+  # Append audit comment.
+  local today
+  today=$(date -u +%Y-%m-%d)
+  rewritten="${rewritten} <!-- Auto-corrected ${today}: was ${audit_was}, arithmetic says ${new_band} -->"
+
+  # In-place replacement of just that one line. We re-emit the file via
+  # awk to avoid sed's escaping pitfalls with `&`, `/`, etc.
+  local tmp
+  tmp=$(mktemp)
+  awk -v ln="$target_bullet_line" -v new="$rewritten" '
+    NR == ln { print new; next }
+    { print }
+  ' "$plan_file" > "$tmp"
+  mv "$tmp" "$plan_file"
+  return 0
+}
+
+# ---------- arg dispatch ----------
+
+if [ "$#" -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+MODE="$1"
+shift
+case "$MODE" in
+  --parse)
+    if [ "$#" -ne 1 ]; then
+      err "plan-drift-correct --parse <report-file>"
+      exit 2
+    fi
+    mode_parse "$1"
+    exit $?
+    ;;
+  --drift)
+    if [ "$#" -ne 2 ]; then
+      err "plan-drift-correct --drift <stated> <actual>"
+      exit 2
+    fi
+    mode_drift "$1" "$2"
+    exit $?
+    ;;
+  --correct)
+    if [ "$#" -lt 4 ]; then
+      err "plan-drift-correct --correct <plan-file> <phase> <bullet> <new-band> [--audit \"original\"]"
+      exit 2
+    fi
+    mode_correct "$@"
+    exit $?
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    err "plan-drift-correct: unknown mode '$MODE'"
+    err "  modes: --parse | --drift | --correct"
+    exit 2
+    ;;
+esac

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -679,6 +679,26 @@ Use cases:
 - `### Execution: delegate /run-plan plans/SUB_PLAN.md finish auto` — meta-plans
 - `### Execution: delegate /draft-plan plans/FOO.md <description>` — plan generation
 
+### Plan-text drift signals
+
+Include this VERBATIM in the dispatch prompt (delegate mode) so the
+delegated skill's implementing agent surfaces stale numeric acceptance
+criteria during its work:
+
+> If during your work you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+Tokens are parsed by `scripts/plan-drift-correct.sh --parse <report-file>`
+in Phase 3.5. Format is single-line, space-delimited; `<field>` MUST NOT
+contain `:` or `=`.
+
 ### Direct mode
 
 When `LANDING_MODE` is `direct`:
@@ -868,6 +888,28 @@ agent hasn't returned after 2 hours, declare it **failed**:
    those exact tests. Do not stop after the easy items and declare the hard
    ones "future work."
 
+### Plan-text drift signals
+
+Include this VERBATIM in every implementation-agent prompt (worktree
+mode) so the agent flags numeric acceptance bands that don't match
+reality at execution time:
+
+> If during your work you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+Tokens are parsed by `scripts/plan-drift-correct.sh --parse <report-file>`
+in Phase 3.5. Format is single-line, space-delimited; `<field>` MUST NOT
+contain `:` or `=`. Phase format: `phase=1`, `phase=4A`, etc.; bullet is
+the 1-indexed ordinal of a numeric-bearing bullet within the phase's
+`### Acceptance Criteria` section.
+
 ### PR mode (Phase 2)
 
 When `LANDING_MODE == pr`, the orchestrator creates a persistent worktree with
@@ -1038,6 +1080,26 @@ If this phase used delegate execution, verification runs on **main**:
 4. Dispatch a verification agent if needed (same rules as worktree mode
    below, but targeting main instead of a worktree path).
 
+#### Plan-text drift signals (delegate mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> If during your verification you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+**Verifiers MUST re-detect drift independently.** Do not forward the
+implementation agent's tokens — re-measure each numeric acceptance
+criterion against current reality. If implementation skipped the check
+OR implementation IS the source of drift, the verifier catches it.
+Phase 3.5 processes the UNION of both reports' tokens.
+
 ### Worktree mode verification
 
 1. **Dispatch verification agent** targeting the worktree's changes. The
@@ -1137,6 +1199,26 @@ If this phase used delegate execution, verification runs on **main**:
      After the fix agent finishes, re-verify (max 2 rounds). If still
      failing after 2 fix+verify cycles, **STOP** — needs human judgment.
      Invoke the Failure Protocol.
+
+#### Plan-text drift signals (worktree mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> If during your verification you observe a plan's acceptance criterion
+> contains a numeric target (lines / tests / cases / commits / files)
+> that doesn't match reality, emit a line of the form:
+>
+> ```
+> PLAN-TEXT-DRIFT: phase=<N> bullet=<M> field=<str> plan=<stated> actual=<measured>
+> ```
+>
+> in your final report. One per drift. Advisory — continue your work.
+
+**Verifiers MUST re-detect drift independently.** Do not forward the
+implementation agent's tokens — re-measure each numeric acceptance
+criterion against current reality. If implementation skipped the check
+OR implementation IS the source of drift, the verifier catches it.
+Phase 3.5 processes the UNION of both reports' tokens.
 
 ### Post-verification tracking
 
@@ -1704,6 +1786,11 @@ template is in the same file.
   with DATA: (1) current phase and when it started, (2) agent duration and
   tool call count, (3) errors or retries. Do not say "everything is fine"
   if an agent has been running >30 minutes or retried 2+ times.
+- **Plan-text drift signals.** Implementation and verification
+  agents MUST emit a `PLAN-TEXT-DRIFT:` token (format above) for
+  each numeric acceptance criterion that doesn't match reality.
+  Phase 3.5 parses these to decide whether to auto-correct the
+  plan. Token format forbids `:` and `=` inside `<field>`.
 
 ## Edge Cases
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -50,6 +50,7 @@ run_suite "test-stop-dev.sh" "tests/test-stop-dev.sh"
 run_suite "test-quickfix.sh" "tests/test-quickfix.sh"
 run_suite "test-update-zskills-rerender.sh" "tests/test-update-zskills-rerender.sh"
 run_suite "test-mirror-skill.sh" "tests/test-mirror-skill.sh"
+run_suite "test-plan-drift-correct.sh" "tests/test-plan-drift-correct.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test-plan-drift-correct.sh
+++ b/tests/test-plan-drift-correct.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Tests for scripts/plan-drift-correct.sh.
+#
+# Covers all three modes (--parse, --drift, --correct) across the five
+# supported <stated> forms (range, ≤, ≥, ~/literal, exactly), plus the
+# error / "unsupported" / "unlocatable" exit branches. Per CLAUDE.md,
+# scratch fixtures live under /tmp/zskills-tests/<basename-of-cwd>/.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/plan-drift-correct.sh"
+
+TEST_OUT="/tmp/zskills-tests/$(basename "$REPO_ROOT")/plan-drift-correct"
+mkdir -p "$TEST_OUT"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# expect_drift <label> <stated> <actual> <expected-stdout>
+expect_drift() {
+  local label="$1" stated="$2" actual="$3" expected="$4"
+  local out
+  out=$(bash "$SCRIPT" --drift "$stated" "$actual" 2>&1)
+  if [ "$out" = "$expected" ]; then
+    pass "$label  ($stated × $actual → $out)"
+  else
+    fail "$label — expected '$expected', got '$out'  ($stated × $actual)"
+  fi
+}
+
+# expect_rc <label> <args...>  ENV: EXPECTED_RC
+expect_rc() {
+  local expected_rc="$1"; shift
+  local label="$1"; shift
+  bash "$SCRIPT" "$@" >/dev/null 2>&1
+  local rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    pass "$label (rc=$rc)"
+  else
+    fail "$label — expected rc=$expected_rc, got rc=$rc"
+  fi
+}
+
+echo "=== --drift: range form ==="
+# midpoint(340,380)=360; |277-360|=83; ceil(83*100/360)=ceil(23.06)=24
+expect_drift "range hyphen 340-380 vs 277"   "340-380" 277 24
+# en-dash variant: midpoint(340,380)=360; |360-360|=0
+expect_drift "range en-dash 340–380 vs 360"  "340–380" 360 0
+expect_drift "range 100-200 vs 150"          "100-200" 150 0
+
+echo ""
+echo "=== --drift: ≤ / <= / 'at most' form ==="
+expect_drift "≤50 vs 40 (within bound)"      "≤50" 40 0
+expect_drift "<=50 vs 60 (over bound)"       "<=50" 60 20
+expect_drift "'at most 50' vs 60"            "at most 50" 60 20
+
+echo ""
+echo "=== --drift: ≥ / >= / 'at least' form ==="
+expect_drift "≥35 vs 50 (within bound)"      "≥35" 50 0
+expect_drift ">=35 vs 20 (under bound)"      ">=35" 20 43
+expect_drift "'at least 35' vs 20"           "at least 35" 20 43
+
+echo ""
+echo "=== --drift: ~ / approximately / expected / literal form ==="
+expect_drift "~357 vs 277"                   "~357" 277 23
+expect_drift "approximately 100 vs 90"       "approximately 100" 90 10
+expect_drift "expected 100 vs 110"           "expected 100" 110 10
+expect_drift "literal 100 vs 90"             "100" 90 10
+
+echo ""
+echo "=== --drift: exactly form ==="
+expect_drift "exactly 5 vs 5"                "exactly 5" 5 0
+expect_drift "exactly 5 vs 6 (mismatch → 999)" "exactly 5" 6 999
+
+echo ""
+echo "=== --drift: unsupported form returns rc=2 ==="
+expect_rc 2 "'roughly 400-600' is unsupported"     --drift "roughly 400-600" 500
+expect_rc 2 "'(40 + 12)' is unsupported"           --drift "(40 + 12)" 50
+
+echo ""
+echo "=== --parse: well-formed token ==="
+WELL="$TEST_OUT/well-formed.txt"
+cat > "$WELL" <<'EOF'
+Lots of report text here.
+
+PLAN-TEXT-DRIFT: phase=1 bullet=3 field=skill-line-count plan=340-380 actual=277
+
+More text.
+EOF
+out=$(bash "$SCRIPT" --parse "$WELL" 2>&1); rc=$?
+expected_one='1|3|skill-line-count|340-380|277'
+if [ "$rc" = "0" ] && [ "$out" = "$expected_one" ]; then
+  pass "parse: single well-formed token"
+else
+  fail "parse: single well-formed — got rc=$rc, out='$out'"
+fi
+
+echo ""
+echo "=== --parse: multiple tokens, one file ==="
+MULTI="$TEST_OUT/multi-token.txt"
+cat > "$MULTI" <<'EOF'
+PLAN-TEXT-DRIFT: phase=1 bullet=3 field=skill-line-count plan=340-380 actual=277
+Some intervening prose.
+PLAN-TEXT-DRIFT: phase=4A bullet=2 field=test-count plan=at most 50 actual=60
+EOF
+out=$(bash "$SCRIPT" --parse "$MULTI" 2>&1); rc=$?
+expected_multi='1|3|skill-line-count|340-380|277
+4A|2|test-count|at most 50|60'
+if [ "$rc" = "0" ] && [ "$out" = "$expected_multi" ]; then
+  pass "parse: multiple tokens emit one record per line"
+else
+  fail "parse: multi — got rc=$rc, out='$out'"
+fi
+
+echo ""
+echo "=== --parse: malformed token rejection ==="
+# Field with colon
+BAD_FIELD="$TEST_OUT/bad-field.txt"
+cat > "$BAD_FIELD" <<'EOF'
+PLAN-TEXT-DRIFT: phase=1 bullet=3 field=has:colon plan=10 actual=20
+EOF
+expect_rc 1 "parse: field with ':' rejected"  --parse "$BAD_FIELD"
+
+# Field with '=' (would create parse ambiguity)
+BAD_EQ="$TEST_OUT/bad-eq.txt"
+cat > "$BAD_EQ" <<'EOF'
+PLAN-TEXT-DRIFT: phase=1 bullet=3 field=has=eq plan=10 actual=20
+EOF
+expect_rc 1 "parse: field with '=' rejected"  --parse "$BAD_EQ"
+
+# Missing 'actual=' altogether
+BAD_MISSING="$TEST_OUT/bad-missing.txt"
+cat > "$BAD_MISSING" <<'EOF'
+PLAN-TEXT-DRIFT: phase=1 bullet=3 field=foo plan=10
+EOF
+expect_rc 1 "parse: missing 'actual=' rejected"  --parse "$BAD_MISSING"
+
+echo ""
+echo "=== --correct: in-place edit with audit comment ==="
+PLAN="$TEST_OUT/plan-correct.md"
+cat > "$PLAN" <<'EOF'
+## Phase 1 — Foo
+
+### Acceptance Criteria
+
+- [ ] Skill is approximately 357 lines (target band 340-380).
+- [ ] Test count at most 50.
+
+## Phase 2 — Bar
+
+### Acceptance Criteria
+
+- [ ] Something.
+EOF
+bash "$SCRIPT" --correct "$PLAN" 1 1 "277" --audit "approximately 357" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "correct: exit code 0 expected, got $rc"
+else
+  if grep -q 'Skill is 277 lines' "$PLAN" && grep -q 'Auto-corrected' "$PLAN" && grep -q 'was approximately 357' "$PLAN"; then
+    pass "correct: bullet rewritten + audit comment appended"
+  else
+    fail "correct: edit didn't apply expected substitutions in $PLAN"
+  fi
+fi
+
+echo ""
+echo "=== --correct: phase not found ==="
+PLAN_NF="$TEST_OUT/plan-no-phase.md"
+cat > "$PLAN_NF" <<'EOF'
+## Phase 1 — Foo
+
+### Acceptance Criteria
+
+- [ ] Approximately 100.
+EOF
+expect_rc 1 "correct: phase 7 (not present) returns rc=1"  --correct "$PLAN_NF" 7 1 "200" --audit "Approximately 100"
+
+echo ""
+echo "=== --correct: bullet ordinal too large ==="
+expect_rc 1 "correct: bullet 99 doesn't exist returns rc=1"  --correct "$PLAN_NF" 1 99 "200" --audit "Approximately 100"
+
+echo ""
+echo "=== --correct: --audit literal not found ==="
+expect_rc 1 "correct: --audit literal not in line returns rc=1"  --correct "$PLAN_NF" 1 1 "200" --audit "completely-unrelated-string"
+
+echo ""
+echo "=== --correct: --audit required (no heuristic substitution) ==="
+expect_rc 1 "correct: missing --audit refused"  --correct "$PLAN_NF" 1 1 "200"
+
+echo ""
+echo "=== --correct: invalid phase / bullet syntax ==="
+expect_rc 2 "correct: phase 'abc' is invalid"  --correct "$PLAN_NF" "abc" 1 "200" --audit "Approximately 100"
+expect_rc 2 "correct: bullet '0' is invalid (must be ≥1)"  --correct "$PLAN_NF" 1 0 "200" --audit "Approximately 100"
+
+echo ""
+echo "=== general usage errors ==="
+expect_rc 2 "no args"  ""
+expect_rc 2 "unknown mode"  --bogus
+expect_rc 2 "drift: missing actual"  --drift "100"
+expect_rc 2 "drift: non-integer actual"  --drift "100" "ten"
+expect_rc 2 "parse: file not found"  --parse "/tmp/zskills-tests/nonexistent-$$.txt"
+
+echo ""
+echo "---"
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi


### PR DESCRIPTION
## Plan: Improve /run-plan Staleness Detection (Arithmetic Drift)

Phase 1 of `plans/IMPROVE_STALENESS_DETECTION.md`. Foundation phase: ships the structured token grammar, the helper script, and 34 unit tests.

<!-- run-plan:progress:start -->
**Phases completed:**
- Phase 1 — Standardize PLAN-TEXT-DRIFT token + scripts/plan-drift-correct.sh (✅)
- Phase 2 — Post-implement auto-correct gate (Phase 3.5) (⬚ — next)
- Phase 3 — Pre-dispatch arithmetic gate (Phase 1 step 6 extension) + tests + docs (⬚)
<!-- run-plan:progress:end -->

## Summary

- New `PLAN-TEXT-DRIFT:` structured token (`phase=N bullet=M field=X plan=Y actual=Z`) for impl/verify agents to flag stale numeric acceptance bands.
- New `scripts/plan-drift-correct.sh` (501 lines, `set -eu`, no `eval`, no `jq`, no `$(())` over user input) with `--parse` / `--drift` / `--correct` modes; supports 5 stated forms (range, ≤, ≥, ~/literal, exactly); "any other form" exits 2.
- New `tests/test-plan-drift-correct.sh` (34 cases — covers all 5 stated forms × parse/compute/correct axes plus error paths).
- `### Plan-text drift signals` H3 added to 4 dispatch sections in `skills/run-plan/SKILL.md` (Phase 2 Worktree, Phase 2 Delegate, Phase 3 Worktree verification, Phase 3 Delegate verification) plus Key Rules bullet.
- `docs/tracking/TRACKING_NAMING.md`: phasestep-prefix allow-list extended for `phasestep.run-plan.<id>.<phase>.drift-detect`.
- CHANGELOG entry; mirror parity (`diff -r skills/run-plan .claude/skills/run-plan` empty).

Phases 2 (post-implement auto-correct gate, `## Phase 3.5`) and 3 (pre-dispatch arithmetic gate + `--eval` integer arithmetic) will land in subsequent PRs as part of `/run-plan plans/IMPROVE_STALENESS_DETECTION.md finish auto`.

## Test plan

- [x] `test -x scripts/plan-drift-correct.sh` (executable)
- [x] `bash -n scripts/plan-drift-correct.sh` (syntax clean)
- [x] `bash tests/test-plan-drift-correct.sh` exits 0 with 34 cases passing
- [x] `bash tests/run-all.sh` exits 0 with 100% pass rate (897/897, +34 from baseline 863)
- [x] Mirror parity: `diff -r skills/run-plan .claude/skills/run-plan` empty
- [x] 5 `PLAN-TEXT-DRIFT:` mentions in `skills/run-plan/SKILL.md` (a-e enumerated in plan AC bullet 5)
- [x] Byte-preservation diff lines 1–285 of SKILL.md is empty
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)