### PR TITLE
Fix #143: Agent-tool preflight on 5 multi-agent skills

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -21,6 +21,23 @@ downstream. A weak plan executed perfectly is still a weak result.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /draft-plan requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/draft-plan <description...>`
+>   - Top-level `Skill` tool: `Skill(skill="draft-plan", args="<description...>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/.claude/skills/draft-tests/SKILL.md
+++ b/.claude/skills/draft-tests/SKILL.md
@@ -37,6 +37,23 @@ existing trailing sections.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /draft-tests requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/draft-tests <plan-file>`
+>   - Top-level `Skill` tool: `Skill(skill="draft-tests", args="<plan-file>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/.claude/skills/refine-plan/SKILL.md
+++ b/.claude/skills/refine-plan/SKILL.md
@@ -32,6 +32,23 @@ after refinement.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /refine-plan requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/refine-plan <plan-file>`
+>   - Top-level `Skill` tool: `Skill(skill="refine-plan", args="<plan-file>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -19,6 +19,23 @@ followed by `/run-plan` (execute).
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill `Skill`-loads `/research-and-plan` and `/run-plan`, which internally dispatch reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /research-and-go requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/research-and-go <description>`
+>   - Top-level `Skill` tool: `Skill(skill="research-and-go", args="<description>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/.claude/skills/research-and-plan/SKILL.md
+++ b/.claude/skills/research-and-plan/SKILL.md
@@ -16,6 +16,23 @@ are pure delegation — no drafting happens during execution.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /research-and-plan requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/research-and-plan <description...>`
+>   - Top-level `Skill` tool: `Skill(skill="research-and-plan", args="<description...>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 - **output FILE** (optional) — meta-plan output path. Default:

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -21,6 +21,23 @@ downstream. A weak plan executed perfectly is still a weak result.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /draft-plan requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/draft-plan <description...>`
+>   - Top-level `Skill` tool: `Skill(skill="draft-plan", args="<description...>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/skills/draft-tests/SKILL.md
+++ b/skills/draft-tests/SKILL.md
@@ -37,6 +37,23 @@ existing trailing sections.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /draft-tests requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/draft-tests <plan-file>`
+>   - Top-level `Skill` tool: `Skill(skill="draft-tests", args="<plan-file>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/skills/refine-plan/SKILL.md
+++ b/skills/refine-plan/SKILL.md
@@ -32,6 +32,23 @@ after refinement.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /refine-plan requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/refine-plan <plan-file>`
+>   - Top-level `Skill` tool: `Skill(skill="refine-plan", args="<plan-file>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -19,6 +19,23 @@ followed by `/run-plan` (execute).
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill `Skill`-loads `/research-and-plan` and `/run-plan`, which internally dispatch reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /research-and-go requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/research-and-go <description>`
+>   - Top-level `Skill` tool: `Skill(skill="research-and-go", args="<description>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 ```

--- a/skills/research-and-plan/SKILL.md
+++ b/skills/research-and-plan/SKILL.md
@@ -16,6 +16,23 @@ are pure delegation — no drafting happens during execution.
 
 **Ultrathink throughout.**
 
+## Preflight — top-level dispatch required
+
+This skill internally dispatches reviewer + devil's-advocate + refiner sub-agents in parallel. It MUST run in a context that has the `Agent` (or `Task`) tool available.
+
+Before doing any other work, verify your tool list contains `Agent` or `Task`. If neither is present, STOP and report:
+
+> ERROR: /research-and-plan requires top-level Agent dispatch capability. This invocation is running as a subagent (no Agent tool — verified by inspecting your tool list). Subagents cannot dispatch sub-subagents (Anthropic design — https://code.claude.com/docs/en/sub-agents).
+>
+> Re-invoke as one of:
+>   - User slash command: `/research-and-plan <description...>`
+>   - Top-level `Skill` tool: `Skill(skill="research-and-plan", args="<description...>")`
+>   - Inline orchestration by a top-level Claude that has `Agent`
+>
+> Do NOT continue. Single-agent inline degradation produces rubber-stamp findings without the adversarial diversity this skill's value depends on. The CLAUDE.md memory anchor `feedback_multi_agent_skills_top_level.md` is the recurring failure mode this preflight catches.
+
+Do not proceed past this preflight without `Agent` access.
+
 ## Arguments
 
 - **output FILE** (optional) — meta-plan output path. Default:

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -801,6 +801,26 @@ check_fixed update-zskills "WI2.2: runtime-read note" \
   'Runtime-read fields (read by hooks and helper scripts at every invocation, NOT install-filled)'
 
 echo ""
+echo "=== Multi-agent adversarial-loop skills — Agent-tool-required preflight (issue #143) ==="
+# These five skills internally dispatch reviewer + devil's-advocate + refiner
+# sub-agents (or, in research-and-go's case, Skill-load sibling skills that
+# do). They MUST run at top level where the `Agent` tool exists. The
+# preflight block surfaces the failure mode loudly when one is dispatched as
+# a subagent. The structural section heading is the stable anchor: prose
+# inside the block can drift, but `## Preflight — top-level dispatch required`
+# must be present in every one of these five skills.
+check_fixed refine-plan       "preflight: Agent-tool-required heading (issue #143)" \
+  '## Preflight — top-level dispatch required'
+check_fixed draft-plan        "preflight: Agent-tool-required heading (issue #143)" \
+  '## Preflight — top-level dispatch required'
+check_fixed draft-tests       "preflight: Agent-tool-required heading (issue #143)" \
+  '## Preflight — top-level dispatch required'
+check_fixed research-and-plan "preflight: Agent-tool-required heading (issue #143)" \
+  '## Preflight — top-level dispatch required'
+check_fixed research-and-go   "preflight: Agent-tool-required heading (issue #143)" \
+  '## Preflight — top-level dispatch required'
+
+echo ""
 echo "=== /draft-tests — behavior contracts (WI 6.3) ==="
 # Anchor: tests/test-skill-conformance.sh draft-tests block — one check
 # per WI 6.3 sub-bullet of plans/DRAFT_TESTS_SKILL_PLAN.md (current count:


### PR DESCRIPTION
Fixes #143

## Changes

Adds a `## Preflight — top-level dispatch required` block at the top of 5 multi-agent adversarial-loop skills so the silent dispatch-as-subagent failure mode fails loud at the next occurrence.

- `skills/refine-plan/SKILL.md` (+ mirror)
- `skills/draft-plan/SKILL.md` (+ mirror)
- `skills/draft-tests/SKILL.md` (+ mirror)
- `skills/research-and-plan/SKILL.md` (+ mirror)
- `skills/research-and-go/SKILL.md` (+ mirror, variant wording: "Skill-loads /research-and-plan and /run-plan, which internally dispatch...")
- `tests/test-skill-conformance.sh` — 5 new `check_fixed` assertions, one per skill, anchored on the literal heading

Each preflight block tells the agent to verify `Agent` (or `Task`) is in its tool list before doing any work; if not, STOP with an error that names three legitimate re-invocation paths and references `feedback_multi_agent_skills_top_level.md`.

## Test plan

- [x] Conformance suite runs the 5 new checks (`bash tests/run-all.sh` → 252/252 conformance, full suite 1801→1807)
- [x] Source/mirror byte-parity verified for all 5 skills
- [x] `research-and-go` uses variant wording; other 4 use direct wording
- [x] Each preflight references `feedback_multi_agent_skills_top_level.md` (per AC, not the example block's misspelling)
- [ ] Future dispatched-as-subagent invocation of any of the 5 skills surfaces the error message instead of silently degrading
