### PR TITLE
[zskills-monitor-plan] ZSKILLS_MONITOR — Phase 9 (migrate /plans rebuild to Python aggregator)

### DIFF
--- a/.claude/skills/plans/SKILL.md
+++ b/.claude/skills/plans/SKILL.md
@@ -20,12 +20,90 @@ their classification, status, and priority.
 - **details** `/plans details` — show every plan with a one-line description
 - **For batch execution:** see `/work-on-plans`.
 
+## Single source of truth
+
+All four modes consume the **Phase 4 Python aggregator**
+(`skills/zskills-dashboard/scripts/zskills_monitor/collect.py`) — never
+re-parse plan frontmatter or progress trackers from skill prose. The
+aggregator is the canonical classifier; this skill is a thin renderer
+over its JSON output.
+
+Canonical invocation (used by every mode below):
+
+```bash
+MAIN_ROOT=$(git rev-parse --show-toplevel)
+PYTHONPATH="$MAIN_ROOT/skills/zskills-dashboard/scripts" \
+  python3 -m zskills_monitor.collect
+```
+
+The CLI emits a single JSON document on stdout matching the
+`collect_snapshot()` schema. The fields this skill consumes from each
+`snapshot.plans[]` entry are:
+
+- `slug`, `file`, `title`, `blurb`, `phase_count`, `phases_done`
+- `status` — frontmatter value (`active`, `complete`, `landed`, `conflict`,
+  or empty → defaults to `active`)
+- `category` — one of `"canary"`, `"issue_tracker"`, `"reference"`,
+  `"executable"` (set by `collect.py`'s `_categorize_plan`)
+- `meta_plan` — `true` if the plan body invokes `Skill: { skill: "run-plan", … }`;
+  `sub_plans` lists the slugs of its delegated children
+
+Example aggregator emission (single plan entry, fields trimmed for
+clarity — note the JSON shape this skill consumes):
+
+```json
+{
+  "slug": "example-plan",
+  "title": "Example Plan",
+  "status": "active",
+  "phase_count": 5,
+  "phases_done": 0,
+  "category": "executable",
+  "meta_plan": false,
+  "sub_plans": [],
+  "queue": {"column": "drafted", "index": -1, "mode": null}
+}
+```
+
+Canaries surface as `"category": "canary"`; issue-tracker docs as
+`"category": "issue_tracker"`; reference docs as `"category": "reference"`;
+and meta-plans add `"meta_plan": true` plus a non-empty `sub_plans[]`.
+- `queue.column` — current monitor-state column (`ready`, `drafted`,
+  `reviewed`, `landed`, etc.) or `null` if hidden
+- `phases[]` — per-row tracker entries with `n`, `name`, `status`, `commit`
+
+If `python3` is missing, the module fails to import, or the CLI exits
+non-zero, every mode below reports the error to the user verbatim and
+exits non-zero. **There is no bash fallback** — the prose classifier was
+removed when this skill migrated to the aggregator.
+
+## Index → snapshot section mapping
+
+The six sections of `plans/PLAN_INDEX.md` are derived from the
+aggregator's `category`, `status`, `phases_done`, and `queue.column`
+fields per this mapping (used by Mode: Rebuild, Mode: Show, and Mode:
+Details to group plans):
+
+| Section | Selector |
+|---------|----------|
+| **Ready to Run** | `category=="executable"` AND `status=="active"` AND `phases_done == 0` AND `queue.column != "ready"`; OR `queue.column == "ready"` (any plan explicitly placed in the ready column wins regardless of phase progress) |
+| **In Progress** | `category=="executable"` AND `status=="active"` AND `phases_done >= 1` AND `phases_done < phase_count` |
+| **Needs Review** | `category=="executable"` AND `status=="conflict"` |
+| **Complete** | `status` in `{"complete","landed"}` |
+| **Canaries** | `category=="canary"` (regardless of status — canaries never promote into other sections) |
+| **Reference (not executable)** | `category` in `{"reference","issue_tracker"}` |
+
+**Meta-plans** (`meta_plan==true`) are listed at the top level of
+whichever section their `status`/category place them in, with each entry
+in `sub_plans[]` indented beneath them using `↳` prefix. Sub-plans do
+NOT appear as separate top-level entries.
+
 ## Mode: Show (bare `/plans`)
 
-1. Read `plans/PLAN_INDEX.md`
+1. Read `plans/PLAN_INDEX.md`.
 2. If the file does not exist, **auto-run rebuild** (Mode: Rebuild below) to
    create it, then display the newly generated index.
-3. If the file exists, display a **actionable dashboard** — not a one-line
+3. If the file exists, display an **actionable dashboard** — not a one-line
    summary. Show the actual plan names and status so the user can decide
    what to work on:
 
@@ -66,11 +144,26 @@ their classification, status, and priority.
 Show every plan with a one-line description, grouped by status. Useful
 when you have many plans and can't remember what each one is about.
 
-1. Read `plans/PLAN_INDEX.md` (auto-rebuild if missing).
-2. For each plan in the index, read its `## Overview` section (first
-   paragraph only) and extract a one-line blurb.
-3. Display grouped by status (Ready, In Progress, Complete, Canaries),
-   with the blurb after each plan name:
+1. Invoke the canonical aggregator CLI (see "Single source of truth"
+   above):
+
+   ```bash
+   MAIN_ROOT=$(git rev-parse --show-toplevel)
+   SNAPSHOT=$(PYTHONPATH="$MAIN_ROOT/skills/zskills-dashboard/scripts" \
+     python3 -m zskills_monitor.collect) || {
+       echo "ERROR: zskills_monitor.collect failed (rc=$?)" >&2
+       exit 1
+     }
+   ```
+
+   Parse `$SNAPSHOT` as JSON.
+2. Group `snapshot.plans[]` per the section mapping above
+   (Ready / In Progress / Needs Review / Complete / Canaries /
+   Reference). Use each plan's `blurb` field directly — `collect.py`
+   already extracted the first paragraph after `## Overview`, trimmed
+   to 240 characters.
+3. Display grouped by status (Ready, In Progress, Complete, Canaries,
+   Reference), with the blurb after each plan name:
 
    ```
    Ready to Run:
@@ -97,150 +190,93 @@ when you have many plans and can't remember what each one is about.
      ...
    ```
 
-   The Canaries group renders the index's Canaries section verbatim. Use
-   the same symbol-counting rules from Mode: Rebuild Step 3 (`⬚` and `⬜`
-   are both pending) when displaying tracker status. Do not promote
-   canaries into other groups.
-
+   Within the Canaries group, derive the per-canary tracker state from
+   the snapshot's `phases[]` array: all rows `done` → `Complete`; some
+   `done` and some not → `In Progress`; none `done` → `Ready`; empty
+   `phases[]` (no Progress Tracker present) → `Manual — no tracker`. Do
+   not promote canaries into other groups.
 4. **Exit.**
 
 ## Mode: Rebuild (`/plans rebuild`)
 
-Scan `plans/`, classify every `.md` file, and write a fresh `plans/PLAN_INDEX.md`.
+Regenerate `plans/PLAN_INDEX.md` from the aggregator snapshot. The
+implementing agent shells out to `python3 -m zskills_monitor.collect`
+and renders the six-section index from the returned JSON — there is
+**no in-prose classifier**. All status, category, phase-count, and
+meta-plan inference happens inside `collect.py`.
 
-### Step 1 — Inventory
+### Step 1 — Invoke the aggregator
 
 ```bash
-ls plans/*.md
+MAIN_ROOT=$(git rev-parse --show-toplevel)
+SNAPSHOT_JSON=$(PYTHONPATH="$MAIN_ROOT/skills/zskills-dashboard/scripts" \
+  python3 -m zskills_monitor.collect)
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  echo "ERROR: python3 -m zskills_monitor.collect failed (rc=$RC)" >&2
+  echo "Cannot regenerate plans/PLAN_INDEX.md — bailing out." >&2
+  exit 1
+fi
 ```
 
-Get all plan files. Ignore subdirectories (e.g., `plans/blocks/`).
+If the invocation fails (e.g. `python3` missing, `zskills_monitor`
+package unimportable, runtime exception), the rebuild aborts with a
+non-zero exit and the diagnostic above. **Do not** synthesize a
+fallback classifier — Phase 9 of `plans/ZSKILLS_MONITOR_PLAN.md`
+explicitly removes the legacy bash classifier so that
+`collect.py` is the single source of truth for plan classification.
 
-Also count block plan files for the coverage summary:
-```bash
-BLOCK_PLANS=$(find plans/blocks -name '*.md' 2>/dev/null | wc -l)
-BLOCK_IMPLS=$(grep -c "    type: '" src/library/registry.js 2>/dev/null)
-```
-Use the registry file for the implementation count — it's the authoritative
-registry. `find *Block.js` undercounts because some components (Resistor.js,
-Capacitor.js, etc.) don't follow the `*Block.js` naming convention.
+### Step 2 — Group `snapshot.plans[]` into sections
 
-### Step 2 — Classify each file
+Apply the section-selector table from "Index → snapshot section
+mapping" above. Concretely (parse `$SNAPSHOT_JSON` with a JSON-aware
+helper — `python3 -c 'import json,sys; …'` is fine):
 
