### PR TITLE
test(mirror-skill): cover orphan-dir branch (empty + non-empty) (#89)

### DIFF
--- a/tests/test-mirror-skill.sh
+++ b/tests/test-mirror-skill.sh
@@ -146,6 +146,48 @@ else
 fi
 cleanup_fixture "$F"
 
+# --- Test 7: orphan-dir empty ----------------------------------------
+# Source has SKILL.md only; mirror has SKILL.md + an empty references/.
+# Helper's `elif [ -d "$orphan" ]` branch should rmdir the empty
+# references/ directory, leaving diff -rq clean.
+F=$(make_fixture orphan-dir-empty)
+mkdir -p "$F/skills/epsilon"
+echo "epsilon content" > "$F/skills/epsilon/SKILL.md"
+mkdir -p "$F/.claude/skills/epsilon/references"
+echo "epsilon content" > "$F/.claude/skills/epsilon/SKILL.md"
+out=$( cd "$F" && bash "$HELPER" epsilon 2>&1 )
+ec=$?
+if [ "$ec" -eq 0 ] \
+   && [ ! -e "$F/.claude/skills/epsilon/references" ] \
+   && diff -rq "$F/skills/epsilon/" "$F/.claude/skills/epsilon/" >/dev/null 2>&1; then
+  pass "orphan-dir empty: empty mirror subdir is removed"
+else
+  fail "orphan-dir empty (exit=$ec, out=$out, dir-exists=$( [ -e "$F/.claude/skills/epsilon/references" ] && echo yes || echo no ))"
+fi
+cleanup_fixture "$F"
+
+# --- Test 8: orphan-dir non-empty ------------------------------------
+# Source has SKILL.md only; mirror has SKILL.md + references/notes.md.
+# Helper's `elif [ -d "$orphan" ]` branch should walk the dir with
+# `find -type f` to rm the file, then rmdir the now-empty parent.
+F=$(make_fixture orphan-dir-nonempty)
+mkdir -p "$F/skills/zeta"
+echo "zeta content" > "$F/skills/zeta/SKILL.md"
+mkdir -p "$F/.claude/skills/zeta/references"
+echo "zeta content"  > "$F/.claude/skills/zeta/SKILL.md"
+echo "stale notes"   > "$F/.claude/skills/zeta/references/notes.md"
+out=$( cd "$F" && bash "$HELPER" zeta 2>&1 )
+ec=$?
+if [ "$ec" -eq 0 ] \
+   && [ ! -e "$F/.claude/skills/zeta/references/notes.md" ] \
+   && [ ! -e "$F/.claude/skills/zeta/references" ] \
+   && diff -rq "$F/skills/zeta/" "$F/.claude/skills/zeta/" >/dev/null 2>&1; then
+  pass "orphan-dir non-empty: file removed then empty parent rmdir'd"
+else
+  fail "orphan-dir non-empty (exit=$ec, out=$out, file-exists=$( [ -e "$F/.claude/skills/zeta/references/notes.md" ] && echo yes || echo no ), dir-exists=$( [ -e "$F/.claude/skills/zeta/references" ] && echo yes || echo no ))"
+fi
+cleanup_fixture "$F"
+
 echo ""
 echo "---"
 printf 'Results: %d passed, %d failed (of %d)\n' \


### PR DESCRIPTION
Fixes #89.

## Summary

`scripts/mirror-skill.sh` has explicit code for **non-empty orphan directories** in the mirror (the `elif [ -d "$orphan" ]` branch — find-deletes files, depth-first `rmdir`s the parent), but **no test exercises that path**. The branch is currently dead code in practice (today's mirrors are single-file `SKILL.md`-only), but the helper was specifically built for the multi-file-mirror case (#84's motivation). The first time a real orphan-dir scenario hits, the path runs without ever having been tested.

Adds 2 test cases to `tests/test-mirror-skill.sh`:

1. **Empty orphan dir** — source has `SKILL.md` only; mirror has `SKILL.md` + empty `references/`. Helper removes `references/`.
2. **Non-empty orphan dir** — source has `SKILL.md` only; mirror has `SKILL.md` + `references/notes.md`. Helper removes the file then `rmdir`s the empty parent.

Both assert `diff -rq` clean and helper exit 0. Pattern matches existing fixtures (`make_fixture` / `cleanup_fixture`, unique labels, matching pass/fail echo idiom).

This is **purely additive coverage** — no behavior change to `scripts/mirror-skill.sh` itself.

## Test plan

- [x] Full suite green: `bash tests/run-all.sh` → exit 0, `Overall: 1350/1350 passed, 0 failed` (baseline 1348 + 2 new cases)
- [x] `bash tests/test-mirror-skill.sh` standalone: 8/8 PASS (was 6/6)
- [x] No source-code change: `scripts/mirror-skill.sh` untouched
- [x] Independent verifier subagent ran `/verify-changes worktree` and reported PASS
