### PR TITLE
feat(dashboard): activity feed includes git-history commits

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   startup). State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status|restart].
 metadata:
-  version: "2026.05.15+629f7f"
+  version: "2026.05.15+bc1c37"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -778,6 +778,145 @@ def _scan_tracking_markers(
 
 
 # ---------------------------------------------------------------------------
+# Git-history activity (commits that don't have a tracking marker)
+# ---------------------------------------------------------------------------
+
+# Subject patterns we extract: trailing "(#N)" PR ref (squash-merge style)
+# and any "#N" issue reference. PR_RE is anchored to end-of-string so
+# inline "(#999)" body refs don't trigger.
+_PR_TRAILER_RE = re.compile(r"\(#(\d+)\)\s*$")
+_ISSUE_HASH_RE = re.compile(r"(?:^|\W)#(\d+)\b")
+
+
+def _scan_git_history(
+    main_root: pathlib.Path,
+    errors: List[Dict[str, str]],
+    *,
+    since_hours: int = 72,
+    max_commits: int = 200,
+    fulfilled_pr_numbers: Optional[set] = None,
+) -> List[Dict[str, Any]]:
+    """Read commits from `git log` and emit activity-row records.
+
+    Each commit becomes a record shaped like a tracking-marker record so
+    the existing _sort_key + UI renderer accept it without special-casing.
+    Commits whose trailing `(#N)` PR number is in `fulfilled_pr_numbers`
+    (built from fulfilled.land-pr.* markers) are skipped — the marker is
+    richer.
+    """
+    if not (main_root / ".git").exists():
+        return []
+    if fulfilled_pr_numbers is None:
+        fulfilled_pr_numbers = set()
+    since_arg = f"--since={int(since_hours)} hours ago"
+    fmt = "%H%x1f%cI%x1f%s"  # SHA, ISO commit date, subject — unit-separator-joined
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(main_root),
+                "log",
+                since_arg,
+                f"--max-count={int(max_commits)}",
+                f"--pretty=format:{fmt}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        errors.append({
+            "source": "git history",
+            "message": f"git log failed: {exc}",
+        })
+        return []
+    if result.returncode != 0:
+        # Empty repo / no commits in window is not an error here.
+        if result.stderr.strip():
+            errors.append({
+                "source": "git history",
+                "message": f"git log rc={result.returncode}: {result.stderr.strip()[:200]}",
+            })
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for line in result.stdout.split("\n"):
+        line = line.rstrip()
+        if not line:
+            continue
+        parts = line.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        sha, iso_date, subject = parts
+        pr_num = ""
+        m = _PR_TRAILER_RE.search(subject)
+        if m:
+            pr_num = m.group(1)
+            if pr_num in fulfilled_pr_numbers:
+                continue  # dedup'd by richer marker
+        issue_num = ""
+        m2 = _ISSUE_HASH_RE.search(subject)
+        if m2 and m2.group(1) != pr_num:
+            issue_num = m2.group(1)
+        record: Dict[str, Any] = {
+            "timestamp": iso_date,
+            "pipeline": "",
+            "kind": "commit",
+            "id": sha[:7],
+            "skill": "",
+            "status": "",
+            "output": "",
+            "location": "git",
+            "parent": None,
+            "subject": subject,
+            "sha": sha,
+            "pr": pr_num,
+            "issue": issue_num,
+        }
+        out.append(record)
+    return out
+
+
+def _extract_pr_numbers_from_markers(
+    activity: List[Dict[str, Any]],
+    main_root: pathlib.Path,
+) -> set:
+    """Walk fulfilled.land-pr.* markers to collect PR numbers for dedup."""
+    nums: set = set()
+    base = main_root / ".zskills" / "tracking"
+    if not base.is_dir():
+        return nums
+    # Match either flat or per-pipeline subdir; the basename is what carries
+    # the marker kind/id, and we only care about fulfilled.land-pr.*.
+    pr_url_re = re.compile(r"github\.com/[^/]+/[^/]+/pull/(\d+)")
+    try:
+        for entry in base.iterdir():
+            candidates: List[pathlib.Path] = []
+            if entry.is_file() and entry.name.startswith("fulfilled.land-pr."):
+                candidates.append(entry)
+            elif entry.is_dir():
+                try:
+                    for sub in entry.iterdir():
+                        if sub.is_file() and sub.name.startswith("fulfilled.land-pr."):
+                            candidates.append(sub)
+                except OSError:
+                    continue
+            for p in candidates:
+                fields = _parse_marker_file(p)
+                if fields is None:
+                    continue
+                pr_field = fields.get("pr", "")
+                m = pr_url_re.search(pr_field)
+                if m:
+                    nums.add(m.group(1))
+    except OSError:
+        return nums
+    return nums
+
+
+# ---------------------------------------------------------------------------
 # Worktree + branch listing (reuse briefing.py helpers)
 # ---------------------------------------------------------------------------
 
