### PR TITLE
fix(dashboard): make modal dismissable (display:flex was overriding [hidden])

### DIFF
--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -269,6 +269,13 @@ code, pre, .mono {
   overflow-y: auto;
 }
 
+/* The class selector above otherwise wins by source order against the
+   browser-default `[hidden] { display: none }` rule (equal specificity),
+   leaving the modal permanently visible. Restore the default. */
+.modal-root[hidden] {
+  display: none;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;

--- a/.claude/zskills-config.json
+++ b/.claude/zskills-config.json
@@ -2,41 +2,39 @@
   "$schema": "./zskills-config.schema.json",
   "project_name": "zskills",
   "timezone": "America/New_York",
-
   "execution": {
     "landing": "pr",
     "main_protected": true,
     "branch_prefix": "feat/"
   },
-
   "commit": {
     "co_author": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
   },
-
   "testing": {
     "unit_cmd": "bash tests/run-all.sh",
     "full_cmd": "bash tests/run-all.sh",
     "output_file": ".test-results.txt",
-    "file_patterns": ["tests/**/*.sh"]
+    "file_patterns": [
+      "tests/**/*.sh"
+    ]
   },
-
   "dev_server": {
     "cmd": "",
     "default_port": 8080,
     "main_repo_path": "/workspaces/zskills"
   },
-
   "ui": {
     "file_patterns": "",
     "auth_bypass": ""
   },
-
   "ci": {
     "auto_fix": true,
     "max_fix_attempts": 2
   },
-
   "agents": {
     "min_model": "auto"
+  },
+  "dashboard": {
+    "work_on_plans_trigger": ""
   }
 }

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -269,6 +269,13 @@ code, pre, .mono {
   overflow-y: auto;
 }
 
+/* The class selector above otherwise wins by source order against the
+   browser-default `[hidden] { display: none }` rule (equal specificity),
+   leaving the modal permanently visible. Restore the default. */
+.modal-root[hidden] {
+  display: none;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Lead bug

`.modal-root` declares `display: flex` at `skills/zskills-dashboard/scripts/zskills_monitor/static/app.css:265`. That class selector has equal CSS specificity (0,1,0) to the browser-default `[hidden] { display: none }` rule but loses on source order — meaning the HTML `hidden` attribute is a no-op for `.modal-root`. The modal is permanently rendered.

**User-visible symptom:** every fresh load of `/zskills-dashboard` shows a blank modal-card (× button only) over a 70%-opacity backdrop, with no dismiss path:

| Action | Behavior |
|---|---|
| Click × | calls `closeModal()` → sets `hidden=true` → CSS still shows it |
| Click backdrop | same |
| Press Escape | same |

## Fix

Add `.modal-root[hidden] { display: none; }` to override:

```css
.modal-root[hidden] {
  display: none;
}
```

**Verified via playwright** (`http://127.0.0.1:8080/`):
- Before: `getComputedStyle(modal-root).display = "flex"`, `rect.height = 720` despite `hidden=true`
- After: both flip to `"none"` / `0`. Modal dismissal works.

## Audit

This is the **only** `[hidden]`-attribute element with that bug pattern. Verified all 9 elements with `hidden` in `index.html`:

| Element | `display:` declared? | Bug? |
|---|---|---|
| `.conn-banner` | no | ✓ safe |
| `.errors-banner` | no | ✓ safe |
| `.dm-footnote` | no | ✓ safe |
| `.empty` (5 instances) | no | ✓ safe |
| **`.modal-root`** | **`display: flex`** | **BUG** |

`.toast-region` and `.default-mode-area` also declare `display: flex` but neither uses the `hidden` attribute, so they're fine.

## Bundled

Also absorbs the one-time `.claude/zskills-config.json` migration that the dashboard server writes on first start (`dashboard.work_on_plans_trigger: ""` block). Migration source belongs in `/update-zskills` + schema, not server-side — tracked as #165. This commit just absorbs the side-effect once. Reformatting churn (blank-line strips, multi-line arrays) is unfortunate Python `json.dumps` output and is one-time.

## Test plan

- [x] Modal dismisses correctly post-fix (playwright)
- [x] Mirror parity (`diff -q` clean)
- [x] Audit: no other `[hidden]`-class element has `display:` declared
- [ ] **CI on PR push**