### PR TITLE
fix(skills): mark /land-pr as helper-only via user-invocable: false

### DIFF
--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: land-pr
-description: Land an existing feature branch as a PR. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. Caller invokes only at orchestrator level (not from within Agent-dispatched subagents). Invoked directly by users with hand-crafted feature branches, and via Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix.
+user-invocable: false
+description: Helper skill — the canonical PR-landing primitive. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge an existing feature branch. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. Caller invokes only at orchestrator level (not from within Agent-dispatched subagents). Dispatched via Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix. Not designed for direct user invocation — the API (--body-file, --result-file required) is caller-oriented; users wanting to ship a branch should use /commit pr.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>]
 ---
 
@@ -9,8 +10,11 @@ argument-hint: --branch <name> --title <title> --body-file <path> --result-file 
 `/land-pr` owns the rebase → push → create-or-detect → monitor → merge
 sequence for a feature branch that is already in a presentable state.
 Five callers (`/run-plan`, `/commit pr`, `/do pr`, `/fix-issues pr`,
-`/quickfix`) dispatch into this skill via the Skill tool; users may also
-invoke it directly via the slash command.
+`/quickfix`) dispatch into this skill via the Skill tool. `/land-pr` is
+a helper, not a user-facing command: the API requires `--body-file` and
+`--result-file`, both of which only make sense when a caller has set
+them up. Users wanting to ship an existing branch should use `/commit pr`,
+which dispatches `/land-pr` internally with the right arguments.
 
 The skill is a **prose-driven procedure**: when invoked, you (Claude) read
 this SKILL.md and execute the procedure step-by-step, calling the four
@@ -212,14 +216,14 @@ CALL_ERROR_FILE=""
 
 ### Step 2 — Resume-mode short-circuit (`--pr <num>`)
 
-If `$PR_RESUME` is set, skip rebase / push / create — the caller (or
-user) has already done those and wants to monitor an existing PR.
-Set `PR_NUMBER=$PR_RESUME` and jump to step 6 (monitor).
+If `$PR_RESUME` is set, skip rebase / push / create — the caller has
+already done those and wants to monitor an existing PR. Set
+`PR_NUMBER=$PR_RESUME` and jump to step 6 (monitor).
 
-**Use case for `--pr <num>`:** caller (or user) previously invoked
+**Use case for `--pr <num>`:** caller previously invoked
 `/land-pr --no-monitor` (or had a monitor timeout); the PR exists and
-the branch is pushed; now they want to monitor (or re-monitor) without
-re-running rebase/push/create.
+the branch is pushed; now the caller wants to monitor (or re-monitor)
+without re-running rebase/push/create.
 
 ```bash
 if [ -n "$PR_RESUME" ]; then
@@ -305,11 +309,9 @@ If `$NO_MONITOR` is true and PR creation succeeded, set
 `STATUS=created` `CI_STATUS=not-monitored` and jump to step 8.
 
 **Use case for `--no-monitor`:** caller wants to report the PR URL
-mid-flight (e.g., interactive `/land-pr` invocation where the user
-wants the URL fast and will check CI themselves), or caller wants to
-split the create-and-monitor flow across two cron-fired turns. None of
-the 5 callers in this plan use `--no-monitor` — it's a flag for
-direct user invocation and future callers.
+mid-flight, or split the create-and-monitor flow across two cron-fired
+turns. None of the 5 callers in this plan use `--no-monitor` — it is
+reserved for future callers.
 
 ```bash
 if [ -z "$STATUS" ] && [ "$NO_MONITOR" = "true" ]; then

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: land-pr
-description: Land an existing feature branch as a PR. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. Caller invokes only at orchestrator level (not from within Agent-dispatched subagents). Invoked directly by users with hand-crafted feature branches, and via Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix.
+user-invocable: false
+description: Helper skill — the canonical PR-landing primitive. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge an existing feature branch. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. Caller invokes only at orchestrator level (not from within Agent-dispatched subagents). Dispatched via Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix. Not designed for direct user invocation — the API (--body-file, --result-file required) is caller-oriented; users wanting to ship a branch should use /commit pr.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>]
 ---
 
