### PR TITLE
fix(run-plan): add pr-preflight.sh helper for self-filtering pipeline's own PR (#177)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   self-schedule recurring runs via cron. Use `next` to check schedule, `stop`
   to cancel.
 metadata:
-  version: "2026.05.03+82aa34"
+  version: "2026.05.07+392b64"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -657,6 +657,40 @@ Before parsing, check for stale state from a previous failed run:
    This catches stragglers from crashed agents, container restarts, or any
    remaining edge cases. Defense in depth — `.claude/skills/commit/scripts/land-phase.sh` is the
    primary fix (called after each phase landing), the preflight is the safety net.
+
+### Plan-cited preflights — open-PR file-path conflict gate
+
+When a plan touches a path prefix (e.g. `skills/update-zskills/`) across
+multiple phases AND runs in PR mode, every phase's preflight needs to
+self-filter the pipeline's OWN PR. Inlining `gh pr list --state open --limit
+100 --json number,title,files | grep -F '<prefix>'` in each phase trips the
+gate from Phase 2 onward, because the pipeline's own feature branch becomes
+the only matching PR (issue #177).
+
+Plans MUST cite the helper instead of inlining the gh+grep pattern:
+
+```bash
+# In a plan phase that needs an open-PR conflict gate. The orchestrator
+# already tracks $RUN_PLAN_PR_NUMBER (the pipeline's own PR) — pass it via
+# --exclude-pr so the gate self-filters.
+if ! bash "$CLAUDE_PROJECT_DIR/.claude/skills/run-plan/scripts/pr-preflight.sh" \
+     --path-prefix "skills/update-zskills/" \
+     --exclude-pr "${RUN_PLAN_PR_NUMBER:-}"; then
+  echo "FAIL: open PR(s) touch the path; coordinate before continuing." >&2
+  exit 1
+fi
+```
+
+The helper:
+- Takes `--path-prefix <prefix>` (required) and `--exclude-pr <num>` (optional).
+- Emits matching PR numbers on stdout, one per line; empty when clean.
+- Exit 0 when clean, 1 when at least one matching PR remains, 2 on arg or
+  gh error.
+- `--exclude-pr` may be empty — the script then performs no exclusion, so
+  it is safe to call BEFORE the orchestrator knows the pipeline's PR
+  number (e.g. Phase 1 of a plan that has not yet been pushed).
+
+Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
 
 ### Parse plan
 

--- a/.claude/skills/run-plan/scripts/pr-preflight.sh
+++ b/.claude/skills/run-plan/scripts/pr-preflight.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# pr-preflight.sh — open-PR file-path conflict gate for /run-plan PR-mode
+# pipelines.
+#
+# Purpose: when a plan touches a path prefix (e.g. `skills/update-zskills/`)
+# across multiple phases, every phase needs a coordination preflight that
+# answers "is anyone else's open PR touching this path?" The gate must
+# self-filter the pipeline's OWN PR (issue #177) — without --exclude-pr,
+# the pipeline trips on its own feature branch starting at Phase 2.
+#
+# This helper replaces the inlined `gh pr list --state open --limit 100
+# --json number,title,files | grep -F '<prefix>'` pattern that previously
+# appeared in plan files. Plans cite this script instead.
+#
+# Usage:
+#   bash skills/run-plan/scripts/pr-preflight.sh \
+#     --path-prefix skills/update-zskills/ \
+#     [--exclude-pr 175] \
+#     [--limit 100]
+#
+# Output discipline:
+#   - stdout: matching PR numbers, one per line. Empty when clean.
+#   - stderr: progress, warnings, errors.
+#
+# Exit codes:
+#   0  — no conflict (zero matching PRs after exclusion)
+#   1  — at least one matching PR (hard-abort gate trips)
+#   2  — argument or environment error (bad flags, gh failure, etc.)
+#
+# Plans use this as: `bash <script> --path-prefix X --exclude-pr "$PR" || abort`
+#
+# Test hook:
+#   GH_PR_LIST_JSON_OVERRIDE — when set, the helper uses this string as the
+#   raw `gh pr list` JSON output instead of invoking `gh`. Only consumed by
+#   tests/test-pr-preflight.sh.
+#
+# No jq. JSON parsing is pure bash regex (BASH_REMATCH). Pattern follows
+# .claude/skills/update-zskills/scripts/zskills-resolve-config.sh.
+
+set -euo pipefail
+
+PATH_PREFIX=""
+EXCLUDE_PR=""
+LIMIT="100"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --path-prefix) PATH_PREFIX="${2:-}"; shift 2 ;;
+    --exclude-pr)  EXCLUDE_PR="${2:-}";  shift 2 ;;
+    --limit)       LIMIT="${2:-}";        shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "$0" >&2
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown arg '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$PATH_PREFIX" ]; then
+  echo "ERROR: --path-prefix is required" >&2
+  exit 2
+fi
+
+# Validate --exclude-pr (when provided) is a positive integer. Empty is
+# allowed and means "no exclusion" — the script is safe to call before the
+# orchestrator knows the pipeline's PR number.
+if [ -n "$EXCLUDE_PR" ]; then
+  if ! [[ "$EXCLUDE_PR" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --exclude-pr must be a positive integer; got '$EXCLUDE_PR'" >&2
+    exit 2
+  fi
+fi
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --limit must be a positive integer; got '$LIMIT'" >&2
+  exit 2
+fi
+
+# Acquire raw gh output (or test override).
+if [ -n "${GH_PR_LIST_JSON_OVERRIDE:-}" ]; then
+  RAW="$GH_PR_LIST_JSON_OVERRIDE"
+else
+  if ! RAW=$(gh pr list --state open --limit "$LIMIT" --json number,title,files 2>&1); then
+    echo "ERROR: 'gh pr list' failed: $RAW" >&2
+    exit 2
+  fi
+fi
+
+# Soft-cap warning: if the JSON contains as many `"number":` occurrences as
+# the limit, the next page may exist. (refine-plan F-R2-9 in
+# plans/SKILL_VERSIONING.md.)
+RAW_COUNT=$(printf '%s' "$RAW" | grep -c '"number":' || true)
+if [ "$RAW_COUNT" -ge "$LIMIT" ]; then
+  echo "WARN: gh pr list returned $RAW_COUNT PRs (limit=$LIMIT); re-run with --limit higher to verify no missed entries." >&2
+fi
+
+# Split the JSON array into per-PR object chunks. The shape from
+# `gh pr list --json number,title,files` is:
+#   [{"number":N,"title":"T","files":[{"path":"P",...},...]},...]
+#
+# We split on the boundary between consecutive PR objects ('},{' at the
+# top level) and check each chunk independently. This avoids cross-PR
+# false matches that the un-split `grep -F` form silently produced.
+#
+# Pure bash: replace '},{' with a record separator (newline + sentinel),
+# then iterate.
+
+# Strip outer brackets `[` and `]` if present, then split.
+STRIPPED="${RAW#\[}"
+STRIPPED="${STRIPPED%\]}"
+
+# Empty result → no PRs.
+if [ -z "$STRIPPED" ]; then
+  exit 0
+fi
+
+# Replace '},{' with '}\n{' so each PR object lives on its own line.
+# Use bash parameter expansion.
+SPLIT="${STRIPPED//\},\{/$'}\n{'}"
+
+MATCHES=()
+while IFS= read -r CHUNK; do
+  [ -z "$CHUNK" ] && continue
+
+  # Extract PR number (first occurrence of "number":N at the top of chunk).
+  if [[ "$CHUNK" =~ \"number\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
+    PR_NUM="${BASH_REMATCH[1]}"
+  else
+    # Malformed chunk — skip silently (defensive; shouldn't happen with
+    # well-formed gh output).
+    continue
+  fi
+
+  # Self-filter: skip the pipeline's own PR.
+  if [ -n "$EXCLUDE_PR" ] && [ "$PR_NUM" = "$EXCLUDE_PR" ]; then
+    continue
+  fi
+
+  # Check if this chunk's files contain the path prefix. Use grep -F over
+  # the chunk: matches against the JSON-encoded `"path":"<prefix>..."`
+  # strings.
+  if printf '%s' "$CHUNK" | grep -qF "\"path\":\"$PATH_PREFIX"; then
+    MATCHES+=("$PR_NUM")
+  fi
+done <<< "$SPLIT"
+
+if [ "${#MATCHES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# Emit matches one per line on stdout.
+for PR in "${MATCHES[@]}"; do
+  echo "$PR"
+done
+
+# Stderr summary so plans/users see a human-readable abort line.
+echo "FAIL: ${#MATCHES[@]} open PR(s) touch '$PATH_PREFIX' (excluding ${EXCLUDE_PR:-<none>}): ${MATCHES[*]}" >&2
+
+exit 1

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   self-schedule recurring runs via cron. Use `next` to check schedule, `stop`
   to cancel.
 metadata:
-  version: "2026.05.03+82aa34"
+  version: "2026.05.07+392b64"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -657,6 +657,40 @@ Before parsing, check for stale state from a previous failed run:
    This catches stragglers from crashed agents, container restarts, or any
    remaining edge cases. Defense in depth — `.claude/skills/commit/scripts/land-phase.sh` is the
    primary fix (called after each phase landing), the preflight is the safety net.
+
+### Plan-cited preflights — open-PR file-path conflict gate
+
+When a plan touches a path prefix (e.g. `skills/update-zskills/`) across
+multiple phases AND runs in PR mode, every phase's preflight needs to
+self-filter the pipeline's OWN PR. Inlining `gh pr list --state open --limit
+100 --json number,title,files | grep -F '<prefix>'` in each phase trips the
+gate from Phase 2 onward, because the pipeline's own feature branch becomes
+the only matching PR (issue #177).
+
+Plans MUST cite the helper instead of inlining the gh+grep pattern:
+
+```bash
+# In a plan phase that needs an open-PR conflict gate. The orchestrator
+# already tracks $RUN_PLAN_PR_NUMBER (the pipeline's own PR) — pass it via
+# --exclude-pr so the gate self-filters.
+if ! bash "$CLAUDE_PROJECT_DIR/.claude/skills/run-plan/scripts/pr-preflight.sh" \
+     --path-prefix "skills/update-zskills/" \
+     --exclude-pr "${RUN_PLAN_PR_NUMBER:-}"; then
+  echo "FAIL: open PR(s) touch the path; coordinate before continuing." >&2
+  exit 1
+fi
+```
+
+The helper:
+- Takes `--path-prefix <prefix>` (required) and `--exclude-pr <num>` (optional).
+- Emits matching PR numbers on stdout, one per line; empty when clean.
+- Exit 0 when clean, 1 when at least one matching PR remains, 2 on arg or
+  gh error.
+- `--exclude-pr` may be empty — the script then performs no exclusion, so
+  it is safe to call BEFORE the orchestrator knows the pipeline's PR
+  number (e.g. Phase 1 of a plan that has not yet been pushed).
+
+Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
 
 ### Parse plan
 

--- a/skills/run-plan/scripts/pr-preflight.sh
+++ b/skills/run-plan/scripts/pr-preflight.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# pr-preflight.sh — open-PR file-path conflict gate for /run-plan PR-mode
+# pipelines.
+#
+# Purpose: when a plan touches a path prefix (e.g. `skills/update-zskills/`)
+# across multiple phases, every phase needs a coordination preflight that
+# answers "is anyone else's open PR touching this path?" The gate must
+# self-filter the pipeline's OWN PR (issue #177) — without --exclude-pr,
+# the pipeline trips on its own feature branch starting at Phase 2.
+#
+# This helper replaces the inlined `gh pr list --state open --limit 100
+# --json number,title,files | grep -F '<prefix>'` pattern that previously
+# appeared in plan files. Plans cite this script instead.
+#
+# Usage:
+#   bash skills/run-plan/scripts/pr-preflight.sh \
+#     --path-prefix skills/update-zskills/ \
+#     [--exclude-pr 175] \
+#     [--limit 100]
+#
+# Output discipline:
+#   - stdout: matching PR numbers, one per line. Empty when clean.
+#   - stderr: progress, warnings, errors.
+#
+# Exit codes:
+#   0  — no conflict (zero matching PRs after exclusion)
+#   1  — at least one matching PR (hard-abort gate trips)
+#   2  — argument or environment error (bad flags, gh failure, etc.)
+#
+# Plans use this as: `bash <script> --path-prefix X --exclude-pr "$PR" || abort`
+#
+# Test hook:
+#   GH_PR_LIST_JSON_OVERRIDE — when set, the helper uses this string as the
+#   raw `gh pr list` JSON output instead of invoking `gh`. Only consumed by
+#   tests/test-pr-preflight.sh.
+#
+# No jq. JSON parsing is pure bash regex (BASH_REMATCH). Pattern follows
+# .claude/skills/update-zskills/scripts/zskills-resolve-config.sh.
+
+set -euo pipefail
+
+PATH_PREFIX=""
+EXCLUDE_PR=""
+LIMIT="100"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --path-prefix) PATH_PREFIX="${2:-}"; shift 2 ;;
+    --exclude-pr)  EXCLUDE_PR="${2:-}";  shift 2 ;;
+    --limit)       LIMIT="${2:-}";        shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "$0" >&2
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown arg '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$PATH_PREFIX" ]; then
+  echo "ERROR: --path-prefix is required" >&2
+  exit 2
+fi
+
+# Validate --exclude-pr (when provided) is a positive integer. Empty is
+# allowed and means "no exclusion" — the script is safe to call before the
+# orchestrator knows the pipeline's PR number.
+if [ -n "$EXCLUDE_PR" ]; then
+  if ! [[ "$EXCLUDE_PR" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --exclude-pr must be a positive integer; got '$EXCLUDE_PR'" >&2
+    exit 2
+  fi
+fi
+
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --limit must be a positive integer; got '$LIMIT'" >&2
+  exit 2
+fi
+
+# Acquire raw gh output (or test override).
+if [ -n "${GH_PR_LIST_JSON_OVERRIDE:-}" ]; then
+  RAW="$GH_PR_LIST_JSON_OVERRIDE"
+else
+  if ! RAW=$(gh pr list --state open --limit "$LIMIT" --json number,title,files 2>&1); then
+    echo "ERROR: 'gh pr list' failed: $RAW" >&2
+    exit 2
+  fi
+fi
+
+# Soft-cap warning: if the JSON contains as many `"number":` occurrences as
+# the limit, the next page may exist. (refine-plan F-R2-9 in
+# plans/SKILL_VERSIONING.md.)
+RAW_COUNT=$(printf '%s' "$RAW" | grep -c '"number":' || true)
+if [ "$RAW_COUNT" -ge "$LIMIT" ]; then
+  echo "WARN: gh pr list returned $RAW_COUNT PRs (limit=$LIMIT); re-run with --limit higher to verify no missed entries." >&2
+fi
+
+# Split the JSON array into per-PR object chunks. The shape from
+# `gh pr list --json number,title,files` is:
+#   [{"number":N,"title":"T","files":[{"path":"P",...},...]},...]
+#
+# We split on the boundary between consecutive PR objects ('},{' at the
+# top level) and check each chunk independently. This avoids cross-PR
+# false matches that the un-split `grep -F` form silently produced.
+#
+# Pure bash: replace '},{' with a record separator (newline + sentinel),
+# then iterate.
+
+# Strip outer brackets `[` and `]` if present, then split.
+STRIPPED="${RAW#\[}"
+STRIPPED="${STRIPPED%\]}"
+
+# Empty result → no PRs.
+if [ -z "$STRIPPED" ]; then
+  exit 0
+fi
+
+# Replace '},{' with '}\n{' so each PR object lives on its own line.
+# Use bash parameter expansion.
+SPLIT="${STRIPPED//\},\{/$'}\n{'}"
+
+MATCHES=()
+while IFS= read -r CHUNK; do
+  [ -z "$CHUNK" ] && continue
+
+  # Extract PR number (first occurrence of "number":N at the top of chunk).
+  if [[ "$CHUNK" =~ \"number\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
+    PR_NUM="${BASH_REMATCH[1]}"
+  else
+    # Malformed chunk — skip silently (defensive; shouldn't happen with
+    # well-formed gh output).
+    continue
+  fi
+
+  # Self-filter: skip the pipeline's own PR.
+  if [ -n "$EXCLUDE_PR" ] && [ "$PR_NUM" = "$EXCLUDE_PR" ]; then
+    continue
+  fi
+
+  # Check if this chunk's files contain the path prefix. Use grep -F over
+  # the chunk: matches against the JSON-encoded `"path":"<prefix>..."`
+  # strings.
+  if printf '%s' "$CHUNK" | grep -qF "\"path\":\"$PATH_PREFIX"; then
+    MATCHES+=("$PR_NUM")
+  fi
+done <<< "$SPLIT"
+
+if [ "${#MATCHES[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# Emit matches one per line on stdout.
+for PR in "${MATCHES[@]}"; do
+  echo "$PR"
+done
+
+# Stderr summary so plans/users see a human-readable abort line.
+echo "FAIL: ${#MATCHES[@]} open PR(s) touch '$PATH_PREFIX' (excluding ${EXCLUDE_PR:-<none>}): ${MATCHES[*]}" >&2
+
+exit 1

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -88,6 +88,7 @@ run_suite "test_zskills_monitor_collect.sh" "tests/test_zskills_monitor_collect.
 run_suite "test_zskills_monitor_server.sh" "tests/test_zskills_monitor_server.sh"
 run_suite "test-stub-callouts.sh" "tests/test-stub-callouts.sh"
 run_suite "test-post-create-worktree.sh" "tests/test-post-create-worktree.sh"
+run_suite "test-pr-preflight.sh" "tests/test-pr-preflight.sh"
 run_suite "test_zskills_monitor_dashboard_ui.sh" "tests/test_zskills_monitor_dashboard_ui.sh"
 run_suite "test_zskills_dashboard_skill.sh" "tests/test_zskills_dashboard_skill.sh"
 run_suite "test_plans_rebuild_uses_collect.sh" "tests/test_plans_rebuild_uses_collect.sh"

--- a/tests/test-pr-preflight.sh
+++ b/tests/test-pr-preflight.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Tests for skills/run-plan/scripts/pr-preflight.sh — the open-PR file-path
+# conflict gate that self-filters the pipeline's own PR (issue #177).
+# Run from repo root: bash tests/test-pr-preflight.sh
+#
+# Coverage:
+#   1. No open PRs touch path           → exit 0, empty stdout
+#   2. One PR touches path, NOT excluded → exit 1, stdout = that PR
+#   3. Only the excluded PR matches      → exit 0, empty stdout (#177 case)
+#   4. Multiple match, one excluded      → exit 1, stdout = remaining PRs
+#   5. --exclude-pr omitted              → no exclusion (returns all matches)
+#   6. Missing --path-prefix             → exit 2 (arg error)
+#   7. Bad --exclude-pr (non-numeric)    → exit 2 (arg error)
+#   8. Empty `[]` JSON                   → exit 0
+#   9. Path prefix matches in one PR but not another (boundary) → only that PR
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/skills/run-plan/scripts/pr-preflight.sh"
+
+WORK="/tmp/zskills-tests/$(basename "$REPO_ROOT")/pr-preflight"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# Helper: run the script with a JSON override, capture stdout/exit.
+# Args: $1=label, $2=expected_exit, $3=expected_stdout (newline-joined),
+#       $4=json, $5..=script args
+run_case() {
+  local label="$1" expected_exit="$2" expected_stdout="$3" json="$4"; shift 4
+  local actual_stdout actual_exit
+  actual_stdout=$(GH_PR_LIST_JSON_OVERRIDE="$json" bash "$SCRIPT" "$@" 2>/dev/null) || actual_exit=$?
+  actual_exit="${actual_exit:-0}"
+
+  if [ "$actual_exit" != "$expected_exit" ]; then
+    fail "$label — expected exit=$expected_exit got exit=$actual_exit (stdout: '$actual_stdout')"
+    return
+  fi
+  if [ "$actual_stdout" != "$expected_stdout" ]; then
+    fail "$label — expected stdout='$expected_stdout' got stdout='$actual_stdout'"
+    return
+  fi
+  pass "$label (exit=$actual_exit)"
+}
+
+# Helper: run without setting GH_PR_LIST_JSON_OVERRIDE (for arg-error cases).
+run_no_override() {
+  local label="$1" expected_exit="$2"; shift 2
+  local actual_exit
+  bash "$SCRIPT" "$@" >/dev/null 2>&1 || actual_exit=$?
+  actual_exit="${actual_exit:-0}"
+  if [ "$actual_exit" = "$expected_exit" ]; then
+    pass "$label (exit=$actual_exit)"
+  else
+    fail "$label — expected exit=$expected_exit got exit=$actual_exit"
+  fi
+}
+
+echo "=== pr-preflight.sh tests ==="
+
+# ---------------------------------------------------------------
+# Case 1: No open PRs touch path → exit 0, empty stdout
+# ---------------------------------------------------------------
+JSON_NO_MATCH='[{"number":100,"title":"A","files":[{"path":"src/foo.js"}]},{"number":101,"title":"B","files":[{"path":"docs/bar.md"}]}]'
+run_case "1: no PR touches path" 0 "" "$JSON_NO_MATCH" \
+  --path-prefix "skills/update-zskills/" --exclude-pr 175
+
+# ---------------------------------------------------------------
+# Case 2: One PR matches, not the excluded one → exit 1, stdout = that PR
+# ---------------------------------------------------------------
+JSON_ONE_MATCH='[{"number":175,"title":"self","files":[{"path":"src/foo.js"}]},{"number":200,"title":"other","files":[{"path":"skills/update-zskills/SKILL.md"},{"path":"src/bar.js"}]}]'
+run_case "2: one PR matches, not excluded" 1 "200" "$JSON_ONE_MATCH" \
+  --path-prefix "skills/update-zskills/" --exclude-pr 175
+
+# ---------------------------------------------------------------
+# Case 3: Only excluded PR matches (the #177 bug case) → exit 0, empty
+# ---------------------------------------------------------------
+JSON_ONLY_SELF='[{"number":175,"title":"self","files":[{"path":"skills/update-zskills/SKILL.md"},{"path":"plans/SKILL_VERSIONING.md"}]},{"number":200,"title":"other","files":[{"path":"src/foo.js"}]}]'
+run_case "3: only excluded PR matches (#177 bug case)" 0 "" "$JSON_ONLY_SELF" \
+  --path-prefix "skills/update-zskills/" --exclude-pr 175
+
+# ---------------------------------------------------------------
+# Case 4: Multiple match, one excluded → exit 1, stdout = remaining PRs (newline-joined)
+# ---------------------------------------------------------------
+JSON_MULTI_MATCH='[{"number":175,"title":"self","files":[{"path":"skills/update-zskills/SKILL.md"}]},{"number":200,"title":"other-a","files":[{"path":"skills/update-zskills/foo.md"}]},{"number":201,"title":"other-b","files":[{"path":"skills/update-zskills/bar.md"},{"path":"src/x.js"}]}]'
+run_case "4: multiple match, one excluded" 1 "200
+201" "$JSON_MULTI_MATCH" \
+  --path-prefix "skills/update-zskills/" --exclude-pr 175
+
+# ---------------------------------------------------------------
+# Case 5: --exclude-pr omitted → no exclusion (returns all matches incl. 175)
+# ---------------------------------------------------------------
+run_case "5: --exclude-pr omitted (no exclusion)" 1 "175
+200
+201" "$JSON_MULTI_MATCH" \
+  --path-prefix "skills/update-zskills/"
+
+# ---------------------------------------------------------------
+# Case 6: Missing --path-prefix → exit 2
+# ---------------------------------------------------------------
+run_no_override "6: missing --path-prefix exits 2" 2 --exclude-pr 175
+
+# ---------------------------------------------------------------
+# Case 7: Bad --exclude-pr (non-numeric) → exit 2
+# ---------------------------------------------------------------
+run_no_override "7: non-numeric --exclude-pr exits 2" 2 \
+  --path-prefix "skills/foo/" --exclude-pr "abc"
+
+# ---------------------------------------------------------------
+# Case 8: Empty `[]` JSON → exit 0
+# ---------------------------------------------------------------
+run_case "8: empty JSON array" 0 "" "[]" \
+  --path-prefix "skills/update-zskills/" --exclude-pr 175
+
+# ---------------------------------------------------------------
+# Case 9: Boundary — path prefix is a substring of another path that
+# should NOT match (e.g. 'skills/update' should NOT match 'skills/update-zskills/'
+# when prefix is 'skills/update-zskills-other/').
+# ---------------------------------------------------------------
+JSON_NEAR_MISS='[{"number":300,"title":"near","files":[{"path":"skills/update-zskills/SKILL.md"}]},{"number":301,"title":"hit","files":[{"path":"skills/update-zskills-other/SKILL.md"}]}]'
+run_case "9: prefix discriminates near-miss paths" 1 "301" "$JSON_NEAR_MISS" \
+  --path-prefix "skills/update-zskills-other/" --exclude-pr 175
+
+echo ""
+echo "---"
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$((PASS_COUNT + FAIL_COUNT))"
+if [ "$FAIL_COUNT" -gt 0 ]; then exit 1; fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #177. Adds `skills/run-plan/scripts/pr-preflight.sh` so `/run-plan` PR-mode preflights that grep `gh pr list` for path-prefix matches can self-filter the pipeline's own PR via `--exclude-pr "${RUN_PLAN_PR_NUMBER:-}"`. `/run-plan` SKILL.md prose updated to cite the helper instead of inlining the `gh pr list ... | grep -F` pipeline.

## Test plan

- [x] 9-case unit suite at `tests/test-pr-preflight.sh` (registered in `tests/run-all.sh`)
- [x] Full `tests/run-all.sh` 2712/2712 PASS in worktree
- [x] `diff -rq skills/run-plan .claude/skills/run-plan` clean (mirror parity)
- [x] `metadata.version` bumped on `skills/run-plan/SKILL.md`
- [x] No `--no-verify`

## Notes

- `--exclude-pr` is optional; empty-string default is `set -u` safe
- Pure bash regex JSON parsing (no jq)
