### PR TITLE
fix(run-plan): forbid `git checkout`-based smoke revert when file under test is uncommitted

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1146,6 +1146,43 @@ criterion against current reality. If implementation skipped the check
 OR implementation IS the source of drift, the verifier catches it.
 Phase 3.5 processes the UNION of both reports' tokens.
 
+#### Smoke-procedure revert mechanics (delegate mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> Many plan ACs include manual smoke procedures: temporarily modify a
+> file under test → run a script → confirm a behavior change → revert
+> the throwaway. When you revert, **first check whether the file has
+> uncommitted changes**: `git status -s <file>`. A line beginning with
+> ` M`, `MM`, `AM`, or any other dirty-state marker means uncommitted
+> impl work is present.
+>
+> - **Uncommitted: DO NOT use `git checkout <file>`.** It reverts to
+>   HEAD, which is the pre-implementation state — silently wiping the
+>   implementer's uncommitted work. /run-plan's design contract is
+>   "implementer writes, verifier commits"; the file you're
+>   smoke-testing typically has uncommitted impl changes. Use Edit to
+>   remove the specific throwaway lines you added, or save+restore
+>   with `cp <file> /tmp/$(basename <file>).pre-smoke` and
+>   `cp /tmp/$(basename <file>).pre-smoke <file>` (basename avoids
+>   creating nested /tmp paths that don't exist for relative paths
+>   with subdirectories).
+> - **Clean (no uncommitted changes)**: `git checkout <file>` is safe
+>   and reverts only your throwaway.
+>
+> This guidance applies to **mid-smoke reverts only**. Post-failure
+> rollbacks (e.g., Phase 3.5 plan-file rollback) run after something
+> has gone wrong on files that should match HEAD — `git checkout` is
+> correct there.
+>
+> If you suspect the file under test has been clobbered (file size
+> drops, expected lines vanish), STOP. Do NOT reconstruct from the
+> spec — even if you re-run every AC against the reconstruction, the
+> orchestrator cannot validate that your reconstruction matches the
+> implementer's actual intent. Invoke the Failure Protocol so the
+> orchestrator can re-dispatch implementation cleanly against a
+> known-clean baseline.
+
 ### Worktree mode verification
 
 1. **Dispatch verification agent** targeting the worktree's changes. The
@@ -1265,6 +1302,43 @@ implementation agent's tokens — re-measure each numeric acceptance
 criterion against current reality. If implementation skipped the check
 OR implementation IS the source of drift, the verifier catches it.
 Phase 3.5 processes the UNION of both reports' tokens.
+
+#### Smoke-procedure revert mechanics (worktree mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> Many plan ACs include manual smoke procedures: temporarily modify a
+> file under test → run a script → confirm a behavior change → revert
+> the throwaway. When you revert, **first check whether the file has
+> uncommitted changes**: `git status -s <file>`. A line beginning with
+> ` M`, `MM`, `AM`, or any other dirty-state marker means uncommitted
+> impl work is present.
+>
+> - **Uncommitted: DO NOT use `git checkout <file>`.** It reverts to
+>   HEAD, which is the pre-implementation state — silently wiping the
+>   implementer's uncommitted work. /run-plan's design contract is
+>   "implementer writes, verifier commits"; the file you're
+>   smoke-testing typically has uncommitted impl changes. Use Edit to
+>   remove the specific throwaway lines you added, or save+restore
+>   with `cp <file> /tmp/$(basename <file>).pre-smoke` and
+>   `cp /tmp/$(basename <file>).pre-smoke <file>` (basename avoids
+>   creating nested /tmp paths that don't exist for relative paths
+>   with subdirectories).
+> - **Clean (no uncommitted changes)**: `git checkout <file>` is safe
+>   and reverts only your throwaway.
+>
+> This guidance applies to **mid-smoke reverts only**. Post-failure
+> rollbacks (e.g., Phase 3.5 plan-file rollback) run after something
+> has gone wrong on files that should match HEAD — `git checkout` is
+> correct there.
+>
+> If you suspect the file under test has been clobbered (file size
+> drops, expected lines vanish), STOP. Do NOT reconstruct from the
+> spec — even if you re-run every AC against the reconstruction, the
+> orchestrator cannot validate that your reconstruction matches the
+> implementer's actual intent. Invoke the Failure Protocol so the
+> orchestrator can re-dispatch implementation cleanly against a
+> known-clean baseline.
 
 ### Post-verification tracking
 

