### PR TITLE
[scripts-into-skills-plan] SCRIPTS_INTO_SKILLS — Phase 5 (tests + README/CLAUDE.md residual sweep)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -186,9 +186,6 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    if [[ "$CONFIG_CONTENT" =~ \"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      DEV_SERVER_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"port_script\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
-     PORT_SCRIPT="${BASH_REMATCH[1]}"
-   fi
    if [[ "$CONFIG_CONTENT" =~ \"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      MAIN_REPO_PATH="${BASH_REMATCH[1]}"
    fi
@@ -324,7 +321,6 @@ for each field F in schema:
 | Placeholder | Config path | Example |
 |-------------|-------------|---------|
 | `{{DEV_SERVER_CMD}}` | `dev_server.cmd` | `npm start` |
-| `{{PORT_SCRIPT}}` | `dev_server.port_script` | `scripts/port.sh` |
 | `{{AUTH_BYPASS}}` | `ui.auth_bypass` | `localStorage.setItem(...)` |
 
 Runtime-read fields (not install-filled): `testing.unit_cmd`, `testing.full_cmd`, `ui.file_patterns`, `dev_server.main_repo_path`. Hooks and helper scripts read these directly from `.claude/zskills-config.json` at every invocation — see Phase 1 of `plans/DRIFT_ARCH_FIX.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Skill distribution repo and presentation site for Z Skills.
 - `block-diagram/` — add-on skills (3)
 - `.claude/skills/` — installed skill copies (what Claude Code reads)
 - `hooks/` — source hook scripts
-- `scripts/` — consumer-customizable stubs (stop-dev.sh, test-all.sh) and release-only repo tooling (build-prod.sh, mirror-skill.sh); skill machinery (including port.sh, clear-tracking.sh, statusline.sh) moved to `.claude/skills/<owner>/scripts/`
+- `scripts/` — consumer-customizable stubs (stop-dev.sh, test-all.sh) and release-only repo tooling (build-prod.sh, mirror-skill.sh); skill machinery moved to `.claude/skills/<owner>/scripts/` (port.sh, clear-tracking.sh, statusline.sh in `update-zskills`; plan-drift-correct.sh in `run-plan`; full mapping in `skills/update-zskills/references/script-ownership.md`)
 - `CLAUDE_TEMPLATE.md` — template for CLAUDE.md generation in target projects
 - `PRESENTATION.html` — main site (index.html redirects here)
 - `README.md`, `CHANGELOG.md` — documentation
@@ -41,8 +41,9 @@ mkdir -p "$TEST_OUT"
 Then read `"$TEST_OUT/.test-results.txt"` to inspect failures. Never pipe
 through `| tail`, `| head`, `| grep` -- it loses output and forces re-runs.
 `/tmp/zskills-tests/` is per-worktree-basename, so parallel pipelines do
-not collide. `.claude/skills/commit/scripts/land-phase.sh` removes the per-worktree dir on
-successful landing. Always compute `$TEST_OUT` from `$(pwd)` AFTER you
+not collide. The landing script (now bundled in the `commit` skill) removes
+the per-worktree dir on successful landing. Always compute `$TEST_OUT` from
+`$(pwd)` AFTER you
 have `cd`-ed into the correct repo/worktree root; or derive it from an
 explicit `$WORKTREE_PATH` the caller passes you (never assume cwd if you
 were just handed a path).
@@ -159,7 +160,8 @@ for the authoritative scheme, delegation semantics, and migration
 strategy. When writing markers from a skill: construct them under
 `.zskills/tracking/$PIPELINE_ID/` using the `requires.*`, `fulfilled.*`,
 and `step.*` basenames — never flat under `.zskills/tracking/` directly.
-Use `.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh` (lands in Phase 2 of the unify
-plan) before writing any constructed `PIPELINE_ID` to disk. `.landed` is
-NOT a tracking marker — it is a separate worktree-state artifact managed
-by `/commit land` and `.claude/skills/commit/scripts/write-landed.sh`.
+Use the sanitize-pipeline-id script (bundled in the `create-worktree` skill;
+lands in Phase 2 of the unify plan) before writing any constructed
+`PIPELINE_ID` to disk. `.landed` is NOT a tracking marker — it is a separate
+worktree-state artifact managed by `/commit land` (via the landing script
+bundled in the `commit` skill).

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -21,7 +21,7 @@ When using the Agent tool:
 {{DEV_SERVER_CMD}}
 ```
 
-The port is determined automatically by `{{PORT_SCRIPT}}`: **8080** for the main repo (`{{MAIN_REPO_PATH}}`), a **deterministic unique port** for each worktree (derived from the project root path). Run `bash {{PORT_SCRIPT}}` to see your port. Override with `DEV_PORT=NNNN` env var if needed.
+The port is determined automatically — run `bash .claude/skills/update-zskills/scripts/port.sh` to see it. **8080** for the main repo (`{{MAIN_REPO_PATH}}`), a **deterministic unique port** for each worktree (derived from the project root path). Override with `DEV_PORT=NNNN` env var if needed.
 
 **To stop this worktree's dev server, run `bash scripts/stop-dev.sh`.** It sends SIGTERM to the PIDs recorded in `var/dev.pid`. Contract: your `{{DEV_SERVER_CMD}}` must write each spawned child PID (one per line) to `var/dev.pid` on start, and should clear it on clean shutdown. `var/` is gitignored.
 
@@ -185,4 +185,4 @@ to main. Use PR mode or feature branches.
 
 ## Tracking Enforcement
 
-Tracking file enforcement is active when `.zskills/tracking/` exists and the session is associated with a pipeline (via `.zskills-tracked` file or transcript). Skills create tracking files during pipeline execution; hooks check them before allowing `git commit`, `git cherry-pick`, and `git push`. Pipeline scoping (suffix matching on pipeline ID) ensures one pipeline's markers don't block another. The orchestrator writes `.zskills-tracked` (single-line pipeline ID) in both the worktree and main repo roots before dispatching agents, and removes it after pipeline completion. The `clear-tracking.sh` script in `scripts/` lets the user manually clear stale tracking state -- agents are blocked from running it directly.
+Tracking file enforcement is active when `.zskills/tracking/` exists and the session is associated with a pipeline (via `.zskills-tracked` file or transcript). Skills create tracking files during pipeline execution; hooks check them before allowing `git commit`, `git cherry-pick`, and `git push`. Pipeline scoping (suffix matching on pipeline ID) ensures one pipeline's markers don't block another. The orchestrator writes `.zskills-tracked` (single-line pipeline ID) in both the worktree and main repo roots before dispatching agents, and removes it after pipeline completion. The `.claude/skills/update-zskills/scripts/clear-tracking.sh` script lets the user manually clear stale tracking state -- agents are blocked from running it directly.

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 5/7 | **In progress** — Phases 1+2+3a+3b+4 done (registry + 14 Tier-1 scripts moved + default_port + cross-skill sweep + /update-zskills install flow rewrite + stale-Tier-1 migration); 943/943 tests (+12 migration cases); Phases 5, 6 remaining |
+| [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 6/7 | **In progress** — Phases 1+2+3a+3b+4+5 done (full Tier-1 relocation + cross-skill sweep + /update-zskills install flow rewrite + stale-Tier-1 migration + residual doc/test sweep + port_script schema removal); 943/943 tests; Phase 6 (docs close-out + frontmatter flip) is the final phase |
 | [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 3/3 | **Complete** — all 3 phases landed; defense-in-depth drift detection chain (pre-authoring /refine-plan Dimension 7, pre-dispatch Phase 1 step 6 b, post-implement Phase 3.5); 931/931 tests, +68 plan-drift cases |
 | [plan-restructure-run-plan.md](reports/plan-restructure-run-plan.md) | 5/5 | **Complete** — all phases landed; 531/531 tests PASS; mirror parity clean; real-GitHub canaries deferred to user |
 | [plan-ci-fix-cycle-canary.md](reports/plan-ci-fix-cycle-canary.md) | 1/1 | **Complete** — CI-fix-cycle canary (pending this PR) |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ at [`config/zskills-config.schema.json`](config/zskills-config.schema.json).
   },
   "dev_server": {
     "cmd": "npm start",
-    "port_script": ".claude/skills/update-zskills/scripts/port.sh",
     "main_repo_path": "/home/you/projects/my-app"
   },
   "ui": {
@@ -225,7 +224,7 @@ Key fields:
   `/verify-changes`, `/run-plan`, the pre-commit hook, and others.
 - **`testing.output_file`** — Where test output gets captured. Never
   pipe test output; always capture to this file.
-- **`dev_server.cmd` / `port_script` / `main_repo_path`** — Lets
+- **`dev_server.cmd` / `main_repo_path`** — Lets
   worktree agents find the running dev server in the main repo.
   `main_repo_path` must be the absolute path to your repo's root
   (substitute your own — the example above is illustrative).
@@ -272,9 +271,10 @@ Two other file types sit alongside tracking markers:
   orchestrator writes it before dispatching work, removes it after the
   pipeline completes. Hooks use it to scope marker matching.
 - **`.landed`** (worktree root) — a YAML-ish marker written by
-  `/commit land` / `.claude/skills/commit/scripts/write-landed.sh` when a worktree's work has
-  been cherry-picked (or merged) to main. `status: full` = safe to
-  remove the worktree. `status: partial` / `not-landed` = inspect first.
+  `/commit land` (via the script bundled in the `commit` skill) when a
+  worktree's work has been cherry-picked (or merged) to main. `status: full`
+  = safe to remove the worktree. `status: partial` / `not-landed` = inspect
+  first.
 
 ## Hook policies
 

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -93,10 +93,6 @@
           "default": 8080,
           "description": "Default dev server port for the main repo; worktrees get a hash-derived port in 9000-60000."
         },
-        "port_script": {
-          "type": "string",
-          "description": "Script that outputs the dev server port. Example: scripts/port.sh"
-        },
         "main_repo_path": {
           "type": "string",
           "description": "Absolute path to the main repo. Used by worktree agents to find the dev server."

--- a/plans/SCRIPTS_INTO_SKILLS_PLAN.md
+++ b/plans/SCRIPTS_INTO_SKILLS_PLAN.md
@@ -113,7 +113,7 @@ decision belongs in the follow-up plan, not here.
 | 3a — Move shared Tier 1 scripts and update same-skill internals (create-worktree, worktree-add-safe, land-phase, write-landed, sanitize-pipeline-id, clear-tracking, port [+ config-driven default_port]) | ✅ Done | `596a498` | midpoint — landing deferred to 3b's PR squash; 7 scripts moved; default_port wired |
 | 3b — Update cross-skill callers (grep-driven sweep across skills/ .claude/skills/ CLAUDE.md README.md RELEASING.md) and tests | ✅ Done | `64dc37d` | landed via combined 3a+3b PR squash; 13 skills + hooks + 6 tests + docs swept; port.sh PROJECT_ROOT fix; 931/931 tests |
 | 4 — Update `/update-zskills` install flow: drop Tier-1 copies, install via skill mirror, add stale-Tier-1 migration | ✅ Done | `18404ae` | landed via PR squash; Step D rewrite + Step D.5 migration + tier1-shipped-hashes.txt; port_script strip; 943/943 tests (+12 migration cases) |
-| 5 — Update zskills tests + sweep README/CLAUDE.md/CLAUDE_TEMPLATE for residual references | 🟡 | `608c5fb` | residual sweep — 20 files, +39/-47; port_script schema field dropped; CLAUDE_PROJECT_DIR ordering check; 943/943 |
+| 5 — Update zskills tests + sweep README/CLAUDE.md/CLAUDE_TEMPLATE for residual references | ✅ Done | `608c5fb` | landed via PR squash; 20 files, +39/-47; port_script schema field dropped; CLAUDE_PROJECT_DIR ordering check; 943/943 |
 | 6 — Docs and close-out: CHANGELOG, plan registry, frontmatter flip | ⬚ |  |  |
 
 ## Phase 1 — Inventory cleanup: fix dead refs, write ownership registry

--- a/plans/SCRIPTS_INTO_SKILLS_PLAN.md
+++ b/plans/SCRIPTS_INTO_SKILLS_PLAN.md
@@ -113,7 +113,7 @@ decision belongs in the follow-up plan, not here.
 | 3a — Move shared Tier 1 scripts and update same-skill internals (create-worktree, worktree-add-safe, land-phase, write-landed, sanitize-pipeline-id, clear-tracking, port [+ config-driven default_port]) | ✅ Done | `596a498` | midpoint — landing deferred to 3b's PR squash; 7 scripts moved; default_port wired |
 | 3b — Update cross-skill callers (grep-driven sweep across skills/ .claude/skills/ CLAUDE.md README.md RELEASING.md) and tests | ✅ Done | `64dc37d` | landed via combined 3a+3b PR squash; 13 skills + hooks + 6 tests + docs swept; port.sh PROJECT_ROOT fix; 931/931 tests |
 | 4 — Update `/update-zskills` install flow: drop Tier-1 copies, install via skill mirror, add stale-Tier-1 migration | ✅ Done | `18404ae` | landed via PR squash; Step D rewrite + Step D.5 migration + tier1-shipped-hashes.txt; port_script strip; 943/943 tests (+12 migration cases) |
-| 5 — Update zskills tests + sweep README/CLAUDE.md/CLAUDE_TEMPLATE for residual references | ⬚ |  |  |
+| 5 — Update zskills tests + sweep README/CLAUDE.md/CLAUDE_TEMPLATE for residual references | 🟡 | `608c5fb` | residual sweep — 20 files, +39/-47; port_script schema field dropped; CLAUDE_PROJECT_DIR ordering check; 943/943 |
 | 6 — Docs and close-out: CHANGELOG, plan registry, frontmatter flip | ⬚ |  |  |
 
 ## Phase 1 — Inventory cleanup: fix dead refs, write ownership registry

--- a/reports/plan-scripts-into-skills-plan.md
+++ b/reports/plan-scripts-into-skills-plan.md
@@ -1,5 +1,42 @@
 # Plan Report — Move skill-owned scripts into the skills that use them
 
+## Phase — 5 Tests + README/CLAUDE.md/CLAUDE_TEMPLATE residual sweep [UNFINALIZED]
+
+**Plan:** plans/SCRIPTS_INTO_SKILLS_PLAN.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-scripts-into-skills-plan
+**Branch:** feat/scripts-into-skills-plan
+**Commits:** 608c5fb (impl: 20 files, +39/-47), d4809e7 (tracker mark in-progress)
+
+### Work Items
+
+| # | Item | Status | Source |
+|---|------|--------|--------|
+| 5.x | Residual sweep across CLAUDE.md, CLAUDE_TEMPLATE.md, README.md, schema, tests, fixtures | Done | 608c5fb |
+| 5.5.a | port_script field dropped from schema, README, SKILL.md `{{PORT_SCRIPT}}`, this-repo config | Done | 608c5fb |
+| 5.5.d | README helper-scripts list verified bare-basename form (Phase 3b WI 3b.2.a output preserved) | Done | 608c5fb |
+| 5.7 | tests/run-all.sh exports CLAUDE_PROJECT_DIR after REPO_ROOT (ordering check) | Done | 608c5fb |
+| 5.x | bash tests/run-all.sh exits 0 (943/943, no delta) | Done | 608c5fb |
+
+### Verification
+
+- Test suite: PASSED (943/943, no delta from baseline — sweep is doc/test cleanup, no behavioral changes)
+- Schema audit: `port_script` removal is Phase-5-scope (sibling properties intact); not a regression
+- Verifier independently audited all 10 ACs; all pass
+- Hook help-text: 12 new-form `clear-tracking.sh` matches in `block-unsafe-generic.sh` (6 lines × 2 files); `stop-dev.sh` Tier-2 references intact (count=4)
+
+### PLAN-TEXT-DRIFT findings
+
+- **AC5 stale text vs. WI 5.5.d**: AC5 grep was written against pre-3b form (`scripts/test-all|scripts/stop-dev`), WI 5.5.d explicitly checks bare basenames per Phase 3b WI 3b.2.a's bullet-list rewrite. Implementation followed WI 5.5.d (correct), AC5 prose is stale. Non-blocking — Tier-2 references ARE intact.
+
+### Notes
+
+- Small targeted phase: 20 files, +39/-47 lines (cleanup, not new behavior).
+- Schema `port_script` removal completes the migration: `port.sh` lives at `.claude/skills/update-zskills/scripts/port.sh` only, no consumer override field needed.
+- After landing: 6/7 phases done; Phase 6 (docs close-out + frontmatter flip) is the final phase.
+
+---
+
 ## Phase — 4 /update-zskills install flow rewrite + stale-Tier-1 migration [UNFINALIZED]
 
 **Plan:** plans/SCRIPTS_INTO_SKILLS_PLAN.md

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -186,9 +186,6 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    if [[ "$CONFIG_CONTENT" =~ \"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      DEV_SERVER_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"port_script\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
-     PORT_SCRIPT="${BASH_REMATCH[1]}"
-   fi
    if [[ "$CONFIG_CONTENT" =~ \"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      MAIN_REPO_PATH="${BASH_REMATCH[1]}"
    fi
@@ -324,7 +321,6 @@ for each field F in schema:
 | Placeholder | Config path | Example |
 |-------------|-------------|---------|
 | `{{DEV_SERVER_CMD}}` | `dev_server.cmd` | `npm start` |
-| `{{PORT_SCRIPT}}` | `dev_server.port_script` | `scripts/port.sh` |
 | `{{AUTH_BYPASS}}` | `ui.auth_bypass` | `localStorage.setItem(...)` |
 
 Runtime-read fields (not install-filled): `testing.unit_cmd`, `testing.full_cmd`, `ui.file_patterns`, `dev_server.main_repo_path`. Hooks and helper scripts read these directly from `.claude/zskills-config.json` at every invocation — see Phase 1 of `plans/DRIFT_ARCH_FIX.md`.

--- a/tests/fixtures/canary/plan-prose-sentinel.md
+++ b/tests/fixtures/canary/plan-prose-sentinel.md
@@ -3,7 +3,7 @@
 
   This file contains the yellow-circle emoji (U+1F7E1) in PROSE only
   (never in a markdown table row starting with '|'). The fixture tests
-  that scripts/post-run-invariants.sh invariant #6 does NOT false-positive
+  that the post-run-invariants script (bundled in run-plan skill) invariant #6 does NOT false-positive
   on prose mentions of the sentinel after the row-scoped grep fix.
 
   If invariant #6 ever regresses to whole-file grep, this fixture will

--- a/tests/fixtures/canary/plan-with-sentinel.md
+++ b/tests/fixtures/canary/plan-with-sentinel.md
@@ -2,7 +2,7 @@
   FIXTURE — NOT A REAL PLAN.
 
   This file intentionally contains the yellow-circle emoji (U+1F7E1) in
-  the Progress Tracker table row below to test scripts/post-run-invariants.sh
+  the Progress Tracker table row below to test skills/run-plan/scripts/post-run-invariants.sh
   invariant #6 firing. Invariant #6 greps for that character in --plan-file
   and fails if it finds one. The presence of the sentinel here is the whole
   point of the fixture; do NOT "clean" it up.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -4,6 +4,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+export CLAUDE_PROJECT_DIR="$REPO_ROOT"
 
 TOTAL_PASS=0
 TOTAL_FAIL=0

--- a/tests/test-apply-preset.sh
+++ b/tests/test-apply-preset.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for scripts/apply-preset.sh
+# Tests for skills/update-zskills/scripts/apply-preset.sh
 # Run from repo root: bash tests/test-apply-preset.sh
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/tests/test-briefing-parity.sh
+++ b/tests/test-briefing-parity.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for scripts/briefing.py (and parity with briefing.cjs)
+# Tests for skills/briefing/scripts/briefing.py (and parity with briefing.cjs)
 # Run from repo root: bash tests/test-briefing-parity.sh
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -133,13 +133,13 @@ expect_allow 'heredoc containing git stash -u' "$(printf 'cat <<EOF\ngit stash -
 # ---------------------------------------------------------------------------
 # Phase 2 — land-phase.sh reproducers
 # ---------------------------------------------------------------------------
-# Script signature is ONE arg: `bash scripts/land-phase.sh <worktree-path>`.
+# Script signature is ONE arg: `bash skills/commit/scripts/land-phase.sh <worktree-path>`.
 # MAIN_ROOT resolution uses `git rev-parse --git-common-dir` from CWD, so
 # every invocation subshell-cd's into the fixture's primary repo first.
 SCRIPT="$REPO_ROOT/skills/commit/scripts/land-phase.sh"
 
 section "write-landed.sh: rc-checked atomic marker writes (3 cases)"
-# Locks in the rc-check behavior introduced with scripts/write-landed.sh.
+# Locks in the rc-check behavior introduced with skills/commit/scripts/write-landed.sh.
 # The ad-hoc cat+mv pattern this helper replaces silently wrote empty/
 # partial markers on disk-full / read-only failures; the helper catches
 # those via `if ! cat ...` and `if ! mv ...` with loud stderr + rc=1.
@@ -190,7 +190,7 @@ expect_script_exit \
   bash -c "cd \"$dirty_primary\" && bash \"$SCRIPT\" \"$dirty_worktree\""
 
 section "land-phase.sh: tracked ephemeral rejected (4 cases)"
-# Array-drift guard: confirm scripts/land-phase.sh still lists exactly the
+# Array-drift guard: confirm skills/commit/scripts/land-phase.sh still lists exactly the
 # four ephemeral names we cover below. If the script's list drifts from
 # this plan's list, fail loudly so test authors update this phase rather
 # than silently passing against a changed list.
@@ -887,7 +887,7 @@ assert_tracking_deny \
   "concurrent-same-slug: run-plan.foo cannot see draft-plan.foo fulfillment" \
   "$tn1_out" "verify-changes.foo"
 
-# Case 2 — Glob-special chars sanitized by scripts/sanitize-pipeline-id.sh
+# Case 2 — Glob-special chars sanitized by skills/create-worktree/scripts/sanitize-pipeline-id.sh
 # BEFORE they reach disk. Verify the sanitizer collapses *, ?, [, ], and
 # spaces into '_' so writers never persist glob-special basenames.
 tn2_raw='has space*?[abc]'

--- a/tests/test-compute-cron-fire.sh
+++ b/tests/test-compute-cron-fire.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for scripts/compute-cron-fire.sh
+# Tests for skills/run-plan/scripts/compute-cron-fire.sh
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/tests/test-create-worktree.sh
+++ b/tests/test-create-worktree.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for scripts/create-worktree.sh — 21-case suite.
+# Tests for skills/create-worktree/scripts/create-worktree.sh — 21-case suite.
 # Run from repo root: bash tests/test-create-worktree.sh
 #
 # Cases 1-13 cover foundational behaviour: path-template variants,
@@ -118,7 +118,7 @@ trap cleanup EXIT
 
 mkdir -p "$TEST_TMPDIR"
 
-echo "=== Phase 1b — scripts/create-worktree.sh (20 cases) ==="
+echo "=== Phase 1b — skills/create-worktree/scripts/create-worktree.sh (20 cases) ==="
 
 # ────────────────────────────────────────────────────────────────────
 # Case 1 — Fresh creation (plain, no flags). rc=0, stdout=absolute path,

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2713,7 +2713,7 @@ _drift_fail=0
 for tok in '{{UNIT_TEST_CMD}}' '{{FULL_TEST_CMD}}' '{{UI_FILE_PATTERNS}}' '{{MAIN_REPO_PATH}}'; do
   if grep -Fq "$tok" \
     "$REPO_ROOT/.claude/hooks/block-unsafe-project.sh" \
-    "$REPO_ROOT/scripts/port.sh" \
+    "$REPO_ROOT/skills/update-zskills/scripts/port.sh" \
     "$REPO_ROOT/scripts/test-all.sh"; then
     fail "drift-regression: migrated placeholder $tok still present in installed hook/scripts"
     _drift_fail=1

--- a/tests/test-plan-drift-correct.sh
+++ b/tests/test-plan-drift-correct.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for scripts/plan-drift-correct.sh.
+# Tests for skills/run-plan/scripts/plan-drift-correct.sh.
 #
 # Covers all three modes (--parse, --drift, --correct) across the five
 # supported <stated> forms (range, ≤, ≥, ~/literal, exactly), plus the

--- a/tests/test-port.sh
+++ b/tests/test-port.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for scripts/port.sh
+# Tests for skills/update-zskills/scripts/port.sh
 # Run from repo root: bash tests/test-port.sh
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -408,7 +408,7 @@ fi
 # ────────────────────────────────────────────────────────────────────
 # Case 9 — Tracking setup (WI 1.8)
 # ────────────────────────────────────────────────────────────────────
-if grep -q 'scripts/sanitize-pipeline-id.sh' "$SKILL" \
+if grep -q 'skills/create-worktree/scripts/sanitize-pipeline-id.sh' "$SKILL" \
    && grep -qE 'echo.*ZSKILLS_PIPELINE_ID=\$PIPELINE_ID' "$SKILL" \
    && grep -q 'fulfilled.quickfix' "$SKILL" \
    && grep -q "trap 'finalize_marker \$?' EXIT" "$SKILL"; then

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -357,7 +357,7 @@ check_fixed update-zskills "WI2.2: runtime-read note" \
 
 echo ""
 echo "=== create-worktree.sh caller contract ==="
-# Every multi-line `bash ".../scripts/create-worktree.sh" \` invocation in
+# Every multi-line `bash ".../skills/create-worktree/scripts/create-worktree.sh" \` invocation in
 # skills/ must include `--pipeline-id` within the next 12 lines. Doc-prose
 # mentions (non-backslash-terminated `create-worktree.sh` lines) are not
 # invocations and are ignored here.

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -126,11 +126,12 @@ if [ -d ".claude/skills/cleanup-merged" ]; then
 fi
 
 # Cross-skill invariant: no skill statically prescribes `isolation: "worktree"`.
-# All worktree work must go through scripts/create-worktree.sh (manual creation)
-# per plans/EXECUTION_MODES.md. Word-boundary on "with" distinguishes prescriptions
-# ("Dispatch ... with `isolation: "worktree"`") from negative warnings ("WITHOUT
-# `isolation: "worktree"`"), so existing migrated skills don't false-positive.
-check 'no skill prescribes isolation: worktree (use scripts/create-worktree.sh)' \
+# All worktree work must go through skills/create-worktree/scripts/create-worktree.sh
+# (manual creation) per plans/EXECUTION_MODES.md. Word-boundary on "with"
+# distinguishes prescriptions ("Dispatch ... with `isolation: "worktree"`") from
+# negative warnings ("WITHOUT `isolation: "worktree"`"), so existing migrated skills
+# don't false-positive.
+check 'no skill prescribes isolation: worktree (use skills/create-worktree/scripts/create-worktree.sh)' \
   '! grep -rEn '"'"'\bwith[[:space:]]+`?isolation: *"worktree"'"'"' skills/ block-diagram/ 2>/dev/null'
 
 # Emit format expected by tests/run-all.sh


### PR DESCRIPTION
## Plan: Move skill-owned scripts into the skills that use them

Phase 5 of `plans/SCRIPTS_INTO_SKILLS_PLAN.md`. Small targeted residual sweep after Phase 3b's primary cross-skill caller sweep. Picks up doc/test references and removes the obsolete `port_script` schema field.

<!-- run-plan:progress:start -->
**Phases completed:**
- Phase 1 — Inventory cleanup + ownership registry (✅ #95)
- Phase 2 — Move single-owner Tier-1 scripts (✅ #96)
- Phase 3a + 3b — Move shared Tier-1 scripts + cross-skill sweep (✅ #97)
- Phase 4 — `/update-zskills` install flow rewrite + stale-Tier-1 migration (✅ #98)
- Phase 5 — Tests + README/CLAUDE.md/CLAUDE_TEMPLATE residual sweep (✅ this PR)
- Phase 6 — Docs and close-out (⬚ — final)
<!-- run-plan:progress:end -->

## Summary

20 files changed, +39/-47 lines. Targeted cleanup, not new behavior:

- **Doc updates**: CLAUDE.md, CLAUDE_TEMPLATE.md, README.md residual Tier-1 path references
- **Schema cleanup**: `config/zskills-config.schema.json` — `port_script` property dropped (single-canonical-path: `port.sh` lives at `.claude/skills/update-zskills/scripts/port.sh` only)
- **Test updates**: 11 test files swept for residual paths
- **Test fixtures**: `tests/fixtures/canary/plan-prose-sentinel.md`, `plan-with-sentinel.md` updated
- **`/update-zskills` SKILL.md**: residual references in install flow
- **`tests/run-all.sh`**: CLAUDE_PROJECT_DIR exported after REPO_ROOT (ordering check via WI 5.7)

## Test plan

- [x] All target docs (CLAUDE.md, CLAUDE_TEMPLATE.md, README.md) zero-match-of-old-Tier-1 (verifier-disambiguated)
- [x] Hook help-text: 12 new-form `clear-tracking.sh` matches; Tier-2 `stop-dev.sh` references intact
- [x] `port_script` field dropped from schema, README, SKILL.md placeholder, this-repo config
- [x] CLAUDE_TEMPLATE Tier-2 references intact (`scripts/stop-dev` count = 1)
- [x] `tests/run-all.sh` exports `CLAUDE_PROJECT_DIR` after `REPO_ROOT` (ordering verified)
- [x] `bash tests/run-all.sh` exits 0 with 943/943 passing (no delta from baseline — sweep is doc/test cleanup only)
- [ ] CI green on this PR

## PLAN-TEXT-DRIFT findings (non-blocking)

AC5's grep wording in the spec is stale relative to Phase 3b WI 3b.2.a's bullet-list rewrite of the README helper-scripts list. WI 5.5.d's verification block correctly checks bare basenames (the post-3b form) and passes; the parallel AC line in the Acceptance Criteria block was not updated. Tier-2 references ARE intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)