### PR TITLE
Fix #165: move dashboard config migration to /update-zskills + schema

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -283,6 +283,22 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    If the `commit` key is absent, add the whole block; if the `commit`
    block exists but lacks `co_author`, add only that field. Idempotent:
    re-running on an already-backfilled config is a no-op.
+3.6. **Backfill `dashboard.work_on_plans_trigger` if absent.** If the
+   existing config does not contain a `"dashboard"` block with a
+   `"work_on_plans_trigger"` field (e.g. configs written before the
+   `/zskills-dashboard` skill was introduced), splice in an empty
+   default so the dashboard server can read the field unconditionally.
+   Default value: `""` (empty string — disables the Run button until
+   the consumer wires a trigger script). The server is **read-only** on
+   `.claude/zskills-config.json` — adding the field here is the sole
+   migration point. Matches the same style as 3.5: targeted `Edit` or
+   small `sed`-based rewrite that preserves every other field
+   unchanged. If the `dashboard` key is absent, add the whole block; if
+   the `dashboard` block exists but lacks `work_on_plans_trigger`, add
+   only that field. Idempotent: re-running on an already-backfilled
+   config is a no-op. Detection regex (bash): test against
+   `\"dashboard\"[[:space:]]*:[[:space:]]*\{[^}]*\"work_on_plans_trigger\"`
+   — if it does NOT match, the backfill applies.
 4. Copy `config/zskills-config.schema.json` from `$PORTABLE` to
    `.claude/zskills-config.schema.json` in the target project (so the
    `$schema` reference in the config resolves correctly).