--- a/.claude/skills/run-plan/references/failure-protocol.md
+++ b/.claude/skills/run-plan/references/failure-protocol.md
@@ -90,6 +90,17 @@ Invoke this protocol for ANY of these:
 - `npm run test:all` fails after cherry-picks are landed
 - Verification fails after 2 fix+verify cycles (auto mode)
 - Preflight checks detect stale state (conflict markers, orphaned stash)
+- **Verifier clobbered the implementer's uncommitted work** (e.g., a
+  smoke-revert step ran `git checkout <file>` on a file with
+  uncommitted impl changes, reverting it to HEAD and wiping the impl).
+  Recovery: the verifier reports the suspected clobber and STOPs
+  without committing. The orchestrator re-dispatches implementation
+  cleanly against the pre-impl HEAD baseline (which is the verifier's
+  current working-tree state, since the clobber reverted to it). Do
+  NOT have the verifier reconstruct from the plan spec — the
+  orchestrator cannot validate reconstruction matches implementer
+  intent. See the "Smoke-procedure revert mechanics" verbatim block in
+  Phase 3 of `skills/run-plan/SKILL.md` for the prevention guidance.
 - Any unrecoverable error that stops the run from completing normally
 
 Do NOT invoke for:

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1146,6 +1146,43 @@ criterion against current reality. If implementation skipped the check
 OR implementation IS the source of drift, the verifier catches it.
 Phase 3.5 processes the UNION of both reports' tokens.
 
+#### Smoke-procedure revert mechanics (delegate mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> Many plan ACs include manual smoke procedures: temporarily modify a
+> file under test → run a script → confirm a behavior change → revert
+> the throwaway. When you revert, **first check whether the file has
+> uncommitted changes**: `git status -s <file>`. A line beginning with
+> ` M`, `MM`, `AM`, or any other dirty-state marker means uncommitted
+> impl work is present.
+>
+> - **Uncommitted: DO NOT use `git checkout <file>`.** It reverts to
+>   HEAD, which is the pre-implementation state — silently wiping the
+>   implementer's uncommitted work. /run-plan's design contract is
+>   "implementer writes, verifier commits"; the file you're
+>   smoke-testing typically has uncommitted impl changes. Use Edit to
+>   remove the specific throwaway lines you added, or save+restore
+>   with `cp <file> /tmp/$(basename <file>).pre-smoke` and
+>   `cp /tmp/$(basename <file>).pre-smoke <file>` (basename avoids
+>   creating nested /tmp paths that don't exist for relative paths
+>   with subdirectories).
+> - **Clean (no uncommitted changes)**: `git checkout <file>` is safe
+>   and reverts only your throwaway.
+>
+> This guidance applies to **mid-smoke reverts only**. Post-failure
+> rollbacks (e.g., Phase 3.5 plan-file rollback) run after something
+> has gone wrong on files that should match HEAD — `git checkout` is
+> correct there.
+>
+> If you suspect the file under test has been clobbered (file size
+> drops, expected lines vanish), STOP. Do NOT reconstruct from the
+> spec — even if you re-run every AC against the reconstruction, the
+> orchestrator cannot validate that your reconstruction matches the
+> implementer's actual intent. Invoke the Failure Protocol so the
+> orchestrator can re-dispatch implementation cleanly against a
+> known-clean baseline.
+
 ### Worktree mode verification
 
 1. **Dispatch verification agent** targeting the worktree's changes. The
@@ -1265,6 +1302,43 @@ implementation agent's tokens — re-measure each numeric acceptance
 criterion against current reality. If implementation skipped the check
 OR implementation IS the source of drift, the verifier catches it.
 Phase 3.5 processes the UNION of both reports' tokens.
