### PR TITLE
[scripts-into-skills-plan] SCRIPTS_INTO_SKILLS — Phase 1 (inventory + ownership registry)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -298,13 +298,23 @@ Draft plans for issues previously skipped as "too complex for batch fix."
 Accepts optional `auto` — `/fix-issues plan auto` skips the selection gate
 and drafts plans for all found issues.
 
-1. **Run `node scripts/skipped-issues.cjs --check-gh`** — this scans the
-   ENTIRE `SPRINT_REPORT.md` across all sprints, extracts skipped issue
-   numbers (including ranges like #148-#168), deduplicates against existing
-   executable plans in `plans/`, and checks GitHub issue state. Output is
-   JSON with each issue classified as `needs-plan`, `has-plan`, or `closed`.
+1. **Find skipped issues from `plans/SPRINT_REPORT.md`.** Scan the entire
+   sprint report for issue numbers under "Skipped" / "Too Complex" /
+   "Remaining Open" headings. Use grep to extract candidate numbers
+   (handles bare `#NNN`, ranges like `#148-#168`, and `#NNN, #MMM` lists):
 
-   Use the script output directly — do NOT manually grep SPRINT_REPORT.md.
+   ```bash
+   grep -nE '#[0-9]+' plans/SPRINT_REPORT.md | grep -iE 'skip|complex|remain'
+   ```
+
+   Then for each candidate `#N`:
+   - Check `plans/` for an existing executable plan covering it:
+     `grep -l "#$N\b" plans/*.md` (existing plan = skip)
+   - Check GitHub state: `gh issue view "$N" --json state -q .state`
+     (`OPEN` = candidate; `CLOSED` = skip)
+
+   Build the working list of `needs-plan` issues from candidates that
+   have NO existing plan AND are still `OPEN`. Skip the rest.
 
 2. **Deduplicate** — check `plans/` for existing plans that already cover
    each issue. Also check whether the issue is still open on GitHub
@@ -495,14 +505,26 @@ alert user, write failure to report).
    gh issue list --state open --limit 500 --json number,title,labels,createdAt
    ```
 
-2. **Run the sync script** to find gaps between GitHub and plan files:
+2. **Find gaps** between GitHub open issues and plan tracker files. List
+   the trackers, then for each open GH issue number check whether it
+   appears in any tracker:
+
    ```bash
