### PR TITLE
Fix #133: extract /commit pr Step 6 CI poll into poll-ci.sh

### DIFF
--- a/.claude/skills/commit/modes/pr.md
+++ b/.claude/skills/commit/modes/pr.md
@@ -60,29 +60,28 @@ fi
 ```
 
 **Step 6 — Poll CI checks (report only, no fix cycle):**
+
+> Past failure (2026-04-30): agent skipped Step 6 on PR #131 push, read the
+> previous inline bash block as suggestion-prose, did one snapshot
+> `gh pr checks 131` showing `pending`, reported that in the summary, and
+> exited. User discovered the midnight CI flake 20+ minutes later by manual
+> polling. **DO NOT skip this step.** The polling logic now lives in
+> `scripts/poll-ci.sh` so it must be invoked explicitly — paraphrasing or
+> substituting a single `gh pr checks` snapshot is a skill-step skip.
+
 ```bash
 if [ -n "$PR_URL" ]; then
   PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
-  CHECK_COUNT=0
-  for _i in 1 2 3; do
-    CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
-    [ "$CHECK_COUNT" != "0" ] && break
-    sleep 10
-  done
-  if [ "$CHECK_COUNT" != "0" ]; then
-    # `gh pr checks --watch` exit code is unreliable across gh versions
-    # (can return 0 even when a check failed). Use --watch only to block
-    # until completion; then re-check with `gh pr checks` (no --watch),
-    # which DOES signal via exit code reliably.
-    timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null
-    if gh pr checks "$PR_NUMBER" >/dev/null 2>&1; then
-      echo "CI checks passed."
-    else
-      echo "CI checks failed. Run /verify-changes to diagnose."
-    fi
-  fi
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/commit/scripts/poll-ci.sh" "$PR_NUMBER"
 fi
 ```
+
+`scripts/poll-ci.sh` does exactly what the previous inline block did: polls
+up to 30s for checks to register, then `timeout 600 gh pr checks --watch` to
+block, then re-checks via `gh pr checks` (no `--watch`, exit code is
+reliable there) and prints "CI checks passed." (exit 0) or "CI checks
+failed. Run /verify-changes to diagnose." (exit 1). See `scripts/poll-ci.sh`
+for the implementation and the `--watch`-exit-code rationale.
 
 Note: `PR_NUMBER` is derived from `$PR_URL` returned by `gh pr create` or
 `gh pr view "$EXISTING_PR"` — NOT via a bare `gh pr view` call (which relies

--- a/.claude/skills/commit/scripts/poll-ci.sh
+++ b/.claude/skills/commit/scripts/poll-ci.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# poll-ci.sh — Block until a PR's CI checks complete, then report pass/fail.
+#
+# Extracted from /commit pr Step 6 (skills/commit/modes/pr.md). Lives as a
+# script — not inline prose — so the agent can't paraphrase or skip it.
+# Past failure (2026-04-30): on PR #131, the orchestrator read Step 6 as
+# suggestion-prose, did one snapshot `gh pr checks 131` showing `pending`,
+# reported "CI: pending (poll with `gh pr checks 131`)" in its summary, and
+# exited. User discovered the midnight CI flake 20+ minutes later by manual
+# polling. See issue #133.
+#
+# Behavior is identical to the previous inline block: poll up to 3×10s for
+# checks to register, then `timeout 600 gh pr checks --watch` to block, then
+# re-check via `gh pr checks` (no --watch, exit code is reliable) and emit
+# "CI checks passed." or "CI checks failed. Run /verify-changes to diagnose."
+#
+# Usage: bash poll-ci.sh <PR_NUMBER>
+# Exit:
+#   0 — checks passed (or no checks ever registered → no-op)
+#   1 — checks failed
+#   2 — usage error
+
+set -u
+
+PR_NUMBER="${1:-}"
+if [ -z "$PR_NUMBER" ]; then
+  echo "Usage: bash $(basename "$0") <PR_NUMBER>" >&2
+  exit 2
+fi
+
+# Step 1: poll up to 30s for checks to register on the PR.
+CHECK_COUNT=0
+for _i in 1 2 3; do
+  CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
+  [ "$CHECK_COUNT" != "0" ] && break
+  sleep 10
+done
+
+# No checks ever registered — nothing to poll. Exit 0 (matches the previous
+# inline behavior of falling out of the if-block silently).
+if [ "$CHECK_COUNT" = "0" ]; then
+  exit 0
+fi
+
+# Step 2: block until checks complete.
+# `gh pr checks --watch` exit code is unreliable across gh versions (can
+# return 0 even when a check failed), so use --watch only to block; then
+# re-check with `gh pr checks` (no --watch), whose exit code IS reliable.
+timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null
+
+if gh pr checks "$PR_NUMBER" >/dev/null 2>&1; then
+  echo "CI checks passed."
+  exit 0
+else
+  echo "CI checks failed. Run /verify-changes to diagnose."
+  exit 1
+fi

--- a/skills/commit/modes/pr.md
+++ b/skills/commit/modes/pr.md
@@ -60,29 +60,28 @@ fi
 ```
 
 **Step 6 — Poll CI checks (report only, no fix cycle):**
