### PR TITLE
[zskills-monitor-plan] ZSKILLS_MONITOR — Phase 7 (interactive queue + write-back)

### DIFF
--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -932,6 +932,14 @@ class MonitorHandler(BaseHTTPRequestHandler):
         def err_log(msg: str) -> None:
             sys.stderr.write(f"[work-state] {msg}\n")
 
+        # Phase 7: surface whether a /work-on-plans trigger is configured
+        # so the Run/Status widget can pick the right idle render.
+        cfg = _read_config(main_root)
+        trigger_configured = False
+        if isinstance(cfg.get("dashboard"), dict):
+            trig = cfg["dashboard"].get("work_on_plans_trigger", "")
+            trigger_configured = bool(trig)
+
         with _state_lock(main_root):
             doc, was_unparseable = _read_work_state(main_root, error_log=err_log)
             target = main_root / ".zskills" / "work-on-plans-state.json"
@@ -939,17 +947,27 @@ class MonitorHandler(BaseHTTPRequestHandler):
                 # Bootstrap-write idle.
                 idle = {"state": "idle", "updated_at": _now_iso()}
                 _atomic_write_json(target, idle)
-                self._send_json(200, {"state": "idle"})
+                self._send_json(
+                    200,
+                    {"state": "idle", "trigger_configured": trigger_configured},
+                )
                 return
             stale, reason = _is_stale(doc)
             if stale:
                 idle = {"state": "idle", "updated_at": _now_iso()}
                 _atomic_write_json(target, idle)
                 self._send_json(
-                    200, {"state": "idle", "warning": reason}
+                    200,
+                    {
+                        "state": "idle",
+                        "warning": reason,
+                        "trigger_configured": trigger_configured,
+                    },
                 )
                 return
-        self._send_json(200, doc)
+        out = dict(doc)
+        out["trigger_configured"] = trigger_configured
+        self._send_json(200, out)
 
     def _handle_work_state_reset(self) -> None:
         if not self._origin_ok():

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -392,3 +392,337 @@ code, pre, .mono {
   pointer-events: none;
   margin-top: 4px;
 }
