### PR TITLE
fix(skills): subagent dispatch timeout + Monitor anti-pattern callout (Phase C)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -342,6 +342,15 @@ Verification intensity matches the change type (from Phase 1):
 - **Run `$FULL_TEST_CMD`** (resolve via
   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
   if you don't already have it in your environment) — all suites must pass, not just unit tests.
+  **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
+  min); default 120000ms is shorter than the suite's runtime (~3-4
+  min). Do NOT recover from a Bash timeout by retrying with
+  `run_in_background: true` + `Monitor` / `BashOutput` — wake events
+  do not reliably deliver to subagents (you may be one), so the wait
+  never returns and the dispatch hangs at "Tests are running. Let me
+  wait for the monitor." Past failure: 6+ subagent crashes with that
+  phrase across 2026-04-29 and 2026-04-30. Always foreground-Bash with
+  explicit long timeout; capture to file; read the file on return.
 - **If tests fail: fix them.** Do not check if failures are pre-existing.
   Do not stash, checkout old commits, or create comparison worktrees.
   If you touched code and tests fail, they're yours to fix. (See

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -780,7 +780,18 @@ Each agent follows this fix workflow:
 4. Write regression tests (unit and/or E2E as appropriate)
 5. Run `$FULL_TEST_CMD` (resolve via
    `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if you don't already have it in your environment) — all suites must pass
+   if you don't already have it in your environment) — all suites must pass.
+   **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
+   min). The default 120000ms is shorter than the suite's actual runtime
+   (~3-4 min in zskills). **Do NOT recover from a timeout by retrying
+   with `run_in_background: true` + `Monitor` / `BashOutput` polling** —
+   wake events for background processes do not reliably deliver to
+   subagents, so the wait never returns and the dispatch hangs at "Tests
+   are running. Let me wait for the monitor." Past failure: 6+ subagent
+   crashes with exactly that phrase across 2026-04-29 and 2026-04-30
+   sessions. Always foreground-Bash with explicit long timeout; capture
+   to file via `> "$TEST_OUT/$TEST_OUTPUT_FILE" 2>&1` and read the file
+   when the Bash call returns.
 6. **Agent verification** via `/manual-testing` if UI files changed —
    use playwright-cli with real events, take screenshots as evidence.
    The pre-commit hook will BLOCK your commit if UI files are staged

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1045,9 +1045,24 @@ agent hasn't returned after 2 hours, declare it **failed**:
    VERBATIM in every implementation and verification agent prompt:
 
    > **Worktree test recipe:**
+   >
+   > **CRITICAL — Bash tool timeout:** when invoking `$FULL_TEST_CMD` via
+   > the `Bash` tool, **pass `timeout: 600000`** (10 minutes). The default
+   > 120000ms (2 min) is shorter than the suite's actual runtime (~3-4
+   > min in zskills) and causes the Bash call to time out. **Do NOT
+   > recover by retrying with `run_in_background: true` + `Monitor` /
+   > `BashOutput` polling** — wake events for background processes do
+   > not reliably deliver to subagents (you are a subagent), so the wait
+   > never returns and the dispatch hangs at "Tests are running. Let me
+   > wait for the monitor." Past failure: 6+ subagent crashes with
+   > exactly that phrase across 2026-04-29 and 2026-04-30 sessions.
+   > Always foreground-Bash with explicit long timeout; capture to file
+   > as below; read the file when the call returns.
+   >
    > 1. Start a dev server FIRST: `$DEV_SERVER_CMD &`
    > 2. Wait for it: `sleep 3`
-   > 3. Run tests with output captured to a file:
+   > 3. Run tests with output captured to a file (`Bash` tool with
+   >    `timeout: 600000`):
    >    ```bash
    >    TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
    >    mkdir -p "$TEST_OUT"

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -301,7 +301,20 @@ Then proceed to Phase 4. Do not search for an alternate test command.
 
 Otherwise (`TEST_MODE=config`, `$FULL_TEST_CMD` set):
 
-1. **Run the full test suite with output captured to a file:**
+**Bash-tool timeout for the full suite (CRITICAL).** When invoking the
+test command via the `Bash` tool, pass `timeout: 600000` (10 min). The
+default 120000ms is shorter than the suite's actual runtime (~3-4 min
+in zskills). If the Bash call times out, do NOT recover by retrying
+with `run_in_background: true` + `Monitor` / `BashOutput` polling —
+wake events for background processes do not reliably deliver to
+subagents, so the wait never returns and the dispatch hangs at "Tests
+are running. Let me wait for the monitor." Past failure: 6+ subagent
+crashes with exactly that phrase across 2026-04-29 and 2026-04-30
+sessions. Always foreground-Bash with explicit long timeout; capture
+to file as below; read the file when the call returns.
+
+1. **Run the full test suite with output captured to a file** (resolve via
+   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`):
    ```bash
    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
    TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -342,6 +342,15 @@ Verification intensity matches the change type (from Phase 1):
 - **Run `$FULL_TEST_CMD`** (resolve via
   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
   if you don't already have it in your environment) — all suites must pass, not just unit tests.
+  **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
+  min); default 120000ms is shorter than the suite's runtime (~3-4
+  min). Do NOT recover from a Bash timeout by retrying with
+  `run_in_background: true` + `Monitor` / `BashOutput` — wake events
+  do not reliably deliver to subagents (you may be one), so the wait
+  never returns and the dispatch hangs at "Tests are running. Let me
+  wait for the monitor." Past failure: 6+ subagent crashes with that
+  phrase across 2026-04-29 and 2026-04-30. Always foreground-Bash with
+  explicit long timeout; capture to file; read the file on return.
 - **If tests fail: fix them.** Do not check if failures are pre-existing.
   Do not stash, checkout old commits, or create comparison worktrees.
   If you touched code and tests fail, they're yours to fix. (See

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -780,7 +780,18 @@ Each agent follows this fix workflow:
 4. Write regression tests (unit and/or E2E as appropriate)
 5. Run `$FULL_TEST_CMD` (resolve via
    `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if you don't already have it in your environment) — all suites must pass
+   if you don't already have it in your environment) — all suites must pass.
+   **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
+   min). The default 120000ms is shorter than the suite's actual runtime
+   (~3-4 min in zskills). **Do NOT recover from a timeout by retrying
+   with `run_in_background: true` + `Monitor` / `BashOutput` polling** —
+   wake events for background processes do not reliably deliver to
+   subagents, so the wait never returns and the dispatch hangs at "Tests
+   are running. Let me wait for the monitor." Past failure: 6+ subagent
+   crashes with exactly that phrase across 2026-04-29 and 2026-04-30
+   sessions. Always foreground-Bash with explicit long timeout; capture
+   to file via `> "$TEST_OUT/$TEST_OUTPUT_FILE" 2>&1` and read the file
+   when the Bash call returns.
 6. **Agent verification** via `/manual-testing` if UI files changed —
    use playwright-cli with real events, take screenshots as evidence.
    The pre-commit hook will BLOCK your commit if UI files are staged

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1045,9 +1045,24 @@ agent hasn't returned after 2 hours, declare it **failed**:
    VERBATIM in every implementation and verification agent prompt:
 
    > **Worktree test recipe:**
+   >
+   > **CRITICAL — Bash tool timeout:** when invoking `$FULL_TEST_CMD` via
+   > the `Bash` tool, **pass `timeout: 600000`** (10 minutes). The default
+   > 120000ms (2 min) is shorter than the suite's actual runtime (~3-4
+   > min in zskills) and causes the Bash call to time out. **Do NOT
+   > recover by retrying with `run_in_background: true` + `Monitor` /
+   > `BashOutput` polling** — wake events for background processes do
+   > not reliably deliver to subagents (you are a subagent), so the wait
+   > never returns and the dispatch hangs at "Tests are running. Let me
+   > wait for the monitor." Past failure: 6+ subagent crashes with
+   > exactly that phrase across 2026-04-29 and 2026-04-30 sessions.
+   > Always foreground-Bash with explicit long timeout; capture to file
+   > as below; read the file when the call returns.
+   >
    > 1. Start a dev server FIRST: `$DEV_SERVER_CMD &`
    > 2. Wait for it: `sleep 3`
-   > 3. Run tests with output captured to a file:
+   > 3. Run tests with output captured to a file (`Bash` tool with
+   >    `timeout: 600000`):
    >    ```bash
    >    TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
    >    mkdir -p "$TEST_OUT"

--- a/skills/verify-changes/SKILL.md
+++ b/skills/verify-changes/SKILL.md
@@ -301,7 +301,20 @@ Then proceed to Phase 4. Do not search for an alternate test command.
 
 Otherwise (`TEST_MODE=config`, `$FULL_TEST_CMD` set):
 
-1. **Run the full test suite with output captured to a file:**
+**Bash-tool timeout for the full suite (CRITICAL).** When invoking the
+test command via the `Bash` tool, pass `timeout: 600000` (10 min). The
+default 120000ms is shorter than the suite's actual runtime (~3-4 min
+in zskills). If the Bash call times out, do NOT recover by retrying
+with `run_in_background: true` + `Monitor` / `BashOutput` polling —
+wake events for background processes do not reliably deliver to
+subagents, so the wait never returns and the dispatch hangs at "Tests
+are running. Let me wait for the monitor." Past failure: 6+ subagent
+crashes with exactly that phrase across 2026-04-29 and 2026-04-30
+sessions. Always foreground-Bash with explicit long timeout; capture
+to file as below; read the file when the call returns.
+
+1. **Run the full test suite with output captured to a file** (resolve via
+   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`):
    ```bash
    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
    TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"


### PR DESCRIPTION
## What

Adds explicit `Bash`-tool-timeout guidance to the test-running prose in four skills, plus an explicit anti-pattern callout against the `Monitor` / `BashOutput` retry pattern that has been crashing dispatched subagents.

## Root cause

Test suite grew to ~230s with PR #140 (DRAFT_TESTS Phase 6 added +457 tests). Default `Bash` tool timeout is 120s. Dispatched subagents running `bash tests/run-all.sh` started timing out. On timeout, agents reflexively retried with `run_in_background: true` + `Monitor` / `BashOutput` polling — but `Monitor` wake events do NOT reliably deliver to one-shot subagent dispatches, so the wait never returned and the dispatch hung at "Tests are running. Let me wait for the monitor." Observed in 6+ crashes across 2026-04-29 and 2026-04-30 sessions.

## Fix

Prominent CRITICAL callout added in the canonical test-running spots in:

- `skills/run-plan/SKILL.md` (worktree-test-recipe blockquote)
- `skills/fix-issues/SKILL.md` (Phase 3 fix-agent workflow)
- `skills/verify-changes/SKILL.md` (Phase 3 test-running step)
- `skills/do/SKILL.md` (code-changes section)

Each callout instructs agents to:
1. Pass `timeout: 600000` (10 min) on the `Bash` tool invocation
2. NEVER fall back to `run_in_background: true` + `Monitor` / `BashOutput` on timeout
3. Always foreground-`Bash` with explicit long timeout; capture to file; read the file on return

`.claude/skills/` mirror updated for all four skills via `scripts/mirror-skill.sh`.

## Test plan

- [x] Conformance: `bash tests/test-skill-conformance.sh` → 197/197 PASS (PROSE-IMPERATIVE substitution-discipline coverage preserved)
- [x] Invariants: `bash tests/test-skill-invariants.sh` → 41/41 PASS
- [x] Full suite: `bash tests/run-all.sh` → 1698/1698 PASS (no regression)
- [x] Mirror parity: `diff -q` clean for all 4 skill pairs
- [x] Independent agent review pending
- [ ] **CI on PR push**
- [ ] **Real-world test**: next subagent dispatch that runs the test suite (in /run-plan or /fix-issues) should NOT crash with "Let me wait for the monitor."

## Notable wrinkle

Initial draft of verify-changes used `**CRITICAL**` as continuation prose under a numbered bullet — the conformance PROSE-IMPERATIVE detector mis-matched `**` against its `[-*]` bullet pattern (false-positive). Restructured to a standalone preamble paragraph that doesn't false-positive. The detector regex itself could be tightened (require space after `*`, or distinguish from `**`), but that's out of scope here — filed mentally as a future hardening.

## Phase C of recovery plan

Phase A ([PR #145](https://github.com/zeveck/zskills-dev/pull/145)) restored main to green; Phase B+E ([PR #147](https://github.com/zeveck/zskills-dev/pull/147)) added test honesty + drift invariant. This addresses the underlying cause of the subagent crash pattern. Phase D (post-merge CI gate) follows.