### PR TITLE
fix(land-pr): wrong-branch push, .landed commits-list, .landed marker auto-detect (#188, #203, #205)

### DIFF
--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper skill — the canonical PR-landing primitive **for agent dispatch via the Skill tool**. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge an existing feature branch. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. **Designed for orchestrator agents** (the Skill tool with --body-file / --result-file args) — including both the 5 conformance-locked caller skills (/run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix) AND any top-level orchestrator agent landing a one-off PR. **Not designed for interactive human slash-command invocation** — humans wanting to ship a branch should type /commit pr instead (which dispatches /land-pr).
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>]
 metadata:
-  version: "2026.05.02+e41e24"
+  version: "2026.05.07+74a34a"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -391,7 +391,7 @@ if [ -n "$PR_NUMBER" ] && [ "$STATUS" != "rebase-conflict" ] && [ "$STATUS" != "
 fi
 ```
 
-### Step 8 — Compose `.landed` (only if `--worktree-path`)
+### Step 8 — Compose `.landed` (auto-detect worktree if `--worktree-path` omitted)
 
 Use this **status mapping table** to derive `.landed`'s `status` field.
 **Evaluation: top-down, first-match-wins.** Failure-exits and
@@ -413,10 +413,37 @@ changed after) should NOT be reported as `landed`.
 | 9 | MERGE_REQUESTED=false (auto-merge-disabled-on-repo) AND CI_STATUS in {pass, none, skipped} | pr-ready |
 | 10 | MERGE_REQUESTED=false (auto-not-requested) AND CI_STATUS in {pass, none, skipped} | pr-ready |
 
-Compose the body and pipe to `write-landed.sh`:
+Compose the body and pipe to `write-landed.sh`. When `--worktree-path`
+is omitted, auto-detect from cwd: if cwd is a registered **linked**
+worktree of the current repo (NOT the main worktree, which has no
+associated branch-of-work to mark), use it as the marker target. This
+closes the Issue #205 gap where orchestrator-direct `/land-pr` dispatch
+from inside a worktree but without `--worktree-path` silently skipped
+the `.landed` write. `--worktree-path` remains an explicit override.
 
 <!-- allow-hardcoded: TZ=America/New_York reason: matches the schema doc above and the established idiom across skills; per-skill $TIMEZONE migration is scoped to plans/SKILL_FILE_DRIFT_FIX.md, not this plan -->
 ```bash
+# Auto-detect WORKTREE_PATH from cwd when caller didn't pass --worktree-path.
+# Detection uses `git rev-parse` (worktree root + git-dir vs git-common-dir
+# divergence indicates a LINKED worktree, not the main worktree) plus
+# membership in `git worktree list --porcelain` for defense-in-depth.
+if [ -z "$WORKTREE_PATH" ]; then
+  CANDIDATE=$(git rev-parse --show-toplevel 2>/dev/null) || CANDIDATE=""
+  if [ -n "$CANDIDATE" ]; then
+    GIT_DIR=$(git -C "$CANDIDATE" rev-parse --git-dir 2>/dev/null) || GIT_DIR=""
+    GIT_COMMON_DIR=$(git -C "$CANDIDATE" rev-parse --git-common-dir 2>/dev/null) || GIT_COMMON_DIR=""
+    # Linked worktree: per-worktree git-dir differs from common-dir.
+    # Main worktree (or non-worktree dir): they match (or are empty on failure).
+    if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
+      # Verify membership in `git worktree list` to guard against odd
+      # checkout layouts that happen to expose distinct git-dirs.
+      if git -C "$CANDIDATE" worktree list --porcelain 2>/dev/null | grep -qF "worktree $CANDIDATE"; then
+        WORKTREE_PATH="$CANDIDATE"
+      fi
+    fi
+  fi
+fi
+
 if [ -n "$WORKTREE_PATH" ]; then
   # Derive .landed status from the table above.
   LANDED_STATUS="pr-ready"  # default fallback
@@ -445,11 +472,18 @@ if [ -n "$WORKTREE_PATH" ]; then
   esac
 
   # Metadata-only capture; on rare git failures (detached HEAD with
-  # missing $BASE_BRANCH ref) COMMITS_LIST stays empty rather than
+  # missing origin/$BASE_BRANCH ref) COMMITS_LIST stays empty rather than
   # aborting .landed write. Stderr goes to a discarded log, not the
   # null device — keeps the file inspectable post-mortem.
+  #
+  # Use `origin/$BASE_BRANCH` (NOT local `$BASE_BRANCH`): in multi-PR
+  # sequential sprints, local main goes stale relative to origin/main
+  # after each auto-merge, which over-populates this list with squash
+  # commits from prior sprints' PRs (Issue #203). pr-rebase.sh fetches
+  # origin/$BASE_BRANCH earlier in the pipeline, so it's always current
+  # by the time we reach Step 8.
   GIT_LOG_STDERR="/tmp/land-pr-commits-list-stderr-$BRANCH_SLUG-$$.log"
-  COMMITS_LIST=$(cd "$WORKTREE_PATH" && git log --format=%H "$BASE_BRANCH..HEAD" 2>"$GIT_LOG_STDERR" | tr '\n' ' ' | sed 's/ $//')
+  COMMITS_LIST=$(cd "$WORKTREE_PATH" && git log --format=%H "origin/$BASE_BRANCH..HEAD" 2>"$GIT_LOG_STDERR" | tr '\n' ' ' | sed 's/ $//')
   LANDED_DATE=$(TZ=America/New_York date -Iseconds)
 
   {

--- a/.claude/skills/land-pr/scripts/pr-push-and-create.sh
+++ b/.claude/skills/land-pr/scripts/pr-push-and-create.sh
@@ -7,7 +7,10 @@
 # Behavior:
 #   1. Detect existing PR via `gh pr list --head <branch> --base <base> --json`.
 #      Parse with bash regex (no jq binary).
-#   2. Push (-u origin <branch>; or `git push` if upstream is set).
+#   2. Push (-u origin <branch>); always push $BRANCH explicitly
+#      (NOT bare `git push` — which silently no-ops when CWD's current
+#      branch differs from $BRANCH; Issue #188). Verify post-push that
+#      remote HEAD == local HEAD via `git ls-remote`.
 #   3. If a PR already exists: emit PR_EXISTING=true and the URL/number,
 #      exit 0. Body update is the CALLER's responsibility, not /land-pr's
 #      (HTML-comment-marker splice preservation).
@@ -98,26 +101,31 @@ if [[ "$PR_LIST_JSON" =~ \"number\":[[:space:]]*([0-9]+) ]]; then
   fi
 fi
 
-# Step 2 — Push the branch. Use -u origin if no upstream is configured;
-# otherwise plain `git push` (preserves any user-configured remote name).
-if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>"$STDERR_LOG"; then
-  if ! git push >"$STDERR_LOG" 2>&1; then
-    ERR_FILE="/tmp/land-pr-push-error-$BRANCH_SLUG-$$.txt"
-    cp "$STDERR_LOG" "$ERR_FILE"
-    echo "ERROR: pr-push-and-create.sh: git push failed — see $ERR_FILE" >&2
-    cat "$STDERR_LOG" >&2
-    echo "CALL_ERROR_FILE=$ERR_FILE"
-    exit 12
-  fi
-else
-  if ! git push -u origin "$BRANCH" >"$STDERR_LOG" 2>&1; then
-    ERR_FILE="/tmp/land-pr-push-error-$BRANCH_SLUG-$$.txt"
-    cp "$STDERR_LOG" "$ERR_FILE"
-    echo "ERROR: pr-push-and-create.sh: git push -u origin $BRANCH failed — see $ERR_FILE" >&2
-    cat "$STDERR_LOG" >&2
-    echo "CALL_ERROR_FILE=$ERR_FILE"
-    exit 12
-  fi
+# Step 2 — Push $BRANCH explicitly. Do NOT use bare `git push` (which
+# pushes CWD's current branch and silently no-ops when current != $BRANCH;
+# Issue #188 root cause). `-u` sets upstream tracking idempotently
+# (no-op if already set).
+if ! git push -u origin "$BRANCH" >"$STDERR_LOG" 2>&1; then
+  ERR_FILE="/tmp/land-pr-push-error-$BRANCH_SLUG-$$.txt"
+  cp "$STDERR_LOG" "$ERR_FILE"
+  echo "ERROR: pr-push-and-create.sh: git push -u origin $BRANCH failed — see $ERR_FILE" >&2
+  cat "$STDERR_LOG" >&2
+  echo "CALL_ERROR_FILE=$ERR_FILE"
+  exit 12
+fi
+
+# Defense-in-depth: post-push verification. Confirm the remote ref now
+# matches the local ref. Catches silent no-op pushes (e.g., if origin
+# was misconfigured, if a sibling agent force-pushed something else,
+# or if a future regression of the push command reintroduces Issue #188).
+LOCAL_HEAD=$(git rev-parse "refs/heads/$BRANCH" 2>"$STDERR_LOG")
+REMOTE_HEAD=$(git ls-remote origin "refs/heads/$BRANCH" 2>>"$STDERR_LOG" | awk '{print $1}')
+if [ -z "$REMOTE_HEAD" ] || [ "$LOCAL_HEAD" != "$REMOTE_HEAD" ]; then
+  ERR_FILE="/tmp/land-pr-push-verify-error-$BRANCH_SLUG-$$.txt"
+  cp "$STDERR_LOG" "$ERR_FILE"
+  echo "ERROR: pr-push-and-create.sh: post-push verification failed — local HEAD $LOCAL_HEAD does not match remote HEAD ${REMOTE_HEAD:-<empty>}; remote ref may not exist or may be at the wrong commit. See $ERR_FILE" >&2
+  echo "CALL_ERROR_FILE=$ERR_FILE"
+  exit 12
 fi
 
 # Step 3 — Existing PR detected? Emit and exit. Caller owns body update.

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper skill — the canonical PR-landing primitive **for agent dispatch via the Skill tool**. Rebase, push, create-or-detect PR, poll CI, and (gated on caller's --auto flag) auto-merge an existing feature branch. Returns structured state via --result-file for caller-driven fix-cycle loops on CI failure. **Designed for orchestrator agents** (the Skill tool with --body-file / --result-file args) — including both the 5 conformance-locked caller skills (/run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix) AND any top-level orchestrator agent landing a one-off PR. **Not designed for interactive human slash-command invocation** — humans wanting to ship a branch should type /commit pr instead (which dispatches /land-pr).
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>]
 metadata:
-  version: "2026.05.02+e41e24"
+  version: "2026.05.07+74a34a"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -391,7 +391,7 @@ if [ -n "$PR_NUMBER" ] && [ "$STATUS" != "rebase-conflict" ] && [ "$STATUS" != "
 fi
 ```
 
-### Step 8 — Compose `.landed` (only if `--worktree-path`)
+### Step 8 — Compose `.landed` (auto-detect worktree if `--worktree-path` omitted)
 
 Use this **status mapping table** to derive `.landed`'s `status` field.
 **Evaluation: top-down, first-match-wins.** Failure-exits and
@@ -413,10 +413,37 @@ changed after) should NOT be reported as `landed`.
 | 9 | MERGE_REQUESTED=false (auto-merge-disabled-on-repo) AND CI_STATUS in {pass, none, skipped} | pr-ready |
 | 10 | MERGE_REQUESTED=false (auto-not-requested) AND CI_STATUS in {pass, none, skipped} | pr-ready |
 
-Compose the body and pipe to `write-landed.sh`:
+Compose the body and pipe to `write-landed.sh`. When `--worktree-path`
+is omitted, auto-detect from cwd: if cwd is a registered **linked**
+worktree of the current repo (NOT the main worktree, which has no
+associated branch-of-work to mark), use it as the marker target. This
+closes the Issue #205 gap where orchestrator-direct `/land-pr` dispatch
+from inside a worktree but without `--worktree-path` silently skipped
+the `.landed` write. `--worktree-path` remains an explicit override.
 
 <!-- allow-hardcoded: TZ=America/New_York reason: matches the schema doc above and the established idiom across skills; per-skill $TIMEZONE migration is scoped to plans/SKILL_FILE_DRIFT_FIX.md, not this plan -->
 ```bash
+# Auto-detect WORKTREE_PATH from cwd when caller didn't pass --worktree-path.
+# Detection uses `git rev-parse` (worktree root + git-dir vs git-common-dir
+# divergence indicates a LINKED worktree, not the main worktree) plus
+# membership in `git worktree list --porcelain` for defense-in-depth.
+if [ -z "$WORKTREE_PATH" ]; then
+  CANDIDATE=$(git rev-parse --show-toplevel 2>/dev/null) || CANDIDATE=""
+  if [ -n "$CANDIDATE" ]; then
+    GIT_DIR=$(git -C "$CANDIDATE" rev-parse --git-dir 2>/dev/null) || GIT_DIR=""
+    GIT_COMMON_DIR=$(git -C "$CANDIDATE" rev-parse --git-common-dir 2>/dev/null) || GIT_COMMON_DIR=""
+    # Linked worktree: per-worktree git-dir differs from common-dir.
+    # Main worktree (or non-worktree dir): they match (or are empty on failure).
+    if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
+      # Verify membership in `git worktree list` to guard against odd
+      # checkout layouts that happen to expose distinct git-dirs.
+      if git -C "$CANDIDATE" worktree list --porcelain 2>/dev/null | grep -qF "worktree $CANDIDATE"; then
+        WORKTREE_PATH="$CANDIDATE"
+      fi
+    fi
+  fi
+fi
+
 if [ -n "$WORKTREE_PATH" ]; then
   # Derive .landed status from the table above.
   LANDED_STATUS="pr-ready"  # default fallback
@@ -445,11 +472,18 @@ if [ -n "$WORKTREE_PATH" ]; then
   esac
 
   # Metadata-only capture; on rare git failures (detached HEAD with
-  # missing $BASE_BRANCH ref) COMMITS_LIST stays empty rather than
+  # missing origin/$BASE_BRANCH ref) COMMITS_LIST stays empty rather than
   # aborting .landed write. Stderr goes to a discarded log, not the
   # null device — keeps the file inspectable post-mortem.
+  #
+  # Use `origin/$BASE_BRANCH` (NOT local `$BASE_BRANCH`): in multi-PR
+  # sequential sprints, local main goes stale relative to origin/main
+  # after each auto-merge, which over-populates this list with squash
+  # commits from prior sprints' PRs (Issue #203). pr-rebase.sh fetches
+  # origin/$BASE_BRANCH earlier in the pipeline, so it's always current
+  # by the time we reach Step 8.
   GIT_LOG_STDERR="/tmp/land-pr-commits-list-stderr-$BRANCH_SLUG-$$.log"
-  COMMITS_LIST=$(cd "$WORKTREE_PATH" && git log --format=%H "$BASE_BRANCH..HEAD" 2>"$GIT_LOG_STDERR" | tr '\n' ' ' | sed 's/ $//')
+  COMMITS_LIST=$(cd "$WORKTREE_PATH" && git log --format=%H "origin/$BASE_BRANCH..HEAD" 2>"$GIT_LOG_STDERR" | tr '\n' ' ' | sed 's/ $//')
   LANDED_DATE=$(TZ=America/New_York date -Iseconds)
 
   {

--- a/skills/land-pr/scripts/pr-push-and-create.sh
+++ b/skills/land-pr/scripts/pr-push-and-create.sh
@@ -7,7 +7,10 @@
 # Behavior:
 #   1. Detect existing PR via `gh pr list --head <branch> --base <base> --json`.
 #      Parse with bash regex (no jq binary).
-#   2. Push (-u origin <branch>; or `git push` if upstream is set).
+#   2. Push (-u origin <branch>); always push $BRANCH explicitly
+#      (NOT bare `git push` — which silently no-ops when CWD's current
+#      branch differs from $BRANCH; Issue #188). Verify post-push that
+#      remote HEAD == local HEAD via `git ls-remote`.
 #   3. If a PR already exists: emit PR_EXISTING=true and the URL/number,
 #      exit 0. Body update is the CALLER's responsibility, not /land-pr's
 #      (HTML-comment-marker splice preservation).
@@ -98,26 +101,31 @@ if [[ "$PR_LIST_JSON" =~ \"number\":[[:space:]]*([0-9]+) ]]; then
   fi
 fi
 
-# Step 2 — Push the branch. Use -u origin if no upstream is configured;
-# otherwise plain `git push` (preserves any user-configured remote name).
-if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>"$STDERR_LOG"; then
-  if ! git push >"$STDERR_LOG" 2>&1; then
-    ERR_FILE="/tmp/land-pr-push-error-$BRANCH_SLUG-$$.txt"
-    cp "$STDERR_LOG" "$ERR_FILE"
-    echo "ERROR: pr-push-and-create.sh: git push failed — see $ERR_FILE" >&2
-    cat "$STDERR_LOG" >&2
-    echo "CALL_ERROR_FILE=$ERR_FILE"
-    exit 12
-  fi
-else
-  if ! git push -u origin "$BRANCH" >"$STDERR_LOG" 2>&1; then
-    ERR_FILE="/tmp/land-pr-push-error-$BRANCH_SLUG-$$.txt"
-    cp "$STDERR_LOG" "$ERR_FILE"
-    echo "ERROR: pr-push-and-create.sh: git push -u origin $BRANCH failed — see $ERR_FILE" >&2
-    cat "$STDERR_LOG" >&2
-    echo "CALL_ERROR_FILE=$ERR_FILE"
-    exit 12
-  fi
+# Step 2 — Push $BRANCH explicitly. Do NOT use bare `git push` (which
+# pushes CWD's current branch and silently no-ops when current != $BRANCH;
+# Issue #188 root cause). `-u` sets upstream tracking idempotently
+# (no-op if already set).
+if ! git push -u origin "$BRANCH" >"$STDERR_LOG" 2>&1; then
+  ERR_FILE="/tmp/land-pr-push-error-$BRANCH_SLUG-$$.txt"
+  cp "$STDERR_LOG" "$ERR_FILE"
+  echo "ERROR: pr-push-and-create.sh: git push -u origin $BRANCH failed — see $ERR_FILE" >&2
+  cat "$STDERR_LOG" >&2
+  echo "CALL_ERROR_FILE=$ERR_FILE"
+  exit 12
+fi
+
+# Defense-in-depth: post-push verification. Confirm the remote ref now
+# matches the local ref. Catches silent no-op pushes (e.g., if origin
+# was misconfigured, if a sibling agent force-pushed something else,
+# or if a future regression of the push command reintroduces Issue #188).
+LOCAL_HEAD=$(git rev-parse "refs/heads/$BRANCH" 2>"$STDERR_LOG")
+REMOTE_HEAD=$(git ls-remote origin "refs/heads/$BRANCH" 2>>"$STDERR_LOG" | awk '{print $1}')
+if [ -z "$REMOTE_HEAD" ] || [ "$LOCAL_HEAD" != "$REMOTE_HEAD" ]; then
+  ERR_FILE="/tmp/land-pr-push-verify-error-$BRANCH_SLUG-$$.txt"
+  cp "$STDERR_LOG" "$ERR_FILE"
+  echo "ERROR: pr-push-and-create.sh: post-push verification failed — local HEAD $LOCAL_HEAD does not match remote HEAD ${REMOTE_HEAD:-<empty>}; remote ref may not exist or may be at the wrong commit. See $ERR_FILE" >&2
+  echo "CALL_ERROR_FILE=$ERR_FILE"
+  exit 12
 fi
 
 # Step 3 — Existing PR detected? Emit and exit. Caller owns body update.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -77,6 +77,7 @@ run_suite "test-update-zskills-agent-install" "tests/test-update-zskills-agent-i
 run_suite "test-update-zskills-rerender.sh" "tests/test-update-zskills-rerender.sh"
 run_suite "test-mirror-skill.sh" "tests/test-mirror-skill.sh"
 run_suite "test-land-pr-scripts.sh" "tests/test-land-pr-scripts.sh"
+run_suite "test-land-pr-worktree-detect.sh" "tests/test-land-pr-worktree-detect.sh"
 run_suite "test-landed-schema.sh" "tests/test-landed-schema.sh"
 run_suite "test-zskills-resolve-config.sh" "tests/test-zskills-resolve-config.sh"
 run_suite "test-json-set-string-field.sh" "tests/test-json-set-string-field.sh"

--- a/tests/test-land-pr-scripts.sh
+++ b/tests/test-land-pr-scripts.sh
@@ -184,12 +184,11 @@ cleanup_fixture "$F"
 # Failure mode #4 — push-failed
 # ----------------------------------------------------------------------
 F=$(new_fixture mode4)
-# pr-push-and-create.sh sequence:
+# pr-push-and-create.sh sequence (post-Issue-#188 fix):
 #   gh pr list --head ... --json --> empty array, exit 0
-#   git rev-parse --abbrev-ref --symbolic-full-name @{u} --> exit 0 (upstream set)
-#   git push --> exit 1, stderr captured to sidecar
+#   git push -u origin <branch> --> exit 1, stderr captured to sidecar
+#   (no rev-parse/ls-remote verify — push fails first, error short-circuits)
 prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
-prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" push      1 exit 1
 prep_git "$F/state-git" push      1 stderr 'remote: Permission denied'
 mkdir -p "$F/work"
@@ -211,8 +210,10 @@ cleanup_fixture "$F"
 F=$(new_fixture mode5)
 # pr_list returns empty (no existing PR detected at read time)
 prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
-prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" push      1 exit 0
+# Post-push verification (Issue #188 fix): rev-parse local + ls-remote remote.
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+prep_git "$F/state-git" ls-remote 1 stdout 'abc123	refs/heads/feat/x'
 # pr_create fails with "already exists" — race
 prep_gh  "$F/state-gh"  pr_create 1 exit 1
 prep_gh  "$F/state-gh"  pr_create 1 stderr 'pull request already exists for branch feat/x'
@@ -234,8 +235,9 @@ cleanup_fixture "$F"
 # ----------------------------------------------------------------------
 F=$(new_fixture mode6a)
 prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
-prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" push      1 exit 0
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+prep_git "$F/state-git" ls-remote 1 stdout 'abc123	refs/heads/feat/x'
 prep_gh  "$F/state-gh"  pr_create 1 stdout 'https://github.com/o/r/pull/abc'
 mkdir -p "$F/work"; echo "PR body" > "$F/work/body.md"
 run_sut "$F" bash "$SCRIPTS_DIR/pr-push-and-create.sh" \
@@ -251,8 +253,9 @@ cleanup_fixture "$F"
 # `gh pr view` is NOT invoked.
 F=$(new_fixture mode6b)
 prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
-prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" push      1 exit 0
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+prep_git "$F/state-git" ls-remote 1 stdout 'abc123	refs/heads/feat/x'
 prep_gh  "$F/state-gh"  pr_create 1 stdout 'https://github.com/o/r/pull/42'
 mkdir -p "$F/work"; echo "PR body" > "$F/work/body.md"
 run_sut "$F" bash "$SCRIPTS_DIR/pr-push-and-create.sh" \
@@ -373,8 +376,9 @@ cleanup_fixture "$F"
 F=$(new_fixture idem2)
 # pr_list returns existing PR
 prep_gh  "$F/state-gh"  pr_list   1 stdout '[{"number":7,"url":"https://github.com/o/r/pull/7"}]'
-prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" push      1 exit 0
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+prep_git "$F/state-git" ls-remote 1 stdout 'abc123	refs/heads/feat/x'
 mkdir -p "$F/work"; echo "PR body" > "$F/work/body.md"
 run_sut "$F" bash "$SCRIPTS_DIR/pr-push-and-create.sh" \
   --branch feat/x --base main --title 'T' --body-file "$F/work/body.md"
@@ -482,6 +486,72 @@ if [ "$SUT_RC" -eq 10 ] \
   fi
 else
   fail "[slug] branch-slash sanitized" "rc=$SUT_RC out=$SUT_OUT"
+fi
+cleanup_fixture "$F"
+
+# ----------------------------------------------------------------------
+# Issue #188 regression: pr-push-and-create.sh must push $BRANCH
+# explicitly (not bare `git push`). Pre-fix code used CWD's current
+# branch via @{u}, which silently no-opped when CWD != $BRANCH.
+# Assertion: the recorded `git push` invocation log contains the
+# explicit `-u origin <branch>` form.
+# ----------------------------------------------------------------------
+F=$(new_fixture issue188_explicit_push)
+prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
+prep_git "$F/state-git" push      1 exit 0
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+prep_git "$F/state-git" ls-remote 1 stdout 'abc123	refs/heads/feat/x'
+prep_gh  "$F/state-gh"  pr_create 1 stdout 'https://github.com/o/r/pull/77'
+mkdir -p "$F/work"; echo "PR body" > "$F/work/body.md"
+run_sut "$F" bash "$SCRIPTS_DIR/pr-push-and-create.sh" \
+  --branch feat/x --base main --title 'T' --body-file "$F/work/body.md"
+INVOCATIONS_FILE="$F/state-git/_invocations.log"
+PUSH_LINE=$(grep '^push ' "$INVOCATIONS_FILE" 2>/dev/null || echo "")
+if [ "$SUT_RC" -eq 0 ] \
+   && [[ "$PUSH_LINE" == *"-u"*"origin"*"feat/x"* ]]; then
+  pass "[issue188] pr-push-and-create always pushes \$BRANCH explicitly (-u origin <branch>)"
+else
+  fail "[issue188] pr-push-and-create explicit-branch push" "rc=$SUT_RC push_line='$PUSH_LINE'"
+fi
+cleanup_fixture "$F"
+
+# ----------------------------------------------------------------------
+# Issue #188 defense-in-depth: post-push verification catches silent
+# no-op pushes. Mock push exits 0 but ls-remote returns a different
+# (or empty) SHA — assertion: script exits 12 with CALL_ERROR_FILE.
+# ----------------------------------------------------------------------
+F=$(new_fixture issue188_verify_mismatch)
+prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
+prep_git "$F/state-git" push      1 exit 0
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+# ls-remote returns a different SHA — silent no-op simulation
+prep_git "$F/state-git" ls-remote 1 stdout 'deadbeef	refs/heads/feat/x'
+mkdir -p "$F/work"; echo "PR body" > "$F/work/body.md"
+run_sut "$F" bash "$SCRIPTS_DIR/pr-push-and-create.sh" \
+  --branch feat/x --base main --title 'T' --body-file "$F/work/body.md"
+if [ "$SUT_RC" -eq 12 ] \
+   && [[ "$SUT_OUT" =~ CALL_ERROR_FILE=([^[:space:]]+) ]] \
+   && [[ "$SUT_ERR" == *"post-push verification failed"* ]]; then
+  pass "[issue188] post-push verification catches local/remote SHA mismatch (exit 12)"
+else
+  fail "[issue188] post-push verification mismatch" "rc=$SUT_RC out=$SUT_OUT err=$SUT_ERR"
+fi
+cleanup_fixture "$F"
+
+# Companion: ls-remote returns empty (remote ref not present) — also exit 12.
+F=$(new_fixture issue188_verify_empty)
+prep_gh  "$F/state-gh"  pr_list   1 stdout '[]'
+prep_git "$F/state-git" push      1 exit 0
+prep_git "$F/state-git" rev-parse 1 stdout 'abc123'
+prep_git "$F/state-git" ls-remote 1 stdout ''
+mkdir -p "$F/work"; echo "PR body" > "$F/work/body.md"
+run_sut "$F" bash "$SCRIPTS_DIR/pr-push-and-create.sh" \
+  --branch feat/x --base main --title 'T' --body-file "$F/work/body.md"
+if [ "$SUT_RC" -eq 12 ] \
+   && [[ "$SUT_ERR" == *"post-push verification failed"* ]]; then
+  pass "[issue188] post-push verification catches empty remote ref (exit 12)"
+else
+  fail "[issue188] post-push verification empty-remote" "rc=$SUT_RC err=$SUT_ERR"
 fi
 cleanup_fixture "$F"
 

--- a/tests/test-land-pr-worktree-detect.sh
+++ b/tests/test-land-pr-worktree-detect.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# tests/test-land-pr-worktree-detect.sh — regression tests for Issue #205.
+#
+# /land-pr Step 8 (`Compose .landed`) was previously gated on
+# `--worktree-path`; when a caller omitted that arg but ran the skill
+# from inside a worktree, the marker was silently skipped. The fix
+# auto-detects worktree status from cwd via:
+#   - git rev-parse --show-toplevel
+#   - git rev-parse --git-dir != git rev-parse --git-common-dir
+#   - membership in `git worktree list --porcelain`
+#
+# This test extracts the auto-detect bash block from SKILL.md and runs
+# it against real git fixtures. Failure here means SKILL.md drifted
+# from the reference implementation and Issue #205 may have regressed.
+#
+# Cases:
+#   A. --worktree-path explicit override → WORKTREE_PATH preserved
+#   B. cwd inside a registered worktree, --worktree-path empty → auto-detected
+#   C. cwd is the main repo (not a worktree) → WORKTREE_PATH stays empty
+#   D. cwd inside a non-git directory → WORKTREE_PATH stays empty, no error
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_FILE="$REPO_ROOT/skills/land-pr/SKILL.md"
+
+PASS=0
+FAIL=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+if [ ! -f "$SKILL_FILE" ]; then
+  echo "FAIL: SKILL.md not found at $SKILL_FILE" >&2
+  exit 1
+fi
+
+# The auto-detect block we test: pulled inline rather than extracted
+# from SKILL.md, but verify that SKILL.md still contains the expected
+# anchors (regression guard against silent prose drift).
+for anchor in 'git rev-parse --show-toplevel' 'rev-parse --git-dir' 'rev-parse --git-common-dir' 'worktree list --porcelain'; do
+  if ! grep -qF "$anchor" "$SKILL_FILE"; then
+    fail "[anchor] SKILL.md missing auto-detect anchor: $anchor" "(Issue #205 regression)"
+  else
+    pass "[anchor] SKILL.md contains auto-detect anchor: $anchor"
+  fi
+done
+
+# The reference auto-detect block (must mirror SKILL.md Step 8):
+run_autodetect() {
+  local input_path="${1:-}"
+  WORKTREE_PATH="$input_path"
+  if [ -z "$WORKTREE_PATH" ]; then
+    CANDIDATE=$(git rev-parse --show-toplevel 2>/dev/null) || CANDIDATE=""
+    if [ -n "$CANDIDATE" ]; then
+      GIT_DIR=$(git -C "$CANDIDATE" rev-parse --git-dir 2>/dev/null) || GIT_DIR=""
+      GIT_COMMON_DIR=$(git -C "$CANDIDATE" rev-parse --git-common-dir 2>/dev/null) || GIT_COMMON_DIR=""
+      if [ -n "$GIT_DIR" ] && [ -n "$GIT_COMMON_DIR" ] && [ "$GIT_DIR" != "$GIT_COMMON_DIR" ]; then
+        if git -C "$CANDIDATE" worktree list --porcelain 2>/dev/null | grep -qF "worktree $CANDIDATE"; then
+          WORKTREE_PATH="$CANDIDATE"
+        fi
+      fi
+    fi
+  fi
+  printf '%s' "$WORKTREE_PATH"
+}
+
+# ---- Set up shared fixture: a fresh git repo + a worktree ----------
+FIXTURE="/tmp/land-pr-wt-detect-$$"
+rm -rf "$FIXTURE"
+mkdir -p "$FIXTURE/main-repo"
+( cd "$FIXTURE/main-repo" \
+  && git init -q -b main \
+  && git config user.email t@t \
+  && git config user.name t \
+  && echo "x" > a.txt \
+  && git add a.txt \
+  && git commit -q -m init ) || { echo "fixture init failed"; exit 1; }
+( cd "$FIXTURE/main-repo" \
+  && git worktree add -q -b feat/x "$FIXTURE/wt-feat-x" >/dev/null 2>&1 ) \
+  || { echo "worktree create failed"; exit 1; }
+
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# ---- Case A: explicit --worktree-path takes precedence (override) ---
+result=$(cd "$FIXTURE/main-repo" && run_autodetect "/some/explicit/path")
+if [ "$result" = "/some/explicit/path" ]; then
+  pass "[caseA] explicit --worktree-path is preserved (override semantics)"
+else
+  fail "[caseA] explicit-path override" "got='$result' expected='/some/explicit/path'"
+fi
+
+# ---- Case B: cwd inside registered worktree, --worktree-path empty -
+result=$(cd "$FIXTURE/wt-feat-x" && run_autodetect "")
+# Resolve symlinks for comparison (macOS /tmp -> /private/tmp; Linux is direct)
+expected=$(cd "$FIXTURE/wt-feat-x" && pwd -P)
+got=$( [ -n "$result" ] && cd "$result" && pwd -P || printf '' )
+if [ "$got" = "$expected" ] && [ -n "$result" ]; then
+  pass "[caseB] cwd inside worktree → auto-detected ($result)"
+else
+  fail "[caseB] auto-detect from worktree cwd" "got='$result' expected≈'$expected'"
+fi
+
+# ---- Case C: cwd is main repo (not a linked worktree) → empty -----
+result=$(cd "$FIXTURE/main-repo" && run_autodetect "")
+if [ -z "$result" ]; then
+  pass "[caseC] cwd is main repo → no auto-detect (no false-positive)"
+else
+  fail "[caseC] main-repo no false-positive" "got='$result' expected empty"
+fi
+
+# ---- Case D: cwd is non-git directory → empty, no error -----------
+mkdir -p "$FIXTURE/non-git"
+result=$(cd "$FIXTURE/non-git" && run_autodetect "" 2>/dev/null)
+if [ -z "$result" ]; then
+  pass "[caseD] cwd is non-git dir → no auto-detect, no error"
+else
+  fail "[caseD] non-git no false-positive" "got='$result' expected empty"
+fi
+
+echo ""
+echo "---"
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -620,6 +620,18 @@ check_fixed land-pr "pr number from url"           'PR_NUMBER="${PR_URL##*/}"'
 check       land-pr "pr number numeric check"      'PR_NUMBER" =~ \^\[0-9\]\+\$'
 check       land-pr "push error-check first-time"  'if ! git push -u origin'
 
+# --- Issue #188 regression guard: pr-push-and-create.sh must NOT use
+# bare `git push` (which silently no-ops when CWD's current branch
+# differs from $BRANCH). The push must always be `git push -u origin
+# "$BRANCH"` explicitly.
+check_not_in_file land-pr scripts/pr-push-and-create.sh \
+  "no bare git push (Issue #188)" \
+  '^[[:space:]]*git push[[:space:]]*$|^[[:space:]]*if ! git push[[:space:]]*>'
+# Companion: post-push verification via ls-remote must be present.
+check_in_file land-pr scripts/pr-push-and-create.sh \
+  "post-push verification via ls-remote (Issue #188)" \
+  'git ls-remote origin'
+
 # --- BRANCH_SLUG derivation (foundation bug fix from Phase 1A) ---
 check_fixed land-pr "BRANCH_SLUG derivation"  'BRANCH_SLUG'
 


### PR DESCRIPTION
## Summary

Bundled fix for **3 GitHub issues** (Fixes #188, Fixes #203, Fixes #205) — all touch `skills/land-pr/` and would have rebase-conflicted on `metadata.version` if separated.

**#188** — `pr-push-and-create.sh` push step pushed CWD's current branch instead of `$BRANCH`, silently no-oped, then `gh pr create` failed with "No commits between main and <branch>". Fix: always-explicit `git push -u origin "$BRANCH"` plus post-push `git ls-remote` verification (mismatch → exit 12 with `CALL_ERROR_FILE`).

**#203** — `.landed` `commits:` over-population in sequential-PR sprints. Local `$BASE_BRANCH` (= `main`) stale relative to `origin/main` after parallel auto-merges → COMMITS_LIST included unrelated squash commits of preceding PRs. Fix: change `$BASE_BRANCH` → `origin/$BASE_BRANCH` in `skills/land-pr/SKILL.md` Step 8 COMMITS_LIST composition (one-char ref change).

**#205** — `.landed` Step 8 marker write silently skipped when `--worktree-path` omitted. Fix: auto-detect from cwd via `git rev-parse --show-toplevel` + `git worktree list` membership; treat `--worktree-path` as override, not gate. Failed-quiet is now closed for orchestrator-direct dispatches.

`metadata.version` on `skills/land-pr` bumped from `2026.05.02+e41e24` → `2026.05.07+74a34a` (correct same-day-bump; comparator exits 0). Mirror regenerated.

## Test plan

- [x] **#188:** New `[issue188] pr-push-and-create always pushes $BRANCH explicitly` case in `tests/test-land-pr-scripts.sh` asserts the recorded push invocation contains `-u origin <branch>` regardless of CWD's current branch (structural invariant at the SUT-mock layer). 2 verification-failure cases (SHA mismatch, empty remote) both exit 12.
- [x] **#188:** Conformance assertion in `tests/test-skill-conformance.sh` blocks regression to bare `git push` and requires `git ls-remote origin`.
- [x] **#203:** Test gap documented (faithful reproducer requires multi-squash sequential-PR fixture, disproportionate for one-char ref change). Existing `[ -n "$COMMITS_LIST" ]` empty-guard handles edges.
- [x] **#205:** New `tests/test-land-pr-worktree-detect.sh` (8 cases): 4 anchor checks against SKILL.md prose + 4 behavioral cases — A (explicit `--worktree-path` override preserved), B (cwd inside registered worktree → auto-detected with symlink-normalized comparison), C (cwd is main repo → empty, no false-positive), D (cwd is non-git dir → empty, no error).
- [x] Full suite: 2745/2745 pass.
- [x] Mirror parity: `diff -rq skills/land-pr .claude/skills/land-pr` clean.
- [x] Three `Fixes #NNN` trailers in commit body ensure all 3 issues auto-close on merge.
