### PR TITLE
[zskills-monitor-plan] ZSKILLS_MONITOR — Phase 2 (remove /plans work modes)

### DIFF
--- a/.claude/skills/plans/SKILL.md
+++ b/.claude/skills/plans/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: plans
 disable-model-invocation: true
-argument-hint: "[rebuild | next | details | work N [auto] [every SCHEDULE] [now]] | stop | next-run"
+argument-hint: "[rebuild | next | details]"
 description: >-
-  Plan dashboard and batch executor. View plan status, find the next
-  ready plan, or work through plans automatically.
-  Usage: /plans [rebuild | next | work N [auto] [every SCHEDULE]]
+  Plan dashboard. View plan status, find the next ready plan. For batch
+  execution, see `/work-on-plans`.
 ---
 
-# /plans [rebuild | next | details | work N] — Plan Dashboard & Executor
+# /plans [rebuild | next | details] — Plan Dashboard
 
 Maintains `plans/PLAN_INDEX.md` — a structured index of all plan files with
-their classification, status, and priority. Also supports batch execution
-of ready plans (like `/fix-issues` for bugs).
+their classification, status, and priority.
 
 **Modes:**
 
@@ -20,9 +18,7 @@ of ready plans (like `/fix-issues` for bugs).
 - **rebuild** `/plans rebuild` — scan all plans, classify, regenerate
 - **next** `/plans next` — show the highest-priority ready-to-run plan with command
 - **details** `/plans details` — show every plan with a one-line description
-- **work** `/plans work N [auto]` — batch-execute next N ready plans
-- **stop** `/plans stop` — cancel scheduled runs
-- **next-run** `/plans next-run` — when does the next scheduled run fire?
+- **For batch execution:** see `/work-on-plans`.
 
 ## Mode: Show (bare `/plans`)
 
@@ -60,7 +56,10 @@ of ready plans (like `/fix-issues` for bugs).
 
 4. If the file is older than 24 hours (check mtime), append:
    > ⚠️ Index is older than 24 hours. Run `/plans rebuild` to refresh.
-5. **Exit.**
+5. Append a one-line footer:
+   > Note: this ranking is independent of the monitor dashboard's Ready
+   > queue. For interactive prioritization, open /zskills-dashboard.
+6. **Exit.**
 
 ## Mode: Details (`/plans details`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 2026-04-28
 
