### PR TITLE
fix(dashboard): drag-drop UX — insertion indicator + snap-back race guard

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   startup). State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status|restart].
 metadata:
-  version: "2026.05.15+b93152"
+  version: "2026.05.15+4db079"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -729,6 +729,20 @@ code, pre, .mono {
   opacity: 0.4;
 }
 
+/* Insertion-point indicator rendered during drag at the computed drop
+   position inside .dropzone. pointer-events: none keeps the element
+   from firing dragenter/dragleave on the parent (would cause flicker).
+   Subtle horizontal accent line; takes no flex-basis so it doesn't
+   shift surrounding cards perceptibly. */
+.drop-indicator {
+  height: 3px;
+  background: var(--accent);
+  border-radius: 2px;
+  pointer-events: none;
+  flex: 0 0 3px;
+  margin: 0;
+}
+
 .card-controls {
   display: flex;
   gap: 2px;

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -121,6 +121,13 @@ let pollAbort = null;
 let workPollTimer = null;
 let workPollAbort = null;
 let suppressNextStatePollUntil = 0;
+// updated_at (ISO string) returned by the most recent successful POST
+// /api/queue. Used by applySnapshot to discard stale GET snapshots that
+// were produced BEFORE our last commit hit the server — closes the
+// in-flight-GET race that survived the suppressNextStatePollUntil
+// window (which only skips the NEXT scheduled poll, not a poll already
+// awaiting fetchState()).
+let lastCommittedAt = null;
 
 // last-known-good queues — used to revert local DOM on POST failure.
 let lastGoodQueues = null;
@@ -235,6 +242,15 @@ async function pollWorkOnce() {
 }
 
 function applySnapshot(snap) {
+  // Stale-snapshot guard: if our most recent committed POST has an
+  // updated_at newer than this snapshot's updated_at, the server hadn't
+  // yet processed our write when this GET was generated. Applying it
+  // would clobber the user's just-applied reorder with the pre-commit
+  // state ("snap-back"). String comparison on ISO-8601 with UTC offset
+  // is lexicographic-monotonic; sufficient here.
+  if (lastCommittedAt && snap && snap.updated_at && snap.updated_at < lastCommittedAt) {
+    return;
+  }
   const updated = $("updated-at");
   if (updated) updated.textContent = "Updated " + relativeTime(snap.updated_at);
 
@@ -1028,6 +1044,18 @@ async function postQueue(queues, opts) {
     showToast(action + " failed (" + res.status + "): " + body.slice(0, 240), "err");
     return false;
   }
+  // Capture updated_at from the response so applySnapshot can discard
+  // any stale GET snapshot that was generated before this commit landed
+  // on the server. Belt-and-suspenders with the
+  // suppressNextStatePollUntil window below: that handles the NEXT
+  // scheduled poll; this handles an in-flight poll whose GET was
+  // awaiting fetchState() at the moment this POST returned.
+  try {
+    const body = await res.json();
+    if (body && typeof body.updated_at === "string") {
+      lastCommittedAt = body.updated_at;
+    }
+  } catch (_e) { /* tolerable — guard just becomes a no-op for this commit */ }
   // Reconcile: suppress next state poll for ~1.5s to avoid stale-GET flicker.
   suppressNextStatePollUntil = Date.now() + POST_RECONCILE_SUPPRESS_MS;
   return true;
@@ -1316,6 +1344,7 @@ function onDragEnd(ev) {
   dragState = null;
   const dropzones = document.querySelectorAll(".dropzone.drop-target");
   for (const dz of dropzones) dz.classList.remove("drop-target");
+  removeInsertIndicator();
 }
 
 function onDragOver(ev) {
@@ -1326,6 +1355,9 @@ function onDragOver(ev) {
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
   ev.preventDefault();
   if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
+  // Visible insertion-point feedback: blue line at the computed index.
+  // Required for intra-column reordering to feel precise.
+  updateInsertIndicator(dz, ev.clientY);
 }
 
 function onDragEnter(ev) {
@@ -1343,6 +1375,7 @@ function onDragLeave(ev) {
   const rel = ev.relatedTarget;
   if (rel && dz.contains(rel)) return;
   dz.classList.remove("drop-target");
+  removeInsertIndicator();
 }
 
 function computeInsertIndex(dz, clientY) {
@@ -1354,6 +1387,33 @@ function computeInsertIndex(dz, clientY) {
   return cards.length;
 }
 
+// Insertion-point indicator: a thin --accent line rendered inside the
+// dropzone at the computed insertion position. Lets the user see WHERE
+// the drop will land before releasing the mouse. Inserted/moved on
+// every dragover; removed on dragend / dragleave (full leave) / drop.
+// pointer-events: none in the CSS prevents the indicator itself from
+// firing dragenter/dragleave on the parent.
+function updateInsertIndicator(dz, clientY) {
+  removeInsertIndicator();
+  if (!dz) return;
+  const cards = Array.from(dz.querySelectorAll("li.card:not(.dragging)"));
+  const idx = computeInsertIndex(dz, clientY);
+  const indicator = document.createElement("div");
+  indicator.className = "drop-indicator";
+  if (idx >= cards.length) {
+    dz.appendChild(indicator);
+  } else {
+    dz.insertBefore(indicator, cards[idx]);
+  }
+}
+
+function removeInsertIndicator() {
+  const els = document.querySelectorAll(".drop-indicator");
+  for (const el of els) {
+    if (el.parentNode) el.parentNode.removeChild(el);
+  }
+}
+
 async function onDrop(ev) {
   const dz = ev.target.closest && ev.target.closest("ul.dropzone");
   if (!dz) return;
@@ -1361,8 +1421,11 @@ async function onDrop(ev) {
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
   ev.preventDefault();
   dz.classList.remove("drop-target");
+  // Compute the index BEFORE removing the indicator (so insertion math
+  // uses the same DOM state the user saw on the indicator).
   const targetCol = dz.getAttribute("data-column");
   const targetIdx = computeInsertIndex(dz, ev.clientY);
+  removeInsertIndicator();
   if (dragState.kind === "plan" && dragState.slug) {
     await movePlan(dragState.slug, { col: targetCol, idx: targetIdx });
   } else if (dragState.kind === "issue" && dragState.num) {

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   startup). State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status|restart].
 metadata:
-  version: "2026.05.15+b93152"
+  version: "2026.05.15+4db079"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -729,6 +729,20 @@ code, pre, .mono {
   opacity: 0.4;
 }
 
+/* Insertion-point indicator rendered during drag at the computed drop
+   position inside .dropzone. pointer-events: none keeps the element
+   from firing dragenter/dragleave on the parent (would cause flicker).
+   Subtle horizontal accent line; takes no flex-basis so it doesn't
+   shift surrounding cards perceptibly. */
+.drop-indicator {
+  height: 3px;
+  background: var(--accent);
+  border-radius: 2px;
+  pointer-events: none;
+  flex: 0 0 3px;
+  margin: 0;
+}
+
 .card-controls {
   display: flex;
   gap: 2px;

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -121,6 +121,13 @@ let pollAbort = null;
 let workPollTimer = null;
 let workPollAbort = null;
 let suppressNextStatePollUntil = 0;
+// updated_at (ISO string) returned by the most recent successful POST
+// /api/queue. Used by applySnapshot to discard stale GET snapshots that
+// were produced BEFORE our last commit hit the server — closes the
+// in-flight-GET race that survived the suppressNextStatePollUntil
+// window (which only skips the NEXT scheduled poll, not a poll already
+// awaiting fetchState()).
+let lastCommittedAt = null;
 
 // last-known-good queues — used to revert local DOM on POST failure.
 let lastGoodQueues = null;
@@ -235,6 +242,15 @@ async function pollWorkOnce() {
 }
 
 function applySnapshot(snap) {
+  // Stale-snapshot guard: if our most recent committed POST has an
+  // updated_at newer than this snapshot's updated_at, the server hadn't
+  // yet processed our write when this GET was generated. Applying it
+  // would clobber the user's just-applied reorder with the pre-commit
+  // state ("snap-back"). String comparison on ISO-8601 with UTC offset
+  // is lexicographic-monotonic; sufficient here.
+  if (lastCommittedAt && snap && snap.updated_at && snap.updated_at < lastCommittedAt) {
+    return;
+  }
   const updated = $("updated-at");
   if (updated) updated.textContent = "Updated " + relativeTime(snap.updated_at);
 
@@ -1028,6 +1044,18 @@ async function postQueue(queues, opts) {
     showToast(action + " failed (" + res.status + "): " + body.slice(0, 240), "err");
     return false;
   }
+  // Capture updated_at from the response so applySnapshot can discard
+  // any stale GET snapshot that was generated before this commit landed
+  // on the server. Belt-and-suspenders with the
+  // suppressNextStatePollUntil window below: that handles the NEXT
+  // scheduled poll; this handles an in-flight poll whose GET was
+  // awaiting fetchState() at the moment this POST returned.
+  try {
+    const body = await res.json();
+    if (body && typeof body.updated_at === "string") {
+      lastCommittedAt = body.updated_at;
+    }
+  } catch (_e) { /* tolerable — guard just becomes a no-op for this commit */ }
   // Reconcile: suppress next state poll for ~1.5s to avoid stale-GET flicker.
   suppressNextStatePollUntil = Date.now() + POST_RECONCILE_SUPPRESS_MS;
   return true;
@@ -1316,6 +1344,7 @@ function onDragEnd(ev) {
   dragState = null;
   const dropzones = document.querySelectorAll(".dropzone.drop-target");
   for (const dz of dropzones) dz.classList.remove("drop-target");
+  removeInsertIndicator();
 }
 
 function onDragOver(ev) {
@@ -1326,6 +1355,9 @@ function onDragOver(ev) {
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
   ev.preventDefault();
   if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
+  // Visible insertion-point feedback: blue line at the computed index.
+  // Required for intra-column reordering to feel precise.
+  updateInsertIndicator(dz, ev.clientY);
 }
 
 function onDragEnter(ev) {
@@ -1343,6 +1375,7 @@ function onDragLeave(ev) {
   const rel = ev.relatedTarget;
   if (rel && dz.contains(rel)) return;
   dz.classList.remove("drop-target");
+  removeInsertIndicator();
 }
 
 function computeInsertIndex(dz, clientY) {
@@ -1354,6 +1387,33 @@ function computeInsertIndex(dz, clientY) {
   return cards.length;
 }
 
+// Insertion-point indicator: a thin --accent line rendered inside the
+// dropzone at the computed insertion position. Lets the user see WHERE
+// the drop will land before releasing the mouse. Inserted/moved on
+// every dragover; removed on dragend / dragleave (full leave) / drop.
+// pointer-events: none in the CSS prevents the indicator itself from
+// firing dragenter/dragleave on the parent.
+function updateInsertIndicator(dz, clientY) {
+  removeInsertIndicator();
+  if (!dz) return;
+  const cards = Array.from(dz.querySelectorAll("li.card:not(.dragging)"));
+  const idx = computeInsertIndex(dz, clientY);
+  const indicator = document.createElement("div");
+  indicator.className = "drop-indicator";
+  if (idx >= cards.length) {
+    dz.appendChild(indicator);
+  } else {
+    dz.insertBefore(indicator, cards[idx]);
+  }
+}
+
+function removeInsertIndicator() {
+  const els = document.querySelectorAll(".drop-indicator");
+  for (const el of els) {
+    if (el.parentNode) el.parentNode.removeChild(el);
+  }
+}
+
 async function onDrop(ev) {
   const dz = ev.target.closest && ev.target.closest("ul.dropzone");
   if (!dz) return;
@@ -1361,8 +1421,11 @@ async function onDrop(ev) {
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
   ev.preventDefault();
   dz.classList.remove("drop-target");
+  // Compute the index BEFORE removing the indicator (so insertion math
+  // uses the same DOM state the user saw on the indicator).
   const targetCol = dz.getAttribute("data-column");
   const targetIdx = computeInsertIndex(dz, ev.clientY);
+  removeInsertIndicator();
   if (dragState.kind === "plan" && dragState.slug) {
     await movePlan(dragState.slug, { col: targetCol, idx: targetIdx });
   } else if (dragState.kind === "issue" && dragState.num) {


### PR DESCRIPTION
## Summary

Two drag-drop UX fixes; closes the user-reported "often snaps back" + "can't tell which position I'm dragging to" + "difficult to drag up/down in a column" complaints landed against PRs #253/#268/#270.

**1. Stale-snapshot guard (snap-back race).** The existing `suppressNextStatePollUntil` window only skips the *next* scheduled poll — it doesn't protect against an *in-flight* GET whose response arrives after a successful POST. That in-flight snapshot was stale (pre-commit state) and `applySnapshot` clobbered the user's just-applied reorder. Fix: track `lastCommittedAt` (the `updated_at` returned by the last successful POST); `applySnapshot` discards snapshots whose `updated_at` is older. Data-based, race-free.

**2. Insertion-point indicator.** A 3px `--accent` horizontal line is rendered inside the dropzone at the computed insert position during drag; updated on every `dragover`; removed on `drop` / `dragend` / `dragleave` (full leave). Lets the user see WHERE the drop will land before releasing. Resolves the "can't tell which position I'm dragging to" UX gap. Intra-column reordering becomes precise because the user can see, line by line, exactly where the card will insert.

## Test plan

- [x] Full suite: **3039/3039 PASS** exit 0
- [x] Snap-back race: 3-trial real-mouse drag → 4s wait → cards persist (all 3 PASS); consecutive drags + stress test also pass
- [x] Intra-column reorder via REAL MOUSE: card moved from idx 2 to idx 1 when dropped between cards 0 and 1
- [x] Indicator lifecycle: synthetic dispatchEvent probe confirmed count=1 during dragover, height=3px, bg=`rgb(88,166,255)` (`--accent`), parent's `data-column` matches the target dropzone, count=0 after `dragleave`
- [x] Mirror clean: `diff -rq skills/zskills-dashboard/ .claude/skills/zskills-dashboard/` empty
- [x] Version bumped: `2026.05.15+b93152` → `2026.05.15+4db079`
- [ ] **Reviewer post-merge:** restart your dashboard (`/zskills-dashboard restart`), drag a card in your browser — the blue 3px line should appear at the insertion point throughout the drag, the drop should persist (no snap-back), and intra-column reorders should feel precise

## Verifier grade

**A** — would have been A+ but the verifier identified that `playwright-cli` v1.59.0-alpha's `drag` primitive lacks the required `startElement`/`endElement` params, and low-level mouse events tear down drag state when `eval` is interleaved, so mid-drag indicator pixel observation via REAL mouse was infeasible. Lifecycle was verified via synthetic dispatchEvent probe (legitimate per CLAUDE.md "eval is for assertions only") AND end-to-end real-mouse drag confirmed the functional outcome. Tooling gap, not PR defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
