### PR TITLE
hook(block-bypassed-land-pr): close transparent-prefix bypass class

### DIFF
--- a/.claude/hooks/block-bypassed-land-pr.sh
+++ b/.claude/hooks/block-bypassed-land-pr.sh
@@ -95,6 +95,30 @@ is_gh_pr_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup gh pr create`, `time gh pr create`, `timeout 30 gh pr create`,
+  # etc. are operationally equivalent to `gh pr create`. Without this
+  # skip an agent reaching for `timeout 30 gh pr create` (e.g., after a
+  # previous PR-create hung) would bypass the gate.
+  #
+  # `timeout` consumes its DURATION arg as well (2 tokens); the others
+  # consume just 1. List is small and curated; do NOT generalize to
+  # "skip any unknown leading word" — that would whitelist user aliases.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i+=2)) ;;
+      *)
+        break ;;
+    esac
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -246,6 +246,30 @@ is_gh_pr_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup gh pr create`, `time gh pr create`, `timeout 30 gh pr create`,
+  # etc. are operationally equivalent to `gh pr create`. Without this
+  # skip an agent reaching for `timeout 30 gh pr create` (e.g., after a
+  # previous PR-create hung) would bypass the gate.
+  #
+  # `timeout` consumes its DURATION arg as well (2 tokens); the others
+  # consume just 1. List is small and curated; do NOT generalize to
+  # "skip any unknown leading word" — that would whitelist user aliases.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i+=2)) ;;
+      *)
+        break ;;
+    esac
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/hooks/block-bypassed-land-pr.sh
+++ b/hooks/block-bypassed-land-pr.sh
@@ -95,6 +95,30 @@ is_gh_pr_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup gh pr create`, `time gh pr create`, `timeout 30 gh pr create`,
+  # etc. are operationally equivalent to `gh pr create`. Without this
+  # skip an agent reaching for `timeout 30 gh pr create` (e.g., after a
+  # previous PR-create hung) would bypass the gate.
+  #
+  # `timeout` consumes its DURATION arg as well (2 tokens); the others
+  # consume just 1. List is small and curated; do NOT generalize to
+  # "skip any unknown leading word" — that would whitelist user aliases.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i+=2)) ;;
+      *)
+        break ;;
+    esac
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/tests/test-block-bypassed-land-pr.sh
+++ b/tests/test-block-bypassed-land-pr.sh
@@ -38,6 +38,12 @@
 #   C26  ./gh pr create                                → DENY (relative-path)
 #   C27  legitimate FPs (git commit -m, grep, etc.)    → ALLOW (token-aware)
 #   C28  legitimate gh pr verbs (view/list/checks/...) → ALLOW
+#   C29  transparent-prefix wrappers (command/exec/    → DENY (prefix-skip
+#         nohup/nice/time/timeout) + gh pr create        in is_gh_pr_subcommand)
+#   C30  timeout 30 gh pr merge --auto                 → DENY (prefix + merge)
+#   C31  time git push origin main / timeout 60 ls     → ALLOW (prefix-skip
+#         (prefix-skip is conservative: doesn't match     reaches non-gh; exits)
+#          non-gh commands after prefix)
 #
 #   AC5.4  Instrumented stub: hook on non-`gh pr ` commands must NOT
 #          invoke land-pr-bypass-message.sh.
@@ -380,6 +386,46 @@ for legit in "gh pr view 123" "gh pr checks --watch" "gh pr list" "gh pr diff" "
   assert_allow "C28/$legit → ALLOW (legitimate gh pr verb)" \
     "$HOOK_EXIT" "$HOOK_OUT"
 done
+
+# ─────────────────── C29: transparent-prefix wrappers → DENY ─────
+# These prefixes execute the next argv as a separate process (or
+# in-place for `exec`/`command`); operationally equivalent to direct
+# invocation. Closes the prefix-class hole an agent could reach for
+# (e.g., `timeout 30 gh pr create` after a previous PR-create hung).
+for prefix_form in \
+  "command gh pr create -B main" \
+  "exec gh pr create -B main" \
+  "nohup gh pr create" \
+  "nice gh pr create" \
+  "time gh pr create" \
+  "timeout 30 gh pr create" \
+  "/usr/bin/timeout 60 gh pr create -B main"; do
+  clean_tracking
+  run_hook "$(mkenv "$prefix_form")"
+  assert_deny "C29/$prefix_form → DENY (transparent-prefix wrapper)" \
+    "$HOOK_OUT" ""
+done
+
+# ─────────────────── C30: prefix + merge --auto → DENY ───────────
+clean_tracking
+run_hook "$(mkenv "timeout 30 gh pr merge 123 --auto")"
+assert_deny "C30: timeout 30 gh pr merge --auto → DENY (prefix + merge variant)" \
+  "$HOOK_OUT" ""
+
+# ─────────────────── C31: prefix is NOT a generic allow ──────────
+# Adding `command/time/timeout/...` to the transparent-prefix skip MUST
+# NOT cause unrelated invocations to fall through. Confirm a non-gh
+# command after the prefix correctly ALLOWs (because the walker reaches
+# `git`, not `gh`, and exits without matching).
+clean_tracking
+run_hook "$(mkenv "time git push origin main")"
+assert_allow "C31: time git push origin main → ALLOW (prefix-skip doesn't make non-gh commands match)" \
+  "$HOOK_EXIT" "$HOOK_OUT"
+
+clean_tracking
+run_hook "$(mkenv "timeout 60 ls -la")"
+assert_allow "C31b: timeout 60 ls -la → ALLOW (no gh anywhere)" \
+  "$HOOK_EXIT" "$HOOK_OUT"
 
 # ──────────────────────────────────────────────────────────────
 # AC5.4 — instrumented-stub early-exit assertion.


### PR DESCRIPTION
## Close the transparent-prefix bypass class

PR #251 closed the `bash -c '<inner>'` wrapper bypass via tokenize-walker + wrapper-recursion. A prefix-wrapper class remained allowed:

```
command gh pr create
exec gh pr create
nohup gh pr create
nice gh pr create
time gh pr create
timeout 30 gh pr create
/usr/bin/timeout 60 gh pr create
```

These prefixes execute the next `argv` as a separate process (or in-place for `exec`/`command`), so they're operationally equivalent to direct invocation. An agent reaching for `timeout 30 gh pr create` (e.g., after a previous PR-create hung) would have slipped past the walker because the first token was `timeout`, not `gh`.

## Fix

Extend `is_gh_pr_subcommand` with a transparent-prefix skip block placed immediately after the env-var-prefix skip. Recognizes:

- `command`, `exec`, `nohup`, `nice`, `time` → consume 1 token
- `timeout` → consume 2 tokens (prefix + its `DURATION` arg)
- Path prefixes tolerated (`/usr/bin/timeout`)

List is small and curated — **NOT** generalized to "skip any unknown leading word" because that would whitelist user aliases.

Applied identically in source-of-truth (`hooks/_lib/git-tokenwalk.sh`) and the inlined hook copy (`hooks/block-bypassed-land-pr.sh`); drift-gated by `tests/test-hook-helper-drift.sh`.

## Remaining holes (informational; follow-up issue worth filing)

The conservative skip does not close these forms (an agent would need to discover specific flag forms):

- `time -v gh pr create` (GNU `time` with `-v` flag)
- `timeout --foreground 30 gh pr create` (`timeout` with flags before duration)
- `nohup -- gh pr create`
- `command -p gh pr create` (POSIX `command` builtin's `-p` flag)

These are narrower than the classes this PR closes. Also still allowed (out of scope per the racing-to-done threat model — require deliberate concealment intent): variable indirection across statements, base64-encoded payloads, fetched scripts.

## Test plan

- [x] C29: all 7 transparent-prefix forms DENY
- [x] C30: `timeout 30 gh pr merge --auto` DENY
- [x] C31: conservative-skip preserved — `time git push origin main` and `timeout 60 ls -la` ALLOW (prefix-skip reaches non-`gh` first token, exits without matching)
- [x] All PR #251 DENY classes (direct, `bash -c`, chain, walk-past, path-prefixed) still DENY
- [x] All legitimate ALLOW cases preserved (`gh pr view`/`list`/`checks`/`merge` w/o `--auto`, `git commit -m '...gh pr create...'`, `grep '...'`, wrapper-script invocations)
- [x] 2998/2998 tests pass
- [x] Drift gate: inlined and source-of-truth byte-identical (10/10 pass)
- [x] Mirror parity: `diff` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