@@ -1182,8 +1321,29 @@ def collect_snapshot(
     worktrees = _list_worktrees(main_root, errors)
     branches = _list_branches(main_root, errors)
 
-    # Tracking activity
-    activity = _scan_tracking_markers(main_root, errors)
+    # Tracking activity + git-history events (commits with no marker).
+    # Tracking markers are richer (skill, id, pipeline) so they win on
+    # dedup; commits whose trailing `(#N)` matches a fulfilled.land-pr.*
+    # marker's PR number are dropped.
+    marker_activity = _scan_tracking_markers(main_root, errors)
+    fulfilled_prs = _extract_pr_numbers_from_markers(marker_activity, main_root)
+    git_activity = _scan_git_history(
+        main_root, errors, fulfilled_pr_numbers=fulfilled_prs,
+    )
+    activity = marker_activity + git_activity
+
+    def _activity_sort_key(rec: Dict[str, Any]):
+        ts = rec.get("timestamp", "")
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return -dt.astimezone(timezone.utc).timestamp()
+        except Exception:
+            return 0.0
+
+    activity.sort(key=_activity_sort_key)
+    activity = activity[:200]
 
     # Queues block (raw state-file-shape mirror, plus default_mode)
     queues_block: Dict[str, Any] = {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -369,6 +369,7 @@ code, pre, .mono {
 .activity-row .a-status-fail    { color: var(--red); }
 .activity-row .a-status-running { color: var(--orange); }
 .activity-row .a-parent { color: var(--text-dim); font-style: italic; margin-left: 6px; }
+.activity-row .a-subject { color: var(--text); }
 .activity-row .a-time { color: var(--text-dim); }
 
 .modal-root {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -406,6 +406,7 @@ function fingerprintIssues(issues, queues) {
 function fingerprintActivity(act) {
   return JSON.stringify(act.slice(0, 20).map(a => [
     a.timestamp, a.pipeline, a.kind, a.id, a.skill, a.status, a.parent,
+    a.subject, a.pr,
   ]));
 }
 
@@ -863,21 +864,34 @@ function renderActivity(activity) {
   empty.hidden = true;
   for (const a of rows) {
     const row = el("div", { cls: "activity-row" });
-    row.appendChild(el("span", { cls: "a-pipe mono", text: a.pipeline || "(legacy)" }));
-    const mid = el("span");
-    if (a.skill) {
-      mid.appendChild(el("span", { cls: "a-skill mono", text: a.skill }));
+    if (a.kind === "commit") {
+      // Git-history row: short SHA + commit subject. Subject already
+      // conveys what changed; no need for pipeline/skill columns.
+      row.appendChild(el("span", { cls: "a-pipe mono", text: a.id || "" }));
+      const mid = el("span");
+      mid.appendChild(el("span", { cls: "a-subject", text: a.subject || "" }));
+      if (a.pr) {
+        mid.appendChild(el("span", { cls: "a-parent", text: " #" + a.pr }));
+      }
+      row.appendChild(mid);
+      row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
+    } else {
+      row.appendChild(el("span", { cls: "a-pipe mono", text: a.pipeline || "(legacy)" }));
+      const mid = el("span");
+      if (a.skill) {
+        mid.appendChild(el("span", { cls: "a-skill mono", text: a.skill }));
+      }
+      mid.appendChild(el("span", { text: " " + (a.kind || "") + (a.id ? " " + a.id : "") }));
+      if (a.status) {
+        const cls = activityStatusClass(a.status);
+        mid.appendChild(el("span", { cls: cls ? "pill " + cls : "pill", text: a.status }));
+      }
+      if (a.parent) {
+        mid.appendChild(el("span", { cls: "a-parent", text: "← " + a.parent }));
+      }
+      row.appendChild(mid);
+      row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
     }
-    mid.appendChild(el("span", { text: " " + (a.kind || "") + (a.id ? " " + a.id : "") }));
-    if (a.status) {
-      const cls = activityStatusClass(a.status);
-      mid.appendChild(el("span", { cls: cls ? "pill " + cls : "pill", text: a.status }));
-    }
-    if (a.parent) {
-      mid.appendChild(el("span", { cls: "a-parent", text: "← " + a.parent }));
-    }
-    row.appendChild(mid);
-    row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
     body.appendChild(row);
   }
 }

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   startup). State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status|restart].
 metadata:
-  version: "2026.05.15+629f7f"
+  version: "2026.05.15+bc1c37"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -778,6 +778,145 @@ def _scan_tracking_markers(
 
 
 # ---------------------------------------------------------------------------
+# Git-history activity (commits that don't have a tracking marker)
+# ---------------------------------------------------------------------------
+
+# Subject patterns we extract: trailing "(#N)" PR ref (squash-merge style)
+# and any "#N" issue reference. PR_RE is anchored to end-of-string so
+# inline "(#999)" body refs don't trigger.
+_PR_TRAILER_RE = re.compile(r"\(#(\d+)\)\s*$")
+_ISSUE_HASH_RE = re.compile(r"(?:^|\W)#(\d+)\b")
+
+
+def _scan_git_history(
+    main_root: pathlib.Path,
+    errors: List[Dict[str, str]],
+    *,
+    since_hours: int = 72,
+    max_commits: int = 200,
+    fulfilled_pr_numbers: Optional[set] = None,
+) -> List[Dict[str, Any]]:
+    """Read commits from `git log` and emit activity-row records.
+
+    Each commit becomes a record shaped like a tracking-marker record so
+    the existing _sort_key + UI renderer accept it without special-casing.
+    Commits whose trailing `(#N)` PR number is in `fulfilled_pr_numbers`
+    (built from fulfilled.land-pr.* markers) are skipped — the marker is
+    richer.
+    """
+    if not (main_root / ".git").exists():
+        return []
+    if fulfilled_pr_numbers is None:
+        fulfilled_pr_numbers = set()
+    since_arg = f"--since={int(since_hours)} hours ago"
+    fmt = "%H%x1f%cI%x1f%s"  # SHA, ISO commit date, subject — unit-separator-joined
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(main_root),
+                "log",
+                since_arg,
+                f"--max-count={int(max_commits)}",
+                f"--pretty=format:{fmt}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        errors.append({
+            "source": "git history",
+            "message": f"git log failed: {exc}",
+        })
+        return []
+    if result.returncode != 0:
+        # Empty repo / no commits in window is not an error here.
+        if result.stderr.strip():
+            errors.append({
+                "source": "git history",
+                "message": f"git log rc={result.returncode}: {result.stderr.strip()[:200]}",
+            })
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for line in result.stdout.split("\n"):
+        line = line.rstrip()
+        if not line:
+            continue
+        parts = line.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        sha, iso_date, subject = parts
+        pr_num = ""
+        m = _PR_TRAILER_RE.search(subject)
+        if m:
+            pr_num = m.group(1)
+            if pr_num in fulfilled_pr_numbers:
+                continue  # dedup'd by richer marker
+        issue_num = ""
+        m2 = _ISSUE_HASH_RE.search(subject)
+        if m2 and m2.group(1) != pr_num:
+            issue_num = m2.group(1)
+        record: Dict[str, Any] = {
+            "timestamp": iso_date,
+            "pipeline": "",
+            "kind": "commit",
+            "id": sha[:7],
+            "skill": "",
+            "status": "",
+            "output": "",
+            "location": "git",
+            "parent": None,
+            "subject": subject,
+            "sha": sha,
+            "pr": pr_num,
+            "issue": issue_num,
+        }
+        out.append(record)
+    return out
+
+
+def _extract_pr_numbers_from_markers(
+    activity: List[Dict[str, Any]],
+    main_root: pathlib.Path,
+) -> set:
+    """Walk fulfilled.land-pr.* markers to collect PR numbers for dedup."""
+    nums: set = set()
+    base = main_root / ".zskills" / "tracking"
+    if not base.is_dir():
+        return nums
+    # Match either flat or per-pipeline subdir; the basename is what carries
+    # the marker kind/id, and we only care about fulfilled.land-pr.*.
+    pr_url_re = re.compile(r"github\.com/[^/]+/[^/]+/pull/(\d+)")
+    try:
+        for entry in base.iterdir():
+            candidates: List[pathlib.Path] = []
+            if entry.is_file() and entry.name.startswith("fulfilled.land-pr."):
+                candidates.append(entry)
+            elif entry.is_dir():
+                try:
+                    for sub in entry.iterdir():
+                        if sub.is_file() and sub.name.startswith("fulfilled.land-pr."):
+                            candidates.append(sub)
+                except OSError:
+                    continue
+            for p in candidates:
+                fields = _parse_marker_file(p)
+                if fields is None:
+                    continue
+                pr_field = fields.get("pr", "")
+                m = pr_url_re.search(pr_field)
+                if m:
+                    nums.add(m.group(1))
+    except OSError:
+        return nums
+    return nums
+
+
+# ---------------------------------------------------------------------------
 # Worktree + branch listing (reuse briefing.py helpers)
 # ---------------------------------------------------------------------------
 
@@ -1182,8 +1321,29 @@ def collect_snapshot(
     worktrees = _list_worktrees(main_root, errors)
     branches = _list_branches(main_root, errors)
 
-    # Tracking activity
-    activity = _scan_tracking_markers(main_root, errors)
+    # Tracking activity + git-history events (commits with no marker).
+    # Tracking markers are richer (skill, id, pipeline) so they win on
+    # dedup; commits whose trailing `(#N)` matches a fulfilled.land-pr.*
+    # marker's PR number are dropped.
+    marker_activity = _scan_tracking_markers(main_root, errors)
+    fulfilled_prs = _extract_pr_numbers_from_markers(marker_activity, main_root)
+    git_activity = _scan_git_history(
+        main_root, errors, fulfilled_pr_numbers=fulfilled_prs,
+    )
+    activity = marker_activity + git_activity
+
+    def _activity_sort_key(rec: Dict[str, Any]):
+        ts = rec.get("timestamp", "")
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return -dt.astimezone(timezone.utc).timestamp()
+        except Exception:
+            return 0.0
+
+    activity.sort(key=_activity_sort_key)
+    activity = activity[:200]
 
     # Queues block (raw state-file-shape mirror, plus default_mode)
     queues_block: Dict[str, Any] = {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -369,6 +369,7 @@ code, pre, .mono {
 .activity-row .a-status-fail    { color: var(--red); }
 .activity-row .a-status-running { color: var(--orange); }
 .activity-row .a-parent { color: var(--text-dim); font-style: italic; margin-left: 6px; }
+.activity-row .a-subject { color: var(--text); }
 .activity-row .a-time { color: var(--text-dim); }
 
 .modal-root {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -406,6 +406,7 @@ function fingerprintIssues(issues, queues) {
 function fingerprintActivity(act) {
   return JSON.stringify(act.slice(0, 20).map(a => [
     a.timestamp, a.pipeline, a.kind, a.id, a.skill, a.status, a.parent,
+    a.subject, a.pr,
   ]));
 }
 
@@ -863,21 +864,34 @@ function renderActivity(activity) {
   empty.hidden = true;
   for (const a of rows) {
     const row = el("div", { cls: "activity-row" });
-    row.appendChild(el("span", { cls: "a-pipe mono", text: a.pipeline || "(legacy)" }));
-    const mid = el("span");
-    if (a.skill) {
-      mid.appendChild(el("span", { cls: "a-skill mono", text: a.skill }));
+    if (a.kind === "commit") {
+      // Git-history row: short SHA + commit subject. Subject already
+      // conveys what changed; no need for pipeline/skill columns.
+      row.appendChild(el("span", { cls: "a-pipe mono", text: a.id || "" }));
+      const mid = el("span");
+      mid.appendChild(el("span", { cls: "a-subject", text: a.subject || "" }));
+      if (a.pr) {
+        mid.appendChild(el("span", { cls: "a-parent", text: " #" + a.pr }));
+      }
+      row.appendChild(mid);
+      row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
+    } else {
+      row.appendChild(el("span", { cls: "a-pipe mono", text: a.pipeline || "(legacy)" }));
+      const mid = el("span");
+      if (a.skill) {
+        mid.appendChild(el("span", { cls: "a-skill mono", text: a.skill }));
+      }
+      mid.appendChild(el("span", { text: " " + (a.kind || "") + (a.id ? " " + a.id : "") }));
+      if (a.status) {
+        const cls = activityStatusClass(a.status);
+        mid.appendChild(el("span", { cls: cls ? "pill " + cls : "pill", text: a.status }));
+      }
+      if (a.parent) {
+        mid.appendChild(el("span", { cls: "a-parent", text: "← " + a.parent }));
+      }
+      row.appendChild(mid);
+      row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
     }
-    mid.appendChild(el("span", { text: " " + (a.kind || "") + (a.id ? " " + a.id : "") }));
-    if (a.status) {
-      const cls = activityStatusClass(a.status);
-      mid.appendChild(el("span", { cls: cls ? "pill " + cls : "pill", text: a.status }));
-    }
-    if (a.parent) {
-      mid.appendChild(el("span", { cls: "a-parent", text: "← " + a.parent }));
-    }
-    row.appendChild(mid);
-    row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));
     body.appendChild(row);
   }
 }


### PR DESCRIPTION
## Summary

Dashboard's "Recent activity" strip previously surfaced only tracking-marker
events written by skills. Orchestrator-direct `/land-pr` calls, manual
commits, and any human work outside skill flows were invisible — hence
the "most recent activity is 6h ago" frustration even when several PRs
had just landed.

This PR adds git-history-based activity rows that interleave with marker
events by timestamp.

### Implementation

- **`_scan_git_history(main_root, errors, *, since_hours=72, max_commits=200, fulfilled_pr_numbers=None)`** — runs `git log --since="72 hours ago" --max-count=200 --pretty=format:%H<US>%cI<US>%s` (list args, `timeout=5`, `check=False`, no shell). Emits one activity record per commit, shaped like a tracking-marker row plus new fields `subject`, `sha`, `pr`, `issue`. Dedup: commits whose trailing `(#N)` PR-trailer matches the fulfilled-marker set are dropped (the marker is richer).
- **`_extract_pr_numbers_from_markers`** — walks both flat `.zskills/tracking/fulfilled.land-pr.*` and per-pipeline `.zskills/tracking/<pipeline>/fulfilled.land-pr.*` markers, parsing the `pr:` URL field to extract PR numbers.
- **`collect_snapshot`** — merges marker_activity + git_activity, re-sorts by timestamp, caps at 200.
- **`renderActivity`** (app.js) — branches on `kind === "commit"` to render `<short-SHA> | <subject> #<pr>` instead of the pipeline/skill marker layout.
- **`fingerprintActivity`** — adds `subject` + `pr` so strip refreshes on new commits.
- **`.activity-row .a-subject`** (app.css) — uses `var(--text)` for subject readability.

## Test plan

- [x] Full suite: **3040/3040 PASS**, exit 0
- [x] Targeted: `bash tests/test_zskills_monitor_collect.sh` — 31/31 PASS
- [x] Live API smoke: worktree-bound dashboard returned 172 activity rows, 31 commits, 0 errors
- [x] Live DOM smoke: `playwright-cli eval` against the rendered strip confirms interleaved marker rows + commit rows by timestamp
- [x] Visual screenshot: activity strip renders both row variants legibly
- [x] Dedup correctness: PR trailer regex anchored to end-of-string (`\(#(\d+)\)\s*$`) so inline `(#999)` body refs don't false-positive
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: `2026.05.15+629f7f` → `2026.05.15+bc1c37`
- [x] Fresh verifier subagent graded **A+** (7/7 checks)
- [ ] **Reviewer post-merge:** restart dashboard (`/zskills-dashboard restart`), watch the activity strip — should now show every recent commit interleaved with marker rows, not just skill-driven activity

## Performance / safety

- 5s subprocess timeout caps the upper bound on `git log` time; large repos still safe.
- Cap at 200 in-memory commits + 200 final cap keeps payload size bounded.
- No new shell-evaluated input; all git args are list-form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
