### PR TITLE
fix(run-plan): normalize $FINISH_MODE — deterministic assignment, canonical values

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   optionally auto-land to main. Can self-schedule recurring runs via cron. Use
   `next` to check schedule, `stop` to cancel.
 metadata:
-  version: "2026.05.11+15c0b8"
+  version: "2026.05.12+27b3fc"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -103,6 +103,25 @@ else
         LANDING_MODE="$CFG_LANDING"
       fi
     fi
+  fi
+fi
+```
+
+**Finish-mode resolution.** `$FINISH_MODE` is set deterministically from
+args (NOT orchestrator-tracked) so downstream conditionals (cherry-pick
+worktree gating, PR title construction, etc.) see a single canonical
+value. Values are exactly `"finish"`, `"finish-auto"`, or empty —
+nothing else is valid. Any downstream check that reads `$FINISH_MODE`
+must match against these three states.
+
+```bash
+# Detect finish mode (canonical values: "finish", "finish-auto", "")
+FINISH_MODE=""
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[fF][iI][nN][iI][sS][hH]($|[[:space:]]) ]]; then
+  if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+    FINISH_MODE="finish-auto"
+  else
+    FINISH_MODE="finish"
   fi
 fi
 ```

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -218,9 +218,15 @@ cd "$WORKTREE_PATH"
 # --- Construct PR title and body ---
 # $PLAN_SLUG, $PLAN_TITLE, $CURRENT_PHASE_NUM, $CURRENT_PHASE_TITLE come from
 # the plan parser (Phase 1 of /run-plan's execution).
-# $FINISH_MODE is true when running in finish mode (all remaining phases).
+# $FINISH_MODE is set deterministically from args by the resolution block
+# in SKILL.md's argument-detection section. Canonical values:
+#   "finish"      — interactive finish mode (all remaining phases, paused between)
+#   "finish-auto" — autonomous chunked finish mode (one phase per cron-fired turn)
+#   ""            — single-phase invocation (default)
+# Both finish-mode flavors share the plan-scoped PR title shape;
+# single-phase invocations get the per-phase title shape.
 
-if [ "$FINISH_MODE" = "true" ]; then
+if [ "$FINISH_MODE" = "finish" ] || [ "$FINISH_MODE" = "finish-auto" ]; then
   PR_TITLE="[${PLAN_SLUG}] ${PLAN_TITLE}"
 else
   PR_TITLE="[${PLAN_SLUG}] Phase ${CURRENT_PHASE_NUM}: ${CURRENT_PHASE_TITLE}"

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   optionally auto-land to main. Can self-schedule recurring runs via cron. Use
   `next` to check schedule, `stop` to cancel.
 metadata:
-  version: "2026.05.11+15c0b8"
+  version: "2026.05.12+27b3fc"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -103,6 +103,25 @@ else
         LANDING_MODE="$CFG_LANDING"
       fi
     fi
+  fi
+fi
+```
+
+**Finish-mode resolution.** `$FINISH_MODE` is set deterministically from
+args (NOT orchestrator-tracked) so downstream conditionals (cherry-pick
+worktree gating, PR title construction, etc.) see a single canonical
+value. Values are exactly `"finish"`, `"finish-auto"`, or empty —
+nothing else is valid. Any downstream check that reads `$FINISH_MODE`
+must match against these three states.
+
+```bash
+# Detect finish mode (canonical values: "finish", "finish-auto", "")
+FINISH_MODE=""
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[fF][iI][nN][iI][sS][hH]($|[[:space:]]) ]]; then
+  if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+    FINISH_MODE="finish-auto"
+  else
+    FINISH_MODE="finish"
   fi
 fi
 ```

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -218,9 +218,15 @@ cd "$WORKTREE_PATH"
 # --- Construct PR title and body ---
 # $PLAN_SLUG, $PLAN_TITLE, $CURRENT_PHASE_NUM, $CURRENT_PHASE_TITLE come from
 # the plan parser (Phase 1 of /run-plan's execution).
-# $FINISH_MODE is true when running in finish mode (all remaining phases).
+# $FINISH_MODE is set deterministically from args by the resolution block
+# in SKILL.md's argument-detection section. Canonical values:
+#   "finish"      — interactive finish mode (all remaining phases, paused between)
+#   "finish-auto" — autonomous chunked finish mode (one phase per cron-fired turn)
+#   ""            — single-phase invocation (default)
+# Both finish-mode flavors share the plan-scoped PR title shape;
+# single-phase invocations get the per-phase title shape.
 
