### PR TITLE
fix(skill-version-stage-check): distinguish 'didn't bump' vs 'didn't stage bump' STOP message (#194)

### DIFF
--- a/scripts/skill-version-stage-check.sh
+++ b/scripts/skill-version-stage-check.sh
@@ -79,17 +79,29 @@ for sk in "${!SKILLS_TO_CHECK[@]}"; do
   staged_hash="${staged_ver##*+}"
   head_hash="${head_ver##*+}"
 
+  # On-disk version is always read — used both as the staged-ver fallback
+  # when SKILL.md isn't staged, and as a discriminator below for the
+  # "bumped on disk but not staged" hint in the asymmetric STOP message.
+  on_disk_ver=$(bash "$GET" "$skill_md" metadata.version) || on_disk_ver=""
+
   # When SKILL.md isn't staged but child files are, the on-disk version
   # IS the comparison target — fall through to staged_ver == on_disk_ver.
   if [ -z "$staged_ver" ]; then
-    on_disk_ver=$(bash "$GET" "$skill_md" metadata.version) || on_disk_ver=""
     staged_ver="$on_disk_ver"
     staged_hash="${staged_ver##*+}"
   fi
 
   # Asymmetric: content changed, version unchanged.
   if [ "$cur_hash" != "$head_hash" ] && [ "$staged_ver" = "$head_ver" ]; then
-    FAIL_LIST+=("$sk: content changed (hash $head_hash → $cur_hash) but staged metadata.version still $staged_ver")
+    # Hint: did the user bump on disk but forget to `git add`? If
+    # on_disk_ver differs from staged_ver (and is non-empty / non-head),
+    # the bump exists in the working tree but isn't staged.
+    hint=""
+    if [ -n "$on_disk_ver" ] && [ "$on_disk_ver" != "$staged_ver" ] \
+       && [ "$on_disk_ver" != "$head_ver" ]; then
+      hint=" (SKILL.md not staged — git add it)"
+    fi
+    FAIL_LIST+=("$sk: content changed (hash $head_hash → $cur_hash) but staged metadata.version still $staged_ver$hint")
   fi
   # Symmetric: version bumped, content unchanged.
   if [ "$cur_hash" = "$head_hash" ] && [ -n "$staged_ver" ] && [ "$staged_ver" != "$head_ver" ]; then

--- a/tests/test-skill-version-enforcement.sh
+++ b/tests/test-skill-version-enforcement.sh
@@ -500,6 +500,43 @@ else
   fail "case 20: expected exit 1 with skills/bar but not skills/foo, got exit=$ec err=$err"
 fi
 
+# Case 21 (s9): body edited and STAGED without bump (case (a) from
+# issue #194) → STOP without "(SKILL.md not staged — git add it)" hint.
+case_no=21
+sandbox=$(make_sandbox "$case_no")
+echo "Body edit." >> "$sandbox/skills/foo/SKILL.md"
+(cd "$sandbox" && git add skills/foo/SKILL.md)
+err=$(run_stage_check "$sandbox" 2>&1)
+ec=$?
+if [ "$ec" -ne 0 ] && [[ "$err" == *"STOP:"* ]] && [[ "$err" != *"not staged"* ]]; then
+  pass "case 21: edited+staged without bump → STOP without 'not staged' hint"
+else
+  fail "case 21: expected STOP without 'not staged' hint, got exit=$ec err=$err"
+fi
+
+# Case 22 (s10): body edited AND staged, SKILL.md bumped on disk but
+# bump NOT re-staged (case (b) from issue #194) → STOP WITH
+# "(SKILL.md not staged — git add it)" hint.
+#
+# Repro: stage the body edit (with old version), then bump version on
+# disk WITHOUT re-staging. staged_blob carries old version; on_disk_ver
+# carries new version. Asymmetric branch fires; hint should appear.
+case_no=22
+sandbox=$(make_sandbox "$case_no")
+# Step 1: edit body and stage it (with old version still in place).
+echo "Body edit." >> "$sandbox/skills/foo/SKILL.md"
+(cd "$sandbox" && git add skills/foo/SKILL.md)
+# Step 2: bump version on disk only — DO NOT re-stage.
+bump_version "$sandbox"
+err=$(run_stage_check "$sandbox" 2>&1)
+ec=$?
+if [ "$ec" -ne 0 ] && [[ "$err" == *"STOP:"* ]] \
+   && [[ "$err" == *"SKILL.md not staged — git add it"* ]]; then
+  pass "case 22: bump on disk but not re-staged → STOP with 'not staged' hint"
+else
+  fail "case 22: expected STOP with 'not staged' hint, got exit=$ec err=$err"
+fi
+
 # ----------------------------------------------------------------------
 # Summary.
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #194. The STOP message now appends `(SKILL.md not staged — git add it)` when the discriminator `on_disk_ver != staged_ver && on_disk_ver != head_ver` fires (case b: bumped on disk but not in the staged blob). Case (a) (no bump at all) gets the original message unchanged.

Lifted `on_disk_ver` computation to top-level so both code paths use it as the staged-ver fallback AND as the case-b discriminator. Behavior identical for all 8 pre-existing stage-check cases.

Variable name discrepancy from issue body: the issue body suggested `staged_ver_was_set_initially`, which doesn't exist in the script. Used the actual signal `on_disk_ver != staged_ver && on_disk_ver != head_ver` — more precise.

## Test plan

- [x] Two new test cases in `tests/test-skill-version-enforcement.sh` (s9: case-a no-hint; s10: case-b with hint)
- [x] Targeted suite 22/22 PASS
- [x] Full `tests/run-all.sh` 2704/2705 PASS — 1 failure is pre-existing flake in `test-hooks.sh` post-run-invariants (root-caused as unscoped `/tmp/inv-test.txt` race; last touched by PR #195/#129; unrelated to this PR per 5-step audit)
- [x] No `--no-verify`

## Notes

- Pure UX text fix; no behavioral change.
- Recommended follow-up: file a separate issue against `tests/test-hooks.sh` to scope `/tmp/inv-test.txt` per worktree (unrelated to this PR).
