### PR TITLE
fix(commit): add positional `auto` mode to /commit pr (closes #236)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -5,13 +5,15 @@ description: >-
   Safe commit workflow with optional scope hint. Inventories all changes,
   classifies related vs. unrelated files, traces dependencies, protects
   other agents' work, and optionally pushes or lands worktree commits.
-  Usage: /commit [pr] [scope] [push|land]
-argument-hint: "[pr] [scope] [push|land]"
+  Positional `auto` (PR mode only) enables auto-merge via /land-pr
+  (matches /run-plan, /fix-issues, /do).
+  Usage: /commit [pr] [scope] [push|land|auto]
+argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.13+63c9a4"
+  version: "2026.05.14+53583d"
 ---
 
-# /commit [pr] [scope] [push|land] — Safe Commit Workflow
+# /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow
 
 Commit current work without picking up or harming unrelated changes.
 
@@ -33,9 +35,23 @@ When no explicit mode token is supplied, the skill consults
 
 ```bash
 FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
+# Positional `auto` token (case-insensitive). Recognized ONLY in PR mode
+# (`/commit pr auto` or — via the config-default-to-pr branch below —
+# `/commit auto`). Matches the convention in /run-plan, /fix-issues, /do.
+# The token never falls through to SCOPE_HINT (stripped in both PR-mode
+# parse paths). Setting AUTO_FLAG outside PR mode is a no-op — `push`
+# and `land` modes do not consult it.
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])([aA][uU][tT][oO])($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
 if [[ "$FIRST_TOKEN" == "pr" ]]; then
   # PR subcommand mode
   SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
+  # Strip the positional `auto` token from SCOPE_HINT so it does not leak
+  # into the PR title / scope-hint downstream. Match `auto` as a
+  # whitespace-bounded token (case-insensitive).
+  SCOPE_HINT=$(echo "$SCOPE_HINT" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
   # ... see Phase 6 (PR mode) below
 fi
 ```
@@ -74,8 +90,10 @@ if [ "$HAS_EXPLICIT_MODE" -eq 0 ]; then
         pr)
           # Treat as `/commit pr` — drop into PR subcommand mode below.
           # SCOPE_HINT keeps any scope words from $ARGUMENTS (no `pr` prefix
-          # to strip, since the user didn't type it).
-          SCOPE_HINT="$ARGUMENTS"
+          # to strip, since the user didn't type it). Strip the positional
+          # `auto` token (AUTO_FLAG was already set above) so it does not
+          # leak into the PR title / downstream scope-hint usage.
+          SCOPE_HINT=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
           DEFAULT_MODE="pr"
           ;;
         direct|"")
@@ -122,6 +140,8 @@ Disambiguation:
 - `/commit` with `execution.landing: "pr"` in config → PR mode (config default)
 - `/commit` with `execution.landing: "direct"` or no config → commit-only (preserved default)
 - `/commit push` or `/commit land` always overrides config — explicit wins
+- `/commit pr auto` → PR mode + auto-merge via `/land-pr --auto`
+- `/commit auto` (config default = pr) → PR mode + auto-merge
 
 Examples:
 - `/commit` → scope: *(none)*, action: commit
@@ -130,8 +150,10 @@ Examples:
 - `/commit push` → scope: *(none)*, action: commit + push
 - `/commit land` → scope: *(none)*, action: land
 - `/commit parser fixes land` → scope: "parser fixes", action: land
-- `/commit pr` → action: PR mode (push + create PR)
+- `/commit pr` → action: PR mode (push + create PR; settles at `pr-ready`)
 - `/commit pr fix pr comments` → PR mode, scope hint: "fix pr comments"
+- `/commit pr auto` → PR mode + auto-merge (passes `--auto` to `/land-pr`)
+- `/commit auto` (config default = pr) → PR mode + auto-merge
 
 PR subcommand behavior is defined in [modes/pr.md](modes/pr.md); land behavior in [modes/land.md](modes/land.md).
 