-if [ "$FINISH_MODE" = "true" ]; then
+if [ "$FINISH_MODE" = "finish" ] || [ "$FINISH_MODE" = "finish-auto" ]; then
   PR_TITLE="[${PLAN_SLUG}] ${PLAN_TITLE}"
 else
   PR_TITLE="[${PLAN_SLUG}] Phase ${CURRENT_PHASE_NUM}: ${CURRENT_PHASE_TITLE}"

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -141,6 +141,8 @@ check_not_in_file_filtered() {
 echo "=== /run-plan — behavior contracts ==="
 check       run-plan "stop-precedence"              'Takes precedence'
 check_fixed run-plan "landing-default"              'LANDING_MODE="cherry-pick"'
+check_fixed run-plan "finish-mode resolution"       'FINISH_MODE="finish-auto"'
+check_fixed run-plan "finish-mode default empty"    'FINISH_MODE=""'
 check       run-plan "direct+main_protected guard"  'direct mode is incompatible with main_protected'
 check_fixed run-plan "cherry-pick create-worktree"  '--prefix cp'
 check_fixed run-plan "cp worktree slug (single-phase)" '"${PLAN_SLUG}-phase-${PHASE}"'
@@ -1252,14 +1254,16 @@ else
 fi
 rm -f "$BQ_TMP"
 
-# Substitution-discipline rule at SKILL.md:179-187 must enumerate all 3 vars.
-DISCIPLINE_BLOCK=$(sed -n '179,187p' "$REPO_ROOT/skills/run-plan/SKILL.md")
+# Substitution-discipline rule (anchored by the "Never hardcode" prose
+# header) must enumerate all 3 vars. Content-anchored — robust against
+# upstream edits that shift line numbers.
+DISCIPLINE_BLOCK=$(awk '/\*\*Never hardcode `npm run test:all`/,/^$/' "$REPO_ROOT/skills/run-plan/SKILL.md")
 if echo "$DISCIPLINE_BLOCK" | grep -q '\$DEV_SERVER_CMD' \
    && echo "$DISCIPLINE_BLOCK" | grep -q '\$FULL_TEST_CMD' \
    && echo "$DISCIPLINE_BLOCK" | grep -q '\$TEST_OUTPUT_FILE'; then
-  pass "substitution-discipline at SKILL.md:179-187 names all 3 vars"
+  pass "substitution-discipline (Never-hardcode block) names all 3 vars"
 else
-  fail "substitution-discipline at SKILL.md:179-187 names all 3 vars" "block: $DISCIPLINE_BLOCK"
+  fail "substitution-discipline (Never-hardcode block) names all 3 vars" "block: $DISCIPLINE_BLOCK"
 fi
 
 echo ""


### PR DESCRIPTION
## Fix: normalize `$FINISH_MODE` — close the contract gap left open by #239

Follow-up to **#239** (Issue [#191](https://github.com/zeveck/zskills-dev/issues/191)).

### Why this exists

PR #239 added a cherry-pick worktree-creation gate in `skills/run-plan/SKILL.md` that reads:

```bash
if [ "$FINISH_MODE" = "finish" ] || [ "$FINISH_MODE" = "finish-auto" ]; then
```

But `$FINISH_MODE` had **no literal assignment anywhere in the skill source.** It was orchestrator-tracked-by-convention — whatever the LLM happened to set determined whether the cherry-pick gate actually fired. Worse, `skills/run-plan/modes/pr.md:223` was already checking `if [ "$FINISH_MODE" = "true" ]` — a value never set anywhere, so that branch was silent dead code.

So the issue #239 closed only worked in the "happens-to-pick-the-right-string" sense; a future orchestrator copying the `modes/pr.md` convention would silently fall to the else branch and reintroduce per-phase cherry-pick worktrees — the original bug.

### What this PR does

1. **Adds an explicit `FINISH_MODE=` resolution block** in SKILL.md's argument-detection section, parallel to `LANDING_MODE`. Resolves deterministically from `$ARGUMENTS` via bash regex. Canonical values are exactly:
   - `"finish"` — interactive finish mode
   - `"finish-auto"` — autonomous chunked finish mode
   - `""` — single-phase (default)
2. **Updates `modes/pr.md:223`** to check both canonical values (was `= "true"` — silent dead branch).
3. **Adds two conformance assertions** locking the resolution literal AND the default-empty fallback, so future drift fails CI.
4. **Converts a line-number-pinned conformance assertion to content-anchored** (`sed -n '179,187p'` → `awk '/Never hardcode/,/^$/'`). The new FINISH_MODE block shifts line numbers; the content anchor survives future shifts too.

### Test plan

- [x] `bash tests/run-all.sh` — **2870/2870 passed, 0 failed** (2867 baseline + 1 from #239 + 2 from this PR)
- [x] `bash tests/test-skill-conformance.sh` — all assertions pass including the new ones
- [x] `diff -rq skills/run-plan .claude/skills/run-plan` empty (mirror parity)
- [x] `bash scripts/skill-version-stage-check.sh` exit 0
- [x] Substantive: nested regex order verified (a bare `auto` without `finish` cannot trigger `finish-auto`)
- [x] All three downstream consumers verified to use canonical values
- [ ] CI green (delegated to /land-pr monitoring)

### Confidence

The dead-branch in `modes/pr.md` is concrete evidence the convention was broken before #239 ever landed — this PR fixes both the new gate and the old silent bug in one go.
