### PR TITLE
Fix #132: briefing.cjs midnight ET hourCycle h24 quirk

### DIFF
--- a/.claude/skills/briefing/scripts/briefing.cjs
+++ b/.claude/skills/briefing/scripts/briefing.cjs
@@ -595,10 +595,14 @@ function parseCommits(opts = {}) {
 function formatET(date) {
   const d = date || new Date();
   try {
+    // hourCycle: 'h23' is REQUIRED — `hour12: false` alone is ambiguous between
+    // h23 (midnight = 00) and h24 (midnight = 24). Some Node/ICU builds resolve
+    // it to h24, which produces `24:41 ET` at 00:41 ET and breaks parity with
+    // briefing.py (which uses %H, always 0-23). See issue #132.
     const fmt = new Intl.DateTimeFormat('en-US', {
       timeZone: 'America/New_York',
       year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit', hour12: false,
+      hour: '2-digit', minute: '2-digit', hour12: false, hourCycle: 'h23',
     });
     const parts = {};
     for (const p of fmt.formatToParts(d)) parts[p.type] = p.value;

--- a/.claude/skills/briefing/scripts/briefing.cjs
+++ b/.claude/skills/briefing/scripts/briefing.cjs
@@ -595,18 +595,25 @@ function parseCommits(opts = {}) {
 function formatET(date) {
   const d = date || new Date();
   try {
-    // hourCycle: 'h23' is REQUIRED — `hour12: false` alone is ambiguous between
-    // h23 (midnight = 00) and h24 (midnight = 24). Some Node/ICU builds resolve
-    // it to h24, which produces `24:41 ET` at 00:41 ET and breaks parity with
-    // briefing.py (which uses %H, always 0-23). See issue #132.
+    // Use hourCycle:'h23' alone — NOT hour12:false. Per MDN: when both
+    // hour12 and hourCycle are specified, hour12 takes precedence and
+    // hourCycle is silently ignored. With hour12:false alone, en-US locale
+    // can resolve to h24 on older Node/ICU builds (e.g., CI's ubuntu-latest
+    // default Node), emitting `24:30 ET` at 00:30 ET and breaking parity
+    // with briefing.py (which uses %H, always 0-23). hourCycle:'h23' alone
+    // is the only spec-portable way to force midnight = 00. See issue #132.
     const fmt = new Intl.DateTimeFormat('en-US', {
       timeZone: 'America/New_York',
       year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit', hour12: false, hourCycle: 'h23',
+      hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
     });
     const parts = {};
     for (const p of fmt.formatToParts(d)) parts[p.type] = p.value;
-    return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute} ET`;
+    // Belt-and-suspenders: even with hourCycle:'h23', some Node/ICU
+    // builds (e.g., older Node 18 on CI) still resolve en-US to h24 for
+    // midnight, emitting '24'. Normalize here.
+    const hour = parts.hour === '24' ? '00' : parts.hour;
+    return `${parts.year}-${parts.month}-${parts.day} ${hour}:${parts.minute} ET`;
   } catch {
     // Fallback if Intl not available
     return d.toISOString().slice(0, 16).replace('T', ' ') + ' UTC';

--- a/skills/briefing/scripts/briefing.cjs
+++ b/skills/briefing/scripts/briefing.cjs
@@ -595,10 +595,14 @@ function parseCommits(opts = {}) {
 function formatET(date) {
   const d = date || new Date();
   try {
+    // hourCycle: 'h23' is REQUIRED — `hour12: false` alone is ambiguous between
+    // h23 (midnight = 00) and h24 (midnight = 24). Some Node/ICU builds resolve
+    // it to h24, which produces `24:41 ET` at 00:41 ET and breaks parity with
+    // briefing.py (which uses %H, always 0-23). See issue #132.
     const fmt = new Intl.DateTimeFormat('en-US', {
       timeZone: 'America/New_York',
       year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit', hour12: false,
+      hour: '2-digit', minute: '2-digit', hour12: false, hourCycle: 'h23',
     });
     const parts = {};
     for (const p of fmt.formatToParts(d)) parts[p.type] = p.value;

--- a/skills/briefing/scripts/briefing.cjs
+++ b/skills/briefing/scripts/briefing.cjs
@@ -595,18 +595,25 @@ function parseCommits(opts = {}) {
 function formatET(date) {
   const d = date || new Date();
   try {
-    // hourCycle: 'h23' is REQUIRED — `hour12: false` alone is ambiguous between
-    // h23 (midnight = 00) and h24 (midnight = 24). Some Node/ICU builds resolve
-    // it to h24, which produces `24:41 ET` at 00:41 ET and breaks parity with
-    // briefing.py (which uses %H, always 0-23). See issue #132.
+    // Use hourCycle:'h23' alone — NOT hour12:false. Per MDN: when both
+    // hour12 and hourCycle are specified, hour12 takes precedence and
+    // hourCycle is silently ignored. With hour12:false alone, en-US locale
+    // can resolve to h24 on older Node/ICU builds (e.g., CI's ubuntu-latest
+    // default Node), emitting `24:30 ET` at 00:30 ET and breaking parity
+    // with briefing.py (which uses %H, always 0-23). hourCycle:'h23' alone
+    // is the only spec-portable way to force midnight = 00. See issue #132.
     const fmt = new Intl.DateTimeFormat('en-US', {
       timeZone: 'America/New_York',
       year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit', hour12: false, hourCycle: 'h23',
+      hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
     });
     const parts = {};
     for (const p of fmt.formatToParts(d)) parts[p.type] = p.value;
-    return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute} ET`;
+    // Belt-and-suspenders: even with hourCycle:'h23', some Node/ICU
+    // builds (e.g., older Node 18 on CI) still resolve en-US to h24 for
+    // midnight, emitting '24'. Normalize here.
+    const hour = parts.hour === '24' ? '00' : parts.hour;
+    return `${parts.year}-${parts.month}-${parts.day} ${hour}:${parts.minute} ET`;
   } catch {
     // Fallback if Intl not available
     return d.toISOString().slice(0, 16).replace('T', ' ') + ' UTC';

--- a/tests/test-briefing-parity.sh
+++ b/tests/test-briefing-parity.sh
@@ -218,6 +218,70 @@ except:
   fi
 
   rm -rf "$FIXTURE_DIR"
+
+  # ---------------------------------------------------------------------
+  # Midnight-ET formatter regression test (issue #132)
+  # ---------------------------------------------------------------------
+  # At 00:xx ET (~04:xx UTC) some Node/ICU builds resolve `hour12: false`
+  # to hourCycle h24, emitting `24:30 ET` instead of `00:30 ET` and
+  # diverging from briefing.py (which uses %H, always 0-23). This test
+  # pins a Date / datetime to midnight ET and asserts both formatters
+  # emit the 00 hour, not 24.
+  echo ""
+  echo "=== Midnight-ET formatter parity (issue #132) ==="
+
+  # Node: 04:30 UTC = 00:30 ET (after DST cutover; works year-round at this
+  # particular wall-clock minute since EDT is UTC-4 and EST is UTC-5;
+  # we test 04:30 UTC which is 00:30 EDT or 23:30 EST. Use a Spring date
+  # to be unambiguous.)
+  node_midnight_out=$(node -e "
+    const { formatET } = require('$REPO_ROOT/skills/briefing/scripts/briefing.cjs');
+    // 2026-04-30T04:30:00Z = 2026-04-30 00:30 EDT (April is in DST)
+    process.stdout.write(formatET(new Date('2026-04-30T04:30:00Z')));
+  " 2>/dev/null)
+  py_midnight_out=$(python3 -c "
+import sys, os
+sys.path.insert(0, '$REPO_ROOT/skills/briefing/scripts')
+from datetime import datetime, timezone
+import briefing
+# 2026-04-30T04:30:00Z = 2026-04-30 00:30 EDT
+d = datetime(2026, 4, 30, 4, 30, 0, tzinfo=timezone.utc)
+sys.stdout.write(briefing.format_et(d))
+" 2>/dev/null)
+
+  expected="2026-04-30 00:30 ET"
+
+  if [[ "$node_midnight_out" == "$expected" ]]; then
+    pass "midnight-ET: briefing.cjs emits '00:30 ET' at 00:30 ET"
+  else
+    fail "midnight-ET: briefing.cjs emitted '$node_midnight_out', expected '$expected'"
+  fi
+
+  if [[ "$py_midnight_out" == "$expected" ]]; then
+    pass "midnight-ET: briefing.py emits '00:30 ET' at 00:30 ET"
+  else
+    fail "midnight-ET: briefing.py emitted '$py_midnight_out', expected '$expected'"
+  fi
+
+  # Belt-and-suspenders: explicitly assert no '24:' hour anywhere.
+  if [[ "$node_midnight_out" != *"24:"* ]]; then
+    pass "midnight-ET: briefing.cjs output has no '24:' hour"
+  else
+    fail "midnight-ET: briefing.cjs output contains '24:' — '$node_midnight_out'"
+  fi
+
+  if [[ "$py_midnight_out" != *"24:"* ]]; then
+    pass "midnight-ET: briefing.py output has no '24:' hour"
+  else
+    fail "midnight-ET: briefing.py output contains '24:' — '$py_midnight_out'"
+  fi
+
+  # Final parity check: outputs are byte-equivalent at midnight ET.
+  if [[ "$node_midnight_out" == "$py_midnight_out" ]]; then
+    pass "midnight-ET: briefing.cjs and briefing.py outputs match"
+  else
+    fail "midnight-ET: outputs diverge — node='$node_midnight_out' py='$py_midnight_out'"
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
Fixes #132

## Changes

- `skills/briefing/scripts/briefing.cjs` — add explicit `hourCycle: 'h23'` to `Intl.DateTimeFormat` options. `hour12: false` alone is ambiguous between h23 (midnight = 00) and h24 (midnight = 24); some Node/ICU builds resolve it to h24, producing `24:41 ET` at 00:41 ET and breaking parity with `briefing.py` (which uses `%H`, always 0-23).
- Comment in source documents the bug and references issue #132.
- Mirror `.claude/skills/briefing/scripts/briefing.cjs` updated via `scripts/mirror-skill.sh briefing`.
- `tests/test-briefing-parity.sh` Phase 4 — 5 new midnight-ET regression assertions: pin time to 04:30Z (00:30 EDT) and assert both impls emit `00:30 ET` (not `24:30`), neither output contains `24:`, both outputs are byte-equivalent.

## Test plan

- [x] Standalone `bash tests/test-briefing-parity.sh` → 21/21 pass (was 16, +5 midnight-ET assertions)
- [x] Full suite `bash tests/run-all.sh` → 1694/1695 pass; 1 pre-existing failure (`test-update-zskills-migration.sh` case 6c — `detect-language.sh` cohabitation, originated in PR #140, unrelated to this fix; confirmed failing on main as well)
- [x] Mirror parity: `diff -q skills/briefing/scripts/briefing.cjs .claude/skills/briefing/scripts/briefing.cjs` empty
- [ ] **CI on PR push** — full regression gate.

## Surfaced in

CI run https://github.com/zeveck/zskills-dev/actions/runs/25147772180 on PR #131 — blocked merge for ~20 min until 01:00 ET rollover.