### PR TITLE
Dashboard UI polish: drag-to-READY + activity strip + folder tabs

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status].
 metadata:
-  version: "2026.05.13+0f19eb"
+  version: "2026.05.14+72ef54"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -96,17 +96,20 @@ code, pre, .mono {
   grid-template-columns: max-content 1fr;
   gap: 12px;
   align-items: start;
-  max-height: 140px;
+  min-height: 60px;
+  height: 140px;
+  max-height: 50vh;
   overflow-x: hidden;
   overflow-y: auto;
+  resize: vertical;
 }
 .strip-title {
   margin: 0;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-  align-self: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  align-self: start;
 }
 .activity-strip-body {
   display: flex;
@@ -124,8 +127,8 @@ code, pre, .mono {
 
 .tablist {
   display: flex;
-  gap: 4px;
-  padding: 0 24px;
+  gap: 2px;
+  padding: 8px 24px 0;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   max-width: 1600px;
@@ -133,35 +136,44 @@ code, pre, .mono {
   overflow-x: auto;
   scrollbar-width: thin;
   scroll-snap-type: x proximity;
+  position: relative;
 }
 .tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
   color: var(--text-dim);
   font-family: inherit;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 10px 16px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 8px 18px;
+  margin-bottom: -1px;
   cursor: pointer;
   flex-shrink: 0;
   scroll-snap-align: start;
   white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
 }
 .tab:hover {
+  background: var(--surface);
   color: var(--text);
-  border-bottom-color: var(--border);
 }
 .tab[aria-selected="true"] {
+  background: var(--bg);
   color: var(--text);
-  border-bottom-color: var(--accent);
+  border-color: var(--border);
+  border-top: 2px solid var(--accent);
+  padding-top: 7px;
   font-weight: 600;
+  position: relative;
+  z-index: 1;
 }
 .tab:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.4);
-  border-radius: 2px 2px 0 0;
+  box-shadow: inset 0 0 0 2px rgba(88, 166, 255, 0.5);
+  border-radius: 6px 6px 0 0;
 }
 .tabpanels {
   padding: 16px 24px;
@@ -671,6 +683,7 @@ code, pre, .mono {
   gap: 6px;
   min-height: 32px;
   padding: 2px;
+  flex: 1;
 }
 
 .dropzone.drop-target {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -25,15 +25,15 @@
   <div id="toast-region" class="toast-region" aria-live="polite" role="status"></div>
 
   <section id="activity-strip" class="activity-strip" aria-label="Recent activity">
-    <h2 class="strip-title">Recent</h2>
+    <h2 class="strip-title">Recent activity</h2>
     <div id="activity-body" class="activity-strip-body"></div>
     <p id="activity-empty" class="empty muted" hidden>No recent activity.</p>
   </section>
 
   <nav class="tablist" role="tablist" aria-label="Dashboard sections" aria-orientation="horizontal">
-    <button type="button" role="tab" id="tab-plans"     aria-controls="plans"     aria-selected="true">Plans</button>
-    <button type="button" role="tab" id="tab-issues"    aria-controls="issues"    aria-selected="false">Issues</button>
-    <button type="button" role="tab" id="tab-branches"  aria-controls="branches"  aria-selected="false">Branches</button>
+    <button type="button" class="tab" role="tab" id="tab-plans"     aria-controls="plans"     aria-selected="true">Plans</button>
+    <button type="button" class="tab" role="tab" id="tab-issues"    aria-controls="issues"    aria-selected="false">Issues</button>
+    <button type="button" class="tab" role="tab" id="tab-branches"  aria-controls="branches"  aria-selected="false">Branches</button>
   </nav>
 
   <main id="tabpanels" class="tabpanels">

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status].
 metadata:
-  version: "2026.05.13+0f19eb"
+  version: "2026.05.14+72ef54"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -96,17 +96,20 @@ code, pre, .mono {
   grid-template-columns: max-content 1fr;
   gap: 12px;
   align-items: start;
-  max-height: 140px;
+  min-height: 60px;
+  height: 140px;
+  max-height: 50vh;
   overflow-x: hidden;
   overflow-y: auto;
+  resize: vertical;
 }
 .strip-title {
   margin: 0;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-dim);
-  align-self: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  align-self: start;
 }
 .activity-strip-body {
   display: flex;
@@ -124,8 +127,8 @@ code, pre, .mono {
 
 .tablist {
   display: flex;
-  gap: 4px;
-  padding: 0 24px;
+  gap: 2px;
+  padding: 8px 24px 0;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   max-width: 1600px;
@@ -133,35 +136,44 @@ code, pre, .mono {
   overflow-x: auto;
   scrollbar-width: thin;
   scroll-snap-type: x proximity;
+  position: relative;
 }
 .tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
   color: var(--text-dim);
   font-family: inherit;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 10px 16px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 8px 18px;
+  margin-bottom: -1px;
   cursor: pointer;
   flex-shrink: 0;
   scroll-snap-align: start;
   white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
 }
 .tab:hover {
+  background: var(--surface);
   color: var(--text);
-  border-bottom-color: var(--border);
 }
 .tab[aria-selected="true"] {
+  background: var(--bg);
   color: var(--text);
-  border-bottom-color: var(--accent);
+  border-color: var(--border);
+  border-top: 2px solid var(--accent);
+  padding-top: 7px;
   font-weight: 600;
+  position: relative;
+  z-index: 1;
 }
 .tab:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.4);
-  border-radius: 2px 2px 0 0;
+  box-shadow: inset 0 0 0 2px rgba(88, 166, 255, 0.5);
+  border-radius: 6px 6px 0 0;
 }
 .tabpanels {
   padding: 16px 24px;
@@ -671,6 +683,7 @@ code, pre, .mono {
   gap: 6px;
   min-height: 32px;
   padding: 2px;
+  flex: 1;
 }
 
 .dropzone.drop-target {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -25,15 +25,15 @@
   <div id="toast-region" class="toast-region" aria-live="polite" role="status"></div>
 
   <section id="activity-strip" class="activity-strip" aria-label="Recent activity">
-    <h2 class="strip-title">Recent</h2>
+    <h2 class="strip-title">Recent activity</h2>
     <div id="activity-body" class="activity-strip-body"></div>
     <p id="activity-empty" class="empty muted" hidden>No recent activity.</p>
   </section>
 
   <nav class="tablist" role="tablist" aria-label="Dashboard sections" aria-orientation="horizontal">
-    <button type="button" role="tab" id="tab-plans"     aria-controls="plans"     aria-selected="true">Plans</button>
-    <button type="button" role="tab" id="tab-issues"    aria-controls="issues"    aria-selected="false">Issues</button>
-    <button type="button" role="tab" id="tab-branches"  aria-controls="branches"  aria-selected="false">Branches</button>
+    <button type="button" class="tab" role="tab" id="tab-plans"     aria-controls="plans"     aria-selected="true">Plans</button>
+    <button type="button" class="tab" role="tab" id="tab-issues"    aria-controls="issues"    aria-selected="false">Issues</button>
+    <button type="button" class="tab" role="tab" id="tab-branches"  aria-controls="branches"  aria-selected="false">Branches</button>
   </nav>
 
   <main id="tabpanels" class="tabpanels">


### PR DESCRIPTION
## Summary

Three UI polish fixes to the dashboard refactor landed in PR #253, plus a latent-bug fix uncovered during verification.

**1. Drag-to-READY now works.** `.dropzone { flex: 1 }` so the dropzone grows to fill its column container. Pre-fix: empty columns had a 32px sliver drop target inside a ~10500px-tall visible column — most drop attempts missed. The READY-drop bug PR #253's Phase 5c diagnosed as a worktree path-resolution asymmetry was actually a CSS layout bug; the actual user-reported symptom (can't drag to READY) is fixed by this one-line change.

**2. Activity strip is now resizable + clearer.** `resize: vertical; min-height: 60px; height: 140px; max-height: 50vh` replaces the fixed `max-height: 140px`. Label changed from "Recent" (0.75rem dim uppercase) to "Recent activity" (0.85rem 600-weight `--text` color, no uppercase).

**3. Tabs now look like tabs, dark-mode-native.** Folder-tab metaphor: inactive tabs sit on `--surface2` (recessed), active tab sits on `--bg` (matching the panel below) with a 2px `--accent` top stripe and `margin-bottom: -1px` so the tab visually merges with the panel beneath. Rounded 6px top corners. Dropped `text-transform: uppercase`. Reuses existing color tokens only.

**4. Latent bug from PR #253: `class="tab"` was missing on the `<button role="tab">` elements**, so PR #253's tab CSS family had **zero DOM targets** and the buttons rendered as default OS chrome. This is what made the user perceive the tabs as "weird white buttons." A fresh verifier caught this on the first verification pass; the fix is the 3-character HTML addition.

## Test plan

- [x] Tests green: 3021/3021, exit 0
- [x] Mirror clean: `diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/` empty
- [x] Version bumped: `2026.05.13+acfe93` → `2026.05.14+72ef54`
- [x] Drag-to-READY verified end-to-end via real-mouse playwright-cli drag — seeded slug landed in `plans.ready` per `/api/state`
- [x] Empty-column dropzone heights confirmed ~10343px (matches sibling columns with cards), not 32px
- [x] Active tab computed styles: bg `rgb(13,17,23)` (`--bg`), border-top 2px `rgb(88,166,255)` (`--accent`), color `rgb(230,237,243)` (`--text`), `margin-bottom: -1px`
- [x] Inactive tab computed styles: bg `rgb(28,33,41)` (`--surface2`), color `rgb(139,148,158)` (`--text-dim`), `border-radius: 6px 6px 0 0`, no border-bottom
- [x] `class="tab"` present on all 3 `<button>` elements; `document.querySelectorAll(".tab").length === 3`
- [x] Click-to-switch verified: clicking Issues tab flips `aria-selected="true"` and visibility
- [x] Activity strip `resize: vertical`, computed min 60px / max 50vh; label reads "Recent activity"
- [ ] **Reviewer to confirm** in their browser: tabs read as folder tabs (not OS buttons), drag-to-READY persists, activity strip is draggable at its bottom edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