-For each file, read enough of the file to classify it correctly. **Do not
-skim.** If the file has a Progress Tracker table, you MUST read every row of
-that table and count the status symbols — not summarize, not eyeball. Read
-the tracker in full even if it sits past the top of the file; do not stop
-after a fixed line budget. Index accuracy is load-bearing: a wrong status
-leads to wasted runs (re-executing done work) or missed work (skipping
-ready plans).
+- **Ready to Run** ← plan where (`category=="executable"` AND
+  `status=="active"` AND `phases_done == 0` AND
+  `queue.column != "ready"`) OR (`queue.column == "ready"`).
+- **In Progress** ← plan where `category=="executable"` AND
+  `status=="active"` AND `1 <= phases_done < phase_count`.
+- **Needs Review** ← plan where `category=="executable"` AND
+  `status=="conflict"`.
+- **Complete** ← plan where `status` is `"complete"` or `"landed"`.
+- **Canaries** ← plan where `category=="canary"`. Render
+  per-canary tracker status from the snapshot's `phases[]`:
+  all done → `Complete`; some done → `In Progress`; none done →
+  `Ready`; no `phases[]` → `Manual — no tracker`.
+- **Reference (not executable)** ← plan where `category` is
+  `"reference"` or `"issue_tracker"`.
 
-Classify into one of four categories:
+For each meta-plan (`meta_plan==true`), list its top-level entry under
+its own section, then indent each slug in its `sub_plans[]` underneath
+with `↳`. Sub-plans MUST NOT appear as separate top-level entries —
+look them up in `snapshot.plans[]` by `slug` and write them only as
+the meta-plan's children.
 
-1. **Canary** — filename matches `CANARY*.md` OR `*_CANARY*.md` (case
-   sensitive on `CANARY`). Examples: `CANARY1_HAPPY.md`,
-   `CANARY11_SCOPE_VIOLATION.md`, `REBASE_CONFLICT_CANARY.md`,
-   `CI_FIX_CYCLE_CANARY.md`, `PARALLEL_CANARYA.md`. The filename match
-   takes precedence over executable-plan content detection: a plan with
-   phases AND a `CANARY`-matching name is classified as a canary, not an
-   executable plan. Canaries are re-runnable test fixtures and are listed
-   in their own section so users do not confuse their tracker state with
-   feature-plan progress.
+### Step 3 — Order within each section
 
-2. **Executable plan** — has `## Phase` sections (numbered phases with work
-   items) OR has a Progress Tracker table (`| Phase | Status |`). These are
-   plans that `/run-plan` can execute.
+- **Ready to Run**: items whose `queue.column == "ready"` come first
+  (in their `queue.index` order from the snapshot — this preserves
+  user-set priority from `/zskills-dashboard`). Then default-column
+  Ready entries, ordered by recency (newest first; tiebreak alphabetical
+  by `slug`). Assign priority labels: `High` for plans referenced as
+  fix-issues "too complex" skips (check `SPRINT_REPORT.md` if it
+  exists for context); `Medium` for plans created within the last 14
+  days; `Low` otherwise.
+- **In Progress / Complete / Reference / Canaries**: alphabetical by
+  `slug`.
+- **Needs Review**: alphabetical by `slug`.
 
-   **Meta-plan detection:** If the plan's phases use `### Execution: delegate
-   /run-plan` directives referencing other plan files, it's a meta-plan. Record
-   which sub-plan files it references. In the index, sub-plans should be
-   indented under their meta-plan rather than listed independently.
+### Step 4 — Write `plans/PLAN_INDEX.md`
 
-3. **Issue tracker** — filename ends in `_ISSUES.md` OR has an "Issue Tracker"
-   or "Issue List" heading OR is primarily a table of GitHub issue numbers.
-   List separately — these are not executable by `/run-plan`.
-   **Deterministic rule:** Files ending in `_ISSUES.md` are ALWAYS classified
-   as issue trackers, regardless of other content (e.g., phase sections).
-   The filename suffix takes precedence over content-based classification.
-
-4. **Reference document** — everything else (research docs, overviews, gap
-   analyses, block library lists). List separately.
-
-### Step 3 — Determine status for executable plans
-
-For each executable plan, determine its status:
-
-1. **Read the Progress Tracker** (if present) — a table with phase rows and
-   status indicators. Read EVERY row; do not stop at the first few. Count the
-   symbols.
-
-   **Pending symbols (treat both as "not done"):**
-   - `⬚` (U+2B1A SQUARE TILE) — used by some plans (e.g., ZSKILLS_MONITOR_PLAN)
-   - `⬜` (U+2B1C WHITE LARGE SQUARE) — used by other plans (e.g., CANARY1_HAPPY)
-
-   The classifier MUST match either symbol as pending. Real plans in this
-   repo use both interchangeably; treating only one as pending causes the
-   other set to misclassify.
-
-   **Done symbols:** `✅` / `✔` / `Done` / `Complete` / a 7+ char hex commit hash.
-
-   Status determination:
-   - All phases done (no `⬚`/`⬜` or other pending markers remain) → **Complete**
-   - Some phases done, others pending (`⬚`/`⬜`/`Not Started`/empty) →
-     **In Progress** (note the current phase name and the next incomplete phase)
-   - No phases done (all rows show `⬚`/`⬜`/`Not Started`/empty) → **Ready**
-
-2. **No Progress Tracker?** Check for other completion signals:
-   - Sections with `**Status:** Done` or `**Status:** Complete` → count as done
-   - If all phase sections have completion markers → **Complete**
-   - If some do → **In Progress**
-   - If the plan has phases but no status indicators at all → **Needs Review**
-     (old-format plan; status is ambiguous — may be complete, may not be)
-   - Only classify as **Ready** if the plan clearly hasn't been started
-     (e.g., freshly created by `/draft-plan`)
-
-### Step 3b — Classify canaries within the Canaries section
-
-For each canary file, determine its tracker-state classification using the
-SAME symbol-counting rules from Step 3 (both `⬚` and `⬜` are pending; `✅` /
-`Done` / commit hash are done). The result feeds the Canaries section, not
-Ready/In Progress/Complete.
-
-- Has Progress Tracker, all rows pending → **Ready** (within Canaries)
-- Has Progress Tracker, some done → **In Progress** (within Canaries)
-- Has Progress Tracker, all done → **Complete** (within Canaries)
-- **No Progress Tracker** (e.g., CANARY8_PARALLEL, CANARY9_FINAL_VERIFY,
-  CANARY11_SCOPE_VIOLATION) → list as **Manual — no tracker**
-
-Do NOT use git history, PR resolution, or any other evidence beyond the
-canary's own Progress Tracker. The canary section is intentionally allowed
-to show stale entries — the point of the section is segregation, not
-ground-truth run history.
-
-### Step 4 — Determine priority for "Ready to Run" plans
-
-Rank ready plans by:
-
-1. **Plans referenced by `/fix-issues` "too complex" skips** — check
-   `SPRINT_REPORT.md` for "Skipped -- Too Complex" entries that reference a
-   plan file. Those plans are highest priority (blocking batch fixes).
-2. **Recently created plans** — sort by git creation date (newest first).
-   Use `git log --diff-filter=A --format=%aI -- <file>` to get each file's
-   initial commit date. This avoids conflating "recently written" with
-   "recently touched by any edit."
-3. **Alphabetical** — tiebreaker.
-
-Assign priority labels: **High** (referenced by fix-issues skips), **Medium**
-(recent), **Low** (older/alphabetical fallback).
-
-### Step 5 — Write `plans/PLAN_INDEX.md`
-
-Write the index file with this structure:
+Render with this structure (preserves the historical six-section shape):
 
 ```markdown
 # Plan Index
 
 Auto-generated by `/plans rebuild`. Last rebuilt: YYYY-MM-DD HH:MM ET.
+
+Totals: N plans — A ready, B in progress, C complete, D canaries, E reference.
 
 ## Ready to Run
 
@@ -256,9 +292,10 @@ Auto-generated by `/plans rebuild`. Last rebuilt: YYYY-MM-DD HH:MM ET.
 
 ## Needs Review
 
-Old-format plans without progress trackers. Status is ambiguous — may be
-complete, partially done, or not started. Triage these once: mark as
-Complete, move to Ready, or rewrite with `/draft-plan plans/FILE.md`.
+Old-format plans without progress trackers, OR plans whose frontmatter
+`status` is `conflict`. Status is ambiguous — may be complete, partially
+done, or not started. Triage these once: mark as Complete, move to
+Ready, or rewrite with `/draft-plan plans/FILE.md`.
 
 | Plan | Phases | Issue | Notes |
 |------|--------|-------|-------|