+
+> Past failure (2026-04-30): agent skipped Step 6 on PR #131 push, read the
+> previous inline bash block as suggestion-prose, did one snapshot
+> `gh pr checks 131` showing `pending`, reported that in the summary, and
+> exited. User discovered the midnight CI flake 20+ minutes later by manual
+> polling. **DO NOT skip this step.** The polling logic now lives in
+> `scripts/poll-ci.sh` so it must be invoked explicitly — paraphrasing or
+> substituting a single `gh pr checks` snapshot is a skill-step skip.
+
 ```bash
 if [ -n "$PR_URL" ]; then
   PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq '.number')
-  CHECK_COUNT=0
-  for _i in 1 2 3; do
-    CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
-    [ "$CHECK_COUNT" != "0" ] && break
-    sleep 10
-  done
-  if [ "$CHECK_COUNT" != "0" ]; then
-    # `gh pr checks --watch` exit code is unreliable across gh versions
-    # (can return 0 even when a check failed). Use --watch only to block
-    # until completion; then re-check with `gh pr checks` (no --watch),
-    # which DOES signal via exit code reliably.
-    timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null
-    if gh pr checks "$PR_NUMBER" >/dev/null 2>&1; then
-      echo "CI checks passed."
-    else
-      echo "CI checks failed. Run /verify-changes to diagnose."
-    fi
-  fi
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/commit/scripts/poll-ci.sh" "$PR_NUMBER"
 fi
 ```
