### PR TITLE
fix(quickfix): widen positional auto case-pattern to all 16 variants (closes #267)

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   enables auto-merge via /land-pr (matches /run-plan, /fix-issues, /do).
   Usage: /quickfix [<description>] [auto] [--branch <name>] [--yes] [--from-here] [--skip-tests] [--force] [--rounds N]
 metadata:
-  version: "2026.05.14+049699"
+  version: "2026.05.15+87a555"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -109,7 +109,7 @@ while [ $i -lt ${#ARGS[@]} ]; do
     # the arg vector — `/quickfix <desc> auto` and `/quickfix auto <desc>`
     # both set AUTO_FLAG=1. Mirrors the convention in /run-plan,
     # /fix-issues, /do. The token never falls through to DESCRIPTION.
-    auto|AUTO|Auto) AUTO_FLAG=1 ;;
+    [aA][uU][tT][oO]) AUTO_FLAG=1 ;;
     --rounds)
       # Greedy-fallthrough: if next arg is numeric, consume it as ROUNDS.
       # If next arg is non-numeric (e.g. "/quickfix fix --rounds in docs"),

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   enables auto-merge via /land-pr (matches /run-plan, /fix-issues, /do).
   Usage: /quickfix [<description>] [auto] [--branch <name>] [--yes] [--from-here] [--skip-tests] [--force] [--rounds N]
 metadata:
-  version: "2026.05.14+049699"
+  version: "2026.05.15+87a555"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -109,7 +109,7 @@ while [ $i -lt ${#ARGS[@]} ]; do
     # the arg vector — `/quickfix <desc> auto` and `/quickfix auto <desc>`
     # both set AUTO_FLAG=1. Mirrors the convention in /run-plan,
     # /fix-issues, /do. The token never falls through to DESCRIPTION.
-    auto|AUTO|Auto) AUTO_FLAG=1 ;;
+    [aA][uU][tT][oO]) AUTO_FLAG=1 ;;
     --rounds)
       # Greedy-fallthrough: if next arg is numeric, consume it as ROUNDS.
       # If next arg is non-numeric (e.g. "/quickfix fix --rounds in docs"),

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -337,10 +337,10 @@ if grep -q '[-][-]branch)' "$SKILL" \
    && grep -q '[-][-]yes|[-]y)' "$SKILL" \
    && grep -q '[-][-]from-here)' "$SKILL" \
    && grep -q '[-][-]skip-tests)' "$SKILL" \
-   && grep -qE '^[[:space:]]*auto\|AUTO\|Auto\)' "$SKILL"; then
-  pass "2  argument parser: --branch / --yes|-y / --from-here / --skip-tests / positional auto (issue #235)"
+   && grep -qE '^[[:space:]]*\[aA\]\[uU\]\[tT\]\[oO\]\)' "$SKILL"; then
+  pass "2  argument parser: --branch / --yes|-y / --from-here / --skip-tests / positional auto (case-insensitive [aA][uU][tT][oO], issues #235/#267)"
 else
-  fail "2  argument parser: one or more flags missing (including positional 'auto' for issue #235)"
+  fail "2  argument parser: one or more flags missing (including positional case-insensitive 'auto' for issues #235/#267)"
 fi
 
 # ────────────────────────────────────────────────────────────────────
@@ -1711,6 +1711,22 @@ if echo "$OUT" | grep -q '^AUTO_FLAG=0$' \
   pass "56 no-auto (default off) + Phase 7 LAND_ARGS conditional --auto append present — issue #235"
 else
   fail "56 no-auto: parser-out=$(echo "$OUT" | tr '\n' '|') land-args-gated-append-count=$GATED_APPEND"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 56b — Issue #267: positional `auto` token is fully case-
+# insensitive. The pattern was widened from `auto|AUTO|Auto` to
+# `[aA][uU][tT][oO]` so that mixed-case variants (e.g. `AuTo`, `aUtO`,
+# `AUto`) also set AUTO_FLAG=1. Mirrors /commit's [aA][uU][tT][oO]
+# convention — fixes the cosmetic asymmetry where /quickfix was
+# narrower than /commit.
+# ────────────────────────────────────────────────────────────────────
+OUT=$(bash "$PARSER_SCRIPT" "fix readme typo" AuTo)
+if echo "$OUT" | grep -q '^AUTO_FLAG=1$' \
+   && echo "$OUT" | grep -q '^DESCRIPTION=fix readme typo$'; then
+  pass "56b positional auto (mixed-case 'AuTo'): AUTO_FLAG=1, DESCRIPTION clean — issue #267"
+else
+  fail "56b positional auto (mixed-case 'AuTo'): $(echo "$OUT" | tr '\n' '|')"
 fi
 
 # ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #267. Sibling to #266 — both filed from the 2026-05-14 verifier audit. Tightens `/quickfix`'s positional-`auto` case-pattern from 3 case variants (`auto|AUTO|Auto`) to all 16 (`[aA][uU][tT][oO]`), matching `/commit`'s regex form (issue #236). Cosmetic asymmetry only; no behavioral defect in normal use.

## The fix

`skills/quickfix/SKILL.md:112`:
```diff
-    auto|AUTO|Auto) AUTO_FLAG=1 ;;
+    [aA][uU][tT][oO]) AUTO_FLAG=1 ;;
```

The case-statement syntax accepts character classes inside `[...]` identically to regex form. All 16 case variants (`auto`, `AUTO`, `Auto`, `AuTo`, `aUto`, ..., `aUtO`) now set `AUTO_FLAG=1`.

## What else changed

- `.claude/skills/quickfix/SKILL.md` mirror regenerated.
- `metadata.version`: `2026.05.14+049699` → `2026.05.15+87a555`.
- `tests/test-quickfix.sh:340` (Case 2 conformance grep) updated to match the new pattern. Grep escaped form: `\[aA\]\[uU\]\[tT\]\[oO\]\)`.
- `tests/test-quickfix.sh:1716-1731` — new Case 56b exercises mixed-case input `AuTo` and asserts `AUTO_FLAG=1` + `DESCRIPTION` clean.

## Cross-repo check

`grep -rn 'auto|AUTO|Auto)' skills/ .claude/skills/ tests/ scripts/ hooks/` returns zero hits. No other locations reference the old pattern.

## Test plan

- [x] `bash tests/run-all.sh` → **3041/3041 PASS** (baseline + 1 new Case 56b).
- [x] Case 56b standalone PASS (mixed-case `AuTo` → AUTO_FLAG=1).
- [x] `diff -rq skills/quickfix .claude/skills/quickfix` → no differences (mirror clean).
- [x] Verifier subagent APPROVE with anchored file:line evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