@@ -295,52 +332,84 @@ for its output file or a PR with its name.
 ```
 
 **Notes for each section:**
+
 - If a section would be empty, include the table header with a single row:
-  `| (none) | | | | |`
-- Use relative links (just the filename, since index is in `plans/`)
-- Count phases by counting `## Phase` headings (or progress tracker rows)
-- For "In Progress" plans, identify both the current phase (last done) and
-  the next phase (first incomplete)
-- **Meta-plan grouping:** If a plan is a meta-plan (has `delegate /run-plan`
-  phases referencing other plan files), indent its sub-plans beneath it
-  with `↳` prefix. Sub-plans should NOT appear as separate top-level entries.
-  This makes the hierarchy visible — e.g., RUNTIME_PARITY_META owns
-  RUNTIME_SIGNAL_FLOW_BLOCKS and RUNTIME_DEPLOY_SERIALIZATION.
-- **Canaries section:** any file whose name matches `CANARY*.md` or
-  `*_CANARY*.md` belongs in the Canaries section, never in
-  Ready/In Progress/Complete — even if its tracker shows the same shape.
-  Tracker Status within the section uses the Step 3 / Step 3b symbol rules
-  (`⬚`/`⬜` pending, `✅`/`Done`/commit hash done). Canaries with no
-  Progress Tracker are listed with Tracker Status `Manual — no tracker`.
-  Stale entries are acceptable: the section is for visual segregation,
-  not ground-truth run history.
+  `| (none) | | | | |`.
+- Use relative links (just the filename, since the index lives in
+  `plans/`).
+- `phase_count` from the snapshot drives the "Phases" column; for
+  In Progress entries, the "Current Phase" is the last `phases[]` row
+  with `status=="done"` and "Next Phase" is the first remaining row.
+- Do NOT recompute classification by reading plan files in this skill;
+  every category/status/phase value comes from the snapshot.
+- Canary tracker status: derive from the snapshot's `phases[]` per
+  Step 2's Canaries rule. Stale entries are acceptable — the section
+  is for visual segregation, not ground-truth run history.
+
+### Step 5 — Block-plan coverage line (optional context)
+
+The "Reference (not executable)" footer line can include a count of
+implemented blocks vs. block plans:
+
+```bash
+BLOCK_PLANS=$(find plans/blocks -name '*.md' 2>/dev/null | wc -l)
+BLOCK_IMPLS=$(grep -c "    type: '" src/library/registry.js 2>/dev/null)
+```
+
+Use the registry file for the implementation count — it's the
+authoritative registry. `find *Block.js` undercounts because some
+components don't follow the `*Block.js` naming convention.
 
 ## Mode: Next (`/plans next`)
 
-1. Read `plans/PLAN_INDEX.md`
-2. If the file does not exist, **auto-run rebuild** to create it first.
-3. Find the first entry in the "Ready to Run" table (highest priority)
+1. Invoke the canonical aggregator CLI (see "Single source of truth"
+   above) and parse the JSON. Apply the section mapping to identify
+   the **Ready to Run** set.
+2. If `plans/PLAN_INDEX.md` is missing, **also auto-run rebuild** so
+   the file exists for subsequent `/plans` calls. This is a
+   side-effect, not the source of truth — `Mode: Next` reads its
+   answer from the snapshot, not from the regenerated index.
+3. Pick the highest-priority Ready entry using Mode: Rebuild Step 3's
+   ordering: `queue.column == "ready"` items first (in
+   `queue.index` order), then default-column Ready entries by
+   recency.
 4. If found, output:
    > **Next plan to run:** `EXAMPLE_PLAN.md`
    > Phases: 5, starting at Phase 1 -- Setup
    > Priority: High (referenced by fix-issues skip #NNN)
    >
    > Run with: `/run-plan plans/EXAMPLE_PLAN.md`
-5. If the "Ready to Run" table is empty or has only `(none)`:
+
+   The "starting at Phase 1 -- …" comes from the first entry in the
+   snapshot plan's `phases[]` whose `status != "done"` (or, if
+   `phases[]` is empty, from the first `## Phase` heading captured by
+   `collect.py` and exposed via `phase_count`).
+5. If the Ready-to-Run set is empty:
    > No plans ready to run. All executable plans are either in progress or complete.
    > Check "In Progress" plans in the index for plans that need attention.
 6. **Exit.**
 
 ## Key Rules
 
+- **Single source of truth.** All classification (`category`,
+  `meta_plan`, status, phase counts) lives in
+  `skills/zskills-dashboard/scripts/zskills_monitor/collect.py`. The
+  prose in this skill never reproduces those rules — it only describes
+  how to render the snapshot's already-computed fields.
 - **Rebuild is idempotent** — running it twice produces the same result
   (assuming no plan files changed between runs).
-- **Never modify plan files** — the index is read-only metadata. It reads
-  plans but never changes them.
-- **Skip `plans/blocks/` subdirectories** — those are block-specific plan
-  files managed by `/add-block`, not executable plans.
+- **Never modify plan files** — the index is read-only metadata. It
+  reads plans (via the aggregator) but never changes them.
+- **Skip `plans/blocks/` subdirectories** — those are block-specific
+  plan files managed by `/add-block`, not executable plans.
+  `collect.py` already restricts to top-level `plans/*.md`.
 - **Skip `PLAN_INDEX.md` itself** — don't index the index.
-- **Relative links** — since the index lives in `plans/`, links are just
-  filenames (e.g., `[FOO.md](FOO.md)`), not `plans/FOO.md`.
-- **Timezone** — always use America/New_York (ET) for the "Last rebuilt"
-  timestamp.
+- **Relative links** — since the index lives in `plans/`, links are
+  just filenames (e.g., `[FOO.md](FOO.md)`), not `plans/FOO.md`.
+- **Timezone** — always use America/New_York (ET) for the "Last
+  rebuilt" timestamp.
+- **No bash fallback.** If `python3 -m zskills_monitor.collect` fails,
+  every mode reports the failure and exits non-zero. Per
+  `feedback_no_premature_backcompat`, this is intentional: maintaining
+  two classifiers (the prose one and the Python one) was the bug
+  Phase 9 closes.

--- a/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/plans/ZSKILLS_MONITOR_PLAN.md
@@ -256,8 +256,8 @@ is appended to `errors[]`.
 | 5 — HTTP server | ✅ Done | `63747e5` | landed via PR squash; server.py 1099 lines; 9 endpoints; 127.0.0.1 only; trigger security contract; flock + atomic writes; +53 tests |
 | 6 — Read-only dashboard UI | ✅ Done | `1239f6c` | landed via PR squash; static HTML/CSS/JS; 5 panels + 2 modals; XSS-safe; +45 tests; 1111/1111 |
 | 7 — Interactive queue + write-back | ✅ Done | `208fb7f` | landed via PR #115 squash; drag-drop + default-mode + per-row chips + run-status + POST write-back; +47 tests; 1158/1158 |
-| 8 — `/zskills-dashboard` skill | 🟡 In Progress | | |
-| 9 — Migrate `/plans rebuild` to Python aggregator | ⬚ | | |
+| 8 — `/zskills-dashboard` skill | ✅ Done | `8ac36d9` | landed via PR #116 squash; SKILL.md 583 lines; start/stop/status w/ cmd+cwd identity check; SIGTERM-only; +35 tests; 1193/1193 |
+| 9 — Migrate `/plans rebuild` to Python aggregator | 🟡 In Progress | | |
 
 ---
 

--- a/skills/plans/SKILL.md
+++ b/skills/plans/SKILL.md
@@ -20,12 +20,90 @@ their classification, status, and priority.
 - **details** `/plans details` — show every plan with a one-line description
 - **For batch execution:** see `/work-on-plans`.
 
