### PR TITLE
[zskills-monitor-plan] ZSKILLS_MONITOR — Phase 8 (/zskills-dashboard skill)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -1,0 +1,583 @@
+---
+name: zskills-dashboard
+disable-model-invocation: true
+argument-hint: "[start|stop|status]"
+description: >-
+  Local web dashboard for this repo — plans, issues, worktrees,
+  branches, tracking activity, drag-and-drop priority queue.
+  Starts a detached Python HTTP server on a port resolved from
+  DEV_PORT / dev_server.default_port / port.sh; stop sends SIGTERM.
+  State at .zskills/monitor-state.json. Usage:
+  /zskills-dashboard [start|stop|status].
+---
+
+# /zskills-dashboard — Local Monitor Dashboard
+
+`/zskills-dashboard` exposes the Phase 5 Python monitor server as a
+first-class skill. It launches the server detached (so it survives the
+parent shell), records the live PID/port in
+`.zskills/dashboard-server.pid`, and provides start/stop/status modes.
+
+The server itself is `skills/zskills-dashboard/scripts/zskills_monitor/`
+(stdlib-only Python, localhost-bound, atomic-write state). This skill
+body wraps it: port resolution, PID-file handling, process-identity
+checks (command name AND cwd), tracking markers for state-changing
+modes, and a SIGTERM-only stop path (CLAUDE.md rule — never escalate
+to SIGKILL).
+
+## Arguments
+
+```
+/zskills-dashboard start    # launch detached server, write PID file
+/zskills-dashboard stop     # SIGTERM the server, remove PID file
+/zskills-dashboard status   # report PID, port, uptime, log path
+```
+
+`status` is the default when `$ARGUMENTS` is empty.
+
+**Parsing rule.** Treat `$ARGUMENTS` as a single token (lowercased,
+trimmed). Anything that is not `start`, `stop`, `status`, or empty is
+a usage error:
+
+> Usage: /zskills-dashboard [start|stop|status]
+
+Exit 2.
+
+## Step 0 — Common setup (every mode)
+
+Anchor `MAIN_ROOT` to the main checkout regardless of which worktree
+the skill was invoked from. The PID file, log file, and tracking
+markers all live under `$MAIN_ROOT/.zskills/`.
+
+```bash
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
+LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
+PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
+PORT_SCRIPT="$MAIN_ROOT/.claude/skills/update-zskills/scripts/port.sh"
+SANITIZE_SCRIPT="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+
+# Source-tree fallback (zskills repo + tests). In normal installed use the
+# .claude/skills/... paths are canonical.
+[ -x "$PORT_SCRIPT" ] || PORT_SCRIPT="$MAIN_ROOT/skills/update-zskills/scripts/port.sh"
+[ -x "$SANITIZE_SCRIPT" ] || SANITIZE_SCRIPT="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+
+# Server's own scripts dir is in-skill — no install/source split.
+mkdir -p "$MAIN_ROOT/.zskills"
+```
+
+### Process-identity check (shared by start and stop)
+
+Whenever a PID is read from the PID file, verify TWO things before
+trusting it:
+
+1. **Command-name match.** `ps -p $PID -o command=` output must match
+   `python3.*zskills_monitor.server`.
+2. **Cwd match.** The process's cwd must equal `$MAIN_ROOT`. On Linux
+   read `/proc/$PID/cwd`; on macOS or Linux without `/proc`, fall back
+   to `lsof -p $PID -d cwd -Fn` and parse the `n<path>` line. If both
+   methods fail (permission denied or tool missing), skip the cwd
+   check and log a warning to stderr — fall through on command-name
+   match alone.
+
+If EITHER check fails (command-name mismatch OR cwd-mismatch when
+verifiable), the PID is stale, PID-reused, or belongs to a different
+worktree's monitor — do NOT kill it. Treat the PID file as stale.
+
+```bash
+# Returns 0 if PID is alive AND identity matches; 1 otherwise.
+# Stdout is the matched command name (for diagnostics on mismatch).
+verify_monitor_identity() {
+  local pid="$1"
+  local cmd cwd_proc cwd_lsof matched_cwd
+
+  # Liveness — kill -0 with a 2>/dev/null because failure here is the
+  # expected branch (dead PID).
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  cmd=$(ps -p "$pid" -o command= || echo "")
+  if [[ ! "$cmd" =~ python3.*zskills_monitor\.server ]]; then
+    printf 'identity-mismatch: command=%s\n' "$cmd" >&2
+    return 1
+  fi
+
+  # cwd verification — Linux /proc first, lsof fallback. Both
+  # operations may fail (tool missing, permissions) — that branch is
+  # expected, so 2>/dev/null is allowed here per CLAUDE.md rule
+  # exception ("where the failure is the expected branch").
+  cwd_proc=$(readlink "/proc/$pid/cwd" 2>/dev/null || echo "")
+  if [ -n "$cwd_proc" ]; then
+    matched_cwd="$cwd_proc"
+  else
+    cwd_lsof=$(lsof -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+    if [ -n "$cwd_lsof" ]; then
+      matched_cwd="$cwd_lsof"
+    else
+      # Neither method worked — log and accept command-name match alone.
+      printf 'identity-warning: cwd unverifiable for PID %s (no /proc, no lsof output); accepting command-name match\n' "$pid" >&2
+      printf '%s\n' "$cmd"
+      return 0
+    fi
+  fi
+
+  if [ "$matched_cwd" != "$MAIN_ROOT" ]; then
+    printf 'identity-mismatch: cwd=%s expected=%s\n' "$matched_cwd" "$MAIN_ROOT" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$cmd"
+  return 0
+}
+```
+
+### Tracking marker helper (state-changing modes only)
+
+`start` and `stop` write a `fulfilled.zskills-dashboard.<id>` marker
+under `.zskills/tracking/zskills-dashboard.<id>/`. `status` is
+read-only and writes nothing (per Phase 8 spec — avoids flooding
+tracking with one subdir per status check).
+
+```bash
+write_tracking_marker() {
+  local mode="$1" pid_val="${2:-}" port_val="${3:-}"
+  local raw="zskills-dashboard-$(date -u +%Y%m%dT%H%M%SZ)"
+  local id
+  id=$(bash "$SANITIZE_SCRIPT" "$raw")
+  local subdir="$MAIN_ROOT/.zskills/tracking/zskills-dashboard.$id"
+  mkdir -p "$subdir"
+  local marker="$subdir/fulfilled.zskills-dashboard.$id"
+  {
+    printf 'skill: zskills-dashboard\n'
+    printf 'id: %s\n' "$id"
+    printf 'mode: %s\n' "$mode"
+    [ -n "$pid_val" ] && printf 'pid: %s\n' "$pid_val"
+    [ -n "$port_val" ] && printf 'port: %s\n' "$port_val"
+    printf 'status: complete\n'
+    printf 'date: %s\n' "$(TZ=America/New_York date -Iseconds)"
+  } > "$marker"
+  echo "ZSKILLS_PIPELINE_ID=zskills-dashboard.$id"
+}
+```
+
+## Mode dispatch
+
+```bash
+SUB="${ARGUMENTS:-status}"
+SUB=$(printf '%s' "$SUB" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+[ -z "$SUB" ] && SUB="status"
+
+case "$SUB" in
+  start)  ;;
+  stop)   ;;
+  status) ;;
+  *)
+    echo "Usage: /zskills-dashboard [start|stop|status]" >&2
+    exit 2
+    ;;
+esac
+```
+
+## start — launch detached server
+
+1. **Inspect existing PID file.** If present, parse `pid` and `port`
+   via `BASH_REMATCH`, run liveness + identity check. On match,
+   announce "already running" and exit 0. On mismatch, warn and remove
+   the stale PID file before continuing.
+
+2. **Resolve the port.** Invoke the canonical `port.sh` (Phase 5's
+   resolution chain — `DEV_PORT` env > `dev_server.default_port` >
+   stub callout > built-in mapping).
+
+3. **Pre-flight.** If something is already listening on the port,
+   print the friendly busy diagnostic and exit 2.
+
+4. **Launch detached.** `nohup python3 -m zskills_monitor.server`
+   under `cd "$MAIN_ROOT"` with `PYTHONPATH` pointing at
+   `$MAIN_ROOT/skills/zskills-dashboard/scripts` so the package is on
+   `sys.path` (per DA-5). Redirect stdout+stderr to
+   `.zskills/dashboard-server.log`; close stdin to prevent terminal
+   read-block; `disown` so the process is detached from the parent
+   shell job table.
+
+5. **Verify.** Sleep briefly, then `curl -sf
+   http://127.0.0.1:$PORT/api/health` and require `"status":"ok"`.
+   On success, print the URL and exit 0; on failure, print the last
+   20 lines of the log and exit 1 (do NOT SIGTERM — there may be
+   nothing running).
+
+```bash
+if [ "$SUB" = "start" ]; then
+  EXISTING_PID=""
+  EXISTING_PORT=""
+  if [ -f "$PID_FILE" ]; then
+    PID_BODY=$(cat "$PID_FILE")
+    if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+      EXISTING_PID="${BASH_REMATCH[2]}"
+    fi
+    if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+      EXISTING_PORT="${BASH_REMATCH[2]}"
+    fi
+
+    if [ -n "$EXISTING_PID" ]; then
+      if verify_monitor_identity "$EXISTING_PID" >/dev/null; then
+        echo "already running at http://127.0.0.1:${EXISTING_PORT:-?}/ (pid $EXISTING_PID)"
+        write_tracking_marker "start-already-running" "$EXISTING_PID" "${EXISTING_PORT:-}"
+        exit 0
+      else
+        echo "WARN: stale PID file at $PID_FILE (pid $EXISTING_PID does not match zskills_monitor); removing." >&2
+        rm -- "$PID_FILE"
+      fi
+    else
+      echo "WARN: PID file $PID_FILE has no parseable pid= line; removing." >&2
+      rm -- "$PID_FILE"
+    fi
+  fi
+
+  # Resolve port via canonical port.sh.
+  if [ ! -x "$PORT_SCRIPT" ]; then
+    echo "ERROR: port resolver not found at $PORT_SCRIPT" >&2
+    exit 1
+  fi
+  PORT=$(bash "$PORT_SCRIPT")
+  if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: port.sh returned non-numeric value: $PORT" >&2
+    exit 1
+  fi
+
+  # Pre-flight: refuse if another holder owns the port.
+  if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    HOLDER=$(lsof -iTCP:"$PORT" -sTCP:LISTEN -Fpcn 2>/dev/null | head -20 | tr '\n' ' ')
+    echo "ERROR: port $PORT is already in use (holder: $HOLDER). Stop the holder manually or set DEV_PORT to a free port; do NOT use SIGKILL." >&2
+    exit 2
+  fi
+
+  # Launch detached. cd into MAIN_ROOT so the server's resolve_main_root
+  # cwd-walk lands here. PYTHONPATH prepend keeps the package importable
+  # without an install. nohup + disown survives parent-shell exit.
+  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to
+  # PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (per DA-5).
+  ( cd "$MAIN_ROOT" && \
+    PYTHONPATH="$PKG_PARENT:${PYTHONPATH:-}" \
+    nohup python3 -m zskills_monitor.server \
+      > "$LOG_FILE" 2>&1 < /dev/null & disown )
+
+  # Health-check loop — up to ~10s for bind + first response. Python
+  # interpreter startup + module imports take 1-2s on common Linux,
+  # longer under containers / slow CI; we don't want a healthy server
+  # to look "broken" because the parent shell polled too eagerly.
+  HEALTHY=0
+  HEALTH_BODY=""
+  for _ in $(seq 1 40); do
+    sleep 0.25
+    HEALTH_BODY=$(curl -sf -m 1 "http://127.0.0.1:$PORT/api/health" || true)
+    # Server emits JSON with `"status": "ok"` (note the space after the
+    # colon — Python's json.dumps default). Tolerate either spacing in
+    # the assertion.
+    if printf '%s' "$HEALTH_BODY" | grep -qE '"status":[[:space:]]*"ok"'; then
+      HEALTHY=1
+      break
+    fi
+  done
+
+  if [ "$HEALTHY" -ne 1 ]; then
+    echo "ERROR: server did not respond on http://127.0.0.1:$PORT/api/health within 10s." >&2
+    echo "Last 20 lines of $LOG_FILE:" >&2
+    tail -n 20 "$LOG_FILE" >&2 || true
+    exit 1
+  fi
+
+  # Verify PID file landed (server writes it after bind). Read pid for
+  # the tracking marker.
+  if [ ! -f "$PID_FILE" ]; then
+    echo "ERROR: server is healthy but PID file was not written at $PID_FILE." >&2
+    exit 1
+  fi
+  PIDFILE_BODY=$(cat "$PID_FILE")
+  NEW_PID=""
+  if [[ "$PIDFILE_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    NEW_PID="${BASH_REMATCH[2]}"
+  fi
+
+  echo "Monitor running at http://127.0.0.1:$PORT/  (pid ${NEW_PID:-?}, log $LOG_FILE)"
+  write_tracking_marker "start" "$NEW_PID" "$PORT"
+  exit 0
+fi
+```
+
+## stop — SIGTERM and clean up
+
+1. No PID file → "No running monitor (no PID file)." Exit 0
+   (idempotent).
+
+2. Parse `pid` and `port`. If the PID is not alive, the file is stale
+   — remove it and exit 0.
+
+3. **Process-identity check** (command name AND cwd, per F-11). If
+   EITHER fails, print the mismatch diagnostic and **refuse to kill**
+   — exit 1 without touching the unrelated process.
+
+4. `kill -TERM $PID`. Poll `kill -0 $PID` every 200ms for up to 5s.
+
+5. If the process is still alive after 5s, refuse to escalate to
+   SIGKILL (CLAUDE.md rule). Print a manual-recovery message and
+   exit 1.
+
+6. Verify the port is free with `lsof`. Remove the PID file. Exit 0.
+
+```bash
+if [ "$SUB" = "stop" ]; then
+  if [ ! -f "$PID_FILE" ]; then
+    echo "No running monitor (no PID file)."
+    write_tracking_marker "stop-no-pidfile"
+    exit 0
+  fi
+
+  PID_BODY=$(cat "$PID_FILE")
+  STOP_PID=""
+  STOP_PORT=""
+  if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    STOP_PID="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+    STOP_PORT="${BASH_REMATCH[2]}"
+  fi
+
+  if [ -z "$STOP_PID" ]; then
+    echo "ERROR: PID file at $PID_FILE has no parseable pid= line; remove it manually." >&2
+    exit 1
+  fi
+
+  # kill -0 — failure is the expected branch (dead PID), so 2>/dev/null
+  # is allowed here per CLAUDE.md rule.
+  if ! kill -0 "$STOP_PID" 2>/dev/null; then
+    echo "Monitor PID file is stale (PID $STOP_PID is not running). Removing $PID_FILE."
+    rm -- "$PID_FILE"
+    write_tracking_marker "stop-stale-pidfile" "$STOP_PID" "${STOP_PORT:-}"
+    exit 0
+  fi
+
+  # Identity check — refuse to kill on either command-name OR cwd mismatch.
+  IDENTITY_CMD=""
+  if ! IDENTITY_CMD=$(verify_monitor_identity "$STOP_PID"); then
+    # Re-read for diagnostics.
+    DIAG_CMD=$(ps -p "$STOP_PID" -o command= || echo "<gone>")
+    DIAG_CWD=$(readlink "/proc/$STOP_PID/cwd" 2>/dev/null \
+      || lsof -p "$STOP_PID" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}' \
+      || echo "<unknown>")
+    echo "PID $STOP_PID does not appear to be zskills-monitor for this repo (matched: $DIAG_CMD; cwd: $DIAG_CWD). Refusing to kill. Remove the PID file manually if stale." >&2
+    exit 1
+  fi
+
+  # SIGTERM only — never escalate to SIGKILL or use process-mass-kill tools.
+  if ! kill -TERM "$STOP_PID"; then
+    echo "ERROR: kill -TERM $STOP_PID failed." >&2
+    exit 1
+  fi
+
+  # Poll for exit (up to ~5s, 200ms granularity).
+  EXITED=0
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do
+    if ! kill -0 "$STOP_PID" 2>/dev/null; then
+      EXITED=1
+      break
+    fi
+    sleep 0.2
+  done
+
+  if [ "$EXITED" -ne 1 ]; then
+    echo "Monitor did not exit within 5s. Run 'lsof -i :$STOP_PORT' and stop manually; do NOT escalate to SIGKILL." >&2
+    exit 1
+  fi
+
+  # Verify port released. lsof returning 0 (still LISTENing) is failure.
+  if [ -n "$STOP_PORT" ]; then
+    if lsof -iTCP:"$STOP_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+      echo "WARN: PID $STOP_PID is gone but port $STOP_PORT still has a listener. Investigate before next start." >&2
+    fi
+  fi
+
+  # Remove PID file (server's own SIGTERM handler already removes it,
+  # but belt-and-suspenders for cases where the file outlived the process).
+  if [ -f "$PID_FILE" ]; then
+    rm -- "$PID_FILE"
+  fi
+
+  echo "Monitor stopped (pid $STOP_PID, port ${STOP_PORT:-?})."
+  write_tracking_marker "stop" "$STOP_PID" "${STOP_PORT:-}"
+  exit 0
+fi
+```
+
+## status — read-only health report
+
+1. No PID file → "Monitor not running." Exit 0.
+
+2. Parse `pid`, `port`, `started_at` via `BASH_REMATCH`. If
+   `started_at` does not match `^[0-9T:+-]+$`, treat the PID file as
+   malformed: print a recovery diagnostic and exit 1 (per DA-8).
+
+3. `kill -0 $PID`. If the process is dead, the PID file is stale —
+   print a recovery message and exit 1 (do NOT auto-clean; status is
+   read-only).
+
+4. Compute uptime from `started_at` (ISO-8601) using `date -d`
+   arithmetic; print URL, PID, uptime, log path. Exit 0.
+
+```bash
+if [ "$SUB" = "status" ]; then
+  if [ ! -f "$PID_FILE" ]; then
+    echo "Monitor not running."
+    exit 0
+  fi
+
+  PID_BODY=$(cat "$PID_FILE")
+  ST_PID=""
+  ST_PORT=""
+  ST_STARTED=""
+  if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    ST_PID="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+    ST_PORT="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')started_at=([^[:space:]]+) ]]; then
+    ST_STARTED="${BASH_REMATCH[2]}"
+  fi
+
+  if [ -z "$ST_PID" ] || [ -z "$ST_PORT" ] || [ -z "$ST_STARTED" ]; then
+    echo "PID file at $PID_FILE is missing required fields (pid/port/started_at). rm it and retry /zskills-dashboard start" >&2
+    exit 1
+  fi
+
+  if [[ ! "$ST_STARTED" =~ ^[0-9T:+-]+$ ]]; then
+    echo "PID file at $PID_FILE has malformed started_at; rm it and retry /zskills-dashboard start" >&2
+    exit 1
+  fi
+
+  # kill -0 — failure is the expected branch (dead PID), so 2>/dev/null
+  # is allowed here per CLAUDE.md rule.
+  if ! kill -0 "$ST_PID" 2>/dev/null; then
+    echo "Monitor PID file is stale (PID $ST_PID not running). Run 'lsof -i :$ST_PORT' to verify port is free, then retry /zskills-dashboard start." >&2
+    exit 1
+  fi
+
+  # Compute uptime via GNU date arithmetic. The started_at line is ISO-8601
+  # with timezone, which `date -d` accepts directly.
+  NOW_EPOCH=$(date +%s)
+  STARTED_EPOCH=$(date -d "$ST_STARTED" +%s 2>/dev/null || echo "")
+  if [ -z "$STARTED_EPOCH" ]; then
+    UPTIME_STR="(uptime unknown — date -d could not parse '$ST_STARTED')"
+  else
+    SECS=$((NOW_EPOCH - STARTED_EPOCH))
+    [ "$SECS" -lt 0 ] && SECS=0
+    H=$((SECS / 3600))
+    M=$(((SECS % 3600) / 60))
+    S=$((SECS % 60))
+    UPTIME_STR=$(printf '%dh %dm %ds' "$H" "$M" "$S")
+  fi
+
+  cat <<STATUS_EOF
+Monitor running at http://127.0.0.1:$ST_PORT/
+  pid:      $ST_PID
+  started:  $ST_STARTED
+  uptime:   $UPTIME_STR
+  log:      $LOG_FILE
+STATUS_EOF
+  exit 0
+fi
+```
+
+## Mirror
+
+After every edit, regenerate the `.claude/skills/zskills-dashboard/`
+mirror via the Tier-2 hook-compatible script:
+
+```bash
+bash scripts/mirror-skill.sh zskills-dashboard
+```
+
+`mirror-skill.sh` does per-file `rm` for orphan removal — it never
+invokes a recursive remove of the mirror tree, which the project's
+`block-unsafe-generic.sh` hook would block. After the script returns,
+`diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/`
+must be empty.
+
+## Configuration
+
+The dashboard reads `.claude/zskills-config.json` for two fields:
+
+- `dev_server.default_port` (integer) — default port when neither
+  `DEV_PORT` env nor a stub callout overrides. Read by `port.sh`.
+- `dashboard.work_on_plans_trigger` (string, optional) — relative path
+  to a user-owned trigger script. When set, the dashboard's "Run"
+  button posts to `/api/trigger`, which spawns the script with the
+  selected `/work-on-plans` invocation as argv[1]. **No default script
+  is shipped** — this is plumbing the consumer must wire. If the field
+  is absent or empty, the Run button is hidden client-side and
+  `/api/trigger` returns 501.
+
+Example `dashboard.work_on_plans_trigger` (consumer-authored):
+
+```bash
+#!/bin/bash
+# scripts/work-on-plans-trigger.sh — consumer-owned plumbing for the
+# dashboard's Run button. argv[1] is the /work-on-plans command line.
+exec >>".zskills/work-on-plans-trigger.log" 2>&1
+echo "[$(date -Iseconds)] trigger: $1"
+# Drop a request file your session-watching tool can pick up:
+mkdir -p .zskills/triggers
+printf '%s\n' "$1" > ".zskills/triggers/$(date -u +%Y%m%dT%H%M%SZ).cmd"
+```
+
+## Tracking markers
+
+`start` and `stop` (and their no-op / stale variants) write a
+`fulfilled.zskills-dashboard.<id>` under
+`.zskills/tracking/zskills-dashboard.<id>/`. The id is
+`zskills-dashboard-<utc-timestamp>` passed through
+`sanitize-pipeline-id.sh`. Subdir-name layout is Option B per
+`docs/tracking/TRACKING_NAMING.md`.
+
+`status` is read-only and writes nothing.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success (server running, stopped cleanly, or no-op idempotent path) |
+| 1 | Health check failed, identity mismatch (refused to kill), stale PID file under `status`, or PID-file malformed |
+| 2 | Usage error, port already in use under `start`, or unknown subcommand |
+
+## Key rules
+
+- **SIGTERM only.** Never escalate to SIGKILL, and never reach for
+  process-mass-kill tools (the obvious ones are forbidden by
+  CLAUDE.md). On a stuck process, surface manual-recovery
+  instructions and exit 1.
+- **Never bypass identity check.** Both command-name AND cwd must
+  match before `stop` will signal a PID. Same defense applies on
+  `start` when checking an existing PID file.
+- **No JSON CLI parser.** Use `BASH_REMATCH` for all parsing (PID
+  file is `.env`-style; config reads via `port.sh`'s own bash regex).
+  Per zskills convention.
+- **No `2>/dev/null` on fallible operations.** The two exceptions
+  documented in CLAUDE.md apply here: `kill -0` (liveness — failure
+  IS the dead-PID branch) and `readlink /proc/$PID/cwd` /
+  `lsof -p ... -d cwd` (non-Linux fallback — failure IS the missing-
+  /proc branch).
+- **MAIN_ROOT-anchored paths.** Every read/write goes through
+  `$MAIN_ROOT/.zskills/...`, never cwd-relative — invoking the skill
+  from a worktree must still see the main repo's PID file.
+- **PYTHONPATH discipline.** `start` prepends
+  `$MAIN_ROOT/skills/zskills-dashboard/scripts` to `PYTHONPATH` so
+  `python3 -m zskills_monitor.server` resolves the package without an
+  install step (per DA-5).
+- **Verify after every state change.** `start` curls
+  `/api/health`; `stop` polls `kill -0` then verifies the port is
+  freed via `lsof`.
+- **Tracking markers for state-changing modes only.** `start` and
+  `stop` write `fulfilled.zskills-dashboard.<id>`; `status` does not.
+- **Mirror via `scripts/mirror-skill.sh`** — never use a recursive
+  remove on the mirror tree (hook will block).

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .zskills/monitor-state.json.lock
 .zskills/work-on-plans-state.json
 .zskills/dashboard-server.pid
+.zskills/dashboard-server.log
 .zskills-tracked
 
 .worktreepurpose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 2026-04-29
+
+### Added — `/zskills-dashboard` skill
+
+`/zskills-dashboard [start|stop|status]` exposes the Phase 5 monitor
+server as a first-class skill. `start` launches the server detached
+(`nohup … & disown`) so it survives the parent shell, writes
+`.zskills/dashboard-server.pid` (`.env`-style: `pid=…`, `port=…`,
+`started_at=…`), and verifies via `/api/health`. `stop` sends SIGTERM
+only (never `kill -9`), polls for exit up to 5s, and verifies the port
+is released. `status` reads the PID file, runs `kill -0`, and prints
+URL/PID/uptime/log path.
+
+Both `start` and `stop` use a **two-factor process-identity check**
+(command name match `python3.*zskills_monitor.server` AND cwd match
+`MAIN_ROOT` via `/proc/$PID/cwd` with `lsof -p $PID -d cwd` fallback)
+so stale or PID-reused entries — and PIDs belonging to a different
+worktree's monitor — never get killed by accident. State-changing
+modes write a `fulfilled.zskills-dashboard.<id>` tracking marker; the
+read-only `status` does not.
+
+New config field: `dashboard.work_on_plans_trigger` (string,
+optional) — relative path to a consumer-authored trigger script. When
+set, the dashboard "Run" button posts to `/api/trigger` and the server
+spawns the script with the selected `/work-on-plans` command as
+argv[1]. **No default script is shipped** — this is plumbing the
+consumer wires. When absent, the Run button is hidden and
+`/api/trigger` returns 501.
+
+Example consumer trigger script:
+
+```bash
+#!/bin/bash
+# scripts/work-on-plans-trigger.sh
+exec >>".zskills/work-on-plans-trigger.log" 2>&1
+echo "[$(date -Iseconds)] trigger: $1"
+mkdir -p .zskills/triggers
+printf '%s\n' "$1" > ".zskills/triggers/$(date -u +%Y%m%dT%H%M%SZ).cmd"
+```
+
+`.zskills/dashboard-server.log` added to `.gitignore`.
+
 ## 2026-04-28
 
 ### Migration — /plans work removed

--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ Key fields:
 - **`agents.min_model`** — Minimum model for subagent dispatch.
   `auto` = "inherit from this session's model." Enforced by the
   `block-agents.sh` hook.
+- **`dashboard.work_on_plans_trigger`** — Optional relative path to a
+  consumer-authored script the `/zskills-dashboard` server invokes
+  when the UI's Run button is clicked. The selected `/work-on-plans`
+  invocation is passed as argv[1]. No default script is shipped (this
+  is plumbing the consumer wires). When absent or empty, the Run
+  button is hidden and `/api/trigger` returns 501. Example:
+  ```bash
+  #!/bin/bash
+  # scripts/work-on-plans-trigger.sh
+  exec >>".zskills/work-on-plans-trigger.log" 2>&1
+  echo "[$(date -Iseconds)] trigger: $1"
+  mkdir -p .zskills/triggers
+  printf '%s\n' "$1" > ".zskills/triggers/$(date -u +%Y%m%dT%H%M%SZ).cmd"
+  ```
 
 ## Tracking scheme
 
@@ -424,6 +438,7 @@ data pipeline.
 | `/manual-testing` | Playwright-cli recipes: real mouse/keyboard events, not eval — test as a user would |
 | `/create-worktree` | Unified worktree creation (used by other skills and ad-hoc): prefix-derived path, safe branch-add with TOCTOU remap |
 | `/update-zskills` | Install or update Z Skills infrastructure in any project |
+| `/zskills-dashboard` | Local web dashboard for plans/issues/worktrees/branches/tracking: `start` launches a detached Python server, `stop` SIGTERMs it, `status` reports uptime |
 
 ### Block Diagram Add-on (`block-diagram/`)
 

--- a/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/plans/ZSKILLS_MONITOR_PLAN.md
@@ -255,8 +255,8 @@ is appended to `errors[]`.
 | 4 — Data aggregation library | ✅ Done | `b720fbb` | landed via PR squash; Python module at skills/zskills-dashboard/scripts/zskills_monitor/; 1277-line collect.py; 12 fixture sets; +29 tests; 1000/1000 |
 | 5 — HTTP server | ✅ Done | `63747e5` | landed via PR squash; server.py 1099 lines; 9 endpoints; 127.0.0.1 only; trigger security contract; flock + atomic writes; +53 tests |
 | 6 — Read-only dashboard UI | ✅ Done | `1239f6c` | landed via PR squash; static HTML/CSS/JS; 5 panels + 2 modals; XSS-safe; +45 tests; 1111/1111 |
-| 7 — Interactive queue + write-back | 🟡 In Progress | | |
-| 8 — `/zskills-dashboard` skill | ⬚ | | |
+| 7 — Interactive queue + write-back | ✅ Done | `208fb7f` | landed via PR #115 squash; drag-drop + default-mode + per-row chips + run-status + POST write-back; +47 tests; 1158/1158 |
+| 8 — `/zskills-dashboard` skill | 🟡 In Progress | | |
 | 9 — Migrate `/plans rebuild` to Python aggregator | ⬚ | | |
 
 ---

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -1,0 +1,583 @@
+---
+name: zskills-dashboard
+disable-model-invocation: true
+argument-hint: "[start|stop|status]"
+description: >-
+  Local web dashboard for this repo — plans, issues, worktrees,
+  branches, tracking activity, drag-and-drop priority queue.
+  Starts a detached Python HTTP server on a port resolved from
+  DEV_PORT / dev_server.default_port / port.sh; stop sends SIGTERM.
+  State at .zskills/monitor-state.json. Usage:
+  /zskills-dashboard [start|stop|status].
+---
+
+# /zskills-dashboard — Local Monitor Dashboard
+
+`/zskills-dashboard` exposes the Phase 5 Python monitor server as a
+first-class skill. It launches the server detached (so it survives the
+parent shell), records the live PID/port in
+`.zskills/dashboard-server.pid`, and provides start/stop/status modes.
+
+The server itself is `skills/zskills-dashboard/scripts/zskills_monitor/`
+(stdlib-only Python, localhost-bound, atomic-write state). This skill
+body wraps it: port resolution, PID-file handling, process-identity
+checks (command name AND cwd), tracking markers for state-changing
+modes, and a SIGTERM-only stop path (CLAUDE.md rule — never escalate
+to SIGKILL).
+
+## Arguments
+
+```
+/zskills-dashboard start    # launch detached server, write PID file
+/zskills-dashboard stop     # SIGTERM the server, remove PID file
+/zskills-dashboard status   # report PID, port, uptime, log path
+```
+
+`status` is the default when `$ARGUMENTS` is empty.
+
+**Parsing rule.** Treat `$ARGUMENTS` as a single token (lowercased,
+trimmed). Anything that is not `start`, `stop`, `status`, or empty is
+a usage error:
+
+> Usage: /zskills-dashboard [start|stop|status]
+
+Exit 2.
+
+## Step 0 — Common setup (every mode)
+
+Anchor `MAIN_ROOT` to the main checkout regardless of which worktree
+the skill was invoked from. The PID file, log file, and tracking
+markers all live under `$MAIN_ROOT/.zskills/`.
+
+```bash
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
+LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
+PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
+PORT_SCRIPT="$MAIN_ROOT/.claude/skills/update-zskills/scripts/port.sh"
+SANITIZE_SCRIPT="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+
+# Source-tree fallback (zskills repo + tests). In normal installed use the
+# .claude/skills/... paths are canonical.
+[ -x "$PORT_SCRIPT" ] || PORT_SCRIPT="$MAIN_ROOT/skills/update-zskills/scripts/port.sh"
+[ -x "$SANITIZE_SCRIPT" ] || SANITIZE_SCRIPT="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+
+# Server's own scripts dir is in-skill — no install/source split.
+mkdir -p "$MAIN_ROOT/.zskills"
+```
+
+### Process-identity check (shared by start and stop)
+
+Whenever a PID is read from the PID file, verify TWO things before
+trusting it:
+
+1. **Command-name match.** `ps -p $PID -o command=` output must match
+   `python3.*zskills_monitor.server`.
+2. **Cwd match.** The process's cwd must equal `$MAIN_ROOT`. On Linux
+   read `/proc/$PID/cwd`; on macOS or Linux without `/proc`, fall back
+   to `lsof -p $PID -d cwd -Fn` and parse the `n<path>` line. If both
+   methods fail (permission denied or tool missing), skip the cwd
+   check and log a warning to stderr — fall through on command-name
+   match alone.
+
+If EITHER check fails (command-name mismatch OR cwd-mismatch when
+verifiable), the PID is stale, PID-reused, or belongs to a different
+worktree's monitor — do NOT kill it. Treat the PID file as stale.
+
+```bash
+# Returns 0 if PID is alive AND identity matches; 1 otherwise.
+# Stdout is the matched command name (for diagnostics on mismatch).
+verify_monitor_identity() {
+  local pid="$1"
+  local cmd cwd_proc cwd_lsof matched_cwd
+
+  # Liveness — kill -0 with a 2>/dev/null because failure here is the
+  # expected branch (dead PID).
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  cmd=$(ps -p "$pid" -o command= || echo "")
+  if [[ ! "$cmd" =~ python3.*zskills_monitor\.server ]]; then
+    printf 'identity-mismatch: command=%s\n' "$cmd" >&2
+    return 1
+  fi
+
+  # cwd verification — Linux /proc first, lsof fallback. Both
+  # operations may fail (tool missing, permissions) — that branch is
+  # expected, so 2>/dev/null is allowed here per CLAUDE.md rule
+  # exception ("where the failure is the expected branch").
+  cwd_proc=$(readlink "/proc/$pid/cwd" 2>/dev/null || echo "")
+  if [ -n "$cwd_proc" ]; then
+    matched_cwd="$cwd_proc"
+  else
+    cwd_lsof=$(lsof -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+    if [ -n "$cwd_lsof" ]; then
+      matched_cwd="$cwd_lsof"
+    else
+      # Neither method worked — log and accept command-name match alone.
+      printf 'identity-warning: cwd unverifiable for PID %s (no /proc, no lsof output); accepting command-name match\n' "$pid" >&2
+      printf '%s\n' "$cmd"
+      return 0
+    fi
+  fi
+
+  if [ "$matched_cwd" != "$MAIN_ROOT" ]; then
+    printf 'identity-mismatch: cwd=%s expected=%s\n' "$matched_cwd" "$MAIN_ROOT" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$cmd"
+  return 0
+}
+```
+
+### Tracking marker helper (state-changing modes only)
+
+`start` and `stop` write a `fulfilled.zskills-dashboard.<id>` marker
+under `.zskills/tracking/zskills-dashboard.<id>/`. `status` is
+read-only and writes nothing (per Phase 8 spec — avoids flooding
+tracking with one subdir per status check).
+
+```bash
+write_tracking_marker() {
+  local mode="$1" pid_val="${2:-}" port_val="${3:-}"
+  local raw="zskills-dashboard-$(date -u +%Y%m%dT%H%M%SZ)"
+  local id
+  id=$(bash "$SANITIZE_SCRIPT" "$raw")
+  local subdir="$MAIN_ROOT/.zskills/tracking/zskills-dashboard.$id"
+  mkdir -p "$subdir"
+  local marker="$subdir/fulfilled.zskills-dashboard.$id"
+  {
+    printf 'skill: zskills-dashboard\n'
+    printf 'id: %s\n' "$id"
+    printf 'mode: %s\n' "$mode"
+    [ -n "$pid_val" ] && printf 'pid: %s\n' "$pid_val"
+    [ -n "$port_val" ] && printf 'port: %s\n' "$port_val"
+    printf 'status: complete\n'
+    printf 'date: %s\n' "$(TZ=America/New_York date -Iseconds)"
+  } > "$marker"
+  echo "ZSKILLS_PIPELINE_ID=zskills-dashboard.$id"
+}
+```
+
+## Mode dispatch
+
+```bash
+SUB="${ARGUMENTS:-status}"
+SUB=$(printf '%s' "$SUB" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+[ -z "$SUB" ] && SUB="status"
+
+case "$SUB" in
+  start)  ;;
+  stop)   ;;
+  status) ;;
+  *)
+    echo "Usage: /zskills-dashboard [start|stop|status]" >&2
+    exit 2
+    ;;
+esac
+```
+
+## start — launch detached server
+
+1. **Inspect existing PID file.** If present, parse `pid` and `port`
+   via `BASH_REMATCH`, run liveness + identity check. On match,
+   announce "already running" and exit 0. On mismatch, warn and remove
+   the stale PID file before continuing.
+
+2. **Resolve the port.** Invoke the canonical `port.sh` (Phase 5's
+   resolution chain — `DEV_PORT` env > `dev_server.default_port` >
+   stub callout > built-in mapping).
+
+3. **Pre-flight.** If something is already listening on the port,
+   print the friendly busy diagnostic and exit 2.
+
+4. **Launch detached.** `nohup python3 -m zskills_monitor.server`
+   under `cd "$MAIN_ROOT"` with `PYTHONPATH` pointing at
+   `$MAIN_ROOT/skills/zskills-dashboard/scripts` so the package is on
+   `sys.path` (per DA-5). Redirect stdout+stderr to
+   `.zskills/dashboard-server.log`; close stdin to prevent terminal
+   read-block; `disown` so the process is detached from the parent
+   shell job table.
+
+5. **Verify.** Sleep briefly, then `curl -sf
+   http://127.0.0.1:$PORT/api/health` and require `"status":"ok"`.
+   On success, print the URL and exit 0; on failure, print the last
+   20 lines of the log and exit 1 (do NOT SIGTERM — there may be
+   nothing running).
+
+```bash
+if [ "$SUB" = "start" ]; then
+  EXISTING_PID=""
+  EXISTING_PORT=""
+  if [ -f "$PID_FILE" ]; then
+    PID_BODY=$(cat "$PID_FILE")
+    if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+      EXISTING_PID="${BASH_REMATCH[2]}"
+    fi
+    if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+      EXISTING_PORT="${BASH_REMATCH[2]}"
+    fi
+
+    if [ -n "$EXISTING_PID" ]; then
+      if verify_monitor_identity "$EXISTING_PID" >/dev/null; then
+        echo "already running at http://127.0.0.1:${EXISTING_PORT:-?}/ (pid $EXISTING_PID)"
+        write_tracking_marker "start-already-running" "$EXISTING_PID" "${EXISTING_PORT:-}"
+        exit 0
+      else
+        echo "WARN: stale PID file at $PID_FILE (pid $EXISTING_PID does not match zskills_monitor); removing." >&2
+        rm -- "$PID_FILE"
+      fi
+    else
+      echo "WARN: PID file $PID_FILE has no parseable pid= line; removing." >&2
+      rm -- "$PID_FILE"
+    fi
+  fi
+
+  # Resolve port via canonical port.sh.
+  if [ ! -x "$PORT_SCRIPT" ]; then
+    echo "ERROR: port resolver not found at $PORT_SCRIPT" >&2
+    exit 1
+  fi
+  PORT=$(bash "$PORT_SCRIPT")
+  if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: port.sh returned non-numeric value: $PORT" >&2
+    exit 1
+  fi
+
+  # Pre-flight: refuse if another holder owns the port.
+  if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    HOLDER=$(lsof -iTCP:"$PORT" -sTCP:LISTEN -Fpcn 2>/dev/null | head -20 | tr '\n' ' ')
+    echo "ERROR: port $PORT is already in use (holder: $HOLDER). Stop the holder manually or set DEV_PORT to a free port; do NOT use SIGKILL." >&2
+    exit 2
+  fi
+
+  # Launch detached. cd into MAIN_ROOT so the server's resolve_main_root
+  # cwd-walk lands here. PYTHONPATH prepend keeps the package importable
+  # without an install. nohup + disown survives parent-shell exit.
+  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to
+  # PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (per DA-5).
+  ( cd "$MAIN_ROOT" && \
+    PYTHONPATH="$PKG_PARENT:${PYTHONPATH:-}" \
+    nohup python3 -m zskills_monitor.server \
+      > "$LOG_FILE" 2>&1 < /dev/null & disown )
+
+  # Health-check loop — up to ~10s for bind + first response. Python
+  # interpreter startup + module imports take 1-2s on common Linux,
+  # longer under containers / slow CI; we don't want a healthy server
+  # to look "broken" because the parent shell polled too eagerly.
+  HEALTHY=0
+  HEALTH_BODY=""
+  for _ in $(seq 1 40); do
+    sleep 0.25
+    HEALTH_BODY=$(curl -sf -m 1 "http://127.0.0.1:$PORT/api/health" || true)
+    # Server emits JSON with `"status": "ok"` (note the space after the
+    # colon — Python's json.dumps default). Tolerate either spacing in
+    # the assertion.
+    if printf '%s' "$HEALTH_BODY" | grep -qE '"status":[[:space:]]*"ok"'; then
+      HEALTHY=1
+      break
+    fi
+  done
+
+  if [ "$HEALTHY" -ne 1 ]; then
+    echo "ERROR: server did not respond on http://127.0.0.1:$PORT/api/health within 10s." >&2
+    echo "Last 20 lines of $LOG_FILE:" >&2
+    tail -n 20 "$LOG_FILE" >&2 || true
+    exit 1
+  fi
+
+  # Verify PID file landed (server writes it after bind). Read pid for
+  # the tracking marker.
+  if [ ! -f "$PID_FILE" ]; then
+    echo "ERROR: server is healthy but PID file was not written at $PID_FILE." >&2
+    exit 1
+  fi
+  PIDFILE_BODY=$(cat "$PID_FILE")
+  NEW_PID=""
+  if [[ "$PIDFILE_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    NEW_PID="${BASH_REMATCH[2]}"
+  fi
+
+  echo "Monitor running at http://127.0.0.1:$PORT/  (pid ${NEW_PID:-?}, log $LOG_FILE)"
+  write_tracking_marker "start" "$NEW_PID" "$PORT"
+  exit 0
+fi
+```
+
+## stop — SIGTERM and clean up
+
+1. No PID file → "No running monitor (no PID file)." Exit 0
+   (idempotent).
+
+2. Parse `pid` and `port`. If the PID is not alive, the file is stale
+   — remove it and exit 0.
+
+3. **Process-identity check** (command name AND cwd, per F-11). If
+   EITHER fails, print the mismatch diagnostic and **refuse to kill**
+   — exit 1 without touching the unrelated process.
+
+4. `kill -TERM $PID`. Poll `kill -0 $PID` every 200ms for up to 5s.
+
+5. If the process is still alive after 5s, refuse to escalate to
+   SIGKILL (CLAUDE.md rule). Print a manual-recovery message and
+   exit 1.
+
+6. Verify the port is free with `lsof`. Remove the PID file. Exit 0.
+
+```bash
+if [ "$SUB" = "stop" ]; then
+  if [ ! -f "$PID_FILE" ]; then
+    echo "No running monitor (no PID file)."
+    write_tracking_marker "stop-no-pidfile"
+    exit 0
+  fi
+
+  PID_BODY=$(cat "$PID_FILE")
+  STOP_PID=""
+  STOP_PORT=""
+  if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    STOP_PID="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+    STOP_PORT="${BASH_REMATCH[2]}"
+  fi
+
+  if [ -z "$STOP_PID" ]; then
+    echo "ERROR: PID file at $PID_FILE has no parseable pid= line; remove it manually." >&2
+    exit 1
+  fi
+
+  # kill -0 — failure is the expected branch (dead PID), so 2>/dev/null
+  # is allowed here per CLAUDE.md rule.
+  if ! kill -0 "$STOP_PID" 2>/dev/null; then
+    echo "Monitor PID file is stale (PID $STOP_PID is not running). Removing $PID_FILE."
+    rm -- "$PID_FILE"
+    write_tracking_marker "stop-stale-pidfile" "$STOP_PID" "${STOP_PORT:-}"
+    exit 0
+  fi
+
+  # Identity check — refuse to kill on either command-name OR cwd mismatch.
+  IDENTITY_CMD=""
+  if ! IDENTITY_CMD=$(verify_monitor_identity "$STOP_PID"); then
+    # Re-read for diagnostics.
+    DIAG_CMD=$(ps -p "$STOP_PID" -o command= || echo "<gone>")
+    DIAG_CWD=$(readlink "/proc/$STOP_PID/cwd" 2>/dev/null \
+      || lsof -p "$STOP_PID" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}' \
+      || echo "<unknown>")
+    echo "PID $STOP_PID does not appear to be zskills-monitor for this repo (matched: $DIAG_CMD; cwd: $DIAG_CWD). Refusing to kill. Remove the PID file manually if stale." >&2
+    exit 1
+  fi
+
+  # SIGTERM only — never escalate to SIGKILL or use process-mass-kill tools.
+  if ! kill -TERM "$STOP_PID"; then
+    echo "ERROR: kill -TERM $STOP_PID failed." >&2
+    exit 1
+  fi
+
+  # Poll for exit (up to ~5s, 200ms granularity).
+  EXITED=0
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do
+    if ! kill -0 "$STOP_PID" 2>/dev/null; then
+      EXITED=1
+      break
+    fi
+    sleep 0.2
+  done
+
+  if [ "$EXITED" -ne 1 ]; then
+    echo "Monitor did not exit within 5s. Run 'lsof -i :$STOP_PORT' and stop manually; do NOT escalate to SIGKILL." >&2
+    exit 1
+  fi
+
+  # Verify port released. lsof returning 0 (still LISTENing) is failure.
+  if [ -n "$STOP_PORT" ]; then
+    if lsof -iTCP:"$STOP_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+      echo "WARN: PID $STOP_PID is gone but port $STOP_PORT still has a listener. Investigate before next start." >&2
+    fi
+  fi
+
+  # Remove PID file (server's own SIGTERM handler already removes it,
+  # but belt-and-suspenders for cases where the file outlived the process).
+  if [ -f "$PID_FILE" ]; then
+    rm -- "$PID_FILE"
+  fi
+
+  echo "Monitor stopped (pid $STOP_PID, port ${STOP_PORT:-?})."
+  write_tracking_marker "stop" "$STOP_PID" "${STOP_PORT:-}"
+  exit 0
+fi
+```
+
+## status — read-only health report
+
+1. No PID file → "Monitor not running." Exit 0.
+
+2. Parse `pid`, `port`, `started_at` via `BASH_REMATCH`. If
+   `started_at` does not match `^[0-9T:+-]+$`, treat the PID file as
+   malformed: print a recovery diagnostic and exit 1 (per DA-8).
+
+3. `kill -0 $PID`. If the process is dead, the PID file is stale —
+   print a recovery message and exit 1 (do NOT auto-clean; status is
+   read-only).
+
+4. Compute uptime from `started_at` (ISO-8601) using `date -d`
+   arithmetic; print URL, PID, uptime, log path. Exit 0.
+
+```bash
+if [ "$SUB" = "status" ]; then
+  if [ ! -f "$PID_FILE" ]; then
+    echo "Monitor not running."
+    exit 0
+  fi
+
+  PID_BODY=$(cat "$PID_FILE")
+  ST_PID=""
+  ST_PORT=""
+  ST_STARTED=""
+  if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    ST_PID="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+    ST_PORT="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')started_at=([^[:space:]]+) ]]; then
+    ST_STARTED="${BASH_REMATCH[2]}"
+  fi
+
+  if [ -z "$ST_PID" ] || [ -z "$ST_PORT" ] || [ -z "$ST_STARTED" ]; then
+    echo "PID file at $PID_FILE is missing required fields (pid/port/started_at). rm it and retry /zskills-dashboard start" >&2
+    exit 1
+  fi
+
+  if [[ ! "$ST_STARTED" =~ ^[0-9T:+-]+$ ]]; then
+    echo "PID file at $PID_FILE has malformed started_at; rm it and retry /zskills-dashboard start" >&2
+    exit 1
+  fi
+
+  # kill -0 — failure is the expected branch (dead PID), so 2>/dev/null
+  # is allowed here per CLAUDE.md rule.
+  if ! kill -0 "$ST_PID" 2>/dev/null; then
+    echo "Monitor PID file is stale (PID $ST_PID not running). Run 'lsof -i :$ST_PORT' to verify port is free, then retry /zskills-dashboard start." >&2
+    exit 1
+  fi
+
+  # Compute uptime via GNU date arithmetic. The started_at line is ISO-8601
+  # with timezone, which `date -d` accepts directly.
+  NOW_EPOCH=$(date +%s)
+  STARTED_EPOCH=$(date -d "$ST_STARTED" +%s 2>/dev/null || echo "")
+  if [ -z "$STARTED_EPOCH" ]; then
+    UPTIME_STR="(uptime unknown — date -d could not parse '$ST_STARTED')"
+  else
+    SECS=$((NOW_EPOCH - STARTED_EPOCH))
+    [ "$SECS" -lt 0 ] && SECS=0
+    H=$((SECS / 3600))
+    M=$(((SECS % 3600) / 60))
+    S=$((SECS % 60))
+    UPTIME_STR=$(printf '%dh %dm %ds' "$H" "$M" "$S")
+  fi
+
+  cat <<STATUS_EOF
+Monitor running at http://127.0.0.1:$ST_PORT/
+  pid:      $ST_PID
+  started:  $ST_STARTED
+  uptime:   $UPTIME_STR
+  log:      $LOG_FILE
+STATUS_EOF
+  exit 0
+fi
+```
+
+## Mirror
+
+After every edit, regenerate the `.claude/skills/zskills-dashboard/`
+mirror via the Tier-2 hook-compatible script:
+
+```bash
+bash scripts/mirror-skill.sh zskills-dashboard
+```
+
+`mirror-skill.sh` does per-file `rm` for orphan removal — it never
+invokes a recursive remove of the mirror tree, which the project's
+`block-unsafe-generic.sh` hook would block. After the script returns,
+`diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/`
+must be empty.
+
+## Configuration
+
+The dashboard reads `.claude/zskills-config.json` for two fields:
+
+- `dev_server.default_port` (integer) — default port when neither
+  `DEV_PORT` env nor a stub callout overrides. Read by `port.sh`.
+- `dashboard.work_on_plans_trigger` (string, optional) — relative path
+  to a user-owned trigger script. When set, the dashboard's "Run"
+  button posts to `/api/trigger`, which spawns the script with the
+  selected `/work-on-plans` invocation as argv[1]. **No default script
+  is shipped** — this is plumbing the consumer must wire. If the field
+  is absent or empty, the Run button is hidden client-side and
+  `/api/trigger` returns 501.
+
+Example `dashboard.work_on_plans_trigger` (consumer-authored):
+
+```bash
+#!/bin/bash
+# scripts/work-on-plans-trigger.sh — consumer-owned plumbing for the
+# dashboard's Run button. argv[1] is the /work-on-plans command line.
+exec >>".zskills/work-on-plans-trigger.log" 2>&1
+echo "[$(date -Iseconds)] trigger: $1"
+# Drop a request file your session-watching tool can pick up:
+mkdir -p .zskills/triggers
+printf '%s\n' "$1" > ".zskills/triggers/$(date -u +%Y%m%dT%H%M%SZ).cmd"
+```
+
+## Tracking markers
+
+`start` and `stop` (and their no-op / stale variants) write a
+`fulfilled.zskills-dashboard.<id>` under
+`.zskills/tracking/zskills-dashboard.<id>/`. The id is
+`zskills-dashboard-<utc-timestamp>` passed through
+`sanitize-pipeline-id.sh`. Subdir-name layout is Option B per
+`docs/tracking/TRACKING_NAMING.md`.
+
+`status` is read-only and writes nothing.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success (server running, stopped cleanly, or no-op idempotent path) |
+| 1 | Health check failed, identity mismatch (refused to kill), stale PID file under `status`, or PID-file malformed |
+| 2 | Usage error, port already in use under `start`, or unknown subcommand |
+
+## Key rules
+
+- **SIGTERM only.** Never escalate to SIGKILL, and never reach for
+  process-mass-kill tools (the obvious ones are forbidden by
+  CLAUDE.md). On a stuck process, surface manual-recovery
+  instructions and exit 1.
+- **Never bypass identity check.** Both command-name AND cwd must
+  match before `stop` will signal a PID. Same defense applies on
+  `start` when checking an existing PID file.
+- **No JSON CLI parser.** Use `BASH_REMATCH` for all parsing (PID
+  file is `.env`-style; config reads via `port.sh`'s own bash regex).
+  Per zskills convention.
+- **No `2>/dev/null` on fallible operations.** The two exceptions
+  documented in CLAUDE.md apply here: `kill -0` (liveness — failure
+  IS the dead-PID branch) and `readlink /proc/$PID/cwd` /
+  `lsof -p ... -d cwd` (non-Linux fallback — failure IS the missing-
+  /proc branch).
+- **MAIN_ROOT-anchored paths.** Every read/write goes through
+  `$MAIN_ROOT/.zskills/...`, never cwd-relative — invoking the skill
+  from a worktree must still see the main repo's PID file.
+- **PYTHONPATH discipline.** `start` prepends
+  `$MAIN_ROOT/skills/zskills-dashboard/scripts` to `PYTHONPATH` so
+  `python3 -m zskills_monitor.server` resolves the package without an
+  install step (per DA-5).
+- **Verify after every state change.** `start` curls
+  `/api/health`; `stop` polls `kill -0` then verifies the port is
+  freed via `lsof`.
+- **Tracking markers for state-changing modes only.** `start` and
+  `stop` write `fulfilled.zskills-dashboard.<id>`; `status` does not.
+- **Mirror via `scripts/mirror-skill.sh`** — never use a recursive
+  remove on the mirror tree (hook will block).

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -58,6 +58,7 @@ run_suite "test_zskills_monitor_server.sh" "tests/test_zskills_monitor_server.sh
 run_suite "test-stub-callouts.sh" "tests/test-stub-callouts.sh"
 run_suite "test-post-create-worktree.sh" "tests/test-post-create-worktree.sh"
 run_suite "test_zskills_monitor_dashboard_ui.sh" "tests/test_zskills_monitor_dashboard_ui.sh"
+run_suite "test_zskills_dashboard_skill.sh" "tests/test_zskills_dashboard_skill.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test_zskills_dashboard_skill.sh
+++ b/tests/test_zskills_dashboard_skill.sh
@@ -1,0 +1,864 @@
+#!/bin/bash
+# Tests for skills/zskills-dashboard/SKILL.md — Phase 8 of
+# plans/ZSKILLS_MONITOR_PLAN.md.
+#
+# Strategy: SKILL.md is markdown-with-bash that the LLM executes inline.
+# We re-implement the load-bearing blocks (Step 0 helpers + start/stop/
+# status mode bodies) here as ordinary shell functions and drive them
+# against tmpdir-scoped MAIN_ROOTs. Static-grep ACs are checked against
+# the actual SKILL.md so any wording divergence will fail.
+#
+# Each Acceptance Criterion in the Phase 8 spec maps to one or more
+# pass/fail lines below, tagged AC-N where N is the order of the AC
+# in the spec's "Acceptance Criteria" list.
+#
+# Run from repo root: bash tests/test_zskills_dashboard_skill.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_DIR="$REPO_ROOT/skills/zskills-dashboard"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+MIRROR_DIR="$REPO_ROOT/.claude/skills/zskills-dashboard"
+MIRROR_MD="$MIRROR_DIR/SKILL.md"
+PKG_PARENT="$SKILL_DIR/scripts"
+SERVER_PY="$PKG_PARENT/zskills_monitor/server.py"
+PORT_SCRIPT_SRC="$REPO_ROOT/skills/update-zskills/scripts/port.sh"
+SANITIZE_SCRIPT_SRC="$REPO_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+skip() { printf '\033[33m  SKIP\033[0m %s\n' "$1"; SKIP_COUNT=$((SKIP_COUNT+1)); }
+
+print_summary_and_exit() {
+  echo ""
+  echo "---"
+  local total=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+  if [ "$FAIL_COUNT" -eq 0 ]; then
+    printf '\033[32mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$total"
+    exit 0
+  else
+    printf '\033[31mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$total"
+    exit 1
+  fi
+}
+
+# Per-process scratch root.
+TMP_ROOT="/tmp/zskills-dashboard-skill-test.$$"
+mkdir -p "$TMP_ROOT"
+
+TRACKED_PIDS=""
+cleanup() {
+  for p in $TRACKED_PIDS; do
+    if kill -0 "$p" 2>/dev/null; then
+      kill -TERM "$p" 2>/dev/null || true
+      sleep 0.5
+    fi
+    if kill -0 "$p" 2>/dev/null; then
+      # SIGTERM-only cleanup — no SIGKILL escalation, even on test
+      # teardown. The test process itself exits regardless; orphans
+      # will be reaped by init.
+      true
+    fi
+  done
+  case "$TMP_ROOT" in
+    /tmp/zskills-dashboard-skill-test.*)
+      rm -rf -- "$TMP_ROOT"
+      ;;
+  esac
+}
+trap cleanup EXIT INT TERM
+
+###############################################################################
+# AC-1: SKILL.md exists with the specified frontmatter.
+# AC-3: no `\bjq\b` matches.
+# AC-4: no `kill -9 / killall / pkill / fuser -k` matches.
+# AC-15 (extra): PYTHONPATH discipline — at least one match for
+#   PYTHONPATH=...skills/zskills-dashboard/scripts.
+# AC-16 (extra): mirror-skill.sh referenced; no rm -rf .claude/skills.
+###############################################################################
+
+echo ""
+echo "=== Phase 8 AC: static-grep contract ==="
+
+if [ ! -f "$SKILL_MD" ]; then
+  fail "AC-1: SKILL.md exists at $SKILL_MD"
+  print_summary_and_exit
+fi
+pass "AC-1: SKILL.md exists at $SKILL_MD"
+
+# Frontmatter checks.
+if grep -q '^name: zskills-dashboard$' "$SKILL_MD"; then
+  pass "AC-1: frontmatter name: zskills-dashboard"
+else
+  fail "AC-1: frontmatter name field missing or wrong"
+fi
+if grep -q '^disable-model-invocation: true$' "$SKILL_MD"; then
+  pass "AC-1: frontmatter disable-model-invocation: true"
+else
+  fail "AC-1: frontmatter disable-model-invocation flag missing"
+fi
+if grep -q '^argument-hint:.*\[start|stop|status\]' "$SKILL_MD"; then
+  pass "AC-1: frontmatter argument-hint covers [start|stop|status]"
+else
+  fail "AC-1: frontmatter argument-hint missing or wrong"
+fi
+
+# AC-3: jq.
+if grep -nE '\bjq\b' "$SKILL_MD" >/dev/null; then
+  fail "AC-3: forbidden \\bjq\\b token in SKILL.md"
+else
+  pass "AC-3: no \\bjq\\b in SKILL.md"
+fi
+
+# AC-4: SIGKILL / killall family.
+if grep -nE 'kill\s+-9|killall|pkill|fuser\s+-k' "$SKILL_MD" >/dev/null; then
+  fail "AC-4: forbidden SIGKILL/killall family in SKILL.md"
+else
+  pass "AC-4: no SIGKILL / killall / pkill / fuser -k in SKILL.md"
+fi
+
+# AC-15 (extra): PYTHONPATH discipline.
+if grep -nE 'PYTHONPATH=.*skills/zskills-dashboard/scripts' "$SKILL_MD" >/dev/null; then
+  pass "AC-15: PYTHONPATH=...skills/zskills-dashboard/scripts present"
+else
+  fail "AC-15: PYTHONPATH discipline missing"
+fi
+
+# AC-16 (extra): mirror-skill.sh referenced; no rm -rf .claude/skills.
+if grep -nE 'mirror-skill\.sh' "$SKILL_MD" >/dev/null; then
+  pass "AC-16: mirror-skill.sh referenced in SKILL.md"
+else
+  fail "AC-16: mirror-skill.sh not referenced"
+fi
+if grep -nE 'rm\s+-rf\s+\.claude/skills' "$SKILL_MD" >/dev/null; then
+  fail "AC-16: forbidden rm -rf .claude/skills in SKILL.md"
+else
+  pass "AC-16: no rm -rf .claude/skills in SKILL.md"
+fi
+
+###############################################################################
+# AC-2: diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/
+#       returns 0 (whole-tree mirror).
+###############################################################################
+
+if [ ! -d "$MIRROR_DIR" ]; then
+  fail "AC-2: mirror dir exists at $MIRROR_DIR"
+else
+  DIFF_OUT=$(diff -rq "$SKILL_DIR/" "$MIRROR_DIR/" 2>&1 | grep -v __pycache__ || true)
+  if [ -z "$DIFF_OUT" ]; then
+    pass "AC-2: diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/ is clean"
+  else
+    fail "AC-2: mirror diverges from source: $DIFF_OUT"
+  fi
+fi
+
+###############################################################################
+# Skip the live-server tests if python3 / curl are missing, or if the
+# server source isn't present (defensive — this should not happen in CI).
+###############################################################################
+
+if ! command -v python3 >/dev/null 2>&1; then
+  skip "live tests: python3 not available"
+  print_summary_and_exit
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  skip "live tests: curl not available"
+  print_summary_and_exit
+fi
+if [ ! -f "$SERVER_PY" ]; then
+  skip "live tests: server.py missing at $SERVER_PY"
+  print_summary_and_exit
+fi
+if [ ! -x "$PORT_SCRIPT_SRC" ]; then
+  skip "live tests: port.sh missing or non-executable at $PORT_SCRIPT_SRC"
+  print_summary_and_exit
+fi
+if [ ! -x "$SANITIZE_SCRIPT_SRC" ]; then
+  skip "live tests: sanitize-pipeline-id.sh missing or non-executable at $SANITIZE_SCRIPT_SRC"
+  print_summary_and_exit
+fi
+
+###############################################################################
+# SKILL.md bash-block re-implementation. The LLM executes these inline
+# from SKILL.md; tests re-define them as functions parameterised on
+# MAIN_ROOT so we can run multiple isolated fixtures concurrently.
+#
+# IMPORTANT: keep these blocks structurally aligned with SKILL.md. The
+# static-grep AC checks above protect the SKILL.md source of truth from
+# silent drift.
+###############################################################################
+
+# ---------------------------------------------------------------------------
+# verify_monitor_identity — transcribed from SKILL.md Step 0.
+# ---------------------------------------------------------------------------
+verify_monitor_identity() {
+  local pid="$1" main_root="$2"
+  local cmd cwd_proc cwd_lsof matched_cwd
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  cmd=$(ps -p "$pid" -o command= || echo "")
+  if [[ ! "$cmd" =~ python3.*zskills_monitor\.server ]]; then
+    printf 'identity-mismatch: command=%s\n' "$cmd" >&2
+    return 1
+  fi
+
+  cwd_proc=$(readlink "/proc/$pid/cwd" 2>/dev/null || echo "")
+  if [ -n "$cwd_proc" ]; then
+    matched_cwd="$cwd_proc"
+  else
+    cwd_lsof=$(lsof -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}')
+    if [ -n "$cwd_lsof" ]; then
+      matched_cwd="$cwd_lsof"
+    else
+      printf 'identity-warning: cwd unverifiable for PID %s; accepting command-name match\n' "$pid" >&2
+      printf '%s\n' "$cmd"
+      return 0
+    fi
+  fi
+
+  if [ "$matched_cwd" != "$main_root" ]; then
+    printf 'identity-mismatch: cwd=%s expected=%s\n' "$matched_cwd" "$main_root" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$cmd"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# write_tracking_marker — transcribed from SKILL.md Step 0.
+# ---------------------------------------------------------------------------
+write_tracking_marker() {
+  local main_root="$1" mode="$2" pid_val="${3:-}" port_val="${4:-}"
+  local raw="zskills-dashboard-$(date -u +%Y%m%dT%H%M%SZ)-$$-$RANDOM"
+  local id
+  id=$(bash "$SANITIZE_SCRIPT_SRC" "$raw")
+  local subdir="$main_root/.zskills/tracking/zskills-dashboard.$id"
+  mkdir -p "$subdir"
+  local marker="$subdir/fulfilled.zskills-dashboard.$id"
+  {
+    printf 'skill: zskills-dashboard\n'
+    printf 'id: %s\n' "$id"
+    printf 'mode: %s\n' "$mode"
+    [ -n "$pid_val" ] && printf 'pid: %s\n' "$pid_val"
+    [ -n "$port_val" ] && printf 'port: %s\n' "$port_val"
+    printf 'status: complete\n'
+    printf 'date: %s\n' "$(TZ=America/New_York date -Iseconds)"
+  } > "$marker"
+}
+
+# ---------------------------------------------------------------------------
+# do_start / do_stop / do_status — transcribed from SKILL.md mode bodies,
+# parameterised on a passed-in MAIN_ROOT (the LLM resolves it from cwd
+# via `git rev-parse --git-common-dir`; tests pass it explicitly).
+# ---------------------------------------------------------------------------
+
+do_start() {
+  local MAIN_ROOT="$1"
+  local PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
+  local LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
+  local PORT_SCRIPT="$PORT_SCRIPT_SRC"
+  local PKG_PARENT_LOCAL="$PKG_PARENT"
+
+  mkdir -p "$MAIN_ROOT/.zskills"
+
+  # Existing PID file?
+  if [ -f "$PID_FILE" ]; then
+    local PID_BODY existing_pid existing_port
+    PID_BODY=$(cat "$PID_FILE")
+    existing_pid=""
+    existing_port=""
+    if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+      existing_pid="${BASH_REMATCH[2]}"
+    fi
+    if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+      existing_port="${BASH_REMATCH[2]}"
+    fi
+    if [ -n "$existing_pid" ]; then
+      if verify_monitor_identity "$existing_pid" "$MAIN_ROOT" >/dev/null; then
+        echo "already running at http://127.0.0.1:${existing_port:-?}/ (pid $existing_pid)"
+        write_tracking_marker "$MAIN_ROOT" "start-already-running" "$existing_pid" "${existing_port:-}"
+        return 0
+      else
+        echo "WARN: stale PID file at $PID_FILE; removing." >&2
+        rm -- "$PID_FILE"
+      fi
+    else
+      rm -- "$PID_FILE"
+    fi
+  fi
+
+  local PORT
+  # In production (SKILL.md) cwd already equals MAIN_ROOT (the user
+  # invoked the skill from inside the repo). In tests the calling bash
+  # runs from the zskills source tree, so we must cd into MAIN_ROOT
+  # before invoking port.sh — otherwise port.sh's `git rev-parse
+  # --show-toplevel` resolves to the wrong repo and we pick a port
+  # that's different from what the launched server picks (the server
+  # cd's into MAIN_ROOT before resolve_port).
+  PORT=$( cd "$MAIN_ROOT" && bash "$PORT_SCRIPT" )
+  if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: port.sh returned non-numeric value: $PORT" >&2
+    return 1
+  fi
+
+  if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "ERROR: port $PORT already in use." >&2
+    return 2
+  fi
+
+  ( cd "$MAIN_ROOT" && \
+    PYTHONPATH="$PKG_PARENT_LOCAL:${PYTHONPATH:-}" \
+    nohup python3 -m zskills_monitor.server \
+      > "$LOG_FILE" 2>&1 < /dev/null & disown )
+
+  local HEALTHY=0 HEALTH_BODY=""
+  # Match SKILL.md (~10s wall-clock — handles slow Python startup in CI).
+  for _ in $(seq 1 40); do
+    sleep 0.25
+    HEALTH_BODY=$(curl -sf -m 1 "http://127.0.0.1:$PORT/api/health" || true)
+    if printf '%s' "$HEALTH_BODY" | grep -qE '"status":[[:space:]]*"ok"'; then
+      HEALTHY=1
+      break
+    fi
+  done
+  if [ "$HEALTHY" -ne 1 ]; then
+    echo "ERROR: server did not respond on /api/health within 10s." >&2
+    tail -n 20 "$LOG_FILE" >&2 || true
+    return 1
+  fi
+
+  if [ ! -f "$PID_FILE" ]; then
+    echo "ERROR: server is healthy but PID file was not written." >&2
+    return 1
+  fi
+  local NEW_PID="" PIDFILE_BODY
+  PIDFILE_BODY=$(cat "$PID_FILE")
+  if [[ "$PIDFILE_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    NEW_PID="${BASH_REMATCH[2]}"
+  fi
+
+  echo "Monitor running at http://127.0.0.1:$PORT/ (pid ${NEW_PID:-?})"
+  TRACKED_PIDS="$TRACKED_PIDS ${NEW_PID:-}"
+  write_tracking_marker "$MAIN_ROOT" "start" "$NEW_PID" "$PORT"
+  return 0
+}
+
+do_stop() {
+  local MAIN_ROOT="$1"
+  local PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
+
+  if [ ! -f "$PID_FILE" ]; then
+    echo "No running monitor (no PID file)."
+    write_tracking_marker "$MAIN_ROOT" "stop-no-pidfile"
+    return 0
+  fi
+
+  local PID_BODY stop_pid stop_port
+  PID_BODY=$(cat "$PID_FILE")
+  stop_pid=""
+  stop_port=""
+  if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    stop_pid="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+    stop_port="${BASH_REMATCH[2]}"
+  fi
+  if [ -z "$stop_pid" ]; then
+    echo "ERROR: PID file has no parseable pid= line." >&2
+    return 1
+  fi
+
+  if ! kill -0 "$stop_pid" 2>/dev/null; then
+    echo "Monitor PID file is stale (PID $stop_pid not running). Removing $PID_FILE."
+    rm -- "$PID_FILE"
+    write_tracking_marker "$MAIN_ROOT" "stop-stale-pidfile" "$stop_pid" "${stop_port:-}"
+    return 0
+  fi
+
+  local IDENTITY_CMD=""
+  if ! IDENTITY_CMD=$(verify_monitor_identity "$stop_pid" "$MAIN_ROOT"); then
+    local DIAG_CMD DIAG_CWD
+    DIAG_CMD=$(ps -p "$stop_pid" -o command= || echo "<gone>")
+    DIAG_CWD=$(readlink "/proc/$stop_pid/cwd" 2>/dev/null \
+      || lsof -p "$stop_pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {sub(/^n/,""); print; exit}' \
+      || echo "<unknown>")
+    echo "PID $stop_pid does not appear to be zskills-monitor for this repo (matched: $DIAG_CMD; cwd: $DIAG_CWD). Refusing to kill. Remove the PID file manually if stale." >&2
+    return 1
+  fi
+
+  if ! kill -TERM "$stop_pid"; then
+    echo "ERROR: kill -TERM $stop_pid failed." >&2
+    return 1
+  fi
+
+  local EXITED=0
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do
+    if ! kill -0 "$stop_pid" 2>/dev/null; then
+      EXITED=1
+      break
+    fi
+    sleep 0.2
+  done
+  if [ "$EXITED" -ne 1 ]; then
+    echo "Monitor did not exit within 5s. Refusing to escalate." >&2
+    return 1
+  fi
+
+  if [ -n "$stop_port" ]; then
+    if lsof -iTCP:"$stop_port" -sTCP:LISTEN >/dev/null 2>&1; then
+      echo "WARN: port $stop_port still has a listener after PID $stop_pid exited." >&2
+    fi
+  fi
+
+  if [ -f "$PID_FILE" ]; then
+    rm -- "$PID_FILE"
+  fi
+  echo "Monitor stopped (pid $stop_pid, port ${stop_port:-?})."
+  write_tracking_marker "$MAIN_ROOT" "stop" "$stop_pid" "${stop_port:-}"
+  return 0
+}
+
+do_status() {
+  local MAIN_ROOT="$1"
+  local PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
+  local LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
+
+  if [ ! -f "$PID_FILE" ]; then
+    echo "Monitor not running."
+    return 0
+  fi
+
+  local PID_BODY st_pid st_port st_started
+  PID_BODY=$(cat "$PID_FILE")
+  st_pid=""
+  st_port=""
+  st_started=""
+  if [[ "$PID_BODY" =~ (^|$'\n')pid=([0-9]+) ]]; then
+    st_pid="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')port=([0-9]+) ]]; then
+    st_port="${BASH_REMATCH[2]}"
+  fi
+  if [[ "$PID_BODY" =~ (^|$'\n')started_at=([^[:space:]]+) ]]; then
+    st_started="${BASH_REMATCH[2]}"
+  fi
+
+  if [ -z "$st_pid" ] || [ -z "$st_port" ] || [ -z "$st_started" ]; then
+    echo "PID file at $PID_FILE is missing required fields." >&2
+    return 1
+  fi
+  if [[ ! "$st_started" =~ ^[0-9T:+-]+$ ]]; then
+    echo "PID file at $PID_FILE has malformed started_at; rm it and retry /zskills-dashboard start" >&2
+    return 1
+  fi
+  if ! kill -0 "$st_pid" 2>/dev/null; then
+    echo "Monitor PID file is stale (PID $st_pid not running). Run 'lsof -i :$st_port' to verify port is free, then retry /zskills-dashboard start." >&2
+    return 1
+  fi
+
+  local NOW_EPOCH STARTED_EPOCH SECS H M S UPTIME_STR
+  NOW_EPOCH=$(date +%s)
+  STARTED_EPOCH=$(date -d "$st_started" +%s 2>/dev/null || echo "")
+  if [ -z "$STARTED_EPOCH" ]; then
+    UPTIME_STR="(unknown)"
+  else
+    SECS=$((NOW_EPOCH - STARTED_EPOCH))
+    [ "$SECS" -lt 0 ] && SECS=0
+    H=$((SECS / 3600))
+    M=$(((SECS % 3600) / 60))
+    S=$((SECS % 60))
+    UPTIME_STR=$(printf '%dh %dm %ds' "$H" "$M" "$S")
+  fi
+
+  cat <<STATUS_EOF
+Monitor running at http://127.0.0.1:$st_port/
+  pid:      $st_pid
+  started:  $st_started
+  uptime:   $UPTIME_STR
+  log:      $LOG_FILE
+STATUS_EOF
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Fixture builder — minimal git repo (so MAIN_ROOT walk works in `cd
+# "$(git rev-parse --git-common-dir)/.."`) with a per-fixture port.
+# ---------------------------------------------------------------------------
+make_fixture() {
+  local label="$1" port="$2"
+  local f="$TMP_ROOT/$label"
+  mkdir -p "$f/.claude" "$f/.zskills"
+  ( cd "$f" && git init -q && git config user.email "t@e.com" && git config user.name "t" && \
+    git commit --allow-empty -q -m init )
+  cat > "$f/.claude/zskills-config.json" <<EOF
+{
+  "dev_server": { "default_port": $port, "main_repo_path": "$f" },
+  "execution": { "landing": "pr" }
+}
+EOF
+  echo "$f"
+}
+
+# Pick well-spaced base ports per fixture so AC-13 (worktree process)
+# can run concurrently with the main fixture.
+BASE_A=$(( 19800 + ($$ % 100) ))
+BASE_B=$(( BASE_A + 1 ))
+BASE_C=$(( BASE_A + 2 ))
+
+###############################################################################
+# AC-5: start writes a PID file and /api/health returns 200 within 1s;
+#       status after start prints `^Monitor running`.
+# AC-6: PID-file shape (pid=<int>, port=<int>, started_at=ISO).
+###############################################################################
+
+echo ""
+echo "=== Phase 8 AC: live start/stop/status (lifecycle) ==="
+
+FX_A=$(make_fixture A "$BASE_A")
+
+if do_start "$FX_A" >"$TMP_ROOT/A.start.out" 2>&1; then
+  if grep -qE '^Monitor running at http://127\.0\.0\.1:' "$TMP_ROOT/A.start.out"; then
+    pass "AC-5: start prints 'Monitor running at http://127.0.0.1:...'"
+  else
+    fail "AC-5: start output missing expected line: $(cat "$TMP_ROOT/A.start.out")"
+  fi
+  if [ -f "$FX_A/.zskills/dashboard-server.pid" ]; then
+    pass "AC-5: PID file written at .zskills/dashboard-server.pid"
+  else
+    fail "AC-5: PID file NOT written"
+  fi
+
+  # /api/health smoke (port already verified inside do_start, but we re-check
+  # because the AC explicitly mentions a 200 response within 1s).
+  HEALTH=$(curl -sf -m 1 "http://127.0.0.1:$BASE_A/api/health" || true)
+  if printf '%s' "$HEALTH" | grep -qE '"status":[[:space:]]*"ok"'; then
+    pass "AC-5: /api/health returns ok"
+  else
+    fail "AC-5: /api/health did not return ok: $HEALTH"
+  fi
+
+  # AC-6: PID-file shape.
+  PID_FILE_A="$FX_A/.zskills/dashboard-server.pid"
+  if grep -qE '^pid=[0-9]+$' "$PID_FILE_A"; then
+    pass "AC-6: PID file has pid=<int>"
+  else
+    fail "AC-6: PID file pid= line malformed: $(cat "$PID_FILE_A")"
+  fi
+  if grep -qE '^port=[0-9]+$' "$PID_FILE_A"; then
+    pass "AC-6: PID file has port=<int>"
+  else
+    fail "AC-6: PID file port= line malformed: $(cat "$PID_FILE_A")"
+  fi
+  if grep -qE '^started_at=[0-9T:+-]+$' "$PID_FILE_A"; then
+    pass "AC-6: PID file has started_at=<ISO-token-shape>"
+  else
+    fail "AC-6: PID file started_at= line malformed: $(cat "$PID_FILE_A")"
+  fi
+
+  # AC-5 (status side): status after start prints `^Monitor running`.
+  if do_status "$FX_A" >"$TMP_ROOT/A.status.out" 2>&1; then
+    if grep -qE '^Monitor running' "$TMP_ROOT/A.status.out"; then
+      pass "AC-5: status after start prints '^Monitor running'"
+    else
+      fail "AC-5: status output missing 'Monitor running': $(cat "$TMP_ROOT/A.status.out")"
+    fi
+  else
+    fail "AC-5: status returned non-zero after start"
+  fi
+else
+  fail "AC-5: start returned non-zero: $(cat "$TMP_ROOT/A.start.out")"
+fi
+
+###############################################################################
+# AC-8: start twice → second run detects live PID + matching command +
+#       matching cwd and prints the URL without launching a duplicate.
+###############################################################################
+
+if do_start "$FX_A" >"$TMP_ROOT/A.start2.out" 2>&1; then
+  if grep -qE 'already running at http://127\.0\.0\.1:' "$TMP_ROOT/A.start2.out"; then
+    pass "AC-8: start twice — second prints 'already running' (no duplicate)"
+  else
+    fail "AC-8: start twice — unexpected output: $(cat "$TMP_ROOT/A.start2.out")"
+  fi
+else
+  fail "AC-8: start twice returned non-zero (expected 0 when already running)"
+fi
+
+###############################################################################
+# AC-12 (early): tracking markers exist after start; not after status.
+###############################################################################
+
+# Count tracking subdirs under .zskills/tracking/zskills-dashboard.* —
+# we expect at least 2 markers (initial start + already-running start;
+# status would NOT add a subdir).
+COUNT_AFTER_TWO_STARTS=$(find "$FX_A/.zskills/tracking" -maxdepth 1 -type d -name 'zskills-dashboard.*' 2>/dev/null | wc -l | tr -d ' ')
+if [ "${COUNT_AFTER_TWO_STARTS:-0}" -ge 2 ]; then
+  pass "AC-12: tracking subdir(s) exist after start ($COUNT_AFTER_TWO_STARTS)"
+else
+  fail "AC-12: expected ≥2 tracking subdirs after two starts, got $COUNT_AFTER_TWO_STARTS"
+fi
+
+# Check at least one marker has the expected fields.
+MARKER_FILE=$(find "$FX_A/.zskills/tracking" -name 'fulfilled.zskills-dashboard.*' -type f 2>/dev/null | head -1)
+if [ -n "$MARKER_FILE" ]; then
+  if grep -q '^skill: zskills-dashboard$' "$MARKER_FILE" \
+     && grep -q '^id: ' "$MARKER_FILE" \
+     && grep -q '^status: ' "$MARKER_FILE" \
+     && grep -q '^date: ' "$MARKER_FILE"; then
+    pass "AC-12: marker has skill: / id: / status: / date: fields"
+  else
+    fail "AC-12: marker missing fields: $(cat "$MARKER_FILE")"
+  fi
+else
+  fail "AC-12: no fulfilled.zskills-dashboard.* marker found"
+fi
+
+# status should NOT add a new subdir.
+STATUS_BEFORE=$(find "$FX_A/.zskills/tracking" -maxdepth 1 -type d -name 'zskills-dashboard.*' 2>/dev/null | wc -l | tr -d ' ')
+do_status "$FX_A" >/dev/null 2>&1 || true
+STATUS_AFTER=$(find "$FX_A/.zskills/tracking" -maxdepth 1 -type d -name 'zskills-dashboard.*' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$STATUS_BEFORE" = "$STATUS_AFTER" ]; then
+  pass "AC-12: status does NOT add a new tracking subdir (read-only)"
+else
+  fail "AC-12: status added a tracking subdir (was $STATUS_BEFORE, now $STATUS_AFTER)"
+fi
+
+###############################################################################
+# AC-13: detachment survival in a fresh shell.
+###############################################################################
+
+# The do_start subshell ran `nohup … & disown`, so the server should be
+# reparented away from the test-process job table. Read its PID and run
+# kill -0 + curl from a fresh `bash -c` (the AC's "new shell"
+# equivalent). The AC explicitly includes a curl /api/health from the
+# new shell, parsing the same PID file shape.
+FRESH_SHELL_OUT=$(bash -c '
+  PID=$(grep -oE "^pid=[0-9]+" "'"$FX_A"'/.zskills/dashboard-server.pid" | cut -d= -f2)
+  PORT=$(grep -oE "^port=[0-9]+" "'"$FX_A"'/.zskills/dashboard-server.pid" | cut -d= -f2)
+  if kill -0 "$PID" 2>/dev/null && curl -sf -m 1 "http://127.0.0.1:$PORT/api/health" | grep -q "\"status\""; then
+    echo "ALIVE"
+  else
+    echo "DEAD"
+  fi
+')
+if [ "$FRESH_SHELL_OUT" = "ALIVE" ]; then
+  pass "AC-13: detachment survival — kill -0 + /api/health succeed in fresh shell"
+else
+  fail "AC-13: server did not survive parent-shell exit (got: $FRESH_SHELL_OUT)"
+fi
+
+###############################################################################
+# AC-14: PID-reuse defense — PID file pointing at a non-monitor process
+#         (e.g. bash/sleep) is treated as stale; start does NOT print
+#         "already running" against it.
+###############################################################################
+
+FX_REUSE=$(make_fixture reuse "$BASE_C")
+# Spawn a long-running sleep as the "wrong" process.
+sleep 30 &
+DECOY_PID=$!
+TRACKED_PIDS="$TRACKED_PIDS $DECOY_PID"
+# Write a PID file claiming this PID is the monitor.
+cat > "$FX_REUSE/.zskills/dashboard-server.pid" <<EOF
+pid=$DECOY_PID
+port=$BASE_C
+started_at=$(date -Iseconds)
+EOF
+# Run start. Identity check should fail (cmd is "sleep", not python3.*zskills_monitor.server).
+# Expected: warn + remove PID file, then attempt to launch a fresh server.
+if do_start "$FX_REUSE" >"$TMP_ROOT/reuse.start.out" 2>&1; then
+  REUSE_RC=0
+else
+  REUSE_RC=$?
+fi
+if grep -qE 'already running' "$TMP_ROOT/reuse.start.out"; then
+  fail "AC-14: PID-reuse defense — start incorrectly said 'already running' against decoy"
+else
+  pass "AC-14: PID-reuse defense — start did NOT say 'already running' against decoy"
+fi
+# Decoy should still be alive (start removed PID file, did NOT signal decoy).
+if kill -0 "$DECOY_PID" 2>/dev/null; then
+  pass "AC-14: PID-reuse defense — decoy process untouched (no kill sent)"
+else
+  fail "AC-14: PID-reuse defense — decoy process was killed (should be untouched)"
+fi
+# Stop whatever the start launched (if anything).
+if [ -f "$FX_REUSE/.zskills/dashboard-server.pid" ]; then
+  do_stop "$FX_REUSE" >/dev/null 2>&1 || true
+fi
+kill -TERM "$DECOY_PID" 2>/dev/null || true
+
+###############################################################################
+# AC-10: stop mode PID-mismatch defense (command-name).
+#   Write a PID file pointing at a long-running unrelated process; run
+#   stop and verify it prints the mismatch diagnostic, does NOT kill the
+#   process, and exits 1.
+###############################################################################
+
+FX_CMD=$(make_fixture cmdmiss "$BASE_C")
+sleep 30 &
+DECOY2_PID=$!
+TRACKED_PIDS="$TRACKED_PIDS $DECOY2_PID"
+cat > "$FX_CMD/.zskills/dashboard-server.pid" <<EOF
+pid=$DECOY2_PID
+port=$BASE_C
+started_at=$(date -Iseconds)
+EOF
+if do_stop "$FX_CMD" >"$TMP_ROOT/cmdmiss.stop.out" 2>&1; then
+  CMDMISS_RC=0
+else
+  CMDMISS_RC=$?
+fi
+if [ "$CMDMISS_RC" -eq 1 ]; then
+  pass "AC-10: stop PID-mismatch (command-name) — exit 1"
+else
+  fail "AC-10: stop PID-mismatch (command-name) — exit was $CMDMISS_RC, expected 1"
+fi
+if grep -q 'does not appear to be zskills-monitor' "$TMP_ROOT/cmdmiss.stop.out"; then
+  pass "AC-10: stop PID-mismatch (command-name) — diagnostic printed"
+else
+  fail "AC-10: stop PID-mismatch (command-name) — diagnostic missing: $(cat "$TMP_ROOT/cmdmiss.stop.out")"
+fi
+if kill -0 "$DECOY2_PID" 2>/dev/null; then
+  pass "AC-10: stop PID-mismatch (command-name) — decoy untouched"
+else
+  fail "AC-10: stop PID-mismatch (command-name) — decoy was killed"
+fi
+kill -TERM "$DECOY2_PID" 2>/dev/null || true
+
+###############################################################################
+# AC-11: stop mode PID-mismatch defense (cwd).
+#   Launch a second monitor in a different MAIN_ROOT (FX_B). From FX_A,
+#   write a PID file pointing at FX_B's monitor PID and run stop.
+#   The cwd check must fail and the monitor must NOT be killed.
+###############################################################################
+
+FX_B=$(make_fixture B "$BASE_B")
+do_start "$FX_B" >"$TMP_ROOT/B.start.out" 2>&1
+B_PID=""
+if [ -f "$FX_B/.zskills/dashboard-server.pid" ]; then
+  B_PID=$(grep -oE '^pid=[0-9]+' "$FX_B/.zskills/dashboard-server.pid" | cut -d= -f2)
+fi
+if [ -n "$B_PID" ] && kill -0 "$B_PID" 2>/dev/null; then
+  pass "AC-11: pre-condition — second monitor running in FX_B (pid $B_PID)"
+
+  # Cross-write FX_B's PID into FX_A's PID file.
+  cat > "$FX_A/.zskills/dashboard-server.pid" <<EOF
+pid=$B_PID
+port=$BASE_B
+started_at=$(date -Iseconds)
+EOF
+  if do_stop "$FX_A" >"$TMP_ROOT/cwdmiss.stop.out" 2>&1; then
+    CWDMISS_RC=0
+  else
+    CWDMISS_RC=$?
+  fi
+  if [ "$CWDMISS_RC" -eq 1 ]; then
+    pass "AC-11: stop PID-mismatch (cwd) — exit 1"
+  else
+    fail "AC-11: stop PID-mismatch (cwd) — exit was $CWDMISS_RC, expected 1"
+  fi
+  if grep -q 'does not appear to be zskills-monitor for this repo' "$TMP_ROOT/cwdmiss.stop.out"; then
+    pass "AC-11: stop PID-mismatch (cwd) — diagnostic printed"
+  else
+    fail "AC-11: stop PID-mismatch (cwd) — diagnostic missing: $(cat "$TMP_ROOT/cwdmiss.stop.out")"
+  fi
+  if kill -0 "$B_PID" 2>/dev/null; then
+    pass "AC-11: stop PID-mismatch (cwd) — FX_B's monitor untouched"
+  else
+    fail "AC-11: stop PID-mismatch (cwd) — FX_B's monitor was killed!"
+  fi
+
+  # Stop FX_B cleanly. FX_A's PID file currently points at FX_B's
+  # (now-killed) PID. Rewrite it to FX_A's actual monitor PID so AC-7
+  # has a real target. We saved FX_A's own pid in NEW_PID inside the
+  # earlier do_start, but that's a function-local; recover it from
+  # `pgrep`-equivalent on FX_A's MAIN_ROOT (readlink /proc/$$/cwd).
+  do_stop "$FX_B" >/dev/null 2>&1 || true
+  rm -f "$FX_A/.zskills/dashboard-server.pid"
+  # Find FX_A's still-running monitor (cwd matches FX_A) and rewrite
+  # the PID file so AC-7's stop has a legitimate target. We scan all
+  # python3 zskills_monitor.server processes' /proc cwd's.
+  for cand in $(pgrep -f 'python3.*zskills_monitor.server' 2>/dev/null); do
+    cand_cwd=$(readlink "/proc/$cand/cwd" 2>/dev/null || echo "")
+    if [ "$cand_cwd" = "$FX_A" ]; then
+      # Re-derive its port via /proc/<pid>/net/tcp would be complex;
+      # easiest is to assume BASE_A is bound (the only port FX_A's
+      # config knows). Curl /api/health and parse the port field.
+      A_HEALTH=$(curl -sf -m 1 "http://127.0.0.1:$BASE_A/api/health" || true)
+      if printf '%s' "$A_HEALTH" | grep -qE '"status":[[:space:]]*"ok"'; then
+        cat > "$FX_A/.zskills/dashboard-server.pid" <<EOF
+pid=$cand
+port=$BASE_A
+started_at=$(date -Iseconds)
+EOF
+      fi
+      break
+    fi
+  done
+else
+  fail "AC-11: pre-condition — second monitor in FX_B did not start (skipping cwd-mismatch test)"
+fi
+
+###############################################################################
+# AC-7: stop removes the PID file and frees the port within 5s.
+# AC-9: stop twice → second prints no-PID-file message, exits 0.
+###############################################################################
+
+# AC-7 needs a live monitor with a matching PID file. The PID file was
+# rewritten in the AC-11 cleanup above; if missing (recovery branch
+# failed), we cannot exercise AC-7.
+if [ -f "$FX_A/.zskills/dashboard-server.pid" ]; then
+  STOP_PORT_AC7=$(grep -oE '^port=[0-9]+' "$FX_A/.zskills/dashboard-server.pid" | cut -d= -f2)
+  STOP_START_TS=$(date +%s)
+  if do_stop "$FX_A" >"$TMP_ROOT/A.stop.out" 2>&1; then
+    STOP_END_TS=$(date +%s)
+    STOP_ELAPSED=$((STOP_END_TS - STOP_START_TS))
+    if [ "$STOP_ELAPSED" -le 5 ]; then
+      pass "AC-7: stop completed within 5s (took ${STOP_ELAPSED}s)"
+    else
+      fail "AC-7: stop took ${STOP_ELAPSED}s (>5s)"
+    fi
+    if [ ! -f "$FX_A/.zskills/dashboard-server.pid" ]; then
+      pass "AC-7: stop removed the PID file"
+    else
+      fail "AC-7: stop did NOT remove the PID file"
+    fi
+    if [ -n "$STOP_PORT_AC7" ]; then
+      if lsof -iTCP:"$STOP_PORT_AC7" -sTCP:LISTEN >/dev/null 2>&1; then
+        fail "AC-7: port $STOP_PORT_AC7 still has a listener after stop"
+      else
+        pass "AC-7: port $STOP_PORT_AC7 is free after stop"
+      fi
+    fi
+  else
+    fail "AC-7: stop returned non-zero: $(cat "$TMP_ROOT/A.stop.out")"
+  fi
+
+  # AC-9: stop twice → second is no-op, exit 0.
+  if do_stop "$FX_A" >"$TMP_ROOT/A.stop2.out" 2>&1; then
+    if grep -q 'No running monitor' "$TMP_ROOT/A.stop2.out"; then
+      pass "AC-9: stop twice — second prints 'No running monitor' (idempotent)"
+    else
+      fail "AC-9: stop twice — unexpected output: $(cat "$TMP_ROOT/A.stop2.out")"
+    fi
+  else
+    fail "AC-9: stop twice — second invocation returned non-zero"
+  fi
+else
+  fail "AC-7 / AC-9: FX_A has no PID file to stop (cleanup branch failed)"
+fi
+
+print_summary_and_exit


### PR DESCRIPTION
## Summary

Phase 8 of `plans/ZSKILLS_MONITOR_PLAN.md`. Wraps the Phase 5 server in a `/zskills-dashboard [start|stop|status]` skill. Detached launch via `nohup … & disown`; SIGTERM-only stop with 5s poll (no `-9` escalation); status reports uptime + URL.

- **skills/zskills-dashboard/SKILL.md** (583 lines) — `disable-model-invocation: true`; MAIN_ROOT anchoring; process-identity check (command-name match `python3.*zskills_monitor.server` PLUS cwd match via `readlink /proc/$PID/cwd` with `lsof -p $PID -d cwd` fallback); BASH_REMATCH-only PID-file parsing (no jq); PYTHONPATH includes `skills/zskills-dashboard/scripts`; tracking markers for state-changing modes only; mirror via `scripts/mirror-skill.sh`.
- **.claude/skills/zskills-dashboard/SKILL.md** — byte-identical mirror.
- **tests/test_zskills_dashboard_skill.sh** (864 lines, +35 cases) — covers all 16 ACs incl. PID-mismatch defenses (cmd-name AND cwd), detachment survival across shells, double-start, double-stop, PID-reuse, tracking-marker presence/absence by mode.
- **tests/run-all.sh, .gitignore, CHANGELOG.md, README.md** — registry, log ignore, docs for the new skill + `dashboard.work_on_plans_trigger` config field.

Tracker also marks Phase 7 ✅ Done with squash hash `208fb7f` from PR #115.

## Test plan

- [x] Full test suite: 1193/1193 (was 1158, +35 dashboard-skill cases)
- [x] No `kill -9` / `killall` / `pkill` / `fuser -k` in SKILL.md
- [x] No `jq` in SKILL.md (BASH_REMATCH-only parsing)
- [x] Process-identity check (cmd + cwd) on both start AND stop
- [x] PYTHONPATH discipline grep matches
- [x] Mirror via mirror-skill.sh; no rm -rf .claude/skills
- [x] disable-model-invocation: true in frontmatter
- [x] Detachment survival in fresh shell (test verifies kill -0 + curl /api/health from new shell)
- [x] PID-mismatch defenses (cmd-name and cwd) refuse to kill, exit 1 with diagnostic
- [x] No PLAN-TEXT-DRIFT
- [ ] USER VERIFY: run `/zskills-dashboard start`, browse to printed URL, exercise dashboard, then `/zskills-dashboard stop`; confirm log at `.zskills/dashboard-server.log` is sane

🤖 Generated with [Claude Code](https://claude.com/claude-code)