### PR TITLE
fix(update-zskills): extend source-asset probe + stop-and-ask instead of silent auto-clone (#126)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -81,7 +81,56 @@ root (which has the same structure). To find them:
    both `$PORTABLE` and `$ZSKILLS_PATH`.
 3. Check if `/tmp/zskills` exists and contains `CLAUDE_TEMPLATE.md`. If
    yes, use it.
-4. **Auto-clone fallback:** Clone the repo:
+4. **Extended probe — common downstream clone locations.** If none of
+   the above matched, check the following paths IN ORDER (first valid
+   wins). A path is valid iff the directory exists and contains all
+   four of `CLAUDE_TEMPLATE.md`, `hooks/`, `scripts/`, and `skills/` —
+   the same validity test as the existing tiers. If the path is a git
+   clone, also store it as `$ZSKILLS_PATH`.
+   1. `$PWD/../zskills` (project's sibling)
+   2. `$PWD/../../zskills` (grandparent-sibling)
+   3. `~/src/zskills`
+   4. `~/code/zskills`
+   5. `~/projects/zskills`
+   6. `~/zskills`
+
+   Track each location you checked (matched and unmatched) for the
+   stop-and-ask prompt below.
+5. **Stop-and-ask fallback.** If no path above matched, do NOT silently
+   auto-clone. Instead, print the full list of locations that were
+   checked (tiers 1-3 plus the six extended-probe paths from tier 4),
+   then ask the user in plain conversation text (NOT
+   `AskUserQuestion`, per Key Rule 7):
+
+   > Couldn't locate zskills source. Checked:
+   >   - ./zskills-portable/
+   >   - ./zskills/
+   >   - /tmp/zskills
+   >   - $PWD/../zskills
+   >   - $PWD/../../zskills
+   >   - ~/src/zskills
+   >   - ~/code/zskills
+   >   - ~/projects/zskills
+   >   - ~/zskills
+   >
+   > Options:
+   >   (a) paste a path to your clone
+   >   (b) type `clone` to clone fresh to /tmp/zskills
+   >   (c) type `abort` to cancel
+
+   Wait for the user's reply. Then:
+   - **Pasted path:** Validate it with the same directory-contains
+     check (`CLAUDE_TEMPLATE.md` + `hooks/` + `scripts/` + `skills/`).
+     If valid, use it as `$PORTABLE` (and `$ZSKILLS_PATH` if it's a
+     git clone). If invalid, report what's missing and re-ask the same
+     options once; on a second invalid reply, treat as `abort`.
+   - **`clone`:** Fall through to the auto-clone behavior below.
+   - **`abort`:** Print "Aborted — no zskills source resolved." and
+     exit cleanly. Do not modify the project.
+   - **Anything else:** Treat as `abort`.
+
+6. **Auto-clone fallback (only when the user typed `clone` above).**
+   Clone the repo:
    ```bash
    git clone https://github.com/zeveck/zskills.git /tmp/zskills
    ```

--- a/QUEUED_QUICKFIXES.md
+++ b/QUEUED_QUICKFIXES.md
@@ -1,6 +1,6 @@
 # Queued /quickfix Prompts
 
-Four `/quickfix` invocations to run when ready. Prompts 1 and 2 address recurring failure modes in `/draft-plan` and `/refine-plan`; Prompt 3 fixes `/update-zskills` source-asset discovery; Prompt 4 adds positional-tail guidance to `/refine-plan`. Prompts 1, 2, and 4 are independent of each other (no line-range overlap, but 1 and 2 both edit `skills/draft-plan/SKILL.md` so let one PR land before kicking off the other). Prompt 3 must wait for SCRIPTS_INTO_SKILLS_PLAN, SKILL_FILE_DRIFT_FIX, and DEFAULT_PORT_CONFIG to land first.
+Three `/quickfix` invocations to run when ready (Prompt 3 was moved to issue #126 on 2026-04-29 — see breadcrumb below). Prompts 1 and 2 address recurring failure modes in `/draft-plan` and `/refine-plan`; Prompt 4 adds positional-tail guidance to `/refine-plan`. Prompts 1, 2, and 4 are independent of each other (no line-range overlap, but 1 and 2 both edit `skills/draft-plan/SKILL.md` so let one PR land before kicking off the other).
 
 Source context: produced 2026-04-26 from a session where both bugs surfaced (file collision in `/tmp/draft-plan-review-round-1.md` exposed the convergence-by-refiner-self-declaration pattern). Re-reviewed 2026-04-27 by three independent Opus agents; revisions to Prompts 2 and 4 incorporated below (Edit-replace clarification on QF2, prose-mirror clarification on QF4, in-scope spaces-in-paths fix added to QF4 Sub-edit 5).
 
@@ -66,27 +66,7 @@ After landing, file a follow-up GitHub issue: `gh issue create --title "Apply or
 
 ## Prompt 3 — `/update-zskills` source-asset discovery: extend probe + stop-and-ask
 
-Source context: queued 2026-04-26 from a session triaging Simon Greenwold's feedback. Originally drafted as a standalone `/quickfix` invocation; queued instead because (a) low urgency — doesn't break installs, just produces silent re-clone when a non-`/tmp` clone exists; (b) `skills/update-zskills/SKILL.md` is going to churn from active plans (DEFAULT_PORT_CONFIG, SCRIPTS_INTO_SKILLS_PLAN, SKILL_FILE_DRIFT_FIX) — running this now would create a refine-after-rebase loop. Anchored on Step 0's section name and the 4-tier probe (not line numbers) so it survives the file churn.
-
-```
-/quickfix Fix /update-zskills: extend the source-asset locator probe and replace the silent auto-clone fallback with stop-and-ask.
-
-Edit skills/update-zskills/SKILL.md Step 0 ("Locate Portable Assets" — the section describing the existing 4-tier probe: zskills-portable/ → ./zskills/ → /tmp/zskills → silent auto-clone). Then mirror to .claude/skills/update-zskills/ via `rm -rf` + `cp -r` + `diff -rq`.
-
-Two changes:
-
-A. Extend the probe between tiers 3 and 4. After /tmp/zskills fails, check these locations IN ORDER (first valid wins; same validity test as the existing tiers — directory contains CLAUDE_TEMPLATE.md + hooks/ + scripts/ + skills/):
-  1. $PWD/../zskills (project's sibling)
-  2. $PWD/../../zskills (grandparent-sibling)
-  3. ~/src/zskills
-  4. ~/code/zskills
-  5. ~/projects/zskills
-  6. ~/zskills
-
-B. Replace the silent tier-4 auto-clone with stop-and-ask. Print the list of locations that were checked. Ask in plain prose (NOT AskUserQuestion, per the skill's Key Rule 7): "Couldn't locate zskills source. Options: (a) paste a path to your clone, (b) type 'clone' to clone fresh to /tmp/zskills, (c) type 'abort' to cancel." Validate any pasted path; abort exits cleanly with a message; 'clone' falls back to the original auto-clone behavior.
-
-Feedback context: Simon Greenwold cloned to a non-/tmp path and /update-zskills "flailed around like crazy." The fix is better discovery + honest "help me out" — no env var, no flag, no new knowledge required of the user.
-```
+Prompt 3 (QF3) moved to issue #126 2026-04-29.
 
 ---
 

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -81,7 +81,56 @@ root (which has the same structure). To find them:
    both `$PORTABLE` and `$ZSKILLS_PATH`.
 3. Check if `/tmp/zskills` exists and contains `CLAUDE_TEMPLATE.md`. If
    yes, use it.
-4. **Auto-clone fallback:** Clone the repo:
+4. **Extended probe — common downstream clone locations.** If none of
+   the above matched, check the following paths IN ORDER (first valid
+   wins). A path is valid iff the directory exists and contains all
+   four of `CLAUDE_TEMPLATE.md`, `hooks/`, `scripts/`, and `skills/` —
+   the same validity test as the existing tiers. If the path is a git
+   clone, also store it as `$ZSKILLS_PATH`.
+   1. `$PWD/../zskills` (project's sibling)
+   2. `$PWD/../../zskills` (grandparent-sibling)
+   3. `~/src/zskills`
+   4. `~/code/zskills`
+   5. `~/projects/zskills`
+   6. `~/zskills`
+
+   Track each location you checked (matched and unmatched) for the
+   stop-and-ask prompt below.
+5. **Stop-and-ask fallback.** If no path above matched, do NOT silently
+   auto-clone. Instead, print the full list of locations that were
+   checked (tiers 1-3 plus the six extended-probe paths from tier 4),
+   then ask the user in plain conversation text (NOT
+   `AskUserQuestion`, per Key Rule 7):
+
+   > Couldn't locate zskills source. Checked:
+   >   - ./zskills-portable/
+   >   - ./zskills/
+   >   - /tmp/zskills
+   >   - $PWD/../zskills
+   >   - $PWD/../../zskills
+   >   - ~/src/zskills
+   >   - ~/code/zskills
+   >   - ~/projects/zskills
+   >   - ~/zskills
+   >
+   > Options:
+   >   (a) paste a path to your clone
+   >   (b) type `clone` to clone fresh to /tmp/zskills
+   >   (c) type `abort` to cancel
+
+   Wait for the user's reply. Then:
+   - **Pasted path:** Validate it with the same directory-contains
+     check (`CLAUDE_TEMPLATE.md` + `hooks/` + `scripts/` + `skills/`).
+     If valid, use it as `$PORTABLE` (and `$ZSKILLS_PATH` if it's a
+     git clone). If invalid, report what's missing and re-ask the same
+     options once; on a second invalid reply, treat as `abort`.
+   - **`clone`:** Fall through to the auto-clone behavior below.
+   - **`abort`:** Print "Aborted — no zskills source resolved." and
+     exit cleanly. Do not modify the project.
+   - **Anything else:** Treat as `abort`.
+
+6. **Auto-clone fallback (only when the user typed `clone` above).**
+   Clone the repo:
    ```bash
    git clone https://github.com/zeveck/zskills.git /tmp/zskills
    ```


### PR DESCRIPTION
Fixes #126.

## Summary

`/update-zskills` Step 0's source-asset locator silently re-cloned zskills to `/tmp/zskills` when downstream users had a clone in a non-`/tmp` path (reported by Simon Greenwold 2026-04-26 — the skill "flailed around like crazy" against `~/code/zskills`).

Two changes to `skills/update-zskills/SKILL.md` Step 0:

**A.** Extend the probe with 6 additional candidates between existing tier 3 (`/tmp/zskills`) and the auto-clone fallback: `$PWD/../zskills`, `$PWD/../../zskills`, `~/src/zskills`, `~/code/zskills`, `~/projects/zskills`, `~/zskills`. Each gated on the existing dir-contains validity check (`CLAUDE_TEMPLATE.md` + `hooks/` + `scripts/` + `skills/`).

**B.** Replace the silent auto-clone with a stop-and-ask prompt. Print all locations checked, then ask in plain prose (NOT `AskUserQuestion`, per the skill's Key Rule 7): (a) paste a path, (b) type `clone` to fall through to the original auto-clone behavior, (c) type `abort`. Pasted paths re-validate against the same dir-contains check.

Mirror to `.claude/skills/update-zskills/` via `bash scripts/mirror-skill.sh update-zskills`. Remove the QF3 entry from `QUEUED_QUICKFIXES.md` with a one-line breadcrumb to this issue.

## Test plan

- [x] Full suite green: `bash tests/run-all.sh` → exit 0, `Overall: 1348/1348 passed, 0 failed` (no new tests — behavior change to skill prose)
- [x] Mirror parity: `diff -q skills/update-zskills/SKILL.md .claude/skills/update-zskills/SKILL.md` returns empty
- [x] QF3 removed from QUEUED_QUICKFIXES.md, breadcrumb in place
- [x] Stop-and-ask is model-layer prose (no `read -p`, no shell loops); honors Key Rule 7 explicitly
- [x] Independent verifier subagent ran `/verify-changes worktree` and reported PASS
- [ ] **User verification needed** — run `/update-zskills` against a non-`/tmp` clone (e.g., `~/code/zskills` or a sibling dir) to confirm the prompt is clear and validation works. This is a slash-command behavior change, hard to fully E2E without invoking the skill.
