### PR TITLE
fix(fix-issues): defer gh issue close until /land-pr returns success (AC-P.3)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   already-fixed issues. Use plan to draft plans for skipped issues.
   Usage: /fix-issues N [focus] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next.
 metadata:
-  version: "2026.05.14+5f21d5"
+  version: "2026.05.15+ab4898"
 ---
 
 # /fix-issues N [focus] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -295,19 +295,20 @@ Close 3 FIXED issues? (all / comma-separated numbers / none)
 - **If no close candidates found:** skip this step, just show the sync
   summary.
 
-### Step 4 — Close approved issues on GitHub
+### Step 4 — Stage local tracker + sprint-report updates for approved issues
 
 For each approved issue:
 
-1. **Close with a comment** explaining what fixed it:
-   ```bash
-   gh issue close <N> --comment "Fixed in commit <hash>. <brief description of fix>. Tests: <test file(s)>."
-   ```
+1. **Update tracker files** — mark the issue `[x]` in all relevant trackers.
 
-2. **Update tracker files** — mark the issue `[x]` in all relevant trackers.
-
-3. **Update `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`** — if the issue appears in an "Already
+2. **Update `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`** — if the issue appears in an "Already
    Implemented" section, add a note: `Closed by /fix-issues sync`.
+
+The `gh issue close` calls are deferred to Step 5 sub-step 3, AFTER
+`/land-pr` returns a success status (`created`, `monitored`, or `merged`).
+If `/land-pr` fails, the issues remain OPEN on GitHub — preventing
+state divergence between closed-on-GH and unmerged-in-main (AC-P.3 of
+`docs/plans/FIX_ISSUES_SYNC_HARDENING.md`).
 
 ### Step 5 — Commit & report
 
@@ -394,7 +395,9 @@ For each approved issue:
 
    # Build the PR body file. Body intentionally OMITS GitHub auto-close
    # directives (Close[sd]? / Fixe[sd]? / Resolve[sd]? #N) — sync closes
-   # approved issues itself via `gh issue close` in Step 4 after merge.
+   # approved issues itself via `gh issue close` in Step 5 sub-step 3,
+   # only after /land-pr returns a success status (AC-P.3 of
+   # `docs/plans/FIX_ISSUES_SYNC_HARDENING.md`).
    RESULT_FILE=$(mktemp)
    BODY_FILE=$(mktemp)
    {
@@ -439,11 +442,32 @@ For each approved issue:
      esac
    done < "$RESULT_FILE"
 
-   # LP[STATUS] drives the report below. fulfilled.land-pr.${SYNC_ID} is
-   # present on main_root iff LP[STATUS]=merged.
+   # LP[STATUS] drives sub-step 3 (close approved issues on success) and
+   # the report below. fulfilled.land-pr.${SYNC_ID} is present on
+   # main_root iff LP[STATUS]=merged.
    ```
 
-3. **Report:**
+3. **Close approved issues on GitHub** — only if `/land-pr` returned a
+   success status (`created`, `monitored`, or `merged`). On any other
+   status (`push-failed`, `rebase-conflict`, `create-failed`,
+   `monitor-failed`, `merge-failed`, `rebase-failed`), leave issues OPEN
+   to prevent state divergence between closed-on-GH and unmerged-in-main
+   (AC-P.3). The next sync run can re-attempt the close after the
+   underlying landing failure is resolved.
+
+   ```bash
+   case "${LP[STATUS]:-}" in
+     created|monitored|merged)
+       # For each approved issue, close with the fix-commit reference.
+       gh issue close <N> --comment "Fixed in commit <hash>. <brief description of fix>. Tests: <test file(s)>."
+       ;;
+     *)
+       echo "Skipping gh issue close — /land-pr STATUS=${LP[STATUS]:-unknown}. Approved issues remain OPEN; re-run sync after the underlying landing failure is resolved." >&2
+       ;;
+   esac
+   ```
+
+4. **Report:**
    ```
    Sync complete.
      Open issues: N