--- a/.claude/skills/commit/modes/pr.md
+++ b/.claude/skills/commit/modes/pr.md
@@ -57,7 +57,12 @@ sent at orchestrator level.
 `/commit pr` customizations of the canonical pattern:
 - `$LANDED_SOURCE = "commit"`
 - No `--worktree-path` (no worktree — `/commit pr` runs in the main repo)
-- No `--auto` (auto-merge stays OFF for `/commit pr`)
+- **`--auto` is gated on the positional `auto` token** (issue #236 —
+  matches /run-plan, /fix-issues, /do, /quickfix). Without `auto`,
+  auto-merge stays OFF and the PR settles at `pr-ready` after CI passes;
+  with `auto`, `LAND_ARGS` includes `--auto` and `/land-pr`'s existing
+  auto-merge path takes over (same CI gate, same behavior as the other
+  4 skills).
 - `<CALLER_PRE_INVOKE_BODY_PREP>` = empty (commit's body is fixed at PR
   creation; no per-phase update like /run-plan does)
 - `<CALLER_REBASE_CONFLICT_HANDLER>` = no agent-assisted resolution (no
@@ -116,6 +121,14 @@ LAND_OUTCOME=__init__
 
 LANDED_SOURCE="commit"
 LAND_ARGS="--branch=$BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --tracking-id=$BRANCH_SLUG"
+
+# Auto-merge gate (issue #236) — append `--auto` when the caller passed
+# the positional `auto` token (parsed in skills/commit/SKILL.md and
+# propagated as $AUTO_FLAG=1). Mirrors /run-plan, /fix-issues, /do,
+# /quickfix. Without the token, `/land-pr` runs through PR creation +
+# CI poll + fix-cycle but does NOT call `gh pr merge --auto --squash`;
+# the PR settles at `pr-ready` for human review.
+[ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
 
 while :; do
   # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /commit pr.
@@ -190,7 +203,7 @@ while :; do
       else
         LAND_OUTCOME=pr-ready
       fi
-      break ;;  # /land-pr already requested merge if --auto (none for /commit pr)
+      break ;;  # /land-pr already requested merge if --auto (gated on AUTO_FLAG per issue #236)
     pending)
       LAND_OUTCOME=pr-ready
       break ;;  # settle at pr-ready
@@ -282,7 +295,11 @@ rm -f "$TRACK_DIR/requires.land-pr.$BRANCH_SLUG"
 ```
 
 **PR mode does NOT:**
-- Auto-merge (no `--auto` passed to `/land-pr`)
+- Auto-merge **unless the positional `auto` token is passed** (issue #236
+  — `/commit pr auto` or, via config-default-to-pr, `/commit auto`).
+  Without `auto`, `LAND_ARGS` omits `--auto` and the PR settles at
+  `pr-ready` after CI passes; with `auto`, `--auto` is appended and
+  `/land-pr` invokes `gh pr merge --auto --squash`.
 - Write `.landed` markers (`/commit pr` has no worktree)
 - Run Phases 1–5 (all commits must already exist — clean tree is required)
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -5,13 +5,15 @@ description: >-
   Safe commit workflow with optional scope hint. Inventories all changes,
   classifies related vs. unrelated files, traces dependencies, protects
   other agents' work, and optionally pushes or lands worktree commits.
-  Usage: /commit [pr] [scope] [push|land]
-argument-hint: "[pr] [scope] [push|land]"
+  Positional `auto` (PR mode only) enables auto-merge via /land-pr
+  (matches /run-plan, /fix-issues, /do).
+  Usage: /commit [pr] [scope] [push|land|auto]
+argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.13+63c9a4"
+  version: "2026.05.14+53583d"
 ---
 
-# /commit [pr] [scope] [push|land] — Safe Commit Workflow
+# /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow
 
 Commit current work without picking up or harming unrelated changes.
 
@@ -33,9 +35,23 @@ When no explicit mode token is supplied, the skill consults
 
 ```bash
 FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
+# Positional `auto` token (case-insensitive). Recognized ONLY in PR mode
+# (`/commit pr auto` or — via the config-default-to-pr branch below —
+# `/commit auto`). Matches the convention in /run-plan, /fix-issues, /do.
+# The token never falls through to SCOPE_HINT (stripped in both PR-mode
+# parse paths). Setting AUTO_FLAG outside PR mode is a no-op — `push`
+# and `land` modes do not consult it.
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])([aA][uU][tT][oO])($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
 if [[ "$FIRST_TOKEN" == "pr" ]]; then
   # PR subcommand mode
   SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
+  # Strip the positional `auto` token from SCOPE_HINT so it does not leak
+  # into the PR title / scope-hint downstream. Match `auto` as a
+  # whitespace-bounded token (case-insensitive).
+  SCOPE_HINT=$(echo "$SCOPE_HINT" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
   # ... see Phase 6 (PR mode) below
 fi
 ```
@@ -74,8 +90,10 @@ if [ "$HAS_EXPLICIT_MODE" -eq 0 ]; then
         pr)
           # Treat as `/commit pr` — drop into PR subcommand mode below.
           # SCOPE_HINT keeps any scope words from $ARGUMENTS (no `pr` prefix
-          # to strip, since the user didn't type it).
-          SCOPE_HINT="$ARGUMENTS"
+          # to strip, since the user didn't type it). Strip the positional
+          # `auto` token (AUTO_FLAG was already set above) so it does not
+          # leak into the PR title / downstream scope-hint usage.
+          SCOPE_HINT=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
           DEFAULT_MODE="pr"
           ;;
         direct|"")
@@ -122,6 +140,8 @@ Disambiguation:
 - `/commit` with `execution.landing: "pr"` in config → PR mode (config default)
 - `/commit` with `execution.landing: "direct"` or no config → commit-only (preserved default)
 - `/commit push` or `/commit land` always overrides config — explicit wins
+- `/commit pr auto` → PR mode + auto-merge via `/land-pr --auto`
+- `/commit auto` (config default = pr) → PR mode + auto-merge
 
 Examples:
 - `/commit` → scope: *(none)*, action: commit
@@ -130,8 +150,10 @@ Examples:
 - `/commit push` → scope: *(none)*, action: commit + push
 - `/commit land` → scope: *(none)*, action: land
 - `/commit parser fixes land` → scope: "parser fixes", action: land
-- `/commit pr` → action: PR mode (push + create PR)
+- `/commit pr` → action: PR mode (push + create PR; settles at `pr-ready`)
 - `/commit pr fix pr comments` → PR mode, scope hint: "fix pr comments"
+- `/commit pr auto` → PR mode + auto-merge (passes `--auto` to `/land-pr`)
+- `/commit auto` (config default = pr) → PR mode + auto-merge
 
 PR subcommand behavior is defined in [modes/pr.md](modes/pr.md); land behavior in [modes/land.md](modes/land.md).
 

--- a/skills/commit/modes/pr.md
+++ b/skills/commit/modes/pr.md
@@ -57,7 +57,12 @@ sent at orchestrator level.
 `/commit pr` customizations of the canonical pattern:
 - `$LANDED_SOURCE = "commit"`
 - No `--worktree-path` (no worktree — `/commit pr` runs in the main repo)
-- No `--auto` (auto-merge stays OFF for `/commit pr`)
+- **`--auto` is gated on the positional `auto` token** (issue #236 —
+  matches /run-plan, /fix-issues, /do, /quickfix). Without `auto`,
+  auto-merge stays OFF and the PR settles at `pr-ready` after CI passes;
+  with `auto`, `LAND_ARGS` includes `--auto` and `/land-pr`'s existing
+  auto-merge path takes over (same CI gate, same behavior as the other
+  4 skills).
 - `<CALLER_PRE_INVOKE_BODY_PREP>` = empty (commit's body is fixed at PR
   creation; no per-phase update like /run-plan does)
 - `<CALLER_REBASE_CONFLICT_HANDLER>` = no agent-assisted resolution (no
@@ -116,6 +121,14 @@ LAND_OUTCOME=__init__
 
 LANDED_SOURCE="commit"
 LAND_ARGS="--branch=$BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --tracking-id=$BRANCH_SLUG"
+
+# Auto-merge gate (issue #236) — append `--auto` when the caller passed
+# the positional `auto` token (parsed in skills/commit/SKILL.md and
+# propagated as $AUTO_FLAG=1). Mirrors /run-plan, /fix-issues, /do,
+# /quickfix. Without the token, `/land-pr` runs through PR creation +
+# CI poll + fix-cycle but does NOT call `gh pr merge --auto --squash`;
+# the PR settles at `pr-ready` for human review.
+[ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
 
 while :; do
   # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /commit pr.
@@ -190,7 +203,7 @@ while :; do
       else
         LAND_OUTCOME=pr-ready
       fi
-      break ;;  # /land-pr already requested merge if --auto (none for /commit pr)
+      break ;;  # /land-pr already requested merge if --auto (gated on AUTO_FLAG per issue #236)
     pending)
       LAND_OUTCOME=pr-ready
       break ;;  # settle at pr-ready
@@ -282,7 +295,11 @@ rm -f "$TRACK_DIR/requires.land-pr.$BRANCH_SLUG"
 ```
 
 **PR mode does NOT:**
-- Auto-merge (no `--auto` passed to `/land-pr`)
+- Auto-merge **unless the positional `auto` token is passed** (issue #236
+  — `/commit pr auto` or, via config-default-to-pr, `/commit auto`).
+  Without `auto`, `LAND_ARGS` omits `--auto` and the PR settles at
+  `pr-ready` after CI passes; with `auto`, `--auto` is appended and
+  `/land-pr` invokes `gh pr merge --auto --squash`.
 - Write `.landed` markers (`/commit pr` has no worktree)
 - Run Phases 1–5 (all commits must already exist — clean tree is required)
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -74,6 +74,7 @@ run_suite "test-block-bypassed-land-pr.sh" "tests/test-block-bypassed-land-pr.sh
 run_suite "test-tracking-integration.sh" "tests/test-tracking-integration.sh"
 run_suite "test-quickfix.sh" "tests/test-quickfix.sh"
 run_suite "test-do.sh" "tests/test-do.sh"
+run_suite "test-commit.sh" "tests/test-commit.sh"
 run_suite "test-frontmatter-helpers.sh" "tests/test-frontmatter-helpers.sh"
 run_suite "test-update-zskills-migration.sh" "tests/test-update-zskills-migration.sh"
 run_suite "test-update-zskills-agent-install" "tests/test-update-zskills-agent-install.sh"

--- a/tests/test-commit.sh
+++ b/tests/test-commit.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Tests for skills/commit/SKILL.md and skills/commit/modes/pr.md — issue
+# #236: /commit pr needs positional `auto` mode (sibling to #235).
+#
+# Sibling of test-quickfix.sh Cases 54–56. Static-grep against the SKILL
+# source — /commit pr has no extractable preflight slice to drive
+# end-to-end without a heavy fixture (no model-layer parser test seam
+# like /quickfix has). Source-level invariants are the load-bearing
+# regression guard.
+#
+# Cases:
+#   1. argument-hint contains positional `auto` (issue #236)
+#   2. AUTO_FLAG=0 default + case-insensitive `auto` token recognition
+#      in the top-level argument parser
+#   3. SCOPE_HINT strip — `auto` does not leak into PR title / scope
+#      hint (both PR-mode parse paths: explicit `/commit pr` AND
+#      config-default-to-pr `/commit auto`)
+#   4. modes/pr.md Step 4 conditionally appends `--auto` to LAND_ARGS
+#      when AUTO_FLAG=1 (the load-bearing change for issue #236)
+#   5. modes/pr.md "PR mode does NOT" note documents the gate (no longer
+#      blanket "no --auto passed to /land-pr" — must reflect #236)
+#
+# Run from repo root: bash tests/test-commit.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$REPO_ROOT/skills/commit/SKILL.md"
+PR_MODE="$REPO_ROOT/skills/commit/modes/pr.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  printf '\033[32m  PASS\033[0m %s\n' "$1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+fail() {
+  printf '\033[31m  FAIL\033[0m %s\n' "$1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo "=== /commit — positional auto (issue #236) ==="
+
+# ────────────────────────────────────────────────────────────────────
+# Case 1 — argument-hint advertises positional `auto`.
+# ────────────────────────────────────────────────────────────────────
+if grep -qE '^argument-hint: ".*\[auto\].*"' "$SKILL"; then
+  pass "1  argument-hint advertises positional [auto] (issue #236)"
+else
+  fail "1  argument-hint missing [auto] — issue #236"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 2 — AUTO_FLAG=0 default + case-insensitive `auto` token regex
+# in the top-level argument parser.
+# ────────────────────────────────────────────────────────────────────
+AUTO_DEFAULT=$(grep -cE '^AUTO_FLAG=0$' "$SKILL" 2>/dev/null | head -1)
+AUTO_DEFAULT=${AUTO_DEFAULT:-0}
+AUTO_REGEX=$(grep -cE '\[aA\]\[uU\]\[tT\]\[oO\]' "$SKILL" 2>/dev/null | head -1)
+AUTO_REGEX=${AUTO_REGEX:-0}
+if [ "$AUTO_DEFAULT" -ge 1 ] && [ "$AUTO_REGEX" -ge 1 ]; then
+  pass "2  AUTO_FLAG=0 default + case-insensitive [aA][uU][tT][oO] regex present"
+else
+  fail "2  parser: AUTO_FLAG-default-count=$AUTO_DEFAULT auto-regex-count=$AUTO_REGEX (each want >=1)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 3 — SCOPE_HINT strip in BOTH parse paths. The `auto` token must
+# not leak into PR title / scope-hint usage. The strip happens in two
+# places: (a) explicit `/commit pr ...` branch where SCOPE_HINT is
+# computed via `cut -d' ' -f2-` then sed-stripped; (b) config-default
+# branch where SCOPE_HINT is computed from $ARGUMENTS directly with the
+# same sed. Both must use the case-insensitive `[aA][uU][tT][oO]`
+# pattern. Counting the strip-sed occurrences: expect >= 2.
+# ────────────────────────────────────────────────────────────────────
+SCOPE_STRIP=$(grep -cE "sed -E 's/\(\^\|\[\[:space:\]\]\)\[aA\]\[uU\]\[tT\]\[oO\]" "$SKILL" 2>/dev/null | head -1)
+SCOPE_STRIP=${SCOPE_STRIP:-0}
+if [ "$SCOPE_STRIP" -ge 2 ]; then
+  pass "3  SCOPE_HINT strip-sed in both parse paths ($SCOPE_STRIP occurrences, want >=2)"
+else
+  fail "3  SCOPE_HINT strip-sed: $SCOPE_STRIP occurrences (want >=2 — explicit + config-default branches)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 4 — modes/pr.md Step 4 conditionally appends `--auto` to
+# LAND_ARGS when AUTO_FLAG=1. THE load-bearing change for issue #236.
+# Exact form: `[ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"`
+# (matches sibling /quickfix in PR #235 — same idiom).
+# ────────────────────────────────────────────────────────────────────
+GATED_APPEND=$(grep -cE '\[ "\$\{AUTO_FLAG:-0\}" = "1" \] && LAND_ARGS="\$LAND_ARGS --auto"' "$PR_MODE" 2>/dev/null | head -1)
+GATED_APPEND=${GATED_APPEND:-0}
+if [ "$GATED_APPEND" -ge 1 ]; then
+  pass "4  modes/pr.md: conditional --auto LAND_ARGS append present (issue #236)"
+else
+  fail "4  modes/pr.md: gated --auto append count=$GATED_APPEND (want >=1)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 5 — modes/pr.md "PR mode does NOT" note documents the gate.
+# Pre-#236 line was literally: "Auto-merge (no `--auto` passed to
+# `/land-pr`)". That blanket statement must be gone. The replacement
+# documents that auto-merge is gated on the positional `auto` token
+# (the cross-issue invariant per the issue body's constraint).
+# ────────────────────────────────────────────────────────────────────
+OLD_BLANKET=$(grep -cE 'Auto-merge \(no `--auto` passed to `/land-pr`\)' "$PR_MODE" 2>/dev/null | head -1)
+OLD_BLANKET=${OLD_BLANKET:-0}
+NEW_GATED=$(grep -cE 'unless the positional `auto` token is passed' "$PR_MODE" 2>/dev/null | head -1)
+NEW_GATED=${NEW_GATED:-0}
+if [ "$OLD_BLANKET" -eq 0 ] && [ "$NEW_GATED" -ge 1 ]; then
+  pass "5  modes/pr.md: old blanket 'no --auto' gone ($OLD_BLANKET), new gated prose present ($NEW_GATED) — issue #236"
+else
+  fail "5  modes/pr.md: old-blanket=$OLD_BLANKET (want 0), new-gated-prose=$NEW_GATED (want >=1)"
+fi
+
+echo ""
+echo "---"
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$((PASS_COUNT + FAIL_COUNT))"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #236. Sibling to #235 — both add positional `auto` mode using the same constraint (positional token, NOT `--auto` flag). #235 touches `/quickfix`; this PR touches `/commit pr`. Same convention as `/run-plan`, `/fix-issues`, `/do`.

## What changed

- `skills/commit/SKILL.md` argument parser (lines 44-56 region):
  - `AUTO_FLAG=0` default.
  - Case-insensitive regex match for `auto` token (whitespace-bounded). Recognized in both PR-mode parse paths: explicit `/commit pr auto` AND config-default-to-pr `/commit auto`.
  - `SCOPE_HINT` strips `auto` so it doesn't leak into the PR title (both parse paths).
- `skills/commit/modes/pr.md`:
  - Line ~57: rewrote the "No `--auto` (auto-merge stays OFF for /commit pr)" note to document the new positional-`auto` gate (no longer blanket).
  - Line ~122-125: conditional `--auto` append: `[ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"`. Without the token, auto-merge stays OFF (PR settles at `pr-ready` after CI passes); with the token, `/land-pr`'s existing auto-merge path takes over.
- `.claude/skills/commit/{SKILL.md,modes/pr.md}` — mirrors.
- `tests/test-commit.sh` — new file, 120 lines, 5 cases:
  1. `argument-hint` contains positional `auto`.
  2. `AUTO_FLAG=0` default + case-insensitive token recognition.
  3. `SCOPE_HINT` strip in both PR-mode parse paths.
  4. `modes/pr.md` Step 4 conditionally appends `--auto` to `LAND_ARGS`.
  5. `modes/pr.md` "PR mode does NOT" note documents the new gate (no longer blanket "no `--auto` passed").
- `tests/run-all.sh` — registers the new suite (+1 line).
- `metadata.version`: `2026.05.13+63c9a4` → `2026.05.14+53583d`.

## Test plan

- [x] `bash tests/run-all.sh` → **3015/3015 PASS** (baseline 3010 + 5 new cases).
- [x] `diff -rq skills/commit .claude/skills/commit` → no differences (mirror clean).
- [x] Verifier subagent APPROVE with anchored file:line evidence for every AC.
- [x] `/commit pr auto` → AUTO_FLAG=1, PR mode, `--auto` in LAND_ARGS.
- [x] `/commit auto` (config-default-to-pr) → AUTO_FLAG=1, falls into the `pr)` case branch, SCOPE_HINT-strip removes `auto`.
- [x] `/commit pr` (no auto) → AUTO_FLAG=0, current `pr-ready`-without-merge preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
