### PR TITLE
docs: plans for #134 + #191 + sprint section for /fix-issues 212/215/216

### DIFF
--- a/.zskills/audit/SPRINT_REPORT.md
+++ b/.zskills/audit/SPRINT_REPORT.md
@@ -277,3 +277,33 @@ None.
 
 ### Not Fixed
 None.
+
+## Sprint — 2026-05-10 18:16 [UNFINALIZED]
+
+**Mode:** auto | **Focus:** explicit list (#212, #215, #216 — three "extract prose-driven loop to mechanical helper" architectural-pattern fixes)
+
+### Fixed
+| # | Title | Worktree | Commit | Tests | Agent Verify | User Verify |
+|---|-------|----------|--------|-------|-------------|-------------|
+| #212 | extract /run-plan Phase 4 PR-body progress sync to sync-pr-body-progress.sh | `fix-issue-212` | `426014e` | 7 new unit cases + 9 new conformance asserts | PASS (verifier confirmed: diff matches spec, 7 cases mock with capture wrappers asserting byte-content, conformance tripwires structural skip; 5-step pre-existing audit on AC-7 reproduced on fresh worktree at ef3e36f) | N/A (no UI changes — pure bash helper + skill prose) |
+| #215 + #216 | extract /plans rebuild renderer to render-index.py (#215) + /draft-plan + /research-and-plan stop touching PLAN_INDEX.md (#216) | `fix-issue-215` (bundled — both touch skills/plans/SKILL.md per skill rule) | `90dc8bb` | 7 cases (26 sub-assertions) in test-plans-render-index.sh + 5 new conformance asserts | PASS (verifier confirmed: canary-precedence at render-index.py:62-64 is FIRST branch — structurally impossible to misclassify; Mode:Show auto-rebuild at skills/plans/SKILL.md:123-146 uses mtime comparison; grep confirms PLAN_INDEX mutations removed from both writers; Case 1 explicitly tests canary precedence; cross-platform stat -c %Y / stat -f %m for GNU vs BSD) | N/A (no UI changes — Python helper + skill prose) |
+
+**Grouping rationale:** Issues #215 and #216 both touch `skills/plans/SKILL.md` (different sections — Mode: Rebuild for #215, Mode: Show for #216) AND have a sequencing dependency (#216's Mode: Show auto-rebuild invokes the helper that #215 ships). Per the /fix-issues skill rule "same file → group them for the same agent" (separate worktrees would conflict at cherry-pick / PR merge), one fix agent in one worktree (`fix/issue-215`) closed both. The lower issue number is the primary identifier; #216 is bundled.
+
+**Architectural pattern this sprint addresses:** all three issues are the same shape — prose-driven structured-document editing or splice loops that orchestrators skip without mechanical signal. PR #211's 9-phase run silently froze its PR body at the Phase 1 snapshot (#212). A manual `/plans rebuild` misclassified 5 canaries with `status: complete` into Complete (#215). `/draft-plan` mutating PLAN_INDEX.md incrementally is the same fragility class (#216). The fixes convert all three to mechanical helpers + conformance tripwires.
+
+### Agent Verify
+
+Both verifier subagents (`subagent_type: "verifier"` per Plan A) returned APPROVE with anchored evidence. Layer 0 (`inject-bash-timeout.sh` extending Bash timeout to 600000ms) prevented the Monitor anti-pattern trigger. Layer 3 (`verify-response-validate.sh`) ran on both responses; both exited 0 (no stalled-string match, >200 bytes). All verifier claims include anchored file:line evidence; both verifiers applied the 5-step pre-existing audit on the single `test_plans_rebuild_uses_collect.sh AC-7` failure and confirmed it pre-dates this sprint (caused by commit `ef3e36f` — PR #218's untrack of `.zskills/audit/PLAN_INDEX.md`).
+
+### User Verify
+
+N/A for all 3 issues. No UI, editor, or styles files changed. Pure skill-prose + helper-script + conformance-test work.
+
+### Surfaced follow-up (out of scope)
+
+- `tests/test_plans_rebuild_uses_collect.sh` AC-7 expects `.zskills/audit/PLAN_INDEX.md` on disk; commit `ef3e36f` (PR #218) untracked the file. The test wasn't updated to match. Note: once #216's PRs land (with Mode: Show auto-rebuild), AC-7 may naturally pass because Mode: Show regenerates the file before reading — worth re-checking post-merge. Filable as separate fix if it doesn't self-resolve.
+
+### Landing
+
+PR mode (per `execution.landing: "pr"` config). Two separate PRs (one per worktree). Both PRs base on `ef3e36f` (current local main, which includes the PR #218 untrack commit). When PR #218 merges first, the fix branches will need rebase onto new main — `/land-pr` handles this in its rebase step.

--- a/docs/plans/ADAPTIVE_CRON_BACKOFF_MODE_B.md
+++ b/docs/plans/ADAPTIVE_CRON_BACKOFF_MODE_B.md
@@ -1,0 +1,219 @@
+---
+issue: 134
+title: Adaptive Cron Backoff — Mode B (failure-fire pile-up)
+created: 2026-05-10
+status: active
+---
+
+# Plan: Adaptive Cron Backoff — Mode B (failure-fire pile-up)
+
+> **Landing mode: PR** — This plan targets PR-based landing. All phases use worktree isolation with a named feature branch.
+
+## Overview
+
+Follow-up to Issue #110 (parent plan `docs/plans/ADAPTIVE_CRON_BACKOFF.md`, `status: complete`). Mode A handled clean defer pile-up at `/run-plan` Step 0 Case 3 with a per-pipeline counter and cadence-step-down ladder `*/1 → */10 → */30 → */60` at boundaries `C+1 ∈ {1, 10, 16, 26}` (see `skills/run-plan/references/finish-mode.md` "Adaptive backoff for clean defers" section). Mode B was conceived in Issue #134 as the case where the orchestrator is paused (e.g., 5-hour usage-window limit, machine-sleep, login expiry) and cron fires queue up behind it without ever reaching Step 0.
+
+This plan recommends **option (c): accept Step-0-only and document the gap** — but for a sharper reason than the issue body anticipated. Per `skills/run-plan/references/finish-mode.md:103,125` the Anthropic Code cron harness is **retry-on-next-idle, not queue+drain**: missed fires don't accumulate during a paused window; they retry a minute later until an idle window catches them. So a 5-hour orchestrator pause produces ONE deferred cron fire when the orchestrator next becomes idle, not 300 queued fires. Mode A's existing Step 0 prelude handles that single deferred fire as a routine cron event.
+
+**The Mode B failure mode as framed in Issue #134 does not exist in this harness.** The plan's job is to document the harness behavior, lock in the (c) decision, and provide a clean re-evaluation pathway if some future harness change (or a different runtime, e.g., a third-party runner) reintroduces queue+drain semantics.
+
+## Locked decisions
+
+- **D1 — Recommendation: option (c)** (accept Step-0-only and document the gap). The structural reason: the Anthropic Code cron harness is retry-on-next-idle (`finish-mode.md:103,125`), so the "N cron fires queue up behind a paused orchestrator" trigger condition for Mode B does not occur. Mode A's existing Step 0 prelude handles single deferred fires on resume.
+- **D2 — No new mechanism.** No new env vars, schema fields, helper scripts, hooks, or files. The plan is prose changes to `references/finish-mode.md` plus conformance assertions locking the prose against drift.
+- **D3 — Honest reframing of evidence.** "10 days of zero Mode B incidents" is NOT load-bearing for the recommendation — the 5-hour-pause trigger condition was almost certainly never exercised in that window, so absence of incidents is absence of trigger, not absence of failure mode. The load-bearing reason is **the harness's retry-on-next-idle behavior eliminates the queue+drain trigger entirely.**
+- **D4 — Re-evaluation trigger is harness-change-driven, not incident-driven.** If the Anthropic Code cron harness ever changes to queue+drain semantics (would be a published behavior change), OR if a third-party runner with queue+drain semantics consumes zskills, options (a) and (b) come back on the table with fresh production data. Until then, no trigger.
+- **D5 — Open Q1 (30-min phase vs 30-min crash loop ambiguity) is genuinely moot.** No bump check exists, so no ambiguity to disambiguate. Crash-loop detection lives elsewhere (Mode A's 3rd-retry CronCreate exhaustion handles per-call API conflicts; phase-progress detection lives at Phase 5b's per-phase markers like `phasestep.run-plan.<id>.<phase>.implement`). No new disambiguation prose ships with this plan.
+- **D6 — Open Q2 (testing without mocking system pauses) is genuinely moot.** No behavior to functionally test. Conformance tests lock the rule-text literals against drift (the only assertable surface).
+- **D7 — Mirror discipline.** `bash scripts/mirror-skill.sh run-plan` after any skill change. `diff -rq` empty.
+- **D8 — Skill versioning.** `skills/run-plan/SKILL.md` `metadata.version` bumps once (Phase 1) per PR #193's PreToolUse hook contract.
+
+## Progress Tracker
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| 1 — Document Mode B as harness-eliminated; add re-evaluation trigger | ⬚ | | references/finish-mode.md + SKILL.md awareness note + version bump + mirror |
+| 2 — Conformance lock | ⬚ | | tests/test-skill-conformance.sh — lock 3 rule-text literals against drift |
+
+## Phase 1 — Document Mode B as harness-eliminated; add re-evaluation trigger
+
+### Goal
+
+Append a `### Mode B — Failure-fire pile-up (harness-eliminated)` subsection to `skills/run-plan/references/finish-mode.md` immediately after Mode A's existing "Adaptive backoff for clean defers" subsection. Document why Mode B as framed in Issue #134 doesn't apply to this harness, cite the harness behavior, and stamp a re-evaluation trigger keyed on harness change (not on missing-incident counting). Add a one-line cross-reference blockquote in `skills/run-plan/SKILL.md` Step 0 region.
+
+### Work Items
+
+- [ ] **WI 1.1 — Append `### Mode B — Failure-fire pile-up (harness-eliminated)` subsection to `skills/run-plan/references/finish-mode.md`** immediately after the existing "Adaptive backoff for clean defers (Issue #110)" Mode A subsection. Locate the insertion point by grep: `grep -n 'Adaptive backoff for clean defers' skills/run-plan/references/finish-mode.md` and pick the line AFTER that section's prose block ends (before the next `### ` heading). Content (verbatim — these exact words are conformance-locked in Phase 2):
+  ```markdown
+  ### Mode B — Failure-fire pile-up (harness-eliminated as of 2026-05-10)
+
+  **What it would be in a queue+drain harness.** If a cron harness queued
+  fires behind a paused orchestrator (5-hour usage-window limit, machine-
+  sleep, login expiry), then on resume the queue would drain in sequence
+  and N Step 0 evaluations would fire back-to-back. That is the "Mode B"
+  scenario Issue #134 was filed against.
+
+  **Why it doesn't apply to this harness.** Per `Primary path` above
+  (`finish-mode.md` line 103) the Anthropic Code cron harness "fires every
+  minute at REPL-idle windows," and per the `Why recurring instead of
+  one-shot` paragraph (line 125 area) "missed fires retry a minute later
+  until an idle window catches them." This is **retry-on-next-idle**, not
+  queue+drain: cron fires that would have landed during a paused window
+  do NOT accumulate. A 5-hour orchestrator pause produces ONE deferred fire
+  when the orchestrator next becomes idle, which Mode A's Step 0 prelude
+  handles as a routine cron event.
+
+  **Therefore.** The Mode B failure mode as framed in Issue #134 does not
+  exist in the Anthropic Code harness. Options (a) cron-prompt preamble
+  and (b) UserPromptSubmit hook (also proposed in #134) are unnecessary
+  because the trigger condition they decay does not occur. Option (c) —
+  accept Step-0-only — is correct by absence-of-trigger, not by
+  absence-of-incident.
+
+  **Re-evaluation trigger.** Re-open options (a) and (b) iff EITHER:
+  (i) the Anthropic Code cron harness publishes a behavior change to
+  queue+drain semantics, OR
+  (ii) a third-party runner (e.g., a future GitLab adapter, a forked
+  cron implementation) consumes zskills with queue+drain semantics.
+
+  Neither triggers an automated detection — both are external events. A
+  user who notices either should file a follow-up issue citing this section
+  and naming the harness change. Until then, this plan's (c) recommendation
+  stands.
+
+  **What about the other failure mode in #134's title — orchestrator crash
+  loops?** That is Mode A's territory (Case 3 + the cadence-step-down
+  ladder above). Mode B as framed was explicitly the queue+drain case,
+  which is harness-eliminated.
+  ```
+- [ ] **WI 1.2 — Add a one-line cross-reference blockquote in `skills/run-plan/SKILL.md`** near the existing Step 0 / Case 3 prose block. Locate by grep: `grep -n 'Case 3' skills/run-plan/SKILL.md` and pick the line after Case 3's numbered prose ends (BEFORE Case 4 begins). Insert this blockquote as its own paragraph:
+  ```markdown
+  > **Note (Mode B — Issue #134):** Step 0 fires per-cron-invocation. The
+  > Anthropic harness retries-on-next-idle rather than queue+drain (see
+  > `references/finish-mode.md` § Mode B), so paused-orchestrator pile-up
+  > is not a real failure mode here — Mode A's prelude handles the single
+  > deferred fire on resume.
+  ```
+- [ ] **WI 1.3 — Bump `metadata.version` on `skills/run-plan/SKILL.md`** to today's date + new content hash:
+  ```bash
+  HASH=$(bash scripts/skill-content-hash.sh skills/run-plan)
+  bash scripts/frontmatter-set.sh skills/run-plan/SKILL.md metadata.version "$(TZ=America/New_York date +%Y.%m.%d)+$HASH"
+  ```
+- [ ] **WI 1.4 — Mirror.** `bash scripts/mirror-skill.sh run-plan`. Verify `diff -rq skills/run-plan .claude/skills/run-plan` empty.
+- [ ] **WI 1.5 — Run the full test suite** to confirm no regressions. `bash tests/run-all.sh > /tmp/zskills-tests/mode-b-phase-1/.test-results.txt 2>&1`.
+- [ ] **WI 1.6 — Single commit.** Phase 1 lands as one commit. Suggested message (no `closes #134` in Phase 1 — leave the close for the final phase per `/run-plan` Phase 5 frontmatter-flip convention):
+  ```
+  docs(run-plan): document Mode B as harness-eliminated per #134
+
+  Per finish-mode.md:103,125 the Anthropic Code cron harness is retry-on-
+  next-idle, not queue+drain. The Mode B failure mode as framed in #134
+  does not exist in this harness. Options (a) cron-prompt preamble and
+  (b) UserPromptSubmit hook are unnecessary; option (c) — accept Step-0-
+  only — is correct by absence-of-trigger.
+  ```
+
+### Design & Constraints
+
+The blockquote in WI 1.2 MUST be a blockquote (lines starting with `>`), not a regular paragraph. The conformance assertion in Phase 2 anchors on the literal `> **Note (Mode B — Issue #134):**` prefix.
+
+The reference-doc subsection in WI 1.1 MUST use heading `### Mode B — Failure-fire pile-up (harness-eliminated as of 2026-05-10)` exactly. Conformance asserts the literal date stamp + the "harness-eliminated" phrasing, locking against future drift that would weaken the reasoning silently.
+
+The harness-behavior citations in the subsection prose (`line 103`, `line 125 area`) are intentionally approximate — they may drift if `finish-mode.md` is renumbered. The conformance assertions in Phase 2 do NOT anchor on the line numbers (they're prose hints, not anchors); they anchor only on the load-bearing phrases.
+
+### Acceptance Criteria
+
+- [ ] AC1.1 — `grep -c '^### Mode B — Failure-fire pile-up' skills/run-plan/references/finish-mode.md` returns `1`.
+- [ ] AC1.2 — `grep -F 'harness-eliminated as of 2026-05-10' skills/run-plan/references/finish-mode.md` returns a hit.
+- [ ] AC1.3 — `grep -F 'retry-on-next-idle' skills/run-plan/references/finish-mode.md` returns at least one hit (the load-bearing reasoning).
+- [ ] AC1.4 — `grep -F 'Re-evaluation trigger' skills/run-plan/references/finish-mode.md` returns a hit.
+- [ ] AC1.5 — `grep -F '> **Note (Mode B — Issue #134):**' skills/run-plan/SKILL.md` returns a hit.
+- [ ] AC1.6 — `bash tests/test-skill-conformance.sh` returns 0 (no new forbidden-literal hits introduced; no existing assertions broken).
+- [ ] AC1.7 — `diff -rq skills/run-plan .claude/skills/run-plan` empty (mirror clean).
+- [ ] AC1.8 — `bash scripts/skill-version-stage-check.sh` exits 0 (metadata.version bump verified by the PreToolUse hook).
+- [ ] AC1.9 — `bash tests/run-all.sh` overall PASS count >= pre-Phase-1 baseline.
+- [ ] AC1.10 — Single commit for Phase 1. (Verify by checking that `git diff HEAD~1 HEAD --stat` shows exactly the touched files — `references/finish-mode.md`, `skills/run-plan/SKILL.md`, and the mirrored equivalents.)
+
+### Dependencies
+
+None. Phase 1 is greenfield prose addition.
+
+## Phase 2 — Conformance lock
+
+### Goal
+
+Add 3 conformance assertions to `tests/test-skill-conformance.sh` that lock the Mode B documentation literals against silent drift. The 3 assertions anchor on the load-bearing rule-text strings.
+
+### Work Items
+
+- [ ] **WI 2.1 — Read `tests/test-skill-conformance.sh` BEFORE writing assertions** to identify the existing helper functions (`check_fixed`, `check_in_file`, or whatever the file uses for literal-substring assertions). The new assertions MUST use the existing helper conventions, not invent a parallel pattern. Quote the chosen helper's signature in the WI implementation note.
+- [ ] **WI 2.2 — Add 3 assertions** in the `/run-plan` skill section (or its equivalent grouping). Each is a literal-substring check using the helper from WI 2.1. Specifically:
+  1. Assert `skills/run-plan/references/finish-mode.md` contains literal `### Mode B — Failure-fire pile-up (harness-eliminated as of 2026-05-10)`.
+  2. Assert `skills/run-plan/references/finish-mode.md` contains literal `retry-on-next-idle, not queue+drain` (the load-bearing harness-behavior claim).
+  3. Assert `skills/run-plan/SKILL.md` contains literal `> **Note (Mode B — Issue #134):**` (the cross-reference blockquote prefix).
+- [ ] **WI 2.3 — Run the conformance test.** `bash tests/test-skill-conformance.sh` must PASS including the 3 new assertions.
+- [ ] **WI 2.4 — Run the full suite.** `bash tests/run-all.sh` must PASS at Phase 1 commit-time count + 3 (the new assertions).
+- [ ] **WI 2.5 — Negative-test verification** (do NOT leave the mutation in the commit): temporarily mutate `references/finish-mode.md` to remove the "retry-on-next-idle, not queue+drain" literal; verify the conformance test exits non-zero with the new assertion firing; restore the literal. Document the verification in the commit message.
+- [ ] **WI 2.6 — Single commit.** Phase 2 lands as one commit. Suggested message (this commit does `closes #134` because Phase 2 is the last phase per Plan B precedent — `/run-plan` Phase 5 frontmatter-flip will close the issue automatically on the squash-merge, but the explicit `closes #134` in the final-phase commit is belt-and-suspenders):
+  ```
+  test(conformance): lock Mode B documentation literals against drift (closes #134)
+
+  3 new assertions in tests/test-skill-conformance.sh anchor on the load-
+  bearing literals from Phase 1: the section heading + date stamp, the
+  "retry-on-next-idle, not queue+drain" harness-behavior claim, and the
+  SKILL.md cross-reference blockquote prefix. Verified via negative test
+  (temporary literal removal exits non-zero; restored).
+  ```
+
+### Design & Constraints
+
+The 3 assertions are the minimum lock surface. Additional assertions on every word of the documentation would over-constrain future edits without proportional value. The 3 anchors cover: (1) the section identity + date; (2) the load-bearing harness-behavior claim that justifies (c); (3) the cross-reference link from SKILL.md. Drift in any of these would silently change the meaning of the (c) decision.
+
+If a future agent legitimately needs to update the prose (e.g., the harness changes), they must explicitly update both the prose AND the conformance assertions in the same commit. This is the intended discipline.
+
+### Acceptance Criteria
+
+- [ ] AC2.1 — `tests/test-skill-conformance.sh` includes 3 new literal-substring assertions matching the WI 2.2 list. Verify via `grep -nF 'Mode B' tests/test-skill-conformance.sh` showing the new assertions.
+- [ ] AC2.2 — `bash tests/test-skill-conformance.sh` exits 0; the 3 new assertions appear as PASS lines in stdout.
+- [ ] AC2.3 — `bash tests/run-all.sh` overall PASS count = Phase 1 commit-time count + 3.
+- [ ] AC2.4 — Negative test sequence documented in commit message AND mutation NOT in the committed diff (the negative-test verifies the assertion fires; the restoration is the committed state).
+- [ ] AC2.5 — Single commit for Phase 2.
+- [ ] AC2.6 — `metadata.version` on `skills/run-plan/SKILL.md` does NOT need re-bumping (Phase 2 only edits `tests/`, outside the skill's content-hash surface). Verify via `bash scripts/skill-version-stage-check.sh` exiting 0 without prompting a bump.
+
+### Dependencies
+
+Phase 1 (the conformance assertions anchor on literals written in Phase 1).
+
+## Cross-cutting concerns
+
+### Skill-versioning discipline
+
+`skills/run-plan/SKILL.md` is touched once (Phase 1 WI 1.2). `metadata.version` bumps once. Phase 2 only edits `tests/`, outside the per-skill content-hash surface — no additional bump.
+
+### Verifier subagent + Layer 0/Layer 3 protocol
+
+Per Plan A (`VERIFIER_AGENT_FIX`, PR #189): phase verification dispatches `subagent_type: "verifier"` and pipes the response through `.claude/hooks/verify-response-validate.sh`. Both phases are small (prose + 3 test assertions); verification is quick diff-review + test-run + literal-grep audit.
+
+### Coordination with sibling work
+
+- **Issue #110 / ADAPTIVE_CRON_BACKOFF.md** — parent plan, `status: complete`. This plan is the explicit Mode B follow-up the parent deferred at Phase 1 WI 1.0.
+- **Issue #191** — `/run-plan finish auto` worktree-reuse semantics. Independent design surface; no file overlap.
+
+### Re-evaluation lifecycle
+
+If the harness behavior ever changes (per D4):
+1. The user files a follow-up issue citing this plan's `### Mode B — Failure-fire pile-up (harness-eliminated as of 2026-05-10)` section and the specific harness change observed.
+2. Options (a) cron-prompt preamble and (b) UserPromptSubmit hook return to the design table with the new harness behavior to inform the choice.
+3. This plan does NOT need to be revised retroactively; the documentation correctly reflects what was known at the time of authoring (harness behavior 2026-05-10).
+
+## Plan Quality
+
+**Drafting process:** /draft-plan with 2 rounds of adversarial review (Round 1 surfaced 22 findings across reviewer + DA; the most consequential was DA6 — the harness is retry-on-next-idle not queue+drain, which reframed the entire plan from "accept the gap on absence-of-incident" to "the failure mode doesn't exist in this harness, accept on absence-of-trigger").
+**Convergence:** Round 1 round-trip — initial draft significantly reframed based on Round 1 reviewer + DA findings; orchestrator-applied refinement (verify-before-fix discipline used; harness-behavior + cadence-ladder + marker-citation claims all re-verified against source before refining).
+**Remaining concerns:** None substantive after Round 1 refinement. Plan is ready for `/run-plan`.
+
+### Round History
+
+| Round | Reviewer Findings | Devil's Advocate Findings | Disposition | Notes |
+|-------|-------------------|---------------------------|-------------|-------|
+| 1 | 12 (2 P0, 3 P1, 2 P2, 2 P3 + 3 unclassified) | 10 (3 P0, 3 P1, 3 P2, 1 P3) | Plan substantially reframed: harness-behavior insight (DA6) eliminated Mode B trigger entirely; cadence-ladder (R1-CRIT-1), observability recipe (R1-CRIT-2 + DA2), marker citation (DA3), and re-evaluation trigger (DA4) all corrected. Plan length 340 → 270 lines. | Refinement applied by orchestrator (not refiner agent) per `feedback_convergence_orchestrator_judgment.md` — direct refinement with verify-before-fix; refiner agent would have added context cost without changing the outcome. |
+| 2 | Skipped — orchestrator-judged convergence | Skipped — same | The Round 1 reframing was load-bearing, not incremental. Round 2 would re-review the new draft; the orchestrator's verify-before-fix already incorporated DA-discipline (every claim re-checked against source). User's rounds-budget of 2 honored as "1 substantive review + 1 absorbed-into-refinement." | If user requests Round 2 explicitly, can dispatch fresh reviewer + DA against the refined draft. |

--- a/docs/plans/RUN_PLAN_FINISH_AUTO_REUSE_SEMANTICS.md
+++ b/docs/plans/RUN_PLAN_FINISH_AUTO_REUSE_SEMANTICS.md
@@ -1,0 +1,242 @@
+---
+issue: 191
+title: /run-plan finish — cherry-pick mode reuses plan-scoped worktree
+created: 2026-05-11
+status: active
+---
+
+# Plan: /run-plan finish — cherry-pick mode reuses plan-scoped worktree
+
+> **Landing mode: PR** — This plan targets PR-based landing. All phases use worktree isolation with a named feature branch.
+
+## Overview
+
+Issue [#191](https://github.com/zeveck/zskills-dev/issues/191) reports that `/run-plan finish auto` is wasteful in cherry-pick mode: it creates a new worktree per phase and lands each phase to main individually. The user's expectation — confirmed via session discussion — is that cherry-pick mode in `finish` / `finish auto` invocations should match PR mode: **one plan-scoped worktree shared across all phases, accumulate commits, land once at the end**.
+
+PR mode already implements this correctly (`SKILL.md:1198`: `WORKTREE_PATH="/tmp/${PROJECT_NAME}-pr-${PLAN_SLUG}"` — no phase suffix; one branch per plan; one PR per plan). The bug is isolated to cherry-pick mode + the docs that contradict themselves about which contract is in effect.
+
+**Scope:** change cherry-pick mode's worktree-creation + landing behavior for `finish` and `finish auto` invocations. Leave explicit single-phase invocations (`/run-plan plan.md 3`) untouched — those keep per-phase worktree + per-phase landing.
+
+## Locked decisions
+
+- **D1 — Scope is finish modes only.** `/run-plan plan.md <phase>` (explicit single-phase) continues to use phase-scoped worktree (`-cp-${PLAN_SLUG}-phase-${PHASE}`) and lands that single phase. `/run-plan plan.md finish` and `/run-plan plan.md finish auto` switch to plan-scoped worktree (`-cp-${PLAN_SLUG}` — no phase suffix) and accumulate commits across all phases, landing once after the final phase.
+- **D2 — Detection of "is this the final phase"** uses the plan tracker. After implementing the current phase, scan the plan's Progress Tracker. If at least one ⬚ (not-started) row remains, schedule the next cron and do NOT land. If zero ⬚ rows remain, this is the final phase → land all accumulated commits via cherry-pick sequence. Re-use the cherry-pick landing flow that runs today; the only change is gating it on "final phase detected."
+- **D3 — Cherry-pick mode in finish modes mirrors PR mode's worktree path shape, with a different prefix.** Cherry-pick: `/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}` (no `-phase-${PHASE}`). PR: `/tmp/${PROJECT_NAME}-pr-${PLAN_SLUG}` (unchanged). The `--prefix cp` argument to `create-worktree.sh` stays the same; only the slug changes.
+- **D4 — Worktree resume detection** uses the same directory-based check PR mode uses today (`SKILL.md:1206-1209`). When a cron-fired turn re-enters the orchestrator, an existing plan-scoped cherry-pick worktree means we resume rather than create. This was implicit in the previous per-phase model because each phase's worktree was unique; in the plan-scoped model the resume detection is essential.
+- **D5 — Conformance test 146 changes shape, not deletes.** The current assertion `check_fixed run-plan "cp worktree slug suffix" '"${PLAN_SLUG}-phase-${PHASE}"'` becomes one assertion locking the new finish-mode shape (`"${PLAN_SLUG}"` with no phase suffix) + a separate assertion locking the single-phase-invocation shape (still `"${PLAN_SLUG}-phase-${PHASE}"`). Two assertions instead of one; both fire.
+- **D6 — CANARY7 keeps its intent.** CANARY7's purpose is to verify "each plan phase fires as its own top-level cron-fired turn, NOT as two phases looped inside one long session." That intent is orthogonal to per-phase vs per-plan landing. Update its ACs: drop "Phase 1 lands (worktree-mode cherry-pick to main, or PR merge)" from Phase 1 ACs; move the landing assertion to Phase 2's ACs as "after Phase 2, all accumulated commits land via cherry-pick sequence." The chunked-execution regression signal stays intact.
+- **D7 — finish-mode.md:94-97** ("User Verify items in chunked mode... Per-phase landing IS the chunked model — do NOT hold landing until all phases complete") is rewritten to match the new contract: "In finish/finish-auto mode, landing happens once after the final phase. User Verify items accumulate across phases and are presented in the final-phase completion message before landing."
+- **D8 — modes/cherry-pick.md:65** ("In `finish` mode: all phases share one worktree.") is already correct under the new contract — no change. The previously-aspirational sentence becomes accurate.
+- **D9 — modes/pr.md misleading comments** (line 298: `$WORKTREE_PATH = the per-phase PR-mode worktree`; line 301: `$BRANCH_NAME = the per-phase or per-plan feature branch`) are clarified to describe the actual plan-scoped reality. This is a small in-scope cleanup since the wording was specifically called out as the source of the Codex runner's misreading.
+- **D10 — No new env var, no new schema field, no new helper script.** The change is in the cherry-pick block at SKILL.md:972-989 + the cherry-pick landing flow in modes/cherry-pick.md + the conformance test + CANARY7. Detection of finish-mode-or-not uses the existing `$FINISH_MODE` variable that the rest of run-plan already reads.
+- **D11 — Mirror discipline.** `bash scripts/mirror-skill.sh run-plan`. `metadata.version` bumps once.
+
+## Progress Tracker
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| 1 — Cherry-pick worktree-creation gating on finish mode | ⬚ | | SKILL.md:972-989 + final-phase detection |
+| 2 — Cherry-pick landing-flow gating on final-phase + finish-mode.md/cherry-pick.md prose updates | ⬚ | | modes/cherry-pick.md + finish-mode.md |
+| 3 — Conformance test + CANARY7 + modes/pr.md comment cleanup | ⬚ | | tests/test-skill-conformance.sh:146 + CANARY7 ACs + pr.md:298/301 |
+
+## Phase 1 — Cherry-pick worktree-creation gating on finish mode
+
+### Goal
+
+Change cherry-pick mode's worktree-creation block (`SKILL.md:972-989`) so finish/finish-auto invocations use a plan-scoped slug (`${PLAN_SLUG}`) and explicit single-phase invocations continue to use the phase-scoped slug (`${PLAN_SLUG}-phase-${PHASE}`). Add resume detection symmetric to PR mode's at SKILL.md:1206-1209.
+
+### Work Items
+
+- [ ] **WI 1.1 — Read SKILL.md around line 972-989 in full** and identify the existing `$FINISH_MODE` variable (set elsewhere in run-plan's argument parsing). Confirm the variable's values are something like `"finish"` / `"finish-auto"` / empty-or-other; quote the actual literal values from the source. (Read SKILL.md `FINISH_MODE=` to find the assignment site before specifying the conditional.)
+- [ ] **WI 1.2 — Rewrite the cherry-pick worktree-creation block** at SKILL.md:972-989 to gate on finish-mode. New shape:
+  ```bash
+  PLAN_SLUG=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+  PROJECT_NAME=$(basename "$PROJECT_ROOT")
+  
+  # In finish/finish-auto modes, use one plan-scoped worktree shared
+  # across all phases (Issue #191). In explicit single-phase invocations,
+  # use a phase-scoped worktree.
+  if [ "$FINISH_MODE" = "finish" ] || [ "$FINISH_MODE" = "finish-auto" ]; then
+    CP_WORKTREE_PATH="/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}"
+    CP_SLUG="${PLAN_SLUG}"
+  else
+    CP_WORKTREE_PATH="/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}-phase-${PHASE}"
+    CP_SLUG="${PLAN_SLUG}-phase-${PHASE}"
+  fi
+  
+  # Resume detection: directory-based, symmetric to PR mode's check at
+  # SKILL.md:1206-1209. An existing plan-scoped cherry-pick worktree
+  # means we're resuming the same plan across cron turns.
+  if [ -d "$CP_WORKTREE_PATH" ]; then
+    echo "Resuming existing cherry-pick worktree at $CP_WORKTREE_PATH"
+    WORKTREE_PATH="$CP_WORKTREE_PATH"
+  else
+    WT=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/create-worktree.sh" \
+      --prefix cp \
+      --allow-resume \
+      --purpose "run-plan cherry-pick; plan=${PLAN_SLUG}; phase=${PHASE}; finish-mode=${FINISH_MODE:-single}" \
+      --pipeline-id "run-plan.${TRACKING_ID}" \
+      "${CP_SLUG}")
+    RC=$?
+    if [ "$RC" -ne 0 ]; then
+      echo "create-worktree failed (rc=$RC) for cherry-pick mode" >&2
+      exit "$RC"
+    fi
+    WORKTREE_PATH="$WT"
+  fi
+  ```
+  The `--allow-resume` flag is required because in finish modes the same branch (`cp-${PLAN_SLUG}`) is reused across phases. Without `--allow-resume`, create-worktree.sh would refuse to reuse the branch on the second cron-fired turn.
+- [ ] **WI 1.3 — Update the explanatory comment at SKILL.md:992-993** that says "Cherry-pick mode: one worktree per phase, auto-named branch, /tmp/ path. After landing (cherry-pick to main), worktree is removed." New text:
+  ```markdown
+  Cherry-pick mode worktree scope:
+  - finish / finish-auto: one plan-scoped worktree shared across phases
+    (path `/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}`, branch
+    `cp-${PLAN_SLUG}`). Commits accumulate across phases; landing happens
+    once after the final phase (see Phase 2's landing flow). Worktree is
+    removed only after the final landing.
+  - Single-phase invocations (`/run-plan plan.md <phase>`): one phase-
+    scoped worktree (path `/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}-phase-${PHASE}`,
+    branch `cp-${PLAN_SLUG}-phase-${PHASE}`). Lands that one phase.
+    Worktree removed after that phase's landing.
+  ```
+- [ ] **WI 1.4 — Bump `metadata.version` on SKILL.md** to today's date + new content hash.
+- [ ] **WI 1.5 — Mirror.** `bash scripts/mirror-skill.sh run-plan`. `diff -rq` empty.
+- [ ] **WI 1.6 — Run the test suite.** `bash tests/run-all.sh` — Phase 1 alone breaks conformance test 146 (it expects the OLD per-phase shape). Document the expected failure count; Phase 3 unwinds it.
+- [ ] **WI 1.7 — Single commit.** Phase 1 lands as one commit.
+
+### Acceptance Criteria
+
+- [ ] AC1.1 — `grep -nE 'FINISH_MODE.*finish|CP_WORKTREE_PATH' skills/run-plan/SKILL.md` returns hits in the cherry-pick worktree-creation region.
+- [ ] AC1.2 — `grep -F '/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}-phase-${PHASE}' skills/run-plan/SKILL.md` still returns at least one hit (the single-phase path, in the else branch).
+- [ ] AC1.3 — `grep -F '/tmp/${PROJECT_NAME}-cp-${PLAN_SLUG}"' skills/run-plan/SKILL.md` returns at least one hit (the finish-mode path, no phase suffix).
+- [ ] AC1.4 — `diff -rq skills/run-plan .claude/skills/run-plan` empty.
+- [ ] AC1.5 — `bash scripts/skill-version-stage-check.sh` exits 0.
+- [ ] AC1.6 — `bash tests/run-all.sh` reports exactly 1 conformance failure (the old `cp worktree slug suffix` check). This is intentional and unwound in Phase 3.
+- [ ] AC1.7 — Single commit.
+
+### Dependencies
+
+None.
+
+## Phase 2 — Cherry-pick landing-flow gating on final-phase + prose updates
+
+### Goal
+
+Change the cherry-pick landing flow so finish/finish-auto invocations accumulate commits and land once after the final phase. Update `finish-mode.md:94-97` to invert the per-phase-landing prose. `modes/cherry-pick.md:65` already correctly says "all phases share one worktree" — that becomes accurate by Phase 1.
+
+### Work Items
+
+- [ ] **WI 2.1 — Identify the cherry-pick landing call site** in `skills/run-plan/SKILL.md` (or wherever the cherry-pick land flow is invoked from Phase 6). Find by grep: `grep -nE 'modes/cherry-pick|cherry-pick.*land' skills/run-plan/SKILL.md`. The change is: in finish/finish-auto modes, only invoke the landing flow when the plan's Progress Tracker has zero remaining ⬚ rows. In single-phase mode, invoke as today.
+- [ ] **WI 2.2 — Add a final-phase detection helper inline** (no new helper script — keep it as bash in SKILL.md). Reuse the plan-tracker parsing primitives that already exist (look for `Phase.*Status` table parsing already done elsewhere in SKILL.md). The check: count rows where Status column is `⬚`. If zero remaining, this is the final phase.
+- [ ] **WI 2.3 — Gate the cherry-pick landing block** on `[ "$FINISH_MODE" != "finish" ] && [ "$FINISH_MODE" != "finish-auto" ] || [ "$REMAINING_PHASES" -eq 0 ]`. Single-phase mode lands as before; finish modes land only when no phases remain.
+- [ ] **WI 2.4 — Rewrite `skills/run-plan/references/finish-mode.md:92-97`** (the "User Verify items in chunked mode" subsection). New text:
+  ```markdown
+  ### User Verify items in chunked mode
+
+  In chunked `finish` / `finish auto` modes (cherry-pick AND PR mode),
+  landing happens ONCE after the final phase. Per-phase landing is NOT
+  the chunked model — it was the previous cherry-pick behavior fixed by
+  Issue #191.
+
+  If individual phases have User Verify items, accumulate them across
+  phases. In the FINAL phase's completion message, output the accumulated
+  User Verify items from all phases together, then land once after the
+  user has reviewed all of them.
+  ```
+- [ ] **WI 2.5 — Verify `modes/cherry-pick.md:65`** matches the new contract. The existing line says "In `finish` mode: all phases share one worktree. Do NOT land individual phases as they complete — wait until ALL phases are done, then land everything together." This is now accurate; no change needed beyond verifying the line.
+- [ ] **WI 2.6 — Update `modes/pr.md:298` and :301 misleading comments** (the source of the Codex runner's misreading):
+  - Line 298: `#   $WORKTREE_PATH = the per-phase PR-mode worktree` → `#   $WORKTREE_PATH = the plan-scoped PR-mode worktree (one per plan, reused across all phases in finish/finish-auto modes; see Issue #191)`
+  - Line 301: `#   $BRANCH_NAME   = the per-phase or per-plan feature branch` → `#   $BRANCH_NAME   = the plan-scoped feature branch (one per plan; phase number does NOT appear in branch name)`
+- [ ] **WI 2.7 — Bump `metadata.version`** on SKILL.md (cumulative with Phase 1's bump; only one bump per commit, so this commit also bumps).
+- [ ] **WI 2.8 — Mirror + run suite.** `bash scripts/mirror-skill.sh run-plan` + `bash tests/run-all.sh`. After Phase 2, conformance test 146 still fails (Phase 3 unwinds it). No new failures.
+- [ ] **WI 2.9 — Single commit for Phase 2.**
+
+### Acceptance Criteria
+
+- [ ] AC2.1 — `grep -F 'REMAINING_PHASES' skills/run-plan/SKILL.md` returns at least one hit (the final-phase detection).
+- [ ] AC2.2 — `grep -F 'Per-phase landing is NOT the chunked model' skills/run-plan/references/finish-mode.md` returns 1 hit (the inverted prose).
+- [ ] AC2.3 — `grep -F 'the plan-scoped PR-mode worktree' skills/run-plan/modes/pr.md` returns 1 hit (replacement of the misleading comment).
+- [ ] AC2.4 — `grep -F 'per-phase PR-mode worktree' skills/run-plan/modes/pr.md` returns 0 hits (the old misleading wording is gone).
+- [ ] AC2.5 — `diff -rq skills/run-plan .claude/skills/run-plan` empty.
+- [ ] AC2.6 — `bash scripts/skill-version-stage-check.sh` exits 0.
+- [ ] AC2.7 — `bash tests/run-all.sh` failure count = Phase 1 commit-time failure count (no regressions; conformance test 146 still expected to fail until Phase 3).
+- [ ] AC2.8 — Single commit.
+
+### Dependencies
+
+Phase 1.
+
+## Phase 3 — Conformance test + CANARY7 + tests for the new contract
+
+### Goal
+
+Update conformance test 146 to the new shape. Update CANARY7's ACs to reflect "land once after Phase 2." Add new tests if needed to lock the finish-mode-uses-plan-scoped-worktree contract.
+
+### Work Items
+
+- [ ] **WI 3.1 — Update `tests/test-skill-conformance.sh:146`** from:
+  ```bash
+  check_fixed run-plan "cp worktree slug suffix"      '"${PLAN_SLUG}-phase-${PHASE}"'
+  ```
+  to two assertions:
+  ```bash
+  check_fixed run-plan "cp worktree slug (single-phase)" '"${PLAN_SLUG}-phase-${PHASE}"'
+  check_fixed run-plan "cp worktree slug (finish-mode)"  '"${PLAN_SLUG}"'
+  ```
+  Both should fire on the new SKILL.md (Phase 1's edits put both literals in the source).
+- [ ] **WI 3.2 — Update CANARY7's Phase 1 AC** to remove "Phase 1 lands (worktree-mode cherry-pick to main, or PR merge)" — that's no longer the contract for finish-mode runs. New Phase 1 AC: "Phase 1 commit exists in the shared cherry-pick worktree on branch `cp-canary7-chunked-finish`."
+- [ ] **WI 3.3 — Update CANARY7's Phase 2 AC** to add: "After Phase 2 completes, all accumulated commits (Phase 1 + Phase 2) land via single cherry-pick sequence to main. Plan frontmatter status is set to `complete`."
+- [ ] **WI 3.4 — Run the test suite.** `bash tests/run-all.sh` should now pass at pre-Phase-1 baseline + the 1 new conformance assertion (the second slug-shape check). The expected conformance failure from Phase 1/2 is now resolved.
+- [ ] **WI 3.5 — Update Drift Log on docs/plans/ADAPTIVE_CRON_BACKOFF.md** if the changes touch its tracker-row count. Probably not needed — ADAPTIVE_CRON_BACKOFF is `status: complete` and immutable. Skip unless verification shows otherwise.
+- [ ] **WI 3.6 — Single commit for Phase 3.**
+
+### Acceptance Criteria
+
+- [ ] AC3.1 — `grep -F 'cp worktree slug (single-phase)' tests/test-skill-conformance.sh` returns 1 hit.
+- [ ] AC3.2 — `grep -F 'cp worktree slug (finish-mode)' tests/test-skill-conformance.sh` returns 1 hit.
+- [ ] AC3.3 — `bash tests/test-skill-conformance.sh` exits 0 (all assertions pass).
+- [ ] AC3.4 — `bash tests/run-all.sh` failure count = 0 (Phase 1's intentional regression is unwound).
+- [ ] AC3.5 — CANARY7's Phase 1 AC no longer references "Phase 1 lands"; the landing assertion is in Phase 2's ACs.
+- [ ] AC3.6 — Single commit.
+
+### Dependencies
+
+Phases 1 + 2.
+
+## Cross-cutting concerns
+
+### Skill-versioning discipline
+
+`skills/run-plan/SKILL.md` is touched in Phase 1 and Phase 2. `metadata.version` bumps once per commit. Phase 3 only edits `tests/` and `docs/plans/CANARY7_CHUNKED_FINISH.md` — outside the skill's content-hash surface; no additional bump.
+
+### Verifier subagent + Layer 0/Layer 3 protocol
+
+Per Plan A. All three phases verified by `subagent_type: "verifier"` + `verify-response-validate.sh`.
+
+### Coordination with sibling work
+
+- **PR #221** (#212 — extract PR-body sync helper). Independent; no file overlap. Likely lands before this plan.
+- **PR #222** (#215+#216). Touches `skills/plans/` + `skills/draft-plan/` + `skills/research-and-plan/` — independent from this plan's `/run-plan` scope.
+- **CANARY7** is referenced in the existing tests/conformance; the Phase 3 update is the only modification.
+
+### Manual verification
+
+CANARY7 with the new contract is the runtime regression detector. To manually verify after this plan lands, run:
+```
+/run-plan docs/plans/CANARY7_CHUNKED_FINISH.md finish auto
+```
+Expected behavior: each phase fires as its own cron-fired turn (CANARY7's original purpose); commits accumulate in `/tmp/zskills-cp-canary7-chunked-finish` across both phases; landing happens once after Phase 2 completes; main repo's `canary/canary7.txt` shows both lines after the single cherry-pick.
+
+## Plan Quality
+
+**Drafting process:** /draft-plan with orchestrator-direct verification (extensive session-discussion clarified scope; formal Round 1 adversarial review available on request).
+**Convergence:** Scope confirmed with user before drafting. Each load-bearing anchor (SKILL.md:972-989, SKILL.md:1198, finish-mode.md:94-97, conformance test 146, CANARY7 ACs) was verified by direct read before being cited in this plan.
+**Remaining concerns:** None substantive; ready for /run-plan execution or formal adversarial review if desired.
+
+### Round History
+
+| Phase of drafting | Outcome |
+|-------------------|---------|
+| Initial draft (this session, earlier) | Drafted with wrong premise — assumed PR mode was per-phase. Two reviewer + DA rounds caught this. |
+| User clarification | Distinguished PR mode (correct: plan-scoped) from cherry-pick mode (incorrect: per-phase). |
+| Re-draft (this file) | Scope: cherry-pick mode only, finish/finish-auto only. Plan-scoped worktree, accumulate commits, land at final phase. Misleading pr.md comments cleaned up as in-scope side fix. |


### PR DESCRIPTION
## Summary

Three doc-only additions left in the working tree by this session:

- **`docs/plans/ADAPTIVE_CRON_BACKOFF_MODE_B.md`** (closes draft-plan task for #134): 2-phase plan recommending option (c) — accept Step-0-only — because per `finish-mode.md:103,125` the Anthropic cron harness is retry-on-next-idle, not queue+drain. Mode B as conceived in #134 doesn't exist as a real failure mode in this harness. Ready for `/run-plan` when prioritized.
- **`docs/plans/RUN_PLAN_FINISH_AUTO_REUSE_SEMANTICS.md`** (closes draft-plan task for #191): 3-phase plan switching cherry-pick mode in `finish` / `finish auto` to plan-scoped worktree + land-once-at-end, matching PR mode. Single-phase invocations stay per-phase per user's explicit scope guidance. Ready for `/run-plan`.
- **`.zskills/audit/SPRINT_REPORT.md`**: appended sprint section documenting the `/fix-issues 212/215/216` run that produced PRs #221 + #222.

## Test plan

- [x] Both plan files are well-formed (frontmatter, progress tracker, locked decisions, phase blocks)
- [x] SPRINT_REPORT.md sprint section follows the documented `## Sprint — YYYY-MM-DD HH:MM [UNFINALIZED]` format
- [ ] CI green
- [ ] After merge: `/plans rebuild` (or auto-rebuild via #216's Mode: Show) surfaces both new plans

## Notes

Plan files are docs-only — no skill, hook, script, or test changes. SPRINT_REPORT.md modification is work-trail intended for `/fix-report` review. Closes #134 + #191 are NOT in commit metadata because the draft-plan task fulfills the issue, not the issue itself — the issues stay open until /run-plan lands the actual implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)