### PR TITLE
[improve-staleness-detection] Improve /run-plan Staleness Detection — Phase 2 (3.5 auto-correct gate)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1230,12 +1230,139 @@ printf 'phase: %s\nresult: pass\ncompleted: %s\n' "$PHASE" "$(TZ=America/New_Yor
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.run-plan.$TRACKING_ID.verify"
 ```
 
+## Phase 3.5 — Detect and auto-correct plan-text drift
+
+Runs AFTER Phase 3's `### Post-verification tracking` writes
+`step.run-plan.$TRACKING_ID.verify`, and BEFORE Phase 4's tracker
+commit. Reads both the implementation agent's and verification
+agent's reports for `PLAN-TEXT-DRIFT:` tokens and auto-corrects
+the plan file.
+
+### 1. Gather reports
+
+Concatenate the implementation agent's final-message text and the
+verification agent's final-message text into a single parse input.
+Both agents' outputs are available from Phase 2 and Phase 3 agent
+dispatches.
+
+### 2. Parse tokens
+
+```bash
+bash scripts/plan-drift-correct.sh --parse <combined-reports>
+```
+Produces one `<phase>|<bullet>|<field>|<stated>|<actual>` line per
+drift. Zero lines = no drifts → skip to step 6.
+
+### 3. Per-drift decision
+
+For each record, compute drift via:
+```bash
+bash scripts/plan-drift-correct.sh --drift "<stated>" "<actual>"
+```
+Decision table:
+
+| Drift | Byte-preservation / test gate | Action |
+|-------|-------------------------------|--------|
+| ≤10%  | held                          | auto-correct + count |
+| 10-20% | held                         | auto-correct + count + note in phase report |
+| >20%  | held                          | ABORT: do NOT correct, report to user, escalate to Failure Protocol (plan intent likely wrong, not just arithmetic) |
+| any   | failed                        | Failure Protocol (byte-preservation failure always escalates) |
+| unsupported `<stated>` form (exit 2) | — | skip, log as "non-derivable" in phase report |
+
+### 4. Auto-correct
+
+For each "auto-correct" record:
+```bash
+NEW_BAND="$(bash scripts/plan-drift-correct.sh --drift-band <actual> 5)"  # ±5% of actual
+bash scripts/plan-drift-correct.sh --correct <plan-file> <phase> <bullet> "$NEW_BAND" --audit "was <stated>"
+```
+`--audit` appends `<!-- Auto-corrected YYYY-MM-DD: was <stated>, arithmetic says <actual> -->` inline on the bullet.
+
+### 5. Marker ordering and failure handling
+
+`.verify` is ALREADY written by Phase 3. That satisfies the hook's
+landing gate (`hooks/block-unsafe-project.sh.template:341 etc.`
+globs `step.*.verify`). If Phase 3.5 proceeds cleanly, write an
+informational marker:
+
+```bash
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+printf 'phase: %s\ndrifts_found: %s\ndrifts_corrected: %s\ndrifts_escalated: %s\ncompleted: %s\n' \
+  "$PHASE" "$FOUND" "$CORRECTED" "$ESCALATED" "$(TZ=America/New_York date -Iseconds)" \
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/phasestep.run-plan.$TRACKING_ID.$PHASE.drift-detect"
+```
+Uses the `phasestep.*` prefix (informational; hook ignores). The
+`step.*.verify` marker stays as-is.
+
+If Phase 3.5 fails (e.g., `scripts/plan-drift-correct.sh` exits
+non-zero mid-correction, or >20% drift case triggers), the
+orchestrator MUST:
+1. `git checkout -- <plan-file>` to revert any partial corrections.
+2. DELETE `step.run-plan.$TRACKING_ID.verify` (so the landing gate
+   re-blocks — the pipeline is no longer verified-and-clean, it's
+   verified-but-drift-escalated).
+3. Write `phasestep.run-plan.$TRACKING_ID.$PHASE.drift-fail` with
+   the error detail.
+4. Invoke Failure Protocol.
+
+### 6. Commit-location rule
+
+The auto-correction edits the plan file. Where does the edit commit?
+
+**Cherry-pick / direct mode:** commit on main, bundled with Phase 4's
+tracker commit. Combined message:
+```
+chore: mark phase <name> in progress (+ auto-corrected <N> stale acceptance bands)
+```
+If N == 0: default Phase 4 message.
+
+**PR mode:** commit inside the worktree on the feature branch,
+bundled with Phase 4's feature-branch tracker commit. Same combined
+message. The next phase's Phase 1 parse reads the plan file from
+the worktree (since `finish auto` PR-mode runs consecutive phases
+in the SAME worktree), so the corrected band is visible to the next
+phase's thrash-detection.
+
+### 7. Thrash rule
+
+If the SAME `<phase>+<bullet>` pair gets a `PLAN-TEXT-DRIFT:` token
+on a subsequent Phase 3.5 invocation (across phases in the same
+`/run-plan finish auto` execution), the first correction was
+wrong. ABORT:
+1. Write `phasestep.*.drift-fail` with "thrash detected: phase
+   P bullet B re-flagged after correction."
+2. Do NOT correct a second time.
+3. Invoke Failure Protocol.
+
+Thrash rule is scoped to the current `/run-plan` invocation's
+history, NOT across sessions. State is tracked in-memory by the
+orchestrator during `finish auto`; for cron-fired chunked runs,
+the rule relies on re-reading the plan file from the correct
+location (worktree for PR mode, main for cherry-pick / direct).
+
+### 8. Interaction with /refine-plan
+
+Phase 3.5 corrects small arithmetic drift only. If the scan finds
+multiple fields with >10% drift OR the plan's own extraction rules
+are arithmetically inconsistent (detected by the pre-dispatch gate
+in Phase 1 step 6), append a recommendation to the phase report:
+"Recommend running `/refine-plan <plan-file>` after close-out; this
+plan has structural drift beyond per-band correction scope."
+
+Do NOT auto-dispatch `/refine-plan` mid-run — too expensive and
+scope-overlapping.
+
 ## Phase 4 — Update Progress Tracking
 
 After verification passes. The plan file tracks progress across phases — an
 orchestrator concern, not an implementation artifact. Update it promptly so
 the next cron invocation sees the correct phase status and advances
 (preventing infinite loops).