@@ -9,8 +10,11 @@ argument-hint: --branch <name> --title <title> --body-file <path> --result-file 
 `/land-pr` owns the rebase → push → create-or-detect → monitor → merge
 sequence for a feature branch that is already in a presentable state.
 Five callers (`/run-plan`, `/commit pr`, `/do pr`, `/fix-issues pr`,
-`/quickfix`) dispatch into this skill via the Skill tool; users may also
-invoke it directly via the slash command.
+`/quickfix`) dispatch into this skill via the Skill tool. `/land-pr` is
+a helper, not a user-facing command: the API requires `--body-file` and
+`--result-file`, both of which only make sense when a caller has set
+them up. Users wanting to ship an existing branch should use `/commit pr`,
+which dispatches `/land-pr` internally with the right arguments.
 
 The skill is a **prose-driven procedure**: when invoked, you (Claude) read
 this SKILL.md and execute the procedure step-by-step, calling the four
@@ -212,14 +216,14 @@ CALL_ERROR_FILE=""
 
 ### Step 2 — Resume-mode short-circuit (`--pr <num>`)
 
-If `$PR_RESUME` is set, skip rebase / push / create — the caller (or
-user) has already done those and wants to monitor an existing PR.
-Set `PR_NUMBER=$PR_RESUME` and jump to step 6 (monitor).
+If `$PR_RESUME` is set, skip rebase / push / create — the caller has
+already done those and wants to monitor an existing PR. Set
+`PR_NUMBER=$PR_RESUME` and jump to step 6 (monitor).
 
-**Use case for `--pr <num>`:** caller (or user) previously invoked
+**Use case for `--pr <num>`:** caller previously invoked
 `/land-pr --no-monitor` (or had a monitor timeout); the PR exists and
-the branch is pushed; now they want to monitor (or re-monitor) without
-re-running rebase/push/create.
+the branch is pushed; now the caller wants to monitor (or re-monitor)
+without re-running rebase/push/create.
 
 ```bash
 if [ -n "$PR_RESUME" ]; then
@@ -305,11 +309,9 @@ If `$NO_MONITOR` is true and PR creation succeeded, set
 `STATUS=created` `CI_STATUS=not-monitored` and jump to step 8.
 
 **Use case for `--no-monitor`:** caller wants to report the PR URL
-mid-flight (e.g., interactive `/land-pr` invocation where the user
-wants the URL fast and will check CI themselves), or caller wants to
-split the create-and-monitor flow across two cron-fired turns. None of
-the 5 callers in this plan use `--no-monitor` — it's a flag for
-direct user invocation and future callers.
+mid-flight, or split the create-and-monitor flow across two cron-fired
+turns. None of the 5 callers in this plan use `--no-monitor` — it is
+reserved for future callers.
 
 ```bash
 if [ -z "$STATUS" ] && [ "$NO_MONITOR" = "true" ]; then


### PR DESCRIPTION
## Summary
- Add `user-invocable: false` to `/land-pr` so it's hidden from the user `/` menu / autocomplete while remaining dispatchable via the Skill tool from its five callers (`/run-plan`, `/commit pr`, `/do pr`, `/fix-issues pr`, `/quickfix`).
- Rewrite the SKILL.md description and lead prose to call `/land-pr` what it is — a helper, not a user-facing command — and point users wanting to ship a branch at `/commit pr`.
- Clean up two "(or user)" parentheticals in the `--pr <num>` and `--no-monitor` use-case prose that no longer apply.

## Why not `disable-model-invocation: true`?

That flag was the obvious-but-wrong choice. Per the [Claude Code skills docs](https://code.claude.com/docs/en/skills.md#control-who-invokes-a-skill):

| Flag | User can `/`-invoke | Model auto-fires | Skill-tool dispatch |
|---|---|---|---|
| `disable-model-invocation: true` | yes | no | **no** (Skill-tool dispatch is model-mediated) |
| `user-invocable: false` | **no** (hidden from `/` menu) | yes | yes |

`disable-model-invocation: true` would have broken the entire PR_LANDING_UNIFICATION design — the five callers all dispatch `/land-pr` via `Skill: { skill: "land-pr", ... }`, which is itself model-driven — while leaving the slash command still exposed to users.

## Test plan
- [x] `head -5 skills/land-pr/SKILL.md` shows `user-invocable: false` and the new "Helper skill —" description
- [x] `diff -q skills/land-pr/SKILL.md .claude/skills/land-pr/SKILL.md` is clean (source and mirror identical)
- [x] No remaining `(or user)` strings in `skills/land-pr/SKILL.md` outside the two intentional new lines pointing users at `/commit pr`
- [ ] `/land-pr` no longer appears in the user `/` autocomplete menu (verify after merge by checking Claude Code's slash picker)
- [ ] `Skill: { skill: "land-pr", args: "..." }` from `/commit pr` still dispatches successfully (verify on next PR-mode run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)