### PR TITLE
fix(plans,dashboard): accept colon-separated phase headings (#183)

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   until the plan converges. Output is a plan file ready for /run-plan.
   Usage: /draft-plan [output FILE] [rounds N] <description...>
 metadata:
-  version: "2026.05.02+8187cd"
+  version: "2026.05.07+a7f2d9"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -295,6 +295,12 @@ status: active    # active | complete
 - **`status`** — always starts as `active`. `/run-plan` updates this to
   `complete` when all phases finish, which also signals it to close the
   linked GitHub issue (if one is present).
+
+**Phase heading format.** Use `## Phase <N> — <Name>` with an em-dash
+(`—`) as the canonical separator. The aggregator (`collect.py`) also
+accepts en-dash (`–`), colon (`:`), and hyphen (`-`) so hand-authored
+plans are not silently demoted to Reference (issue #183), but every
+template in this skill emits em-dash for consistency.
 
 ```markdown
 # Plan: <Title>

--- a/.claude/skills/plans/SKILL.md
+++ b/.claude/skills/plans/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Plan dashboard. View plan status, find the next ready plan. For batch
   execution, see `/work-on-plans`.
 metadata:
-  version: "2026.05.02+03ddc6"
+  version: "2026.05.07+38ab19"
 ---
 
 # /plans [rebuild | next | details] — Plan Dashboard
@@ -385,7 +385,11 @@ components don't follow the `*Block.js` naming convention.
    The "starting at Phase 1 -- …" comes from the first entry in the
    snapshot plan's `phases[]` whose `status != "done"` (or, if
    `phases[]` is empty, from the first `## Phase` heading captured by
-   `collect.py` and exposed via `phase_count`).
+   `collect.py` and exposed via `phase_count`). Phase headings match
+   the form `## Phase <N> <sep> Name` where `<sep>` is one of em-dash
+   (`—`, canonical), en-dash (`–`), colon (`:`), or hyphen (`-`).
+   Plans whose phase headings use any other separator are classified
+   as Reference (`phase_count=0`) and will not appear in Ready-to-Run.
 5. If the Ready-to-Run set is empty:
    > No plans ready to run. All executable plans are either in progress or complete.
    > Check "In Progress" plans in the index for plans that need attention.

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status].
 metadata:
-  version: "2026.05.02+95ccb6"
+  version: "2026.05.07+4218c6"
 ---
 
 # /zskills-dashboard — Local Monitor Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -55,8 +55,12 @@ LANDING_MODE_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Phase heading: `## Phase N — Name` (em-dash or hyphen).
-PHASE_HEADING_RE = re.compile(r"^##\s+Phase\s+(\S+)\s*[—-]\s*(.+)$", re.MULTILINE)
+# Phase heading: `## Phase N <sep> Name` where <sep> is em-dash, en-dash,
+# colon, or hyphen. All four are accepted because hand-authored plans use
+# them interchangeably; the canonical form documented in /draft-plan and
+# /plans is em-dash, but rejecting `:` silently demotes valid plans to
+# Reference (issue #183).
+PHASE_HEADING_RE = re.compile(r"^##\s+Phase\s+(\S+)\s*[—–:\-]\s*(.+)$", re.MULTILINE)
 
 # Progress-tracker row marker — used to find the table.
 TRACKER_HEADER_RE = re.compile(r"^\|\s*Phase\s*\|", re.MULTILINE)