@@ -453,9 +477,10 @@ For each approved issue:
      Likely fixed (needs human review): L (#NNN, #NNN)
      Gaps: [any GH issues not in any tracker]
      PR: ${LP[PR_URL]:-(none)} — STATUS=${LP[STATUS]:-unknown}
+     Closed on GitHub (only if /land-pr success): J (#NNN, ...) or "deferred — /land-pr STATUS=<status>"
    ```
 
-4. **Exit.**
+5. **Exit.**
 
 ## Plan (if `plan` is present)
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   already-fixed issues. Use plan to draft plans for skipped issues.
   Usage: /fix-issues N [focus] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next.
 metadata:
-  version: "2026.05.14+5f21d5"
+  version: "2026.05.15+ab4898"
 ---
 
 # /fix-issues N [focus] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -295,19 +295,20 @@ Close 3 FIXED issues? (all / comma-separated numbers / none)
 - **If no close candidates found:** skip this step, just show the sync
   summary.
 
-### Step 4 — Close approved issues on GitHub
+### Step 4 — Stage local tracker + sprint-report updates for approved issues
 
 For each approved issue:
 
-1. **Close with a comment** explaining what fixed it:
-   ```bash
-   gh issue close <N> --comment "Fixed in commit <hash>. <brief description of fix>. Tests: <test file(s)>."
-   ```
+1. **Update tracker files** — mark the issue `[x]` in all relevant trackers.
 
-2. **Update tracker files** — mark the issue `[x]` in all relevant trackers.
-
-3. **Update `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`** — if the issue appears in an "Already
+2. **Update `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`** — if the issue appears in an "Already
    Implemented" section, add a note: `Closed by /fix-issues sync`.
+
+The `gh issue close` calls are deferred to Step 5 sub-step 3, AFTER
+`/land-pr` returns a success status (`created`, `monitored`, or `merged`).
+If `/land-pr` fails, the issues remain OPEN on GitHub — preventing
+state divergence between closed-on-GH and unmerged-in-main (AC-P.3 of
+`docs/plans/FIX_ISSUES_SYNC_HARDENING.md`).
 
 ### Step 5 — Commit & report
 
@@ -394,7 +395,9 @@ For each approved issue:
 
    # Build the PR body file. Body intentionally OMITS GitHub auto-close
    # directives (Close[sd]? / Fixe[sd]? / Resolve[sd]? #N) — sync closes
-   # approved issues itself via `gh issue close` in Step 4 after merge.
+   # approved issues itself via `gh issue close` in Step 5 sub-step 3,
+   # only after /land-pr returns a success status (AC-P.3 of
+   # `docs/plans/FIX_ISSUES_SYNC_HARDENING.md`).
    RESULT_FILE=$(mktemp)
    BODY_FILE=$(mktemp)
    {
@@ -439,11 +442,32 @@ For each approved issue:
      esac
    done < "$RESULT_FILE"
 
-   # LP[STATUS] drives the report below. fulfilled.land-pr.${SYNC_ID} is
-   # present on main_root iff LP[STATUS]=merged.
+   # LP[STATUS] drives sub-step 3 (close approved issues on success) and
+   # the report below. fulfilled.land-pr.${SYNC_ID} is present on
+   # main_root iff LP[STATUS]=merged.
    ```
 
-3. **Report:**
+3. **Close approved issues on GitHub** — only if `/land-pr` returned a
+   success status (`created`, `monitored`, or `merged`). On any other
+   status (`push-failed`, `rebase-conflict`, `create-failed`,
+   `monitor-failed`, `merge-failed`, `rebase-failed`), leave issues OPEN
+   to prevent state divergence between closed-on-GH and unmerged-in-main
+   (AC-P.3). The next sync run can re-attempt the close after the
+   underlying landing failure is resolved.
+
+   ```bash
+   case "${LP[STATUS]:-}" in
+     created|monitored|merged)
+       # For each approved issue, close with the fix-commit reference.
+       gh issue close <N> --comment "Fixed in commit <hash>. <brief description of fix>. Tests: <test file(s)>."
+       ;;
+     *)
+       echo "Skipping gh issue close — /land-pr STATUS=${LP[STATUS]:-unknown}. Approved issues remain OPEN; re-run sync after the underlying landing failure is resolved." >&2
+       ;;
+   esac
+   ```
+
+4. **Report:**
    ```
    Sync complete.
      Open issues: N
@@ -453,9 +477,10 @@ For each approved issue:
      Likely fixed (needs human review): L (#NNN, #NNN)
      Gaps: [any GH issues not in any tracker]
      PR: ${LP[PR_URL]:-(none)} — STATUS=${LP[STATUS]:-unknown}
+     Closed on GitHub (only if /land-pr success): J (#NNN, ...) or "deferred — /land-pr STATUS=<status>"
    ```
 
-4. **Exit.**
+5. **Exit.**
 
 ## Plan (if `plan` is present)
 


### PR DESCRIPTION
## Summary

Follow-up to PR #269 (just-merged /fix-issues sync hardening). A post-merge `/verify-changes` audit found that AC-P.3 of `docs/plans/FIX_ISSUES_SYNC_HARDENING.md` — "GH issue close calls deferred until `/land-pr` returns success status" — was not actually enforced in the landed implementation: Step 4 (`gh issue close`) textually + executionally preceded Step 5's `/land-pr` dispatch. On `/land-pr` failure (or human PR rejection), issues would be closed on GitHub while the tracker work sat unmerged on main — the exact state divergence AC-P.3 promised to prevent.

This PR re-orders `/fix-issues sync` so:

- **Step 4** now stages only local tracker + SPRINT_REPORT.md edits. No `gh issue close`.
- **Step 5 sub-step 3** (new) wraps `gh issue close` in `case "${LP[STATUS]:-}" in created|monitored|merged) ... ;; *) skip+stderr-warn ;; esac` — guard matches AC-P.3's stated success set verbatim. Failure path is explicit (warn to stderr; issues remain OPEN; next sync retry).
- **Step 5 sub-step 4 = Report** (renumbered from 3), sub-step 5 = Exit. Report block now includes a per-issue close status line.
- Comment at line ~397 corrected: "Step 4 after merge" → "Step 5 sub-step 3, only after /land-pr returns a success status (AC-P.3)."

metadata.version bumped `2026.05.14+5f21d5` → `2026.05.15+ab4898`; mirror byte-identical.

## Test plan

- [x] `bash tests/run-all.sh`: 3039/3039 pass, 0 fail.
- [x] `bash tests/test-skill-conformance.sh`: 404/404 pass.
- [x] `diff -rq skills/fix-issues .claude/skills/fix-issues` empty (mirror byte-identical).
- [x] `awk '/^### Step 4 /,/^### Step 5 /' skills/fix-issues/SKILL.md | grep -cE 'gh issue close'` → 1 (prose reference only, NOT a call).
- [x] `awk '/^### Step 5 /,/^## /' skills/fix-issues/SKILL.md | grep -cE 'gh issue close'` → 3 (the actual call + failure-arm + body-comment).
- [x] `awk '/^### Step 5 /,/^## /' skills/fix-issues/SKILL.md | grep -cE 'created\|monitored\|merged'` → 1 (guard pattern matches AC-P.3 verbatim).
- [x] Fresh verifier subagent independently confirmed re-order is correct and committed the change at `b2b567c`.
- [ ] Synthetic test: invoke /fix-issues sync on a scratch repo with approved-issue list set, force /land-pr to fail (e.g., uncommittable main). Expected post-fix: GH issues stay OPEN. Test plan; not part of this PR diff.

Forward-fix of the AC-P.3 ordering bug — no revert of PR #269 needed. Bare references to AC-P.3 / PR #269 only; no GitHub auto-close directives.
