### PR TITLE
[block-diagram-tracking-catchup] Block-Diagram Tracking-Naming Catch-up

### DIFF
--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-block-diagram-tracking-catchup.md](reports/plan-block-diagram-tracking-catchup.md) | 2/3 | **In progress** — Phases 1+2 done (19 tracking sites migrated; cross-skill invariant lint installed; 3 new canary cases for block-diagram delegation pair / missing fulfillment / cross-name isolation; 975/975 tests); Phase 3 remaining |
+| [plan-block-diagram-tracking-catchup.md](reports/plan-block-diagram-tracking-catchup.md) | 3/3 | **Complete** — all 3 phases landed (19 tracking sites migrated to subdir layout with sanitised slugs; cross-skill invariant lint + 3 canary cases; framework-coverage meta-lint with awk-joined multi-line support); 1005/1005 tests; landing via PR squash |
 | [plan-zskills-monitor-plan.md](reports/plan-zskills-monitor-plan.md) | 4/9 | **In progress** — Phases 1+2+3+4 done (/work-on-plans CLI shipped + /plans work retired + flock + Python aggregation library); 1000/1000 tests; Phases 5-9 remaining |
 | [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 7/7 | **Complete** — all 7 phases landed (full Tier-1 relocation + cross-skill sweep + /update-zskills install flow rewrite + safe stale-Tier-1 migration + residual sweep + docs close-out); 943/943 tests; landed via PRs #95, #96, #97, #98, #99, plus this final PR |
 | [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 3/3 | **Complete** — all 3 phases landed; defense-in-depth drift detection chain (pre-authoring /refine-plan Dimension 7, pre-dispatch Phase 1 step 6 b, post-implement Phase 3.5); 931/931 tests, +68 plan-drift cases |

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,7 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
-| [plan-block-diagram-tracking-catchup.md](reports/plan-block-diagram-tracking-catchup.md) | 1/3 | **In progress** — Phase 1 done (19 tracking sites in add-block + add-example migrated to subdir layout, BLOCK_SLUG/NAME_SLUG sanitisation, pre-#97 caller-path fix at L16/L20); Phases 2-3 remaining |
+| [plan-block-diagram-tracking-catchup.md](reports/plan-block-diagram-tracking-catchup.md) | 2/3 | **In progress** — Phases 1+2 done (19 tracking sites migrated; cross-skill invariant lint installed; 3 new canary cases for block-diagram delegation pair / missing fulfillment / cross-name isolation; 975/975 tests); Phase 3 remaining |
 | [plan-zskills-monitor-plan.md](reports/plan-zskills-monitor-plan.md) | 4/9 | **In progress** — Phases 1+2+3+4 done (/work-on-plans CLI shipped + /plans work retired + flock + Python aggregation library); 1000/1000 tests; Phases 5-9 remaining |
 | [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 7/7 | **Complete** — all 7 phases landed (full Tier-1 relocation + cross-skill sweep + /update-zskills install flow rewrite + safe stale-Tier-1 migration + residual sweep + docs close-out); 943/943 tests; landed via PRs #95, #96, #97, #98, #99, plus this final PR |
 | [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 3/3 | **Complete** — all 3 phases landed; defense-in-depth drift detection chain (pre-authoring /refine-plan Dimension 7, pre-dispatch Phase 1 step 6 b, post-implement Phase 3.5); 931/931 tests, +68 plan-drift cases |

--- a/PLAN_REPORT.md
+++ b/PLAN_REPORT.md
@@ -10,6 +10,7 @@ No items currently awaiting sign-off.
 
 | Report | Phases | Status |
 |--------|--------|--------|
+| [plan-block-diagram-tracking-catchup.md](reports/plan-block-diagram-tracking-catchup.md) | 1/3 | **In progress** — Phase 1 done (19 tracking sites in add-block + add-example migrated to subdir layout, BLOCK_SLUG/NAME_SLUG sanitisation, pre-#97 caller-path fix at L16/L20); Phases 2-3 remaining |
 | [plan-zskills-monitor-plan.md](reports/plan-zskills-monitor-plan.md) | 4/9 | **In progress** — Phases 1+2+3+4 done (/work-on-plans CLI shipped + /plans work retired + flock + Python aggregation library); 1000/1000 tests; Phases 5-9 remaining |
 | [plan-scripts-into-skills-plan.md](reports/plan-scripts-into-skills-plan.md) | 7/7 | **Complete** — all 7 phases landed (full Tier-1 relocation + cross-skill sweep + /update-zskills install flow rewrite + safe stale-Tier-1 migration + residual sweep + docs close-out); 943/943 tests; landed via PRs #95, #96, #97, #98, #99, plus this final PR |
 | [plan-improve-staleness-detection.md](reports/plan-improve-staleness-detection.md) | 3/3 | **Complete** — all 3 phases landed; defense-in-depth drift detection chain (pre-authoring /refine-plan Dimension 7, pre-dispatch Phase 1 step 6 b, post-implement Phase 3.5); 931/931 tests, +68 plan-drift cases |

--- a/block-diagram/add-block/SKILL.md
+++ b/block-diagram/add-block/SKILL.md
@@ -13,11 +13,11 @@ implementation workflow. Steps 11–12 are verification and landing.
 
 **All implementation happens in a pre-created worktree.** Before dispatching
 the implementation agent, the orchestrator creates the worktree via
-`scripts/create-worktree.sh`:
+`.claude/skills/create-worktree/scripts/create-worktree.sh`:
 
 ```bash
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
-WORKTREE_PATH=$(bash "$MAIN_ROOT/scripts/create-worktree.sh" \
+WORKTREE_PATH=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/create-worktree.sh" \
   --prefix add-block \
   --purpose "add-block; block=${BLOCK_NAME}" \
   --pipeline-id "add-block.${BLOCK_NAME}" \
@@ -65,6 +65,41 @@ Do NOT do step 7 per-block when batching. Defer it until all blocks are implemen
 Use the **first** block name from the user's invocation as the `${BLOCK_NAME}`
 slug for the orchestrator's `create-worktree.sh` call (mirrors fix-issues's
 "lowest issue number" convention for grouped issues).
+
+---
+
+## Tracking setup
+
+Before any tracking-marker writes (Step 6 onward), resolve `PIPELINE_ID`
+and `BLOCK_SLUG` once. Both the orchestrator (which dispatches the
+implementation sub-agent) and the in-worktree implementation sub-agent
+run this block; the sanitizer is deterministic so both yield the same
+PIPELINE_ID and BLOCK_SLUG given the same `$BLOCK_NAME`.
+
+```bash
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+# 3-tier PIPELINE_ID resolution: env → worktree .zskills-tracked
+# (parent's PIPELINE_ID inherited via the worktree file written by
+# create-worktree.sh --pipeline-id) → fallback synthesized id.
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-}"
+if [ -z "$PIPELINE_ID" ] && [ -f ".zskills-tracked" ]; then
+  PIPELINE_ID=$(tr -d '[:space:]' < ".zskills-tracked")
+fi
+: "${PIPELINE_ID:=add-block.${BLOCK_NAME}}"
+PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+# Sanitised per-marker suffix slug — pairs with add-example's NAME_SLUG.
+BLOCK_SLUG=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$BLOCK_NAME")
+mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+```
+
+Tier-1 (env) covers cron-fired top-level turns. Tier-2 (`.zskills-tracked`)
+is the path that fires in practice for `/add-block`'s normal flow, since
+the preamble dispatches through `create-worktree.sh --pipeline-id`. Tier-3
+(`add-block.${BLOCK_NAME}` synthesized) covers truly standalone direct
+invocations.
+
+Marker basenames use `${BLOCK_SLUG}` on disk; user-facing prose and echo
+messages keep `${BLOCK_NAME}` for legibility.
 
 ---
 
@@ -379,10 +414,8 @@ All existing tests must continue to pass (unit, E2E, and codegen suites).
 
 After Step 6 tests pass:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
-mkdir -p "$MAIN_ROOT/.zskills/tracking"
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.tests"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.tests"
 ```
 
 In batch mode, each block gets its own tracking marker keyed by BlockName.
@@ -393,13 +426,16 @@ In batch mode, each block gets its own tracking marker keyed by BlockName.
 
 ### Pre-example delegation
 
-Before invoking `/add-example`, create a delegation requirement marker:
+Before invoking `/add-example`, create a delegation requirement marker.
+In batch mode, `BLOCK_NAME` is the aggregate (e.g., `math-batch` or the
+first-block name — same convention as the worktree's `--pipeline-id`).
+This single `requires` marker pairs with the single `/add-example`
+invocation that follows; do NOT loop per-block.
+
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
-mkdir -p "$MAIN_ROOT/.zskills/tracking"
 printf 'skill: add-example\nparent: add-block\nblock: %s\ndate: %s\n' \
   "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/requires.add-example.${BLOCK_NAME}"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.add-example.${BLOCK_SLUG}"
 ```
 
 Use the `/add-example` skill to create an example model for this block
@@ -408,6 +444,22 @@ Use the `/add-example` skill to create an example model for this block
 ```
 /add-example <block-type(s)> [concept hint]
 ```
+
+**Delegation contract — NAME == BLOCK_NAME.** When invoking
+`/add-example`, pass the `<block-type(s)>` argument verbatim as both the
+displayed argument AND the `$NAME` variable the sub-skill will see. In
+single-block mode this is `$BLOCK_NAME`; in batch mode it is the same
+comma-separated list (or aggregate slug — first-block name or
+`<category>-batch`) you used for the worktree's `--pipeline-id` (see
+Batch Mode above). The sanitizer is deterministic, so identical input on
+both sides yields identical `BLOCK_SLUG` / `NAME_SLUG` and the basenames
+pair-match.
+
+Example: `BLOCK_NAME="My Block"` → `BLOCK_SLUG=My_Block`; the
+`/add-example "My Block"` call sees `NAME=My Block` →
+`NAME_SLUG=My_Block`. Both sides write `requires.add-example.My_Block`
+and `fulfilled.add-example.My_Block` under the same `add-block.My_Block/`
+subdir.
 
 In batch mode, invoke `/add-example` once after all blocks are implemented,
 passing all block types as a comma-separated list. One model that showcases
@@ -421,9 +473,8 @@ unit tests with value assertions, browser verification, and screenshots.
 
 After `/add-example` completes:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.example"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.example"
 ```
 
 If the example was deferred (batch mode, will be done later), create the
@@ -431,7 +482,7 @@ deferred marker instead with the reason:
 ```bash
 printf 'block: %s\ndeferred: true\nreason: batch mode — example deferred until all blocks implemented\ndate: %s\n' \
   "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.example-deferred"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.example-deferred"
 ```
 
 ---
@@ -506,9 +557,8 @@ handled by `/add-example` (Step 7), not here.
 
 After codegen is implemented:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.codegen"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.codegen"
 ```
 
 ### If Rust codegen cannot be implemented now
@@ -530,10 +580,9 @@ Create a GitHub issue and add an entry to `plans/BUILD_ISSUES.md` following the 
 
 After deferring codegen, create the deferred marker with the GitHub issue number:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'block: %s\ndeferred: true\nissue: #%s\ndate: %s\n' \
   "$BLOCK_NAME" "$ISSUE_NUMBER" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.codegen-deferred"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.codegen-deferred"
 ```
 
 ---
@@ -562,9 +611,8 @@ Use the `/manual-testing` skill with `playwright-cli` to verify the block works 
 
 After Step 9 manual testing completes:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.manual-test"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.manual-test"
 ```
 
 ---
@@ -625,11 +673,10 @@ for EACH block added. Fix any failures — do not "note" them as gaps.
 Before running the self-audit checklist, verify tracking files exist for
 critical steps. If any are missing, go back and complete the step:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 # All four must exist (or their -deferred variant)
 for marker in tests example codegen manual-test; do
-  if [ ! -f "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.${marker}" ] && \
-     [ ! -f "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.${marker}-deferred" ]; then
+  if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.${marker}" ] && \
+     [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.${marker}-deferred" ]; then
     echo "MISSING: step.add-block.${BLOCK_NAME}.${marker} — go back and complete this step"
   fi
 done
@@ -680,9 +727,8 @@ noted" instead of failing. These checks prevent that.
 
 After the self-audit checklist passes:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.self-audit"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.self-audit"
 ```
 
 ---
@@ -693,10 +739,9 @@ printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -I
 
 Before dispatching the verification agent, create a delegation requirement:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'skill: verify-changes\nparent: add-block\nblock: %s\ndate: %s\n' \
   "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/requires.verify-changes.${BLOCK_NAME}"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.verify-changes.${BLOCK_SLUG}"
 ```
 
 ### Dispatch protocol
@@ -745,9 +790,8 @@ If verification fails: dispatch a fix agent (max 2 fix+verify rounds).
 
 After verification completes:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-block.${BLOCK_NAME}.verify"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.verify"
 ```
 
 ---

--- a/block-diagram/add-example/SKILL.md
+++ b/block-diagram/add-example/SKILL.md
@@ -21,14 +21,36 @@ verification, distilled from real mistakes.
 
 ## Fulfillment Tracking
 
-On entry, create the fulfillment marker so the parent skill (e.g.,
-`/add-block`) knows this delegation was accepted:
+On entry, resolve `PIPELINE_ID` and `NAME_SLUG`, then create the
+fulfillment marker so the parent skill (e.g., `/add-block`) knows this
+delegation was accepted. `add-example` may run as a sub-skill (delegated
+from `/add-block`) OR standalone (`/add-example` is registered as a
+top-level slash command — see frontmatter and `block-diagram/README.md`).
+Resolution is therefore 3-tier with a synthesized fallback so direct
+invocation works. In delegated mode, tier-2 `.zskills-tracked` always
+fires (the parent's worktree wrote it), so the synthesized fallback never
+triggers and markers correctly land in the parent's subdir.
+
 ```bash
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
-mkdir -p "$MAIN_ROOT/.zskills/tracking"
+# 3-tier PIPELINE_ID resolution: env → worktree .zskills-tracked
+# (parent's PIPELINE_ID, written by add-block's create-worktree.sh
+# --pipeline-id call) → synthesized fallback for standalone use.
+# In delegated mode tier 2 always fires; tier 3 fires only when
+# /add-example is invoked directly with no parent worktree.
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-}"
+if [ -z "$PIPELINE_ID" ] && [ -f ".zskills-tracked" ]; then
+  PIPELINE_ID=$(tr -d '[:space:]' < ".zskills-tracked")
+fi
+: "${PIPELINE_ID:=add-example.${NAME}}"
+PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+# Sanitised per-marker suffix slug — pairs with add-block's BLOCK_SLUG
+# when invoked under delegation (orchestrator passes NAME == BLOCK_NAME).
+NAME_SLUG=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$NAME")
+mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 printf 'skill: add-example\nname: %s\nstatus: started\ndate: %s\n' \
   "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/fulfilled.add-example.${NAME}"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.add-example.${NAME_SLUG}"
 ```
 
 Where `$NAME` is derived from the block type(s) or model name (e.g.,
@@ -155,9 +177,8 @@ mkdir -p examples/<name>/screenshots
 
 After Phase 2 (build) is complete:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-example.${NAME}.build"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-example.${NAME_SLUG}.build"
 ```
 
 ---
@@ -195,9 +216,8 @@ In `tests/codegen-compile.test.js`, add the model to the appropriate tier:
 
 After Phase 3 (register) is complete:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-example.${NAME}.register"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-example.${NAME_SLUG}.register"
 ```
 
 ---
@@ -228,9 +248,8 @@ mv .playwright/output/screenshot-*.png examples/<name>/screenshots/01-model-with
 
 After Phase 4b (screenshot) is complete:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-example.${NAME}.screenshot"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-example.${NAME_SLUG}.screenshot"
 ```
 
 ### 4c. Write unit tests
@@ -261,9 +280,8 @@ All 3 suites must pass (unit, e2e, codegen). Report each suite's result.
 
 After Phase 4c/4d (tests pass):
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-example.${NAME}.tests"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-example.${NAME_SLUG}.tests"
 ```
 
 ---
@@ -285,16 +303,15 @@ Send a verification agent (or do it yourself) to check:
 
 After Phase 5a (verification) is complete:
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/step.add-example.${NAME}.verify"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-example.${NAME_SLUG}.verify"
 ```
 
 Update the fulfillment marker to reflect completion:
 ```bash
 printf 'skill: add-example\nname: %s\nstatus: completed\ndate: %s\n' \
   "$NAME" "$(TZ=America/New_York date -Iseconds)" \
-  > "$MAIN_ROOT/.zskills/tracking/fulfilled.add-example.${NAME}"
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.add-example.${NAME_SLUG}"
 ```
 
 ### 5b. Retake screenshot if needed

--- a/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+++ b/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
@@ -43,7 +43,7 @@ phase, three phases, three PRs).
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Migrate add-block + add-example writers (paired) | ✅ Done | `0e9c37e` | 19 sites migrated (12 add-block + 7 add-example); pre-#97 caller-path cleanup at L16/L20; delegation dry-run output 5/5 expected paths; 943/943 tests pass. |
-| 2 — Lint guard + canary cases for block-diagram | ⬚ | | Mirrors `tests/test-skill-invariants.sh:128-134`; extends canary by 2 cases. |
+| 2 — Lint guard + canary cases for block-diagram | ✅ Done | `6662368` | Lint installed (writer-shape regex); 3 canary cases added (delegation pair, missing fulfillment, cross-name isolation); section header (8) → (11); manual smoke confirmed lint fails on reverted Phase 1 site. 975/975 tests pass. |
 | 3 — Framework-coverage CI guard for block-diagram (recommended) | ⬚ | | Decision in Design & Constraints below; one-work-item phase. |
 
 ## Shared Conventions
@@ -797,7 +797,8 @@ existing skills.
       = 0. Paste the run into the PR body.
 - [ ] New invariant lint present. Verification:
       `grep -F 'no skill writes flat-layout tracking markers'
-      tests/test-skill-invariants.sh` returns 1 line.
+      tests/test-skill-invariants.sh` returns ≥1 line.
+      <!-- Auto-corrected 2026-04-29: was "returns 1 line"; the verbatim insert block in Work Item 2 contains the phrase in both the header comment and the check description string, so the actual count is 2. The lint is functionally correct; only the AC verification command's count was off-by-one. -->
 - [ ] Lint fails on a deliberately-reverted Phase 1 site (manual
       smoke). Procedure: temporarily change one
       `$PIPELINE_ID/step.add-block` reference back to flat,

--- a/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+++ b/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
@@ -42,7 +42,7 @@ phase, three phases, three PRs).
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Migrate add-block + add-example writers (paired) | ⬚ | | One commit; 19 sites; bundled per delegation. |
+| 1 — Migrate add-block + add-example writers (paired) | ✅ Done | `0e9c37e` | 19 sites migrated (12 add-block + 7 add-example); pre-#97 caller-path cleanup at L16/L20; delegation dry-run output 5/5 expected paths; 943/943 tests pass. |
 | 2 — Lint guard + canary cases for block-diagram | ⬚ | | Mirrors `tests/test-skill-invariants.sh:128-134`; extends canary by 2 cases. |
 | 3 — Framework-coverage CI guard for block-diagram (recommended) | ⬚ | | Decision in Design & Constraints below; one-work-item phase. |
 

--- a/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+++ b/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
@@ -1,7 +1,7 @@
 ---
 title: Block-Diagram Tracking-Naming Catch-up
 created: 2026-04-26
-status: active
+status: complete
 ---
 
 # Plan: Block-Diagram Tracking-Naming Catch-up
@@ -44,7 +44,7 @@ phase, three phases, three PRs).
 |-------|--------|--------|-------|
 | 1 — Migrate add-block + add-example writers (paired) | ✅ Done | `0e9c37e` | 19 sites migrated (12 add-block + 7 add-example); pre-#97 caller-path cleanup at L16/L20; delegation dry-run output 5/5 expected paths; 943/943 tests pass. |
 | 2 — Lint guard + canary cases for block-diagram | ✅ Done | `6662368` | Lint installed (writer-shape regex); 3 canary cases added (delegation pair, missing fulfillment, cross-name isolation); section header (8) → (11); manual smoke confirmed lint fails on reverted Phase 1 site. 975/975 tests pass. |
-| 3 — Framework-coverage CI guard for block-diagram (recommended) | ⬚ | | Decision in Design & Constraints below; one-work-item phase. |
+| 3 — Framework-coverage CI guard for block-diagram (recommended) | ✅ Done | `27d7315` | Meta-lint added to `tests/test-skill-invariants.sh` (post-Phase-2 flat-layout check); awk-joins `\` continuations BEFORE the regex (multi-line smoke verified the join works); `# block-diagram-exempt:` opt-out supported; reads via `$REPO_ROOT` (invocation-independent). 1005/1005 tests pass. |
 
 ## Shared Conventions
 

--- a/reports/plan-block-diagram-tracking-catchup.md
+++ b/reports/plan-block-diagram-tracking-catchup.md
@@ -1,0 +1,50 @@
+# Plan Report — Block-Diagram Tracking-Naming Catch-up
+
+## Phase — 1 Migrate add-block + add-example writers (paired) [UNFINALIZED]
+
+**Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-block-diagram-tracking-catchup
+**Branch:** feat/block-diagram-tracking-catchup
+**Commits:** 0e9c37e
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Pre-tracking caller cleanup at SKILL.md:16,20 (`scripts/create-worktree.sh` → `.claude/skills/create-worktree/scripts/create-worktree.sh`) | Done | 0e9c37e |
+| 2 | add-block: Top-of-skill PIPELINE_ID resolution + BLOCK_SLUG | Done | 0e9c37e |
+| 3 | add-block: 12 tracking sites migrated to `$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/` subdir layout | Done | 0e9c37e |
+| 4 | add-block: 2 sanitizer calls via `.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh` (PIPELINE_ID + BLOCK_SLUG) | Done | 0e9c37e |
+| 5 | add-block: Delegation contract pinned (NAME == BLOCK_NAME), worked example for whitespace-bearing identifiers | Done | 0e9c37e |
+| 6 | add-block: Batch-mode aggregate `requires.add-example.${BLOCK_SLUG}` prose | Done | 0e9c37e |
+| 7 | add-example: Top-of-skill 3-tier PIPELINE_ID resolver (env → `.zskills-tracked` → `add-example.${NAME}`) + NAME_SLUG | Done | 0e9c37e |
+| 8 | add-example: 7 tracking sites migrated to subdir layout | Done | 0e9c37e |
+| 9 | add-example: 2 sanitizer calls (PIPELINE_ID + NAME_SLUG) | Done | 0e9c37e |
+| 10 | add-example: Tier-3 fallback (no exit-1 on missing PIPELINE_ID) — supports standalone use | Done | 0e9c37e |
+
+### Verification
+
+- **Test suite:** PASSED (943/943 in verifier session). One transient `parity: worktrees` flake observed in implementer session; verifier reproduced 943/943 PASS and confirmed test source has no `block-diagram/` references — pre-existing host-environment flake from concurrent worktree mutations during the test run, not a regression.
+- **Acceptance criteria (all 14 + dry-run):**
+  - Zero flat writes ✓
+  - add-block subdir-write count = 12 ✓
+  - add-example subdir-write count = 7 ✓
+  - Sanitizer calls = 2/2 ✓
+  - No pre-#97 sanitizer or create-worktree paths ✓
+  - BLOCK_SLUG / NAME_SLUG present ✓
+  - ZSKILLS_PIPELINE_ID block in both ✓
+  - add-example tier-3 fallback present, no hard-error exit ✓
+  - No mirror sync edits ✓
+  - No new sanitizer file ✓
+  - No migrate-tracking helper ✓
+  - All 28 fenced bash blocks compile (`bash -n`) ✓
+- **Delegation dry-run:** 5/5 expected paths produced exactly:
+  - `add-block.Gain/{requires,fulfilled}.add-example.Gain` (Case A: clean ID, parent/child pair-match)
+  - `add-block.My_Block/{requires,fulfilled}.add-example.My_Block` (Case B: whitespace ID `My Block`, sanitised slug pair-matches)
+  - `add-example.Integrator/fulfilled.add-example.Integrator` (Case C: standalone, tier-3 fallback)
+
+### Notes
+
+- `block-diagram/` is NOT mirrored to `.claude/skills/`, so no mirror sync was needed (Shared Conventions). Verified: `grep -c '^\.claude/skills/'` on diff → 0.
+- `parity: worktrees` flake (impl session) was caused by transient `cw-smoke-*` worktrees spawned by `tests/test-create-worktree.sh` interleaving between node and python `git worktree list` calls. Re-running tests in the verifier session showed 943/943 pass — flake is environmental and pre-dates this change. Not failing verification.

--- a/reports/plan-block-diagram-tracking-catchup.md
+++ b/reports/plan-block-diagram-tracking-catchup.md
@@ -1,7 +1,37 @@
 # Plan Report — Block-Diagram Tracking-Naming Catch-up
 
-## Phase — 2 Lint guard + canary cases for block-diagram [UNFINALIZED]
+**Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+**Status:** ✅ Complete (3/3 phases landed; landing via PR squash)
 
+## Phase — 3 Framework-coverage CI guard for block-diagram
+
+**Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-block-diagram-tracking-catchup
+**Branch:** feat/block-diagram-tracking-catchup
+**Commits:** 27d7315
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Pre-implementation enumeration: 2 framework-enum checks (isolation:worktree + Phase-2 flat-layout); both already cover `block-diagram/` | Done | 27d7315 |
+| 2 | Meta-lint added to `tests/test-skill-invariants.sh` after all existing checks; uses awk-join to collapse `\` continuations BEFORE the regex; reads via `$REPO_ROOT` (invocation-independent) | Done | 27d7315 |
+| 3 | Single-line smoke (independently re-run by verifier): `META-LINT FAIL` fires on throwaway, exit 1 | Done | 27d7315 |
+| 4 | Multi-line smoke (CRITICAL — independently re-run): awk-join collapses `\\\n`; `META-LINT FAIL` fires on multi-line throwaway | Done | 27d7315 |
+| 5 | Opt-out smoke: `# block-diagram-exempt: <reason>` on preceding line suppresses the meta-lint | Done | 27d7315 |
+| 6 | Detection-regex precision: existing single-skill probes (`skills/<name>/SKILL.md` with alpha after slash) continue to pass without exemptions | Done | 27d7315 |
+
+### Verification
+
+- **Test suite:** PASSED (1005/1005). Phase 1's `parity: worktrees` flake did not reproduce in this turn.
+- **Acceptance criteria (8 + 3 independent smokes):** all pass — meta-lint phrase exact-1 occurrence; `$REPO_ROOT` (not `$0`); clean RC=0 with no `META-LINT FAIL:` lines; single-line + multi-line smoke fire; opt-out suppresses; existing single-skill probes pass; full suite green.
+
+### Notes
+
+- The verifier's smoke procedure (specifying `git checkout` to revert throwaways) accidentally clobbered the implementer's uncommitted Phase 3 work; verifier reconstructed from `/tmp/phase3-text.md` (verbatim plan spec) and re-ran all ACs against the reconstruction. Outcome byte-equivalent; behavior verified end-to-end. Follow-up: the meta-lint smoke procedure should use `Edit` (not `git checkout`) when the file under test is uncommitted.
+
+## Phase — 2 Lint guard + canary cases for block-diagram
 **Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
 **Status:** Completed (verified)
 **Worktree:** /tmp/zskills-pr-block-diagram-tracking-catchup
@@ -40,8 +70,7 @@
 
 - Branch is rebased onto `7afd6f0` (the main HEAD captured at start of Phase 2). Main has since advanced again (zskills-monitor-plan Phase 4 landed during this turn). Final-phase landing will need a fresh rebase before push — handled by Phase 3's run.
 
-## Phase — 1 Migrate add-block + add-example writers (paired) [UNFINALIZED]
-
+## Phase — 1 Migrate add-block + add-example writers (paired)
 **Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
 **Status:** Completed (verified)
 **Worktree:** /tmp/zskills-pr-block-diagram-tracking-catchup

--- a/reports/plan-block-diagram-tracking-catchup.md
+++ b/reports/plan-block-diagram-tracking-catchup.md
@@ -1,5 +1,45 @@
 # Plan Report — Block-Diagram Tracking-Naming Catch-up
 
+## Phase — 2 Lint guard + canary cases for block-diagram [UNFINALIZED]
+
+**Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-block-diagram-tracking-catchup
+**Branch:** feat/block-diagram-tracking-catchup
+**Commits:** 6662368
+
+### Work Items
+
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Baseline grep `> "[^"]*\.zskills/tracking/[a-zA-Z]'` in `skills/` + `block-diagram/` returns 0 (Phase 1 migration verified clean) | Done | 6662368 |
+| 2 | Cross-skill invariant lint added to `tests/test-skill-invariants.sh` (post-`isolation: "worktree"` check) | Done | 6662368 |
+| 3 | Manual lint smoke: revert one Phase 1 site → lint fails (exit 1, FAIL line); restore → lint passes (exit 0) | Done | 6662368 |
+| 4 | Canary case 9 — `block-diagram delegation pair: requires + fulfilled co-located in PIPELINE_ID subdir → allow` | Done | 6662368 |
+| 5 | Canary case 10 — `block-diagram missing fulfillment: requires.add-example.Integrator unfulfilled → deny` | Done | 6662368 |
+| 6 | Canary case 11 — `block-diagram cross-name isolation: Gain not blocked by Integrator's unmet requires` | Done | 6662368 |
+| 7 | Section header in `tests/test-canary-failures.sh` updated `(8 cases)` → `(11 cases)` | Done | 6662368 |
+
+### Verification
+
+- **Test suite:** PASSED (975/975 in verifier session). Phase 1's `parity: worktrees` host-environment flake did not reproduce.
+- **Acceptance criteria:**
+  - Baseline grep returns 0 ✓
+  - Lint phrase present (≥1 line; actual 2 — auto-corrected from stale "1 line" in AC2 because the verbatim insert block contains the phrase in both the header comment and the check description) ✓
+  - Manual lint smoke independently re-run by verifier: PASS → revert site → FAIL with lint diagnostic → restore → PASS, with `git diff block-diagram/` clean afterward ✓
+  - Section header `(11 cases)` exactly 1 line ✓
+  - 3 new cases pass with PASS lines ✓
+  - Pre/post canary count delta = 3 (101 → 104) ✓
+  - Full suite green ✓
+
+### Plan-text drift auto-corrected
+
+- **AC2 (lint phrase grep count):** `1 line` → `≥1 line`. Reason: the verbatim insert block specified by Work Item 2 contains the phrase `no skill writes flat-layout tracking markers` in both the header comment and the check description string. A faithful insertion produces 2 matches, not 1. The lint is functionally correct; only the AC verification command's expected count was stale. Inline audit comment recorded next to the AC.
+
+### Notes
+
+- Branch is rebased onto `7afd6f0` (the main HEAD captured at start of Phase 2). Main has since advanced again (zskills-monitor-plan Phase 4 landed during this turn). Final-phase landing will need a fresh rebase before push — handled by Phase 3's run.
+
 ## Phase — 1 Migrate add-block + add-example writers (paired) [UNFINALIZED]
 
 **Plan:** plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md

--- a/tests/test-canary-failures.sh
+++ b/tests/test-canary-failures.sh
@@ -868,7 +868,7 @@ assert_tracking_allow() {
   fi
 }
 
-section "Tracking marker naming (subdir scope) (8 cases)"
+section "Tracking marker naming (subdir scope) (11 cases)"
 
 # Case 1 — Concurrent-same-slug isolation: two pipelines with the same
 # TRACKING_ID (foo) under different orchestrator prefixes (run-plan.foo vs
@@ -984,6 +984,59 @@ tn8_out=$(run_tracking_hook "$tn8_repo")
 assert_tracking_allow \
   "meta.* prefix: metadata files do not match requires.* glob, no enforcement fires" \
   "$tn8_out"
+
+# Case 9 — block-diagram delegation pair (add-block ↔ add-example).
+# add-block (parent) writes requires.add-example.${BLOCK_SLUG};
+# add-example (child) writes fulfilled.add-example.${NAME_SLUG} from
+# the same worktree. Both must land in the parent's $PIPELINE_ID
+# subdir for the hook's pair-matching gate to resolve. Verifies the
+# post-catchup layout. Fixture YAML matches the writer shape from
+# Phase 1.
+tn9_repo=$(setup_tracking_fixture)
+mkdir -p "$tn9_repo/.zskills/tracking/add-block.Gain"
+printf 'skill: add-example\nparent: add-block\nblock: Gain\ndate: 2026-04-26T10:00:00-04:00\n' \
+  > "$tn9_repo/.zskills/tracking/add-block.Gain/requires.add-example.Gain"
+printf 'skill: add-example\nname: Gain\nstatus: completed\ndate: 2026-04-26T10:05:00-04:00\n' \
+  > "$tn9_repo/.zskills/tracking/add-block.Gain/fulfilled.add-example.Gain"
+printf 'add-block.Gain\n' > "$tn9_repo/.zskills-tracked"
+tn9_out=$(run_tracking_hook "$tn9_repo")
+assert_tracking_allow \
+  "block-diagram delegation pair: requires + fulfilled co-located in PIPELINE_ID subdir → allow" \
+  "$tn9_out"
+
+# Case 10 — block-diagram missing fulfillment: parent's requires marker
+# is present but no fulfilled.add-example.<slug> → hook must block.
+# Confirms the gate actually fires when the pair is incomplete.
+tn10_repo=$(setup_tracking_fixture)
+mkdir -p "$tn10_repo/.zskills/tracking/add-block.Integrator"
+printf 'skill: add-example\nparent: add-block\nblock: Integrator\ndate: 2026-04-26T10:00:00-04:00\n' \
+  > "$tn10_repo/.zskills/tracking/add-block.Integrator/requires.add-example.Integrator"
+printf 'add-block.Integrator\n' > "$tn10_repo/.zskills-tracked"
+tn10_out=$(run_tracking_hook "$tn10_repo")
+assert_tracking_deny \
+  "block-diagram missing fulfillment: requires.add-example.Integrator unfulfilled → deny" \
+  "$tn10_out" "add-example.Integrator"
+
+# Case 11 — cross-name isolation: pipeline add-block.Gain has its
+# requires fulfilled, but a sibling add-block.Integrator pipeline
+# exists with an unfulfilled requires. The active pipeline (Gain)
+# must NOT be blocked by Integrator's unmet requirement (subdir
+# scoping). Mirrors fix-issues sprint isolation (case 7) for the
+# block-diagram namespace.
+tn11_repo=$(setup_tracking_fixture)
+mkdir -p "$tn11_repo/.zskills/tracking/add-block.Gain"
+mkdir -p "$tn11_repo/.zskills/tracking/add-block.Integrator"
+printf 'skill: add-example\nparent: add-block\nblock: Gain\ndate: 2026-04-26T10:00:00-04:00\n' \
+  > "$tn11_repo/.zskills/tracking/add-block.Gain/requires.add-example.Gain"
+printf 'skill: add-example\nname: Gain\nstatus: completed\ndate: 2026-04-26T10:05:00-04:00\n' \
+  > "$tn11_repo/.zskills/tracking/add-block.Gain/fulfilled.add-example.Gain"
+printf 'skill: add-example\nparent: add-block\nblock: Integrator\ndate: 2026-04-26T11:00:00-04:00\n' \
+  > "$tn11_repo/.zskills/tracking/add-block.Integrator/requires.add-example.Integrator"
+printf 'add-block.Gain\n' > "$tn11_repo/.zskills-tracked"
+tn11_out=$(run_tracking_hook "$tn11_repo")
+assert_tracking_allow \
+  "block-diagram cross-name isolation: Gain not blocked by Integrator's unmet requires" \
+  "$tn11_out"
 
 # --- Phase 5: /commit reviewer prompt + Phase 7 anti-stash discipline ---
 

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -134,6 +134,17 @@ fi
 check 'no skill prescribes isolation: worktree (use skills/create-worktree/scripts/create-worktree.sh)' \
   '! grep -rEn '"'"'\bwith[[:space:]]+`?isolation: *"worktree"'"'"' skills/ block-diagram/ 2>/dev/null'
 
+# Cross-skill invariant: no skill writes flat-layout tracking markers.
+# Post-UNIFY_TRACKING_NAMES Phase 6, only $PIPELINE_ID-subdir writes
+# are visible to the hook. Pattern matches `> "…/.zskills/tracking/<basename>"`
+# where <basename> starts with a letter (rules out `$PIPELINE_ID/...`
+# which begins with `$`). Pinned to the writer shape `> "…"` so prose
+# and comment hits in skills/{quickfix,research-and-go,session-report,
+# verify-changes,run-plan}/SKILL.md don't false-positive. See
+# plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md for baseline-zero proof.
+check 'no skill writes flat-layout tracking markers (post-UNIFY_TRACKING_NAMES)' \
+  '! grep -rEn '"'"'> "[^"]*\.zskills/tracking/[a-zA-Z]'"'"' skills/ block-diagram/ 2>/dev/null'
+
 # Emit format expected by tests/run-all.sh
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -145,6 +145,80 @@ check 'no skill prescribes isolation: worktree (use skills/create-worktree/scrip
 check 'no skill writes flat-layout tracking markers (post-UNIFY_TRACKING_NAMES)' \
   '! grep -rEn '"'"'> "[^"]*\.zskills/tracking/[a-zA-Z]'"'"' skills/ block-diagram/ 2>/dev/null'
 
+# Meta-lint: every framework-wide cross-skill check must cover
+# block-diagram/. Two prior framework migrations (isolation:worktree,
+# UNIFY_TRACKING_NAMES) silently skipped block-diagram/ because the
+# check enumerated skills/ alone.
+#
+# Detection rule: a `check` line references `skills/` as a
+# framework-wide enumeration (matches the regex `[^A-Za-z]skills/`
+# followed by whitespace, a quote, or end-of-line — NOT followed by
+# a skill-name segment like `skills/run-plan/SKILL.md`). Such a
+# check must also contain ` block-diagram/` (with whitespace
+# boundary) somewhere in the same logical check invocation.
+#
+# CRITICAL — line-continuation handling: real `check` invocations
+# span TWO physical lines via trailing `\` continuation, e.g.:
+#   check '<desc>' \                  ← head: matches `^check`, lacks `skills/`
+#     '! grep -rE ... skills/ ...'    ← body: has `skills/`, lacks `^check`
+# A naive per-physical-line regex never finds the `^check && skills/`
+# conjunction and the meta-lint passes vacuously. The pre-process
+# step below joins `\\n` continuations so each logical check
+# invocation collapses to one line BEFORE the regex runs.
+#
+# Opt-out: prefix the check with the comment
+#   # block-diagram-exempt: <reason>
+# on the immediately preceding line. Use sparingly — exemptions
+# are by definition the surface that grows to bite us next time.
+SCRIPT="$REPO_ROOT/tests/test-skill-invariants.sh"
+_meta_skipped=0
+_meta_failed=0
+# Collapse `\\n` continuations into single logical lines.
+# awk: when a line ends with `\`, drop the `\` and buffer; on the
+# next line, prepend the buffer and emit. Comment lines pass
+# through unchanged so the `# block-diagram-exempt:` opt-out
+# still works on the preceding-line basis.
+joined=$(awk '
+  /\\$/ { sub(/\\$/,""); buf = buf $0; next }
+  buf   { print buf $0; buf = ""; next }
+        { print }
+' "$SCRIPT")
+while IFS= read -r line; do
+  case "$line" in
+    *"# block-diagram-exempt:"*) _meta_skipped=1; continue ;;
+  esac
+  # Match logical-check lines that enumerate skills/ as a path.
+  # Regex: skills/ preceded by non-alpha, followed by space,
+  # single-quote, double-quote, or end-of-line (i.e., a path arg
+  # at a directory boundary) — NOT skills/<name>/ (alpha after
+  # slash, single-skill probe) NOR skills/$f/... (variable
+  # interpolation, also single-skill probe by convention). The
+  # post-slash class must be path-terminator-shaped, not just
+  # non-alpha — `$` is non-alpha, but `skills/$f/SKILL.md` is the
+  # mirror-sync per-skill loop body at
+  # `tests/test-skill-invariants.sh:101-102`, which is single-skill
+  # by intent. After the awk-join above, both predicates evaluate
+  # against the same logical line.
+  if printf '%s' "$line" | grep -qE '^[[:space:]]*check ' \
+     && printf '%s' "$line" | grep -qE '[^A-Za-z]skills/([[:space:]'\''"]|$)'; then
+    if [ "$_meta_skipped" -eq 1 ]; then
+      _meta_skipped=0
+      continue
+    fi
+    if ! printf '%s' "$line" | grep -qE '[^A-Za-z]block-diagram/'; then
+      echo "META-LINT FAIL: framework-wide check missing block-diagram/ coverage: $line" >&2
+      _meta_failed=1
+    fi
+  else
+    _meta_skipped=0
+  fi
+done <<<"$joined"
+if [ "$_meta_failed" -eq 0 ]; then
+  check 'meta: framework-wide checks cover block-diagram/' 'true'
+else
+  check 'meta: framework-wide checks cover block-diagram/' 'false'
+fi
+
 # Emit format expected by tests/run-all.sh
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Plan: Block-Diagram Tracking-Naming Catch-up

Catch `block-diagram/` up to two prior framework-wide migrations it almost
missed: `isolation: "worktree"` removal (caught reactively by PR #66) and
the UNIFY_TRACKING_NAMES subdir migration (caught reactively by issue #65).

Closes #65.

<!-- run-plan:progress:start -->
**Phases completed:**

- **Phase 1** (commit `8ba9ae7`) — 19 tracking sites in `block-diagram/add-block/SKILL.md` (12) and `block-diagram/add-example/SKILL.md` (7) migrated from flat `.zskills/tracking/<basename>` to subdir `.zskills/tracking/$PIPELINE_ID/<basename>` layout, with sanitised `${BLOCK_SLUG}`/`${NAME_SLUG}` suffixes so parent/child basenames pair-match under arbitrary user input. Pre-#97 caller-path fix at `add-block/SKILL.md:16,20` (`scripts/create-worktree.sh` → `.claude/skills/create-worktree/scripts/create-worktree.sh`). `block-diagram/` is NOT mirrored to `.claude/skills/`, so no mirror sync.
- **Phase 2** (commit `95c880d`) — Cross-skill invariant lint added to `tests/test-skill-invariants.sh` enforcing zero flat-layout tracking writes (writer-shape regex `> "[^"]*\.zskills/tracking/[a-zA-Z]'`). Three new canary cases in `tests/test-canary-failures.sh`: delegation pair (allow), missing fulfillment (deny), cross-name isolation (Gain not blocked by Integrator's unmet requires). Section header bumped 8 → 11 cases.
- **Phase 3** (commit `27d7315`) — Framework-coverage meta-lint in `tests/test-skill-invariants.sh` that scans the file's own `check` invocations and asserts every framework-wide enumeration of `skills/` also covers `block-diagram/`. CRITICAL: awk-joins `\` line continuations BEFORE the regex runs (real production checks are multi-line; a per-physical-line approach passes vacuously). Multi-line smoke independently verified the awk-join. Opt-out via `# block-diagram-exempt: <reason>` comment. Reads via `$REPO_ROOT` (invocation-independent).

<!-- run-plan:progress:end -->

## Acceptance evidence

### Phase 1 — Delegation dry-run (`add-block` ↔ `add-example` pair-match)

Cases A (clean ID `Gain`), B (whitespace ID `My Block` → slug `My_Block`), C (standalone `add-example`) produced the 5 expected paths exactly:

```
.../tracking/add-block.Gain/fulfilled.add-example.Gain
.../tracking/add-block.Gain/requires.add-example.Gain
.../tracking/add-block.My_Block/fulfilled.add-example.My_Block
.../tracking/add-block.My_Block/requires.add-example.My_Block
.../tracking/add-example.Integrator/fulfilled.add-example.Integrator
```

A+B prove parent/child pair-match under both clean and whitespace-bearing inputs (sanitiser slugs; DA1). C proves standalone `/add-example` does NOT exit-1 and lands its own pipeline (DA3).

### Phase 2 — Baseline grep (zero flat writes post-Phase-1)

```
$ grep -rEn '> "[^"]*\.zskills/tracking/[a-zA-Z]' skills/ block-diagram/ 2>/dev/null | wc -l
0
```

### Phase 2 — Manual lint smoke (revert one Phase 1 site → lint fails → restore → passes)

Reverted line 418 of `block-diagram/add-block/SKILL.md` from subdir `$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.tests` back to flat `step.add-block.${BLOCK_SLUG}.tests`:

- Before revert: `Results: 35 passed, 0 failed`, exit 0
- After flat-layout revert: `FAIL: no skill writes flat-layout tracking markers ...`, `Results: 34 passed, 1 failed`, exit 1
- After re-revert: `Results: 35 passed, 0 failed`, exit 0
- `git diff block-diagram/`: clean

### Phase 3 — Pre-implementation enumeration

The framework-enum regex on current `tests/test-skill-invariants.sh` (post-Phase-1, post-Phase-2) matches exactly two checks; both already cover `block-diagram/`:

```
MATCH: check 'no skill prescribes isolation: worktree (use skills/create-worktree/scripts/create-worktree.sh)'
       '! grep -rEn ... skills/ block-diagram/ 2>/dev/null'
       --> covers block-diagram/: YES

MATCH: check 'no skill writes flat-layout tracking markers (post-UNIFY_TRACKING_NAMES)'
       '! grep -rEn ... skills/ block-diagram/ 2>/dev/null'
       --> covers block-diagram/: YES
```

### Phase 3 — Manual smokes (CRITICAL: multi-line)

- **Single-line:** `check 'demo' '! grep -rE foo skills/'` → `META-LINT FAIL: framework-wide check missing block-diagram/ coverage` in stderr, exit 1, 35 passed/2 failed.
- **Multi-line (CRITICAL):** `check 'multi-line demo' \` + body line `'! grep -rE foo skills/'` → awk-join collapses both physical lines into one logical check, `META-LINT FAIL` fires on the joined line, exit 1, 35 passed/2 failed. **Without this, the meta-lint would pass vacuously against real production-shape checks (which all use multi-line `\` continuation).** This is the regression class the lint exists to prevent.
- **Opt-out:** prefix with `# block-diagram-exempt: demo` on the immediately preceding line → meta-lint suppressed (`META-LINT FAIL` count = 0 in stderr); the throwaway's underlying grep still fails (no `foo` in `skills/`) — that's the demo failing, not the meta-lint.

## Plan-text drift auto-corrected (Phase 2 only)

- **AC2 (lint phrase grep count):** `1 line` → `≥1 line`. The verbatim insert block in Work Item 2 of Phase 2 contains the phrase `no skill writes flat-layout tracking markers` in BOTH the header comment and the check description string. A faithful insertion produces 2 matches, not 1. The lint is functionally correct; the AC's count was off-by-one. Inline audit comment recorded next to the AC.

## Test plan

- [x] All 3 phases verified by independent fresh subagents — no work skipped, no gaps "noted as non-blockers"
- [x] Local full suite: `bash tests/run-all.sh` → 1005/1005 PASS, 0 failed (post-rebase onto current main `410f641`)
- [x] Phase 1 delegation dry-run: 5/5 expected paths produced exactly
- [x] Phase 2 manual lint smoke: revert site → fail → restore → pass; `git diff` clean
- [x] Phase 3 single-line smoke: `META-LINT FAIL` fires on framework-enum check lacking `block-diagram/`
- [x] Phase 3 multi-line smoke (CRITICAL): awk-join verified; `META-LINT FAIL` fires on multi-line `\\\n`-joined check
- [x] Phase 3 opt-out smoke: `# block-diagram-exempt:` comment suppresses
- [ ] CI green (verified via `gh pr checks` post-push)
- [ ] Squash-merge applies cleanly to `main`

**Report:** See `reports/plan-block-diagram-tracking-catchup.md` for per-phase details.

---
Generated by `/run-plan plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md finish auto`