+
+#### Smoke-procedure revert mechanics (worktree mode verification)
+
+Include this VERBATIM in the verifier dispatch prompt:
+
+> Many plan ACs include manual smoke procedures: temporarily modify a
+> file under test → run a script → confirm a behavior change → revert
+> the throwaway. When you revert, **first check whether the file has
+> uncommitted changes**: `git status -s <file>`. A line beginning with
+> ` M`, `MM`, `AM`, or any other dirty-state marker means uncommitted
+> impl work is present.
+>
+> - **Uncommitted: DO NOT use `git checkout <file>`.** It reverts to
+>   HEAD, which is the pre-implementation state — silently wiping the
+>   implementer's uncommitted work. /run-plan's design contract is
+>   "implementer writes, verifier commits"; the file you're
+>   smoke-testing typically has uncommitted impl changes. Use Edit to
+>   remove the specific throwaway lines you added, or save+restore
+>   with `cp <file> /tmp/$(basename <file>).pre-smoke` and
+>   `cp /tmp/$(basename <file>).pre-smoke <file>` (basename avoids
+>   creating nested /tmp paths that don't exist for relative paths
+>   with subdirectories).
+> - **Clean (no uncommitted changes)**: `git checkout <file>` is safe
+>   and reverts only your throwaway.
+>
+> This guidance applies to **mid-smoke reverts only**. Post-failure
+> rollbacks (e.g., Phase 3.5 plan-file rollback) run after something
+> has gone wrong on files that should match HEAD — `git checkout` is
+> correct there.
+>
+> If you suspect the file under test has been clobbered (file size
+> drops, expected lines vanish), STOP. Do NOT reconstruct from the
+> spec — even if you re-run every AC against the reconstruction, the
+> orchestrator cannot validate that your reconstruction matches the
+> implementer's actual intent. Invoke the Failure Protocol so the
+> orchestrator can re-dispatch implementation cleanly against a
+> known-clean baseline.
 
 ### Post-verification tracking
 

--- a/skills/run-plan/references/failure-protocol.md
+++ b/skills/run-plan/references/failure-protocol.md
@@ -90,6 +90,17 @@ Invoke this protocol for ANY of these:
 - `npm run test:all` fails after cherry-picks are landed
 - Verification fails after 2 fix+verify cycles (auto mode)
 - Preflight checks detect stale state (conflict markers, orphaned stash)
+- **Verifier clobbered the implementer's uncommitted work** (e.g., a
+  smoke-revert step ran `git checkout <file>` on a file with
+  uncommitted impl changes, reverting it to HEAD and wiping the impl).
+  Recovery: the verifier reports the suspected clobber and STOPs
+  without committing. The orchestrator re-dispatches implementation
+  cleanly against the pre-impl HEAD baseline (which is the verifier's
+  current working-tree state, since the clobber reverted to it). Do
+  NOT have the verifier reconstruct from the plan spec — the
+  orchestrator cannot validate reconstruction matches implementer
+  intent. See the "Smoke-procedure revert mechanics" verbatim block in
+  Phase 3 of `skills/run-plan/SKILL.md` for the prevention guidance.
 - Any unrecoverable error that stops the run from completing normally
 
 Do NOT invoke for:


### PR DESCRIPTION
## Summary

Closes #112.

The `/run-plan` verifier subagent runs manual smoke procedures from plan ACs (modify file → run script → revert). When the verifier reverts via `git checkout <file>`, it wipes the implementer's **uncommitted** work — because /run-plan's design contract is *"implementer writes, verifier commits"* (`skills/run-plan/SKILL.md:876`). The verifier may then commit a regression because surface checks pass against the wiped file.

**Concrete failure that triggered this:** PR #109 (block-diagram-tracking-catchup) Phase 3 verifier executed `git checkout tests/test-skill-invariants.sh` mid-smoke, wiped ~74 lines of meta-lint, then reconstructed from spec — outcome correct but verification bypassed (the orchestrator could not validate that the reconstruction matched implementer intent).

## What changed

Added a verbatim **Smoke-procedure revert mechanics** block to `skills/run-plan/SKILL.md` at **two** sites — delegate-mode verifier dispatch and worktree-mode verifier dispatch — both immediately after the existing *Plan-text drift signals* verbatim blocks.