@@ -333,8 +337,9 @@ def _resolve_landing_mode(
 
 
 def _parse_phase_headings(content: str) -> List[Dict[str, Any]]:
-    """Return [{n, name}] from `## Phase <N> — Name` (em-dash or hyphen).
+    """Return [{n, name}] from `## Phase <N> <sep> Name`.
 
+    `<sep>` may be em-dash (—), en-dash (–), colon (:), or hyphen (-).
     `n` is the phase token as a string (alphanumeric: '1', '5c', 'A').
     """
     out: List[Dict[str, Any]] = []

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   until the plan converges. Output is a plan file ready for /run-plan.
   Usage: /draft-plan [output FILE] [rounds N] <description...>
 metadata:
-  version: "2026.05.02+8187cd"
+  version: "2026.05.07+a7f2d9"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -295,6 +295,12 @@ status: active    # active | complete
 - **`status`** — always starts as `active`. `/run-plan` updates this to
   `complete` when all phases finish, which also signals it to close the
   linked GitHub issue (if one is present).
+
+**Phase heading format.** Use `## Phase <N> — <Name>` with an em-dash
+(`—`) as the canonical separator. The aggregator (`collect.py`) also
+accepts en-dash (`–`), colon (`:`), and hyphen (`-`) so hand-authored
+plans are not silently demoted to Reference (issue #183), but every
+template in this skill emits em-dash for consistency.
 
 ```markdown
 # Plan: <Title>

--- a/skills/plans/SKILL.md
+++ b/skills/plans/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Plan dashboard. View plan status, find the next ready plan. For batch
   execution, see `/work-on-plans`.
 metadata:
-  version: "2026.05.02+03ddc6"
+  version: "2026.05.07+38ab19"
 ---
 
 # /plans [rebuild | next | details] — Plan Dashboard
@@ -385,7 +385,11 @@ components don't follow the `*Block.js` naming convention.
    The "starting at Phase 1 -- …" comes from the first entry in the
    snapshot plan's `phases[]` whose `status != "done"` (or, if
    `phases[]` is empty, from the first `## Phase` heading captured by
-   `collect.py` and exposed via `phase_count`).
+   `collect.py` and exposed via `phase_count`). Phase headings match
+   the form `## Phase <N> <sep> Name` where `<sep>` is one of em-dash
+   (`—`, canonical), en-dash (`–`), colon (`:`), or hyphen (`-`).
+   Plans whose phase headings use any other separator are classified
+   as Reference (`phase_count=0`) and will not appear in Ready-to-Run.
 5. If the Ready-to-Run set is empty:
    > No plans ready to run. All executable plans are either in progress or complete.
    > Check "In Progress" plans in the index for plans that need attention.

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status].
 metadata:
-  version: "2026.05.02+95ccb6"
+  version: "2026.05.07+4218c6"
 ---
 
 # /zskills-dashboard — Local Monitor Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -55,8 +55,12 @@ LANDING_MODE_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
-# Phase heading: `## Phase N — Name` (em-dash or hyphen).
-PHASE_HEADING_RE = re.compile(r"^##\s+Phase\s+(\S+)\s*[—-]\s*(.+)$", re.MULTILINE)
+# Phase heading: `## Phase N <sep> Name` where <sep> is em-dash, en-dash,
+# colon, or hyphen. All four are accepted because hand-authored plans use
+# them interchangeably; the canonical form documented in /draft-plan and
+# /plans is em-dash, but rejecting `:` silently demotes valid plans to
+# Reference (issue #183).
+PHASE_HEADING_RE = re.compile(r"^##\s+Phase\s+(\S+)\s*[—–:\-]\s*(.+)$", re.MULTILINE)
 
 # Progress-tracker row marker — used to find the table.
 TRACKER_HEADER_RE = re.compile(r"^\|\s*Phase\s*\|", re.MULTILINE)
@@ -333,8 +337,9 @@ def _resolve_landing_mode(
 
 
 def _parse_phase_headings(content: str) -> List[Dict[str, Any]]:
-    """Return [{n, name}] from `## Phase <N> — Name` (em-dash or hyphen).
+    """Return [{n, name}] from `## Phase <N> <sep> Name`.
 
+    `<sep>` may be em-dash (—), en-dash (–), colon (:), or hyphen (-).
     `n` is the phase token as a string (alphanumeric: '1', '5c', 'A').
     """
     out: List[Dict[str, Any]] = []

--- a/tests/fixtures/monitor/phase-heading-separators/plans/SEPARATORS_PLAN.md
+++ b/tests/fixtures/monitor/phase-heading-separators/plans/SEPARATORS_PLAN.md
@@ -1,0 +1,32 @@
+---
+title: Phase Heading Separators
+status: active
+created: 2026-05-07
+---
+
+# Phase Heading Separators
+
+> **Landing mode: PR**
+
+## Overview
+
+Regression fixture for issue #183 — `/plans` previously demoted plans with
+colon-separated phase headings to Reference. This fixture exercises all four
+accepted separators (em-dash, en-dash, colon, hyphen) in a single plan so the
+aggregator must classify it as `executable` with `phase_count=4`.
+
+## Phase 1 — Em-dash separator
+
+Canonical form.
+
+## Phase 2: Colon separator
+
+The form that issue #183 reports as silently broken.
+
+## Phase 3 – En-dash separator
+
+Unicode en-dash, often produced by editor autocorrect.
+
+## Phase 4 - Hyphen separator
+
+Plain ASCII hyphen.

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -179,6 +179,47 @@ import json,sys; d=json.load(sys.stdin); print(d["plans"][0]["meta_plan"])')
   || fail "category-canary meta_plan should be False, got '$META_CANARY'"
 
 # ---------------------------------------------------------------------------
+# AC: Phase-heading separator coverage (issue #183)
+# ---------------------------------------------------------------------------
+# A plan whose phases use colon, en-dash, em-dash, or hyphen separators MUST
+# be classified as executable with phase_count == 4. The pre-fix regex
+# `[—-]` accepted only em-dash + hyphen, silently demoting colon-separated
+# plans (the most common hand-authored form) to Reference. This test would
+# have caught the original bug — pre-fix `phase_count` would be 1 (only the
+# em-dash heading would match) and `category` would be `reference`.
+echo ""
+echo "=== Issue #183: phase-heading separator coverage ==="
+
+SEP_OUT=$(run_collect phase-heading-separators)
+SEP_RESULT=$(printf '%s' "$SEP_OUT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+p = d["plans"][0]
+print(p["category"], p["phase_count"])
+')
+if [ "$SEP_RESULT" = "executable 4" ]; then
+  pass "phase-heading-separators: em-dash/colon/en-dash/hyphen all match (category=executable, phase_count=4)"
+else
+  fail "phase-heading-separators: got '$SEP_RESULT' (expected 'executable 4')"
+fi
+
+# Direct regex unit test on the parser entry point — guards the regex even
+# if categorize logic shifts in future.
+SEP_PARSE=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+from zskills_monitor.collect import _parse_phase_headings
+content = "## Phase 1 — Em-dash\n## Phase 2: Colon\n## Phase 3 – En-dash\n## Phase 4 - Hyphen\n"
+phases = _parse_phase_headings(content)
+print(",".join(p["n"] + "=" + p["name"] for p in phases))
+')
+if [ "$SEP_PARSE" = "1=Em-dash,2=Colon,3=En-dash,4=Hyphen" ]; then
+  pass "_parse_phase_headings: all four separators (em-dash, colon, en-dash, hyphen) recognised"
+else
+  fail "_parse_phase_headings separator coverage: got '$SEP_PARSE'"
+fi
+
+# ---------------------------------------------------------------------------
 # AC: Queue annotation (v1.1 ready/finish)
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Fixes #183 — `/plans` regex rejects colon-separated phase headings.

The phase-heading regex in `skills/zskills-dashboard/scripts/zskills_monitor/collect.py` accepted only em-dash and hyphen separators (`[—-]`); markdown-conventional `## Phase N: Name` form misclassified plans as Reference docs instead of executable. Fix: regex now accepts em-dash, en-dash, colon, hyphen (`[—–:\-]`). Skill prose updated in `skills/plans/SKILL.md`, `skills/draft-plan/SKILL.md` to document canonical separator + acceptance set.

`metadata.version` bumped on 3 affected skills (`plans`, `draft-plan`, `zskills-dashboard`); mirrors regenerated.

## Test plan

- [x] New fixture at `tests/fixtures/monitor/phase-heading-separators/plans/SEPARATORS_PLAN.md` exercises all 4 separator variants in one plan; new test asserts `category=executable, phase_count=4`.
- [x] Direct parser-level assertion calls `_parse_phase_headings` and verifies all 4 names parse.
- [x] Pre-fix regex demonstrably failed: `[—-]` matched only 2/4 of the new fixture's headings.
- [x] Full test suite: 2722/2722 pass.
- [x] Mirror parity clean (`diff -rq` empty for all 3 touched skills).
