### PR TITLE
docs(sprint): record /fix-issues 1 225 sprint section

### DIFF
--- a/.zskills/audit/SPRINT_REPORT.md
+++ b/.zskills/audit/SPRINT_REPORT.md
@@ -307,3 +307,16 @@ N/A for all 3 issues. No UI, editor, or styles files changed. Pure skill-prose +
 ### Landing
 
 PR mode (per `execution.landing: "pr"` config). Two separate PRs (one per worktree). Both PRs base on `ef3e36f` (current local main, which includes the PR #218 untrack commit). When PR #218 merges first, the fix branches will need rebase onto new main — `/land-pr` handles this in its rebase step.
+
+## Sprint — 2026-05-11 16:40 [UNFINALIZED]
+
+**Mode:** auto | **Landing:** pr | **Focus:** issue-225
+
+### Fixed
+| # | Title | Worktree | Commit | Tests | Agent Verify | User Verify |
+|---|-------|----------|--------|-------|-------------|-------------|
+| #225 | create-worktree.sh: assert local main is not ahead of origin/main | /tmp/zskills-fix-issue-225 | da9729d | +1 case (test-create-worktree.sh #23 AHEAD-check) | PASS (verifier subagent ran tests/run-all.sh 2867/2867) | N/A (script change, no UI) |
+
+**Sprint scope:** Single mechanical fix per the rewritten #225 (Layer 2 only). Added `AHEAD_COUNT=$(git -C "$MAIN_ROOT" rev-list --count "origin/$BASE..$BASE")` check after the existing ff-merge BEHIND-check in `skills/create-worktree/scripts/create-worktree.sh`. New exit code 10. Tier-1 registry updated; mirrors regenerated; `metadata.version` bumped on `create-worktree` (2026.05.11+410738) and `update-zskills` (2026.05.11+dd37bf) since `tier1-shipped-hashes.txt` lives under update-zskills.
+
+**Implementer-verifier handoff note:** The exit-code header table in the script grew from 5/6/7/8 to 5/6/7/8/9/10 — exit 9 (consumer post-create-worktree.sh failure) was a pre-existing-but-undocumented code that the implementer added to the header alongside the new 10. Minor in-scope cleanup, verified correct.


### PR DESCRIPTION
## Summary

Commits the pending sprint section in `.zskills/audit/SPRINT_REPORT.md` left in main's working tree by `/fix-issues 1 225 auto pr` Phase 5. The sprint records #225's fix landing via PR #232.

This is housekeeping per the /fix-issues design (Phase 5 writes SPRINT_REPORT.md but defers the commit to /fix-report or a follow-up PR). Surfaced an architectural smell in the process — /fix-issues writes a tracked file in main's working tree from the orchestrator on main, which conflicts with main_protected. Captured in conversation; will be addressed in a future plan covering /fix-issues Phase 5 worktree-write discipline.

## Test plan
- [x] `bash tests/run-all.sh` passed before commit (2868/2868)
- [x] Single file change, additive only (+13 lines, no removals)
- [x] CI green on PR
