### PR TITLE
[quickfix-do-triage-plan] Phase 3: CLAUDE_TEMPLATE.md + plan complete + follow-up #155

### DIFF
--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -196,8 +196,10 @@ Three landing modes control how agent work reaches main:
 - `/run-plan plans/X.md finish auto pr`
 - `/fix-issues 10 pr`
 - `/research-and-go Build an RPG. pr`
-- `/quickfix Fix README typo` — low-ceremony PR for trivial changes (no worktree; picks up in-flight edits in main)
-- `/do Add dark mode. pr`
+- `/quickfix Fix README typo --force` — low-ceremony PR for trivial changes (no worktree; picks up in-flight edits in main; `--force` skips triage + review)
+- `/do Add dark mode. --rounds 2 --force. pr`
+
+Both skills now triage tasks and run a fresh-agent plan review before execution. Use `--force` to bypass.
 
 After a PR merges on GitHub, run `/cleanup-merged` to catch your local clone up (checkout main, pull, delete merged feature branches). Safe to run anytime; bails on a dirty tree.
 

--- a/plans/QUICKFIX_DO_TRIAGE_PLAN.md
+++ b/plans/QUICKFIX_DO_TRIAGE_PLAN.md
@@ -824,7 +824,7 @@ Phase 1a, Phase 1b, Phase 2a, Phase 2b.
 
 ## Follow-ups (out of scope for this plan)
 
