### PR TITLE
chore(devcontainer): track .playwright/cli.config.json + ignore runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ __pycache__/
 .claude/scheduled_tasks.lock
 .claude/logs/
 DOC_PARTY_COMPARISON.md
+
+# Playwright runtime artifacts (snapshots, console logs, video, traces).
+# Track only the cli.config.json that .devcontainer/setup.sh writes.
+.playwright/*
+!.playwright/cli.config.json

--- a/.playwright/cli.config.json
+++ b/.playwright/cli.config.json
@@ -1,0 +1,11 @@
+{
+  "browser": {
+    "browserName": "chromium",
+    "launchOptions": {
+      "channel": "chrome",
+      "headless": true,
+      "args": ["--no-sandbox"]
+    }
+  },
+  "outputDir": ".playwright/output"
+}


### PR DESCRIPTION
## What

Tracks `.playwright/cli.config.json` (the file `.devcontainer/setup.sh` writes on postCreate) and adds `.playwright/*` to `.gitignore` with an exception for the config.

## Why

`.devcontainer/setup.sh` writes the config with `args: ["--no-sandbox"]` because Chrome's namespace sandbox needs `CAP_SYS_ADMIN` which Docker containers don't have. Without that config, `playwright-cli open <url>` FATALs with `Failed to move to new namespace: Operation not permitted`.

A fresh clone with no postCreate run, OR a checkout where postCreate failed somewhere before reaching the config-write step, leaves Playwright broken out-of-the-box. Discovered this session — the file was missing on this checkout despite setup.sh being correct, so I bailed on Playwright with "container can't do it" before realizing the config was just gone. Tracking it eliminates the fragility entirely.

## Diff

- `.gitignore`: add `.playwright/*` then `!.playwright/cli.config.json`
- `.playwright/cli.config.json`: the file the setup script writes (chromium browserName, chrome channel, headless: true, `--no-sandbox`)

## Test plan

- [x] `git add .playwright/cli.config.json` succeeds (config tracked)
- [x] `git add .playwright/output/<file>` refused as ignored
- [x] `git status -s -uall` shows only the config file under `.playwright/`
- [x] `playwright-cli open http://127.0.0.1:8080/` succeeds with config in place (verified this session — without the config, Chrome FATALs)
- [ ] **CI on PR push**

## Note on related issue

The dashboard's modal-can't-be-dismissed bug was discovered while diagnosing this Playwright failure. That fix is a separate PR (different scope, different files, different reviewer attention).