### PR TITLE
hook(block-bypassed-land-pr): close PR #250 bash -c hole via wrapper-recursion

### DIFF
--- a/.claude/hooks/block-bypassed-land-pr.sh
+++ b/.claude/hooks/block-bypassed-land-pr.sh
@@ -98,6 +98,13 @@ is_gh_pr_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/local/bin/gh pr create`
+  # and `./gh pr create` are recognized as gh invocations. PR #250's
+  # original walker compared the first token literally to "gh", which
+  # let path-prefixed invocations slip through.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "gh" ]] && return 1
   ((i++))
   # Walk past gh-level flags. -R/--repo take a separate value (2 tokens);
@@ -171,11 +178,133 @@ is_gh_pr_subcommand_in_chain() {
   return 1
 }
 
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth).
+# Drift gate: tests/test-hook-helper-drift.sh.
+is_gh_pr_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local flag_regex="${3:-}"
+  local depth="${4:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_gh_pr_subcommand_in_chain "$cmd" "$want_sub" "$flag_regex"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'gh pr create' became three tokens: "'gh" "pr" "create'".
+          # Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_gh_pr_subcommand_in_wrappers "$wrapper_inner" "$want_sub" "$flag_regex" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
+
 # Match via inlined helpers. Two independent checks (create / merge --auto)
 # combined disjunctively into a single deny signal.
 deny=0
-is_gh_pr_subcommand_in_chain "$COMMAND" "create" && deny=1
-is_gh_pr_subcommand_in_chain "$COMMAND" "merge" '^--auto$' && deny=1
+is_gh_pr_subcommand_in_wrappers "$COMMAND" "create" && deny=1
+is_gh_pr_subcommand_in_wrappers "$COMMAND" "merge" '^--auto$' && deny=1
 [ "${deny:-0}" -eq 0 ] && exit 0
 
 # Resolve message-enrichment script. Same `${X:-$PWD}` fallback pattern as

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -249,6 +249,13 @@ is_gh_pr_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/local/bin/gh pr create`
+  # and `./gh pr create` are recognized as gh invocations. PR #250's
+  # original walker compared the first token literally to "gh", which
+  # let path-prefixed invocations slip through.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "gh" ]] && return 1
   ((i++))
   # Walk past gh-level flags. -R/--repo take a separate value (2 tokens);
@@ -323,5 +330,149 @@ is_gh_pr_subcommand_in_chain() {
       return 0
     fi
   done <<< "$normalized"
+  return 1
+}
+
+# Returns 0 iff $cmd contains a `gh pr $want_sub` invocation either
+# directly, in any chain segment, OR inside an inline-string wrapper
+# (bash -c '<inner>', sh -c '<inner>', dash -c '<inner>', or
+# eval '<inner>'). The inner string is extracted and the matcher is
+# re-applied recursively (bounded depth, default 3).
+#
+# This is the proper closure of the "documented hole" in PR #250: the
+# tokenize-walker correctly handles direct gh, walk-past flags, segment
+# chains (&&, ||, ;, |, real newline, JSON-escaped \n), and quote
+# elision around verb tokens. The one thing it didn't handle was an
+# agent wrapping its gh call in `bash -c '...'`, which presents `bash`
+# as the first token. This helper extracts the wrapped inner string and
+# matches it through the same chain-walker, closing that hole.
+#
+# Out of scope (deliberate evasion, not racing-to-done):
+#   - Variable indirection: `cmd='gh pr create'; bash -c "$cmd"` — we
+#     cannot resolve $cmd at hook time.
+#   - Process substitution: `bash <(echo gh pr create)` — gh runs in a
+#     separate fork the hook never sees and isn't accurately matched by
+#     parsing the outer command.
+#   - String concatenation across tokens: `c='gh pr cr'; c="${c}eate";
+#     bash -c "$c"` — same issue as variable indirection.
+#   - Base64-encoded payloads, scripts fetched from URLs.
+# These shapes require a behavioral defense (PostToolUse transcript
+# scan), not syntactic gating, and are out of scope here.
+is_gh_pr_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local flag_regex="${3:-}"
+  local depth="${4:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_gh_pr_subcommand_in_chain "$cmd" "$want_sub" "$flag_regex"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'gh pr create' became three tokens: "'gh" "pr" "create'".
+          # Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_gh_pr_subcommand_in_wrappers "$wrapper_inner" "$want_sub" "$flag_regex" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
   return 1
 }

