### PR TITLE
Dashboard polish round 2: tab overflow + dark scrollbars + resize grip

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status].
 metadata:
-  version: "2026.05.14+72ef54"
+  version: "2026.05.14+3574f7"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -15,6 +15,19 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Dark-mode scrollbars (Firefox + WebKit/Chromium). Applies globally to
+   every scrollable container in the dashboard. */
+html { scrollbar-color: var(--border) var(--surface); scrollbar-width: thin; }
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-track { background: var(--surface); }
+*::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 5px;
+  border: 2px solid var(--surface);
+}
+*::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+*::-webkit-scrollbar-corner { background: var(--surface); }
+
 html, body {
   background: var(--bg);
   color: var(--text);
@@ -103,6 +116,22 @@ code, pre, .mono {
   overflow-y: auto;
   resize: vertical;
 }
+/* Dark-mode-visible resize grip on the bottom-right corner. The default
+   browser handle is light-gray dots that disappear on the dark surface.
+   Lines drawn at 45° in --text-dim against --surface remain legible. */
+.activity-strip::-webkit-resizer {
+  background-color: var(--surface);
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%, transparent 30%,
+    var(--text-dim) 30%, var(--text-dim) 40%,
+    transparent 40%, transparent 55%,
+    var(--text-dim) 55%, var(--text-dim) 65%,
+    transparent 65%, transparent 80%,
+    var(--text-dim) 80%, var(--text-dim) 90%,
+    transparent 90%
+  );
+}
 .strip-title {
   margin: 0;
   font-size: 0.85rem;
@@ -134,6 +163,7 @@ code, pre, .mono {
   max-width: 1600px;
   margin: 0 auto;
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: thin;
   scroll-snap-type: x proximity;
   position: relative;

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status].
 metadata:
-  version: "2026.05.14+72ef54"
+  version: "2026.05.14+3574f7"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -15,6 +15,19 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+/* Dark-mode scrollbars (Firefox + WebKit/Chromium). Applies globally to
+   every scrollable container in the dashboard. */
+html { scrollbar-color: var(--border) var(--surface); scrollbar-width: thin; }
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-track { background: var(--surface); }
+*::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 5px;
+  border: 2px solid var(--surface);
+}
+*::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+*::-webkit-scrollbar-corner { background: var(--surface); }
+
 html, body {
   background: var(--bg);
   color: var(--text);
@@ -103,6 +116,22 @@ code, pre, .mono {
   overflow-y: auto;
   resize: vertical;
 }
+/* Dark-mode-visible resize grip on the bottom-right corner. The default
+   browser handle is light-gray dots that disappear on the dark surface.
+   Lines drawn at 45° in --text-dim against --surface remain legible. */
+.activity-strip::-webkit-resizer {
+  background-color: var(--surface);
+  background-image: linear-gradient(
+    135deg,
+    transparent 0%, transparent 30%,
+    var(--text-dim) 30%, var(--text-dim) 40%,
+    transparent 40%, transparent 55%,
+    var(--text-dim) 55%, var(--text-dim) 65%,
+    transparent 65%, transparent 80%,
+    var(--text-dim) 80%, var(--text-dim) 90%,
+    transparent 90%
+  );
+}
 .strip-title {
   margin: 0;
   font-size: 0.85rem;
@@ -134,6 +163,7 @@ code, pre, .mono {
   max-width: 1600px;
   margin: 0 auto;
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: thin;
   scroll-snap-type: x proximity;
   position: relative;


### PR DESCRIPTION
## Summary

Three small CSS fixes follow-up to PR #263 (dashboard UI polish).

**1. Tablist no longer renders a 1px vertical scrollbar.** PR #263's active tab uses `margin-bottom: -1px` so the tab visually merges with the panel below — this creates 1px of vertical overflow inside `.tablist`. Because `overflow-x: auto` was set, the CSS spec auto-promotes `overflow-y` to non-`visible`, which made the browser render a vestigial vertical scrollbar in the tab row. Fix: explicit `overflow-y: hidden` declares intent ("scroll horizontally only; the 1px overlap is intentional").

**2. Activity-strip resize handle now visible in dark mode.** PR #263 added `resize: vertical` but the default browser resize handle (light-gray dots in the bottom-right corner) was invisible against `--surface` (#161b22). Fix: `.activity-strip::-webkit-resizer` styled with a `linear-gradient` of `--text-dim` diagonal stripes against `--surface`. The native resize functionality is unchanged; the affordance is now visually findable. End-to-end real-mouse drag confirmed: strip height grew from 140px → 242px during a +100px drag of the corner.

**3. Dark-mode scrollbars across the dashboard.** All scrollbars previously used the default OS palette, which appeared light-on-dark against the rest of the UI. Fix: global `html { scrollbar-color: var(--border) var(--surface); scrollbar-width: thin }` (Firefox) plus `*::-webkit-scrollbar{,-track,-thumb,-thumb:hover,-corner}` (Chromium/WebKit) rules. Every scrollable container (activity strip, dropzones, tablist horizontal scroll on narrow viewports) now uses the dark palette.

## Test plan

- [x] Tests green: 3021/3021, exit 0 (one earlier run had 6 failures all caused by leaked test-fixture servers from this session's prior test runs blocking ports 19888/19890; verified pre-existing-environmental via `git log main..HEAD -- tests/test_zskills_dashboard_skill.sh` returning empty)
- [x] Mirror clean: `diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/` empty
- [x] Version bumped: `2026.05.14+72ef54` → `2026.05.14+3574f7`
- [x] Tablist: `overflowY: hidden` applied, `overflowX: auto` preserved; no vertical scrollbar rendered (visual confirmation)
- [x] Resize grip: `::-webkit-resizer` shows `background-image: linear-gradient(135deg, ..., rgb(139,148,158), ...)` with `bg: rgb(22,27,34)` (`--surface`)
- [x] Resize grip functional: real-mouse drag of bottom-right corner +100px increased strip height from 140 → 242
- [x] Scrollbar: computed `scrollbar-color: rgb(48,54,61) rgb(22,54,61)` (`--border` thumb, `--surface` track) cascades from `html` rule to activity strip
- [ ] **Reviewer to confirm in their browser:** no vertical scrollbar in the tab row, the resize grip is visible and grabbable, all scrollbars use the dark palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)