+
+`scripts/poll-ci.sh` does exactly what the previous inline block did: polls
+up to 30s for checks to register, then `timeout 600 gh pr checks --watch` to
+block, then re-checks via `gh pr checks` (no `--watch`, exit code is
+reliable there) and prints "CI checks passed." (exit 0) or "CI checks
+failed. Run /verify-changes to diagnose." (exit 1). See `scripts/poll-ci.sh`
+for the implementation and the `--watch`-exit-code rationale.
 
 Note: `PR_NUMBER` is derived from `$PR_URL` returned by `gh pr create` or
 `gh pr view "$EXISTING_PR"` — NOT via a bare `gh pr view` call (which relies

--- a/skills/commit/scripts/poll-ci.sh
+++ b/skills/commit/scripts/poll-ci.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# poll-ci.sh — Block until a PR's CI checks complete, then report pass/fail.
+#
+# Extracted from /commit pr Step 6 (skills/commit/modes/pr.md). Lives as a
+# script — not inline prose — so the agent can't paraphrase or skip it.
+# Past failure (2026-04-30): on PR #131, the orchestrator read Step 6 as
+# suggestion-prose, did one snapshot `gh pr checks 131` showing `pending`,
+# reported "CI: pending (poll with `gh pr checks 131`)" in its summary, and
+# exited. User discovered the midnight CI flake 20+ minutes later by manual
+# polling. See issue #133.
+#
+# Behavior is identical to the previous inline block: poll up to 3×10s for
+# checks to register, then `timeout 600 gh pr checks --watch` to block, then
+# re-check via `gh pr checks` (no --watch, exit code is reliable) and emit
+# "CI checks passed." or "CI checks failed. Run /verify-changes to diagnose."
+#
+# Usage: bash poll-ci.sh <PR_NUMBER>
+# Exit:
+#   0 — checks passed (or no checks ever registered → no-op)
+#   1 — checks failed
+#   2 — usage error
+
+set -u
+
+PR_NUMBER="${1:-}"
+if [ -z "$PR_NUMBER" ]; then
+  echo "Usage: bash $(basename "$0") <PR_NUMBER>" >&2
+  exit 2
+fi
+
+# Step 1: poll up to 30s for checks to register on the PR.
+CHECK_COUNT=0
+for _i in 1 2 3; do
+  CHECK_COUNT=$(gh pr checks "$PR_NUMBER" --json name --jq 'length' 2>/dev/null || echo "0")
+  [ "$CHECK_COUNT" != "0" ] && break
+  sleep 10
+done
+
+# No checks ever registered — nothing to poll. Exit 0 (matches the previous
+# inline behavior of falling out of the if-block silently).
+if [ "$CHECK_COUNT" = "0" ]; then
+  exit 0
+fi
+
+# Step 2: block until checks complete.
+# `gh pr checks --watch` exit code is unreliable across gh versions (can
+# return 0 even when a check failed), so use --watch only to block; then
+# re-check with `gh pr checks` (no --watch), whose exit code IS reliable.
+timeout 600 gh pr checks "$PR_NUMBER" --watch 2>/dev/null
+
+if gh pr checks "$PR_NUMBER" >/dev/null 2>&1; then
+  echo "CI checks passed."
+  exit 0
+else
+  echo "CI checks failed. Run /verify-changes to diagnose."
+  exit 1
+fi

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -143,6 +143,13 @@ check       commit "no-amend after hook fail" 'NEVER.*--amend.*hook|--amend woul
 check       commit "origin/main for log"      'git log origin/main\.\.HEAD'
 check       commit "--watch unreliable"       '--watch.*(exit code is unreliable|UNRELIABLE)'
 check_fixed commit "write-landed"             'bash "$CLAUDE_PROJECT_DIR/.claude/skills/commit/scripts/write-landed.sh"'
+# Issue #133: /commit pr Step 6 (CI poll) was being skipped by the agent
+# because it was inline-bash-prose. Step 6 now references scripts/poll-ci.sh
+# AND carries a "Past failure:" preamble citing PR #131. Either alone is
+# acceptable per the issue AC; we assert both since this fix ships option 1
+# + option 2 together.
+check_fixed commit "step6: poll-ci.sh invocation" 'bash "$CLAUDE_PROJECT_DIR/.claude/skills/commit/scripts/poll-ci.sh"'
+check       commit "step6: past-failure preamble" 'Past failure.*PR #131|skipped Step 6 on PR #131'
 check       commit "read-only reviewer"       'You are read-only|you are read-only'
 # Config-driven default mode (issue #56): /commit with no explicit mode
 # token must consult execution.landing in .claude/zskills-config.json


### PR DESCRIPTION
Fixes #133

## Changes

Implements **option 1 + option 2** per the issue body's recommendation ("Option 3 is overkill for a polling step"):

- **Option 2 (script extraction)**: New `skills/commit/scripts/poll-ci.sh` (57 lines, executable). Extracted from the prior inline bash block in `skills/commit/modes/pr.md` Step 6. Behavior is byte-equivalent: poll up to 3×10s for checks to register, then `timeout 600 gh pr checks --watch` to block, then re-check via plain `gh pr checks` (whose exit code IS reliable, unlike `--watch`). Exits 0 on pass, 1 on fail, 2 on usage error.
- **Option 1 (past-failure preamble)**: `skills/commit/modes/pr.md` Step 6 prose now opens with a `Past failure (2026-04-30): agent skipped Step 6 on PR #131 push...` blockquote and replaces the inline block with `bash "$CLAUDE_PROJECT_DIR/.claude/skills/commit/scripts/poll-ci.sh" "$PR_NUMBER"`. The agent must invoke the named script — paraphrasing or substituting a snapshot is now a visible skip.
- Mirror `.claude/skills/commit/modes/pr.md` and `.claude/skills/commit/scripts/poll-ci.sh` via `scripts/mirror-skill.sh commit`.
- `tests/test-skill-conformance.sh` — 2 new assertions: (a) Step 6 contains `bash "$CLAUDE_PROJECT_DIR/.claude/skills/commit/scripts/poll-ci.sh"` invocation, (b) Step 6 contains `Past failure.*PR #131` or `skipped Step 6 on PR #131` preamble.

Why not option 3 (tracking marker + hook): per the issue body's reasoning, polling is a transient per-PR action — the marker would have a 1-PR lifecycle and the hook block surface is cross-skill (would gate everything from `/run-plan` to `/commit`). Disproportionate machinery for a single skill-step skip. The script-invocation pattern delivers mechanical enforcement (the agent must run a named script, hard to paraphrase) without the hook complexity.

## Test plan

- [x] Full suite `bash tests/run-all.sh` → 1691/1692 pass; +2 conformance assertions; 1 pre-existing failure (`test-update-zskills-migration.sh` case 6c, `detect-language.sh` cohabitation from PR #140, unrelated)
- [x] Mirror parity: `diff -q` clean for both `modes/pr.md` and `scripts/poll-ci.sh`
- [x] `poll-ci.sh` is executable (`chmod +x`)
- [x] **Self-test**: this PR's CI poll itself will exercise the previous (inline) Step 6 logic during landing — `poll-ci.sh` is consumed only after this PR merges. Until then, `/commit pr` and `/fix-issues pr` continue to use the inline block.
- [ ] **CI on PR push** — full regression gate.

## Surfaced in

This session's PR #131 landing flow.