+### Migration — /plans work removed
+
+The `/plans work`, `/plans stop`, and `/plans next-run` modes are
+retired. Batch execution of ready plans now lives in the dedicated
+`/work-on-plans` skill (shipped earlier in this dashboard cycle).
+`/plans` keeps only the read-only index-maintenance modes: bare,
+`rebuild`, `next`, `details`. Affected files: `skills/plans/SKILL.md`,
+`README.md`, `PRESENTATION.html` (cron-scheduling example row),
+`CHANGELOG.md`.
+
+Migrate `/plans work N [auto] [every SCHEDULE]` invocations to
+`/work-on-plans N [auto] [every SCHEDULE]`. The argument shape is
+preserved.
+
+**Cron-cleanup scope.** `CronList` and `CronDelete` are session-scoped
+(see `project_scheduling_primitives`). Cleanup of old `/plans work …
+every SCHEDULE` crons run from this phase only sees the running
+session's cron table — it cannot reach crons registered in your main
+session, other sprints, or worktree sessions you've left open. If you
+ever ran `/plans work … every SCHEDULE` in another session, you must
+run `CronList` + manual `CronDelete` from each affected session OR
+wait for those sessions to terminate (in-session crons die with the
+session, so any session you've already closed needs no cleanup).
+
 ### Added
 - refactor(scripts): move Tier-1 scripts into owning skills; /update-zskills migrates stale copies
   — 14 skill-machinery scripts relocated from `scripts/` into

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-zskills-monitor-plan.md](reports/plan-zskills-monitor-plan.md) | 1/9 | **In progress** — Phase 1 done (/work-on-plans execute-only CLI shipped, 677-line skill, parent: marker docs); Phases 2-9 remaining |
+| [plan-zskills-monitor-plan.md](reports/plan-zskills-monitor-plan.md) | 2/9 | **In progress** — Phases 1+2 done (/work-on-plans shipped + /plans work modes retired); Phases 3-9 remaining |
 | [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 7/7 | **Complete** — all 7 phases landed (full Tier-1 relocation + cross-skill sweep + /update-zskills install flow rewrite + safe stale-Tier-1 migration + residual sweep + docs close-out); 943/943 tests; landed via PRs #95, #96, #97, #98, #99, plus this final PR |
 | [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 3/3 | **Complete** — all 3 phases landed; defense-in-depth drift detection chain (pre-authoring /refine-plan Dimension 7, pre-dispatch Phase 1 step 6 b, post-implement Phase 3.5); 931/931 tests, +68 plan-drift cases |
 | [plan-restructure-run-plan.md](reports/plan-restructure-run-plan.md) | 5/5 | **Complete** — all phases landed; 531/531 tests PASS; mirror parity clean; real-GitHub canaries deferred to user |

--- a/PRESENTATION.html
+++ b/PRESENTATION.html
@@ -512,8 +512,8 @@
       <td>Commit audit + issue filing each fire</td>
     </tr>
     <tr>
-      <td><code>/plans</code></td>
-      <td><code>/plans work 3 auto every 6h</code></td>
+      <td><code>/work-on-plans</code></td>
+      <td><code>/work-on-plans 3 auto every 6h</code></td>
       <td>Execute next 3 ready plans each fire</td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -381,7 +381,8 @@ data pipeline.
 | `/refine-plan` | Refine in-progress plans: review remaining phases against completed work, generate Drift Log |
 | `/research-and-plan` | Decompose broad goals into focused sub-plans with dependency ordering |
 | `/research-and-go` | Full autonomous pipeline: decompose, plan, execute — one command, walk away |
-| `/plans` | Plan dashboard: index, status tracking, priority ranking, batch execution |
+| `/plans` | Plan dashboard: index, status tracking, priority ranking |
+| `/work-on-plans` | Batch-execute prioritized ready queue from the monitor dashboard |
 
 #### Build
 

--- a/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/plans/ZSKILLS_MONITOR_PLAN.md
@@ -250,7 +250,7 @@ is appended to `errors[]`.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — `/work-on-plans` execute-only CLI | ✅ Done | `12270a0` | landed via PR squash; new skill (677 lines) + parent: marker docs; 943/943 |
-| 2 — Remove `/plans work` modes | ⬚ | | |
+| 2 — Remove `/plans work` modes | 🟡 | `76dbece` | 5 files updated; /plans work retired; 943/943 |
 | 3 — `/work-on-plans` queue mutation + scheduling | ⬚ | | |
 | 4 — Data aggregation library | ⬚ | | |
 | 5 — HTTP server | ⬚ | | |

--- a/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/plans/ZSKILLS_MONITOR_PLAN.md
@@ -250,7 +250,7 @@ is appended to `errors[]`.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — `/work-on-plans` execute-only CLI | ✅ Done | `12270a0` | landed via PR squash; new skill (677 lines) + parent: marker docs; 943/943 |
-| 2 — Remove `/plans work` modes | 🟡 | `76dbece` | 5 files updated; /plans work retired; 943/943 |
+| 2 — Remove `/plans work` modes | ✅ Done | `76dbece` | landed via PR squash; 5 files updated; /plans work retired; 943/943 |
 | 3 — `/work-on-plans` queue mutation + scheduling | ⬚ | | |
 | 4 — Data aggregation library | ⬚ | | |
 | 5 — HTTP server | ⬚ | | |

--- a/reports/plan-zskills-monitor-plan.md
+++ b/reports/plan-zskills-monitor-plan.md
@@ -1,5 +1,39 @@
 # Plan Report — Zskills Monitor Dashboard
 
+## Phase — 2 Remove /plans work modes [UNFINALIZED]
+
+**Plan:** plans/ZSKILLS_MONITOR_PLAN.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-zskills-monitor-plan
+**Branch:** feat/zskills-monitor-plan
+**Commits:** 76dbece (impl: 5 files updated), 783db9d (tracker mark in-progress)
+
+### Work Items
+
+| # | Item | Status | Source |
+|---|------|--------|--------|
+| 2.1 | skills/plans/SKILL.md — argument-hint, description, H1 trimmed; pointer to /work-on-plans; work/stop/next-run removed | Done | 76dbece |
+| 2.2 | README.md — /plans row drops "batch execution"; new /work-on-plans row | Done | 76dbece |
+| 2.3 | CHANGELOG.md — Migration entry + Cron-cleanup scope paragraph (session-scoped caveat) | Done | 76dbece |
+| 2.4 | PRESENTATION.html — cron-scheduling row example uses /work-on-plans | Done | 76dbece |
+| 2.5 | /plans bare-mode footer ranking-independent note | Done | 76dbece |
+| 2.6 | Cron cleanup (best-effort, session-scoped) | Done | 76dbece |
+| 2.7 | Mirror parity for /plans skill | Done | 76dbece |
+
+### Verification
+
+- Test suite: PASSED (943/943, no delta — docs/skill-text only)
+- All 7 ACs pass; verifier independently re-detected zero PLAN-TEXT-DRIFT
+- PRESENTATION.html row Skill cell change (`/plans` → `/work-on-plans`) verified consistent with table pattern
+- /plans skill no longer claims batch execution; pointer to /work-on-plans is canonical migration path
+
+### Notes
+
+- Phase 2 is the cleanup half of the Phase 1+2 migration. Phase 1 shipped /work-on-plans; Phase 2 retires the older /plans work modes.
+- Cron cleanup is session-scoped (CronList/CronDelete only see this session's crons) — caveat noted in CHANGELOG.
+
+---
+
 ## Phase — 1 /work-on-plans execute-only CLI [UNFINALIZED]
 
 **Plan:** plans/ZSKILLS_MONITOR_PLAN.md

--- a/skills/plans/SKILL.md
+++ b/skills/plans/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: plans
 disable-model-invocation: true
-argument-hint: "[rebuild | next | details | work N [auto] [every SCHEDULE] [now]] | stop | next-run"
+argument-hint: "[rebuild | next | details]"
 description: >-
-  Plan dashboard and batch executor. View plan status, find the next
-  ready plan, or work through plans automatically.
-  Usage: /plans [rebuild | next | work N [auto] [every SCHEDULE]]
+  Plan dashboard. View plan status, find the next ready plan. For batch
+  execution, see `/work-on-plans`.
 ---
 
-# /plans [rebuild | next | details | work N] — Plan Dashboard & Executor
+# /plans [rebuild | next | details] — Plan Dashboard
 
 Maintains `plans/PLAN_INDEX.md` — a structured index of all plan files with
-their classification, status, and priority. Also supports batch execution
-of ready plans (like `/fix-issues` for bugs).
+their classification, status, and priority.
 
 **Modes:**
 
@@ -20,9 +18,7 @@ of ready plans (like `/fix-issues` for bugs).
 - **rebuild** `/plans rebuild` — scan all plans, classify, regenerate
 - **next** `/plans next` — show the highest-priority ready-to-run plan with command
 - **details** `/plans details` — show every plan with a one-line description
-- **work** `/plans work N [auto]` — batch-execute next N ready plans
-- **stop** `/plans stop` — cancel scheduled runs
-- **next-run** `/plans next-run` — when does the next scheduled run fire?
+- **For batch execution:** see `/work-on-plans`.
 
 ## Mode: Show (bare `/plans`)
 
@@ -60,7 +56,10 @@ of ready plans (like `/fix-issues` for bugs).
 
 4. If the file is older than 24 hours (check mtime), append:
    > ⚠️ Index is older than 24 hours. Run `/plans rebuild` to refresh.
-5. **Exit.**
+5. Append a one-line footer:
+   > Note: this ranking is independent of the monitor dashboard's Ready
+   > queue. For interactive prioritization, open /zskills-dashboard.
+6. **Exit.**
 
 ## Mode: Details (`/plans details`)
 


### PR DESCRIPTION
## Plan: Zskills Monitor Dashboard

Phase 2 of `plans/ZSKILLS_MONITOR_PLAN.md`. Retires the now-obsolete `/plans work` modes — `/work-on-plans` (Phase 1, PR #102) is the migration target.

<!-- run-plan:progress:start -->
**Phases completed:**
- Phase 1 — `/work-on-plans` execute-only CLI (✅ #102)
- Phase 2 — Remove `/plans work` modes (✅ this PR)
- Phase 3 — `/work-on-plans` queue mutation + scheduling (⬚ — next)
- Phase 4 — Data aggregation library (⬚)
- Phase 5 — HTTP server (⬚)
- Phase 6 — Read-only dashboard UI (⬚)
- Phase 7 — Interactive queue + write-back (⬚)
- Phase 8 — `/zskills-dashboard` skill (⬚)
- Phase 9 — Migrate `/plans rebuild` to Python aggregator (⬚)
<!-- run-plan:progress:end -->

## Summary

5 files updated, +48/-25 lines:

- **`skills/plans/SKILL.md`** + mirror: argument-hint trimmed to `[rebuild | next | details]`; description rewritten ("View plan status, find the next ready plan. For batch execution, see `/work-on-plans`."); H1 dropped "& Executor"; work/stop/next-run mode-summary bullets removed
- **README.md**: `/plans` row no longer claims batch execution; new `/work-on-plans` row added
- **CHANGELOG.md**: new `### Migration — /plans work removed` entry under `## 2026-04-28` with **Cron-cleanup scope** paragraph (CronList/CronDelete are session-scoped)
- **PRESENTATION.html**: cron-scheduling row's example uses `<code>/work-on-plans 3 auto every 6h</code>` and Skill cell updated for consistency
- `/plans` bare-mode footer mentions ranking is independent of monitor dashboard's Ready queue

Mirror parity holds (`diff -rq skills/plans/ .claude/skills/plans/` empty).

## Test plan

- [x] `skills/plans/SKILL.md` no longer references `work N`, `next-run`, `/plans work|stop|next-run`
- [x] argument-hint matches `"[rebuild | next | details]"`
- [x] README.md /plans row drops "batch execution"; new /work-on-plans row at line 385
- [x] CHANGELOG.md migration entry + cron-cleanup-scope paragraph present
- [x] PRESENTATION.html: zero `/plans work` matches; one `<code>/work-on-plans 3 auto every 6h</code>` match
- [x] /plans bare-mode footer ranking-independent note present
- [x] Mirror parity for /plans skill
- [x] `bash tests/run-all.sh` exits 0 with 943/943 (no delta)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)