The new block:

- **Conditional prohibition** (not blanket): `git status -s <file>` first; only forbid `git checkout <file>` when the file has uncommitted changes (` M`/`MM`/`AM` markers). When clean, `git checkout` is safe.
- **Working revert recipes**: `Edit` to remove specific throwaway lines, OR `cp <file> /tmp/$(basename <file>).pre-smoke` save+restore. The `$(basename ...)` form is required — the original draft of `cp <file> /tmp/<file>.pre-smoke` would silently fail on relative paths with subdirs (e.g., `tests/test-skill-invariants.sh` — exactly the PR #109 case — would try to write to `/tmp/tests/...` which doesn't exist).
- **Explicit scope**: applies to **mid-smoke reverts only**. Post-failure rollbacks (Phase 3.5 plan-file rollback at `SKILL.md:1347`, plan ACs in `RESTRUCTURE_RUN_PLAN.md:970`, `IMPROVE_STALENESS_DETECTION.md:237`) run on files that should match HEAD — `git checkout` is correct there. The block calls this out so the warning doesn't over-apply.
- **STOP + Failure Protocol** on suspected clobber (size drops, lines vanish), with a corresponding new entry in `skills/run-plan/references/failure-protocol.md` describing the recovery path: orchestrator re-dispatches implementation against the pre-impl HEAD baseline that the clobber reverted to (which is already a known-clean state). Forbids spec-based reconstruction — even if the verifier re-runs every AC, the orchestrator can't validate the reconstruction matches implementer intent.

Mirror parity: `bash scripts/mirror-skill.sh run-plan` ran clean — both source and `.claude/` copies updated.

## Files changed

- `skills/run-plan/SKILL.md` — +74 lines (two verbatim insertions, identical content, parallel sites)
- `.claude/skills/run-plan/SKILL.md` — +74 lines (mirror)
- `skills/run-plan/references/failure-protocol.md` — +11 lines (new \"verifier clobbered impl\" trigger entry)
- `.claude/skills/run-plan/references/failure-protocol.md` — +11 lines (mirror)

Total: +170 lines across 4 files.

## Verifier review

This fix was reviewed by an independent subagent before landing. Verdict: **YES-WITH-EDITS** on the original issue draft. All 4 required edits incorporated:

1. ✅ Fixed the `cp` path bug — now uses `$(basename ...)` to avoid nested-/tmp paths.
2. ✅ Made the prohibition conditional on `git status -s <file>` rather than blanket.
3. ✅ Reframed the spec-reconstruction concern accurately ("orchestrator can't validate" rather than "bypasses verification").
4. ✅ Added Failure Protocol entry so the \"STOP + invoke Failure Protocol\" route has a documented landing.

Verifier flagged Alternative E (move smoke-procedure mechanics from plan ACs into skill source so plans only specify *what to verify*, not *how to revert*) as the structurally better long-term fix. Out of scope here; could be a follow-up enhancement issue.

## Test plan

- [x] Mirror parity: `diff -q skills/run-plan/SKILL.md .claude/skills/run-plan/SKILL.md` — clean
- [x] Mirror parity: `diff -q skills/run-plan/references/failure-protocol.md .claude/skills/run-plan/references/failure-protocol.md` — clean
- [x] Warning phrase grep: `grep -c 'DO NOT use \`git checkout <file>\`' skills/run-plan/SKILL.md` returns 2 (delegate + worktree); same for `.claude/` copy
- [x] Failure Protocol entry: `grep -F 'Verifier clobbered the implementer' skills/run-plan/references/failure-protocol.md` returns 1 line; same for `.claude/` copy
- [x] Full suite: `bash tests/run-all.sh` → 1110/1110 PASS, 0 failed
- [ ] CI green (verified post-push)
- [ ] Real-world: next `/run-plan` cycle through a plan with smoke ACs shows the verifier choosing Edit-based revert (will be observed naturally on the next plan run)

## Out of scope

- Alternative E (mechanics-in-skill-source) — separate enhancement issue if desired
- Defense-in-depth in `/draft-plan` (require plans to specify safe revert mechanics in smoke ACs) — separate enhancement issue if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)