@@ -337,6 +353,9 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
      "ci": {
        "auto_fix": true,
        "max_fix_attempts": 2
+     },
+     "dashboard": {
+       "work_on_plans_trigger": ""
      }
    }
    ```

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -507,6 +507,14 @@ must be empty.
 
 ## Configuration
 
+**Read-only boundary.** The server reads `.claude/zskills-config.json`
+(never writes); writes only to `.zskills/*` (its own state — PID file,
+log file, monitor-state.json, tracking markers). The
+`dashboard.work_on_plans_trigger` field is declared in
+`config/zskills-config.schema.json` and added by `/update-zskills` on
+install/update (Step 3.6 backfill). The server treats absent/missing
+fields as empty rather than mutating user config.
+
 The dashboard reads `.claude/zskills-config.json` for two fields:
 
 - `dev_server.default_port` (integer) — default port when neither

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -204,8 +204,17 @@ def resolve_port(
 
 
 # ---------------------------------------------------------------------------
-# Config load (also bootstraps the dashboard block on first run)
+# Config load (READ-ONLY on .claude/zskills-config.json)
 # ---------------------------------------------------------------------------
+#
+# The server NEVER writes to .claude/zskills-config.json. The
+# `dashboard.work_on_plans_trigger` field is declared in the schema and
+# added by /update-zskills on install/update against existing configs
+# (see skills/update-zskills/SKILL.md Step 3.6). If the field is absent
+# at server startup (consumer hasn't run /update-zskills since the field
+# was introduced), the server treats it as empty — the Run button is
+# hidden, /api/trigger returns 501. No config mutation, no json.dumps
+# reformatting churn.
 
 
 def _read_config(main_root: pathlib.Path) -> Dict[str, Any]:
@@ -220,32 +229,6 @@ def _read_config(main_root: pathlib.Path) -> Dict[str, Any]:
     except (json.JSONDecodeError, ValueError):
         return {}
     return loaded if isinstance(loaded, dict) else {}
-
-
-def ensure_dashboard_config_block(main_root: pathlib.Path) -> None:
-    """Add `dashboard: {work_on_plans_trigger: ""}` to the config if
-    absent. This mutation is idempotent and uses an atomic write.
-
-    Per the plan: Phase 5 owns introduction of the block; downstream
-    phases assume it's present.
-    """
-    cfg_path = main_root / ".claude" / "zskills-config.json"
-    if not cfg_path.is_file():
-        return
-    try:
-        body = cfg_path.read_text(encoding="utf-8")
-        loaded = json.loads(body)
-    except (OSError, json.JSONDecodeError, ValueError):
-        return
-    if not isinstance(loaded, dict):
-        return
-    if isinstance(loaded.get("dashboard"), dict):
-        return
-    loaded["dashboard"] = {"work_on_plans_trigger": ""}
-    new_body = json.dumps(loaded, indent=2) + "\n"
-    tmp = cfg_path.with_suffix(cfg_path.suffix + ".tmp")
-    tmp.write_text(new_body, encoding="utf-8")
-    os.replace(str(tmp), str(cfg_path))
 
 
 # ---------------------------------------------------------------------------
@@ -1057,8 +1040,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     # Ensure .zskills/ exists before any state write
     (main_root / ".zskills").mkdir(parents=True, exist_ok=True)
 
-    # Bootstrap dashboard config block if missing
-    ensure_dashboard_config_block(main_root)
+    # Note: .claude/zskills-config.json is READ-ONLY for the server.
+    # The dashboard.work_on_plans_trigger field is added by
+    # /update-zskills (schema migration), not bootstrapped here.
 
     port = resolve_port(main_root, cli_port=args.port)
 

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -142,6 +142,17 @@
           "examples": ["auto", "claude-opus-4-6", "claude-sonnet-4-6"]
         }
       }
+    },
+    "dashboard": {
+      "type": "object",
+      "description": "Local monitor dashboard configuration. Read by the zskills-dashboard server (read-only — never written by the server).",
+      "properties": {
+        "work_on_plans_trigger": {
+          "type": "string",
+          "default": "",
+          "description": "Relative path to a consumer-authored trigger script. When set, the dashboard's Run button posts to /api/trigger, which spawns the script with the selected /work-on-plans invocation as argv[1]. No default script is shipped. If absent or empty, the Run button is hidden client-side and /api/trigger returns 501."
+        }
+      }
     }
   }
 }

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -283,6 +283,22 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    If the `commit` key is absent, add the whole block; if the `commit`
    block exists but lacks `co_author`, add only that field. Idempotent:
    re-running on an already-backfilled config is a no-op.
+3.6. **Backfill `dashboard.work_on_plans_trigger` if absent.** If the
+   existing config does not contain a `"dashboard"` block with a
+   `"work_on_plans_trigger"` field (e.g. configs written before the
+   `/zskills-dashboard` skill was introduced), splice in an empty
+   default so the dashboard server can read the field unconditionally.
+   Default value: `""` (empty string — disables the Run button until
+   the consumer wires a trigger script). The server is **read-only** on
+   `.claude/zskills-config.json` — adding the field here is the sole
+   migration point. Matches the same style as 3.5: targeted `Edit` or
+   small `sed`-based rewrite that preserves every other field
+   unchanged. If the `dashboard` key is absent, add the whole block; if
+   the `dashboard` block exists but lacks `work_on_plans_trigger`, add
+   only that field. Idempotent: re-running on an already-backfilled
+   config is a no-op. Detection regex (bash): test against
+   `\"dashboard\"[[:space:]]*:[[:space:]]*\{[^}]*\"work_on_plans_trigger\"`
+   — if it does NOT match, the backfill applies.
 4. Copy `config/zskills-config.schema.json` from `$PORTABLE` to
    `.claude/zskills-config.schema.json` in the target project (so the
    `$schema` reference in the config resolves correctly).
@@ -337,6 +353,9 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
      "ci": {
        "auto_fix": true,
        "max_fix_attempts": 2
+     },
+     "dashboard": {
+       "work_on_plans_trigger": ""
      }
    }
    ```

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -507,6 +507,14 @@ must be empty.
 
 ## Configuration
 
+**Read-only boundary.** The server reads `.claude/zskills-config.json`
+(never writes); writes only to `.zskills/*` (its own state — PID file,
+log file, monitor-state.json, tracking markers). The
+`dashboard.work_on_plans_trigger` field is declared in
+`config/zskills-config.schema.json` and added by `/update-zskills` on
+install/update (Step 3.6 backfill). The server treats absent/missing
+fields as empty rather than mutating user config.
+
 The dashboard reads `.claude/zskills-config.json` for two fields:
 
 - `dev_server.default_port` (integer) — default port when neither

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -204,8 +204,17 @@ def resolve_port(
 
 
 # ---------------------------------------------------------------------------
-# Config load (also bootstraps the dashboard block on first run)
+# Config load (READ-ONLY on .claude/zskills-config.json)
 # ---------------------------------------------------------------------------
+#
+# The server NEVER writes to .claude/zskills-config.json. The
+# `dashboard.work_on_plans_trigger` field is declared in the schema and
+# added by /update-zskills on install/update against existing configs
+# (see skills/update-zskills/SKILL.md Step 3.6). If the field is absent
+# at server startup (consumer hasn't run /update-zskills since the field
+# was introduced), the server treats it as empty — the Run button is
+# hidden, /api/trigger returns 501. No config mutation, no json.dumps
+# reformatting churn.
 
 
 def _read_config(main_root: pathlib.Path) -> Dict[str, Any]:
@@ -220,32 +229,6 @@ def _read_config(main_root: pathlib.Path) -> Dict[str, Any]:
     except (json.JSONDecodeError, ValueError):
         return {}
     return loaded if isinstance(loaded, dict) else {}
-
-
-def ensure_dashboard_config_block(main_root: pathlib.Path) -> None:
-    """Add `dashboard: {work_on_plans_trigger: ""}` to the config if
-    absent. This mutation is idempotent and uses an atomic write.
-
-    Per the plan: Phase 5 owns introduction of the block; downstream
-    phases assume it's present.
-    """
-    cfg_path = main_root / ".claude" / "zskills-config.json"
-    if not cfg_path.is_file():
-        return
-    try:
-        body = cfg_path.read_text(encoding="utf-8")
-        loaded = json.loads(body)
-    except (OSError, json.JSONDecodeError, ValueError):
-        return
-    if not isinstance(loaded, dict):
-        return
-    if isinstance(loaded.get("dashboard"), dict):
-        return
-    loaded["dashboard"] = {"work_on_plans_trigger": ""}
-    new_body = json.dumps(loaded, indent=2) + "\n"
-    tmp = cfg_path.with_suffix(cfg_path.suffix + ".tmp")
-    tmp.write_text(new_body, encoding="utf-8")
-    os.replace(str(tmp), str(cfg_path))
 
 
 # ---------------------------------------------------------------------------
@@ -1057,8 +1040,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     # Ensure .zskills/ exists before any state write
     (main_root / ".zskills").mkdir(parents=True, exist_ok=True)
 
-    # Bootstrap dashboard config block if missing
-    ensure_dashboard_config_block(main_root)
+    # Note: .claude/zskills-config.json is READ-ONLY for the server.
+    # The dashboard.work_on_plans_trigger field is added by
+    # /update-zskills (schema migration), not bootstrapped here.
 
     port = resolve_port(main_root, cli_port=args.port)
 

--- a/tests/test_zskills_monitor_server.sh
+++ b/tests/test_zskills_monitor_server.sh
@@ -201,11 +201,14 @@ else
   skip "ss not available — skipping 127.0.0.1 bind check"
 fi
 
-# Config-block bootstrap
+# Config is read-only for the server (issue #165). The fixture config
+# above does NOT include a dashboard block; the server must not mutate
+# the file on startup. /update-zskills owns the dashboard-block
+# migration (skills/update-zskills/SKILL.md Step 3.6), not the server.
 if grep -qE '"dashboard":' "$MR1/.claude/zskills-config.json"; then
-  pass "config-block bootstrap added dashboard block"
+  fail "server mutated zskills-config.json (added dashboard block) — must be read-only per issue #165"
 else
-  fail "dashboard block not added to config"
+  pass "server is read-only on zskills-config.json (dashboard block not added)"
 fi
 
 # SIGTERM exit ≤5s + PID removed


### PR DESCRIPTION
Fixes #165

## Changes

Removes startup-time config mutation from the dashboard server. `dashboard.work_on_plans_trigger` is now declared in the schema and added by `/update-zskills` on install/update against existing configs (idempotent) — same canonical pattern as every other config field.

- `config/zskills-config.schema.json`: declares `dashboard.work_on_plans_trigger` (string, default `""`)
- `skills/update-zskills/SKILL.md` (+ mirror): new Step 3.6 idempotent backfill (parallel to existing 3.5 commit.co_author backfill); greenfield template now includes the dashboard block
- `skills/zskills-dashboard/scripts/zskills_monitor/server.py` (+ mirror): removes `ensure_dashboard_config_block()` (44 lines) and its startup call site; replaced with explanatory comments documenting the read-only contract
- `skills/zskills-dashboard/SKILL.md` (+ mirror): documents the read-only boundary in the Configuration section
- `tests/test_zskills_monitor_server.sh`: flips the bootstrap assertion — now asserts the server does NOT mutate `zskills-config.json` on first launch

Side-effect of the fix: the `json.dumps(loaded, indent=2)` reformatting churn (blank-line strips, one-line-array re-wrapping) disappears because the server no longer rewrites the config.

## Test plan

- [x] Schema declares the field, well-formed
- [x] `/update-zskills` Step 3.6 is idempotent (only adds when absent)
- [x] `grep ensure_dashboard_config_block server.py` → 0 hits
- [x] `grep zskills-config.json server.py` → all hits are reads, no writes
- [x] Test inverts assertion to lock the new contract (not weakened — still asserts something concrete)
- [x] All mirrors byte-identical to source
- [ ] First-ever `/zskills-dashboard start` on a fresh checkout produces zero diff to user config (verify post-merge)