+## Single source of truth
+
+All four modes consume the **Phase 4 Python aggregator**
+(`skills/zskills-dashboard/scripts/zskills_monitor/collect.py`) — never
+re-parse plan frontmatter or progress trackers from skill prose. The
+aggregator is the canonical classifier; this skill is a thin renderer
+over its JSON output.
+
+Canonical invocation (used by every mode below):
+
+```bash
+MAIN_ROOT=$(git rev-parse --show-toplevel)
+PYTHONPATH="$MAIN_ROOT/skills/zskills-dashboard/scripts" \
+  python3 -m zskills_monitor.collect
+```
+
+The CLI emits a single JSON document on stdout matching the
+`collect_snapshot()` schema. The fields this skill consumes from each
+`snapshot.plans[]` entry are:
+
+- `slug`, `file`, `title`, `blurb`, `phase_count`, `phases_done`
+- `status` — frontmatter value (`active`, `complete`, `landed`, `conflict`,
+  or empty → defaults to `active`)
+- `category` — one of `"canary"`, `"issue_tracker"`, `"reference"`,
+  `"executable"` (set by `collect.py`'s `_categorize_plan`)
+- `meta_plan` — `true` if the plan body invokes `Skill: { skill: "run-plan", … }`;
+  `sub_plans` lists the slugs of its delegated children
+
+Example aggregator emission (single plan entry, fields trimmed for
+clarity — note the JSON shape this skill consumes):
+
+```json
+{
+  "slug": "example-plan",
+  "title": "Example Plan",
+  "status": "active",
+  "phase_count": 5,
+  "phases_done": 0,
+  "category": "executable",
+  "meta_plan": false,
+  "sub_plans": [],
+  "queue": {"column": "drafted", "index": -1, "mode": null}
+}
+```
+
+Canaries surface as `"category": "canary"`; issue-tracker docs as
+`"category": "issue_tracker"`; reference docs as `"category": "reference"`;
+and meta-plans add `"meta_plan": true` plus a non-empty `sub_plans[]`.
+- `queue.column` — current monitor-state column (`ready`, `drafted`,
+  `reviewed`, `landed`, etc.) or `null` if hidden
+- `phases[]` — per-row tracker entries with `n`, `name`, `status`, `commit`
+
+If `python3` is missing, the module fails to import, or the CLI exits
+non-zero, every mode below reports the error to the user verbatim and
+exits non-zero. **There is no bash fallback** — the prose classifier was
+removed when this skill migrated to the aggregator.
+
+## Index → snapshot section mapping
+
+The six sections of `plans/PLAN_INDEX.md` are derived from the
+aggregator's `category`, `status`, `phases_done`, and `queue.column`
+fields per this mapping (used by Mode: Rebuild, Mode: Show, and Mode:
+Details to group plans):
+
+| Section | Selector |
+|---------|----------|
+| **Ready to Run** | `category=="executable"` AND `status=="active"` AND `phases_done == 0` AND `queue.column != "ready"`; OR `queue.column == "ready"` (any plan explicitly placed in the ready column wins regardless of phase progress) |
+| **In Progress** | `category=="executable"` AND `status=="active"` AND `phases_done >= 1` AND `phases_done < phase_count` |
+| **Needs Review** | `category=="executable"` AND `status=="conflict"` |
+| **Complete** | `status` in `{"complete","landed"}` |
+| **Canaries** | `category=="canary"` (regardless of status — canaries never promote into other sections) |
+| **Reference (not executable)** | `category` in `{"reference","issue_tracker"}` |
+
+**Meta-plans** (`meta_plan==true`) are listed at the top level of
+whichever section their `status`/category place them in, with each entry
+in `sub_plans[]` indented beneath them using `↳` prefix. Sub-plans do
+NOT appear as separate top-level entries.
+
 ## Mode: Show (bare `/plans`)
 
-1. Read `plans/PLAN_INDEX.md`
+1. Read `plans/PLAN_INDEX.md`.
 2. If the file does not exist, **auto-run rebuild** (Mode: Rebuild below) to
    create it, then display the newly generated index.
-3. If the file exists, display a **actionable dashboard** — not a one-line
+3. If the file exists, display an **actionable dashboard** — not a one-line
    summary. Show the actual plan names and status so the user can decide
    what to work on:
 
@@ -66,11 +144,26 @@ their classification, status, and priority.
 Show every plan with a one-line description, grouped by status. Useful
 when you have many plans and can't remember what each one is about.
 
-1. Read `plans/PLAN_INDEX.md` (auto-rebuild if missing).
-2. For each plan in the index, read its `## Overview` section (first
-   paragraph only) and extract a one-line blurb.
-3. Display grouped by status (Ready, In Progress, Complete, Canaries),
-   with the blurb after each plan name:
+1. Invoke the canonical aggregator CLI (see "Single source of truth"
+   above):
+
+   ```bash
+   MAIN_ROOT=$(git rev-parse --show-toplevel)
+   SNAPSHOT=$(PYTHONPATH="$MAIN_ROOT/skills/zskills-dashboard/scripts" \
+     python3 -m zskills_monitor.collect) || {
+       echo "ERROR: zskills_monitor.collect failed (rc=$?)" >&2
+       exit 1
+     }
+   ```
+
+   Parse `$SNAPSHOT` as JSON.
+2. Group `snapshot.plans[]` per the section mapping above
+   (Ready / In Progress / Needs Review / Complete / Canaries /
+   Reference). Use each plan's `blurb` field directly — `collect.py`
+   already extracted the first paragraph after `## Overview`, trimmed
+   to 240 characters.
+3. Display grouped by status (Ready, In Progress, Complete, Canaries,
+   Reference), with the blurb after each plan name:
 
    ```
    Ready to Run:
@@ -97,150 +190,93 @@ when you have many plans and can't remember what each one is about.
      ...
    ```
 
-   The Canaries group renders the index's Canaries section verbatim. Use
-   the same symbol-counting rules from Mode: Rebuild Step 3 (`⬚` and `⬜`
-   are both pending) when displaying tracker status. Do not promote
-   canaries into other groups.
-
+   Within the Canaries group, derive the per-canary tracker state from
+   the snapshot's `phases[]` array: all rows `done` → `Complete`; some
+   `done` and some not → `In Progress`; none `done` → `Ready`; empty
+   `phases[]` (no Progress Tracker present) → `Manual — no tracker`. Do
+   not promote canaries into other groups.
 4. **Exit.**
 
 ## Mode: Rebuild (`/plans rebuild`)
 
-Scan `plans/`, classify every `.md` file, and write a fresh `plans/PLAN_INDEX.md`.
+Regenerate `plans/PLAN_INDEX.md` from the aggregator snapshot. The
+implementing agent shells out to `python3 -m zskills_monitor.collect`
+and renders the six-section index from the returned JSON — there is
+**no in-prose classifier**. All status, category, phase-count, and
+meta-plan inference happens inside `collect.py`.
 
-### Step 1 — Inventory
+### Step 1 — Invoke the aggregator
 
 ```bash
-ls plans/*.md
+MAIN_ROOT=$(git rev-parse --show-toplevel)
+SNAPSHOT_JSON=$(PYTHONPATH="$MAIN_ROOT/skills/zskills-dashboard/scripts" \
+  python3 -m zskills_monitor.collect)
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  echo "ERROR: python3 -m zskills_monitor.collect failed (rc=$RC)" >&2
+  echo "Cannot regenerate plans/PLAN_INDEX.md — bailing out." >&2
+  exit 1
+fi
 ```
 
-Get all plan files. Ignore subdirectories (e.g., `plans/blocks/`).
+If the invocation fails (e.g. `python3` missing, `zskills_monitor`
+package unimportable, runtime exception), the rebuild aborts with a
+non-zero exit and the diagnostic above. **Do not** synthesize a
+fallback classifier — Phase 9 of `plans/ZSKILLS_MONITOR_PLAN.md`
+explicitly removes the legacy bash classifier so that
+`collect.py` is the single source of truth for plan classification.
 
-Also count block plan files for the coverage summary:
-```bash
-BLOCK_PLANS=$(find plans/blocks -name '*.md' 2>/dev/null | wc -l)
-BLOCK_IMPLS=$(grep -c "    type: '" src/library/registry.js 2>/dev/null)
-```
-Use the registry file for the implementation count — it's the authoritative
-registry. `find *Block.js` undercounts because some components (Resistor.js,
-Capacitor.js, etc.) don't follow the `*Block.js` naming convention.
+### Step 2 — Group `snapshot.plans[]` into sections
 
-### Step 2 — Classify each file
+Apply the section-selector table from "Index → snapshot section
+mapping" above. Concretely (parse `$SNAPSHOT_JSON` with a JSON-aware
+helper — `python3 -c 'import json,sys; …'` is fine):
 
-For each file, read enough of the file to classify it correctly. **Do not
-skim.** If the file has a Progress Tracker table, you MUST read every row of
-that table and count the status symbols — not summarize, not eyeball. Read
-the tracker in full even if it sits past the top of the file; do not stop
-after a fixed line budget. Index accuracy is load-bearing: a wrong status
-leads to wasted runs (re-executing done work) or missed work (skipping
-ready plans).
+- **Ready to Run** ← plan where (`category=="executable"` AND
+  `status=="active"` AND `phases_done == 0` AND
+  `queue.column != "ready"`) OR (`queue.column == "ready"`).
+- **In Progress** ← plan where `category=="executable"` AND
+  `status=="active"` AND `1 <= phases_done < phase_count`.
+- **Needs Review** ← plan where `category=="executable"` AND
+  `status=="conflict"`.
+- **Complete** ← plan where `status` is `"complete"` or `"landed"`.
+- **Canaries** ← plan where `category=="canary"`. Render
+  per-canary tracker status from the snapshot's `phases[]`:
+  all done → `Complete`; some done → `In Progress`; none done →
+  `Ready`; no `phases[]` → `Manual — no tracker`.
+- **Reference (not executable)** ← plan where `category` is
+  `"reference"` or `"issue_tracker"`.
 