-   node ${CLAUDE_SKILL_DIR}/scripts/sync-issues.js
+   ls plans/*ISSUES*.md plans/ISSUES_PLAN.md 2>/dev/null
+
+   gh issue list --state open --limit 500 --json number -q '.[].number' \
+     | while read -r N; do
+         if ! grep -q "#$N\b" plans/*ISSUES*.md plans/ISSUES_PLAN.md 2>/dev/null; then
+           echo "GAP: #$N not in any tracker"
+         fi
+       done
    ```
 
-3. **Run the stats script** to see current distribution:
+3. **Tally label distribution** to see current spread:
+
    ```bash
-   node ${CLAUDE_SKILL_DIR}/scripts/issue-stats.js
+   gh issue list --state open --limit 500 --json labels \
+     -q '.[].labels[].name' | sort | uniq -c | sort -rn
    ```
 
 4. **Update ALL issue trackers** — scan `plans/` for tracker files:

--- a/.claude/skills/review-feedback/SKILL.md
+++ b/.claude/skills/review-feedback/SKILL.md
@@ -25,14 +25,8 @@ will specify the path). This file is exported from the app via
 
 ## Workflow
 
-1. **Read** the feedback JSON file:
-   ```bash
-   cat feedback.json
-   ```
-   Or run the summary helper first:
-   ```bash
-   node scripts/review-feedback.js feedback.json
-   ```
+1. **Read** the feedback JSON file directly with the Read tool (or
+   `cat feedback.json` for a quick scan).
 
 2. **For each pending entry**, evaluate:
    - Is it a real, actionable bug or feature request?

--- a/.claude/skills/update-zskills/references/script-ownership.md
+++ b/.claude/skills/update-zskills/references/script-ownership.md
@@ -1,0 +1,126 @@
+# Script Ownership Registry
+
+Authoritative ownership table for every script under `scripts/` (Tier-1
+machinery that moves into a skill, and Tier-2 release/consumer-tooling
+that stays put). This file is parsed by `/run-plan` Phase 4 migration
+logic and the drift test in WI 4.8 case 6a — preserve the column layout.
+
+## Tier definitions
+
+- **Tier 1** — zskills internal machinery; source moves into the
+  owning skill at `skills/<owner>/scripts/<name>`. Cross-skill callers
+  invoke via `"$CLAUDE_PROJECT_DIR/.claude/skills/<owner>/scripts/<name>"`
+  (shipped) or `"$REPO_ROOT/skills/<owner>/scripts/<name>"` (zskills
+  source-tree tests).
+- **Tier 2** — release-only repo tooling consumed by CI, OR
+  consumer-customizable utility (template/stub). Stays at `scripts/`.
+  Hooks, `CLAUDE_TEMPLATE.md`, and `README.md` config schemas continue
+  to name `scripts/<x>.sh`.
+
+## Ownership table
+
+| Script                       | Tier   | Owner / disposition          |
+|------------------------------|--------|------------------------------|
+| `apply-preset.sh`            | 1      | `update-zskills`             |
+| `briefing.cjs`               | 1      | `briefing`                   |
+| `briefing.py`                | 1      | `briefing`                   |
+| `build-prod.sh`              | 2      | release-only repo tooling; never installed to consumers (called by `.github/workflows/ship-to-prod.yml:80`; documented in `RELEASING.md:5,47,64,71,78,82`) |
+| `clear-tracking.sh`          | 1      | `update-zskills`             |
+| `compute-cron-fire.sh`       | 1      | `run-plan`                   |
+| `create-worktree.sh`         | 1      | `create-worktree`            |
+| `land-phase.sh`              | 1      | `commit`                     |
+| `mirror-skill.sh`            | 2      | release/repo tooling; called by `tests/test-mirror-skill.sh` and (per Phase 1 Design) by every phase's mirror-discipline step in lieu of `rm -rf .claude/skills/<name> && cp -a ...` |
+| `plan-drift-correct.sh`      | 1      | `run-plan`                   |
+| `port.sh`                    | 1      | `update-zskills`             |
+| `post-run-invariants.sh`     | 1      | `run-plan`                   |
+| `sanitize-pipeline-id.sh`    | 1      | `create-worktree`            |
+| `statusline.sh`              | 1      | `update-zskills` (source moves; install destination still `~/.claude/statusline-command.sh`) |
+| `stop-dev.sh`                | 2      | currently functional generic implementation; consumer stack writes PIDs to `var/dev.pid`. **Note:** full conversion to a formal failing stub is deferred to a follow-up plan covering the consumer stub-callout pattern. |
+| `test-all.sh`                | 2      | already a partial template (`{{E2E_TEST_CMD}}` placeholders); customized by consumer with their own test commands. **Note:** full conversion to a formal failing stub is deferred to the same follow-up plan. |
+| `worktree-add-safe.sh`       | 1      | `create-worktree`            |
+| `write-landed.sh`            | 1      | `commit`                     |
+
+Total: 14 Tier 1 (`apply-preset`, `briefing.cjs`, `briefing.py`,
+`clear-tracking`, `compute-cron-fire`, `create-worktree`, `land-phase`,
+`plan-drift-correct`, `port`, `post-run-invariants`,
+`sanitize-pipeline-id`, `statusline`, `worktree-add-safe`,
+`write-landed`); 4 Tier 2 (`build-prod.sh`, `mirror-skill.sh`,
+`stop-dev.sh`, `test-all.sh`).
+
+## Format contract
+
+Future agents adding rows MUST preserve this exact layout — it is parsed
+by `awk -F'|'` in multiple places (Phase 4 WI 4.2 hash-file generator,
+WI 4.8 case 6a drift test, Phase 5 WI 5.1, Phase 3b WI 3b.1):
+
+- **Column 1** — `` `script-name.ext` `` (backtick-quoted, surrounded by
+  whitespace).
+- **Column 2** — ` 1 ` or ` 2 ` (literal digit, with surrounding
+  whitespace; no other content).
+- **Column 3** — owner-or-disposition prose. Tier-1 rows name a single
+  owning skill (in backticks). Tier-2 rows describe disposition.
+
+Adding a row in any other format breaks the parsers and the canonical
+Tier-1 enumeration below.
+
+## Cross-skill path convention
+
+- **Source-tree zskills tests** invoke scripts via the absolute
+  `"$REPO_ROOT/skills/<owner>/scripts/<name>"` form. The bare-relative
+  `skills/<owner>/scripts/<name>` form is FORBIDDEN. `tests/run-all.sh`
+  exports `CLAUDE_PROJECT_DIR="$REPO_ROOT"` (Phase 5 WI 5.7) so
+  cross-skill invocations also resolve under tests.
+- **Shipped (consumer-side) and cross-skill callers** MUST use the
+  bare-`$CLAUDE_PROJECT_DIR` form
+  `"$CLAUDE_PROJECT_DIR/.claude/skills/<owner>/scripts/<name>"`.
+  The harness sets `CLAUDE_PROJECT_DIR` in spawned bash blocks; if it
+  is unset at a callsite, fail loud rather than silently expand to an
+  invalid path.
+- **Same-skill internal callers** (e.g., `create-worktree.sh` invoking
+  `worktree-add-safe.sh` in its own skill) compute a path from the
+  script's own location:
+  `SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)`. Symlink invocation is
+  not supported in this form (use `readlink -f` resolution if needed).
+
+## Canonical Tier-1 name parser (DA-5 single source of truth)
+
+Every grep sweep across this plan that enumerates Tier-1 names MUST
+drive off this file:
+
+```bash
+TIER1_NAMES=$(awk -F'|' '$3 ~ /^[[:space:]]*1[[:space:]]*$/ {
+  gsub(/[[:space:]`]/, "", $2); print $2
+}' skills/update-zskills/references/script-ownership.md)
+```
+
+Phases 3b, 5, and 6 keep illustrative closed lists for human readability
+in their grep recipes, but their acceptance criteria reference the
+parser-driven form so a future row addition does not drift the sweep.
+
+## STALE_LIST
+
+The STALE_LIST is the set of `scripts/<name>` paths that Phase 4's
+`/update-zskills` migration logic detects in a consumer's checkout and
+removes after confirming the new skill-mirrored copies exist. It is the
+Tier-1 name set with a `scripts/` prefix:
+
+```
+scripts/apply-preset.sh
+scripts/briefing.cjs
+scripts/briefing.py
+scripts/clear-tracking.sh
+scripts/compute-cron-fire.sh
+scripts/create-worktree.sh
+scripts/land-phase.sh
+scripts/plan-drift-correct.sh
+scripts/port.sh
+scripts/post-run-invariants.sh
+scripts/sanitize-pipeline-id.sh
+scripts/statusline.sh
+scripts/worktree-add-safe.sh
+scripts/write-landed.sh
+```
+
+Phase 4 reads this list (or recomputes it via the parser above) when
+deciding which legacy `scripts/<name>` files to delete in a consumer
+repo on next `update-zskills` run.

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,6 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
+| [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 1/7 | **In progress** — Phase 1 done (dead refs fixed; script-ownership.md registry: 14 Tier-1 + 4 Tier-2); Phases 2, 3a, 3b, 4, 5, 6 remaining |
 | [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 3/3 | **Complete** — all 3 phases landed; defense-in-depth drift detection chain (pre-authoring /refine-plan Dimension 7, pre-dispatch Phase 1 step 6 b, post-implement Phase 3.5); 931/931 tests, +68 plan-drift cases |
 | [plan-restructure-run-plan.md](reports/plan-restructure-run-plan.md) | 5/5 | **Complete** — all phases landed; 531/531 tests PASS; mirror parity clean; real-GitHub canaries deferred to user |
 | [plan-ci-fix-cycle-canary.md](reports/plan-ci-fix-cycle-canary.md) | 1/1 | **Complete** — CI-fix-cycle canary (pending this PR) |

--- a/plans/SCRIPTS_INTO_SKILLS_PLAN.md
+++ b/plans/SCRIPTS_INTO_SKILLS_PLAN.md
@@ -108,7 +108,7 @@ decision belongs in the follow-up plan, not here.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Inventory cleanup: fix dead refs, write ownership registry | 🟡 | `49c666b` | dead refs replaced; script-ownership.md written; mirror parity |
+| 1 — Inventory cleanup: fix dead refs, write ownership registry | ✅ Done | `49c666b` | landed via PR squash; dead refs replaced; script-ownership.md written; mirror parity |
 | 2 — Move single-owner Tier 1 scripts (apply-preset, compute-cron-fire, post-run-invariants, briefing.*, statusline) | ⬚ |  |  |
 | 3a — Move shared Tier 1 scripts and update same-skill internals (create-worktree, worktree-add-safe, land-phase, write-landed, sanitize-pipeline-id, clear-tracking, port [+ config-driven default_port]) | ⬚ |  |  |
 | 3b — Update cross-skill callers (grep-driven sweep across skills/ .claude/skills/ CLAUDE.md README.md RELEASING.md) and tests | ⬚ |  |  |

--- a/plans/SCRIPTS_INTO_SKILLS_PLAN.md
+++ b/plans/SCRIPTS_INTO_SKILLS_PLAN.md
@@ -81,11 +81,12 @@ zskills machinery (move into a skill, update callers and hook
 help-text) or consumer-customizable (stays at `scripts/`).
 
 **The COUNT-vs-EXISTENCE framing is partially resolved.** Tier-1
-machinery now leaves consumer `scripts/` entirely (13 moves). What
+machinery now leaves consumer `scripts/` entirely (14 moves). What
 remains in `scripts/` is genuinely consumer-customizable
-(`stop-dev.sh`, `test-all.sh`) plus release-only repo tooling
-(`build-prod.sh`) that never ships to consumers. The split is now
-ownership-driven, not call-form-driven.
+(`stop-dev.sh`, `test-all.sh`) plus repo-tooling helpers that
+either never ship to consumers (`build-prod.sh`) or wrap hook-blocked
+operations (`mirror-skill.sh`). The split is now ownership-driven,
+not call-form-driven.
 
 **Stub-callout pattern (out of scope for this plan).** The principled
 end state for `stop-dev.sh` and `test-all.sh` is the consumer
@@ -107,7 +108,7 @@ decision belongs in the follow-up plan, not here.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Inventory cleanup: fix dead refs, write ownership registry | ⬚ |  |  |
+| 1 — Inventory cleanup: fix dead refs, write ownership registry | 🟡 | `49c666b` | dead refs replaced; script-ownership.md written; mirror parity |
 | 2 — Move single-owner Tier 1 scripts (apply-preset, compute-cron-fire, post-run-invariants, briefing.*, statusline) | ⬚ |  |  |
 | 3a — Move shared Tier 1 scripts and update same-skill internals (create-worktree, worktree-add-safe, land-phase, write-landed, sanitize-pipeline-id, clear-tracking, port [+ config-driven default_port]) | ⬚ |  |  |
 | 3b — Update cross-skill callers (grep-driven sweep across skills/ .claude/skills/ CLAUDE.md README.md RELEASING.md) and tests | ⬚ |  |  |
@@ -2411,7 +2412,7 @@ to `RELEASING.md`.
       `RELEASING.md` (DA-12 fix).** The plan's user-visible blast
       radius across schema, README, CLAUDE.md, CLAUDE_TEMPLATE.md,
       hook help-text, this-repo config, two new files in
-      `references/`, and 13 scripts moved out of `scripts/` warrants
+      `references/`, and 14 scripts moved out of `scripts/` warrants
       more than two CHANGELOG lines for downstream consumers. Add a
       `### Migration: SCRIPTS_INTO_SKILLS_PLAN (post-<version>)`
       section to `RELEASING.md` (or a new `MIGRATION.md` one-pager)

--- a/plans/SCRIPTS_INTO_SKILLS_PLAN.md
+++ b/plans/SCRIPTS_INTO_SKILLS_PLAN.md
@@ -45,6 +45,8 @@ Tier 2 after R1/D1 verified it is consumed by
 | `compute-cron-fire.sh`       | 1      | `run-plan`                   |
 | `create-worktree.sh`         | 1      | `create-worktree`            |
 | `land-phase.sh`              | 1      | `commit`                     |
+| `mirror-skill.sh`            | 2      | release/repo tooling; called by `tests/test-mirror-skill.sh` and (per Phase 1 Design) by every phase's mirror-discipline step in lieu of `rm -rf .claude/skills/<name> && cp -a ...` |
+| `plan-drift-correct.sh`      | 1      | `run-plan`                   |
 | `port.sh`                    | 1      | `update-zskills`             |
 | `post-run-invariants.sh`     | 1      | `run-plan`                   |
 | `sanitize-pipeline-id.sh`    | 1      | `create-worktree`            |
@@ -54,8 +56,8 @@ Tier 2 after R1/D1 verified it is consumed by
 | `worktree-add-safe.sh`       | 1      | `create-worktree`            |
 | `write-landed.sh`            | 1      | `commit`                     |
 
-13 Tier 1 moves, 3 Tier 2 stay-puts (`build-prod.sh`, `stop-dev.sh`,
-`test-all.sh`), zero deletes.
+14 Tier 1 moves, 4 Tier 2 stay-puts (`build-prod.sh`, `mirror-skill.sh`,
+`stop-dev.sh`, `test-all.sh`), zero deletes.
 
 **Skills with only Tier-2 references are unchanged in their script
 choices.** `verify-changes`, `cleanup-merged`, `fix-report`,

--- a/plans/SCRIPTS_INTO_SKILLS_PLAN.md
+++ b/plans/SCRIPTS_INTO_SKILLS_PLAN.md
@@ -115,7 +115,7 @@ decision belongs in the follow-up plan, not here.
 
 ## Phase 1 — Inventory cleanup: fix dead refs, write ownership registry
 
-#### Goal
+### Goal
 
 Close one pre-existing hole (four dead references that fail at runtime),
 seed the ownership table in a place future agents will read, and clean
@@ -123,7 +123,7 @@ two non-script artifacts from `scripts/`. (The "orphan" originally
 listed here — `build-prod.sh` — was reclassified Tier 2 after R1/D1
 verification; no deletion happens.)
 
-#### Work Items
+### Work Items
 
 - [ ] 1.2 — **Dead reference fix in `skills/fix-issues/SKILL.md`.** Three
       references to scripts that don't exist on disk and never have:
@@ -237,7 +237,7 @@ verification; no deletion happens.)
         `scripts/__pycache__/` to `.gitignore` if not already present
         (verify with `grep '__pycache__' .gitignore`).
 
-#### Design & Constraints
+### Design & Constraints
 
 **Cross-skill path convention** (recorded in
 `skills/update-zskills/references/script-ownership.md` per WI 1.4 and
@@ -323,7 +323,7 @@ is hook-compatible: it uses `cp -a "$SRC/." "$DST/"` plus per-file
 The script is also tested (`tests/test-mirror-skill.sh`); the helper
 is the canonical mirror primitive going forward.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] `test -f scripts/build-prod.sh` (Tier-2; not deleted; verified
       consumed by `.github/workflows/ship-to-prod.yml:80`).
@@ -350,13 +350,13 @@ is the canonical mirror primitive going forward.
       same for `review-feedback` and `update-zskills`.
 - [ ] `bash tests/run-all.sh` exits 0.
 
-#### Dependencies
+### Dependencies
 
 None.
 
 ## Phase 2 — Move single-owner Tier 1 scripts
 
-#### Goal
+### Goal
 
 Move scripts whose only zskills caller is one skill into that skill's
 `scripts/` subdir. No cross-skill path updates needed yet — these
@@ -370,7 +370,7 @@ ownership table; 8 callsites all in `skills/run-plan/SKILL.md`),
 `post-run-invariants.sh` (→ `run-plan`), `briefing.cjs` (→ `briefing`),
 `briefing.py` (→ `briefing`), `statusline.sh` (→ `update-zskills`).
 
-#### Work Items
+### Work Items
 
 - [ ] 2.1 — **`apply-preset.sh` → `skills/update-zskills/scripts/apply-preset.sh`.**
       `git mv scripts/apply-preset.sh skills/update-zskills/scripts/apply-preset.sh`
@@ -531,7 +531,7 @@ ownership table; 8 callsites all in `skills/run-plan/SKILL.md`),
 - [ ] 2.9 — Run `bash tests/run-all.sh`. Expect green; if not, fix
       paths in whatever WI missed a reference (do NOT weaken tests).
 
-#### Design & Constraints
+### Design & Constraints
 
 **Why these scripts together.** Single-owner moves are independent of
 each other; they share only the mechanical pattern (`git mv`, update
@@ -575,7 +575,7 @@ later, in Phase 3 (`create-worktree.sh` → `worktree-add-safe.sh`,
 
 **Mirror discipline.** Per Phase 1 (use `bash scripts/mirror-skill.sh`).
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] `! test -e scripts/apply-preset.sh && test -f skills/update-zskills/scripts/apply-preset.sh && test -f .claude/skills/update-zskills/scripts/apply-preset.sh`.
 - [ ] `! test -e scripts/compute-cron-fire.sh && test -f skills/run-plan/scripts/compute-cron-fire.sh && test -f .claude/skills/run-plan/scripts/compute-cron-fire.sh`.
@@ -628,13 +628,13 @@ later, in Phase 3 (`create-worktree.sh` → `worktree-add-safe.sh`,
       same for `run-plan` and `briefing`.
 - [ ] `bash tests/run-all.sh` exits 0.
 
-#### Dependencies
+### Dependencies
 
 Phase 1 (registry doc).
 
 ## Phase 3a — Move shared Tier 1 scripts and update same-skill internals
 
-#### Goal
+### Goal
 
 Move the seven shared Tier 1 scripts (`create-worktree.sh`,
 `worktree-add-safe.sh`, `land-phase.sh`, `write-landed.sh`,
@@ -645,7 +645,7 @@ owning skills, and update same-skill internal references
 config-driven `port.sh` default-port read). Cross-skill caller
 updates are deferred to Phase 3b.
 
-#### Work Items
+### Work Items
 
 - [ ] 3a.1 — **`create-worktree.sh` and `worktree-add-safe.sh` →
       `skills/create-worktree/scripts/`.**
@@ -813,7 +813,7 @@ updates are deferred to Phase 3b.
       callers that tests trace through. Phase 3a's gate is: same-skill
       internals + install-integrity gate work in isolation.
 
-#### Design & Constraints
+### Design & Constraints
 
 **Why split same-skill internals from cross-skill sweep.** Per D17
 (major): combining all 11 WIs across 8 skills produced a 30-edit
@@ -902,7 +902,7 @@ invocation becomes a need, switch to
 
 **Mirror discipline.** Per Phase 1 (use `bash scripts/mirror-skill.sh`).
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] None of the seven shared Tier 1 scripts exist at
       `scripts/<name>` anymore:
@@ -942,13 +942,13 @@ invocation becomes a need, switch to
       ```
       Document expected-failing suites in the Phase 3a commit message.
 
-#### Dependencies
+### Dependencies
 
 Phases 1, 2.
 
 ## Phase 3b — Update cross-skill callers via grep-driven sweep
 
-#### Goal
+### Goal
 
 Update every cross-skill caller of the five shared Tier 1 scripts.
 Phase 3a left the source tree with scripts moved + same-skill
@@ -958,7 +958,7 @@ internals updated, but cross-skill callers in `do`, `fix-issues`,
 recipe, not a same-script call) all still name the old paths. This
 phase sweeps and updates them.
 
-#### Work Items
+### Work Items
 
 - [ ] 3b.1 — **Grep-driven cross-skill sweep, all seven scripts.**
       For each Tier-1 script name parsed from `script-ownership.md`
@@ -1222,7 +1222,7 @@ phase sweeps and updates them.
       form. The bare-relative form is FORBIDDEN.
 - [ ] 3b.10 — `bash tests/run-all.sh`. Expect green.
 
-#### Design & Constraints
+### Design & Constraints
 
 **Grep-driven, not enumeration-driven.** Per R8/D3/D10 (major):
 prior draft enumerated specific line numbers (`run-plan:712, :911`)
@@ -1288,7 +1288,7 @@ WI 5.5.d becomes a verification step.
 
 **Mirror discipline.** Per Phase 1 (use `bash scripts/mirror-skill.sh`).
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] All seven Tier 1 scripts at the canonical skill-dir location AND
       the mirror:
@@ -1361,13 +1361,13 @@ phase's edits do not introduce new `CLAUDE_SKILL_DIR` mentions
 because the canonical form is `$CLAUDE_PROJECT_DIR`. If a regression
 check is desired, the Phase 1 AC already covers it.)
 
-#### Dependencies
+### Dependencies
 
 Phases 1, 2, 3a.
 
 ## Phase 4 — Update `/update-zskills` install flow and add stale-Tier-1 migration
 
-#### Goal
+### Goal
 
 (a) Stop copying Tier 1 scripts into consumer `scripts/`. Consumers
 receive them via the existing skill-mirror path
@@ -1375,7 +1375,7 @@ receive them via the existing skill-mirror path
 scripts on consumer disk left over from prior installs and offer to
 remove them after verifying they match a known zskills version.
 
-#### Work Items
+### Work Items
 
 - [ ] 4.1 — **Edit `skills/update-zskills/SKILL.md` Step D.** Per R4
       verification (`sed -n '895,910p' skills/update-zskills/SKILL.md`),
@@ -1862,7 +1862,7 @@ remove them after verifying they match a known zskills version.
       with siblings).
 - [ ] 4.10 — `bash tests/run-all.sh`.
 
-#### Design & Constraints
+### Design & Constraints
 
 **git is required.** `git hash-object --stdin` (fed CRLF-normalized
 content) is the migration-side hash function. If git is not on
@@ -1983,7 +1983,7 @@ entirely.
 
 **Mirror discipline.** Per Phase 1 (use `bash scripts/mirror-skill.sh`).
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] `grep -c '^#### Step D' skills/update-zskills/SKILL.md` ≥ 1.
 - [ ] **Old-Tier-1 names absent from Step D's bullet list.** Extract
@@ -2039,20 +2039,20 @@ entirely.
 - [ ] `diff -r skills/update-zskills .claude/skills/update-zskills`
       empty.
 
-#### Dependencies
+### Dependencies
 
 Phases 1, 2, 3a, 3b.
 
 ## Phase 5 — Update zskills tests and sweep README/CLAUDE.md/CLAUDE_TEMPLATE
 
-#### Goal
+### Goal
 
 Catch any test path that still names `scripts/<tier-1>.sh` directly,
 update README and CLAUDE.md to reflect the new locations of Tier-1
 scripts, and confirm hook help-text paths and CLAUDE_TEMPLATE for
 Tier-2 scripts remain accurate.
 
-#### Work Items
+### Work Items
 
 - [ ] 5.1 — Sweep `tests/` for any remaining Tier-1 path references.
       Drive the sweep off `script-ownership.md` (DA-5 / F-3 fix —
@@ -2251,7 +2251,7 @@ Tier-2 scripts remain accurate.
 - [ ] 5.8 — Re-run `bash tests/run-all.sh` to confirm Phase 5 edits
       didn't regress.
 
-#### Design & Constraints
+### Design & Constraints
 
 **Why this phase has real edits, not just verification.** The
 original draft framed Phase 5 as "mostly verification" but R5 (major)
@@ -2284,7 +2284,7 @@ at `scripts/`).
 skill mirror needed unless WI 5.1 turns up an unexpected skill-side
 path.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] **Tests + hooks zero-match-of-old-paths (DA-5 / F-3 fix —
       driven from `script-ownership.md`):**
@@ -2353,20 +2353,20 @@ path.
       exits 0 (asserts ordering, not just presence).
 - [ ] `bash tests/run-all.sh` exits 0.
 
-#### Dependencies
+### Dependencies
 
 Phases 1, 2, 3a, 3b, 4.
 
 ## Phase 6 — Docs and close-out
 
-#### Goal
+### Goal
 
 CHANGELOG entry, plan registry entry if applicable, frontmatter flip
 to `complete`, sweep `docs/` for stale path references introduced
 since this plan was drafted, and add a consumer-facing migration note
 to `RELEASING.md`.
 
-#### Work Items
+### Work Items
 
 - [ ] 6.0b — **Sweep `docs/` for stale Tier-1 path references (F-10
       fix; redundant with Phase 2 WI 2.2b's specific
@@ -2460,7 +2460,7 @@ to `RELEASING.md`.
       entries (WI 6.1, 6.1b) remain as the per-line summary; this
       WI is the longer-form companion.
 
-#### Design & Constraints
+### Design & Constraints
 
 **No edits to historical entries.** Per D12: WI 6.1 only inserts a
 new line at the top of the unreleased section. Do NOT modify lines
@@ -2487,7 +2487,7 @@ context). Adding a section there — rather than a new top-level
 
 No skill edits, no skill mirror needed.
 
-#### Acceptance Criteria
+### Acceptance Criteria
 
 - [ ] **CHANGELOG entries present (literal pin per R6/D11):**
       ```bash
@@ -2519,7 +2519,7 @@ No skill edits, no skill mirror needed.
       `status: complete` and `completed:` lines.
 - [ ] `bash tests/run-all.sh` exits 0.
 
-#### Dependencies
+### Dependencies
 
 Phases 1–5.
 

--- a/reports/plan-scripts-into-skills-plan.md
+++ b/reports/plan-scripts-into-skills-plan.md
@@ -1,0 +1,47 @@
+# Plan Report — Move skill-owned scripts into the skills that use them
+
+## Phase — 1 Inventory cleanup: fix dead refs, write ownership registry [UNFINALIZED]
+
+**Plan:** plans/SCRIPTS_INTO_SKILLS_PLAN.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-scripts-into-skills-plan
+**Branch:** feat/scripts-into-skills-plan
+**Commits:** 7fc20c4 (orchestrator H4→H3 heading fix), 49c666b (impl + ownership registry), bb4d661 (tracker + prose drift fix)
+
+### Work Items
+
+| # | Item | Status | Source |
+|---|------|--------|--------|
+| 1.2 | 3 dead script refs in skills/fix-issues/SKILL.md replaced with manual gh recipes (skipped-issues.cjs, sync-issues.js, issue-stats.js) | Done | 49c666b |
+| 1.3 | review-feedback.js ref stripped from skills/review-feedback/SKILL.md | Done | 49c666b |
+| 1.4 | skills/update-zskills/references/script-ownership.md written (18 rows: 14 Tier-1 + 4 Tier-2). Plan Overview table synchronized | Done | 49c666b |
+| 1.5 | Mirror parity for fix-issues, review-feedback, update-zskills | Done | 49c666b |
+| 1.6 | rel-root-cw-cw-smoke-43859 verified absent; __pycache__ deferred to Phase 2 WI 2.8b per plan | Done | 49c666b |
+| (orchestrator) | H4 → H3 phase sub-heading restoration (refine-plan output had wrong levels) | Done | 7fc20c4 |
+| (orchestrator) | Phase 4 tracker mark-in-progress + 3 prose drift fixes (verifier-flagged "13 moves" → "14"; Tier-2 list updated) | Done | bb4d661 |
+
+### Verification
+
+- Test suite: PASSED (931/931, no delta from baseline — docs-only phase)
+- All 9 acceptance criteria verified by independent verification agent
+- Mirror parity holds for all 3 skills (`diff -r` clean)
+- Verifier independently re-detected 3 PLAN-TEXT-DRIFT prose drifts (13→14 / Tier-2 omitted mirror-skill.sh) — fixed inline in commit `bb4d661`
+- `script-ownership.md` registry contract: 14 Tier-1 + 4 Tier-2 rows; canonical Tier-1 parser; STALE_LIST documented
+
+### Notes
+
+- Phase 1 is foundational/registry only — no script moves yet.
+- Phase 2 will move single-owner Tier-1 scripts (apply-preset, compute-cron-fire, post-run-invariants, briefing.*, statusline) into their owning skills' `scripts/` subdirs.
+- Phase 3a/3b will move shared Tier-1 scripts (create-worktree, worktree-add-safe, land-phase, etc.) and sweep cross-skill callers.
+- Phase 4 will rewrite `/update-zskills` install flow.
+- Phase 5 will sweep tests + README/CLAUDE.md/CLAUDE_TEMPLATE.
+- Phase 6: docs and close-out.
+
+### PLAN-TEXT-DRIFT findings
+
+3 prose drifts caught by the verifier (binding ACs all passed):
+- Line 84 ("13 moves" → 14): fixed inline in bb4d661
+- Line 86 (Tier-2 list omitted mirror-skill.sh): fixed inline
+- Line 2414 ("13 scripts moved" → 14): fixed inline
+
+These were stragglers from the refine-plan output where per-table counts synced but free-form prose did not. All 3 corrected on the feature branch.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -298,13 +298,23 @@ Draft plans for issues previously skipped as "too complex for batch fix."
 Accepts optional `auto` — `/fix-issues plan auto` skips the selection gate
 and drafts plans for all found issues.
 
-1. **Run `node scripts/skipped-issues.cjs --check-gh`** — this scans the
-   ENTIRE `SPRINT_REPORT.md` across all sprints, extracts skipped issue
-   numbers (including ranges like #148-#168), deduplicates against existing
-   executable plans in `plans/`, and checks GitHub issue state. Output is
-   JSON with each issue classified as `needs-plan`, `has-plan`, or `closed`.
+1. **Find skipped issues from `plans/SPRINT_REPORT.md`.** Scan the entire
+   sprint report for issue numbers under "Skipped" / "Too Complex" /
+   "Remaining Open" headings. Use grep to extract candidate numbers
+   (handles bare `#NNN`, ranges like `#148-#168`, and `#NNN, #MMM` lists):
 
-   Use the script output directly — do NOT manually grep SPRINT_REPORT.md.
+   ```bash
+   grep -nE '#[0-9]+' plans/SPRINT_REPORT.md | grep -iE 'skip|complex|remain'
+   ```
+
+   Then for each candidate `#N`:
+   - Check `plans/` for an existing executable plan covering it:
+     `grep -l "#$N\b" plans/*.md` (existing plan = skip)
+   - Check GitHub state: `gh issue view "$N" --json state -q .state`
+     (`OPEN` = candidate; `CLOSED` = skip)
+
+   Build the working list of `needs-plan` issues from candidates that
+   have NO existing plan AND are still `OPEN`. Skip the rest.
 
 2. **Deduplicate** — check `plans/` for existing plans that already cover
    each issue. Also check whether the issue is still open on GitHub
@@ -495,14 +505,26 @@ alert user, write failure to report).
    gh issue list --state open --limit 500 --json number,title,labels,createdAt
    ```
 
-2. **Run the sync script** to find gaps between GitHub and plan files:
+2. **Find gaps** between GitHub open issues and plan tracker files. List
+   the trackers, then for each open GH issue number check whether it
+   appears in any tracker:
+
    ```bash
-   node ${CLAUDE_SKILL_DIR}/scripts/sync-issues.js
+   ls plans/*ISSUES*.md plans/ISSUES_PLAN.md 2>/dev/null
+
+   gh issue list --state open --limit 500 --json number -q '.[].number' \
+     | while read -r N; do
+         if ! grep -q "#$N\b" plans/*ISSUES*.md plans/ISSUES_PLAN.md 2>/dev/null; then
+           echo "GAP: #$N not in any tracker"
+         fi
+       done
    ```
 
-3. **Run the stats script** to see current distribution:
+3. **Tally label distribution** to see current spread:
+
    ```bash
-   node ${CLAUDE_SKILL_DIR}/scripts/issue-stats.js
+   gh issue list --state open --limit 500 --json labels \
+     -q '.[].labels[].name' | sort | uniq -c | sort -rn
    ```
 
 4. **Update ALL issue trackers** — scan `plans/` for tracker files:

--- a/skills/review-feedback/SKILL.md
+++ b/skills/review-feedback/SKILL.md
@@ -25,14 +25,8 @@ will specify the path). This file is exported from the app via
 
 ## Workflow
 
-1. **Read** the feedback JSON file:
-   ```bash
-   cat feedback.json
-   ```
-   Or run the summary helper first:
-   ```bash
-   node scripts/review-feedback.js feedback.json
-   ```
+1. **Read** the feedback JSON file directly with the Read tool (or
+   `cat feedback.json` for a quick scan).
 
 2. **For each pending entry**, evaluate:
    - Is it a real, actionable bug or feature request?

--- a/skills/update-zskills/references/script-ownership.md
+++ b/skills/update-zskills/references/script-ownership.md
@@ -1,0 +1,126 @@
+# Script Ownership Registry
+
+Authoritative ownership table for every script under `scripts/` (Tier-1
+machinery that moves into a skill, and Tier-2 release/consumer-tooling
+that stays put). This file is parsed by `/run-plan` Phase 4 migration
+logic and the drift test in WI 4.8 case 6a — preserve the column layout.
+
+## Tier definitions
+
+- **Tier 1** — zskills internal machinery; source moves into the
+  owning skill at `skills/<owner>/scripts/<name>`. Cross-skill callers
+  invoke via `"$CLAUDE_PROJECT_DIR/.claude/skills/<owner>/scripts/<name>"`
+  (shipped) or `"$REPO_ROOT/skills/<owner>/scripts/<name>"` (zskills
+  source-tree tests).
+- **Tier 2** — release-only repo tooling consumed by CI, OR
+  consumer-customizable utility (template/stub). Stays at `scripts/`.
+  Hooks, `CLAUDE_TEMPLATE.md`, and `README.md` config schemas continue
+  to name `scripts/<x>.sh`.
+
+## Ownership table
+
+| Script                       | Tier   | Owner / disposition          |
+|------------------------------|--------|------------------------------|
+| `apply-preset.sh`            | 1      | `update-zskills`             |
+| `briefing.cjs`               | 1      | `briefing`                   |
+| `briefing.py`                | 1      | `briefing`                   |
+| `build-prod.sh`              | 2      | release-only repo tooling; never installed to consumers (called by `.github/workflows/ship-to-prod.yml:80`; documented in `RELEASING.md:5,47,64,71,78,82`) |
+| `clear-tracking.sh`          | 1      | `update-zskills`             |
+| `compute-cron-fire.sh`       | 1      | `run-plan`                   |
+| `create-worktree.sh`         | 1      | `create-worktree`            |
+| `land-phase.sh`              | 1      | `commit`                     |
+| `mirror-skill.sh`            | 2      | release/repo tooling; called by `tests/test-mirror-skill.sh` and (per Phase 1 Design) by every phase's mirror-discipline step in lieu of `rm -rf .claude/skills/<name> && cp -a ...` |
+| `plan-drift-correct.sh`      | 1      | `run-plan`                   |
+| `port.sh`                    | 1      | `update-zskills`             |
+| `post-run-invariants.sh`     | 1      | `run-plan`                   |
+| `sanitize-pipeline-id.sh`    | 1      | `create-worktree`            |
+| `statusline.sh`              | 1      | `update-zskills` (source moves; install destination still `~/.claude/statusline-command.sh`) |
+| `stop-dev.sh`                | 2      | currently functional generic implementation; consumer stack writes PIDs to `var/dev.pid`. **Note:** full conversion to a formal failing stub is deferred to a follow-up plan covering the consumer stub-callout pattern. |
+| `test-all.sh`                | 2      | already a partial template (`{{E2E_TEST_CMD}}` placeholders); customized by consumer with their own test commands. **Note:** full conversion to a formal failing stub is deferred to the same follow-up plan. |
+| `worktree-add-safe.sh`       | 1      | `create-worktree`            |
+| `write-landed.sh`            | 1      | `commit`                     |
+
+Total: 14 Tier 1 (`apply-preset`, `briefing.cjs`, `briefing.py`,
+`clear-tracking`, `compute-cron-fire`, `create-worktree`, `land-phase`,
+`plan-drift-correct`, `port`, `post-run-invariants`,
+`sanitize-pipeline-id`, `statusline`, `worktree-add-safe`,
+`write-landed`); 4 Tier 2 (`build-prod.sh`, `mirror-skill.sh`,
+`stop-dev.sh`, `test-all.sh`).
+
+## Format contract
+
+Future agents adding rows MUST preserve this exact layout — it is parsed
+by `awk -F'|'` in multiple places (Phase 4 WI 4.2 hash-file generator,
+WI 4.8 case 6a drift test, Phase 5 WI 5.1, Phase 3b WI 3b.1):
+
+- **Column 1** — `` `script-name.ext` `` (backtick-quoted, surrounded by
+  whitespace).
+- **Column 2** — ` 1 ` or ` 2 ` (literal digit, with surrounding
+  whitespace; no other content).
+- **Column 3** — owner-or-disposition prose. Tier-1 rows name a single
+  owning skill (in backticks). Tier-2 rows describe disposition.
+
+Adding a row in any other format breaks the parsers and the canonical
+Tier-1 enumeration below.
+
+## Cross-skill path convention
+
+- **Source-tree zskills tests** invoke scripts via the absolute
+  `"$REPO_ROOT/skills/<owner>/scripts/<name>"` form. The bare-relative
+  `skills/<owner>/scripts/<name>` form is FORBIDDEN. `tests/run-all.sh`
+  exports `CLAUDE_PROJECT_DIR="$REPO_ROOT"` (Phase 5 WI 5.7) so
+  cross-skill invocations also resolve under tests.
+- **Shipped (consumer-side) and cross-skill callers** MUST use the
+  bare-`$CLAUDE_PROJECT_DIR` form
+  `"$CLAUDE_PROJECT_DIR/.claude/skills/<owner>/scripts/<name>"`.
+  The harness sets `CLAUDE_PROJECT_DIR` in spawned bash blocks; if it
+  is unset at a callsite, fail loud rather than silently expand to an
+  invalid path.
+- **Same-skill internal callers** (e.g., `create-worktree.sh` invoking
+  `worktree-add-safe.sh` in its own skill) compute a path from the
+  script's own location:
+  `SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)`. Symlink invocation is
+  not supported in this form (use `readlink -f` resolution if needed).
+
+## Canonical Tier-1 name parser (DA-5 single source of truth)
+
+Every grep sweep across this plan that enumerates Tier-1 names MUST
+drive off this file:
+
+```bash
+TIER1_NAMES=$(awk -F'|' '$3 ~ /^[[:space:]]*1[[:space:]]*$/ {
+  gsub(/[[:space:]`]/, "", $2); print $2
+}' skills/update-zskills/references/script-ownership.md)
+```
+
+Phases 3b, 5, and 6 keep illustrative closed lists for human readability
+in their grep recipes, but their acceptance criteria reference the
+parser-driven form so a future row addition does not drift the sweep.
+
+## STALE_LIST
+
+The STALE_LIST is the set of `scripts/<name>` paths that Phase 4's
+`/update-zskills` migration logic detects in a consumer's checkout and
+removes after confirming the new skill-mirrored copies exist. It is the
+Tier-1 name set with a `scripts/` prefix:
+
+```
+scripts/apply-preset.sh
+scripts/briefing.cjs
+scripts/briefing.py
+scripts/clear-tracking.sh
+scripts/compute-cron-fire.sh
+scripts/create-worktree.sh
+scripts/land-phase.sh
+scripts/plan-drift-correct.sh
+scripts/port.sh
+scripts/post-run-invariants.sh
+scripts/sanitize-pipeline-id.sh
+scripts/statusline.sh
+scripts/worktree-add-safe.sh
+scripts/write-landed.sh
+```
+
+Phase 4 reads this list (or recomputes it via the parser above) when
+deciding which legacy `scripts/<name>` files to delete in a consumer
+repo on next `update-zskills` run.


### PR DESCRIPTION
## Plan: Move skill-owned scripts into the skills that use them

Phase 1 of `plans/SCRIPTS_INTO_SKILLS_PLAN.md`. Foundation: fix pre-existing dead references and write the canonical `script-ownership.md` registry that subsequent phases consume.

<!-- run-plan:progress:start -->
**Phases completed:**
- Phase 1 — Inventory cleanup: fix dead refs, write ownership registry (✅ this PR)
- Phase 2 — Move single-owner Tier 1 scripts (⬚)
- Phase 3a — Move shared Tier 1 scripts and update same-skill internals (⬚)
- Phase 3b — Update cross-skill callers via grep-driven sweep (⬚)
- Phase 4 — Update /update-zskills install flow + stale-Tier-1 migration (⬚)
- Phase 5 — Update tests + sweep README/CLAUDE.md/CLAUDE_TEMPLATE (⬚)
- Phase 6 — Docs and close-out (⬚)
<!-- run-plan:progress:end -->

## Summary

- **WI 1.2**: 3 dead script references in `skills/fix-issues/SKILL.md` replaced with executable manual `gh` recipes (`skipped-issues.cjs`, `sync-issues.js`, `issue-stats.js` were referenced but never existed).
- **WI 1.3**: stripped `node scripts/review-feedback.js` reference from `skills/review-feedback/SKILL.md` (use Read tool to inspect feedback.json directly).
- **WI 1.4**: wrote `skills/update-zskills/references/script-ownership.md` — the canonical 18-row registry: 14 Tier-1 (skill machinery, moves into owning skills' `scripts/` subdirs) + 4 Tier-2 (consumer-facing or repo tooling, stays at top-level `scripts/`). Includes Tier definitions, format contract, cross-skill path convention, canonical Tier-1 name parser, and STALE_LIST. Plan Overview table synchronized.
- **WI 1.5**: mirror parity for fix-issues, review-feedback, update-zskills via `bash scripts/mirror-skill.sh skills/<name>` (the hook-compatible helper from PR #88).
- **WI 1.6**: `scripts/rel-root-cw-cw-smoke-43859/` verified absent; `__pycache__` cleanup deferred to Phase 2 WI 2.8b per plan.

Two orchestrator-bookkeeping commits also included: `7fc20c4` (refine-plan H4→H3 heading-level fix) and `bb4d661` (3 prose drift fixes the verifier independently flagged: "13 moves" → "14"; Tier-2 list updated to include `mirror-skill.sh`).

## Test plan

- [x] `test -f scripts/build-prod.sh` (pre-existing dead-ref WI 1.1 anchor — file present)
- [x] `grep -rn 'skipped-issues\.cjs\|sync-issues\.js\|issue-stats\.js\|review-feedback\.js' skills/ .claude/skills/` returns zero matches
- [x] `skills/update-zskills/references/script-ownership.md` exists in source AND mirror; 14 Tier-1 + 4 Tier-2 = 18 rows
- [x] `mirror-skill.sh` and `plan-drift-correct.sh` listed in registry (≥1 each)
- [x] `! test -e scripts/rel-root-cw-cw-smoke-43859`
- [x] `diff -r skills/<name> .claude/skills/<name>` empty for fix-issues, review-feedback, update-zskills
- [x] `bash tests/run-all.sh` exits 0 with 100% pass rate (931/931, no delta)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)