### PR TITLE
fix(tests): close Tier-1 drift detection gap (Phase B+E)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Required by tests/test-update-zskills-migration.sh case 6c
+          # (commit-cohabitation): the test uses `git log -1 -- <path>` and
+          # `merge-base --is-ancestor`, both of which need full history.
+          # With the default fetch-depth: 1 (shallow), case 6c's prior code
+          # would silently call `pass "shallow clone — skipped"` and the
+          # test was invisible in CI for ~24h while drift accumulated on
+          # main (issue surfaced 2026-05-01). Phase B of recovery.
+          fetch-depth: 0
 
       - name: Configure git for test setup
         run: |

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -135,6 +135,45 @@ if [ -d ".claude/skills/cleanup-merged" ]; then
     "diff -q 'skills/cleanup-merged/SKILL.md' '.claude/skills/cleanup-merged/SKILL.md' >/dev/null"
 fi
 
+# Tier-1 drift invariant (Phase E of 2026-05-01 recovery): every Tier-1
+# script's CURRENT blob hash must be in
+# `skills/update-zskills/references/tier1-shipped-hashes.txt`. Trivial
+# check, can't be skipped, runs in shallow clones, catches drift at PR
+# time. Complementary to test-update-zskills-migration.sh case 6c
+# (which uses git history) — this one only needs the current tree.
+#
+# Past failure: 10 Tier-1 scripts drifted across PRs #128-#142 because
+# case 6c (the only existing check) silently skipped on shallow clones
+# in CI, and authors had no easy way to know they needed to update the
+# hash file. This invariant is unconditional.
+TIER1_DRIFT_OUT=$(
+  awk -F'|' 'NR>1 && $3 ~ /^[[:space:]]*1[[:space:]]*$/ {
+    gsub(/[[:space:]`]/, "", $2);
+    owner=$4;
+    sub(/^[[:space:]`]+/, "", owner);
+    sub(/[[:space:]`(].*$/, "", owner);
+    if (length($2) > 0) print $2 "\t" owner
+  }' skills/update-zskills/references/script-ownership.md \
+  | while IFS=$'\t' read -r name owner; do
+      src="skills/$owner/scripts/$name"
+      if [ ! -f "$src" ]; then
+        src="block-diagram/$owner/scripts/$name"
+        [ -f "$src" ] || continue
+      fi
+      current_hash=$(git ls-tree HEAD "$src" 2>/dev/null | awk '{print $3}')
+      [ -z "$current_hash" ] && continue
+      if ! grep -qF "$current_hash" skills/update-zskills/references/tier1-shipped-hashes.txt; then
+        echo "DRIFT: $name -> $current_hash ($src)"
+      fi
+    done
+)
+if [ -z "$TIER1_DRIFT_OUT" ]; then
+  check 'Tier-1 drift: every current Tier-1 blob hash is in tier1-shipped-hashes.txt' 'true'
+else
+  echo "$TIER1_DRIFT_OUT" >&2
+  check 'Tier-1 drift: every current Tier-1 blob hash is in tier1-shipped-hashes.txt' 'false'
+fi
+
 # Cross-skill invariant: no skill statically prescribes `isolation: "worktree"`.
 # All worktree work must go through skills/create-worktree/scripts/create-worktree.sh
 # (manual creation) per plans/EXECUTION_MODES.md. Word-boundary on "with"

--- a/tests/test-update-zskills-migration.sh
+++ b/tests/test-update-zskills-migration.sh
@@ -52,9 +52,11 @@ mkdir -p "$TEST_OUT"
 
 PASS_COUNT=0
 FAIL_COUNT=0
+SKIP_COUNT=0
 
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+skip() { printf '\033[33m  SKIP\033[0m %s\n' "$1"; SKIP_COUNT=$((SKIP_COUNT+1)); }
 
 # --- Oracle: Step D.5 migration -------------------------------------------
 # Args:
@@ -461,11 +463,17 @@ test_case_6b_hash_format() {
 
 # Case 6c: commit-cohabitation — when a Tier-1 script changes, the hash
 # file must change in the same commit (or later). Owner-literal pathspec
-# from script-ownership.md column 4 (DA-10 fix). Skip with warning on
-# shallow clones.
+# from script-ownership.md column 4 (DA-10 fix). Requires full git
+# history (fetch-depth: 0 in CI; non-shallow locally).
+#
+# Past failure (2026-04-30 → 2026-05-01): this test previously called
+# `pass "shallow clone — skipped (warning)"` on shallow clones, making
+# it invisible in CI and silently masking ~24h of accumulated Tier-1
+# drift across PRs #128, #131, #135-#142. The skip-as-pass anti-pattern
+# is corrected here: shallow now FAILs loudly.
 test_case_6c_commit_cohabitation() {
   if [ "$(git -C "$REPO_ROOT" rev-parse --is-shallow-repository)" = "true" ]; then
-    pass "case 6c: shallow clone — skipped (warning)"
+    fail "case 6c: shallow clone" "this test requires full git history (set fetch-depth: 0 in CI; run \`git fetch --unshallow\` locally). Previously skipped-as-PASS, masking ~24h of Tier-1 drift on main."
     return
   fi
 
@@ -474,9 +482,10 @@ test_case_6c_commit_cohabitation() {
   last_hash_commit=$(git -C "$REPO_ROOT" log -1 --pretty=format:%H -- "$hash_path")
   if [ -z "$last_hash_commit" ]; then
     # The hash file may have been generated in this very worktree but not
-    # yet committed (verifier-pre-commit state). Skip with warning; the
-    # check will run on the CI clone after this PR lands.
-    pass "case 6c: hash file uncommitted in this worktree — skipped (pre-commit)"
+    # yet committed (verifier-pre-commit state). This is a legitimate
+    # transient state (the post-merge CI fires after the commit lands),
+    # so emit a real SKIP rather than a fake PASS.
+    skip "case 6c: hash file uncommitted in this worktree (pre-commit state)"
     return
   fi
 
@@ -525,12 +534,17 @@ test_case_6b_hash_format
 test_case_6c_commit_cohabitation
 
 echo
-TOTAL=$((PASS_COUNT + FAIL_COUNT))
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
 if [ "$FAIL_COUNT" -eq 0 ]; then
-  printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  if [ "$SKIP_COUNT" -gt 0 ]; then
+    printf '\033[32mResults: %d passed, 0 failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$SKIP_COUNT" "$TOTAL"
+  else
+    printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  fi
   exit 0
 else
-  printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' \
-    "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  printf '\033[31mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$TOTAL"
   exit 1
 fi


### PR DESCRIPTION
## What

**Phase B + Phase E** of the 2026-05-01 recovery plan. Phase A ([PR #145](https://github.com/zeveck/zskills-dev/pull/145)) just restored main to green by backfilling 10 missing Tier-1 blob hashes. This PR closes the gap that allowed those drifts to accumulate undetected.

### Phase B — Test honesty + CI fetch-depth

1. **`.github/workflows/test.yml`** — add `fetch-depth: 0` to `actions/checkout@v4`. Required by `tests/test-update-zskills-migration.sh` case 6c (commit-cohabitation), which uses `git log -1 -- <path>` and `merge-base --is-ancestor` — both need full history.

2. **`tests/test-update-zskills-migration.sh`** — case 6c's shallow-clone branch previously called `pass "shallow clone — skipped"`, hiding the test from CI for ~24h while drift accumulated on main across PRs #128, #131, #135-#142. **Replaced with `fail`** — pass-counted-as-skip is dishonest signaling; the test must FAIL loudly when its precondition isn't met. Added a real `skip` accumulator (no longer counted as pass) for the legitimate "hash file uncommitted in this worktree" pre-commit state, and updated the Results: line to report skips separately when present.

### Phase E — Drift invariant test

3. **`tests/test-skill-invariants.sh`** — new check: for every Tier-1 script in `script-ownership.md`, the current `git ls-tree HEAD <path>` blob hash must be in `tier1-shipped-hashes.txt`. Trivial check, can't be skipped, runs in shallow clones, catches drift at PR time before merge. Complements case 6c (which uses git history) — this one only needs the current tree.

## Why this matters

The hidden chain: **case 6c silently skipped** on shallow CI → 10 PRs landed on main without updating the hash file → main's CI was actually red the whole time → branch protection only checks PR-level CI, not post-merge → silent accumulation. This PR fixes the test honesty (Phase B) AND adds a stricter invariant that catches drift even without git history (Phase E).

## Test plan

- [x] `bash tests/test-update-zskills-migration.sh` → `Results: 12 passed, 0 failed (of 12)` (case 6c passes on full-history clone)
- [x] `bash tests/test-skill-invariants.sh` → `Results: 41 passed, 0 failed` (was 40; +1 drift invariant)
- [x] Full suite `bash tests/run-all.sh` → 1698/1698 pass, 0 failed (was 1697/1697; +1 from new check)
- [x] **Break-and-revert proof of new invariant**: removing `briefing.cjs` hash from tier1-shipped-hashes.txt → invariant fails with `DRIFT: briefing.cjs -> 123b9efa... (skills/briefing/scripts/briefing.cjs)`. Restoring → 41/41 PASS.
- [x] Independent agent review pending
- [ ] **CI on PR push** — primary regression gate. Now with `fetch-depth: 0`, case 6c will actually run.
- [ ] **CI on post-merge main** — verify it stays green.

## Subsequent phases

- **Phase C** — fix sub-agent dispatch timeout for long test suites (separate PR)
- **Phase D** — close post-merge CI protection gap (separate PR; needs design decision on notification mechanism)