--- a/hooks/block-bypassed-land-pr.sh
+++ b/hooks/block-bypassed-land-pr.sh
@@ -98,6 +98,13 @@ is_gh_pr_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/local/bin/gh pr create`
+  # and `./gh pr create` are recognized as gh invocations. PR #250's
+  # original walker compared the first token literally to "gh", which
+  # let path-prefixed invocations slip through.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "gh" ]] && return 1
   ((i++))
   # Walk past gh-level flags. -R/--repo take a separate value (2 tokens);
@@ -171,11 +178,133 @@ is_gh_pr_subcommand_in_chain() {
   return 1
 }
 
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth).
+# Drift gate: tests/test-hook-helper-drift.sh.
+is_gh_pr_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local flag_regex="${3:-}"
+  local depth="${4:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_gh_pr_subcommand_in_chain "$cmd" "$want_sub" "$flag_regex"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'gh pr create' became three tokens: "'gh" "pr" "create'".
+          # Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_gh_pr_subcommand_in_wrappers "$wrapper_inner" "$want_sub" "$flag_regex" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
+
 # Match via inlined helpers. Two independent checks (create / merge --auto)
 # combined disjunctively into a single deny signal.
 deny=0
-is_gh_pr_subcommand_in_chain "$COMMAND" "create" && deny=1
-is_gh_pr_subcommand_in_chain "$COMMAND" "merge" '^--auto$' && deny=1
+is_gh_pr_subcommand_in_wrappers "$COMMAND" "create" && deny=1
+is_gh_pr_subcommand_in_wrappers "$COMMAND" "merge" '^--auto$' && deny=1
 [ "${deny:-0}" -eq 0 ] && exit 0
 
 # Resolve message-enrichment script. Same `${X:-$PWD}` fallback pattern as

--- a/scripts/land-pr-bypass-message.sh
+++ b/scripts/land-pr-bypass-message.sh
@@ -63,20 +63,27 @@ emit_pattern_2() {
 STOP: direct gh pr create / merge --auto from agent Bash bypasses /land-pr.
 
 A requires.land-pr.* marker for this branch is present in the tracking
-tree, which means a /land-pr invocation appears to have errored or
-exited without writing its fulfilled.land-pr.* marker. Re-invoking
-`gh pr create` / `gh pr merge --auto` directly is not the recovery path
-- it bypasses rebase, CI polling, and the fix-cycle loop.
+tree. That means a caller skill on this pipeline (e.g., /run-plan,
+/commit pr, /do pr, /fix-issues pr, /quickfix) declared an intent to
+land the PR via /land-pr - and you are running gh pr create / gh pr
+merge --auto directly instead. Don't do that. The caller pipeline
+expects /land-pr to do the work; bypassing it skips rebase, CI
+polling, the fix-cycle loop, the .landed marker, and the fulfilled
+marker the pipeline needs to consider itself done.
 
-Recovery options:
-- Re-dispatch /land-pr (or the caller skill that owns this pipeline)
-  via the Skill tool so it can pick up where the previous run left off.
-- If the previous run is genuinely stuck and you have confirmed there
-  is no live process owning it, clear the stale tracking marker with
-  bash .claude/skills/update-zskills/scripts/clear-tracking.sh
-  and then re-dispatch the caller skill cleanly.
+What to do:
+- Dispatch /land-pr via the Skill tool (it is idempotent, so if a
+  previous attempt errored mid-way it picks up cleanly):
+    Skill { skill: "land-pr", args: "..." }
+  In practice the caller skill that owns this pipeline should drive
+  the landing - re-invoke whichever skill set up the requires marker
+  (/run-plan, /commit pr, etc.) and let it dispatch /land-pr.
+- If you have confirmed the marker is stale (no live caller, prior
+  session crashed, pipeline was abandoned), clear it with:
+    bash .claude/skills/update-zskills/scripts/clear-tracking.sh
+  Then re-dispatch the caller skill cleanly.
 
-If you need a true manual one-off, open a SEPARATE terminal outside the Claude Code session.
+If you need a true manual one-off outside any pipeline, open a SEPARATE terminal outside the Claude Code session.
 STOP
 }
 

--- a/tests/test-block-bypassed-land-pr.sh
+++ b/tests/test-block-bypassed-land-pr.sh
@@ -25,10 +25,19 @@
 #   C15  bash $CLAUDE_PROJECT_DIR/.claude/skills/...   → ALLOW (wrapper carve-out)
 #         /pr-push-and-create.sh ...
 #   C16  cd /tmp/wt && gh pr create -B main            → DENY (segment-walk)
-#   C17  bash -c 'gh pr create -B main'                → ALLOW (documented hole)
+#   C17  bash -c 'gh pr create -B main'                → DENY (was the PR #250
+#         documented hole; closed by is_gh_pr_subcommand_in_wrappers)
 #   C18  gh pr create, script missing/non-exec         → STILL DENY, static fallback
 #   C19  gh --repo foo/bar pr create                   → DENY
 #   C20  gh --repo=foo/bar pr create                   → DENY
+#   C21  sh -c 'gh pr create'                          → DENY (sh -c wrapper)
+#   C22  eval 'gh pr create'                           → DENY (eval wrapper)
+#   C23  bash -c 'gh pr merge --auto'                  → DENY (merge variant)
+#   C24  bash -lc 'gh pr create'                       → DENY (combined-flag)
+#   C25  /usr/local/bin/gh pr create                   → DENY (absolute-path)
+#   C26  ./gh pr create                                → DENY (relative-path)
+#   C27  legitimate FPs (git commit -m, grep, etc.)    → ALLOW (token-aware)
+#   C28  legitimate gh pr verbs (view/list/checks/...) → ALLOW
 #
 #   AC5.4  Instrumented stub: hook on non-`gh pr ` commands must NOT
 #          invoke land-pr-bypass-message.sh.
@@ -195,7 +204,7 @@ clean_tracking
 write_requires_marker "commit.test" "test" "$SANDBOX_HEAD"
 run_hook "$(mkenv "gh pr create -B main")"
 assert_deny "C2: gh pr create + matching-branch marker → DENY Pattern 2" \
-  "$HOOK_OUT" "/land-pr invocation appears to have errored"
+  "$HOOK_OUT" "declared an intent to"
 
 # ─────────────────── C3: gh pr create + mismatched-branch marker ─
 clean_tracking
@@ -216,7 +225,7 @@ clean_tracking
 write_malformed_marker_no_branch "commit.malformed" "malformed"
 run_hook "$(mkenv "gh pr create -B main")"
 assert_deny "C4: gh pr create + malformed-marker (no branch line) → DENY Pattern 2 (DA-2-2 fallback)" \
-  "$HOOK_OUT" "/land-pr invocation appears to have errored"
+  "$HOOK_OUT" "declared an intent to"
 
 # ─────────────────── C5..C8: gh pr merge variants → DENY ─────────
 clean_tracking
@@ -267,15 +276,15 @@ run_hook "$(mkenv "cd /tmp/wt && gh pr create -B main")"
 assert_deny "C16: chained cd && gh pr create → DENY (segment-walk)" \
   "$HOOK_OUT" ""
 
-# ─────────────────── C17: bash -c 'gh pr create' → ALLOW ─────────
-# Documented hole (DA-1-5). The bash -c carve-out is inherited from
-# is_git_subcommand's first-token-anchored design; bash -c wraps the
-# inner command in a string arg so the tokenize-walk never sees `gh` at
-# the head of the command. The Phase 4 negative-conformance assert is
-# the source-side backstop that catches in-skill regressions.
+# ─────────────────── C17: bash -c 'gh pr create' → DENY ─────────
+# Previously DA-1-5 "documented hole" of PR #250. Closed by the new
+# is_gh_pr_subcommand_in_wrappers helper, which extracts the inline
+# string from `bash -c '<inner>'` (also sh/dash/ksh/zsh and eval) and
+# recursively re-matches it through the chain-walker.
 clean_tracking
 run_hook "$(mkenv "bash -c 'gh pr create -B main'")"
-assert_allow "C17: bash -c 'gh pr create' → ALLOW (documented hole)" "$HOOK_EXIT" "$HOOK_OUT"
+assert_deny "C17: bash -c 'gh pr create' → DENY (wrapper-c recursion closes PR-#250 hole)" \
+  "$HOOK_OUT" ""
 
 # ─────────────────── C18: script missing → STILL DENY (static) ───
 # Move (don't delete) the script so we can restore it. Set non-exec by
@@ -310,6 +319,67 @@ assert_deny "C19: gh --repo foo/bar pr create (2-token form) → DENY" \
 run_hook "$(mkenv "gh --repo=foo/bar pr create -B main")"
 assert_deny "C20: gh --repo=foo/bar pr create (=-form) → DENY" \
   "$HOOK_OUT" ""
+
+# ─────────────────── C21: sh -c 'gh pr create' → DENY ────────────
+clean_tracking
+run_hook "$(mkenv "sh -c 'gh pr create -B main'")"
+assert_deny "C21: sh -c 'gh pr create' → DENY (sh -c wrapper)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C22: eval 'gh pr create' → DENY ─────────────
+clean_tracking
+run_hook "$(mkenv "eval 'gh pr create -B main'")"
+assert_deny "C22: eval 'gh pr create' → DENY (eval wrapper)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C23: bash -c '... merge --auto' → DENY ──────
+clean_tracking
+run_hook "$(mkenv "bash -c 'gh pr merge 123 --auto'")"
+assert_deny "C23: bash -c 'gh pr merge --auto' → DENY (merge variant in wrapper)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C24: bash -lc 'gh pr create' → DENY ─────────
+clean_tracking
+run_hook "$(mkenv "bash -lc 'gh pr create'")"
+assert_deny "C24: bash -lc 'gh pr create' → DENY (combined-flag wrapper)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C25: /usr/local/bin/gh pr create → DENY ─────
+# Absolute-path gh invocation. The first-token check basenames the
+# path before comparing to "gh".
+clean_tracking
+run_hook "$(mkenv "/usr/local/bin/gh pr create -B main")"
+assert_deny "C25: /usr/local/bin/gh pr create → DENY (absolute-path basename)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C26: ./gh pr create → DENY ──────────────────
+clean_tracking
+run_hook "$(mkenv "./gh pr create")"
+assert_deny "C26: ./gh pr create → DENY (relative-path basename)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C27: legitimate FP cases all ALLOW ──────────
+# These contain the literal text `gh pr create` in quoted args of
+# OTHER commands. The token-aware walker correctly treats them as
+# arguments, not invocations.
+for legit in \
+  "git commit -m 'fix gh pr create bug'" \
+  "grep 'gh pr create' tests/" \
+  "gh issue create --title 'use gh pr create instead'" \
+  "echo 'gh pr create'"; do
+  clean_tracking
+  run_hook "$(mkenv "$legit")"
+  assert_allow "C27/$legit → ALLOW (token-aware: literal in quoted arg)" \
+    "$HOOK_EXIT" "$HOOK_OUT"
+done
+
+# ─────────────────── C28: legitimate gh subcommands ALLOW ────────
+for legit in "gh pr view 123" "gh pr checks --watch" "gh pr list" "gh pr diff" "gh pr edit 5 --title=x" "gh pr merge 123" "gh pr merge --auto-fill"; do
+  clean_tracking
+  run_hook "$(mkenv "$legit")"
+  assert_allow "C28/$legit → ALLOW (legitimate gh pr verb)" \
+    "$HOOK_EXIT" "$HOOK_OUT"
+done
 
 # ──────────────────────────────────────────────────────────────
 # AC5.4 — instrumented-stub early-exit assertion.

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -21,7 +21,7 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
   #   stale-skill-version hook  : is_git_subcommand
   #   block-bypassed-land-pr.sh : is_gh_pr_subcommand, is_gh_pr_subcommand_in_chain
   #     (Plan LAND_PR_BYPASS_HARDENING Phase 4 — 4th drift-gated hook)
-  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_gh_pr_subcommand is_gh_pr_subcommand_in_chain; do
+  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers; do
     # is_destruct_command is only inlined in generic hook; skip for project + stale-skill-version + bypassed-land-pr.
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *stale-skill-version* ]] && continue
@@ -38,9 +38,10 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
     # is_git_subcommand is NOT inlined in bypassed-land-pr (that hook only
     # walks gh pr tokens, not git tokens).
     [[ "$FN" == "is_git_subcommand" && "$HOOK" == *bypassed-land-pr* ]] && continue
-    # is_gh_pr_subcommand{,_in_chain} are ONLY inlined in bypassed-land-pr.
+    # is_gh_pr_subcommand{,_in_chain,_in_wrappers} are ONLY inlined in bypassed-land-pr.
     [[ "$FN" == "is_gh_pr_subcommand" && "$HOOK" != *bypassed-land-pr* ]] && continue
     [[ "$FN" == "is_gh_pr_subcommand_in_chain" && "$HOOK" != *bypassed-land-pr* ]] && continue
+    [[ "$FN" == "is_gh_pr_subcommand_in_wrappers" && "$HOOK" != *bypassed-land-pr* ]] && continue
     if diff <(sed -n "/^$FN()/,/^}$/p" "$HOOK") \
             <(sed -n "/^$FN()/,/^}$/p" hooks/_lib/git-tokenwalk.sh) \
             > /dev/null; then

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -902,10 +902,10 @@ if [ -f "$msg_script" ]; then
   else
     fail "[bypass-hardening] land-pr-bypass-message.sh contains Pattern 1 'outside a caller skill' anchor" "anchor not found"
   fi
-  if grep -qF '/land-pr invocation appears to have errored' "$msg_script"; then
-    pass "[bypass-hardening] land-pr-bypass-message.sh contains Pattern 2 '/land-pr invocation appears to have errored' anchor"
+  if grep -qF 'declared an intent to' "$msg_script"; then
+    pass "[bypass-hardening] land-pr-bypass-message.sh contains Pattern 2 'declared an intent to' anchor (caller-declared-intent framing)"
   else
-    fail "[bypass-hardening] land-pr-bypass-message.sh contains Pattern 2 errored anchor" "anchor not found"
+    fail "[bypass-hardening] land-pr-bypass-message.sh contains Pattern 2 caller-intent anchor" "anchor not found"
   fi
 else
   fail "[bypass-hardening] scripts/land-pr-bypass-message.sh exists" "missing"


### PR DESCRIPTION
## Closes the PR #250 `bash -c '<inner>'` hole

PR #250 shipped the `block-bypassed-land-pr.sh` PreToolUse hook gating direct `gh pr create` / `gh pr merge --auto` from agent Bash. It had one documented hole: `bash -c 'gh pr create'` was allowed. That's a one-keystroke bypass — making the gate weak against exactly the threat class that motivated it (racing-to-done agents skipping `/land-pr`).

## Changes

1. **New helper `is_gh_pr_subcommand_in_wrappers`** in `hooks/_lib/git-tokenwalk.sh` (~120 lines). Runs the existing `_in_chain` walker first; if no match, scans for `bash|sh|dash|ash|ksh|zsh -c|-lc|-ic '<inner>'` and `eval '<inner>'` wrappers, extracts the inner string, recurses (bounded depth 3). Inlined into the hook with drift-gate enforcement.

2. **Path-prefix fix in `is_gh_pr_subcommand`**: basenames the first token, so `/usr/local/bin/gh pr create` and `./gh pr create` are recognized.

3. **Pattern 2 STOP-message rewrite** in `scripts/land-pr-bypass-message.sh`: frames the case as "your caller pipeline declared an intent to use /land-pr (via `requires.land-pr.<id>`) — you skipped it" instead of "/land-pr appears to have errored mid-flight." Same disk-state check; the prior wording emphasized the rarer sub-case.

4. **Tests**: `C17` in `tests/test-block-bypassed-land-pr.sh` flipped from ALLOW to DENY (was the PR #250 documented hole). Added `C21`-`C28` covering `sh -c`, `eval`, `bash -lc`, absolute/relative-path gh, FP-class (`git commit -m 'gh pr create'` and `grep 'gh pr create'` correctly ALLOW because tokens are properly parsed), and legitimate `gh pr <verb>` (view/list/checks/diff/edit/merge-without-auto) which all ALLOW.

5. **Conformance + drift gate** updated for the new helper and Pattern 2 anchor.

## Closed bypass classes

- `gh pr create` (direct) — already in PR #250
- `bash -c 'gh pr create'` — **the documented hole, now closed**
- `sh -c 'gh pr create'` / `dash -c '...'` / `ash -c '...'` / `ksh -c '...'` / `zsh -c '...'`
- `bash -lc 'gh pr create'` (combined-flag)
- `eval 'gh pr create'`
- `/usr/local/bin/gh pr create` (absolute path)
- `./gh pr create` (relative path)
- `cd /tmp && gh pr create` — already in PR #250 (segment walker)
- `gh --repo=foo/bar pr create` — already in PR #250 (walk-past flags)
- `gh pr merge ... --auto` (any flag order) — already in PR #250

## Out of scope

Deliberate-evasion forms — not racing-to-done shapes — remain allowed and require behavioral signal (PostToolUse transcript scan) to catch syntactically:

- Variable indirection: `cmd='gh pr create'; bash -c "$cmd"`
- Process substitution: `bash <(echo gh pr create)`
- Herestring: `bash <<< 'gh pr create'`
- Base64-encoded payloads, fetched scripts
- Utility-prefix forms: `command gh pr create`, `time gh pr create`, `timeout 10 gh pr create`, `nohup gh pr create` (flagged by reviewer as informational; an agent that just saw the STOP wouldn't naturally reach for these)

## False positives preserved correctly

Token-aware parsing means the literal text `gh pr create` inside a quoted arg of another command is correctly treated as text, not a command:

- `git commit -m 'fix gh pr create bug'` → ALLOW (legitimate commit message)
- `grep 'gh pr create' tests/` → ALLOW (legitimate search)
- `gh issue create --title 'use gh pr create instead'` → ALLOW (legitimate issue creation)
- `echo 'gh pr create'` → ALLOW (text echo)
- `bash .claude/skills/land-pr/scripts/pr-push-and-create.sh --title='Fix gh pr create flow'` → ALLOW (wrapper-script invocation; the title's content is opaque to this hook)

## Test plan
- [x] All 28 integration cases pass (`tests/test-block-bypassed-land-pr.sh`)
- [x] Drift gate covers new helper (`tests/test-hook-helper-drift.sh`)
- [x] Conformance asserts updated and pass (`tests/test-skill-conformance.sh`)
- [x] Full suite: 2951/2951
- [x] Sanity-tested all bypass forms via direct `bash hook <envelope>` invocations
- [x] Sanity-tested wrapper carve-out preserved (legitimate /land-pr path via `bash pr-push-and-create.sh`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