-Classify into one of four categories:
+For each meta-plan (`meta_plan==true`), list its top-level entry under
+its own section, then indent each slug in its `sub_plans[]` underneath
+with `↳`. Sub-plans MUST NOT appear as separate top-level entries —
+look them up in `snapshot.plans[]` by `slug` and write them only as
+the meta-plan's children.
 
-1. **Canary** — filename matches `CANARY*.md` OR `*_CANARY*.md` (case
-   sensitive on `CANARY`). Examples: `CANARY1_HAPPY.md`,
-   `CANARY11_SCOPE_VIOLATION.md`, `REBASE_CONFLICT_CANARY.md`,
-   `CI_FIX_CYCLE_CANARY.md`, `PARALLEL_CANARYA.md`. The filename match
-   takes precedence over executable-plan content detection: a plan with
-   phases AND a `CANARY`-matching name is classified as a canary, not an
-   executable plan. Canaries are re-runnable test fixtures and are listed
-   in their own section so users do not confuse their tracker state with
-   feature-plan progress.
+### Step 3 — Order within each section
 
-2. **Executable plan** — has `## Phase` sections (numbered phases with work
-   items) OR has a Progress Tracker table (`| Phase | Status |`). These are
-   plans that `/run-plan` can execute.
+- **Ready to Run**: items whose `queue.column == "ready"` come first
+  (in their `queue.index` order from the snapshot — this preserves
+  user-set priority from `/zskills-dashboard`). Then default-column
+  Ready entries, ordered by recency (newest first; tiebreak alphabetical
+  by `slug`). Assign priority labels: `High` for plans referenced as
+  fix-issues "too complex" skips (check `SPRINT_REPORT.md` if it
+  exists for context); `Medium` for plans created within the last 14
+  days; `Low` otherwise.
+- **In Progress / Complete / Reference / Canaries**: alphabetical by
+  `slug`.
+- **Needs Review**: alphabetical by `slug`.
 
-   **Meta-plan detection:** If the plan's phases use `### Execution: delegate
-   /run-plan` directives referencing other plan files, it's a meta-plan. Record
-   which sub-plan files it references. In the index, sub-plans should be
-   indented under their meta-plan rather than listed independently.
+### Step 4 — Write `plans/PLAN_INDEX.md`
 
-3. **Issue tracker** — filename ends in `_ISSUES.md` OR has an "Issue Tracker"
-   or "Issue List" heading OR is primarily a table of GitHub issue numbers.
-   List separately — these are not executable by `/run-plan`.
-   **Deterministic rule:** Files ending in `_ISSUES.md` are ALWAYS classified
-   as issue trackers, regardless of other content (e.g., phase sections).
-   The filename suffix takes precedence over content-based classification.
-
-4. **Reference document** — everything else (research docs, overviews, gap
-   analyses, block library lists). List separately.
-
-### Step 3 — Determine status for executable plans
-
-For each executable plan, determine its status:
-
-1. **Read the Progress Tracker** (if present) — a table with phase rows and
-   status indicators. Read EVERY row; do not stop at the first few. Count the
-   symbols.
-
-   **Pending symbols (treat both as "not done"):**
-   - `⬚` (U+2B1A SQUARE TILE) — used by some plans (e.g., ZSKILLS_MONITOR_PLAN)
-   - `⬜` (U+2B1C WHITE LARGE SQUARE) — used by other plans (e.g., CANARY1_HAPPY)
-
-   The classifier MUST match either symbol as pending. Real plans in this
-   repo use both interchangeably; treating only one as pending causes the
-   other set to misclassify.
-
-   **Done symbols:** `✅` / `✔` / `Done` / `Complete` / a 7+ char hex commit hash.
-
-   Status determination:
-   - All phases done (no `⬚`/`⬜` or other pending markers remain) → **Complete**
-   - Some phases done, others pending (`⬚`/`⬜`/`Not Started`/empty) →
-     **In Progress** (note the current phase name and the next incomplete phase)
-   - No phases done (all rows show `⬚`/`⬜`/`Not Started`/empty) → **Ready**
-
-2. **No Progress Tracker?** Check for other completion signals:
-   - Sections with `**Status:** Done` or `**Status:** Complete` → count as done
-   - If all phase sections have completion markers → **Complete**
-   - If some do → **In Progress**
-   - If the plan has phases but no status indicators at all → **Needs Review**
-     (old-format plan; status is ambiguous — may be complete, may not be)
-   - Only classify as **Ready** if the plan clearly hasn't been started
-     (e.g., freshly created by `/draft-plan`)
-
-### Step 3b — Classify canaries within the Canaries section
-
-For each canary file, determine its tracker-state classification using the
-SAME symbol-counting rules from Step 3 (both `⬚` and `⬜` are pending; `✅` /
-`Done` / commit hash are done). The result feeds the Canaries section, not
-Ready/In Progress/Complete.
-
-- Has Progress Tracker, all rows pending → **Ready** (within Canaries)
-- Has Progress Tracker, some done → **In Progress** (within Canaries)
-- Has Progress Tracker, all done → **Complete** (within Canaries)
-- **No Progress Tracker** (e.g., CANARY8_PARALLEL, CANARY9_FINAL_VERIFY,
-  CANARY11_SCOPE_VIOLATION) → list as **Manual — no tracker**
-
-Do NOT use git history, PR resolution, or any other evidence beyond the
-canary's own Progress Tracker. The canary section is intentionally allowed
-to show stale entries — the point of the section is segregation, not
-ground-truth run history.
-
-### Step 4 — Determine priority for "Ready to Run" plans
-
-Rank ready plans by:
-
-1. **Plans referenced by `/fix-issues` "too complex" skips** — check
-   `SPRINT_REPORT.md` for "Skipped -- Too Complex" entries that reference a
-   plan file. Those plans are highest priority (blocking batch fixes).
-2. **Recently created plans** — sort by git creation date (newest first).
-   Use `git log --diff-filter=A --format=%aI -- <file>` to get each file's
-   initial commit date. This avoids conflating "recently written" with
-   "recently touched by any edit."
-3. **Alphabetical** — tiebreaker.
-
-Assign priority labels: **High** (referenced by fix-issues skips), **Medium**
-(recent), **Low** (older/alphabetical fallback).
-
-### Step 5 — Write `plans/PLAN_INDEX.md`
-
-Write the index file with this structure:
+Render with this structure (preserves the historical six-section shape):
 
 ```markdown
 # Plan Index
 
 Auto-generated by `/plans rebuild`. Last rebuilt: YYYY-MM-DD HH:MM ET.
+
+Totals: N plans — A ready, B in progress, C complete, D canaries, E reference.
 
 ## Ready to Run
 
@@ -256,9 +292,10 @@ Auto-generated by `/plans rebuild`. Last rebuilt: YYYY-MM-DD HH:MM ET.
 
 ## Needs Review
 
-Old-format plans without progress trackers. Status is ambiguous — may be
-complete, partially done, or not started. Triage these once: mark as
-Complete, move to Ready, or rewrite with `/draft-plan plans/FILE.md`.
+Old-format plans without progress trackers, OR plans whose frontmatter
+`status` is `conflict`. Status is ambiguous — may be complete, partially
+done, or not started. Triage these once: mark as Complete, move to
+Ready, or rewrite with `/draft-plan plans/FILE.md`.
 
 | Plan | Phases | Issue | Notes |
 |------|--------|-------|-------|
@@ -295,52 +332,84 @@ for its output file or a PR with its name.
 ```
 
 **Notes for each section:**
+
 - If a section would be empty, include the table header with a single row:
-  `| (none) | | | | |`
-- Use relative links (just the filename, since index is in `plans/`)
-- Count phases by counting `## Phase` headings (or progress tracker rows)
-- For "In Progress" plans, identify both the current phase (last done) and
-  the next phase (first incomplete)
-- **Meta-plan grouping:** If a plan is a meta-plan (has `delegate /run-plan`
-  phases referencing other plan files), indent its sub-plans beneath it
-  with `↳` prefix. Sub-plans should NOT appear as separate top-level entries.
-  This makes the hierarchy visible — e.g., RUNTIME_PARITY_META owns
-  RUNTIME_SIGNAL_FLOW_BLOCKS and RUNTIME_DEPLOY_SERIALIZATION.
-- **Canaries section:** any file whose name matches `CANARY*.md` or
-  `*_CANARY*.md` belongs in the Canaries section, never in
-  Ready/In Progress/Complete — even if its tracker shows the same shape.
-  Tracker Status within the section uses the Step 3 / Step 3b symbol rules
-  (`⬚`/`⬜` pending, `✅`/`Done`/commit hash done). Canaries with no
-  Progress Tracker are listed with Tracker Status `Manual — no tracker`.
-  Stale entries are acceptable: the section is for visual segregation,
-  not ground-truth run history.
+  `| (none) | | | | |`.
+- Use relative links (just the filename, since the index lives in
+  `plans/`).
+- `phase_count` from the snapshot drives the "Phases" column; for
+  In Progress entries, the "Current Phase" is the last `phases[]` row
+  with `status=="done"` and "Next Phase" is the first remaining row.
+- Do NOT recompute classification by reading plan files in this skill;
+  every category/status/phase value comes from the snapshot.
+- Canary tracker status: derive from the snapshot's `phases[]` per
+  Step 2's Canaries rule. Stale entries are acceptable — the section
+  is for visual segregation, not ground-truth run history.
+
+### Step 5 — Block-plan coverage line (optional context)
+
+The "Reference (not executable)" footer line can include a count of
+implemented blocks vs. block plans:
+
+```bash
+BLOCK_PLANS=$(find plans/blocks -name '*.md' 2>/dev/null | wc -l)
+BLOCK_IMPLS=$(grep -c "    type: '" src/library/registry.js 2>/dev/null)
+```
+
+Use the registry file for the implementation count — it's the
+authoritative registry. `find *Block.js` undercounts because some
+components don't follow the `*Block.js` naming convention.
 
 ## Mode: Next (`/plans next`)
 
