### PR TITLE
docs(plans): mark ZSKILLS_MONITOR_PLAN complete

### DIFF
--- a/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/plans/ZSKILLS_MONITOR_PLAN.md
@@ -1,7 +1,7 @@
 ---
 title: Zskills Monitor Dashboard
 created: 2026-04-18
-status: active
+status: complete
 ---
 
 # Plan: Zskills Monitor Dashboard
@@ -257,7 +257,7 @@ is appended to `errors[]`.
 | 6 — Read-only dashboard UI | ✅ Done | `1239f6c` | landed via PR squash; static HTML/CSS/JS; 5 panels + 2 modals; XSS-safe; +45 tests; 1111/1111 |
 | 7 — Interactive queue + write-back | ✅ Done | `208fb7f` | landed via PR #115 squash; drag-drop + default-mode + per-row chips + run-status + POST write-back; +47 tests; 1158/1158 |
 | 8 — `/zskills-dashboard` skill | ✅ Done | `8ac36d9` | landed via PR #116 squash; SKILL.md 583 lines; start/stop/status w/ cmd+cwd identity check; SIGTERM-only; +35 tests; 1193/1193 |
-| 9 — Migrate `/plans rebuild` to Python aggregator | 🟡 In Progress | | |
+| 9 — Migrate `/plans rebuild` to Python aggregator | ✅ Done | `84521bd` | landed via PR #117 squash; SKILL.md +69 lines; 3 modes wire to python3 -m zskills_monitor.collect; no bash fallback; +20 tests; 1213/1213 |
 
 ---
 


### PR DESCRIPTION
## Summary

All 9 phases of `plans/ZSKILLS_MONITOR_PLAN.md` have landed. Plan-completion bookkeeping:

- Phase 9 ✅ Done | `84521bd` (PR #117)
- Frontmatter: `status: active` → `status: complete`

## Phase landing summary

| Phase | PR | Squash |
|-------|-----|--------|
| 1 — `/work-on-plans` execute-only CLI | #102 | `12270a0` |
| 2 — Remove `/plans work` modes | #104 | `76dbece` |
| 3 — `/work-on-plans` queue mutation + scheduling | #107 | `f9290b7` |
| 4 — Python data aggregation library | #108 | `b720fbb` |
| 5 — HTTP server | #111 | `63747e5` |
| 6 — Read-only dashboard UI | #113 | `1239f6c` |
| 7 — Interactive queue + write-back | #115 | `208fb7f` |
| 8 — `/zskills-dashboard` skill | #116 | `8ac36d9` |
| 9 — Migrate `/plans rebuild` to Python aggregator | #117 | `84521bd` |

Tests: 943 → 1213 (+270 cases across the 9 phases).

## Test plan

- [x] Smoke: `bash tests/run-all.sh` → 1213/1213 passed
- [x] Frontmatter flipped to `complete` (matches other completed plans like SCRIPTS_INTO_SKILLS_PLAN)
- [x] All 9 phase rows show ✅ Done with squash hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)