-- `/commit pr` exhibits the same gate-routing-around behavior /quickfix and /do had before this plan. Apply the same orthogonal triage + inline-plan + review pattern in a follow-up plan. (Tracked as a GitHub issue, number recorded after Phase 3 WI 3.3.)
+- `/commit pr` exhibits the same gate-routing-around behavior /quickfix and /do had before this plan. Apply the same orthogonal triage + inline-plan + review pattern in a follow-up plan. (Tracked: https://github.com/zeveck/zskills-dev/issues/155)
 
 ---
 

--- a/plans/QUICKFIX_DO_TRIAGE_PLAN.md
+++ b/plans/QUICKFIX_DO_TRIAGE_PLAN.md
@@ -1,7 +1,7 @@
 ---
 title: /quickfix and /do — Triage Gate, Inline Plan, and Fresh-Agent Plan Review
 created: 2026-04-25
-status: active
+status: complete
 ---
 
 # Plan: /quickfix and /do — Triage Gate, Inline Plan, and Fresh-Agent Plan Review
@@ -20,7 +20,7 @@ status: active
 | 1b    | ✅ Done (`73ff49a`) | /quickfix — extend tests/test-quickfix.sh to cover triage / review / --force / --rounds |
 | 2a    | ✅ Done (`4a6c659`) | /do — flags, triage gate (BEFORE cron registration), inline plan, fresh-agent review (skill source + mirror) |
 | 2b    | ✅ Done (`dc0005d`) | /do — create tests/test-do.sh, wire into run-all.sh |
-| 3     | ⬚ | Cross-cutting — CLAUDE_TEMPLATE.md, full-suite run, /commit pr follow-up issue |
+| 3     | ✅ Done (`59613d4`) | Cross-cutting — CLAUDE_TEMPLATE.md, full-suite run, /commit pr follow-up issue |
 
 **Phase 1a effort note:** Phase 1a touches WI 1.2 (parser), inserts WI 1.5.4 / 1.5.4a / 1.5.4b, edits WI 1.5.5 prose, edits WI 1.8 marker logic, refreshes the WI 1.3 Check 3 hook citation (WI 1a.6.7), and mirrors. Expect roughly 250-300 lines added to `skills/quickfix/SKILL.md` (planning estimate, not an acceptance criterion) and **20** grep-presence AC additions in the Acceptance Criteria block (counted by `awk '/^### Acceptance Criteria/,/^### Dependencies/' ... | grep -cE '^- .*grep'`). Implementer should plan ~2-3 hours of careful prose work.
 

--- a/reports/plan-quickfix-do-triage-plan.md
+++ b/reports/plan-quickfix-do-triage-plan.md
@@ -1,5 +1,57 @@
 # Plan Report — /quickfix and /do Triage Gate, Inline Plan, Fresh-Agent Review
 
+## Plan complete — 2026-05-01
+
+All five phases landed via PR mode in a single autonomous `finish auto` run.
+
+| Phase | Status | Commit | PR |
+|-------|--------|--------|-----|
+| 1a | ✅ Done | `d779788` | [#151](https://github.com/zeveck/zskills-dev/pull/151) |
+| 1b | ✅ Done | `73ff49a` | [#152](https://github.com/zeveck/zskills-dev/pull/152) |
+| 2a | ✅ Done | `4a6c659` | [#153](https://github.com/zeveck/zskills-dev/pull/153) |
+| 2b | ✅ Done | `dc0005d` | [#154](https://github.com/zeveck/zskills-dev/pull/154) |
+| 3  | ✅ Done | `59613d4` | (this PR) |
+
+**Test suite trajectory:** 1698 (pre-plan baseline) → 1709 (after Phase 1b adds 10 quickfix cases, +1 split) → 1722 (after Phase 2b adds 13 do cases). No regressions across all five phases.
+
+**Follow-up:** [#155](https://github.com/zeveck/zskills-dev/issues/155) — apply triage gate + plan review to `/commit pr`.
+
+---
+
+## Phase — 3 Cross-cutting: CLAUDE_TEMPLATE.md, full-suite run, follow-up issue
+
+**Plan:** plans/QUICKFIX_DO_TRIAGE_PLAN.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-quickfix-do-triage-plan (PR mode)
+**Implementation commit:** 59613d4
+
+### Work Items
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| 3.1 | CLAUDE_TEMPLATE.md L199-200 — append `--force`/`--rounds N` to /quickfix and /do bullets + one-line triage note | Done | Anchor verified: matches plan's "**Usage:** Append keyword..." section verbatim. /quickfix bullet renders `--force`; /do bullet renders `--rounds 2 --force` (to satisfy AC2 grep). |
+| 3.2 | Full project `bash tests/run-all.sh` runs clean | Done | 1722/1722 PASS; CI also green via `gh pr checks` before merge |
+| 3.3 | File `/commit pr` follow-up issue, link in `## Follow-ups` | Done | Issue #155 created (state: OPEN); plan parenthetical updated to `(Tracked: https://github.com/zeveck/zskills-dev/issues/155)` |
+
+### Verification
+
+- **Test suite:** PASSED (1722/1722, no change from baseline — CLAUDE_TEMPLATE.md is documentation)
+- **All 4 ACs PASS** — both grep ACs for `--force` examples; full-suite clean; Tracked URL anchor matches real issue URL
+- **PLAN-TEXT-DRIFT:** none
+
+### Diff stat
+
+- `CLAUDE_TEMPLATE.md`: +3 / −2 (3 lines changed)
+- `plans/QUICKFIX_DO_TRIAGE_PLAN.md`: +1 / −1 (Tracked URL parenthetical)
+
+### Commits on `feat/quickfix-do-triage-plan` (Phase 3 only)
+
+```
+59613d4 docs(template): document --force / --rounds + triage gate (Phase 3)
+```
+
+---
+
 ## Phase — 2b /do: create test suite, wire into runner
 
 **Plan:** plans/QUICKFIX_DO_TRIAGE_PLAN.md


### PR DESCRIPTION
## Phase 3 — Cross-cutting: CLAUDE_TEMPLATE.md + full-suite + follow-up issue

**Final phase of QUICKFIX_DO_TRIAGE_PLAN.** All five phases land; the plan completes.

### What this PR does

- **WI 3.1** — CLAUDE_TEMPLATE.md L199-200: appended `--force` to the /quickfix example and `--rounds 2 --force` to the /do example, plus a one-line note: "Both skills now triage tasks and run a fresh-agent plan review before execution. Use `--force` to bypass."
- **WI 3.2** — Full project `bash tests/run-all.sh` runs clean: **1722/1722 passed**.
- **WI 3.3** — Filed follow-up [#155](https://github.com/zeveck/zskills-dev/issues/155) — apply the same triage + plan-review pattern to `/commit pr`. Plan's `## Follow-ups` parenthetical updated to `(Tracked: https://github.com/zeveck/zskills-dev/issues/155)`.
- **Plan completion** — frontmatter flipped to `status: complete`. Tracker shows all 5 phases ✅ Done.

<!-- run-plan:progress:start -->
**Phase 1a:** ✅ Done (`d779788`) [PR #151] — /quickfix triage + flags + inline plan + review
**Phase 1b:** ✅ Done (`73ff49a`) [PR #152] — extend tests/test-quickfix.sh (10 cases)
**Phase 2a:** ✅ Done (`4a6c659`) [PR #153] — /do triage + flags + inline plan + review (BEFORE cron)
**Phase 2b:** ✅ Done (`dc0005d`) [PR #154] — create tests/test-do.sh (13 cases) + wire run-all.sh
**Phase 3:**  ✅ Done (`59613d4`) — this PR
<!-- run-plan:progress:end -->

## Plan summary

`/quickfix` and `/do` are fire-and-forget skills for small tasks. Before this plan, they accepted any description and dispatched unconditionally. This plan added three orthogonal pre-execution gates to both skills:

1. **Triage gate** — model-layer judgment redirects out-of-contract requests to `/draft-plan`, `/run-plan`, or `/fix-issues` via per-target message templates. `--force` bypasses.
2. **Inline plan composition** — ≤60-line text-fence template rendered in the model's response (NOT written to disk).
3. **Fresh-agent plan review** — adversarial reviewer with `OBSERVABLE-SIGNAL RULE` (>4 Acceptance bullets → auto-REVISE); APPROVE/REVISE/REJECT verdicts; `--rounds N` controls depth (default 1; 0 skips with WARN); `$ROUNDS` exhaustion soft-rejects unless `--force`.

For `/do`, the cron-zombie regression guard required triage + review run BEFORE `CronCreate`. Phase 2a renamed the existing Phase 0 to Phase 0c and inserted Phase 0a (triage) + Phase 0b (review) ahead of it — reading order `0a → 0b → 0c → 1 → 1.5 → 2 → ...`.

Test suite trajectory: 1698 → 1709 (+11 quickfix; Case 51 split into 51a/51b) → 1722 (+13 /do cases). No regressions.

## Test plan

- [x] All 4 ACs pass (`grep -qE '^- \`/quickfix.*--force' CLAUDE_TEMPLATE.md`, `grep -qE '^- \`/do.*--force' CLAUDE_TEMPLATE.md`, full-suite clean, Tracked URL anchor)
- [x] Issue #155 verified to exist (state: OPEN)
- [x] Test suite 1722/1722 (no regression)
- [x] Frontmatter flipped to `status: complete` — Step 0 Case 1 will self-terminate the cron on next idle fire
- [x] All 5 phases ✅ Done in tracker
- [x] Hygiene: only `CLAUDE_TEMPLATE.md`, `plans/QUICKFIX_DO_TRIAGE_PLAN.md`, and `reports/plan-quickfix-do-triage-plan.md` modified

## Plan

`plans/QUICKFIX_DO_TRIAGE_PLAN.md` (Phase 3 + plan complete) — see `reports/plan-quickfix-do-triage-plan.md` for the full per-phase verification log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)