+
+> If Phase 3.5 auto-corrected any acceptance bands, those edits are
+> staged alongside the tracker update here and land as a single
+> commit.
 
 **Commit location depends on `LANDING_MODE`** (see PR-mode bookkeeping rule):
 cherry-pick/direct commits on main; PR mode `cd "$WORKTREE_PATH"` first and

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 1/3 | **In progress** — Phase 1 done (PLAN-TEXT-DRIFT token + scripts/plan-drift-correct.sh, 34 tests); Phase 2 (post-implement auto-correct gate) and Phase 3 (pre-dispatch arithmetic gate + --eval) remaining |
+| [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 2/3 | **In progress** — Phases 1+2 done (PLAN-TEXT-DRIFT token + script in P1; Phase 3.5 auto-correct gate in P2; 902/902 tests, +39 plan-drift cases); Phase 3 (pre-dispatch arithmetic gate + --eval) remaining |
 | [plan-restructure-run-plan.md](reports/plan-restructure-run-plan.md) | 5/5 | **Complete** — all phases landed; 531/531 tests PASS; mirror parity clean; real-GitHub canaries deferred to user |
 | [plan-ci-fix-cycle-canary.md](reports/plan-ci-fix-cycle-canary.md) | 1/1 | **Complete** — CI-fix-cycle canary (pending this PR) |
 | [plan-parallel-canarya.md](reports/plan-parallel-canarya.md) | 1/1 | **Complete** — concurrent-pipeline in-vivo canary |

--- a/plans/IMPROVE_STALENESS_DETECTION.md
+++ b/plans/IMPROVE_STALENESS_DETECTION.md
@@ -24,7 +24,7 @@ Combined with `/refine-plan` Dimension 7, these form a defense-in-depth chain: *
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Standardize `PLAN-TEXT-DRIFT:` token + `scripts/plan-drift-correct.sh`        | ✅ Done | `33fa174` | landed via PR squash; 897/897 tests |
-| 2 — Post-implement auto-correct gate (Phase 3.5)                                  | 🟡 | `e370ab9` | Phase 3.5 inserted; 39 cases (+5); 902/902 |
+| 2 — Post-implement auto-correct gate (Phase 3.5)                                  | ✅ Done | `e370ab9` | landed via PR squash; Phase 3.5 inserted; 902/902 tests |
 | 3 — Pre-dispatch arithmetic gate (Phase 1 step 6 extension) + tests + docs        | ⬚ | | |
 
 ---

--- a/plans/IMPROVE_STALENESS_DETECTION.md
+++ b/plans/IMPROVE_STALENESS_DETECTION.md
@@ -24,7 +24,7 @@ Combined with `/refine-plan` Dimension 7, these form a defense-in-depth chain: *
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Standardize `PLAN-TEXT-DRIFT:` token + `scripts/plan-drift-correct.sh`        | ✅ Done | `33fa174` | landed via PR squash; 897/897 tests |
-| 2 — Post-implement auto-correct gate (Phase 3.5)                                  | ⬚ | | |
+| 2 — Post-implement auto-correct gate (Phase 3.5)                                  | 🟡 | `e370ab9` | Phase 3.5 inserted; 39 cases (+5); 902/902 |
 | 3 — Pre-dispatch arithmetic gate (Phase 1 step 6 extension) + tests + docs        | ⬚ | | |
 
 ---

--- a/reports/plan-improve-staleness-detection.md
+++ b/reports/plan-improve-staleness-detection.md
@@ -1,5 +1,46 @@
 # Plan Report — Improve /run-plan Staleness Detection (Arithmetic Drift)
 
+## Phase — 2 Post-implement auto-correct gate (Phase 3.5) [UNFINALIZED]
+
+**Plan:** plans/IMPROVE_STALENESS_DETECTION.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-improve-staleness-detection
+**Branch:** feat/improve-staleness-detection
+**Commits:** e370ab9 (impl + tests), e5f3128 (tracker mark in-progress)
+
+### Work Items
+
+| # | Item | Status | Source |
+|---|------|--------|--------|
+| 2.1 | New `## Phase 3.5` H2 section in skills/run-plan/SKILL.md | Done | e370ab9 |
+| 2.2 | Verbatim Phase 3.5 content (8 numbered subsections, 5-row decision table) | Done | e370ab9 |
+| 2.3 | Phase 4 opening prose blockquote referencing Phase 3.5 | Done | e370ab9 |
+| 2.4 | Mirror parity (per-file cp) | Done | e370ab9 |
+| 2.5 | 5 new integration test cases for Phase 3.5 orchestration (e2e, thrash, escalate, multi) | Done | e370ab9 |
+| 2.6 | Commit | Done | e370ab9 |
+
+### Verification
+
+- Test suite: PASSED (902/902, +5 from Phase 1 baseline 897)
+- All 8 acceptance criteria verified by independent verification agent
+- Mirror clean: `diff -r skills/run-plan .claude/skills/run-plan` empty
+- Phase 3.5 H2 inserted at line 1233 (between Phase 3's `### Post-verification tracking` and `## Phase 4`)
+- Decision-table 5 rows verbatim (≤10%, 10-20%, >20%, byte-pres failed, unsupported)
+- DELETE-verify-on-failure rule documented; thrash rule scoped per-execution
+- `^## Phase ` count: main 10 → branch 11 (Δ=+1, the new Phase 3.5)
+
+### PLAN-TEXT-DRIFT findings
+
+None against Phase 2 acceptance criteria. Implementer + verifier independently confirmed no drift.
+
+### Notes
+
+- Phase 3.5 wraps `scripts/plan-drift-correct.sh` (Phase 1) into the orchestration flow. Implementation runs the script as a black box; the skill prose only orchestrates parse → drift → correct/escalate decisions and the marker-ordering rules.
+- `step.*.verify` written by Phase 3 satisfies the hook's landing gate; Phase 3.5 success writes informational `phasestep.*.drift-detect`; failure DELETEs `step.*.verify` to re-block landing.
+- Phase 3 will land the pre-dispatch arithmetic gate (Phase 1 step 6 extension) and the `--eval` mode for integer arithmetic.
+
+---
+
 ## Phase — 1 Standardize PLAN-TEXT-DRIFT token + scripts/plan-drift-correct.sh [UNFINALIZED]
 
 **Plan:** plans/IMPROVE_STALENESS_DETECTION.md

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1230,12 +1230,139 @@ printf 'phase: %s\nresult: pass\ncompleted: %s\n' "$PHASE" "$(TZ=America/New_Yor
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.run-plan.$TRACKING_ID.verify"
 ```
 
+## Phase 3.5 — Detect and auto-correct plan-text drift
+
+Runs AFTER Phase 3's `### Post-verification tracking` writes
+`step.run-plan.$TRACKING_ID.verify`, and BEFORE Phase 4's tracker
+commit. Reads both the implementation agent's and verification
+agent's reports for `PLAN-TEXT-DRIFT:` tokens and auto-corrects
+the plan file.
+
+### 1. Gather reports
+
+Concatenate the implementation agent's final-message text and the
+verification agent's final-message text into a single parse input.
+Both agents' outputs are available from Phase 2 and Phase 3 agent
+dispatches.
+
+### 2. Parse tokens
+
+```bash
+bash scripts/plan-drift-correct.sh --parse <combined-reports>
+```
+Produces one `<phase>|<bullet>|<field>|<stated>|<actual>` line per
+drift. Zero lines = no drifts → skip to step 6.
+
+### 3. Per-drift decision
+
+For each record, compute drift via:
+```bash
+bash scripts/plan-drift-correct.sh --drift "<stated>" "<actual>"
+```
+Decision table:
+
+| Drift | Byte-preservation / test gate | Action |
+|-------|-------------------------------|--------|
+| ≤10%  | held                          | auto-correct + count |
+| 10-20% | held                         | auto-correct + count + note in phase report |
+| >20%  | held                          | ABORT: do NOT correct, report to user, escalate to Failure Protocol (plan intent likely wrong, not just arithmetic) |
+| any   | failed                        | Failure Protocol (byte-preservation failure always escalates) |
+| unsupported `<stated>` form (exit 2) | — | skip, log as "non-derivable" in phase report |
+
+### 4. Auto-correct
+
+For each "auto-correct" record:
+```bash
+NEW_BAND="$(bash scripts/plan-drift-correct.sh --drift-band <actual> 5)"  # ±5% of actual
+bash scripts/plan-drift-correct.sh --correct <plan-file> <phase> <bullet> "$NEW_BAND" --audit "was <stated>"
+```
+`--audit` appends `<!-- Auto-corrected YYYY-MM-DD: was <stated>, arithmetic says <actual> -->` inline on the bullet.
+
+### 5. Marker ordering and failure handling
+
+`.verify` is ALREADY written by Phase 3. That satisfies the hook's
+landing gate (`hooks/block-unsafe-project.sh.template:341 etc.`
+globs `step.*.verify`). If Phase 3.5 proceeds cleanly, write an
+informational marker:
+
+```bash
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+printf 'phase: %s\ndrifts_found: %s\ndrifts_corrected: %s\ndrifts_escalated: %s\ncompleted: %s\n' \
+  "$PHASE" "$FOUND" "$CORRECTED" "$ESCALATED" "$(TZ=America/New_York date -Iseconds)" \
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/phasestep.run-plan.$TRACKING_ID.$PHASE.drift-detect"
+```
+Uses the `phasestep.*` prefix (informational; hook ignores). The
+`step.*.verify` marker stays as-is.
+
+If Phase 3.5 fails (e.g., `scripts/plan-drift-correct.sh` exits
+non-zero mid-correction, or >20% drift case triggers), the
+orchestrator MUST:
+1. `git checkout -- <plan-file>` to revert any partial corrections.
+2. DELETE `step.run-plan.$TRACKING_ID.verify` (so the landing gate
+   re-blocks — the pipeline is no longer verified-and-clean, it's
+   verified-but-drift-escalated).
+3. Write `phasestep.run-plan.$TRACKING_ID.$PHASE.drift-fail` with
+   the error detail.
+4. Invoke Failure Protocol.
+
+### 6. Commit-location rule
+
+The auto-correction edits the plan file. Where does the edit commit?
+
+**Cherry-pick / direct mode:** commit on main, bundled with Phase 4's
+tracker commit. Combined message:
+```
+chore: mark phase <name> in progress (+ auto-corrected <N> stale acceptance bands)
+```
+If N == 0: default Phase 4 message.
+
+**PR mode:** commit inside the worktree on the feature branch,
+bundled with Phase 4's feature-branch tracker commit. Same combined
+message. The next phase's Phase 1 parse reads the plan file from
+the worktree (since `finish auto` PR-mode runs consecutive phases
+in the SAME worktree), so the corrected band is visible to the next
+phase's thrash-detection.
+
+### 7. Thrash rule
+
+If the SAME `<phase>+<bullet>` pair gets a `PLAN-TEXT-DRIFT:` token
+on a subsequent Phase 3.5 invocation (across phases in the same
+`/run-plan finish auto` execution), the first correction was
+wrong. ABORT:
+1. Write `phasestep.*.drift-fail` with "thrash detected: phase
+   P bullet B re-flagged after correction."
+2. Do NOT correct a second time.
+3. Invoke Failure Protocol.
+
+Thrash rule is scoped to the current `/run-plan` invocation's
+history, NOT across sessions. State is tracked in-memory by the
+orchestrator during `finish auto`; for cron-fired chunked runs,
+the rule relies on re-reading the plan file from the correct
+location (worktree for PR mode, main for cherry-pick / direct).
+
+### 8. Interaction with /refine-plan
+
+Phase 3.5 corrects small arithmetic drift only. If the scan finds
+multiple fields with >10% drift OR the plan's own extraction rules
+are arithmetically inconsistent (detected by the pre-dispatch gate
+in Phase 1 step 6), append a recommendation to the phase report:
+"Recommend running `/refine-plan <plan-file>` after close-out; this
+plan has structural drift beyond per-band correction scope."
+
+Do NOT auto-dispatch `/refine-plan` mid-run — too expensive and
+scope-overlapping.
+
 ## Phase 4 — Update Progress Tracking
 
 After verification passes. The plan file tracks progress across phases — an
 orchestrator concern, not an implementation artifact. Update it promptly so
 the next cron invocation sees the correct phase status and advances
 (preventing infinite loops).
+
+> If Phase 3.5 auto-corrected any acceptance bands, those edits are
+> staged alongside the tracker update here and land as a single
+> commit.
 
 **Commit location depends on `LANDING_MODE`** (see PR-mode bookkeeping rule):
 cherry-pick/direct commits on main; PR mode `cd "$WORKTREE_PATH"` first and

--- a/tests/test-plan-drift-correct.sh
+++ b/tests/test-plan-drift-correct.sh
@@ -207,6 +207,139 @@ expect_rc 2 "drift: non-integer actual"  --drift "100" "ten"
 expect_rc 2 "parse: file not found"  --parse "/tmp/zskills-tests/nonexistent-$$.txt"
 
 echo ""
+echo "=== Phase 3.5 orchestration: simulated end-to-end --parse → --drift → --correct ==="
+# Simulates the orchestrator's workflow: an agent's combined report contains a
+# PLAN-TEXT-DRIFT token; a stale plan file's acceptance band gets corrected.
+E2E_REPORT="$TEST_OUT/e2e-report.txt"
+cat > "$E2E_REPORT" <<'EOF'
+Implementation report.
+
+PLAN-TEXT-DRIFT: phase=2 bullet=1 field=skill-line-count plan=approximately 357 actual=277
+
+Done.
+EOF
+E2E_PLAN="$TEST_OUT/e2e-plan.md"
+cat > "$E2E_PLAN" <<'EOF'
+## Phase 2 — Foo
+
+### Acceptance Criteria
+
+- [ ] Skill is approximately 357 lines after restructure.
+- [ ] Other thing.
+EOF
+parse_out=$(bash "$SCRIPT" --parse "$E2E_REPORT" 2>&1); parse_rc=$?
+e2e_record="2|1|skill-line-count|approximately 357|277"
+if [ "$parse_rc" = "0" ] && [ "$parse_out" = "$e2e_record" ]; then
+  # Decompose record (using bash IFS split; no eval, no $(()) over user input).
+  IFS='|' read -r e2e_phase e2e_bullet _e2e_field e2e_stated e2e_actual <<< "$parse_out"
+  drift_out=$(bash "$SCRIPT" --drift "$e2e_stated" "$e2e_actual" 2>&1); drift_rc=$?
+  if [ "$drift_rc" = "0" ] && [ "$drift_out" = "23" ]; then
+    bash "$SCRIPT" --correct "$E2E_PLAN" "$e2e_phase" "$e2e_bullet" "$e2e_actual" --audit "$e2e_stated" >/dev/null 2>&1
+    correct_rc=$?
+    if [ "$correct_rc" = "0" ] \
+        && grep -q 'Skill is 277 lines after restructure' "$E2E_PLAN" \
+        && grep -q 'Auto-corrected' "$E2E_PLAN" \
+        && grep -q 'was approximately 357' "$E2E_PLAN"; then
+      pass "Phase 3.5 e2e: parse → drift → correct lands audited band"
+    else
+      fail "Phase 3.5 e2e: --correct stage failed (rc=$correct_rc, plan content unexpected)"
+    fi
+  else
+    fail "Phase 3.5 e2e: --drift stage — expected '23', got rc=$drift_rc out='$drift_out'"
+  fi
+else
+  fail "Phase 3.5 e2e: --parse stage — expected rc=0 + '$e2e_record', got rc=$parse_rc out='$parse_out'"
+fi
+
+echo ""
+echo "=== Phase 3.5 orchestration: thrash determinism (same phase+bullet, repeat --correct) ==="
+# The orchestrator enforces the thrash-rule (abort on second correction). The
+# script itself must be deterministic on repeat: a second --correct invocation
+# with a literal that matches the post-first-correction text must succeed and
+# produce the same end-state band, so the orchestrator's re-detection of a
+# PLAN-TEXT-DRIFT token after a correction reflects a real drift, not script
+# nondeterminism.
+THRASH_PLAN="$TEST_OUT/thrash-plan.md"
+cat > "$THRASH_PLAN" <<'EOF'
+## Phase 1 — Bar
+
+### Acceptance Criteria
+
+- [ ] Foo is approximately 100 widgets.
+EOF
+bash "$SCRIPT" --correct "$THRASH_PLAN" 1 1 "120" --audit "approximately 100" >/dev/null 2>&1
+first_rc=$?
+# After first correction, the line literal is now "120"; second --correct must
+# locate the new literal and rewrite to a third value deterministically.
+bash "$SCRIPT" --correct "$THRASH_PLAN" 1 1 "150" --audit "120" >/dev/null 2>&1
+second_rc=$?
+audit_count=$(grep -o 'Auto-corrected' "$THRASH_PLAN" | wc -l | tr -d ' ')
+if [ "$first_rc" = "0" ] && [ "$second_rc" = "0" ] \
+    && grep -q 'Foo is 150 widgets' "$THRASH_PLAN" \
+    && [ "$audit_count" = "2" ]; then
+  pass "Phase 3.5 thrash: --correct deterministic on repeat (orchestrator enforces abort, not script)"
+else
+  fail "Phase 3.5 thrash: first_rc=$first_rc second_rc=$second_rc, audit-comments=$audit_count"
+fi
+
+echo ""
+echo "=== Phase 3.5 orchestration: >20% drift escalation signal ==="
+# >20% drift case from decision-table: orchestrator reads --drift output and
+# routes >20 to ABORT (no --correct call). Verify --drift returns >20 in
+# representative shapes.
+out=$(bash "$SCRIPT" --drift "100" "200" 2>&1)
+if [ "$out" = "100" ]; then
+  pass "Phase 3.5 escalate: literal 100 vs 200 → drift=100 (>20, ABORT)"
+else
+  fail "Phase 3.5 escalate: literal — expected 100, got '$out'"
+fi
+
+out=$(bash "$SCRIPT" --drift "approximately 50" "100" 2>&1)
+if [ "$out" = "100" ]; then
+  pass "Phase 3.5 escalate: approximately 50 vs 100 → drift=100 (>20, ABORT)"
+else
+  fail "Phase 3.5 escalate: approximately — expected 100, got '$out'"
+fi
+
+echo ""
+echo "=== Phase 3.5 orchestration: multi-drift report → per-record correction ==="
+# Two drifts in one combined-report; orchestrator parses, drifts each, corrects
+# each independently. End state: both bands rewritten with audit comments.
+MULTI_REPORT="$TEST_OUT/e2e-multi-report.txt"
+cat > "$MULTI_REPORT" <<'EOF'
+PLAN-TEXT-DRIFT: phase=1 bullet=1 field=count-a plan=approximately 100 actual=110
+PLAN-TEXT-DRIFT: phase=1 bullet=2 field=count-b plan=at most 50 actual=45
+EOF
+MULTI_PLAN="$TEST_OUT/e2e-multi-plan.md"
+cat > "$MULTI_PLAN" <<'EOF'
+## Phase 1 — Multi
+
+### Acceptance Criteria
+
+- [ ] Count A is approximately 100.
+- [ ] Count B is at most 50.
+EOF
+parsed=$(bash "$SCRIPT" --parse "$MULTI_REPORT" 2>&1); prc=$?
+expected_two='1|1|count-a|approximately 100|110
+1|2|count-b|at most 50|45'
+if [ "$prc" = "0" ] && [ "$parsed" = "$expected_two" ]; then
+  multi_ok=1
+  while IFS='|' read -r mp mb _mf ms ma; do
+    bash "$SCRIPT" --correct "$MULTI_PLAN" "$mp" "$mb" "$ma" --audit "$ms" >/dev/null 2>&1 || multi_ok=0
+  done <<< "$parsed"
+  if [ "$multi_ok" = "1" ] \
+      && grep -q 'Count A is 110' "$MULTI_PLAN" \
+      && grep -q 'Count B is 45' "$MULTI_PLAN" \
+      && [ "$(grep -c 'Auto-corrected' "$MULTI_PLAN")" = "2" ]; then
+    pass "Phase 3.5 multi: parse → loop → correct lands two audited bands"
+  else
+    fail "Phase 3.5 multi: corrections didn't land cleanly (multi_ok=$multi_ok)"
+  fi
+else
+  fail "Phase 3.5 multi: --parse expected 2 records, got rc=$prc out='$parsed'"
+fi
+
+echo ""
 echo "---"
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if [ "$FAIL_COUNT" -eq 0 ]; then


### PR DESCRIPTION
## Plan: Improve /run-plan Staleness Detection (Arithmetic Drift)

Phase 2 of `plans/IMPROVE_STALENESS_DETECTION.md`. Wires `scripts/plan-drift-correct.sh` (Phase 1, PR #90) into `/run-plan`'s flow as a new `## Phase 3.5` post-implement auto-correct gate.

<!-- run-plan:progress:start -->
**Phases completed:**
- Phase 1 — Standardize PLAN-TEXT-DRIFT token + scripts/plan-drift-correct.sh (✅ #90)
- Phase 2 — Post-implement auto-correct gate (Phase 3.5) (✅ this PR)
- Phase 3 — Pre-dispatch arithmetic gate (Phase 1 step 6 extension) + tests + docs (⬚ — next)
<!-- run-plan:progress:end -->

## Summary

- New `## Phase 3.5 — Detect and auto-correct plan-text drift` H2 inserted in `skills/run-plan/SKILL.md` between Phase 3's `### Post-verification tracking` and Phase 4's opening prose.
- 8 numbered subsections: Gather reports → Parse tokens → Per-drift decision (5-row decision table) → Auto-correct → Marker ordering and failure handling → Commit-location rule → Thrash rule → Interaction with /refine-plan.
- Marker-ordering rule: success writes informational `phasestep.run-plan.<id>.<phase>.drift-detect`; failure DELETEs `step.run-plan.<id>.verify` to re-block landing.
- Thrash rule scoped to per-execution (cross-session retries OK, read current plan state).
- Commit-location rule: cherry-pick/direct bundles into Phase 4's "in progress" commit; PR mode commits inside the worktree on the feature branch.
- Phase 4's opening prose extended with a 2-line blockquote referencing Phase 3.5.
- 5 new integration test cases in `tests/test-plan-drift-correct.sh` (e2e, thrash determinism, >20% drift escalation, multi-drift-per-report). Total cases: 34 → 39.
- Mirror parity holds.

Phase 3 (pre-dispatch arithmetic gate, Phase 1 step 6 extension + `--eval` integer arithmetic) lands next via continued `/run-plan plans/IMPROVE_STALENESS_DETECTION.md finish auto`.

## Test plan

- [x] `grep -c '^## Phase 3.5' skills/run-plan/SKILL.md` returns exactly `1`
- [x] DELETE `step.*.verify`-on-failure rule documented verbatim
- [x] Thrash rule documented + scoped per-execution
- [x] Decision-table 5 rows verbatim (≤10%, 10-20%, >20%, byte-pres failed, unsupported)
- [x] `tests/test-plan-drift-correct.sh` ≥39 cases (≥25 gate, ≥5 new gate)
- [x] `bash tests/run-all.sh` exits 0 with 100% pass rate (902/902, +5 from baseline 897)
- [x] Mirror parity: `diff -r skills/run-plan .claude/skills/run-plan` empty
- [x] `^## Phase ` count increases by exactly +1 vs main (10 → 11)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)