+
+/* ---------------------------------------------------------------- Phase 7 */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 6px;
+}
+
+.panel-head .panel-title {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.plans-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.default-mode-area {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.seg-btn {
+  background: var(--surface2);
+  color: var(--text-dim);
+  border: none;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.seg-btn:hover,
+.seg-btn:focus-visible {
+  color: var(--text);
+  outline: none;
+  background: var(--surface);
+}
+
+.seg-btn[aria-pressed="true"] {
+  background: var(--accent);
+  color: #0d1117;
+  font-weight: 600;
+}
+
+.dm-footnote {
+  font-size: 0.78rem;
+  font-style: italic;
+  flex-basis: 100%;
+}
+
+.run-status {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.run-status.run-status-stale {
+  border-color: var(--orange);
+}
+
+.run-status .run-label {
+  color: var(--text-dim);
+}
+
+.run-status .run-text {
+  color: var(--text);
+}
+
+.run-btn,
+.copy-btn,
+.run-stop-btn,
+.clear-stale-btn,
+.add-mini-btn {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 9px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.run-btn:hover,
+.run-btn:focus-visible,
+.copy-btn:hover,
+.copy-btn:focus-visible,
+.run-stop-btn:hover,
+.run-stop-btn:focus-visible,
+.clear-stale-btn:hover,
+.clear-stale-btn:focus-visible,
+.add-mini-btn:hover,
+.add-mini-btn:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.run-btn.primary {
+  background: var(--accent);
+  color: #0d1117;
+  border-color: var(--accent);
+}
+
+.run-n-input {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  width: 56px;
+  font-size: 0.8rem;
+  font-family: inherit;
+}
+
+.run-cmd-snippet {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.85rem;
+}
+
+/* Columns layout */
+
+.columns {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+@media (min-width: 700px) {
+  .columns.columns-3 { grid-template-columns: 1fr 1fr 1fr; }
+  .columns.columns-2 { grid-template-columns: 1fr 1fr; }
+}
+
+.column {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 60px;
+}
+
+.column-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+
+.dropzone {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 32px;
+  padding: 2px;
+}
+
+.dropzone.drop-target {
+  background: rgba(88, 166, 255, 0.1);
+  border-radius: 4px;
+}
+
+.dropzone .card {
+  cursor: grab;
+}
+
+.dropzone .card.dragging {
+  opacity: 0.4;
+}
+
+.card-controls {
+  display: flex;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.move-btn {
+  background: var(--surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.move-btn:hover,
+.move-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  outline: none;
+}
+
+.move-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.mode-chip {
+  background: transparent;
+  border: 1px solid var(--accent2);
+  color: var(--accent2);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.mode-chip[data-source="inherit"] {
+  border-style: dashed;
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.mode-chip:hover,
+.mode-chip:focus-visible {
+  outline: none;
+  filter: brightness(1.2);
+  border-color: var(--accent);
+}
+
+.remove-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--red);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.remove-btn:hover,
+.remove-btn:focus-visible {
+  border-color: var(--red);
+  outline: none;
+}
+
+.toast-region {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.toast {
+  background: var(--surface);
+  border: 1px solid var(--red);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text);
+  font-size: 0.85rem;
+  max-width: 360px;
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.toast.toast-info { border-color: var(--accent); }
+
+.toast-close {
+  background: transparent;
+  color: var(--text-dim);
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.toast-close:hover,
+.toast-close:focus-visible {
+  color: var(--text);
+  outline: none;
+}
+

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1,4 +1,4 @@
-// Z Skills Monitor — read-only dashboard renderer (Phase 6).
+// Z Skills Monitor — interactive dashboard renderer (Phase 7).
 //
 // Loaded as a single ES module from /app.js. Polls /api/state every 2s
 // via setTimeout recursion (NOT setInterval), pauses while document is
@@ -6,9 +6,34 @@
 // so unchanged panels are not re-rendered. All user-authored content
 // rendered via textContent / appendChild — no innerHTML except for
 // hardcoded chrome marked `// chrome-only`.
+//
+// Phase 7 adds drag-and-drop columns for Plans (Drafted/Reviewed/Ready)
+// and Issues (Triage/Ready), POSTs the full queue back to /api/queue
+// on every reorder, polls /api/work-state for the Run/Status widget,
+// and POSTs to /api/trigger and /api/work-state/reset.
 
 const POLL_INTERVAL_MS = 2000;
 const STATE_URL = "/api/state";
+const WORK_STATE_URL = "/api/work-state";
+const QUEUE_URL = "/api/queue";
+const TRIGGER_URL = "/api/trigger";
+const WORK_STATE_RESET_URL = "/api/work-state/reset";
+
+// After a successful POST, suppress the next /api/state poll to avoid
+// flicker from a stale GET that started before the POST landed.
+const POST_RECONCILE_SUPPRESS_MS = 1500;
+
+const PLAN_COLUMNS = ["drafted", "reviewed", "ready"];
+const ISSUE_COLUMNS = ["triage", "ready"];
+const PLAN_COLUMN_LABELS = {
+  drafted: "Drafted",
+  reviewed: "Reviewed",
+  ready: "Ready",
+};
+const ISSUE_COLUMN_LABELS = {
+  triage: "Triage",
+  ready: "Ready",
+};
 
 // ---------------------------------------------------------------- helpers
 
@@ -68,9 +93,20 @@ function basename(p) {
   return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
 }
 
+function formatLocalTime(iso) {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const d = new Date(t);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return hh + ":" + mm;
+}
+
 // --------------------------------------------------------------- snapshot
 
 let lastSnapshot = null;
+let lastWorkState = null;
 const lastFingerprint = {
   errors: null,
   plans: null,
@@ -78,9 +114,18 @@ const lastFingerprint = {
   worktrees: null,
   issues: null,
   activity: null,
+  workState: null,
+  defaultMode: null,
 };
 let pollTimer = null;
 let pollAbort = null;
+let workPollTimer = null;
+let workPollAbort = null;
+let suppressNextStatePollUntil = 0;
+
+// last-known-good queues — used to revert local DOM on POST failure.
+let lastGoodQueues = null;
+let lastGoodDefaultMode = "phase";
 
 function setConnected(ok) {
   const banner = $("conn-banner");
@@ -114,15 +159,43 @@ async function fetchState() {
   }
 }
 
+async function fetchWorkState() {
+  const ctrl = new AbortController();
+  workPollAbort = ctrl;
+  try {
+    const res = await fetch(WORK_STATE_URL, {
+      cache: "no-store",
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (_err) {
+    return null;
+  } finally {
+    if (workPollAbort === ctrl) workPollAbort = null;
+  }
+}
+
 function schedulePoll(delay) {
   if (pollTimer) clearTimeout(pollTimer);
   pollTimer = setTimeout(pollOnce, delay);
 }
 
+function scheduleWorkPoll(delay) {
+  if (workPollTimer) clearTimeout(workPollTimer);
+  workPollTimer = setTimeout(pollWorkOnce, delay);
+}
+
 async function pollOnce() {
   if (document.hidden) {
-    // Pause while tab hidden; visibilitychange handler restarts.
     pollTimer = null;
+    return;
+  }
+  // Reconciliation: skip a single state poll right after a successful
+  // POST, so a GET in flight before the POST lands cannot flash stale
+  // data over the user's just-applied reorder.
+  if (Date.now() < suppressNextStatePollUntil) {
+    schedulePoll(POLL_INTERVAL_MS);
     return;
   }
   const snap = await fetchState();
@@ -131,6 +204,19 @@ async function pollOnce() {
     applySnapshot(snap);
   }
   schedulePoll(POLL_INTERVAL_MS);
+}
+
+async function pollWorkOnce() {
+  if (document.hidden) {
+    workPollTimer = null;
+    return;
+  }
+  const ws = await fetchWorkState();
+  if (ws) {
+    lastWorkState = ws;
+    applyWorkState(ws);
+  }
+  scheduleWorkPoll(POLL_INTERVAL_MS);
 }
 
 function applySnapshot(snap) {
@@ -144,10 +230,21 @@ function applySnapshot(snap) {
     renderErrors(snap.errors || []);
   }
 
-  const plansFp = fingerprintPlans(snap.plans || []);
+  // Capture last-known-good queues from snapshot.queues (server's view).
+  const queues = snap.queues || { plans: {}, issues: {}, default_mode: "phase" };
+  lastGoodQueues = deepCloneQueues(queues, snap.plans || [], snap.issues || []);
+  lastGoodDefaultMode = queues.default_mode || "phase";
+
+  const dmFp = String(lastGoodDefaultMode);
+  if (dmFp !== lastFingerprint.defaultMode) {
+    lastFingerprint.defaultMode = dmFp;
+    renderDefaultMode(lastGoodDefaultMode);
+  }
+
+  const plansFp = fingerprintPlans(snap.plans || [], queues, lastGoodDefaultMode);
   if (plansFp !== lastFingerprint.plans) {
     lastFingerprint.plans = plansFp;
-    renderPlans(snap.plans || []);
+    renderPlans(snap.plans || [], queues, lastGoodDefaultMode);
   }
 
   const branchesFp = fingerprintBranches(snap.branches || [], snap.worktrees || []);
@@ -156,10 +253,10 @@ function applySnapshot(snap) {
     renderBranches(snap.branches || [], snap.worktrees || []);
   }
 
-  const issuesFp = fingerprintIssues(snap.issues || []);
+  const issuesFp = fingerprintIssues(snap.issues || [], queues);
   if (issuesFp !== lastFingerprint.issues) {
     lastFingerprint.issues = issuesFp;
-    renderIssues(snap.issues || []);
+    renderIssues(snap.issues || [], queues);
   }
 
   const wtFp = fingerprintWorktrees(snap.worktrees || []);
@@ -175,10 +272,88 @@ function applySnapshot(snap) {
   }
 }
 
-function fingerprintPlans(plans) {
-  return JSON.stringify(plans.map(p => [
-    p.slug, p.title, p.status, p.landing_mode, p.phase_count, p.phases_done, p.blurb,
-  ]));
+function applyWorkState(ws) {
+  const fp = JSON.stringify(ws);
+  if (fp !== lastFingerprint.workState) {
+    lastFingerprint.workState = fp;
+    renderRunStatus(ws);
+    renderDefaultModeFootnote(ws);
+  }
+}
+
+// Build a queues dict that contains every plan/issue, populated from
+// state where present and inferred from snapshot column hints otherwise.
+// This is the local "source of truth" the UI POSTs back on every drag.
+function deepCloneQueues(queues, plans, issues) {
+  const out = {
+    default_mode: queues.default_mode || "phase",
+    plans: {},
+    issues: {},
+  };
+  for (const c of PLAN_COLUMNS) out.plans[c] = [];
+  for (const c of ISSUE_COLUMNS) out.issues[c] = [];
+
+  // Pre-populate from queues (preserves order).
+  const seenSlugs = new Set();
+  for (const c of PLAN_COLUMNS) {
+    const arr = (queues.plans && queues.plans[c]) || [];
+    for (const e of arr) {
+      const entry = (typeof e === "string") ? { slug: e } : (e || {});
+      if (!entry.slug || seenSlugs.has(entry.slug)) continue;
+      seenSlugs.add(entry.slug);
+      const obj = { slug: entry.slug };
+      if (c === "ready" && entry.mode != null) obj.mode = entry.mode;
+      out.plans[c].push(obj);
+    }
+  }
+  // Add inferred entries for plans not present in state.
+  for (const p of plans) {
+    if (seenSlugs.has(p.slug)) continue;
+    const col = (p.queue && p.queue.column) || "drafted";
+    if (PLAN_COLUMNS.indexOf(col) < 0) continue;
+    seenSlugs.add(p.slug);
+    out.plans[col].push({ slug: p.slug });
+  }
+
+  const seenNums = new Set();
+  for (const c of ISSUE_COLUMNS) {
+    const arr = (queues.issues && queues.issues[c]) || [];
+    for (const n of arr) {
+      const num = parseInt(n, 10);
+      if (!Number.isFinite(num) || seenNums.has(num)) continue;
+      seenNums.add(num);
+      out.issues[c].push(num);
+    }
+  }
+  for (const it of issues) {
+    if (typeof it.number !== "number" || seenNums.has(it.number)) continue;
+    const col = (it.queue && it.queue.column) || "triage";
+    if (ISSUE_COLUMNS.indexOf(col) < 0) continue;
+    seenNums.add(it.number);
+    out.issues[col].push(it.number);
+  }
+  return out;
+}
+
+function fingerprintPlans(plans, queues, defaultMode) {
+  // Include queue position so reorders re-render.
+  const pos = {};
+  for (const c of PLAN_COLUMNS) {
+    const arr = (queues.plans && queues.plans[c]) || [];
+    for (let i = 0; i < arr.length; i++) {
+      const e = arr[i];
+      const slug = (typeof e === "string") ? e : (e && e.slug);
+      if (slug) pos[slug] = [c, i, (e && e.mode) || null];
+    }
+  }
+  return JSON.stringify({
+    dm: defaultMode,
+    rows: plans.map(p => [
+      p.slug, p.title, p.status, p.landing_mode,
+      p.phase_count, p.phases_done, p.blurb,
+      pos[p.slug] || [(p.queue && p.queue.column) || "drafted", -1, null],
+    ]),
+  });
 }
 
 function fingerprintBranches(branches, worktrees) {
@@ -188,9 +363,18 @@ function fingerprintBranches(branches, worktrees) {
   ]));
 }
 
-function fingerprintIssues(issues) {
+function fingerprintIssues(issues, queues) {
+  const pos = {};
+  for (const c of ISSUE_COLUMNS) {
+    const arr = (queues.issues && queues.issues[c]) || [];
+    for (let i = 0; i < arr.length; i++) {
+      const n = parseInt(arr[i], 10);
+      if (Number.isFinite(n)) pos[n] = [c, i];
+    }
+  }
   return JSON.stringify(issues.map(i => [
     i.number, i.title, (i.labels || []).slice().sort(), i.created_at,
+    pos[i.number] || [(i.queue && i.queue.column) || "triage", -1],
   ]));
 }
 
@@ -245,51 +429,57 @@ function modePillClass(mode) {
   return "pill-mode-unknown";
 }
 
-function renderPlans(plans) {
-  const body = $("plans-body");
-  const empty = $("plans-empty");
-  clear(body);
-  if (!plans.length) {
-    empty.hidden = false;
-    return;
-  }
-  empty.hidden = true;
+function planBySlug(plans, slug) {
   for (const p of plans) {
-    const card = el("article", {
-      cls: "card",
-      attrs: {
-        tabindex: "0",
-        role: "button",
-        "data-kind": "plan",
-        "data-slug": p.slug,
-        "aria-label": "Plan " + (p.title || p.slug),
-      },
-    });
-    const head = el("div", { cls: "card-row" });
-    head.appendChild(el("span", { cls: "card-title", text: p.title || p.slug }));
+    if (p.slug === slug) return p;
+  }
+  return null;
+}
+
+function buildPlanCard(plan, slug, col, defaultMode) {
+  const card = el("li", {
+    cls: "card",
+    attrs: {
+      role: "listitem",
+      tabindex: "0",
+      draggable: "true",
+      "data-kind": "plan",
+      "data-slug": slug,
+      "data-column": col,
+      "aria-label": "Plan " + (plan ? (plan.title || slug) : slug),
+    },
+  });
+  const head = el("div", { cls: "card-row" });
+  head.appendChild(el("span", {
+    cls: "card-title",
+    text: (plan && plan.title) || slug,
+  }));
+  if (plan && plan.status) {
     const statusPill = el("span", {
-      cls: "pill " + statusPillClass(p.status),
-      text: p.status || "active",
+      cls: "pill " + statusPillClass(plan.status),
+      text: plan.status,
     });
     head.appendChild(statusPill);
-    card.appendChild(head);
+  }
+  card.appendChild(head);
 
-    if (p.blurb) {
-      card.appendChild(el("div", { cls: "card-blurb", text: p.blurb }));
-    }
+  if (plan && plan.blurb) {
+    card.appendChild(el("div", { cls: "card-blurb", text: plan.blurb }));
+  }
 
+  if (plan) {
     const meta = el("div", { cls: "card-row card-sub" });
-    const ratio = (p.phases_done || 0) + " / " + (p.phase_count || 0) + " phases";
+    const ratio = (plan.phases_done || 0) + " / " + (plan.phase_count || 0) + " phases";
     meta.appendChild(el("span", { text: ratio }));
     const modePill = el("span", {
-      cls: "pill " + modePillClass(p.landing_mode),
-      text: "mode: " + (p.landing_mode || "unknown"),
+      cls: "pill " + modePillClass(plan.landing_mode),
+      text: "mode: " + (plan.landing_mode || "unknown"),
     });
     meta.appendChild(modePill);
     card.appendChild(meta);
 
-    const total = p.phase_count || 0;
-    const done = p.phases_done || 0;
+    const total = plan.phase_count || 0;
+    const done = plan.phases_done || 0;
     if (total > 0) {
       const bar = el("div", { cls: "progress" });
       const fill = el("div", { cls: "progress-fill" });
@@ -298,9 +488,157 @@ function renderPlans(plans) {
       bar.appendChild(fill);
       card.appendChild(bar);
     }
-
-    body.appendChild(card);
   }
+
+  // Per-row mode chip on Ready cards (Phase 7).
+  if (col === "ready") {
+    const entryMode = currentEntryMode(slug);
+    const isOverride = entryMode === "phase" || entryMode === "finish";
+    const displayMode = isOverride ? entryMode : (defaultMode || "phase");
+    const chip = el("button", {
+      cls: "mode-chip",
+      attrs: {
+        type: "button",
+        "data-action": "toggle-mode",
+        "data-slug": slug,
+        "data-source": isOverride ? "explicit" : "inherit",
+        "aria-label": (
+          isOverride
+            ? ("Mode: " + displayMode + " (override). Click to toggle.")
+            : ("Mode: " + displayMode + " (inherits default). Click to set explicit.")
+        ),
+      },
+      text: displayMode,
+    });
+    card.appendChild(chip);
+  }
+
+  // Card controls: ↑ ↓ ← → and remove
+  const controls = el("div", {
+    cls: "card-controls",
+    attrs: { role: "group", "aria-label": "Move this plan" },
+  });
+  controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
+  controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
+  controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
+  controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
+  controls.appendChild(el("button", {
+    cls: "remove-btn",
+    attrs: {
+      type: "button",
+      "data-action": "plan-remove",
+      "data-slug": slug,
+      "aria-label": "Remove from queue",
+    },
+    text: "✕",
+  }));
+  card.appendChild(controls);
+
+  return card;
+}
+
+function makeMoveBtn(action, slug, label, ariaLabel) {
+  return el("button", {
+    cls: "move-btn",
+    attrs: {
+      type: "button",
+      "data-action": action,
+      "data-slug": slug,
+      "aria-label": ariaLabel,
+    },
+    text: label,
+  });
+}
+
+function makeIssueMoveBtn(action, num, label, ariaLabel) {
+  return el("button", {
+    cls: "move-btn",
+    attrs: {
+      type: "button",
+      "data-action": action,
+      "data-number": String(num),
+      "aria-label": ariaLabel,
+    },
+    text: label,
+  });
+}
+
+function currentEntryMode(slug) {
+  if (!lastGoodQueues) return null;
+  const arr = lastGoodQueues.plans.ready || [];
+  for (const e of arr) {
+    if (e && e.slug === slug) return e.mode || null;
+  }
+  return null;
+}
+
+function renderPlans(plans, queues, defaultMode) {
+  const body = $("plans-body");
+  const empty = $("plans-empty");
+  clear(body);
+  if (!plans.length && allColumnsEmpty(queues.plans, PLAN_COLUMNS)) {
+    empty.hidden = false;
+    return;
+  }
+  empty.hidden = true;
+
+  const slugToPlan = {};
+  for (const p of plans) slugToPlan[p.slug] = p;
+
+  const cols = el("div", { cls: "columns columns-3" });
+  for (const c of PLAN_COLUMNS) {
+    const colDiv = el("div", { cls: "column" });
+    const headId = "plans-col-" + c;
+    const head = el("div", { cls: "column-head", attrs: { id: headId } });
+    head.appendChild(el("span", { text: PLAN_COLUMN_LABELS[c] }));
+    const arr = (lastGoodQueues && lastGoodQueues.plans[c]) || [];
+    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    colDiv.appendChild(head);
+
+    const ul = el("ul", {
+      cls: "dropzone",
+      attrs: {
+        role: "list",
+        "data-column": c,
+        "data-kind": "plan",
+        "aria-labelledby": headId,
+      },
+    });
+    for (const entry of arr) {
+      const slug = (typeof entry === "string") ? entry : (entry && entry.slug);
+      if (!slug) continue;
+      const card = buildPlanCard(slugToPlan[slug] || null, slug, c, defaultMode);
+      ul.appendChild(card);
+    }
+    colDiv.appendChild(ul);
+    cols.appendChild(colDiv);
+  }
+  body.appendChild(cols);
+}
+
+function allColumnsEmpty(colsObj, columnNames) {
+  if (!colsObj) return true;
+  for (const c of columnNames) {
+    const arr = colsObj[c] || [];
+    if (arr.length) return false;
+  }
+  return true;
+}
+
+function renderDefaultMode(mode) {
+  const phase = $("dm-phase");
+  const finish = $("dm-finish");
+  if (!phase || !finish) return;
+  const isPhase = mode === "phase";
+  phase.setAttribute("aria-pressed", isPhase ? "true" : "false");
+  finish.setAttribute("aria-pressed", isPhase ? "false" : "true");
+}
+
+function renderDefaultModeFootnote(ws) {
+  const note = $("default-mode-footnote");
+  if (!note) return;
+  const inFlight = ws && ws.state === "sprint";
+  note.hidden = !inFlight;
 }
 
 // -------------------------------------------------------------- branches
@@ -353,41 +691,99 @@ function renderBranches(branches, worktrees) {
 
 // ---------------------------------------------------------------- issues
 
-function renderIssues(issues) {
+function buildIssueCard(issue, num, col) {
+  const card = el("li", {
+    cls: "card",
+    attrs: {
+      role: "listitem",
+      tabindex: "0",
+      draggable: "true",
+      "data-kind": "issue",
+      "data-number": String(num),
+      "data-column": col,
+      "aria-label": "Issue #" + num,
+    },
+  });
+  const head = el("div", { cls: "card-row" });
+  head.appendChild(el("span", {
+    cls: "card-title",
+    text: issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num),
+  }));
+  if (issue && issue.created_at) {
+    head.appendChild(el("span", { cls: "card-sub", text: relativeTime(issue.created_at) }));
+  }
+  card.appendChild(head);
+  if (issue && (issue.labels || []).length) {
+    const labels = el("div", { cls: "card-sub" });
+    for (const lab of issue.labels) {
+      labels.appendChild(el("span", { cls: "label-chip", text: lab }));
+    }
+    card.appendChild(labels);
+  }
+  const controls = el("div", {
+    cls: "card-controls",
+    attrs: { role: "group", "aria-label": "Move this issue" },
+  });
+  controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
+  controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
+  controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
+  controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
+  controls.appendChild(el("button", {
+    cls: "remove-btn",
+    attrs: {
+      type: "button",
+      "data-action": "issue-remove",
+      "data-number": String(num),
+      "aria-label": "Remove issue from queue",
+    },
+    text: "✕",
+  }));
+  card.appendChild(controls);
+  return card;
+}
+
+function renderIssues(issues, queues) {
   const body = $("issues-body");
   const empty = $("issues-empty");
   clear(body);
-  if (!issues.length) {
+  if (!issues.length && allColumnsEmpty(queues.issues, ISSUE_COLUMNS)) {
     empty.hidden = false;
     return;
   }
   empty.hidden = true;
-  for (const it of issues) {
-    const card = el("article", {
-      cls: "card",
+
+  const numToIssue = {};
+  for (const it of issues) numToIssue[it.number] = it;
+
+  const cols = el("div", { cls: "columns columns-2" });
+  for (const c of ISSUE_COLUMNS) {
+    const colDiv = el("div", { cls: "column" });
+    const headId = "issues-col-" + c;
+    const head = el("div", { cls: "column-head", attrs: { id: headId } });
+    head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
+    const arr = (lastGoodQueues && lastGoodQueues.issues[c]) || [];
+    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    colDiv.appendChild(head);
+
+    const ul = el("ul", {
+      cls: "dropzone",
       attrs: {
-        tabindex: "0",
-        role: "button",
+        role: "list",
+        "data-column": c,
         "data-kind": "issue",
-        "data-number": String(it.number),
-        "aria-label": "Issue #" + it.number,
+        "aria-labelledby": headId,
       },
     });
-    const head = el("div", { cls: "card-row" });
-    head.appendChild(el("span", { cls: "card-title", text: "#" + it.number + " " + (it.title || "") }));
-    if (it.created_at) {
-      head.appendChild(el("span", { cls: "card-sub", text: relativeTime(it.created_at) }));
+    for (const num of arr) {
+      const n = parseInt(num, 10);
+      if (!Number.isFinite(n)) continue;
+      const card = buildIssueCard(numToIssue[n] || null, n, c);
+      ul.appendChild(card);
     }
-    card.appendChild(head);
-    if ((it.labels || []).length) {
-      const labels = el("div", { cls: "card-sub" });
-      for (const lab of it.labels) {
-        labels.appendChild(el("span", { cls: "label-chip", text: lab }));
-      }
-      card.appendChild(labels);
-    }
-    body.appendChild(card);
+    colDiv.appendChild(ul);
+    cols.appendChild(colDiv);
   }
+  body.appendChild(cols);
 }
 
 // ------------------------------------------------------------- worktrees
@@ -451,7 +847,6 @@ function renderActivity(activity) {
   const body = $("activity-body");
   const empty = $("activity-empty");
   clear(body);
-  // Newest first (collect.py already sorts) — cap at 20.
   const rows = activity.slice(0, 20);
   if (!rows.length) {
     empty.hidden = false;
@@ -477,6 +872,512 @@ function renderActivity(activity) {
     row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
     body.appendChild(row);
   }
+}
+
+// ----------------------------------------------------------- run-status
+
+function renderRunStatus(ws) {
+  const root = $("run-status");
+  if (!root) return;
+  clear(root);
+  root.classList.remove("run-status-stale");
+  const state = (ws && ws.state) || "idle";
+  const warning = ws && ws.warning;
+
+  if (state === "scheduled") {
+    const sched = ws.schedule || "every ?h";
+    const next = ws.next_fire_at ? formatLocalTime(ws.next_fire_at) : "?";
+    root.appendChild(el("span", { cls: "run-label", text: "Schedule:" }));
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "Running " + sched + " · next fire " + next,
+    }));
+    const stop = el("button", {
+      cls: "run-stop-btn",
+      attrs: { type: "button", "data-action": "run-stop" },
+      text: "Stop",
+    });
+    root.appendChild(stop);
+    return;
+  }
+  if (state === "sprint") {
+    const prog = ws.progress || {};
+    const done = (prog.done != null) ? prog.done : 0;
+    const total = (prog.total != null) ? prog.total : 0;
+    const cur = prog.current_slug || "?";
+    root.appendChild(el("span", { cls: "run-label", text: "Sprint:" }));
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "in progress: " + done + "/" + total + " plans done · current: " + cur,
+    }));
+    return;
+  }
+  if (state === "stale-scheduled") {
+    root.classList.add("run-status-stale");
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "Schedule appears stale — restart with /work-on-plans every 4h",
+    }));
+    return;
+  }
+  if (state === "stale-sprint") {
+    root.classList.add("run-status-stale");
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "Sprint appears abandoned (last update " + (ws.updated_at ? relativeTime(ws.updated_at) : "?") + ")",
+    }));
+    const clearBtn = el("button", {
+      cls: "clear-stale-btn",
+      attrs: { type: "button", "data-action": "clear-stale-sprint" },
+      text: "Clear stale sprint state",
+    });
+    root.appendChild(clearBtn);
+    return;
+  }
+
+  // idle (default)
+  if (warning) {
+    root.classList.add("run-status-stale");
+    root.appendChild(el("span", { cls: "run-text", text: warning }));
+  }
+  const triggerConfigured = !!(ws && ws.trigger_configured);
+  const dm = lastGoodDefaultMode || "phase";
+  if (triggerConfigured) {
+    root.appendChild(el("span", { cls: "run-label", text: "Idle:" }));
+    const nInput = el("input", {
+      cls: "run-n-input",
+      attrs: {
+        type: "number",
+        min: "1",
+        max: "99",
+        value: "3",
+        id: "run-n",
+        "aria-label": "Number of plans to run",
+      },
+    });
+    root.appendChild(nInput);
+    const runBtn = el("button", {
+      cls: "run-btn primary",
+      attrs: { type: "button", "data-action": "run-top-n" },
+      text: "▶ Run top N",
+    });
+    root.appendChild(runBtn);
+  } else {
+    root.appendChild(el("span", { cls: "run-label", text: "Copy and run:" }));
+    const cmd = "/work-on-plans 3 " + dm;
+    root.appendChild(el("code", { cls: "run-cmd-snippet", text: cmd }));
+    const copyBtn = el("button", {
+      cls: "copy-btn",
+      attrs: { type: "button", "data-action": "copy-cmd", "data-cmd": cmd },
+      text: "Copy",
+    });
+    root.appendChild(copyBtn);
+  }
+}
+
+// ---------------------------------------------------------------- toasts
+
+function showToast(message, kind) {
+  const region = $("toast-region");
+  if (!region) return;
+  const toast = el("div", { cls: "toast " + (kind === "info" ? "toast-info" : "") });
+  toast.appendChild(el("span", { text: String(message || "") }));
+  const close = el("button", {
+    cls: "toast-close",
+    attrs: { type: "button", "aria-label": "Dismiss" },
+    text: "×",
+  });
+  close.addEventListener("click", () => {
+    if (toast.parentNode) toast.parentNode.removeChild(toast);
+  });
+  toast.appendChild(close);
+  region.appendChild(toast);
+  // Auto-dismiss after 8s.
+  setTimeout(() => {
+    if (toast.parentNode) toast.parentNode.removeChild(toast);
+  }, 8000);
+}
+
+function announce(regionId, msg) {
+  const region = $(regionId);
+  if (!region) return;
+  // Empty + repopulate so SRs re-announce identical text.
+  region.textContent = "";
+  // Force layout flush before reassign.
+  void region.offsetHeight;
+  region.textContent = msg;
+}
+
+// --------------------------------------------------------- POST queue
+
+async function postQueue(queues, opts) {
+  // Returns true on success; on failure shows toast and returns false.
+  const payload = {
+    default_mode: queues.default_mode || "phase",
+    plans: queues.plans,
+    issues: queues.issues,
+  };
+  let res;
+  try {
+    res = await fetch(QUEUE_URL, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    showToast("POST /api/queue failed: " + (err && err.message ? err.message : err), "err");
+    return false;
+  }
+  if (!res.ok) {
+    let body = "";
+    try { body = await res.text(); } catch (_e) { /* ignore */ }
+    const action = (opts && opts.action) || "update";
+    showToast(action + " failed (" + res.status + "): " + body.slice(0, 240), "err");
+    return false;
+  }
+  // Reconcile: suppress next state poll for ~1.5s to avoid stale-GET flicker.
+  suppressNextStatePollUntil = Date.now() + POST_RECONCILE_SUPPRESS_MS;
+  return true;
+}
+
+async function commitQueueChange(newQueues, opts) {
+  const previous = lastGoodQueues
+    ? JSON.parse(JSON.stringify(lastGoodQueues))
+    : null;
+  // Optimistic: snap UI to new queues immediately.
+  lastGoodQueues = newQueues;
+  if (newQueues.default_mode) lastGoodDefaultMode = newQueues.default_mode;
+  // Force re-render now (don't wait for next poll).
+  const snap = lastSnapshot || { plans: [], issues: [] };
+  renderDefaultMode(lastGoodDefaultMode);
+  renderPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+  renderIssues(snap.issues || [], lastGoodQueues);
+  lastFingerprint.plans = fingerprintPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+  lastFingerprint.issues = fingerprintIssues(snap.issues || [], lastGoodQueues);
+  lastFingerprint.defaultMode = String(lastGoodDefaultMode);
+
+  const ok = await postQueue(newQueues, opts);
+  if (!ok && previous) {
+    // Revert immediately; do not wait for next poll.
+    lastGoodQueues = previous;
+    lastGoodDefaultMode = previous.default_mode || "phase";
+    renderDefaultMode(lastGoodDefaultMode);
+    renderPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+    renderIssues(snap.issues || [], lastGoodQueues);
+    lastFingerprint.plans = fingerprintPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+    lastFingerprint.issues = fingerprintIssues(snap.issues || [], lastGoodQueues);
+    lastFingerprint.defaultMode = String(lastGoodDefaultMode);
+  }
+  return ok;
+}
+
+// ----------------------------------------------------- queue-mutation ops
+
+function findPlan(queues, slug) {
+  for (const c of PLAN_COLUMNS) {
+    const arr = queues.plans[c];
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i].slug === slug) return { col: c, idx: i };
+    }
+  }
+  return null;
+}
+
+function findIssue(queues, num) {
+  for (const c of ISSUE_COLUMNS) {
+    const arr = queues.issues[c];
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i] === num) return { col: c, idx: i };
+    }
+  }
+  return null;
+}
+
+function clonedQueues() {
+  return lastGoodQueues
+    ? JSON.parse(JSON.stringify(lastGoodQueues))
+    : {
+        default_mode: "phase",
+        plans: { drafted: [], reviewed: [], ready: [] },
+        issues: { triage: [], ready: [] },
+      };
+}
+
+async function movePlan(slug, dCol, dIdxAdjust) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc) return;
+  const entry = next.plans[loc.col].splice(loc.idx, 1)[0];
+  let targetCol = loc.col;
+  let targetIdx = loc.idx;
+  if (dCol === "up") {
+    targetIdx = Math.max(0, loc.idx - 1);
+  } else if (dCol === "down") {
+    targetIdx = Math.min(next.plans[loc.col].length, loc.idx + 1);
+  } else if (dCol === "left") {
+    const ci = PLAN_COLUMNS.indexOf(loc.col);
+    if (ci <= 0) {
+      // Restore — no-op.
+      next.plans[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = PLAN_COLUMNS[ci - 1];
+    targetIdx = next.plans[targetCol].length;
+  } else if (dCol === "right") {
+    const ci = PLAN_COLUMNS.indexOf(loc.col);
+    if (ci >= PLAN_COLUMNS.length - 1) {
+      next.plans[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = PLAN_COLUMNS[ci + 1];
+    targetIdx = next.plans[targetCol].length;
+  } else if (typeof dCol === "object" && dCol && dCol.col) {
+    targetCol = dCol.col;
+    targetIdx = (dCol.idx == null) ? next.plans[targetCol].length : dCol.idx;
+  }
+  next.plans[targetCol].splice(targetIdx, 0, entry);
+  const ok = await commitQueueChange(next, { action: "Move plan" });
+  if (ok) {
+    announce("plans-live", "Moved plan " + slug + " to " + PLAN_COLUMN_LABELS[targetCol] + " position " + (targetIdx + 1));
+  }
+}
+
+async function removePlan(slug) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc) return;
+  next.plans[loc.col].splice(loc.idx, 1);
+  const ok = await commitQueueChange(next, { action: "Remove plan" });
+  if (ok) announce("plans-live", "Removed plan " + slug);
+}
+
+async function moveIssue(num, dCol) {
+  const next = clonedQueues();
+  const loc = findIssue(next, num);
+  if (!loc) return;
+  const entry = next.issues[loc.col].splice(loc.idx, 1)[0];
+  let targetCol = loc.col;
+  let targetIdx = loc.idx;
+  if (dCol === "up") {
+    targetIdx = Math.max(0, loc.idx - 1);
+  } else if (dCol === "down") {
+    targetIdx = Math.min(next.issues[loc.col].length, loc.idx + 1);
+  } else if (dCol === "left") {
+    const ci = ISSUE_COLUMNS.indexOf(loc.col);
+    if (ci <= 0) {
+      next.issues[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = ISSUE_COLUMNS[ci - 1];
+    targetIdx = next.issues[targetCol].length;
+  } else if (dCol === "right") {
+    const ci = ISSUE_COLUMNS.indexOf(loc.col);
+    if (ci >= ISSUE_COLUMNS.length - 1) {
+      next.issues[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = ISSUE_COLUMNS[ci + 1];
+    targetIdx = next.issues[targetCol].length;
+  } else if (typeof dCol === "object" && dCol && dCol.col) {
+    targetCol = dCol.col;
+    targetIdx = (dCol.idx == null) ? next.issues[targetCol].length : dCol.idx;
+  }
+  next.issues[targetCol].splice(targetIdx, 0, entry);
+  const ok = await commitQueueChange(next, { action: "Move issue" });
+  if (ok) {
+    announce("issues-live", "Moved issue #" + num + " to " + ISSUE_COLUMN_LABELS[targetCol] + " position " + (targetIdx + 1));
+  }
+}
+
+async function removeIssue(num) {
+  const next = clonedQueues();
+  const loc = findIssue(next, num);
+  if (!loc) return;
+  next.issues[loc.col].splice(loc.idx, 1);
+  const ok = await commitQueueChange(next, { action: "Remove issue" });
+  if (ok) announce("issues-live", "Removed issue #" + num);
+}
+
+async function setDefaultMode(mode) {
+  if (mode !== "phase" && mode !== "finish") return;
+  if (mode === lastGoodDefaultMode) return;
+  const next = clonedQueues();
+  next.default_mode = mode;
+  const ok = await commitQueueChange(next, { action: "Set default mode" });
+  if (ok) announce("plans-live", "Default mode: " + mode);
+}
+
+async function togglePlanMode(slug) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc || loc.col !== "ready") return;
+  const entry = next.plans[loc.col][loc.idx];
+  const cur = entry.mode || null;
+  // Cycle: inherit -> phase -> finish -> inherit.
+  let newMode;
+  if (cur == null) newMode = "phase";
+  else if (cur === "phase") newMode = "finish";
+  else newMode = null;
+  if (newMode == null) {
+    delete entry.mode;
+  } else {
+    entry.mode = newMode;
+  }
+  const ok = await commitQueueChange(next, { action: "Toggle mode" });
+  if (ok) {
+    announce("plans-live",
+      "Mode for " + slug + " set to " + (newMode || "inherit"));
+  }
+}
+
+// -------------------------------------------------------------- trigger
+
+async function postTrigger(command) {
+  let res;
+  try {
+    res = await fetch(TRIGGER_URL, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command }),
+    });
+  } catch (err) {
+    showToast("Trigger failed: " + (err && err.message ? err.message : err), "err");
+    return false;
+  }
+  if (res.status === 501) {
+    showToast(
+      "No /work-on-plans trigger configured — set dashboard.work_on_plans_trigger in zskills-config.json.",
+      "info"
+    );
+    return false;
+  }
+  if (!res.ok) {
+    let body = "";
+    try {
+      const data = await res.json();
+      body = (data && (data.stderr || data.error)) || "";
+    } catch (_e) {
+      try { body = await res.text(); } catch (_ignore) { /* */ }
+    }
+    showToast("Trigger error (" + res.status + "): " + body.slice(0, 240), "err");
+    return false;
+  }
+  let data = null;
+  try { data = await res.json(); } catch (_e) { /* */ }
+  if (data && data.status === "error") {
+    showToast("Trigger script error: " + (data.stderr || "(no stderr)").slice(0, 240), "err");
+    return false;
+  }
+  showToast("Triggered.", "info");
+  // Force a fresh work-state poll so the widget updates.
+  scheduleWorkPoll(0);
+  return true;
+}
+
+async function postWorkStateReset() {
+  let res;
+  try {
+    res = await fetch(WORK_STATE_RESET_URL, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+  } catch (err) {
+    showToast("Reset failed: " + (err && err.message ? err.message : err), "err");
+    return false;
+  }
+  if (!res.ok) {
+    showToast("Reset failed (" + res.status + ")", "err");
+    return false;
+  }
+  showToast("Sprint state cleared.", "info");
+  scheduleWorkPoll(0);
+  return true;
+}
+
+// -------------------------------------------------------- drag-and-drop
+
+let dragState = null;
+
+function onDragStart(ev) {
+  const card = ev.target.closest && ev.target.closest("li.card[draggable='true']");
+  if (!card) return;
+  const kind = card.getAttribute("data-kind");
+  const slug = card.getAttribute("data-slug");
+  const num = card.getAttribute("data-number");
+  dragState = { kind, slug, num };
+  if (ev.dataTransfer) {
+    try {
+      ev.dataTransfer.setData("text/plain", JSON.stringify(dragState));
+      ev.dataTransfer.effectAllowed = "move";
+    } catch (_e) { /* some browsers throw on programmatic types */ }
+  }
+  card.classList.add("dragging");
+}
+
+function onDragEnd(ev) {
+  const card = ev.target.closest && ev.target.closest("li.card");
+  if (card) card.classList.remove("dragging");
+  dragState = null;
+  const dropzones = document.querySelectorAll(".dropzone.drop-target");
+  for (const dz of dropzones) dz.classList.remove("drop-target");
+}
+
+function onDragOver(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  if (!dragState) return;
+  // Kind must match dropzone kind.
+  if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  ev.preventDefault();
+  if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
+}
+
+function onDragEnter(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  if (!dragState) return;
+  if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  dz.classList.add("drop-target");
+}
+
+function onDragLeave(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  // relatedTarget is the element being entered; only clear if leaving fully.
+  const rel = ev.relatedTarget;
+  if (rel && dz.contains(rel)) return;
+  dz.classList.remove("drop-target");
+}
+
+function computeInsertIndex(dz, clientY) {
+  const cards = Array.from(dz.querySelectorAll("li.card:not(.dragging)"));
+  for (let i = 0; i < cards.length; i++) {
+    const r = cards[i].getBoundingClientRect();
+    if (clientY < r.top + r.height / 2) return i;
+  }
+  return cards.length;
+}
+
+async function onDrop(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  if (!dragState) return;
+  if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  ev.preventDefault();
+  dz.classList.remove("drop-target");
+  const targetCol = dz.getAttribute("data-column");
+  const targetIdx = computeInsertIndex(dz, ev.clientY);
+  if (dragState.kind === "plan" && dragState.slug) {
+    await movePlan(dragState.slug, { col: targetCol, idx: targetIdx });
+  } else if (dragState.kind === "issue" && dragState.num) {
+    const n = parseInt(dragState.num, 10);
+    if (Number.isFinite(n)) await moveIssue(n, { col: targetCol, idx: targetIdx });
+  }
+  dragState = null;
 }
 
 // ------------------------------------------------------------------ modal
@@ -534,7 +1435,6 @@ function openModalShell(title) {
   clear(modal.body);
   modal.body.appendChild(el("p", { cls: "muted", text: "Loading…" }));
   modal.root.hidden = false;
-  // Focus the close button so Esc/Tab work immediately.
   modal.close.focus();
 }
 
@@ -582,7 +1482,6 @@ function renderPlanModal(plan) {
     modal.body.appendChild(overview);
   }
 
-  // Phase list
   const phasesSec = el("section");
   phasesSec.appendChild(el("h3", { text: "Phases" }));
   const phaseList = el("ul", { cls: "phase-list" });
@@ -612,7 +1511,6 @@ function renderPlanModal(plan) {
   phasesSec.appendChild(phaseList);
   modal.body.appendChild(phasesSec);
 
-  // Report path (display-only)
   if (plan.report_path) {
     const rp = el("section");
     rp.appendChild(el("h3", { text: "Report" }));
@@ -620,7 +1518,6 @@ function renderPlanModal(plan) {
     modal.body.appendChild(rp);
   }
 
-  // Work-item checkboxes (display-only): rebuild from sub_plans + report
   if (plan.report && plan.report.phases) {
     const repSec = el("section");
     repSec.appendChild(el("h3", { text: "Report Phases" }));
@@ -678,22 +1575,91 @@ function renderIssueModal(issue) {
   modal.body.appendChild(pre);
 }
 
-// --------------------------------------------------------- card dispatch
+// --------------------------------------------------------- click dispatch
 
-function onCardActivate(card) {
-  const kind = card.getAttribute("data-kind");
-  if (kind === "plan") {
-    openPlanModal(card.getAttribute("data-slug"));
-  } else if (kind === "issue") {
-    openIssueModal(card.getAttribute("data-number"));
+async function handleAction(action, target) {
+  const slug = target.getAttribute("data-slug");
+  const numStr = target.getAttribute("data-number");
+  const num = numStr ? parseInt(numStr, 10) : NaN;
+
+  if (action === "plan-up") return movePlan(slug, "up");
+  if (action === "plan-down") return movePlan(slug, "down");
+  if (action === "plan-left") return movePlan(slug, "left");
+  if (action === "plan-right") return movePlan(slug, "right");
+  if (action === "plan-remove") return removePlan(slug);
+  if (action === "toggle-mode") return togglePlanMode(slug);
+
+  if (action === "issue-up") return moveIssue(num, "up");
+  if (action === "issue-down") return moveIssue(num, "down");
+  if (action === "issue-left") return moveIssue(num, "left");
+  if (action === "issue-right") return moveIssue(num, "right");
+  if (action === "issue-remove") return removeIssue(num);
+
+  if (action === "run-top-n") {
+    const input = $("run-n");
+    let n = 3;
+    if (input) {
+      const v = parseInt(input.value, 10);
+      if (Number.isFinite(v) && v >= 1 && v <= 99) n = v;
+    }
+    const cmd = "/work-on-plans " + n + " " + (lastGoodDefaultMode || "phase");
+    return postTrigger(cmd);
   }
-  // worktree / branch cards are display-only in Phase 6.
+  if (action === "run-stop") {
+    return postTrigger("/work-on-plans stop");
+  }
+  if (action === "copy-cmd") {
+    const cmd = target.getAttribute("data-cmd") || "";
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(cmd);
+        showToast("Copied to clipboard.", "info");
+      } catch (_err) {
+        showToast("Copy failed — select text manually.", "err");
+      }
+    } else {
+      showToast("Clipboard API unavailable.", "err");
+    }
+    return;
+  }
+  if (action === "clear-stale-sprint") {
+    return postWorkStateReset();
+  }
 }
 
-function bindCardEvents() {
+function bindActionEvents() {
+  document.body.addEventListener("click", (ev) => {
+    const target = ev.target.closest && ev.target.closest("[data-action]");
+    if (!target) return;
+    const action = target.getAttribute("data-action");
+    if (!action) return;
+    ev.preventDefault();
+    handleAction(action, target);
+  });
+
+  // Default-mode segmented buttons.
+  const phase = $("dm-phase");
+  const finish = $("dm-finish");
+  if (phase) phase.addEventListener("click", () => setDefaultMode("phase"));
+  if (finish) finish.addEventListener("click", () => setDefaultMode("finish"));
+
+  // Drag events at the document level.
+  document.body.addEventListener("dragstart", onDragStart);
+  document.body.addEventListener("dragend", onDragEnd);
+  document.body.addEventListener("dragenter", onDragEnter);
+  document.body.addEventListener("dragleave", onDragLeave);
+  document.body.addEventListener("dragover", onDragOver);
+  document.body.addEventListener("drop", onDrop);
+
+  // Modal open: dblclick or Enter on a non-li card (worktree/branch/issue),
+  // and dblclick (NOT single click) on plan/issue li cards (so single
+  // clicks on buttons inside still work).
   document.body.addEventListener("dblclick", (ev) => {
-    const card = ev.target.closest(".card");
+    const card = ev.target.closest && ev.target.closest(".card");
     if (!card) return;
+    // Don't open modal if click was on a button or the dblclick was
+    // initiated inside the card-controls area.
+    if (ev.target.closest("button")) return;
     onCardActivate(card);
   });
   document.body.addEventListener("keydown", (ev) => {
@@ -706,19 +1672,30 @@ function bindCardEvents() {
   });
 }
 
+function onCardActivate(card) {
+  const kind = card.getAttribute("data-kind");
+  if (kind === "plan") {
+    openPlanModal(card.getAttribute("data-slug"));
+  } else if (kind === "issue") {
+    openIssueModal(card.getAttribute("data-number"));
+  }
+  // worktree / branch cards remain display-only.
+}
+
 // ------------------------------------------------------- visibility / boot
 
 document.addEventListener("visibilitychange", () => {
   if (!document.hidden) {
-    // Force-load on becoming visible.
     schedulePoll(0);
+    scheduleWorkPoll(0);
   }
 });
 
 function boot() {
   modalInit();
-  bindCardEvents();
+  bindActionEvents();
   schedulePoll(0);
+  scheduleWorkPoll(0);
 }
 
 if (document.readyState === "loading") {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -22,11 +22,29 @@
     <ul id="errors-list" class="errors-list"></ul>
   </section>
 
+  <div id="toast-region" class="toast-region" aria-live="polite" role="status"></div>
+
   <main id="grid" class="grid">
     <section class="panel panel-plans" aria-label="Plans">
-      <h2 class="panel-title">Plans</h2>
+      <div class="panel-head">
+        <h2 class="panel-title">Plans</h2>
+        <div class="plans-controls">
+          <div id="default-mode-area" class="default-mode-area">
+            <span class="muted" id="default-mode-label">Default mode:</span>
+            <div class="seg" role="group" aria-labelledby="default-mode-label">
+              <button type="button" id="dm-phase" class="seg-btn" aria-pressed="false">Phase-by-phase</button>
+              <button type="button" id="dm-finish" class="seg-btn" aria-pressed="false">Finish (one PR)</button>
+            </div>
+            <span id="default-mode-footnote" class="dm-footnote muted" hidden>
+              Sprint in flight: change applies to plans not yet dispatched and to future sprints; in-flight plans keep their captured mode.
+            </span>
+          </div>
+        </div>
+      </div>
+      <div id="run-status" class="run-status" aria-label="Run status"></div>
       <div id="plans-body" class="panel-body"></div>
       <p id="plans-empty" class="empty muted" hidden>No plans found.</p>
+      <div id="plans-live" class="sr-only" aria-live="polite"></div>
     </section>
 
     <section class="panel panel-branches" aria-label="Branches">
@@ -39,6 +57,7 @@
       <h2 class="panel-title">Issues</h2>
       <div id="issues-body" class="panel-body"></div>
       <p id="issues-empty" class="empty muted" hidden>No open issues.</p>
+      <div id="issues-live" class="sr-only" aria-live="polite"></div>
     </section>
 
     <section class="panel panel-worktrees" aria-label="Worktrees">

--- a/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/plans/ZSKILLS_MONITOR_PLAN.md
@@ -255,7 +255,7 @@ is appended to `errors[]`.
 | 4 — Data aggregation library | ✅ Done | `b720fbb` | landed via PR squash; Python module at skills/zskills-dashboard/scripts/zskills_monitor/; 1277-line collect.py; 12 fixture sets; +29 tests; 1000/1000 |
 | 5 — HTTP server | ✅ Done | `63747e5` | landed via PR squash; server.py 1099 lines; 9 endpoints; 127.0.0.1 only; trigger security contract; flock + atomic writes; +53 tests |
 | 6 — Read-only dashboard UI | ✅ Done | `1239f6c` | landed via PR squash; static HTML/CSS/JS; 5 panels + 2 modals; XSS-safe; +45 tests; 1111/1111 |
-| 7 — Interactive queue + write-back | ⬚ | | |
+| 7 — Interactive queue + write-back | 🟡 In Progress | | |
 | 8 — `/zskills-dashboard` skill | ⬚ | | |
 | 9 — Migrate `/plans rebuild` to Python aggregator | ⬚ | | |
 

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -932,6 +932,14 @@ class MonitorHandler(BaseHTTPRequestHandler):
         def err_log(msg: str) -> None:
             sys.stderr.write(f"[work-state] {msg}\n")
 
+        # Phase 7: surface whether a /work-on-plans trigger is configured
+        # so the Run/Status widget can pick the right idle render.
+        cfg = _read_config(main_root)
+        trigger_configured = False
+        if isinstance(cfg.get("dashboard"), dict):
+            trig = cfg["dashboard"].get("work_on_plans_trigger", "")
+            trigger_configured = bool(trig)
+
         with _state_lock(main_root):
             doc, was_unparseable = _read_work_state(main_root, error_log=err_log)
             target = main_root / ".zskills" / "work-on-plans-state.json"
@@ -939,17 +947,27 @@ class MonitorHandler(BaseHTTPRequestHandler):
                 # Bootstrap-write idle.
                 idle = {"state": "idle", "updated_at": _now_iso()}
                 _atomic_write_json(target, idle)
-                self._send_json(200, {"state": "idle"})
+                self._send_json(
+                    200,
+                    {"state": "idle", "trigger_configured": trigger_configured},
+                )
                 return
             stale, reason = _is_stale(doc)
             if stale:
                 idle = {"state": "idle", "updated_at": _now_iso()}
                 _atomic_write_json(target, idle)
                 self._send_json(
-                    200, {"state": "idle", "warning": reason}
+                    200,
+                    {
+                        "state": "idle",
+                        "warning": reason,
+                        "trigger_configured": trigger_configured,
+                    },
                 )
                 return
-        self._send_json(200, doc)
+        out = dict(doc)
+        out["trigger_configured"] = trigger_configured
+        self._send_json(200, out)
 
     def _handle_work_state_reset(self) -> None:
         if not self._origin_ok():

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -392,3 +392,337 @@ code, pre, .mono {
   pointer-events: none;
   margin-top: 4px;
 }
+
+/* ---------------------------------------------------------------- Phase 7 */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 6px;
+}
+
+.panel-head .panel-title {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.plans-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.default-mode-area {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.seg-btn {
+  background: var(--surface2);
+  color: var(--text-dim);
+  border: none;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.seg-btn:hover,
+.seg-btn:focus-visible {
+  color: var(--text);
+  outline: none;
+  background: var(--surface);
+}
+
+.seg-btn[aria-pressed="true"] {
+  background: var(--accent);
+  color: #0d1117;
+  font-weight: 600;
+}
+
+.dm-footnote {
+  font-size: 0.78rem;
+  font-style: italic;
+  flex-basis: 100%;
+}
+
+.run-status {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.run-status.run-status-stale {
+  border-color: var(--orange);
+}
+
+.run-status .run-label {
+  color: var(--text-dim);
+}
+
+.run-status .run-text {
+  color: var(--text);
+}
+
+.run-btn,
+.copy-btn,
+.run-stop-btn,
+.clear-stale-btn,
+.add-mini-btn {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 9px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.run-btn:hover,
+.run-btn:focus-visible,
+.copy-btn:hover,
+.copy-btn:focus-visible,
+.run-stop-btn:hover,
+.run-stop-btn:focus-visible,
+.clear-stale-btn:hover,
+.clear-stale-btn:focus-visible,
+.add-mini-btn:hover,
+.add-mini-btn:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.run-btn.primary {
+  background: var(--accent);
+  color: #0d1117;
+  border-color: var(--accent);
+}
+
+.run-n-input {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  width: 56px;
+  font-size: 0.8rem;
+  font-family: inherit;
+}
+
+.run-cmd-snippet {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.85rem;
+}
+
+/* Columns layout */
+
+.columns {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+@media (min-width: 700px) {
+  .columns.columns-3 { grid-template-columns: 1fr 1fr 1fr; }
+  .columns.columns-2 { grid-template-columns: 1fr 1fr; }
+}
+
+.column {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 60px;
+}
+
+.column-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+
+.dropzone {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 32px;
+  padding: 2px;
+}
+
+.dropzone.drop-target {
+  background: rgba(88, 166, 255, 0.1);
+  border-radius: 4px;
+}
+
+.dropzone .card {
+  cursor: grab;
+}
+
+.dropzone .card.dragging {
+  opacity: 0.4;
+}
+
+.card-controls {
+  display: flex;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.move-btn {
+  background: var(--surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.move-btn:hover,
+.move-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  outline: none;
+}
+
+.move-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.mode-chip {
+  background: transparent;
+  border: 1px solid var(--accent2);
+  color: var(--accent2);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.mode-chip[data-source="inherit"] {
+  border-style: dashed;
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.mode-chip:hover,
+.mode-chip:focus-visible {
+  outline: none;
+  filter: brightness(1.2);
+  border-color: var(--accent);
+}
+
+.remove-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--red);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.remove-btn:hover,
+.remove-btn:focus-visible {
+  border-color: var(--red);
+  outline: none;
+}
+
+.toast-region {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 80;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.toast {
+  background: var(--surface);
+  border: 1px solid var(--red);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text);
+  font-size: 0.85rem;
+  max-width: 360px;
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.toast.toast-info { border-color: var(--accent); }
+
+.toast-close {
+  background: transparent;
+  color: var(--text-dim);
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-family: inherit;
+  line-height: 1;
+}
+
+.toast-close:hover,
+.toast-close:focus-visible {
+  color: var(--text);
+  outline: none;
+}
+

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1,4 +1,4 @@
-// Z Skills Monitor — read-only dashboard renderer (Phase 6).
+// Z Skills Monitor — interactive dashboard renderer (Phase 7).
 //
 // Loaded as a single ES module from /app.js. Polls /api/state every 2s
 // via setTimeout recursion (NOT setInterval), pauses while document is
@@ -6,9 +6,34 @@
 // so unchanged panels are not re-rendered. All user-authored content
 // rendered via textContent / appendChild — no innerHTML except for
 // hardcoded chrome marked `// chrome-only`.
+//
+// Phase 7 adds drag-and-drop columns for Plans (Drafted/Reviewed/Ready)
+// and Issues (Triage/Ready), POSTs the full queue back to /api/queue
+// on every reorder, polls /api/work-state for the Run/Status widget,
+// and POSTs to /api/trigger and /api/work-state/reset.
 
 const POLL_INTERVAL_MS = 2000;
 const STATE_URL = "/api/state";
+const WORK_STATE_URL = "/api/work-state";
+const QUEUE_URL = "/api/queue";
+const TRIGGER_URL = "/api/trigger";
+const WORK_STATE_RESET_URL = "/api/work-state/reset";
+
+// After a successful POST, suppress the next /api/state poll to avoid
+// flicker from a stale GET that started before the POST landed.
+const POST_RECONCILE_SUPPRESS_MS = 1500;
+
+const PLAN_COLUMNS = ["drafted", "reviewed", "ready"];
+const ISSUE_COLUMNS = ["triage", "ready"];
+const PLAN_COLUMN_LABELS = {
+  drafted: "Drafted",
+  reviewed: "Reviewed",
+  ready: "Ready",
+};
+const ISSUE_COLUMN_LABELS = {
+  triage: "Triage",
+  ready: "Ready",
+};
 
 // ---------------------------------------------------------------- helpers
 
@@ -68,9 +93,20 @@ function basename(p) {
   return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
 }
 
+function formatLocalTime(iso) {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const d = new Date(t);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return hh + ":" + mm;
+}
+
 // --------------------------------------------------------------- snapshot
 
 let lastSnapshot = null;
+let lastWorkState = null;
 const lastFingerprint = {
   errors: null,
   plans: null,
@@ -78,9 +114,18 @@ const lastFingerprint = {
   worktrees: null,
   issues: null,
   activity: null,
+  workState: null,
+  defaultMode: null,
 };
 let pollTimer = null;
 let pollAbort = null;
+let workPollTimer = null;
+let workPollAbort = null;
+let suppressNextStatePollUntil = 0;
+
+// last-known-good queues — used to revert local DOM on POST failure.
+let lastGoodQueues = null;
+let lastGoodDefaultMode = "phase";
 
 function setConnected(ok) {
   const banner = $("conn-banner");
@@ -114,15 +159,43 @@ async function fetchState() {
   }
 }
 
+async function fetchWorkState() {
+  const ctrl = new AbortController();
+  workPollAbort = ctrl;
+  try {
+    const res = await fetch(WORK_STATE_URL, {
+      cache: "no-store",
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (_err) {
+    return null;
+  } finally {
+    if (workPollAbort === ctrl) workPollAbort = null;
+  }
+}
+
 function schedulePoll(delay) {
   if (pollTimer) clearTimeout(pollTimer);
   pollTimer = setTimeout(pollOnce, delay);
 }
 
+function scheduleWorkPoll(delay) {
+  if (workPollTimer) clearTimeout(workPollTimer);
+  workPollTimer = setTimeout(pollWorkOnce, delay);
+}
+
 async function pollOnce() {
   if (document.hidden) {
-    // Pause while tab hidden; visibilitychange handler restarts.
     pollTimer = null;
+    return;
+  }
+  // Reconciliation: skip a single state poll right after a successful
+  // POST, so a GET in flight before the POST lands cannot flash stale
+  // data over the user's just-applied reorder.
+  if (Date.now() < suppressNextStatePollUntil) {
+    schedulePoll(POLL_INTERVAL_MS);
     return;
   }
   const snap = await fetchState();
@@ -131,6 +204,19 @@ async function pollOnce() {
     applySnapshot(snap);
   }
   schedulePoll(POLL_INTERVAL_MS);
+}
+
+async function pollWorkOnce() {
+  if (document.hidden) {
+    workPollTimer = null;
+    return;
+  }
+  const ws = await fetchWorkState();
+  if (ws) {
+    lastWorkState = ws;
+    applyWorkState(ws);
+  }
+  scheduleWorkPoll(POLL_INTERVAL_MS);
 }
 
 function applySnapshot(snap) {
@@ -144,10 +230,21 @@ function applySnapshot(snap) {
     renderErrors(snap.errors || []);
   }
 
-  const plansFp = fingerprintPlans(snap.plans || []);
+  // Capture last-known-good queues from snapshot.queues (server's view).
+  const queues = snap.queues || { plans: {}, issues: {}, default_mode: "phase" };
+  lastGoodQueues = deepCloneQueues(queues, snap.plans || [], snap.issues || []);
+  lastGoodDefaultMode = queues.default_mode || "phase";
+
+  const dmFp = String(lastGoodDefaultMode);
+  if (dmFp !== lastFingerprint.defaultMode) {
+    lastFingerprint.defaultMode = dmFp;
+    renderDefaultMode(lastGoodDefaultMode);
+  }
+
+  const plansFp = fingerprintPlans(snap.plans || [], queues, lastGoodDefaultMode);
   if (plansFp !== lastFingerprint.plans) {
     lastFingerprint.plans = plansFp;
-    renderPlans(snap.plans || []);
+    renderPlans(snap.plans || [], queues, lastGoodDefaultMode);
   }
 
   const branchesFp = fingerprintBranches(snap.branches || [], snap.worktrees || []);
@@ -156,10 +253,10 @@ function applySnapshot(snap) {
     renderBranches(snap.branches || [], snap.worktrees || []);
   }
 
-  const issuesFp = fingerprintIssues(snap.issues || []);
+  const issuesFp = fingerprintIssues(snap.issues || [], queues);
   if (issuesFp !== lastFingerprint.issues) {
     lastFingerprint.issues = issuesFp;
-    renderIssues(snap.issues || []);
+    renderIssues(snap.issues || [], queues);
   }
 
   const wtFp = fingerprintWorktrees(snap.worktrees || []);
@@ -175,10 +272,88 @@ function applySnapshot(snap) {
   }
 }
 
-function fingerprintPlans(plans) {
-  return JSON.stringify(plans.map(p => [
-    p.slug, p.title, p.status, p.landing_mode, p.phase_count, p.phases_done, p.blurb,
-  ]));
+function applyWorkState(ws) {
+  const fp = JSON.stringify(ws);
+  if (fp !== lastFingerprint.workState) {
+    lastFingerprint.workState = fp;
+    renderRunStatus(ws);
+    renderDefaultModeFootnote(ws);
+  }
+}
+
+// Build a queues dict that contains every plan/issue, populated from
+// state where present and inferred from snapshot column hints otherwise.
+// This is the local "source of truth" the UI POSTs back on every drag.
+function deepCloneQueues(queues, plans, issues) {
+  const out = {
+    default_mode: queues.default_mode || "phase",
+    plans: {},
+    issues: {},
+  };
+  for (const c of PLAN_COLUMNS) out.plans[c] = [];
+  for (const c of ISSUE_COLUMNS) out.issues[c] = [];
+
+  // Pre-populate from queues (preserves order).
+  const seenSlugs = new Set();
+  for (const c of PLAN_COLUMNS) {
+    const arr = (queues.plans && queues.plans[c]) || [];
+    for (const e of arr) {
+      const entry = (typeof e === "string") ? { slug: e } : (e || {});
+      if (!entry.slug || seenSlugs.has(entry.slug)) continue;
+      seenSlugs.add(entry.slug);
+      const obj = { slug: entry.slug };
+      if (c === "ready" && entry.mode != null) obj.mode = entry.mode;
+      out.plans[c].push(obj);
+    }
+  }
+  // Add inferred entries for plans not present in state.
+  for (const p of plans) {
+    if (seenSlugs.has(p.slug)) continue;
+    const col = (p.queue && p.queue.column) || "drafted";
+    if (PLAN_COLUMNS.indexOf(col) < 0) continue;
+    seenSlugs.add(p.slug);
+    out.plans[col].push({ slug: p.slug });
+  }
+
+  const seenNums = new Set();
+  for (const c of ISSUE_COLUMNS) {
+    const arr = (queues.issues && queues.issues[c]) || [];
+    for (const n of arr) {
+      const num = parseInt(n, 10);
+      if (!Number.isFinite(num) || seenNums.has(num)) continue;
+      seenNums.add(num);
+      out.issues[c].push(num);
+    }
+  }
+  for (const it of issues) {
+    if (typeof it.number !== "number" || seenNums.has(it.number)) continue;
+    const col = (it.queue && it.queue.column) || "triage";
+    if (ISSUE_COLUMNS.indexOf(col) < 0) continue;
+    seenNums.add(it.number);
+    out.issues[col].push(it.number);
+  }
+  return out;
+}
+
+function fingerprintPlans(plans, queues, defaultMode) {
+  // Include queue position so reorders re-render.
+  const pos = {};
+  for (const c of PLAN_COLUMNS) {
+    const arr = (queues.plans && queues.plans[c]) || [];
+    for (let i = 0; i < arr.length; i++) {
+      const e = arr[i];
+      const slug = (typeof e === "string") ? e : (e && e.slug);
+      if (slug) pos[slug] = [c, i, (e && e.mode) || null];
+    }
+  }
+  return JSON.stringify({
+    dm: defaultMode,
+    rows: plans.map(p => [
+      p.slug, p.title, p.status, p.landing_mode,
+      p.phase_count, p.phases_done, p.blurb,
+      pos[p.slug] || [(p.queue && p.queue.column) || "drafted", -1, null],
+    ]),
+  });
 }
 
 function fingerprintBranches(branches, worktrees) {
@@ -188,9 +363,18 @@ function fingerprintBranches(branches, worktrees) {
   ]));
 }
 
-function fingerprintIssues(issues) {
+function fingerprintIssues(issues, queues) {
+  const pos = {};
+  for (const c of ISSUE_COLUMNS) {
+    const arr = (queues.issues && queues.issues[c]) || [];
+    for (let i = 0; i < arr.length; i++) {
+      const n = parseInt(arr[i], 10);
+      if (Number.isFinite(n)) pos[n] = [c, i];
+    }
+  }
   return JSON.stringify(issues.map(i => [
     i.number, i.title, (i.labels || []).slice().sort(), i.created_at,
+    pos[i.number] || [(i.queue && i.queue.column) || "triage", -1],
   ]));
 }
 
@@ -245,51 +429,57 @@ function modePillClass(mode) {
   return "pill-mode-unknown";
 }
 
-function renderPlans(plans) {
-  const body = $("plans-body");
-  const empty = $("plans-empty");
-  clear(body);
-  if (!plans.length) {
-    empty.hidden = false;
-    return;
-  }
-  empty.hidden = true;
+function planBySlug(plans, slug) {
   for (const p of plans) {
-    const card = el("article", {
-      cls: "card",
-      attrs: {
-        tabindex: "0",
-        role: "button",
-        "data-kind": "plan",
-        "data-slug": p.slug,
-        "aria-label": "Plan " + (p.title || p.slug),
-      },
-    });
-    const head = el("div", { cls: "card-row" });
-    head.appendChild(el("span", { cls: "card-title", text: p.title || p.slug }));
+    if (p.slug === slug) return p;
+  }
+  return null;
+}
+
+function buildPlanCard(plan, slug, col, defaultMode) {
+  const card = el("li", {
+    cls: "card",
+    attrs: {
+      role: "listitem",
+      tabindex: "0",
+      draggable: "true",
+      "data-kind": "plan",
+      "data-slug": slug,
+      "data-column": col,
+      "aria-label": "Plan " + (plan ? (plan.title || slug) : slug),
+    },
+  });
+  const head = el("div", { cls: "card-row" });
+  head.appendChild(el("span", {
+    cls: "card-title",
+    text: (plan && plan.title) || slug,
+  }));
+  if (plan && plan.status) {
     const statusPill = el("span", {
-      cls: "pill " + statusPillClass(p.status),
-      text: p.status || "active",
+      cls: "pill " + statusPillClass(plan.status),
+      text: plan.status,
     });
     head.appendChild(statusPill);
-    card.appendChild(head);
+  }
+  card.appendChild(head);
 
-    if (p.blurb) {
-      card.appendChild(el("div", { cls: "card-blurb", text: p.blurb }));
-    }
+  if (plan && plan.blurb) {
+    card.appendChild(el("div", { cls: "card-blurb", text: plan.blurb }));
+  }
 
+  if (plan) {
     const meta = el("div", { cls: "card-row card-sub" });
-    const ratio = (p.phases_done || 0) + " / " + (p.phase_count || 0) + " phases";
+    const ratio = (plan.phases_done || 0) + " / " + (plan.phase_count || 0) + " phases";
     meta.appendChild(el("span", { text: ratio }));
     const modePill = el("span", {
-      cls: "pill " + modePillClass(p.landing_mode),
-      text: "mode: " + (p.landing_mode || "unknown"),
+      cls: "pill " + modePillClass(plan.landing_mode),
+      text: "mode: " + (plan.landing_mode || "unknown"),
     });
     meta.appendChild(modePill);
     card.appendChild(meta);
 
-    const total = p.phase_count || 0;
-    const done = p.phases_done || 0;
+    const total = plan.phase_count || 0;
+    const done = plan.phases_done || 0;
     if (total > 0) {
       const bar = el("div", { cls: "progress" });
       const fill = el("div", { cls: "progress-fill" });
@@ -298,9 +488,157 @@ function renderPlans(plans) {
       bar.appendChild(fill);
       card.appendChild(bar);
     }
-
-    body.appendChild(card);
   }
+
+  // Per-row mode chip on Ready cards (Phase 7).
+  if (col === "ready") {
+    const entryMode = currentEntryMode(slug);
+    const isOverride = entryMode === "phase" || entryMode === "finish";
+    const displayMode = isOverride ? entryMode : (defaultMode || "phase");
+    const chip = el("button", {
+      cls: "mode-chip",
+      attrs: {
+        type: "button",
+        "data-action": "toggle-mode",
+        "data-slug": slug,
+        "data-source": isOverride ? "explicit" : "inherit",
+        "aria-label": (
+          isOverride
+            ? ("Mode: " + displayMode + " (override). Click to toggle.")
+            : ("Mode: " + displayMode + " (inherits default). Click to set explicit.")
+        ),
+      },
+      text: displayMode,
+    });
+    card.appendChild(chip);
+  }
+
+  // Card controls: ↑ ↓ ← → and remove
+  const controls = el("div", {
+    cls: "card-controls",
+    attrs: { role: "group", "aria-label": "Move this plan" },
+  });
+  controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
+  controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
+  controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
+  controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
+  controls.appendChild(el("button", {
+    cls: "remove-btn",
+    attrs: {
+      type: "button",
+      "data-action": "plan-remove",
+      "data-slug": slug,
+      "aria-label": "Remove from queue",
+    },
+    text: "✕",
+  }));
+  card.appendChild(controls);
+
+  return card;
+}
+
+function makeMoveBtn(action, slug, label, ariaLabel) {
+  return el("button", {
+    cls: "move-btn",
+    attrs: {
+      type: "button",
+      "data-action": action,
+      "data-slug": slug,
+      "aria-label": ariaLabel,
+    },
+    text: label,
+  });
+}
+
+function makeIssueMoveBtn(action, num, label, ariaLabel) {
+  return el("button", {
+    cls: "move-btn",
+    attrs: {
+      type: "button",
+      "data-action": action,
+      "data-number": String(num),
+      "aria-label": ariaLabel,
+    },
+    text: label,
+  });
+}
+
+function currentEntryMode(slug) {
+  if (!lastGoodQueues) return null;
+  const arr = lastGoodQueues.plans.ready || [];
+  for (const e of arr) {
+    if (e && e.slug === slug) return e.mode || null;
+  }
+  return null;
+}
+
+function renderPlans(plans, queues, defaultMode) {
+  const body = $("plans-body");
+  const empty = $("plans-empty");
+  clear(body);
+  if (!plans.length && allColumnsEmpty(queues.plans, PLAN_COLUMNS)) {
+    empty.hidden = false;
+    return;
+  }
+  empty.hidden = true;
+
+  const slugToPlan = {};
+  for (const p of plans) slugToPlan[p.slug] = p;
+
+  const cols = el("div", { cls: "columns columns-3" });
+  for (const c of PLAN_COLUMNS) {
+    const colDiv = el("div", { cls: "column" });
+    const headId = "plans-col-" + c;
+    const head = el("div", { cls: "column-head", attrs: { id: headId } });
+    head.appendChild(el("span", { text: PLAN_COLUMN_LABELS[c] }));
+    const arr = (lastGoodQueues && lastGoodQueues.plans[c]) || [];
+    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    colDiv.appendChild(head);
+
+    const ul = el("ul", {
+      cls: "dropzone",
+      attrs: {
+        role: "list",
+        "data-column": c,
+        "data-kind": "plan",
+        "aria-labelledby": headId,
+      },
+    });
+    for (const entry of arr) {
+      const slug = (typeof entry === "string") ? entry : (entry && entry.slug);
+      if (!slug) continue;
+      const card = buildPlanCard(slugToPlan[slug] || null, slug, c, defaultMode);
+      ul.appendChild(card);
+    }
+    colDiv.appendChild(ul);
+    cols.appendChild(colDiv);
+  }
+  body.appendChild(cols);
+}
+
+function allColumnsEmpty(colsObj, columnNames) {
+  if (!colsObj) return true;
+  for (const c of columnNames) {
+    const arr = colsObj[c] || [];
+    if (arr.length) return false;
+  }
+  return true;
+}
+
+function renderDefaultMode(mode) {
+  const phase = $("dm-phase");
+  const finish = $("dm-finish");
+  if (!phase || !finish) return;
+  const isPhase = mode === "phase";
+  phase.setAttribute("aria-pressed", isPhase ? "true" : "false");
+  finish.setAttribute("aria-pressed", isPhase ? "false" : "true");
+}
+
+function renderDefaultModeFootnote(ws) {
+  const note = $("default-mode-footnote");
+  if (!note) return;
+  const inFlight = ws && ws.state === "sprint";
+  note.hidden = !inFlight;
 }
 
 // -------------------------------------------------------------- branches
@@ -353,41 +691,99 @@ function renderBranches(branches, worktrees) {
 
 // ---------------------------------------------------------------- issues
 
-function renderIssues(issues) {
+function buildIssueCard(issue, num, col) {
+  const card = el("li", {
+    cls: "card",
+    attrs: {
+      role: "listitem",
+      tabindex: "0",
+      draggable: "true",
+      "data-kind": "issue",
+      "data-number": String(num),
+      "data-column": col,
+      "aria-label": "Issue #" + num,
+    },
+  });
+  const head = el("div", { cls: "card-row" });
+  head.appendChild(el("span", {
+    cls: "card-title",
+    text: issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num),
+  }));
+  if (issue && issue.created_at) {
+    head.appendChild(el("span", { cls: "card-sub", text: relativeTime(issue.created_at) }));
+  }
+  card.appendChild(head);
+  if (issue && (issue.labels || []).length) {
+    const labels = el("div", { cls: "card-sub" });
+    for (const lab of issue.labels) {
+      labels.appendChild(el("span", { cls: "label-chip", text: lab }));
+    }
+    card.appendChild(labels);
+  }
+  const controls = el("div", {
+    cls: "card-controls",
+    attrs: { role: "group", "aria-label": "Move this issue" },
+  });
+  controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
+  controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
+  controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
+  controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
+  controls.appendChild(el("button", {
+    cls: "remove-btn",
+    attrs: {
+      type: "button",
+      "data-action": "issue-remove",
+      "data-number": String(num),
+      "aria-label": "Remove issue from queue",
+    },
+    text: "✕",
+  }));
+  card.appendChild(controls);
+  return card;
+}
+
+function renderIssues(issues, queues) {
   const body = $("issues-body");
   const empty = $("issues-empty");
   clear(body);
-  if (!issues.length) {
+  if (!issues.length && allColumnsEmpty(queues.issues, ISSUE_COLUMNS)) {
     empty.hidden = false;
     return;
   }
   empty.hidden = true;
-  for (const it of issues) {
-    const card = el("article", {
-      cls: "card",
+
+  const numToIssue = {};
+  for (const it of issues) numToIssue[it.number] = it;
+
+  const cols = el("div", { cls: "columns columns-2" });
+  for (const c of ISSUE_COLUMNS) {
+    const colDiv = el("div", { cls: "column" });
+    const headId = "issues-col-" + c;
+    const head = el("div", { cls: "column-head", attrs: { id: headId } });
+    head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
+    const arr = (lastGoodQueues && lastGoodQueues.issues[c]) || [];
+    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    colDiv.appendChild(head);
+
+    const ul = el("ul", {
+      cls: "dropzone",
       attrs: {
-        tabindex: "0",
-        role: "button",
+        role: "list",
+        "data-column": c,
         "data-kind": "issue",
-        "data-number": String(it.number),
-        "aria-label": "Issue #" + it.number,
+        "aria-labelledby": headId,
       },
     });
-    const head = el("div", { cls: "card-row" });
-    head.appendChild(el("span", { cls: "card-title", text: "#" + it.number + " " + (it.title || "") }));
-    if (it.created_at) {
-      head.appendChild(el("span", { cls: "card-sub", text: relativeTime(it.created_at) }));
+    for (const num of arr) {
+      const n = parseInt(num, 10);
+      if (!Number.isFinite(n)) continue;
+      const card = buildIssueCard(numToIssue[n] || null, n, c);
+      ul.appendChild(card);
     }
-    card.appendChild(head);
-    if ((it.labels || []).length) {
-      const labels = el("div", { cls: "card-sub" });
-      for (const lab of it.labels) {
-        labels.appendChild(el("span", { cls: "label-chip", text: lab }));
-      }
-      card.appendChild(labels);
-    }
-    body.appendChild(card);
+    colDiv.appendChild(ul);
+    cols.appendChild(colDiv);
   }
+  body.appendChild(cols);
 }
 
 // ------------------------------------------------------------- worktrees
@@ -451,7 +847,6 @@ function renderActivity(activity) {
   const body = $("activity-body");
   const empty = $("activity-empty");
   clear(body);
-  // Newest first (collect.py already sorts) — cap at 20.
   const rows = activity.slice(0, 20);
   if (!rows.length) {
     empty.hidden = false;
@@ -477,6 +872,512 @@ function renderActivity(activity) {
     row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
     body.appendChild(row);
   }
+}
+
+// ----------------------------------------------------------- run-status
+
+function renderRunStatus(ws) {
+  const root = $("run-status");
+  if (!root) return;
+  clear(root);
+  root.classList.remove("run-status-stale");
+  const state = (ws && ws.state) || "idle";
+  const warning = ws && ws.warning;
+
+  if (state === "scheduled") {
+    const sched = ws.schedule || "every ?h";
+    const next = ws.next_fire_at ? formatLocalTime(ws.next_fire_at) : "?";
+    root.appendChild(el("span", { cls: "run-label", text: "Schedule:" }));
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "Running " + sched + " · next fire " + next,
+    }));
+    const stop = el("button", {
+      cls: "run-stop-btn",
+      attrs: { type: "button", "data-action": "run-stop" },
+      text: "Stop",
+    });
+    root.appendChild(stop);
+    return;
+  }
+  if (state === "sprint") {
+    const prog = ws.progress || {};
+    const done = (prog.done != null) ? prog.done : 0;
+    const total = (prog.total != null) ? prog.total : 0;
+    const cur = prog.current_slug || "?";
+    root.appendChild(el("span", { cls: "run-label", text: "Sprint:" }));
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "in progress: " + done + "/" + total + " plans done · current: " + cur,
+    }));
+    return;
+  }
+  if (state === "stale-scheduled") {
+    root.classList.add("run-status-stale");
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "Schedule appears stale — restart with /work-on-plans every 4h",
+    }));
+    return;
+  }
+  if (state === "stale-sprint") {
+    root.classList.add("run-status-stale");
+    root.appendChild(el("span", {
+      cls: "run-text",
+      text: "Sprint appears abandoned (last update " + (ws.updated_at ? relativeTime(ws.updated_at) : "?") + ")",
+    }));
+    const clearBtn = el("button", {
+      cls: "clear-stale-btn",
+      attrs: { type: "button", "data-action": "clear-stale-sprint" },
+      text: "Clear stale sprint state",
+    });
+    root.appendChild(clearBtn);
+    return;
+  }
+
+  // idle (default)
+  if (warning) {
+    root.classList.add("run-status-stale");
+    root.appendChild(el("span", { cls: "run-text", text: warning }));
+  }
+  const triggerConfigured = !!(ws && ws.trigger_configured);
+  const dm = lastGoodDefaultMode || "phase";
+  if (triggerConfigured) {
+    root.appendChild(el("span", { cls: "run-label", text: "Idle:" }));
+    const nInput = el("input", {
+      cls: "run-n-input",
+      attrs: {
+        type: "number",
+        min: "1",
+        max: "99",
+        value: "3",
+        id: "run-n",
+        "aria-label": "Number of plans to run",
+      },
+    });
+    root.appendChild(nInput);
+    const runBtn = el("button", {
+      cls: "run-btn primary",
+      attrs: { type: "button", "data-action": "run-top-n" },
+      text: "▶ Run top N",
+    });
+    root.appendChild(runBtn);
+  } else {
+    root.appendChild(el("span", { cls: "run-label", text: "Copy and run:" }));
+    const cmd = "/work-on-plans 3 " + dm;
+    root.appendChild(el("code", { cls: "run-cmd-snippet", text: cmd }));
+    const copyBtn = el("button", {
+      cls: "copy-btn",
+      attrs: { type: "button", "data-action": "copy-cmd", "data-cmd": cmd },
+      text: "Copy",
+    });
+    root.appendChild(copyBtn);
+  }
+}
+
+// ---------------------------------------------------------------- toasts
+
+function showToast(message, kind) {
+  const region = $("toast-region");
+  if (!region) return;
+  const toast = el("div", { cls: "toast " + (kind === "info" ? "toast-info" : "") });
+  toast.appendChild(el("span", { text: String(message || "") }));
+  const close = el("button", {
+    cls: "toast-close",
+    attrs: { type: "button", "aria-label": "Dismiss" },
+    text: "×",
+  });
+  close.addEventListener("click", () => {
+    if (toast.parentNode) toast.parentNode.removeChild(toast);
+  });
+  toast.appendChild(close);
+  region.appendChild(toast);
+  // Auto-dismiss after 8s.
+  setTimeout(() => {
+    if (toast.parentNode) toast.parentNode.removeChild(toast);
+  }, 8000);
+}
+
+function announce(regionId, msg) {
+  const region = $(regionId);
+  if (!region) return;
+  // Empty + repopulate so SRs re-announce identical text.
+  region.textContent = "";
+  // Force layout flush before reassign.
+  void region.offsetHeight;
+  region.textContent = msg;
+}
+
+// --------------------------------------------------------- POST queue
+
+async function postQueue(queues, opts) {
+  // Returns true on success; on failure shows toast and returns false.
+  const payload = {
+    default_mode: queues.default_mode || "phase",
+    plans: queues.plans,
+    issues: queues.issues,
+  };
+  let res;
+  try {
+    res = await fetch(QUEUE_URL, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    showToast("POST /api/queue failed: " + (err && err.message ? err.message : err), "err");
+    return false;
+  }
+  if (!res.ok) {
+    let body = "";
+    try { body = await res.text(); } catch (_e) { /* ignore */ }
+    const action = (opts && opts.action) || "update";
+    showToast(action + " failed (" + res.status + "): " + body.slice(0, 240), "err");
+    return false;
+  }
+  // Reconcile: suppress next state poll for ~1.5s to avoid stale-GET flicker.
+  suppressNextStatePollUntil = Date.now() + POST_RECONCILE_SUPPRESS_MS;
+  return true;
+}
+
+async function commitQueueChange(newQueues, opts) {
+  const previous = lastGoodQueues
+    ? JSON.parse(JSON.stringify(lastGoodQueues))
+    : null;
+  // Optimistic: snap UI to new queues immediately.
+  lastGoodQueues = newQueues;
+  if (newQueues.default_mode) lastGoodDefaultMode = newQueues.default_mode;
+  // Force re-render now (don't wait for next poll).
+  const snap = lastSnapshot || { plans: [], issues: [] };
+  renderDefaultMode(lastGoodDefaultMode);
+  renderPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+  renderIssues(snap.issues || [], lastGoodQueues);
+  lastFingerprint.plans = fingerprintPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+  lastFingerprint.issues = fingerprintIssues(snap.issues || [], lastGoodQueues);
+  lastFingerprint.defaultMode = String(lastGoodDefaultMode);
+
+  const ok = await postQueue(newQueues, opts);
+  if (!ok && previous) {
+    // Revert immediately; do not wait for next poll.
+    lastGoodQueues = previous;
+    lastGoodDefaultMode = previous.default_mode || "phase";
+    renderDefaultMode(lastGoodDefaultMode);
+    renderPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+    renderIssues(snap.issues || [], lastGoodQueues);
+    lastFingerprint.plans = fingerprintPlans(snap.plans || [], lastGoodQueues, lastGoodDefaultMode);
+    lastFingerprint.issues = fingerprintIssues(snap.issues || [], lastGoodQueues);
+    lastFingerprint.defaultMode = String(lastGoodDefaultMode);
+  }
+  return ok;
+}
+
+// ----------------------------------------------------- queue-mutation ops
+
+function findPlan(queues, slug) {
+  for (const c of PLAN_COLUMNS) {
+    const arr = queues.plans[c];
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i].slug === slug) return { col: c, idx: i };
+    }
+  }
+  return null;
+}
+
+function findIssue(queues, num) {
+  for (const c of ISSUE_COLUMNS) {
+    const arr = queues.issues[c];
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i] === num) return { col: c, idx: i };
+    }
+  }
+  return null;
+}
+
+function clonedQueues() {
+  return lastGoodQueues
+    ? JSON.parse(JSON.stringify(lastGoodQueues))
+    : {
+        default_mode: "phase",
+        plans: { drafted: [], reviewed: [], ready: [] },
+        issues: { triage: [], ready: [] },
+      };
+}
+
+async function movePlan(slug, dCol, dIdxAdjust) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc) return;
+  const entry = next.plans[loc.col].splice(loc.idx, 1)[0];
+  let targetCol = loc.col;
+  let targetIdx = loc.idx;
+  if (dCol === "up") {
+    targetIdx = Math.max(0, loc.idx - 1);
+  } else if (dCol === "down") {
+    targetIdx = Math.min(next.plans[loc.col].length, loc.idx + 1);
+  } else if (dCol === "left") {
+    const ci = PLAN_COLUMNS.indexOf(loc.col);
+    if (ci <= 0) {
+      // Restore — no-op.
+      next.plans[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = PLAN_COLUMNS[ci - 1];
+    targetIdx = next.plans[targetCol].length;
+  } else if (dCol === "right") {
+    const ci = PLAN_COLUMNS.indexOf(loc.col);
+    if (ci >= PLAN_COLUMNS.length - 1) {
+      next.plans[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = PLAN_COLUMNS[ci + 1];
+    targetIdx = next.plans[targetCol].length;
+  } else if (typeof dCol === "object" && dCol && dCol.col) {
+    targetCol = dCol.col;
+    targetIdx = (dCol.idx == null) ? next.plans[targetCol].length : dCol.idx;
+  }
+  next.plans[targetCol].splice(targetIdx, 0, entry);
+  const ok = await commitQueueChange(next, { action: "Move plan" });
+  if (ok) {
+    announce("plans-live", "Moved plan " + slug + " to " + PLAN_COLUMN_LABELS[targetCol] + " position " + (targetIdx + 1));
+  }
+}
+
+async function removePlan(slug) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc) return;
+  next.plans[loc.col].splice(loc.idx, 1);
+  const ok = await commitQueueChange(next, { action: "Remove plan" });
+  if (ok) announce("plans-live", "Removed plan " + slug);
+}
+
+async function moveIssue(num, dCol) {
+  const next = clonedQueues();
+  const loc = findIssue(next, num);
+  if (!loc) return;
+  const entry = next.issues[loc.col].splice(loc.idx, 1)[0];
+  let targetCol = loc.col;
+  let targetIdx = loc.idx;
+  if (dCol === "up") {
+    targetIdx = Math.max(0, loc.idx - 1);
+  } else if (dCol === "down") {
+    targetIdx = Math.min(next.issues[loc.col].length, loc.idx + 1);
+  } else if (dCol === "left") {
+    const ci = ISSUE_COLUMNS.indexOf(loc.col);
+    if (ci <= 0) {
+      next.issues[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = ISSUE_COLUMNS[ci - 1];
+    targetIdx = next.issues[targetCol].length;
+  } else if (dCol === "right") {
+    const ci = ISSUE_COLUMNS.indexOf(loc.col);
+    if (ci >= ISSUE_COLUMNS.length - 1) {
+      next.issues[loc.col].splice(loc.idx, 0, entry);
+      return;
+    }
+    targetCol = ISSUE_COLUMNS[ci + 1];
+    targetIdx = next.issues[targetCol].length;
+  } else if (typeof dCol === "object" && dCol && dCol.col) {
+    targetCol = dCol.col;
+    targetIdx = (dCol.idx == null) ? next.issues[targetCol].length : dCol.idx;
+  }
+  next.issues[targetCol].splice(targetIdx, 0, entry);
+  const ok = await commitQueueChange(next, { action: "Move issue" });
+  if (ok) {
+    announce("issues-live", "Moved issue #" + num + " to " + ISSUE_COLUMN_LABELS[targetCol] + " position " + (targetIdx + 1));
+  }
+}
+
+async function removeIssue(num) {
+  const next = clonedQueues();
+  const loc = findIssue(next, num);
+  if (!loc) return;
+  next.issues[loc.col].splice(loc.idx, 1);
+  const ok = await commitQueueChange(next, { action: "Remove issue" });
+  if (ok) announce("issues-live", "Removed issue #" + num);
+}
+
+async function setDefaultMode(mode) {
+  if (mode !== "phase" && mode !== "finish") return;
+  if (mode === lastGoodDefaultMode) return;
+  const next = clonedQueues();
+  next.default_mode = mode;
+  const ok = await commitQueueChange(next, { action: "Set default mode" });
+  if (ok) announce("plans-live", "Default mode: " + mode);
+}
+
+async function togglePlanMode(slug) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc || loc.col !== "ready") return;
+  const entry = next.plans[loc.col][loc.idx];
+  const cur = entry.mode || null;
+  // Cycle: inherit -> phase -> finish -> inherit.
+  let newMode;
+  if (cur == null) newMode = "phase";
+  else if (cur === "phase") newMode = "finish";
+  else newMode = null;
+  if (newMode == null) {
+    delete entry.mode;
+  } else {
+    entry.mode = newMode;
+  }
+  const ok = await commitQueueChange(next, { action: "Toggle mode" });
+  if (ok) {
+    announce("plans-live",
+      "Mode for " + slug + " set to " + (newMode || "inherit"));
+  }
+}
+
+// -------------------------------------------------------------- trigger
+
+async function postTrigger(command) {
+  let res;
+  try {
+    res = await fetch(TRIGGER_URL, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command }),
+    });
+  } catch (err) {
+    showToast("Trigger failed: " + (err && err.message ? err.message : err), "err");
+    return false;
+  }
+  if (res.status === 501) {
+    showToast(
+      "No /work-on-plans trigger configured — set dashboard.work_on_plans_trigger in zskills-config.json.",
+      "info"
+    );
+    return false;
+  }
+  if (!res.ok) {
+    let body = "";
+    try {
+      const data = await res.json();
+      body = (data && (data.stderr || data.error)) || "";
+    } catch (_e) {
+      try { body = await res.text(); } catch (_ignore) { /* */ }
+    }
+    showToast("Trigger error (" + res.status + "): " + body.slice(0, 240), "err");
+    return false;
+  }
+  let data = null;
+  try { data = await res.json(); } catch (_e) { /* */ }
+  if (data && data.status === "error") {
+    showToast("Trigger script error: " + (data.stderr || "(no stderr)").slice(0, 240), "err");
+    return false;
+  }
+  showToast("Triggered.", "info");
+  // Force a fresh work-state poll so the widget updates.
+  scheduleWorkPoll(0);
+  return true;
+}
+
+async function postWorkStateReset() {
+  let res;
+  try {
+    res = await fetch(WORK_STATE_RESET_URL, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+  } catch (err) {
+    showToast("Reset failed: " + (err && err.message ? err.message : err), "err");
+    return false;
+  }
+  if (!res.ok) {
+    showToast("Reset failed (" + res.status + ")", "err");
+    return false;
+  }
+  showToast("Sprint state cleared.", "info");
+  scheduleWorkPoll(0);
+  return true;
+}
+
+// -------------------------------------------------------- drag-and-drop
+
+let dragState = null;
+
+function onDragStart(ev) {
+  const card = ev.target.closest && ev.target.closest("li.card[draggable='true']");
+  if (!card) return;
+  const kind = card.getAttribute("data-kind");
+  const slug = card.getAttribute("data-slug");
+  const num = card.getAttribute("data-number");
+  dragState = { kind, slug, num };
+  if (ev.dataTransfer) {
+    try {
+      ev.dataTransfer.setData("text/plain", JSON.stringify(dragState));
+      ev.dataTransfer.effectAllowed = "move";
+    } catch (_e) { /* some browsers throw on programmatic types */ }
+  }
+  card.classList.add("dragging");
+}
+
+function onDragEnd(ev) {
+  const card = ev.target.closest && ev.target.closest("li.card");
+  if (card) card.classList.remove("dragging");
+  dragState = null;
+  const dropzones = document.querySelectorAll(".dropzone.drop-target");
+  for (const dz of dropzones) dz.classList.remove("drop-target");
+}
+
+function onDragOver(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  if (!dragState) return;
+  // Kind must match dropzone kind.
+  if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  ev.preventDefault();
+  if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
+}
+
+function onDragEnter(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  if (!dragState) return;
+  if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  dz.classList.add("drop-target");
+}
+
+function onDragLeave(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  // relatedTarget is the element being entered; only clear if leaving fully.
+  const rel = ev.relatedTarget;
+  if (rel && dz.contains(rel)) return;
+  dz.classList.remove("drop-target");
+}
+
+function computeInsertIndex(dz, clientY) {
+  const cards = Array.from(dz.querySelectorAll("li.card:not(.dragging)"));
+  for (let i = 0; i < cards.length; i++) {
+    const r = cards[i].getBoundingClientRect();
+    if (clientY < r.top + r.height / 2) return i;
+  }
+  return cards.length;
+}
+
+async function onDrop(ev) {
+  const dz = ev.target.closest && ev.target.closest("ul.dropzone");
+  if (!dz) return;
+  if (!dragState) return;
+  if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  ev.preventDefault();
+  dz.classList.remove("drop-target");
+  const targetCol = dz.getAttribute("data-column");
+  const targetIdx = computeInsertIndex(dz, ev.clientY);
+  if (dragState.kind === "plan" && dragState.slug) {
+    await movePlan(dragState.slug, { col: targetCol, idx: targetIdx });
+  } else if (dragState.kind === "issue" && dragState.num) {
+    const n = parseInt(dragState.num, 10);
+    if (Number.isFinite(n)) await moveIssue(n, { col: targetCol, idx: targetIdx });
+  }
+  dragState = null;
 }
 
 // ------------------------------------------------------------------ modal
@@ -534,7 +1435,6 @@ function openModalShell(title) {
   clear(modal.body);
   modal.body.appendChild(el("p", { cls: "muted", text: "Loading…" }));
   modal.root.hidden = false;
-  // Focus the close button so Esc/Tab work immediately.
   modal.close.focus();
 }
 
@@ -582,7 +1482,6 @@ function renderPlanModal(plan) {
     modal.body.appendChild(overview);
   }
 
-  // Phase list
   const phasesSec = el("section");
   phasesSec.appendChild(el("h3", { text: "Phases" }));
   const phaseList = el("ul", { cls: "phase-list" });
@@ -612,7 +1511,6 @@ function renderPlanModal(plan) {
   phasesSec.appendChild(phaseList);
   modal.body.appendChild(phasesSec);
 
-  // Report path (display-only)
   if (plan.report_path) {
     const rp = el("section");
     rp.appendChild(el("h3", { text: "Report" }));
@@ -620,7 +1518,6 @@ function renderPlanModal(plan) {
     modal.body.appendChild(rp);
   }
 
-  // Work-item checkboxes (display-only): rebuild from sub_plans + report
   if (plan.report && plan.report.phases) {
     const repSec = el("section");
     repSec.appendChild(el("h3", { text: "Report Phases" }));
@@ -678,22 +1575,91 @@ function renderIssueModal(issue) {
   modal.body.appendChild(pre);
 }
 
-// --------------------------------------------------------- card dispatch
+// --------------------------------------------------------- click dispatch
 
-function onCardActivate(card) {
-  const kind = card.getAttribute("data-kind");
-  if (kind === "plan") {
-    openPlanModal(card.getAttribute("data-slug"));
-  } else if (kind === "issue") {
-    openIssueModal(card.getAttribute("data-number"));
+async function handleAction(action, target) {
+  const slug = target.getAttribute("data-slug");
+  const numStr = target.getAttribute("data-number");
+  const num = numStr ? parseInt(numStr, 10) : NaN;
+
+  if (action === "plan-up") return movePlan(slug, "up");
+  if (action === "plan-down") return movePlan(slug, "down");
+  if (action === "plan-left") return movePlan(slug, "left");
+  if (action === "plan-right") return movePlan(slug, "right");
+  if (action === "plan-remove") return removePlan(slug);
+  if (action === "toggle-mode") return togglePlanMode(slug);
+
+  if (action === "issue-up") return moveIssue(num, "up");
+  if (action === "issue-down") return moveIssue(num, "down");
+  if (action === "issue-left") return moveIssue(num, "left");
+  if (action === "issue-right") return moveIssue(num, "right");
+  if (action === "issue-remove") return removeIssue(num);
+
+  if (action === "run-top-n") {
+    const input = $("run-n");
+    let n = 3;
+    if (input) {
+      const v = parseInt(input.value, 10);
+      if (Number.isFinite(v) && v >= 1 && v <= 99) n = v;
+    }
+    const cmd = "/work-on-plans " + n + " " + (lastGoodDefaultMode || "phase");
+    return postTrigger(cmd);
   }
-  // worktree / branch cards are display-only in Phase 6.
+  if (action === "run-stop") {
+    return postTrigger("/work-on-plans stop");
+  }
+  if (action === "copy-cmd") {
+    const cmd = target.getAttribute("data-cmd") || "";
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(cmd);
+        showToast("Copied to clipboard.", "info");
+      } catch (_err) {
+        showToast("Copy failed — select text manually.", "err");
+      }
+    } else {
+      showToast("Clipboard API unavailable.", "err");
+    }
+    return;
+  }
+  if (action === "clear-stale-sprint") {
+    return postWorkStateReset();
+  }
 }
 
-function bindCardEvents() {
+function bindActionEvents() {
+  document.body.addEventListener("click", (ev) => {
+    const target = ev.target.closest && ev.target.closest("[data-action]");
+    if (!target) return;
+    const action = target.getAttribute("data-action");
+    if (!action) return;
+    ev.preventDefault();
+    handleAction(action, target);
+  });
+
+  // Default-mode segmented buttons.
+  const phase = $("dm-phase");
+  const finish = $("dm-finish");
+  if (phase) phase.addEventListener("click", () => setDefaultMode("phase"));
+  if (finish) finish.addEventListener("click", () => setDefaultMode("finish"));
+
+  // Drag events at the document level.
+  document.body.addEventListener("dragstart", onDragStart);
+  document.body.addEventListener("dragend", onDragEnd);
+  document.body.addEventListener("dragenter", onDragEnter);
+  document.body.addEventListener("dragleave", onDragLeave);
+  document.body.addEventListener("dragover", onDragOver);
+  document.body.addEventListener("drop", onDrop);
+
+  // Modal open: dblclick or Enter on a non-li card (worktree/branch/issue),
+  // and dblclick (NOT single click) on plan/issue li cards (so single
+  // clicks on buttons inside still work).
   document.body.addEventListener("dblclick", (ev) => {
-    const card = ev.target.closest(".card");
+    const card = ev.target.closest && ev.target.closest(".card");
     if (!card) return;
+    // Don't open modal if click was on a button or the dblclick was
+    // initiated inside the card-controls area.
+    if (ev.target.closest("button")) return;
     onCardActivate(card);
   });
   document.body.addEventListener("keydown", (ev) => {
@@ -706,19 +1672,30 @@ function bindCardEvents() {
   });
 }
 
+function onCardActivate(card) {
+  const kind = card.getAttribute("data-kind");
+  if (kind === "plan") {
+    openPlanModal(card.getAttribute("data-slug"));
+  } else if (kind === "issue") {
+    openIssueModal(card.getAttribute("data-number"));
+  }
+  // worktree / branch cards remain display-only.
+}
+
 // ------------------------------------------------------- visibility / boot
 
 document.addEventListener("visibilitychange", () => {
   if (!document.hidden) {
-    // Force-load on becoming visible.
     schedulePoll(0);
+    scheduleWorkPoll(0);
   }
 });
 
 function boot() {
   modalInit();
-  bindCardEvents();
+  bindActionEvents();
   schedulePoll(0);
+  scheduleWorkPoll(0);
 }
 
 if (document.readyState === "loading") {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -22,11 +22,29 @@
     <ul id="errors-list" class="errors-list"></ul>
   </section>
 
+  <div id="toast-region" class="toast-region" aria-live="polite" role="status"></div>
+
   <main id="grid" class="grid">
     <section class="panel panel-plans" aria-label="Plans">
-      <h2 class="panel-title">Plans</h2>
+      <div class="panel-head">
+        <h2 class="panel-title">Plans</h2>
+        <div class="plans-controls">
+          <div id="default-mode-area" class="default-mode-area">
+            <span class="muted" id="default-mode-label">Default mode:</span>
+            <div class="seg" role="group" aria-labelledby="default-mode-label">
+              <button type="button" id="dm-phase" class="seg-btn" aria-pressed="false">Phase-by-phase</button>
+              <button type="button" id="dm-finish" class="seg-btn" aria-pressed="false">Finish (one PR)</button>
+            </div>
+            <span id="default-mode-footnote" class="dm-footnote muted" hidden>
+              Sprint in flight: change applies to plans not yet dispatched and to future sprints; in-flight plans keep their captured mode.
+            </span>
+          </div>
+        </div>
+      </div>
+      <div id="run-status" class="run-status" aria-label="Run status"></div>
       <div id="plans-body" class="panel-body"></div>
       <p id="plans-empty" class="empty muted" hidden>No plans found.</p>
+      <div id="plans-live" class="sr-only" aria-live="polite"></div>
     </section>
 
     <section class="panel panel-branches" aria-label="Branches">
@@ -39,6 +57,7 @@
       <h2 class="panel-title">Issues</h2>
       <div id="issues-body" class="panel-body"></div>
       <p id="issues-empty" class="empty muted" hidden>No open issues.</p>
+      <div id="issues-live" class="sr-only" aria-live="polite"></div>
     </section>
 
     <section class="panel panel-worktrees" aria-label="Worktrees">

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -382,6 +382,349 @@ else
   fail "errors[] differs across consecutive polls"
 fi
 
+###############################################################################
+# Block 3 — Phase 7: interactive queue + write-back
+###############################################################################
+
+echo ""
+echo "=== Phase 7 AC: static-grep contract ==="
+
+# AC: drag handlers wired (HTML5 native: dragstart/dragend/dragenter/dragleave/dragover/drop).
+for ev in dragstart dragend dragenter dragleave dragover drop; do
+  if grep -q "addEventListener(\"$ev\"" "$APP_JS"; then
+    pass "AC: drag event $ev wired via addEventListener"
+  else
+    fail "AC: drag event $ev NOT wired"
+  fi
+done
+
+# AC: Phase 7 endpoint constants present.
+for url in /api/queue /api/trigger /api/work-state/reset /api/work-state; do
+  if grep -q "\"$url\"" "$APP_JS"; then
+    pass "AC: $url URL constant present"
+  else
+    fail "AC: $url URL constant missing"
+  fi
+done
+
+# AC: cache:'no-store' on every fetch site (poll + work-state + queue + trigger + reset + plan + issue = 7).
+NO_STORE_COUNT=$(grep -c 'cache:[[:space:]]*"no-store"' "$APP_JS" || true)
+if [ "${NO_STORE_COUNT:-0}" -ge 6 ]; then
+  pass "AC: cache:'no-store' on every fetch ($NO_STORE_COUNT ≥ 6)"
+else
+  fail "AC: cache:'no-store' missing on some fetches ($NO_STORE_COUNT)"
+fi
+
+# AC: no innerHTML except chrome-only.
+HITS=$(grep -nE '\.innerHTML\s*=' "$APP_JS" | grep -vE '//\s*chrome-only' || true)
+if [ -z "$HITS" ]; then
+  pass "AC: Phase 7 introduces no innerHTML"
+else
+  fail "AC: forbidden innerHTML lines: $HITS"
+fi
+
+# AC: no setInterval (still setTimeout-recursion only).
+if ! grep -nE 'setInterval\s*\(' "$APP_JS" >/dev/null; then
+  pass "AC: setInterval still not used"
+else
+  fail "AC: setInterval is used; must be setTimeout-recursion"
+fi
+
+# AC: no inline event handlers in the static dir.
+if ! grep -nE 'onclick=|onload=' "$STATIC_DIR" -r >/dev/null; then
+  pass "AC: no inline onclick=/onload= handlers (Phase 7)"
+else
+  fail "AC: found inline event handlers"
+fi
+
+# AC: Default-mode toggle UI present.
+if grep -q 'id="dm-phase"' "$INDEX_HTML" && grep -q 'id="dm-finish"' "$INDEX_HTML"; then
+  pass "AC: default-mode segmented buttons in index.html"
+else
+  fail "AC: default-mode buttons missing"
+fi
+
+# AC: in-flight-sprint footnote element present.
+if grep -q 'id="default-mode-footnote"' "$INDEX_HTML"; then
+  pass "AC: default-mode footnote element present"
+else
+  fail "AC: default-mode footnote element missing"
+fi
+if grep -q 'Sprint in flight' "$INDEX_HTML"; then
+  pass "AC: 'Sprint in flight' footnote text present"
+else
+  fail "AC: 'Sprint in flight' footnote text missing"
+fi
+
+# AC: aria-live regions for plans/issues announcements.
+if grep -q 'id="plans-live"' "$INDEX_HTML" && grep -q 'aria-live="polite"' "$INDEX_HTML"; then
+  pass "AC: plans-live aria-live region present"
+else
+  fail "AC: plans-live region missing"
+fi
+
+# AC: run-status widget root element present.
+if grep -q 'id="run-status"' "$INDEX_HTML"; then
+  pass "AC: run-status widget root present"
+else
+  fail "AC: run-status widget missing"
+fi
+
+# AC: PLAN_COLUMNS / ISSUE_COLUMNS constants in app.js.
+if grep -q 'PLAN_COLUMNS' "$APP_JS" && grep -q 'ISSUE_COLUMNS' "$APP_JS"; then
+  pass "AC: PLAN_COLUMNS / ISSUE_COLUMNS constants present"
+else
+  fail "AC: column constants missing"
+fi
+
+# AC: Reconciliation suppress window present (1500ms).
+if grep -q 'POST_RECONCILE_SUPPRESS_MS' "$APP_JS" && grep -q '1500' "$APP_JS"; then
+  pass "AC: reconciliation suppress window 1500ms present"
+else
+  fail "AC: reconciliation window missing"
+fi
+
+# AC: Mode chip and remove button structure in source.
+if grep -q '"mode-chip"' "$APP_JS" && grep -q '"remove-btn"' "$APP_JS"; then
+  pass "AC: mode-chip + remove-btn render code present"
+else
+  fail "AC: mode-chip / remove-btn missing"
+fi
+
+# AC: Move buttons (↑ ↓ ← →) wired with action attributes.
+for act in plan-up plan-down plan-left plan-right issue-up issue-down issue-left issue-right; do
+  if grep -q "\"$act\"" "$APP_JS"; then
+    pass "AC: action $act wired"
+  else
+    fail "AC: action $act missing"
+  fi
+done
+
+# AC: stale-sprint clear-button POSTs reset endpoint.
+if grep -q 'clear-stale-sprint' "$APP_JS"; then
+  pass "AC: clear-stale-sprint action present"
+else
+  fail "AC: clear-stale-sprint action missing"
+fi
+
+# AC: Trigger button + work-state reset POST sites.
+if grep -q 'TRIGGER_URL' "$APP_JS" && grep -q 'WORK_STATE_RESET_URL' "$APP_JS"; then
+  pass "AC: TRIGGER_URL + WORK_STATE_RESET_URL constants present"
+else
+  fail "AC: trigger/reset constants missing"
+fi
+
+###############################################################################
+# Block 4 — Phase 7: live write-back smoke (server already running)
+###############################################################################
+
+echo ""
+echo "=== Phase 7 AC: live write-back smoke ==="
+
+# Re-use the running server from Block 2 — same port, same MAIN_ROOT ($MR).
+
+# AC: POST /api/queue WITHOUT Origin → 403.
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"plans":{"drafted":[],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue")
+if [ "$CODE" = "403" ]; then
+  pass "AC: POST /api/queue without Origin → 403"
+else
+  fail "AC: POST /api/queue no-origin → $CODE"
+fi
+
+# AC: POST /api/queue WITH valid Origin → 200 + state file written.
+STATE_FILE="$MR/.zskills/monitor-state.json"
+rm -f "$STATE_FILE"
+CODE=$(curl -s -o "$MR/post.body" -w '%{http_code}' -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"default_mode":"phase","plans":{"drafted":[{"slug":"ui-fixture-plan"}],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue")
+if [ "$CODE" = "200" ]; then
+  pass "AC: POST /api/queue with valid Origin → 200"
+else
+  fail "AC: POST /api/queue valid → $CODE (body=$(head -c 200 "$MR/post.body"))"
+fi
+if [ -f "$STATE_FILE" ] && grep -q '"ui-fixture-plan"' "$STATE_FILE"; then
+  pass "AC: monitor-state.json updated by POST"
+else
+  fail "AC: monitor-state.json not updated"
+fi
+
+# AC: default_mode flips on POST.
+DM_BEFORE=$(grep -E '"default_mode"' "$STATE_FILE" | head -1)
+curl -s -o /dev/null -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"default_mode":"finish","plans":{"drafted":[{"slug":"ui-fixture-plan"}],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue"
+DM_AFTER=$(grep -E '"default_mode"' "$STATE_FILE" | head -1)
+if printf '%s' "$DM_AFTER" | grep -q '"finish"'; then
+  pass "AC: default_mode flipped to finish via POST"
+else
+  fail "AC: default_mode did not flip (before=$DM_BEFORE after=$DM_AFTER)"
+fi
+
+# AC: per-row mode override persisted.
+curl -s -o /dev/null -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"plans":{"drafted":[],"reviewed":[],"ready":[{"slug":"ui-fixture-plan","mode":"finish"}]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue"
+if grep -qE '"mode":[[:space:]]*"finish"' "$STATE_FILE"; then
+  pass "AC: per-row mode override persisted"
+else
+  fail "AC: per-row mode override not persisted"
+fi
+
+# AC: invalid POST (unknown column) → 400 + state UNCHANGED.
+HASH_BEFORE=$(cksum "$STATE_FILE" | awk '{print $1}')
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"plans":{"drafted":[],"NOT_A_COLUMN":[],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue")
+HASH_AFTER=$(cksum "$STATE_FILE" | awk '{print $1}')
+if [ "$CODE" = "400" ] && [ "$HASH_BEFORE" = "$HASH_AFTER" ]; then
+  pass "AC: invalid POST (unknown column) → 400, state unchanged"
+else
+  fail "AC: invalid POST: code=$CODE hash_changed=$([ "$HASH_BEFORE" = "$HASH_AFTER" ] && echo no || echo yes)"
+fi
+
+# AC: 100 consecutive POSTs leave state file as valid JSON.
+for i in $(seq 1 100); do
+  curl -s -o /dev/null -X POST \
+    -H "Origin: http://127.0.0.1:$PORT" \
+    -H 'Content-Type: application/json' \
+    -d '{"plans":{"drafted":[{"slug":"ui-fixture-plan"}],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+    "http://127.0.0.1:$PORT/api/queue"
+done
+if python3 -c "import json,sys; json.loads(open('$STATE_FILE').read()); print('ok')" >/dev/null 2>&1; then
+  pass "AC: state file is valid JSON after 100 consecutive POSTs"
+else
+  fail "AC: state file invalid after 100 POSTs"
+fi
+
+# AC: 20 parallel POSTs all return 2xx, final file is valid JSON.
+PAR_TMP="$MR/par-codes.txt"
+: > "$PAR_TMP"
+PAR_PIDS=""
+for i in $(seq 1 20); do
+  (curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+    -H "Origin: http://127.0.0.1:$PORT" \
+    -H 'Content-Type: application/json' \
+    -d "{\"plans\":{\"drafted\":[{\"slug\":\"ui-fixture-plan\"}],\"reviewed\":[],\"ready\":[]},\"issues\":{\"triage\":[$i],\"ready\":[]}}" \
+    "http://127.0.0.1:$PORT/api/queue" >> "$PAR_TMP") &
+  PAR_PIDS="$PAR_PIDS $!"
+done
+# Wait only for the curl children, not the long-running server PID.
+for p in $PAR_PIDS; do wait "$p" || true; done
+ANY_5XX=0
+while read -r line; do
+  case "$line" in
+    5*) ANY_5XX=1 ;;
+  esac
+done < "$PAR_TMP"
+if [ "$ANY_5XX" -eq 0 ]; then
+  pass "AC: 20 parallel POSTs all without 5xx"
+else
+  fail "AC: at least one 5xx in 20 parallel POSTs"
+fi
+if python3 -c "import json,sys; json.loads(open('$STATE_FILE').read()); print('ok')" >/dev/null 2>&1; then
+  pass "AC: state file valid JSON after 20 parallel POSTs"
+else
+  fail "AC: state file invalid after parallel POSTs"
+fi
+
+# AC: Two-tab last-write-wins. POST1 then POST2 sequentially with &.
+curl -s -o /dev/null -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"plans":{"drafted":[{"slug":"a-plan"},{"slug":"b-plan"},{"slug":"c-plan"}],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue" &
+P1=$!
+curl -s -o /dev/null -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"plans":{"drafted":[{"slug":"c-plan"},{"slug":"b-plan"},{"slug":"a-plan"}],"reviewed":[],"ready":[]},"issues":{"triage":[],"ready":[]}}' \
+  "http://127.0.0.1:$PORT/api/queue" &
+P2=$!
+wait "$P1" "$P2"
+# Final state must match exactly one payload (last-writer-wins). Both
+# orderings include the same three slugs, so verify the file is parseable
+# and the slug list is exactly {a-plan, b-plan, c-plan} in some order.
+if python3 -c "import json; d=json.loads(open('$STATE_FILE').read()); slugs=[e['slug'] for e in d['plans']['drafted']]; assert sorted(slugs)==['a-plan','b-plan','c-plan'], slugs; print('ok')" >/dev/null 2>&1; then
+  pass "AC: two-tab last-write-wins: final state matches one full payload"
+else
+  fail "AC: two-tab race produced half-merged state"
+fi
+
+# AC: trigger-not-configured → 501.
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  -H 'Content-Type: application/json' \
+  -d '{"command":"/work-on-plans 1 phase"}' \
+  "http://127.0.0.1:$PORT/api/trigger")
+if [ "$CODE" = "501" ]; then
+  pass "AC: /api/trigger no config → 501 (UI hides Run button)"
+else
+  fail "AC: /api/trigger no-config → $CODE (expected 501)"
+fi
+
+# AC: /api/work-state surfaces trigger_configured flag.
+WS_BODY=$(curl -sf -m 3 "http://127.0.0.1:$PORT/api/work-state")
+if printf '%s' "$WS_BODY" | grep -q '"trigger_configured":[[:space:]]*false'; then
+  pass "AC: /api/work-state surfaces trigger_configured=false"
+else
+  fail "AC: /api/work-state missing trigger_configured: $WS_BODY"
+fi
+
+# Configure a trigger then verify trigger_configured flips to true.
+TRIG="$MR/scripts/trig-ui.sh"
+mkdir -p "$MR/scripts"
+cat >"$TRIG" <<'EOF'
+#!/bin/bash
+echo "argv1=$1"
+EOF
+chmod +x "$TRIG"
+cat >"$MR/.claude/zskills-config.json" <<EOF
+{
+  "dev_server": { "default_port": $PORT },
+  "execution": { "landing": "pr" },
+  "dashboard": { "work_on_plans_trigger": "scripts/trig-ui.sh" }
+}
+EOF
+WS_BODY2=$(curl -sf -m 3 "http://127.0.0.1:$PORT/api/work-state")
+if printf '%s' "$WS_BODY2" | grep -q '"trigger_configured":[[:space:]]*true'; then
+  pass "AC: /api/work-state trigger_configured flips to true after config"
+else
+  fail "AC: trigger_configured did not flip: $WS_BODY2"
+fi
+
+# AC: POST /api/work-state/reset writes idle.
+cat >"$MR/.zskills/work-on-plans-state.json" <<'EOF'
+{"state":"sprint","sprint_id":"x","updated_at":"2026-04-29T00:00:00+00:00"}
+EOF
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  -H "Origin: http://127.0.0.1:$PORT" \
+  "http://127.0.0.1:$PORT/api/work-state/reset")
+if [ "$CODE" = "200" ] && grep -q '"state":[[:space:]]*"idle"' "$MR/.zskills/work-on-plans-state.json"; then
+  pass "AC: POST /api/work-state/reset clears stale sprint"
+else
+  fail "AC: reset → $CODE; file=$(cat "$MR/.zskills/work-on-plans-state.json")"
+fi
+
+# AC: reset without Origin → 403.
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  "http://127.0.0.1:$PORT/api/work-state/reset")
+if [ "$CODE" = "403" ]; then
+  pass "AC: POST /api/work-state/reset without Origin → 403"
+else
+  fail "AC: reset no-origin → $CODE"
+fi
+
 # Stop server cleanly via SIGTERM and verify port is released.
 kill -TERM "$SERVER_PID" 2>/dev/null || true
 for _ in 1 2 3 4 5 6 7 8 9 10; do


### PR DESCRIPTION
## Summary

Phase 7 of `plans/ZSKILLS_MONITOR_PLAN.md`. Adds drag-and-drop queue editing, default-mode toggle, per-row mode chips, run-status widget polling, trigger UI with toasts, and POST write-back to `.zskills/work-state.json` for the zskills-dashboard.

- **server.py +24** — adds `trigger_configured` (boolean) field on `/api/work-state`. Origin check, allowlist, atomic `os.replace`, and cross-process `fcntl.flock LOCK_EX` preserved. No new endpoints.
- **static/index.html +21** — default-mode toggle, run-status widget, aria-live region, sr-only class.
- **static/app.css +334** — queue cards, drag affordances, mode chips, run-status states, toasts.
- **static/app.js +1145 net** — HTML5 drag-drop reorder + cross-column move; optimistic update with 1500 ms reconcile suppress and revert-on-failure; ARIA live announcements; default-mode segmented control; per-row Ready-card mode chip; run-status panel covering all 5 states + idle/trigger branch; dismissible toasts; 7 fetch sites, every one cache:'no-store'.
- **tests/test_zskills_monitor_dashboard_ui.sh +343** — 45 → 92 cases: drag/keyboard/ARIA, default-mode + footnote, mode override, run-status state matrix, POST round-trips with 100 sequential and 20 parallel writes, two-tab last-write-wins, trigger 501/200/403.

Hard safety preserved: zero innerHTML, zero setInterval, zero eval, zero remote URLs, zero inline event handlers. Mirror is byte-identical.

## Test plan

- [x] Full test suite green: 1158/1158 (was 1111 after Phase 6, +47 dashboard-UI cases)
- [x] Hard safety greps: zero innerHTML / setInterval / eval / remote URLs / inline handlers in static/
- [x] Every fetch has cache:'no-store' (7 sites, 7 matches)
- [x] POST /api/queue without Origin → 403; with valid Origin → 200; state file atomically updated
- [x] 100 sequential POSTs → file always valid JSON
- [x] 20 parallel POSTs → no 5xx, file always valid JSON
- [x] Two-tab last-write-wins via fcntl.flock LOCK_EX
- [x] Mirror byte-identical (excluding __pycache__)
- [x] No PLAN-TEXT-DRIFT tokens in changed files
- [ ] USER VERIFY: open dashboard, drag a plan card across columns, confirm reconcile suppresses for ~1.5s and final state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)