### PR TITLE
fix(tests): per-test scratch path to avoid verifier .test-results.txt clobber (#123)

### DIFF
--- a/tests/test_plans_rebuild_uses_collect.sh
+++ b/tests/test_plans_rebuild_uses_collect.sh
@@ -12,7 +12,11 @@
 #     apply the section mapping documented in the SKILL.md, and assert each
 #     fixture lands in the expected section.
 #
-# Output goes to $TEST_OUT/.test-results.txt per CLAUDE.md.
+# Per-test scratch log goes to $TEST_OUT/test_plans_rebuild_uses_collect.log.
+# This is NOT the canonical $TEST_OUT/.test-results.txt verifier capture
+# (CLAUDE.md "Capture test output to a file" idiom) — that path is owned by
+# the OUTER runner capture (e.g. `bash tests/run-all.sh > .../.test-results.txt`)
+# and must not be truncated by individual tests, or earlier failures vanish.
 #
 # Run from repo root: bash tests/test_plans_rebuild_uses_collect.sh
 
@@ -28,7 +32,7 @@ FIXTURES="$REPO_ROOT/tests/fixtures/monitor"
 
 TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
 mkdir -p "$TEST_OUT"
-RESULTS="$TEST_OUT/.test-results.txt"
+RESULTS="$TEST_OUT/test_plans_rebuild_uses_collect.log"
 : > "$RESULTS"
 
 PASS_COUNT=0


### PR DESCRIPTION
Fixes #123.

## Summary

`tests/test_plans_rebuild_uses_collect.sh` was truncating `$TEST_OUT/.test-results.txt` mid-suite (`: > "$RESULTS"` where `RESULTS="$TEST_OUT/.test-results.txt"`). When the suite ran inside a verifier capture using the canonical idiom, only this test's PASS lines survived — earlier failures were silently hidden. Rename the per-test scratch to a unique filename (`test_plans_rebuild_uses_collect.log`) so the canonical path stays intact, and correct the misleading "per CLAUDE.md" comment that conflated per-test scratch with the outer-runner capture.

## Test plan

- [x] Full suite green: `bash tests/run-all.sh` → exit 0, `Overall: 1348/1348 passed, 0 failed`
- [x] Capture line count is in the thousands (1879 lines), not the ~65-line clobber signature
- [x] No other test under `tests/` redirects to `$TEST_OUT/.test-results.txt`: `grep -rn '"\$TEST_OUT/\.test-results\.txt"' tests/` returns empty
- [x] Independent verifier subagent ran `/verify-changes worktree` end-to-end and reported PASS

## Notes

The bug was self-disclosing — any future recurrence drops the verifier capture line count by an order of magnitude. The fix's new comment block warns future authors not to truncate `$TEST_OUT/.test-results.txt` from a test. Optional follow-up: extend `tests/fixtures/forbidden-literals.txt` enforcement from `skills/**/*.md` to `tests/**/*.sh` so this class of bug is caught at lint time rather than via line-count anomaly.