-1. Read `plans/PLAN_INDEX.md`
-2. If the file does not exist, **auto-run rebuild** to create it first.
-3. Find the first entry in the "Ready to Run" table (highest priority)
+1. Invoke the canonical aggregator CLI (see "Single source of truth"
+   above) and parse the JSON. Apply the section mapping to identify
+   the **Ready to Run** set.
+2. If `plans/PLAN_INDEX.md` is missing, **also auto-run rebuild** so
+   the file exists for subsequent `/plans` calls. This is a
+   side-effect, not the source of truth — `Mode: Next` reads its
+   answer from the snapshot, not from the regenerated index.
+3. Pick the highest-priority Ready entry using Mode: Rebuild Step 3's
+   ordering: `queue.column == "ready"` items first (in
+   `queue.index` order), then default-column Ready entries by
+   recency.
 4. If found, output:
    > **Next plan to run:** `EXAMPLE_PLAN.md`
    > Phases: 5, starting at Phase 1 -- Setup
    > Priority: High (referenced by fix-issues skip #NNN)
    >
    > Run with: `/run-plan plans/EXAMPLE_PLAN.md`
-5. If the "Ready to Run" table is empty or has only `(none)`:
+
+   The "starting at Phase 1 -- …" comes from the first entry in the
+   snapshot plan's `phases[]` whose `status != "done"` (or, if
+   `phases[]` is empty, from the first `## Phase` heading captured by
+   `collect.py` and exposed via `phase_count`).
+5. If the Ready-to-Run set is empty:
    > No plans ready to run. All executable plans are either in progress or complete.
    > Check "In Progress" plans in the index for plans that need attention.
 6. **Exit.**
 
 ## Key Rules
 
+- **Single source of truth.** All classification (`category`,
+  `meta_plan`, status, phase counts) lives in
+  `skills/zskills-dashboard/scripts/zskills_monitor/collect.py`. The
+  prose in this skill never reproduces those rules — it only describes
+  how to render the snapshot's already-computed fields.
 - **Rebuild is idempotent** — running it twice produces the same result
   (assuming no plan files changed between runs).
-- **Never modify plan files** — the index is read-only metadata. It reads
-  plans but never changes them.
-- **Skip `plans/blocks/` subdirectories** — those are block-specific plan
-  files managed by `/add-block`, not executable plans.
+- **Never modify plan files** — the index is read-only metadata. It
+  reads plans (via the aggregator) but never changes them.
+- **Skip `plans/blocks/` subdirectories** — those are block-specific
+  plan files managed by `/add-block`, not executable plans.
+  `collect.py` already restricts to top-level `plans/*.md`.
 - **Skip `PLAN_INDEX.md` itself** — don't index the index.
-- **Relative links** — since the index lives in `plans/`, links are just
-  filenames (e.g., `[FOO.md](FOO.md)`), not `plans/FOO.md`.
-- **Timezone** — always use America/New_York (ET) for the "Last rebuilt"
-  timestamp.
+- **Relative links** — since the index lives in `plans/`, links are
+  just filenames (e.g., `[FOO.md](FOO.md)`), not `plans/FOO.md`.
+- **Timezone** — always use America/New_York (ET) for the "Last
+  rebuilt" timestamp.
+- **No bash fallback.** If `python3 -m zskills_monitor.collect` fails,
+  every mode reports the failure and exits non-zero. Per
+  `feedback_no_premature_backcompat`, this is intentional: maintaining
+  two classifiers (the prose one and the Python one) was the bug
+  Phase 9 closes.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -59,6 +59,7 @@ run_suite "test-stub-callouts.sh" "tests/test-stub-callouts.sh"
 run_suite "test-post-create-worktree.sh" "tests/test-post-create-worktree.sh"
 run_suite "test_zskills_monitor_dashboard_ui.sh" "tests/test_zskills_monitor_dashboard_ui.sh"
 run_suite "test_zskills_dashboard_skill.sh" "tests/test_zskills_dashboard_skill.sh"
