### PR TITLE
feat(dashboard): entry links + plan-text drifts

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   startup). State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status|restart].
 metadata:
-  version: "2026.05.15+bc1c37"
+  version: "2026.05.15+7b3fd7"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -39,6 +39,7 @@ SNAPSHOT_TOP_LEVEL_KEYS = {
     "version",
     "updated_at",
     "repo_root",
+    "repo_url",
     "plans",
     "issues",
     "worktrees",
@@ -778,6 +779,44 @@ def _scan_tracking_markers(
 
 
 # ---------------------------------------------------------------------------
+# Repo URL helper (for client-side entry-link construction)
+# ---------------------------------------------------------------------------
+
+# Accept both HTTPS and SSH origin forms, produce the canonical https URL
+# WITHOUT the trailing .git. Returns "" on any failure — client side
+# treats empty as "no links available, fall back to plain text."
+_GIT_HTTPS_RE = re.compile(r"^https?://([^/]+)/([^/]+/[^/]+?)(?:\.git)?/?$")
+_GIT_SSH_RE = re.compile(r"^git@([^:]+):([^/]+/[^/]+?)(?:\.git)?$")
+
+
+def _derive_repo_url(main_root: pathlib.Path) -> str:
+    if not (main_root / ".git").exists():
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(main_root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if result.returncode != 0:
+        return ""
+    url = result.stdout.strip()
+    if not url:
+        return ""
+    m = _GIT_HTTPS_RE.match(url)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    m = _GIT_SSH_RE.match(url)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
 # Git-history activity (commits that don't have a tracking marker)
 # ---------------------------------------------------------------------------
 
@@ -1356,6 +1395,7 @@ def collect_snapshot(
         "version": VERSION,
         "updated_at": _now_iso(),
         "repo_root": str(main_root),
+        "repo_url": _derive_repo_url(main_root),
         "plans": plans,
         "issues": issues,
         "worktrees": worktrees,
@@ -1461,6 +1501,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "version": VERSION,
             "updated_at": _now_iso(),
             "repo_root": str(main_root),
+            "repo_url": "",
             "plans": plans,
             "issues": issues,
             "worktrees": worktrees,

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -286,6 +286,31 @@ code, pre, .mono {
   color: var(--text);
 }
 
+/* card-title-link — used when an entry (plan / issue / branch) has a
+   GitHub URL we can link to. Matches card-title visual weight; underline
+   only on hover so cards still feel like cards, not link lists. */
+.card-title-link {
+  font-weight: 600;
+  color: var(--text);
+  text-decoration: none;
+}
+.card-title-link:hover,
+.card-title-link:focus {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* PR link in the activity strip — subtle, matches surrounding a-parent
+   styling but turns into a link on hover. */
+.activity-row .a-pr-link {
+  text-decoration: none;
+}
+.activity-row .a-pr-link:hover,
+.activity-row .a-pr-link:focus {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 .card-sub {
   color: var(--text-dim);
   font-size: 0.85rem;

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -59,6 +59,41 @@ function el(tag, opts) {
   return node;
 }
 
+// titleNode(text, href) — returns a span containing either plain text
+// (when href is empty) or an <a> with target=_blank. Anchors carry
+// draggable=false so they don't fight the card's HTML5 drag handler;
+// click+drag from anywhere ELSE on the card still works.
+function titleNode(text, href) {
+  if (href) {
+    return el("a", {
+      cls: "card-title-link",
+      text: text,
+      attrs: {
+        href: href,
+        target: "_blank",
+        rel: "noopener noreferrer",
+        draggable: "false",
+      },
+    });
+  }
+  return el("span", { cls: "card-title", text: text });
+}
+
+function planUrl(plan) {
+  if (!repoUrl || !plan || !plan.file) return "";
+  return repoUrl + "/blob/main/" + plan.file;
+}
+
+function issueUrl(issueNum) {
+  if (!repoUrl || !issueNum) return "";
+  return repoUrl + "/issues/" + issueNum;
+}
+
+function branchUrl(branchName) {
+  if (!repoUrl || !branchName) return "";
+  return repoUrl + "/tree/" + branchName;
+}
+
 function relativeTime(iso) {
   if (!iso) return "";
   const t = Date.parse(iso);
@@ -107,6 +142,10 @@ function formatLocalTime(iso) {
 
 let lastSnapshot = null;
 let lastWorkState = null;
+// Repo URL ("https://github.com/<owner>/<repo>") for entry-link
+// construction. Populated from /api/state.repo_url; empty when origin
+// is missing, unparseable, or running in fixture mode.
+let repoUrl = "";
 const lastFingerprint = {
   errors: null,
   plans: null,
@@ -250,6 +289,10 @@ function applySnapshot(snap) {
   // is lexicographic-monotonic; sufficient here.
   if (lastCommittedAt && snap && snap.updated_at && snap.updated_at < lastCommittedAt) {
     return;
+  }
+  // Capture repo_url for entry-link construction in render*().
+  if (snap && typeof snap.repo_url === "string") {
+    repoUrl = snap.repo_url;
   }
   const updated = $("updated-at");
   if (updated) updated.textContent = "Updated " + relativeTime(snap.updated_at);
@@ -469,10 +512,7 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     },
   });
   const head = el("div", { cls: "card-row" });
-  head.appendChild(el("span", {
-    cls: "card-title",
-    text: (plan && plan.title) || slug,
-  }));
+  head.appendChild(titleNode((plan && plan.title) || slug, planUrl(plan)));
   if (plan && plan.status) {
     const statusPill = el("span", {
       cls: "pill " + statusPillClass(plan.status),
@@ -702,7 +742,21 @@ function renderBranches(branches, worktrees) {
       },
     });
     const head = el("div", { cls: "card-row" });
-    head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+    const url = branchUrl(b.name);
+    if (url) {
+      head.appendChild(el("a", {
+        cls: "card-title-link mono",
+        text: b.name,
+        attrs: {
+          href: url,
+          target: "_blank",
+          rel: "noopener noreferrer",
+          draggable: "false",
+        },
+      }));
+    } else {
+      head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+    }
     if (b.last_commit_at) {
       head.appendChild(el("span", { cls: "card-sub", text: relativeTime(b.last_commit_at) }));
     }
@@ -752,10 +806,10 @@ function buildIssueCard(issue, num, col) {
     },
   });
   const head = el("div", { cls: "card-row" });
-  head.appendChild(el("span", {
-    cls: "card-title",
-    text: issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num),
-  }));
+  head.appendChild(titleNode(
+    issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num),
+    issueUrl(num),
+  ));
   if (issue && issue.created_at) {
     head.appendChild(el("span", { cls: "card-sub", text: relativeTime(issue.created_at) }));
   }
@@ -871,7 +925,20 @@ function renderActivity(activity) {
       const mid = el("span");
       mid.appendChild(el("span", { cls: "a-subject", text: a.subject || "" }));
       if (a.pr) {
-        mid.appendChild(el("span", { cls: "a-parent", text: " #" + a.pr }));
+        const prHref = repoUrl ? (repoUrl + "/pull/" + a.pr) : "";
+        if (prHref) {
+          mid.appendChild(el("a", {
+            cls: "a-parent a-pr-link",
+            text: " #" + a.pr,
+            attrs: {
+              href: prHref,
+              target: "_blank",
+              rel: "noopener noreferrer",
+            },
+          }));
+        } else {
+          mid.appendChild(el("span", { cls: "a-parent", text: " #" + a.pr }));
+        }
       }
       row.appendChild(mid);
       row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));

--- a/docs/plans/DASHBOARD_TABS_AND_RENAME.md
+++ b/docs/plans/DASHBOARD_TABS_AND_RENAME.md
@@ -8,7 +8,7 @@ status: complete
 # Plan: Dashboard Tabs and Rename
 
 > **Landing mode: PR** -- This plan targets PR-based landing. All phases run
-> inside a worktree on the feature branch **`feat/dashboard-tabs-rename`**
+> inside a worktree on the feature branch **`feat/dashboard-tabs-and-rename`**
 > (created in Phase 0 via `/create-worktree`). Each phase commits to that
 > branch; the orchestrator dispatches `/land-pr` after Phase 4 completes.
 
@@ -289,16 +289,16 @@ includes every regular file under the skill dir.
 
 ### Goal
 
-Establish the `feat/dashboard-tabs-rename` worktree with verifier-cannot-run
+Establish the `feat/dashboard-tabs-and-rename` worktree with verifier-cannot-run
 defenses (Layer 0 + Layer 3 hooks) in place before any code edits.
 
 ### Work Items
 
-- [ ] Run `bash .claude/skills/create-worktree/scripts/create-worktree.sh dashboard-tabs-rename --pipeline-id dashboard-tabs-rename --branch-name feat/dashboard-tabs-rename` from the main checkout root. Capture the printed worktree path; all subsequent phases `cd` to that worktree.
+- [ ] Run `bash .claude/skills/create-worktree/scripts/create-worktree.sh dashboard-tabs-and-rename --pipeline-id dashboard-tabs-and-rename --branch-name feat/dashboard-tabs-and-rename` from the main checkout root. Capture the printed worktree path; all subsequent phases `cd` to that worktree.
 - [ ] Verify Layer 0 hook present: `test -x .claude/hooks/inject-bash-timeout.sh && head -5 .claude/hooks/inject-bash-timeout.sh`.
 - [ ] Verify Layer 3 hook present: `test -x .claude/hooks/verify-response-validate.sh && head -5 .claude/hooks/verify-response-validate.sh`.
 - [ ] Verify the verifier agent definition is present and has the full tools allowlist: `grep -E '^tools:.*Read.*Grep.*Glob.*Bash.*Edit.*Write' .claude/agents/verifier.md` returns a non-empty match (exit 0).
-- [ ] Verify the worktree is clean: `git status` in the worktree returns "working tree clean" and is on branch `feat/dashboard-tabs-rename` tracking `dev/feat/dashboard-tabs-rename` (or equivalent remote).
+- [ ] Verify the worktree is clean: `git status` in the worktree returns "working tree clean" and is on branch `feat/dashboard-tabs-and-rename` tracking `dev/feat/dashboard-tabs-and-rename` (or equivalent remote).
 - [ ] Confirm `.claude/zskills-config.json` resolves `execution.landing` to `pr` and `execution.branch_prefix` to `feat/` (matching the landing-mode hint in this plan).
 
 ### Design & Constraints
@@ -311,7 +311,7 @@ defenses (Layer 0 + Layer 3 hooks) in place before any code edits.
 
 ### Acceptance Criteria
 
-- [ ] `git worktree list` shows the `feat/dashboard-tabs-rename` branch checked out at the worktree path.
+- [ ] `git worktree list` shows the `feat/dashboard-tabs-and-rename` branch checked out at the worktree path.
 - [ ] All four hook/agent verification commands exit 0 with the expected file content.
 - [ ] No `skills/zskills-dashboard/` files modified in this phase (`git diff main -- skills/zskills-dashboard/` is empty).
 
@@ -459,7 +459,7 @@ assertion strings in lockstep. Internal identifiers (Python package name
 
 ### Dependencies
 
-Phase 0 (worktree on `feat/dashboard-tabs-rename`).
+Phase 0 (worktree on `feat/dashboard-tabs-and-rename`).
 
 ---
 
@@ -1303,7 +1303,7 @@ implementing agent is an anti-pattern.
   7. **Globals stay visible regardless of tab**: kill the server (`kill -TERM "$(cat /tmp/dashboard-phase4.pid)"`). Wait 5s. Switch through **all three tabs**. Assert `#conn-banner` is visible on every tab AND that `#conn-banner.closest("[role=tabpanel]")` is `null` (banner lives outside the tab structure). Restart the server via the same `nohup python3 ...` command used above.
   8. **Narrow viewport**: `playwright-cli resize 600 900` (NOT `--viewport-size`; the actual command is `resize <w> <h>` — verify via `playwright-cli --help | grep -i resize` first if the local build syntax differs). Assert: the tablist overflows horizontally with scroll (`eval 'getComputedStyle(document.querySelector(".tablist")).overflowX'` returns `"auto"`), tabs are still individually clickable, scroll-snap works. Take a screenshot.
   9. **URL hash deep-link**: navigate directly to `http://127.0.0.1:8181/#branches`. Assert page loads with `#tab-branches` active and `#branches` visible. (A brief sub-200ms flash of Plans is acceptable on slow devices; assert end-state, not transient frame.) Refresh (`playwright-cli reload`). Assert tab state survives. Then navigate to `http://127.0.0.1:8181/#worktrees`: assert page falls back to `#plans` active (since `worktrees` is not in `TAB_SLUGS`); `location.hash` may still read `#worktrees` (we never rewrite an unknown hash to avoid the back-stack churn) but `aria-selected="true"` is on `#tab-plans`.
-  9b. **Browser back/forward**: from `/`, click `#tab-issues`, then `#tab-branches`. Press browser back (`playwright-cli back` or `window.history.back()` via `eval`). Assert URL is `/#issues` AND `#tab-issues` is `aria-selected="true"`. Press back again. Assert URL `/#plans` (default — replaceState wrote `#plans` on initial load if hash was empty) OR `/` (if initial hash was absent and never written). Either is correct given `history.replaceState` semantics. Document which behavior is observed.
+  9b. **Browser back/forward under `replaceState` semantics**: from `/`, click `#tab-issues`, then `#tab-branches`. Because tab switches use `history.replaceState` (NOT `pushState`) per the design at line 1098-1100, the back-stack is NOT augmented per click — there is only ever one current entry. Press browser back (`playwright-cli back` or `window.history.back()` via `eval`). Expected: the browser navigates AWAY from the dashboard (e.g., to `about:blank` or the previous page in the playwright session), NOT to `#issues`. Document the observed behavior. This step verifies that we do NOT accidentally pollute the back-stack with one entry per tab click — the user goal is reload-survival, not in-page navigation history.
   10. **Screenshots** (without `--filename`, so files land in `.playwright/output/` per `.devcontainer/setup.sh` config): take one per tab, plus one of the narrow viewport — **4 total**. Rename to `phase4-tab-{plans,issues,branches,narrow}.png` after capture.
   11. **Connection-banner-no-flap (validates Phase 5d fix)**: with
       server running and `#tab-plans` active, drag a plan card 5 times

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   startup). State at .zskills/monitor-state.json. Usage:
   /zskills-dashboard [start|stop|status|restart].
 metadata:
-  version: "2026.05.15+bc1c37"
+  version: "2026.05.15+7b3fd7"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -39,6 +39,7 @@ SNAPSHOT_TOP_LEVEL_KEYS = {
     "version",
     "updated_at",
     "repo_root",
+    "repo_url",
     "plans",
     "issues",
     "worktrees",
@@ -778,6 +779,44 @@ def _scan_tracking_markers(
 
 
 # ---------------------------------------------------------------------------
+# Repo URL helper (for client-side entry-link construction)
+# ---------------------------------------------------------------------------
+
+# Accept both HTTPS and SSH origin forms, produce the canonical https URL
+# WITHOUT the trailing .git. Returns "" on any failure — client side
+# treats empty as "no links available, fall back to plain text."
+_GIT_HTTPS_RE = re.compile(r"^https?://([^/]+)/([^/]+/[^/]+?)(?:\.git)?/?$")
+_GIT_SSH_RE = re.compile(r"^git@([^:]+):([^/]+/[^/]+?)(?:\.git)?$")
+
+
+def _derive_repo_url(main_root: pathlib.Path) -> str:
+    if not (main_root / ".git").exists():
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(main_root), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if result.returncode != 0:
+        return ""
+    url = result.stdout.strip()
+    if not url:
+        return ""
+    m = _GIT_HTTPS_RE.match(url)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    m = _GIT_SSH_RE.match(url)
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
 # Git-history activity (commits that don't have a tracking marker)
 # ---------------------------------------------------------------------------
 
@@ -1356,6 +1395,7 @@ def collect_snapshot(
         "version": VERSION,
         "updated_at": _now_iso(),
         "repo_root": str(main_root),
+        "repo_url": _derive_repo_url(main_root),
         "plans": plans,
         "issues": issues,
         "worktrees": worktrees,
@@ -1461,6 +1501,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             "version": VERSION,
             "updated_at": _now_iso(),
             "repo_root": str(main_root),
+            "repo_url": "",
             "plans": plans,
             "issues": issues,
             "worktrees": worktrees,

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -286,6 +286,31 @@ code, pre, .mono {
   color: var(--text);
 }
 
+/* card-title-link — used when an entry (plan / issue / branch) has a
+   GitHub URL we can link to. Matches card-title visual weight; underline
+   only on hover so cards still feel like cards, not link lists. */
+.card-title-link {
+  font-weight: 600;
+  color: var(--text);
+  text-decoration: none;
+}
+.card-title-link:hover,
+.card-title-link:focus {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* PR link in the activity strip — subtle, matches surrounding a-parent
+   styling but turns into a link on hover. */
+.activity-row .a-pr-link {
+  text-decoration: none;
+}
+.activity-row .a-pr-link:hover,
+.activity-row .a-pr-link:focus {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 .card-sub {
   color: var(--text-dim);
   font-size: 0.85rem;

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -59,6 +59,41 @@ function el(tag, opts) {
   return node;
 }
 
+// titleNode(text, href) — returns a span containing either plain text
+// (when href is empty) or an <a> with target=_blank. Anchors carry
+// draggable=false so they don't fight the card's HTML5 drag handler;
+// click+drag from anywhere ELSE on the card still works.
+function titleNode(text, href) {
+  if (href) {
+    return el("a", {
+      cls: "card-title-link",
+      text: text,
+      attrs: {
+        href: href,
+        target: "_blank",
+        rel: "noopener noreferrer",
+        draggable: "false",
+      },
+    });
+  }
+  return el("span", { cls: "card-title", text: text });
+}
+
+function planUrl(plan) {
+  if (!repoUrl || !plan || !plan.file) return "";
+  return repoUrl + "/blob/main/" + plan.file;
+}
+
+function issueUrl(issueNum) {
+  if (!repoUrl || !issueNum) return "";
+  return repoUrl + "/issues/" + issueNum;
+}
+
+function branchUrl(branchName) {
+  if (!repoUrl || !branchName) return "";
+  return repoUrl + "/tree/" + branchName;
+}
+
 function relativeTime(iso) {
   if (!iso) return "";
   const t = Date.parse(iso);
@@ -107,6 +142,10 @@ function formatLocalTime(iso) {
 
 let lastSnapshot = null;
 let lastWorkState = null;
+// Repo URL ("https://github.com/<owner>/<repo>") for entry-link
+// construction. Populated from /api/state.repo_url; empty when origin
+// is missing, unparseable, or running in fixture mode.
+let repoUrl = "";
 const lastFingerprint = {
   errors: null,
   plans: null,
@@ -250,6 +289,10 @@ function applySnapshot(snap) {
   // is lexicographic-monotonic; sufficient here.
   if (lastCommittedAt && snap && snap.updated_at && snap.updated_at < lastCommittedAt) {
     return;
+  }
+  // Capture repo_url for entry-link construction in render*().
+  if (snap && typeof snap.repo_url === "string") {
+    repoUrl = snap.repo_url;
   }
   const updated = $("updated-at");
   if (updated) updated.textContent = "Updated " + relativeTime(snap.updated_at);
@@ -469,10 +512,7 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     },
   });
   const head = el("div", { cls: "card-row" });
-  head.appendChild(el("span", {
-    cls: "card-title",
-    text: (plan && plan.title) || slug,
-  }));
+  head.appendChild(titleNode((plan && plan.title) || slug, planUrl(plan)));
   if (plan && plan.status) {
     const statusPill = el("span", {
       cls: "pill " + statusPillClass(plan.status),
@@ -702,7 +742,21 @@ function renderBranches(branches, worktrees) {
       },
     });
     const head = el("div", { cls: "card-row" });
-    head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+    const url = branchUrl(b.name);
+    if (url) {
+      head.appendChild(el("a", {
+        cls: "card-title-link mono",
+        text: b.name,
+        attrs: {
+          href: url,
+          target: "_blank",
+          rel: "noopener noreferrer",
+          draggable: "false",
+        },
+      }));
+    } else {
+      head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+    }
     if (b.last_commit_at) {
       head.appendChild(el("span", { cls: "card-sub", text: relativeTime(b.last_commit_at) }));
     }
@@ -752,10 +806,10 @@ function buildIssueCard(issue, num, col) {
     },
   });
   const head = el("div", { cls: "card-row" });
-  head.appendChild(el("span", {
-    cls: "card-title",
-    text: issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num),
-  }));
+  head.appendChild(titleNode(
+    issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num),
+    issueUrl(num),
+  ));
   if (issue && issue.created_at) {
     head.appendChild(el("span", { cls: "card-sub", text: relativeTime(issue.created_at) }));
   }
@@ -871,7 +925,20 @@ function renderActivity(activity) {
       const mid = el("span");
       mid.appendChild(el("span", { cls: "a-subject", text: a.subject || "" }));
       if (a.pr) {
-        mid.appendChild(el("span", { cls: "a-parent", text: " #" + a.pr }));
+        const prHref = repoUrl ? (repoUrl + "/pull/" + a.pr) : "";
+        if (prHref) {
+          mid.appendChild(el("a", {
+            cls: "a-parent a-pr-link",
+            text: " #" + a.pr,
+            attrs: {
+              href: prHref,
+              target: "_blank",
+              rel: "noopener noreferrer",
+            },
+          }));
+        } else {
+          mid.appendChild(el("span", { cls: "a-parent", text: " #" + a.pr }));
+        }
       }
       row.appendChild(mid);
       row.appendChild(el("span", { cls: "a-time", text: relativeTime(a.timestamp) }));

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -62,7 +62,7 @@ else
   fail "CLI --fixture minimal exits 0 (rc=$RC, output: $OUT)"
 fi
 
-EXPECTED_KEYS="activity branches errors issues plans queues repo_root state_file_path updated_at version worktrees"
+EXPECTED_KEYS="activity branches errors issues plans queues repo_root repo_url state_file_path updated_at version worktrees"
 ACTUAL_KEYS=$(printf '%s' "$OUT" | python3 -c '
 import json,sys
 print(" ".join(sorted(json.load(sys.stdin).keys())))


### PR DESCRIPTION
## Summary

Final PR in the dashboard fix-up sprint. Two themes:

### 1. Entry links

Plan, issue, and branch cards now wrap their title text in `<a>` tags
pointing to the matching GitHub URL. PR refs in the git-history activity
strip (PR #274) become clickable too.

- Server derives `repo_url` from `git remote get-url origin` (HTTPS or
  SSH form accepted, trailing `.git` stripped); 2-second subprocess
  timeout, list-form args (no shell injection).
- Client constructs per-entry URLs from `repo_url + slug/number/name/file`
  in `titleNode(text, href)`, `planUrl`, `issueUrl`, `branchUrl`.
- Anchors carry `draggable="false"` + `target="_blank"` + `rel="noopener
  noreferrer"`. The parent `<li class="card" draggable="true">` is
  unaffected: **click title = navigate, drag rest of card = reorder.**
- CSS: subtle hover treatment (`var(--accent)` + underline on `:hover`
  and `:focus`) — no underline at rest, so cards still feel like cards,
  not link lists.

### 2. Plan-text drifts in `docs/plans/DASHBOARD_TABS_AND_RENAME.md`

- **6 instances** of `feat/dashboard-tabs-rename` →
  `feat/dashboard-tabs-and-rename` (matches the actual branch on PR #253;
  verified via `gh pr view 253 --json headRefName`).
- **Phase 4 step 9b** assertion previously claimed `URL is /#issues`
  after browser back, which contradicts the `replaceState` design at
  lines 1098-1100 (`replaceState` does NOT augment the back-stack per
  click). Reframed to describe the actual behavior: back navigates AWAY
  from the dashboard, NOT to a prior tab.

## Test plan

- [x] Full suite: **3040/3040 PASS**, exit 0
- [x] Targeted: `test_zskills_monitor_collect.sh` 31/31 PASS (after
      updating `EXPECTED_KEYS` to include `repo_url`)
- [x] Live API: `/api/state` returns `repo_url: https://github.com/zeveck/zskills-dev`
- [x] Live DOM: 66 plan links, 29 branch links, 8 activity-PR links
- [x] Anchor attrs: `target=_blank`, `rel="noopener noreferrer"`,
      `draggable=false`; parent card `draggable=true` (drag preserved)
- [x] Hrefs correct: plans → `/blob/main/<file>`, branches → `/tree/<name>`,
      PRs → `/pull/<N>`
- [x] Visual screenshot: plans tab renders normally with link-styled
      titles (no broken layout from anchor wrapping)
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: `2026.05.15+bc1c37` → `2026.05.15+7b3fd7`
- [x] Fresh verifier subagent: **A+** (7/7 checks)
- [ ] **Reviewer post-merge:** restart dashboard (`/zskills-dashboard
      restart`), click a plan title — should open the plan file on GitHub
      in a new tab. Drag a plan card by its blurb area — should still
      reorder (drag from title text is suppressed by design).

## Sprint summary (this session's PRs)

| PR | Theme |
|---|---|
| #273 | SIGTERM-self-heal regression fix (closes restart silent-fail) |
| #274 | Git-history activity feed (commits interleave with markers) |
| #275 (this) | Entry links + plan-text drifts |

This closes out the dashboard usability work flagged after PR #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
