### PR TITLE
fix(run-plan): tighten REMAINING_PHASES regex — Status col must be ONLY ⬚ (closes #256)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   optionally auto-land to main. Can self-schedule recurring runs via cron. Use
   `next` to check schedule, `stop` to cancel.
 metadata:
-  version: "2026.05.13+16b5f4"
+  version: "2026.05.14+c9f343"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -2299,14 +2299,21 @@ worktree's copy in PR mode).
 #   - The Status column is where ⬚ / 🟡 / ✅ markers live.
 #   - Header / separator rows (`| Phase | Status | ... |` and
 #     `|-------|--------|...|`) don't contain ⬚, so the regex's
-#     `^\|[^|]*\|[^|]*⬚` (literal `|`, any non-`|`, literal `|`, any
-#     non-`|`, ⬚) matches phase rows only.
+#     `^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|` (literal `|`, any non-`|`,
+#     literal `|`, optional whitespace, ⬚, optional whitespace, literal
+#     `|`) matches phase rows only.
 #   - Plans following the project convention always have Phase in column 1
 #     and Status in column 2 (every plan in docs/plans/ as of #240 does).
-#   - If a future plan reorders columns or uses ⬚ outside the Status
-#     column, this regex will miscount. That's a structural-drift case,
-#     not handled here — fix the plan's tracker shape if it happens.
-REMAINING_PHASES=$(grep -cE '^\|[^|]*\|[^|]*⬚' "$PLAN_FILE_FOR_READ" || true)
+#   - The regex requires the Status cell to contain ONLY the glyph (modulo
+#     whitespace). Narrative prose elsewhere on the page mentioning `⬚`
+#     (disposition tables, design notes, review-history rows that name the
+#     glyph) does NOT match — the col-2 anchor + whitespace-only fence
+#     makes false positives structurally impossible (#256).
+#   - Dependency: Progress Tracker Status cells MUST contain just the glyph
+#     (no trailing text like "⬚ (blocked)") for the regex to count them.
+#     This convention is already in use across plans; the tight regex
+#     makes it structurally required rather than aspirational.
+REMAINING_PHASES=$(grep -cE '^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|' "$PLAN_FILE_FOR_READ" || true)
 REMAINING_PHASES="${REMAINING_PHASES:-0}"
 ```
 

--- a/.zskills/audit/SPRINT_REPORT.md
+++ b/.zskills/audit/SPRINT_REPORT.md
@@ -381,3 +381,28 @@ N/A for both rows. No UI, editor, or styles files changed. Pure skill-prose + ba
 ### Landing
 
 PR mode (per `execution.landing: "pr"` config). Two separate PRs: one per worktree. **First sprint to benefit from `/land-pr` Step 7b** (landed in PR #257 just before this sprint) — local main auto-ff-pulls after each squash merge instead of requiring manual `git pull --ff-only` recovery.
+
+## Sprint — 2026-05-14 15:35 ET [UNFINALIZED]
+
+**Mode:** auto | **Landing:** pr | **Focus:** issue-256
+
+### Fixed
+| # | Title | Worktree | Commit | Tests | Agent Verify | User Verify |
+|---|-------|----------|--------|-------|-------------|-------------|
+| #256 | /run-plan REMAINING_PHASES regex false-positives on ⬚ outside Status column | /tmp/zskills-fix-issue-256 | `c0b8f3e` | +2 cases in tests/test-phase-5b-gate.sh (Case 8 mktemp fixture with tight-vs-loose contrast assertion; Case 8b SKILL.md sentinel grep); suite 3022 → 3023 PASS | PASS (verifier subagent APPROVE; regex change at SKILL.md:2316; comment block 2291-2315 updated; mirror clean) | N/A (skill prose + bash + tests; no UI) |
+
+**Sprint scope:** Single 1-line regex tighten at `skills/run-plan/SKILL.md` REMAINING_PHASES gate. New pattern `^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|` requires Status cell to be ONLY whitespace+⬚+whitespace+closing-pipe. Progress Tracker rows still match; narrative-prose mentions of ⬚ structurally cannot. Closes the "land-time rewrite review history" pattern observed at PR #252 PREAMBLE Phase 6.
+
+**Test discipline:** Case 8 includes a CONTRAST assertion (runs BOTH new and old regex against same fixture, asserts new=2 AND old=3) — proves the fixture exercises the difference. Case 8b is a sentinel grep against SKILL.md source.
+
+### Agent Verify
+
+Verifier subagent (`subagent_type: "verifier"`) returned APPROVE. Layer 3 exit 0. Full suite 3023/3023 PASS in verifier's own run. Mirror parity clean. Committed `c0b8f3e`.
+
+### User Verify
+
+N/A. No UI changes.
+
+### Landing
+
+PR mode. /land-pr --auto dispatch. Step 7b (#254) will auto-ff local main on merge.

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   optionally auto-land to main. Can self-schedule recurring runs via cron. Use
   `next` to check schedule, `stop` to cancel.
 metadata:
-  version: "2026.05.13+16b5f4"
+  version: "2026.05.14+c9f343"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -2299,14 +2299,21 @@ worktree's copy in PR mode).
 #   - The Status column is where ⬚ / 🟡 / ✅ markers live.
 #   - Header / separator rows (`| Phase | Status | ... |` and
 #     `|-------|--------|...|`) don't contain ⬚, so the regex's
-#     `^\|[^|]*\|[^|]*⬚` (literal `|`, any non-`|`, literal `|`, any
-#     non-`|`, ⬚) matches phase rows only.
+#     `^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|` (literal `|`, any non-`|`,
+#     literal `|`, optional whitespace, ⬚, optional whitespace, literal
+#     `|`) matches phase rows only.
 #   - Plans following the project convention always have Phase in column 1
 #     and Status in column 2 (every plan in docs/plans/ as of #240 does).
-#   - If a future plan reorders columns or uses ⬚ outside the Status
-#     column, this regex will miscount. That's a structural-drift case,
-#     not handled here — fix the plan's tracker shape if it happens.
-REMAINING_PHASES=$(grep -cE '^\|[^|]*\|[^|]*⬚' "$PLAN_FILE_FOR_READ" || true)
+#   - The regex requires the Status cell to contain ONLY the glyph (modulo
+#     whitespace). Narrative prose elsewhere on the page mentioning `⬚`
+#     (disposition tables, design notes, review-history rows that name the
+#     glyph) does NOT match — the col-2 anchor + whitespace-only fence
+#     makes false positives structurally impossible (#256).
+#   - Dependency: Progress Tracker Status cells MUST contain just the glyph
+#     (no trailing text like "⬚ (blocked)") for the regex to count them.
+#     This convention is already in use across plans; the tight regex
+#     makes it structurally required rather than aspirational.
+REMAINING_PHASES=$(grep -cE '^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|' "$PLAN_FILE_FOR_READ" || true)
 REMAINING_PHASES="${REMAINING_PHASES:-0}"
 ```
 

--- a/tests/test-phase-5b-gate.sh
+++ b/tests/test-phase-5b-gate.sh
@@ -246,6 +246,47 @@ else
   fail "skill missing 'On attempt 1 only' guidance"
 fi
 
+# Case 8: REMAINING_PHASES regex (#256) — the tightened pattern matches
+# ONLY rows whose Status column contains the glyph alone (modulo
+# whitespace). Narrative prose mentioning ⬚ in OTHER columns (e.g., a
+# disposition table's Finding column reviewing this very glyph) must
+# NOT inflate the count. Regression-guard: the old loose regex would
+# have miscounted the same fixture as 3 — that contrast assertion
+# proves the fixture actually exercises the difference.
+REGEX_FIXTURE=$(mktemp)
+trap '[ -n "$REGEX_FIXTURE" ] && rm -f "$REGEX_FIXTURE"' EXIT
+cat > "$REGEX_FIXTURE" <<'FIXTURE'
+## Progress Tracker
+
+| Phase | Status | Commit | Notes |
+|-------|--------|--------|-------|
+| 1 — Foo | ⬚ |  | |
+| 2 — Bar | ⬚ |  | |
+| 3 — Baz | ✅ | abc1234 | |
+
+## Round Disposition Table
+
+| # | Finding | Severity | Disposition |
+|---|---------|----------|-------------|
+| 1 | Glyph `⬚` parse fragility | MIN | Fixed via regex tightening (#256) |
+FIXTURE
+
+TIGHT_COUNT=$(grep -cE '^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|' "$REGEX_FIXTURE" || true)
+LOOSE_COUNT=$(grep -cE '^\|[^|]*\|[^|]*⬚' "$REGEX_FIXTURE" || true)
+
+if [ "$TIGHT_COUNT" = "2" ] && [ "$LOOSE_COUNT" = "3" ]; then
+  pass "case 8: REMAINING_PHASES tight regex counts 2 (only Status-col ⬚); loose regex would have miscounted 3"
+else
+  fail "case 8: REMAINING_PHASES regex — tight=$TIGHT_COUNT (expected 2), loose=$LOOSE_COUNT (expected 3)"
+fi
+
+# Case 8b: verify the skill source ships the TIGHT pattern, not the loose one.
+if grep -qF "'^\\|[^|]*\\|[[:space:]]*⬚[[:space:]]*\\|'" "$REPO_ROOT/skills/run-plan/SKILL.md"; then
+  pass "case 8b: skill source uses tight REMAINING_PHASES regex (#256)"
+else
+  fail "case 8b: skill source missing tight REMAINING_PHASES regex"
+fi
+
 echo ""
 echo "---"
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"


### PR DESCRIPTION
## Summary

Closes #256. Tightens the `REMAINING_PHASES` regex in `/run-plan` so the second column of a Progress Tracker pipe-table row must contain **only** the `⬚` glyph (plus whitespace) — narrative-prose mentions of `⬚` elsewhere can no longer false-positive.

## Root cause

The old regex `^\|[^|]*\|[^|]*⬚` matched any row whose second column *contained* `⬚` anywhere. Disposition tables (`| 13 | Glyph \`⬚\` parse fragility | MIN | Fixed |`) tripped it. Concrete incident: PR #252 (PREAMBLE_WORKTREE_GATE) Phase 6 landing required rewriting a review-history row's title to neutralize the glyph in narrative prose — an awful pattern that edits historical content to satisfy tooling.

## Fix

`skills/run-plan/SKILL.md:2316` (was line 2309 before comment-block expansion):

```diff
-REMAINING_PHASES=$(grep -cE '^\|[^|]*\|[^|]*⬚' "$PLAN_FILE_FOR_READ" || true)
+REMAINING_PHASES=$(grep -cE '^\|[^|]*\|[[:space:]]*⬚[[:space:]]*\|' "$PLAN_FILE_FOR_READ" || true)
```

Plain reading: "row starts with `|`, column 1 content, `|`, only-whitespace-plus-⬚-plus-only-whitespace, `|`."

## What else changed

- **Comment block at `skills/run-plan/SKILL.md:2291-2315`** — rewritten. Old text warned about the regex's fragility and recommended "fix the plan's tracker shape if it happens." New text documents the tight contract: the regex requires Status cells to be ONLY the glyph (modulo whitespace); narrative-prose `⬚` mentions structurally cannot match. The convention dependency (Progress Tracker Status cells = just the glyph, no `⬚ (blocked)` trailing text) is now documented as required rather than aspirational.
- **`tests/test-phase-5b-gate.sh:249-288`** — Case 8 + Case 8b. Case 8 builds a `mktemp` fixture containing `⬚` in BOTH the Progress Tracker (2 rows) AND a Disposition Table row's Finding column (narrative prose), asserts the new tight regex counts 2 and the old loose regex counts 3 (contrast assertion proves the fixture exercises the difference). Case 8b is a sentinel grep against the SKILL.md source that locks the tight pattern against regression to the loose form.
- **Mirror** `.claude/skills/run-plan/SKILL.md` regenerated via `mirror-skill.sh run-plan`.
- **`metadata.version`** bumped `2026.05.13+16b5f4` → `2026.05.14+c9f343`.

## Test plan

- [x] `bash tests/run-all.sh` → **3023/3023 PASS** (baseline 3022 + 2 new cases).
- [x] `bash tests/test-phase-5b-gate.sh` standalone → all cases including Case 8 + 8b pass.
- [x] `diff -rq skills/run-plan .claude/skills/run-plan` → no differences (mirror clean).
- [x] Verifier subagent APPROVE with anchored file:line evidence.

## Severity

Low. Workaround was mechanical (edit plan-text at land time). But the workaround pattern was corrosive — rewriting review history to satisfy tooling sets a bad precedent. Fix is one regex tighten plus a regression-guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