+run_suite "test_plans_rebuild_uses_collect.sh" "tests/test_plans_rebuild_uses_collect.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test_plans_rebuild_uses_collect.sh
+++ b/tests/test_plans_rebuild_uses_collect.sh
@@ -1,0 +1,409 @@
+#!/bin/bash
+# Tests for skills/plans/SKILL.md (Phase 9 of plans/ZSKILLS_MONITOR_PLAN.md):
+# verifies that `/plans rebuild | next | details` consume the Phase 4 Python
+# aggregator (skills/zskills-dashboard/scripts/zskills_monitor/collect.py) as
+# the single source of truth for plan classification.
+#
+# Two layers of coverage:
+#  1) SKILL.md prose layer — grep that the new wrapper invocation, JSON-field
+#     references, and section mapping are present, and that the OLD prose
+#     classifier is gone.
+#  2) Aggregator-output layer — invoke the aggregator against test fixtures,
+#     apply the section mapping documented in the SKILL.md, and assert each
+#     fixture lands in the expected section.
+#
+# Output goes to $TEST_OUT/.test-results.txt per CLAUDE.md.
+#
+# Run from repo root: bash tests/test_plans_rebuild_uses_collect.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/plans/SKILL.md"
+MIRROR_MD="$REPO_ROOT/.claude/skills/plans/SKILL.md"
+PKG_PARENT="$REPO_ROOT/skills/zskills-dashboard/scripts"
+COLLECT_PY="$PKG_PARENT/zskills_monitor/collect.py"
+FIXTURES="$REPO_ROOT/tests/fixtures/monitor"
+
+TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
+mkdir -p "$TEST_OUT"
+RESULTS="$TEST_OUT/.test-results.txt"
+: > "$RESULTS"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+pass() {
+  printf '\033[32m  PASS\033[0m %s\n' "$1"
+  printf '  PASS %s\n' "$1" >> "$RESULTS"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+fail() {
+  printf '\033[31m  FAIL\033[0m %s\n' "$1"
+  printf '  FAIL %s\n' "$1" >> "$RESULTS"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+skip() {
+  printf '\033[33m  SKIP\033[0m %s\n' "$1"
+  printf '  SKIP %s\n' "$1" >> "$RESULTS"
+  SKIP_COUNT=$((SKIP_COUNT + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+echo "=== Phase 9: /plans rebuild uses collect.py — preconditions ==="
+
+if [ ! -f "$SKILL_MD" ]; then
+  fail "skills/plans/SKILL.md exists"
+  printf 'Results: %d passed, %d failed, %d skipped\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+  exit 1
+fi
+pass "skills/plans/SKILL.md exists"
+
+if [ ! -f "$COLLECT_PY" ]; then
+  fail "collect.py exists at expected path ($COLLECT_PY)"
+  printf 'Results: %d passed, %d failed, %d skipped\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+  exit 1
+fi
+pass "collect.py exists at expected path"
+
+# ---------------------------------------------------------------------------
+# Layer 1: SKILL.md prose grep checks (matches AC-1 through AC-4 verbatim)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 9 AC-1: SKILL.md references zskills_monitor.collect ==="
+
+if grep -nE 'zskills_monitor\.collect|collect_snapshot' "$SKILL_MD" > /dev/null 2>&1; then
+  pass "AC-1: SKILL.md references zskills_monitor.collect or collect_snapshot"
+else
+  fail "AC-1: SKILL.md does not reference zskills_monitor.collect"
+fi
+
+echo ""
+echo "=== Phase 9 AC-2: SKILL.md uses canonical PYTHONPATH prefix ==="
+
+if grep -nE 'PYTHONPATH.*skills/zskills-dashboard/scripts' "$SKILL_MD" > /dev/null 2>&1; then
+  pass "AC-2: SKILL.md uses canonical PYTHONPATH=...skills/zskills-dashboard/scripts prefix"
+else
+  fail "AC-2: SKILL.md missing canonical PYTHONPATH prefix"
+fi
+
+echo ""
+echo "=== Phase 9 AC-3: SKILL.md references Phase 4 category/meta_plan fields ==="
+
+if grep -nE '"category"\s*:\s*"(canary|issue_tracker|reference|executable)"|"meta_plan"\s*:\s*true' \
+    "$SKILL_MD" > /dev/null 2>&1; then
+  pass "AC-3: SKILL.md references category/meta_plan field shape"
+else
+  fail "AC-3: SKILL.md missing category/meta_plan JSON-field reference"
+fi
+
+echo ""
+echo "=== Phase 9 AC-4: old prose classifier removed ==="
+
+# Should return NO matches in the new SKILL.md.
+if grep -nE 'classify as \*\*Ready\*\*|classify every `\.md`' \
+    "$SKILL_MD" > /dev/null 2>&1; then
+  fail "AC-4: SKILL.md still contains old prose classifier phrasing"
+else
+  pass "AC-4: old prose classifier ('classify every .md', 'classify as Ready') removed"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer 1b: source/mirror parity (AC-5)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 9 AC-5: source/mirror byte-parity ==="
+
+if [ ! -f "$MIRROR_MD" ]; then
+  fail "AC-5: .claude/skills/plans/SKILL.md mirror exists"
+else
+  if cmp -s "$SKILL_MD" "$MIRROR_MD"; then
+    pass "AC-5: skills/plans/SKILL.md == .claude/skills/plans/SKILL.md (byte-identical)"
+  else
+    fail "AC-5: skills/plans/SKILL.md and .claude/skills/plans/SKILL.md diverge"
+  fi
+fi
+
+# Stronger: full directory diff (matches AC-5 invocation verbatim).
+DIFF_OUT=$(diff -rq "$REPO_ROOT/skills/plans/" "$REPO_ROOT/.claude/skills/plans/" 2>&1 \
+  | grep -v __pycache__ || true)
+if [ -z "$DIFF_OUT" ]; then
+  pass "AC-5: diff -rq skills/plans/ .claude/skills/plans/ clean (modulo __pycache__)"
+else
+  fail "AC-5: diff -rq output non-empty: $DIFF_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer 2: aggregator-output layer — exercise the section mapping against
+# real fixtures, asserting each lands in the expected section
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 9 AC-6: section mapping matches Phase 4 categorization rules ==="
+
+if ! command -v python3 >/dev/null 2>&1; then
+  skip "python3 not available — skipping aggregator-output tests"
+else
+  # Canary fixture → Canaries section (regardless of status).
+  CAT_CANARY=$(PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.collect \
+    --fixture "$FIXTURES/category-canary" 2>&1 | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+p=d["plans"][0]
+# Apply SKILL.md section mapping.
+status = p["status"]
+cat = p["category"]
+phases_done = p["phases_done"]
+phase_count = p["phase_count"]
+queue_col = (p.get("queue") or {}).get("column")
+if cat == "canary":
+    section = "Canaries"
+elif cat in ("reference","issue_tracker"):
+    section = "Reference"
+elif status in ("complete","landed"):
+    section = "Complete"
+elif cat == "executable" and status == "conflict":
+    section = "Needs Review"
+elif cat == "executable" and status == "active" and phases_done >= 1 and phases_done < phase_count:
+    section = "In Progress"
+elif (cat == "executable" and status == "active" and phases_done == 0 and queue_col != "ready") or queue_col == "ready":
+    section = "Ready to Run"
+else:
+    section = "Other"
+print(section)
+' 2>&1)
+  if [ "$CAT_CANARY" = "Canaries" ]; then
+    pass "AC-6: category-canary fixture lands in Canaries section"
+  else
+    fail "AC-6: category-canary fixture → got '$CAT_CANARY', expected 'Canaries'"
+  fi
+
+  # Issue-tracker fixture → Reference section.
+  CAT_ISSUES=$(PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.collect \
+    --fixture "$FIXTURES/category-issues" 2>&1 | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+p=d["plans"][0]
+status = p["status"]; cat = p["category"]
+phases_done = p["phases_done"]; phase_count = p["phase_count"]
+queue_col = (p.get("queue") or {}).get("column")
+if cat == "canary": section = "Canaries"
+elif cat in ("reference","issue_tracker"): section = "Reference"
+elif status in ("complete","landed"): section = "Complete"
+elif cat == "executable" and status == "conflict": section = "Needs Review"
+elif cat == "executable" and status == "active" and phases_done >= 1 and phases_done < phase_count: section = "In Progress"
+elif (cat == "executable" and status == "active" and phases_done == 0 and queue_col != "ready") or queue_col == "ready": section = "Ready to Run"
+else: section = "Other"
+print(section)
+' 2>&1)
+  if [ "$CAT_ISSUES" = "Reference" ]; then
+    pass "AC-6: category-issues fixture lands in Reference section"
+  else
+    fail "AC-6: category-issues fixture → got '$CAT_ISSUES', expected 'Reference'"
+  fi
+
+  # Meta-plan executable fixture (no progress, status=active) → Ready to Run.
+  CAT_META=$(PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.collect \
+    --fixture "$FIXTURES/category-meta" 2>&1 | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+p=d["plans"][0]
+status = p["status"]; cat = p["category"]
+phases_done = p["phases_done"]; phase_count = p["phase_count"]
+queue_col = (p.get("queue") or {}).get("column")
+meta = p["meta_plan"]; subs = p["sub_plans"]
+if cat == "canary": section = "Canaries"
+elif cat in ("reference","issue_tracker"): section = "Reference"
+elif status in ("complete","landed"): section = "Complete"
+elif cat == "executable" and status == "conflict": section = "Needs Review"
+elif cat == "executable" and status == "active" and phases_done >= 1 and phases_done < phase_count: section = "In Progress"
+elif (cat == "executable" and status == "active" and phases_done == 0 and queue_col != "ready") or queue_col == "ready": section = "Ready to Run"
+else: section = "Other"
+sub_str = ",".join(subs)
+print(section + "|meta=" + str(meta) + "|subs=" + sub_str)
+' 2>&1)
+  if [ "$CAT_META" = "Ready to Run|meta=True|subs=sub" ]; then
+    pass "AC-6: category-meta fixture lands in Ready to Run, meta_plan=True, sub_plans=['sub']"
+  else
+    fail "AC-6: category-meta fixture → got '$CAT_META'"
+  fi
+
+  # with-state fixture has queue.column=ready → Ready to Run regardless of phase progress.
+  CAT_READY=$(PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.collect \
+    --fixture "$FIXTURES/with-state" 2>&1 | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+p=d["plans"][0]
+status = p["status"]; cat = p["category"]
+phases_done = p["phases_done"]; phase_count = p["phase_count"]
+queue_col = (p.get("queue") or {}).get("column")
+if cat == "canary": section = "Canaries"
+elif cat in ("reference","issue_tracker"): section = "Reference"
+elif status in ("complete","landed"): section = "Complete"
+elif cat == "executable" and status == "conflict": section = "Needs Review"
+elif cat == "executable" and status == "active" and phases_done >= 1 and phases_done < phase_count: section = "In Progress"
+elif (cat == "executable" and status == "active" and phases_done == 0 and queue_col != "ready") or queue_col == "ready": section = "Ready to Run"
+else: section = "Other"
+print(f"{section}|queue_col={queue_col}")
+' 2>&1)
+  if [ "$CAT_READY" = "Ready to Run|queue_col=ready" ]; then
+    pass "AC-6: with-state (queue.column=ready) fixture lands in Ready to Run"
+  else
+    fail "AC-6: with-state fixture → got '$CAT_READY'"
+  fi
+
+  # ---------------------------------------------------------------------------
+  # AC-7: smoke — invoke aggregator against the live repo and verify
+  # the plan-set matches what plans/PLAN_INDEX.md references.
+  # ---------------------------------------------------------------------------
+  echo ""
+  echo "=== Phase 9 AC-7: live smoke — plan-set parity with PLAN_INDEX.md ==="
+
+  if [ -f "$REPO_ROOT/plans/PLAN_INDEX.md" ]; then
+    LIVE_OUT=$(PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.collect \
+      --repo-root "$REPO_ROOT" 2>&1)
+    LIVE_RC=$?
+    if [ "$LIVE_RC" -ne 0 ]; then
+      fail "AC-7: aggregator CLI against repo root exits 0 (rc=$LIVE_RC)"
+    else
+      pass "AC-7: aggregator CLI against repo root exits 0"
+
+      # Plans the aggregator reports (basename, sorted).
+      AGG_PLANS=$(printf '%s' "$LIVE_OUT" | python3 -c '
+import json,sys,os
+d=json.load(sys.stdin)
+names = sorted(os.path.basename(p["file"]) for p in d["plans"])
+print("\n".join(names))
+')
+      # Plan filenames referenced in PLAN_INDEX.md (markdown link basenames).
+      INDEX_PLANS=$(grep -oE '\[[A-Z][A-Za-z0-9_]*\.md\]' "$REPO_ROOT/plans/PLAN_INDEX.md" \
+        | sed 's/^\[//; s/\]$//' \
+        | sort -u)
+      # The aggregator reports ALL top-level plans/*.md including the
+      # cross-platform-hooks.md lower-cased ones; the index normalises
+      # those into the Reference section. We assert that EVERY plan in
+      # the index is also reported by the aggregator (subset relation).
+      MISSING=""
+      while IFS= read -r idx_plan; do
+        [ -z "$idx_plan" ] && continue
+        if ! printf '%s\n' "$AGG_PLANS" | grep -Fxq "$idx_plan"; then
+          MISSING="$MISSING $idx_plan"
+        fi
+      done <<< "$INDEX_PLANS"
+      if [ -z "$MISSING" ]; then
+        pass "AC-7: every plan in PLAN_INDEX.md is reported by zskills_monitor.collect"
+      else
+        fail "AC-7: aggregator missing plans found in PLAN_INDEX.md:$MISSING"
+      fi
+
+      # No Python tracebacks in stderr/stdout.
+      if printf '%s' "$LIVE_OUT" | grep -qE 'Traceback|Error:'; then
+        fail "AC-7: aggregator output contains Python traceback or 'Error:'"
+      else
+        pass "AC-7: aggregator output contains no Python traceback"
+      fi
+
+      # Cross-check section assignment of canaries: every plan whose name
+      # starts with CANARY in the aggregator should have category=="canary".
+      MISMATCH=$(printf '%s' "$LIVE_OUT" | python3 -c '
+import json,sys,os
+d=json.load(sys.stdin)
+bad = []
+for p in d["plans"]:
+    base = os.path.basename(p["file"])
+    is_canary_by_name = base.startswith("CANARY")
+    is_canary_by_cat = p["category"] == "canary"
+    if is_canary_by_name != is_canary_by_cat:
+        cat = p["category"]
+        bad.append(base + ": name-says-canary=" + str(is_canary_by_name) + " but category=" + cat)
+print("|".join(bad))
+')
+      if [ -z "$MISMATCH" ]; then
+        pass "AC-7: every CANARY*.md plan has category==canary in aggregator output"
+      else
+        fail "AC-7: canary name/category mismatch: $MISMATCH"
+      fi
+
+      # Cross-check: any plan ending in _ISSUES.md → category=="issue_tracker".
+      ISSUES_MISMATCH=$(printf '%s' "$LIVE_OUT" | python3 -c '
+import json,sys,os,re
+d=json.load(sys.stdin)
+bad = []
+for p in d["plans"]:
+    base = os.path.basename(p["file"])
+    if re.search(r"_ISSUES\.md$", base) and p["category"] != "issue_tracker":
+        bad.append(base + ": category=" + p["category"])
+print("|".join(bad))
+')
+      if [ -z "$ISSUES_MISMATCH" ]; then
+        pass "AC-7: every *_ISSUES.md plan has category==issue_tracker"
+      else
+        fail "AC-7: _ISSUES.md / issue_tracker mismatch: $ISSUES_MISMATCH"
+      fi
+    fi
+  else
+    skip "AC-7: plans/PLAN_INDEX.md absent (skipping live smoke)"
+  fi
+
+  # ---------------------------------------------------------------------------
+  # AC-9: python-missing failure mode — invoking the SKILL.md prose's CLI
+  # with PATH stripped of python3 must exit non-zero (no silent fallback).
+  # ---------------------------------------------------------------------------
+  echo ""
+  echo "=== Phase 9 AC-9: python3-missing failure is loud ==="
+
+  # Run the canonical CLI line with an empty PATH; expect non-zero.
+  TMP_DIR=$(mktemp -d)
+  trap "rm -rf '$TMP_DIR'" EXIT
+  set +e
+  env -i HOME="$HOME" PATH="$TMP_DIR" \
+    bash -c 'PYTHONPATH="'"$PKG_PARENT"'" python3 -m zskills_monitor.collect --fixture "'"$FIXTURES/minimal"'"' \
+    > /dev/null 2>&1
+  RC=$?
+  set -e
+  if [ "$RC" -ne 0 ]; then
+    pass "AC-9: invocation with empty PATH (no python3) exits non-zero (rc=$RC)"
+  else
+    fail "AC-9: invocation with empty PATH unexpectedly succeeded — silent fallback?"
+  fi
+
+  # Stronger: the SKILL.md says rebuild must exit non-zero AND emit a
+  # diagnostic when the CLI fails. Check the rebuild prose contains the
+  # relevant exit-1 + ERROR-message pattern.
+  if grep -nE 'echo "ERROR:.*python3 -m zskills_monitor\.collect failed' "$SKILL_MD" > /dev/null 2>&1; then
+    pass "AC-9: SKILL.md prose includes loud ERROR diagnostic on CLI failure"
+  else
+    fail "AC-9: SKILL.md prose missing loud ERROR diagnostic"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Final: registered in run-all.sh
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 9: registration in tests/run-all.sh ==="
+
+if grep -F 'tests/test_plans_rebuild_uses_collect.sh' "$REPO_ROOT/tests/run-all.sh" > /dev/null 2>&1; then
+  pass "registered in tests/run-all.sh"
+else
+  fail "not registered in tests/run-all.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "---"
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+printf 'Results: %d passed, %d failed, %d skipped (of %d)\n' \
+  "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$TOTAL"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Final phase of `plans/ZSKILLS_MONITOR_PLAN.md`. Eliminates the duplicated classifier between `/plans rebuild` prose and Phase 4's `collect.py`. `/plans rebuild | next | details` now shell out to `PYTHONPATH=…/skills/zskills-dashboard/scripts python3 -m zskills_monitor.collect`, group its JSON snapshot into the 6-section index using the `category`/`meta_plan`/`status`/`phases_done` fields, and render `plans/PLAN_INDEX.md`. Single source of truth: `collect.py`.

- **skills/plans/SKILL.md** (346 → 415, +239/-170) — Mode: Rebuild rewritten to invoke aggregator + section mapping table; Mode: Next + Mode: Details rewritten to read `collect_snapshot()`; "Single source of truth" + "Index → snapshot section mapping" sections added; old prose classifier removed. **No CLI surface change** (frontmatter byte-identical to main). **Standalone-callable contract**: PYTHONPATH prefix mandatory; failure → diagnostic + exit 1; **no bash fallback** per `feedback_no_premature_backcompat`.
- **.claude/skills/plans/SKILL.md** — byte-identical mirror.
- **tests/test_plans_rebuild_uses_collect.sh** (NEW, 409 lines, +20 cases) — prose grep + section-mapping fixture cross-checks + live smoke + python-missing failure path + run-all registration.
- **tests/run-all.sh** — registers new test file.

Tracker also marks Phase 8 ✅ Done with squash hash `8ac36d9` from PR #116.

## Phase 4 categorization note (intentional, not a regression)

`_categorize_plan()` matches `^CANARY` prefix only (not `*_CANARY*` suffix), per the regex shipped in Phase 4 commit `410f641`. Five plans (REBASE_CONFLICT_CANARY.md, CHUNKED_CRON_CANARY.md, CI_FIX_CYCLE_CANARY.md, PARALLEL_CANARYA.md, PARALLEL_CANARYB.md) reclassify from canary → executable. This is documented Phase 4 behavior; Phase 9 faithfully inherits it. Per CLAUDE.md "surface bugs don't patch," any broadening should land in `collect.py`, not back-injected into SKILL.md.

## Test plan

- [x] Full test suite: 1213/1213 (was 1193, +20 plans-rebuild-uses-collect cases)
- [x] All 9 ACs verified by grep: AC-1 (8 matches), AC-2 (3), AC-3 (4), AC-4 (0 matches of old prose), AC-5 (mirror diff exit 0), AC-6 (test exists+executable+registered), AC-7 (smoke clean JSON), AC-8 (frontmatter identical to main), AC-9 (loud non-zero exit + diagnostic when python3 fails)
- [x] No bash fallback in any of the three modes
- [x] No PLAN-TEXT-DRIFT in skills/plans/SKILL.md
- [ ] USER VERIFY: run `/plans rebuild` and confirm `plans/PLAN_INDEX.md` regenerates with fresh "Last rebuilt:" timestamp and the 6 sections look right

## Plan completion

This is the final phase of `plans/ZSKILLS_MONITOR_PLAN.md`. Phases 1-9 all landed. After this PR merges:
- A follow-up commit will mark Phase 9 ✅ Done with the squash hash and flip frontmatter `status: active` → `status: complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)