### PR TITLE
fix(hooks): chain wrappers → source-of-truth + drift gate 4→7 (F2/F3 follow-up)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -179,20 +179,7 @@ is_destruct_command() {
   return 1
 }
 
-# Hook-local wrapper around is_git_subcommand for cd-chained commands.
-# Splits $cmd on shell-segment boundaries (&&, ||, ;, |, literal newline,
-# AND the literal two-char escape `\n` that arrives via JSON-string
-# encoding) and calls is_git_subcommand on each segment, returning 0
-# if ANY segment matches. This restores the old bare-substring's
-# cd-chain semantics (cd /tmp/wt && git commit -m foo) on top of
-# is_git_subcommand's first-token-anchored core.
-#
-# Why segment-walk lives here, not in hooks/_lib/git-tokenwalk.sh:
-#   The lib helper is the single source-of-truth — its contract
-#   (first-token-anchored) is unit-tested at tests/test-tokenize-then-walk.sh.
-#   Segment-walking is a project-hook-specific need (cd-chain
-#   resolution), not a generic helper concern. Keeping it here
-#   keeps the lib's contract minimal and the hook's needs explicit.
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_git_subcommand_in_chain() {
   local cmd="$1"
   local want_sub="$2"
@@ -215,13 +202,7 @@ is_git_subcommand_in_chain() {
   return 1
 }
 
-# Hook-local wrapper around is_destruct_command for shell-chained commands.
-# Splits $cmd on shell-segment boundaries (&&, ||, ;, |, literal newline,
-# AND the literal two-char escape `\n`) and calls is_destruct_command on
-# each segment, returning 0 if ANY segment matches. Preserves coverage of
-# pre-existing test cases like `git commit -m "msg" && kill -9 1234` that
-# the bare-substring regex caught and that first-token-anchoring alone
-# would silently drop. Same construction as is_git_subcommand_in_chain.
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_destruct_command_in_chain() {
   local cmd="$1"
   local want_first="$2"

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -112,20 +112,7 @@ is_git_subcommand() {
   return 0
 }
 
-# Hook-local wrapper around is_git_subcommand for cd-chained commands.
-# Splits $cmd on shell-segment boundaries (&&, ||, ;, |, literal newline,
-# AND the literal two-char escape `\n` that arrives via JSON-string
-# encoding) and calls is_git_subcommand on each segment, returning 0
-# if ANY segment matches. This restores the old bare-substring's
-# cd-chain semantics (cd /tmp/wt && git commit -m foo) on top of
-# is_git_subcommand's first-token-anchored core.
-#
-# Why segment-walk lives here, not in hooks/_lib/git-tokenwalk.sh:
-#   The lib helper is the single source-of-truth — its contract
-#   (first-token-anchored) is unit-tested at tests/test-tokenize-then-walk.sh.
-#   Segment-walking is a project-hook-specific need (cd-chain
-#   resolution), not a generic helper concern. Keeping it here
-#   keeps the lib's contract minimal and the hook's needs explicit.
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_git_subcommand_in_chain() {
   local cmd="$1"
   local want_sub="$2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026-05-07
+
+### Changed — hooks/_lib/git-tokenwalk.sh: chain wrappers added to source-of-truth + drift gate extended (4→7 asserts)
+
+Follow-up to BLOCK_UNSAFE_HARDENING `/verify-changes` finding F2. The two emergent segment-walking wrappers introduced during Phase 3 + Phase 4 (`is_git_subcommand_in_chain` and `is_destruct_command_in_chain`) lived in the hook source files only — byte-identical between the project and generic hooks but not covered by the D7 drift gate. Future divergence between the two project/generic copies of `is_git_subcommand_in_chain` would have been undetected.
+
+Moves both wrappers into `hooks/_lib/git-tokenwalk.sh` (canonical source-of-truth alongside `is_git_subcommand` and `is_destruct_command`). The wrapper bodies inlined into `hooks/block-unsafe-project.sh.template` and `hooks/block-unsafe-generic.sh` are now byte-identical to the source-of-truth; the explanatory headers above each wrapper in the hooks are replaced with the canonical "Inlined from hooks/_lib/git-tokenwalk.sh" one-liner.
+
+Extends `tests/test-hook-helper-drift.sh` from 4 to 7 byte-identity assertions covering the full hook-helper coverage matrix:
+
+| Hook | is_git_subcommand | is_destruct_command | is_git_subcommand_in_chain | is_destruct_command_in_chain |
+|---|:---:|:---:|:---:|:---:|
+| block-unsafe-project.sh.template | ✓ | — | ✓ | — |
+| block-unsafe-generic.sh | ✓ | ✓ | ✓ | ✓ |
+| block-stale-skill-version.sh | ✓ | — | — | — |
+
+No behavior change — same wrapper bodies in the same hooks; test surface +3 cases (drift gate goes from 4 to 7 PASS). Mirrors to `.claude/hooks/` byte-equal.
+
 ## 2026-05-06
 
 ### Added — block-stale-skill-version PreToolUse hook (#193)

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
-# hooks/_lib/git-tokenwalk.sh — source-of-truth helper bodies for
-# is_git_subcommand + is_destruct_command. Inlined verbatim into
-# hooks/block-unsafe-project.sh.template, hooks/block-unsafe-generic.sh,
-# and hooks/block-stale-skill-version.sh (Plan B, post-D6).
-# Maintain HERE only. CI gate: tests/test-hook-helper-drift.sh.
+# hooks/_lib/git-tokenwalk.sh — source-of-truth helper bodies for the
+# tokenize-then-walk classifier family:
+#
+#   Base (first-token-anchored) helpers:
+#     - is_git_subcommand    — tokenize-walk a `git $verb` invocation
+#     - is_destruct_command  — tokenize-walk a `<verb>` invocation (kill, rm, …)
+#
+#   Hook-local segment-walking wrappers (call the base helper per shell segment):
+#     - is_git_subcommand_in_chain   — segment-walk for cd-chained git commands
+#                                      (`cd /tmp/wt && git commit -m foo`)
+#     - is_destruct_command_in_chain — segment-walk for cd-chained destruct verbs
+#                                      (`some_cmd && kill -9 1234`)
+#
+# All four are inlined verbatim into hook source files; the drift gate at
+# tests/test-hook-helper-drift.sh enforces byte-equality at CI time:
+#   - is_git_subcommand   inlined into block-unsafe-project.sh.template,
+#                                       block-unsafe-generic.sh,
+#                                       block-stale-skill-version.sh (Plan B, post-D6)
+#   - is_destruct_command inlined into block-unsafe-generic.sh
+#   - is_git_subcommand_in_chain   inlined into block-unsafe-project.sh.template
+#                                              + block-unsafe-generic.sh
+#   - is_destruct_command_in_chain inlined into block-unsafe-generic.sh only
+#
+# Maintain HERE only.
 set -u
 
 # Returns 0 iff $cmd is a git invocation whose subcommand is $want_sub.
@@ -126,5 +145,57 @@ is_destruct_command() {
     fi
     ((i++))
   done
+  return 1
+}
+
+# Returns 0 iff ANY shell segment of $cmd is a `git $want_sub` invocation.
+# Segments are split on `&&`, `||`, `;`, `|`, real newline, AND the JSON-
+# escaped two-char `\n` literal that arrives via the hook's sed-extracted
+# COMMAND value (the hook does not JSON-decode). Restores the cd-chain
+# semantics the OLD bare-substring whole-buffer regex provided
+# (e.g., `cd /tmp/wt && git commit -m foo` matches) on top of the
+# first-token-anchored is_git_subcommand core.
+is_git_subcommand_in_chain() {
+  local cmd="$1"
+  local want_sub="$2"
+  # Replace shell-segment boundaries with newlines, then iterate.
+  # Handles: && || ; | (real boundaries), literal newline (multi-line
+  # commands), AND the JSON-escaped literal two-char `\n` (which arrives
+  # this way because the hook does not JSON-decode — sed-extracted
+  # values preserve the backslash-n).
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+    if is_git_subcommand "$seg" "$want_sub"; then
+      return 0
+    fi
+  done <<< "$normalized"
+  return 1
+}
+
+# Returns 0 iff ANY shell segment of $cmd is a destructive invocation matching
+# `is_destruct_command "$seg" "$want_first" "$flag_match"`. Same segment-split
+# rules as is_git_subcommand_in_chain. Restores cd-chain semantics for
+# destructive verbs (e.g., `some_cmd && kill -9 1234` matches) on top of the
+# first-token-anchored is_destruct_command core.
+is_destruct_command_in_chain() {
+  local cmd="$1"
+  local want_first="$2"
+  local flag_match="${3:-}"
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+    if is_destruct_command "$seg" "$want_first" "$flag_match"; then
+      return 0
+    fi
+  done <<< "$normalized"
   return 1
 }

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -179,20 +179,7 @@ is_destruct_command() {
   return 1
 }
 
-# Hook-local wrapper around is_git_subcommand for cd-chained commands.
-# Splits $cmd on shell-segment boundaries (&&, ||, ;, |, literal newline,
-# AND the literal two-char escape `\n` that arrives via JSON-string
-# encoding) and calls is_git_subcommand on each segment, returning 0
-# if ANY segment matches. This restores the old bare-substring's
-# cd-chain semantics (cd /tmp/wt && git commit -m foo) on top of
-# is_git_subcommand's first-token-anchored core.
-#
-# Why segment-walk lives here, not in hooks/_lib/git-tokenwalk.sh:
-#   The lib helper is the single source-of-truth — its contract
-#   (first-token-anchored) is unit-tested at tests/test-tokenize-then-walk.sh.
-#   Segment-walking is a project-hook-specific need (cd-chain
-#   resolution), not a generic helper concern. Keeping it here
-#   keeps the lib's contract minimal and the hook's needs explicit.
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_git_subcommand_in_chain() {
   local cmd="$1"
   local want_sub="$2"
@@ -215,13 +202,7 @@ is_git_subcommand_in_chain() {
   return 1
 }
 
-# Hook-local wrapper around is_destruct_command for shell-chained commands.
-# Splits $cmd on shell-segment boundaries (&&, ||, ;, |, literal newline,
-# AND the literal two-char escape `\n`) and calls is_destruct_command on
-# each segment, returning 0 if ANY segment matches. Preserves coverage of
-# pre-existing test cases like `git commit -m "msg" && kill -9 1234` that
-# the bare-substring regex caught and that first-token-anchoring alone
-# would silently drop. Same construction as is_git_subcommand_in_chain.
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_destruct_command_in_chain() {
   local cmd="$1"
   local want_first="$2"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -112,20 +112,7 @@ is_git_subcommand() {
   return 0
 }
 
-# Hook-local wrapper around is_git_subcommand for cd-chained commands.
-# Splits $cmd on shell-segment boundaries (&&, ||, ;, |, literal newline,
-# AND the literal two-char escape `\n` that arrives via JSON-string
-# encoding) and calls is_git_subcommand on each segment, returning 0
-# if ANY segment matches. This restores the old bare-substring's
-# cd-chain semantics (cd /tmp/wt && git commit -m foo) on top of
-# is_git_subcommand's first-token-anchored core.
-#
-# Why segment-walk lives here, not in hooks/_lib/git-tokenwalk.sh:
-#   The lib helper is the single source-of-truth — its contract
-#   (first-token-anchored) is unit-tested at tests/test-tokenize-then-walk.sh.
-#   Segment-walking is a project-hook-specific need (cd-chain
-#   resolution), not a generic helper concern. Keeping it here
-#   keeps the lib's contract minimal and the hook's needs explicit.
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_git_subcommand_in_chain() {
   local cmd="$1"
   local want_sub="$2"

--- a/reports/plan-block-unsafe-hardening.md
+++ b/reports/plan-block-unsafe-hardening.md
@@ -45,6 +45,20 @@ Plan B's existing test surface: 27/27 PASS after rename. Mirror byte-equal. No d
 | Phase 5 (matrices + drift gate + 412 cases) | 2699 | +412 |
 | **Phase 6 (Plan B consolidation + 1 drift gate case)** | **2700** | **+1** |
 
+> **Post-merge addendum (2026-05-07).** Counts above are worktree measurements
+> at the time each phase was verified. Running `bash tests/run-all.sh` on
+> `main` post-squash-merge yields **2701** (+1) — the delta is environmental,
+> not a regression: `tests/test-skill-conformance.sh` enumerates skills under
+> `.claude/skills/` at runtime, and main has an untracked
+> `.claude/skills/social-seo/` directory absent from worktrees. Same git
+> commit, same code, +1 conformance pass for the extra installed-only skill.
+>
+> A follow-up PR landed `is_git_subcommand_in_chain` and
+> `is_destruct_command_in_chain` (the emergent Phase 3/4 wrappers) into
+> `hooks/_lib/git-tokenwalk.sh` as source-of-truth and extended the drift
+> gate from 4 → 7 byte-identity assertions. Closes the only F2 gap surfaced
+> by the post-merge `/verify-changes` review.
+
 ---
 
 ## Phase — 5 CHANGELOG + class-pinned matrices + drift gate + finalization [UNFINALIZED]

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -14,11 +14,22 @@ FAIL_COUNT=0
 pass() { echo "PASS $*"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { echo "FAIL $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh hooks/block-stale-skill-version.sh; do
-  for FN in is_git_subcommand is_destruct_command; do
-    # is_destruct_command is only inlined in generic hook; skip for project.
+  # Helper coverage per hook (which inlined helpers are present in each):
+  #   project hook            : is_git_subcommand,                  is_git_subcommand_in_chain
+  #   generic hook            : is_git_subcommand, is_destruct_command,
+  #                             is_git_subcommand_in_chain, is_destruct_command_in_chain
+  #   stale-skill-version hook: is_git_subcommand
+  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain; do
+    # is_destruct_command is only inlined in generic hook; skip for project + stale-skill-version.
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *project* ]] && continue
-    # is_destruct_command is not inlined in block-stale-skill-version.sh either.
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *stale-skill-version* ]] && continue
+    # Chain wrappers are only inlined in the two block-unsafe hooks.
+    # Skip stale-skill-version (no chain wrapper needed — that hook's
+    # callers operate on the redacted single-segment COMMAND already).
+    [[ "$FN" == "is_git_subcommand_in_chain" && "$HOOK" == *stale-skill-version* ]] && continue
+    # is_destruct_command_in_chain is only inlined in the generic hook.
+    [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *project* ]] && continue
+    [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *stale-skill-version* ]] && continue
     if diff <(sed -n "/^$FN()/,/^}$/p" "$HOOK") \
             <(sed -n "/^$FN()/,/^}$/p" hooks/_lib/git-tokenwalk.sh) \
             > /dev/null; then


### PR DESCRIPTION
## Follow-up to BLOCK_UNSAFE_HARDENING — F2 + F3 from `/verify-changes` review

### F2: chain wrappers excluded from drift gate
Moves the two emergent segment-walking wrappers (`is_git_subcommand_in_chain`, `is_destruct_command_in_chain`) — added during BLOCK_UNSAFE_HARDENING Phases 3 + 4 — into `hooks/_lib/git-tokenwalk.sh` as canonical source-of-truth. The wrappers were byte-identical between the project + generic hooks but not covered by the D7 drift gate; future divergence between the two project/generic copies of `is_git_subcommand_in_chain` would have been undetected.

Drift gate `tests/test-hook-helper-drift.sh` extended from **4 → 7 byte-identity assertions**:

| Hook | base subcmd | base destruct | chain subcmd | chain destruct |
|---|:---:|:---:|:---:|:---:|
| `block-unsafe-project.sh.template` | ✓ | — | ✓ | — |
| `block-unsafe-generic.sh` | ✓ | ✓ | ✓ | ✓ |
| `block-stale-skill-version.sh` | ✓ | — | — | — |

No behavior change — same wrapper bodies in the same hooks. Inlined comments above each chain wrapper now match the canonical "Inlined from hooks/_lib/git-tokenwalk.sh" pattern used for `is_git_subcommand`. Mirrors to `.claude/hooks/` byte-equal.

### F3: test-count delta annotation
Annotates `reports/plan-block-unsafe-hardening.md` Phase 6 section with a post-merge addendum: report's `2700` was a worktree measurement; main reports `2701` because `tests/test-skill-conformance.sh` enumerates `.claude/skills/*/` at runtime and main has an untracked `.claude/skills/social-seo/` absent from worktrees. **Environmental, not a regression** — same git commit, same code, +1 conformance pass for the extra installed-only skill.

### Test surface
- Full suite (worktree): **2703 / 2703 PASS** (delta +3 from baseline 2700: the 3 new drift-gate assertions).
- Drift gate standalone: **7 / 7 PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
