### PR TITLE
fix(update-zskills): CLAUDE_PROJECT_DIR git-common-dir fallback + Read-before-claiming rule

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.13+a209b2"
+  version: "2026.05.15+7d4271"
 ---
 
 # Update Z Skills Infrastructure

--- a/.claude/skills/update-zskills/scripts/zskills-paths.sh
+++ b/.claude/skills/update-zskills/scripts/zskills-paths.sh
@@ -26,13 +26,26 @@
 #     processes (Python, node) MUST `export ZSKILLS_PLANS_DIR` etc.
 #     themselves immediately after sourcing. See caller-side examples below.
 
-# Resolve project root with override-then-default precedence.
+# Resolve project root with precedence: ZSKILLS_PATHS_ROOT (PR-mode
+# worktree anchor) → CLAUDE_PROJECT_DIR (harness-set) → git-common-dir
+# fallback (orchestrator-side Bash where harness didn't inject the var
+# — see zskills-resolve-config.sh for the documented-design rationale).
 _ZSK_PATHS_ROOT="${ZSKILLS_PATHS_ROOT:-${CLAUDE_PROJECT_DIR:-}}"
 if [ -z "$_ZSK_PATHS_ROOT" ]; then
-  echo "zskills-paths.sh: neither ZSKILLS_PATHS_ROOT nor CLAUDE_PROJECT_DIR is set — caller must provide one (absolute path)" >&2
-  # Use return when sourced, exit when executed (mirror dual-mode pattern
-  # from sanitize-pipeline-id.sh).
-  (return 0 2>/dev/null) && return 1 || exit 1
+  if _ZSK_PATHS_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) \
+       && _ZSK_PATHS_ROOT=$(cd "$_ZSK_PATHS_COMMON_DIR/.." && pwd); then
+    if [ -z "${_ZSK_FALLBACK_WARNED:-}" ]; then
+      echo "WARN: zskills: neither ZSKILLS_PATHS_ROOT nor CLAUDE_PROJECT_DIR set; fell back to $_ZSK_PATHS_ROOT via git-common-dir" >&2
+      _ZSK_FALLBACK_WARNED=1
+    fi
+    unset _ZSK_PATHS_COMMON_DIR
+  else
+    echo "zskills-paths.sh: neither ZSKILLS_PATHS_ROOT nor CLAUDE_PROJECT_DIR is set, and not in a git repo — caller must provide one (absolute path)" >&2
+    unset _ZSK_PATHS_COMMON_DIR
+    # Use return when sourced, exit when executed (mirror dual-mode pattern
+    # from sanitize-pipeline-id.sh).
+    (return 0 2>/dev/null) && return 1 || exit 1
+  fi
 fi
 
 # Pre-init vars to empty (empty-pattern-guard from DRIFT_ARCH_FIX). NOT export.

--- a/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh
+++ b/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh
@@ -20,9 +20,39 @@
 # Coexistence: same directory hosts zskills-stub-lib.sh, which exposes
 # `zskills_dispatch_stub`. Domain-disjoint — no naming collisions.
 
-# Fail loud if CLAUDE_PROJECT_DIR is absent. The harness sets it for spawned
-# bash blocks; tests/run-all.sh exports it from REPO_ROOT.
-: "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR not set — harness or tests/run-all.sh export missing}"
+# CLAUDE_PROJECT_DIR resolution.
+#
+# Anthropic's harness only documents this var as set for hook subprocesses
+# (https://code.claude.com/docs/en/hooks — "Command hook fields / Exec
+# form and shell form"); it is NOT documented to be set in Bash-tool
+# subshells. tests/run-all.sh exports it for tests. When neither path
+# applies (orchestrator-side Bash from inside a skill), we fall back to
+# the canonical "find main repo from anywhere" idiom used elsewhere in
+# this codebase (ensure-worktree.sh, create-worktree.sh, land-phase.sh):
+# `git rev-parse --git-common-dir`, whose result resolves through
+# worktree links back to the main repo's `.git`. Then dirname gives the
+# main repo root — matching the harness-set semantics.
+#
+# The stderr WARN fires once per shell (via _ZSK_FALLBACK_WARNED sentinel)
+# so the harness gap stays visible without spamming every source.
+#
+# Outside a git repo, no clean fallback exists and zskills cannot function;
+# fail with a clear error.
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  if _ZSK_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) \
+       && CLAUDE_PROJECT_DIR=$(cd "$_ZSK_COMMON_DIR/.." && pwd); then
+    export CLAUDE_PROJECT_DIR
+    if [ -z "${_ZSK_FALLBACK_WARNED:-}" ]; then
+      echo "WARN: zskills: CLAUDE_PROJECT_DIR not set by harness; fell back to $CLAUDE_PROJECT_DIR via git-common-dir" >&2
+      _ZSK_FALLBACK_WARNED=1
+    fi
+    unset _ZSK_COMMON_DIR
+  else
+    echo "ERROR: zskills: CLAUDE_PROJECT_DIR not set and not in a git repo — cannot resolve project root" >&2
+    unset _ZSK_COMMON_DIR
+    return 127 2>/dev/null || exit 127
+  fi
+fi
 
 _ZSK_CFG="$CLAUDE_PROJECT_DIR/.claude/zskills-config.json"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,31 @@ URLs, or creating files from scratch, check what already exists: `ls` the
 directory, `grep` for the term, read the relevant file. Agents consistently
 skip this step and guess instead of looking.
 
+**Read before claiming.** Do not describe, comment on, or plan around a
+file, function, test, skill, env var, or harness behavior you have not
+just read. "Let CI tell us" and "I'll find out when it breaks" are not
+paths forward -- they are guesses with a deadline. Specifically:
+
+- Before commenting on what a test asserts or a function does -- open
+  the file and quote the relevant lines.
+- Before recommending a workflow that chains skills (`/X then /Y`) --
+  read each skill's `SKILL.md`; do not infer behavior from the name.
+- Before changing a script, config, or invariant -- grep for tests that
+  lock it (`tests/test-*.sh`, fixtures, conformance lists) and read
+  the assertions you'd be invalidating.
+- Before relying on an env var, config field, or harness affordance --
+  confirm it's documented for *your* call context (Bash tool vs. hook
+  subprocess vs. subagent), not an adjacent one. Past failure: assumed
+  `CLAUDE_PROJECT_DIR` was set in Bash tool subshells; Anthropic only
+  documents it for hook subprocesses.
+- Before asserting falsifiable state ("pre-existing on main," "X is
+  unused," "passes elsewhere") -- run the check that would falsify it
+  and cite the command.
+
+If the verifying read is too expensive to do now, say so and stop -- do
+not substitute a guess and let downstream failure do the verification.
+The only research you can skip is what you just verified in this turn.
+
 ## Tracking markers
 
 Tracking markers live in `.zskills/tracking/` and are scoped per pipeline

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -194,6 +194,31 @@ URLs, or creating files from scratch, check what already exists: `ls` the
 directory, `grep` for the term, read the relevant file. Agents consistently
 skip this step and guess instead of looking.
 
+**Read before claiming.** Do not describe, comment on, or plan around a
+file, function, test, skill, env var, or harness behavior you have not
+just read. "Let CI tell us" and "I'll find out when it breaks" are not
+paths forward -- they are guesses with a deadline. Specifically:
+
+- Before commenting on what a test asserts or a function does -- open
+  the file and quote the relevant lines.
+- Before recommending a workflow that chains skills (`/X then /Y`) --
+  read each skill's `SKILL.md`; do not infer behavior from the name.
+- Before changing a script, config, or invariant -- grep for tests that
+  lock it (`tests/test-*.sh`, fixtures, conformance lists) and read
+  the assertions you'd be invalidating.
+- Before relying on an env var, config field, or harness affordance --
+  confirm it's documented for *your* call context (Bash tool vs. hook
+  subprocess vs. subagent), not an adjacent one. Past failure: assumed
+  `CLAUDE_PROJECT_DIR` was set in Bash tool subshells; Anthropic only
+  documents it for hook subprocesses.
+- Before asserting falsifiable state ("pre-existing on main," "X is
+  unused," "passes elsewhere") -- run the check that would falsify it
+  and cite the command.
+
+If the verifying read is too expensive to do now, say so and stop -- do
+not substitute a guess and let downstream failure do the verification.
+The only research you can skip is what you just verified in this turn.
+
 ## Execution Modes
 
 Three landing modes control how agent work reaches main:

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.13+a209b2"
+  version: "2026.05.15+7d4271"
 ---
 
 # Update Z Skills Infrastructure

--- a/skills/update-zskills/scripts/zskills-paths.sh
+++ b/skills/update-zskills/scripts/zskills-paths.sh
@@ -26,13 +26,26 @@
 #     processes (Python, node) MUST `export ZSKILLS_PLANS_DIR` etc.
 #     themselves immediately after sourcing. See caller-side examples below.
 
-# Resolve project root with override-then-default precedence.
+# Resolve project root with precedence: ZSKILLS_PATHS_ROOT (PR-mode
+# worktree anchor) → CLAUDE_PROJECT_DIR (harness-set) → git-common-dir
+# fallback (orchestrator-side Bash where harness didn't inject the var
+# — see zskills-resolve-config.sh for the documented-design rationale).
 _ZSK_PATHS_ROOT="${ZSKILLS_PATHS_ROOT:-${CLAUDE_PROJECT_DIR:-}}"
 if [ -z "$_ZSK_PATHS_ROOT" ]; then
-  echo "zskills-paths.sh: neither ZSKILLS_PATHS_ROOT nor CLAUDE_PROJECT_DIR is set — caller must provide one (absolute path)" >&2
-  # Use return when sourced, exit when executed (mirror dual-mode pattern
-  # from sanitize-pipeline-id.sh).
-  (return 0 2>/dev/null) && return 1 || exit 1
+  if _ZSK_PATHS_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) \
+       && _ZSK_PATHS_ROOT=$(cd "$_ZSK_PATHS_COMMON_DIR/.." && pwd); then
+    if [ -z "${_ZSK_FALLBACK_WARNED:-}" ]; then
+      echo "WARN: zskills: neither ZSKILLS_PATHS_ROOT nor CLAUDE_PROJECT_DIR set; fell back to $_ZSK_PATHS_ROOT via git-common-dir" >&2
+      _ZSK_FALLBACK_WARNED=1
+    fi
+    unset _ZSK_PATHS_COMMON_DIR
+  else
+    echo "zskills-paths.sh: neither ZSKILLS_PATHS_ROOT nor CLAUDE_PROJECT_DIR is set, and not in a git repo — caller must provide one (absolute path)" >&2
+    unset _ZSK_PATHS_COMMON_DIR
+    # Use return when sourced, exit when executed (mirror dual-mode pattern
+    # from sanitize-pipeline-id.sh).
+    (return 0 2>/dev/null) && return 1 || exit 1
+  fi
 fi
 
 # Pre-init vars to empty (empty-pattern-guard from DRIFT_ARCH_FIX). NOT export.

--- a/skills/update-zskills/scripts/zskills-resolve-config.sh
+++ b/skills/update-zskills/scripts/zskills-resolve-config.sh
@@ -20,9 +20,39 @@
 # Coexistence: same directory hosts zskills-stub-lib.sh, which exposes
 # `zskills_dispatch_stub`. Domain-disjoint — no naming collisions.
 
-# Fail loud if CLAUDE_PROJECT_DIR is absent. The harness sets it for spawned
-# bash blocks; tests/run-all.sh exports it from REPO_ROOT.
-: "${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR not set — harness or tests/run-all.sh export missing}"
+# CLAUDE_PROJECT_DIR resolution.
+#
+# Anthropic's harness only documents this var as set for hook subprocesses
+# (https://code.claude.com/docs/en/hooks — "Command hook fields / Exec
+# form and shell form"); it is NOT documented to be set in Bash-tool
+# subshells. tests/run-all.sh exports it for tests. When neither path
+# applies (orchestrator-side Bash from inside a skill), we fall back to
+# the canonical "find main repo from anywhere" idiom used elsewhere in
+# this codebase (ensure-worktree.sh, create-worktree.sh, land-phase.sh):
+# `git rev-parse --git-common-dir`, whose result resolves through
+# worktree links back to the main repo's `.git`. Then dirname gives the
+# main repo root — matching the harness-set semantics.
+#
+# The stderr WARN fires once per shell (via _ZSK_FALLBACK_WARNED sentinel)
+# so the harness gap stays visible without spamming every source.
+#
+# Outside a git repo, no clean fallback exists and zskills cannot function;
+# fail with a clear error.
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  if _ZSK_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) \
+       && CLAUDE_PROJECT_DIR=$(cd "$_ZSK_COMMON_DIR/.." && pwd); then
+    export CLAUDE_PROJECT_DIR
+    if [ -z "${_ZSK_FALLBACK_WARNED:-}" ]; then
+      echo "WARN: zskills: CLAUDE_PROJECT_DIR not set by harness; fell back to $CLAUDE_PROJECT_DIR via git-common-dir" >&2
+      _ZSK_FALLBACK_WARNED=1
+    fi
+    unset _ZSK_COMMON_DIR
+  else
+    echo "ERROR: zskills: CLAUDE_PROJECT_DIR not set and not in a git repo — cannot resolve project root" >&2
+    unset _ZSK_COMMON_DIR
+    return 127 2>/dev/null || exit 127
+  fi
+fi
 
 _ZSK_CFG="$CLAUDE_PROJECT_DIR/.claude/zskills-config.json"
 

--- a/tests/test-zskills-paths.sh
+++ b/tests/test-zskills-paths.sh
@@ -130,32 +130,66 @@ C4_PLANS=$(
   || fail "Case 4: relative-up path" "got '$C4_PLANS', expected '$T4/../external/zskills'"
 rm -rf "$T4"
 
-# --- Case 5: both vars unset → fail loud -----------------------------------
+# --- Case 5: both vars unset, contract depends on whether cwd is in a git repo
+#
+# Old contract (pre-CLAUDE_PROJECT_DIR-fallback PR): both unset → fail loud
+# everywhere. New contract: in a git repo, fall back to git-common-dir with
+# a one-time stderr WARN; outside a git repo, the old loud-failure path
+# still applies because no clean fallback exists. See zskills-resolve-config.sh
+# header and zskills-paths.sh resolution block.
+
 echo ""
-echo "=== Case 5: both \$CLAUDE_PROJECT_DIR and \$ZSKILLS_PATHS_ROOT unset → non-zero ==="
-# Crucial: tests/run-all.sh exports CLAUDE_PROJECT_DIR globally, so unset
-# must happen INSIDE a subshell that inherits then unsets both.
-( unset CLAUDE_PROJECT_DIR ZSKILLS_PATHS_ROOT
+echo "=== Case 5a: both vars unset, IN a git repo → succeed via git-common-dir fallback ==="
+# tests/run-all.sh exports CLAUDE_PROJECT_DIR globally; unset must happen
+# INSIDE a subshell that inherits then unsets both. Subshell stays in the
+# repo root, so `git rev-parse --git-common-dir` resolves successfully.
+( unset CLAUDE_PROJECT_DIR ZSKILLS_PATHS_ROOT _ZSK_FALLBACK_WARNED
   source "$HELPER"
-) 2> "$TEST_OUT/case5.stderr"
+) 2> "$TEST_OUT/case5a.stderr"
+rc=$?
+if [ "$rc" = "0" ]; then
+  pass "Case 5a: helper rc=0 via git-common-dir fallback"
+else
+  fail "Case 5a: helper rc=0 via fallback" \
+    "expected 0, got $rc; stderr: $(cat "$TEST_OUT/case5a.stderr")"
+fi
+if grep -qE "WARN.*fell back.*git-common-dir" "$TEST_OUT/case5a.stderr"; then
+  pass "Case 5a: stderr contains 'WARN ... fell back ... git-common-dir'"
+else
+  fail "Case 5a: stderr fallback WARN" \
+    "got: $(cat "$TEST_OUT/case5a.stderr")"
+fi
+
+echo ""
+echo "=== Case 5b: both vars unset, NOT in a git repo → fail loud ==="
+# Fixture: a tempdir with no .git ancestor (mktemp paths under /tmp have
+# no git parent). cd there before sourcing so git-common-dir returns
+# non-zero and the fallback path falls through to the error branch.
+T5B=$(mktemp -d /tmp/zskills-paths-t5b-XXXXXX)
+( cd "$T5B"
+  unset CLAUDE_PROJECT_DIR ZSKILLS_PATHS_ROOT _ZSK_FALLBACK_WARNED GIT_DIR GIT_WORK_TREE
+  source "$HELPER"
+) 2> "$TEST_OUT/case5b.stderr"
 rc=$?
 if [ "$rc" != "0" ]; then
-  pass "Case 5a: helper exits non-zero when both vars unset (rc=$rc)"
+  pass "Case 5b: helper exits non-zero when both vars unset and not in git repo (rc=$rc)"
 else
-  fail "Case 5a: helper exit code" "expected non-zero, got $rc"
+  fail "Case 5b: helper exit code" \
+    "expected non-zero, got $rc; stderr: $(cat "$TEST_OUT/case5b.stderr")"
 fi
-if grep -q "ZSKILLS_PATHS_ROOT" "$TEST_OUT/case5.stderr"; then
+if grep -q "ZSKILLS_PATHS_ROOT" "$TEST_OUT/case5b.stderr"; then
   pass "Case 5b: stderr names ZSKILLS_PATHS_ROOT"
 else
   fail "Case 5b: stderr ZSKILLS_PATHS_ROOT mention" \
-    "got: $(cat "$TEST_OUT/case5.stderr")"
+    "got: $(cat "$TEST_OUT/case5b.stderr")"
 fi
-if grep -q "CLAUDE_PROJECT_DIR" "$TEST_OUT/case5.stderr"; then
-  pass "Case 5c: stderr names CLAUDE_PROJECT_DIR"
+if grep -q "CLAUDE_PROJECT_DIR" "$TEST_OUT/case5b.stderr"; then
+  pass "Case 5b: stderr names CLAUDE_PROJECT_DIR"
 else
-  fail "Case 5c: stderr CLAUDE_PROJECT_DIR mention" \
-    "got: $(cat "$TEST_OUT/case5.stderr")"
+  fail "Case 5b: stderr CLAUDE_PROJECT_DIR mention" \
+    "got: $(cat "$TEST_OUT/case5b.stderr")"
 fi
+rm -rf "$T5B"
 
 # --- Case 6a: garbage (non-JSON) config → silent fallback ------------------
 echo ""

--- a/tests/test-zskills-resolve-config.sh
+++ b/tests/test-zskills-resolve-config.sh
@@ -31,6 +31,11 @@ PRELUDE_DOC="$REPO_ROOT/references/canonical-config-prelude.md"
 PASS_COUNT=0
 FAIL_COUNT=0
 
+# TEST_OUT for stderr-capture fixtures (Test 9). Per-worktree path so
+# parallel pipelines do not collide (matches the idiom from test-zskills-paths.sh).
+TEST_OUT="/tmp/zskills-tests/$(basename "$REPO_ROOT")"
+mkdir -p "$TEST_OUT"
+
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
 
@@ -361,6 +366,78 @@ T8B_VER=$(
   || fail "Test 8c: \$ZSKILLS_VERSION empty when absent" "got '$T8B_VER'"
 
 rm -rf "$T8" "$T8B"
+
+# --- Test 9: CLAUDE_PROJECT_DIR fallback via git-common-dir -----------------
+#
+# When the harness doesn't inject $CLAUDE_PROJECT_DIR (e.g. orchestrator-side
+# Bash from inside a skill — Anthropic only documents the var as set for
+# hook subprocesses), the helper falls back to the canonical "find main
+# repo from anywhere" idiom (`git rev-parse --git-common-dir | dirname`)
+# and emits a one-time stderr WARN. Outside any git repo, no clean fallback
+# exists and the helper fails loud.
+
+echo ""
+echo "=== Test 9a: \$CLAUDE_PROJECT_DIR unset, IN a git repo → fallback succeeds ==="
+( unset CLAUDE_PROJECT_DIR _ZSK_FALLBACK_WARNED
+  source "$HELPER"
+) 2> "$TEST_OUT/test9a.stderr"
+T9A_RC=$?
+if [ "$T9A_RC" = "0" ]; then
+  pass "Test 9a: helper rc=0 via git-common-dir fallback"
+else
+  fail "Test 9a: helper rc=0 via fallback" \
+    "expected 0, got $T9A_RC; stderr: $(cat "$TEST_OUT/test9a.stderr")"
+fi
+if grep -qE "WARN.*fell back.*git-common-dir" "$TEST_OUT/test9a.stderr"; then
+  pass "Test 9a: stderr contains 'WARN ... fell back ... git-common-dir'"
+else
+  fail "Test 9a: stderr fallback WARN" \
+    "got: $(cat "$TEST_OUT/test9a.stderr")"
+fi
+
+echo ""
+echo "=== Test 9b: \$CLAUDE_PROJECT_DIR unset, NOT in a git repo → fail loud ==="
+T9B=$(mktemp -d /tmp/zskills-resolve-cfg-t9b-XXXXXX)
+( cd "$T9B"
+  unset CLAUDE_PROJECT_DIR _ZSK_FALLBACK_WARNED GIT_DIR GIT_WORK_TREE
+  source "$HELPER"
+) 2> "$TEST_OUT/test9b.stderr"
+T9B_RC=$?
+if [ "$T9B_RC" != "0" ]; then
+  pass "Test 9b: helper exits non-zero outside git repo (rc=$T9B_RC)"
+else
+  fail "Test 9b: helper exit code" \
+    "expected non-zero, got $T9B_RC; stderr: $(cat "$TEST_OUT/test9b.stderr")"
+fi
+if grep -q "CLAUDE_PROJECT_DIR" "$TEST_OUT/test9b.stderr"; then
+  pass "Test 9b: stderr names CLAUDE_PROJECT_DIR"
+else
+  fail "Test 9b: stderr CLAUDE_PROJECT_DIR mention" \
+    "got: $(cat "$TEST_OUT/test9b.stderr")"
+fi
+if grep -qiE "not in a git repo|not.*git" "$TEST_OUT/test9b.stderr"; then
+  pass "Test 9b: stderr explains 'not in a git repo'"
+else
+  fail "Test 9b: stderr git-repo mention" \
+    "got: $(cat "$TEST_OUT/test9b.stderr")"
+fi
+rm -rf "$T9B"
+
+echo ""
+echo "=== Test 9c: WARN suppressed on second source via _ZSK_FALLBACK_WARNED sentinel ==="
+# Both sources run in the SAME subshell so the sentinel set by the first
+# source persists into the second. Expect exactly one WARN line emitted.
+T9C_STDERR=$(
+  unset CLAUDE_PROJECT_DIR _ZSK_FALLBACK_WARNED
+  { source "$HELPER"; source "$HELPER"; } 2>&1 >/dev/null
+)
+T9C_WARN_COUNT=$(printf '%s\n' "$T9C_STDERR" | grep -cE "WARN.*fell back.*git-common-dir" || true)
+if [ "$T9C_WARN_COUNT" = "1" ]; then
+  pass "Test 9c: WARN emitted exactly once across two sources (sentinel works)"
+else
+  fail "Test 9c: WARN once-per-shell" \
+    "expected 1 occurrence, got $T9C_WARN_COUNT; stderr: $T9C_STDERR"
+fi
 
 # --- Summary ---------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- Adds `git rev-parse --git-common-dir` fallback to `skills/update-zskills/scripts/zskills-resolve-config.sh` and `zskills-paths.sh` (plus `.claude/skills/` mirrors) for when the Claude Code harness doesn't inject `$CLAUDE_PROJECT_DIR` into Bash-tool subshells (Anthropic only documents it for hook subprocesses per https://code.claude.com/docs/en/hooks).
- One-time stderr WARN via shared `_ZSK_FALLBACK_WARNED` sentinel preserves visibility into the harness gap without spamming every source.
- `zskills-paths.sh` priority preserved: `ZSKILLS_PATHS_ROOT` (PR-mode anchor) → `CLAUDE_PROJECT_DIR` → git-common-dir → fail. Outside a git repo, both helpers still fail loud (zskills can't function without git anyway).
- New CLAUDE.md / CLAUDE_TEMPLATE.md rule **Read before claiming**, adjacent to the existing "Enumerate before guessing" rule. Names "let CI tell us"/"I'll find out when it breaks" as guesses-with-a-deadline; lists 5 concrete triggers (test assertions, skill chaining, invariant changes, env-var documentation, falsifiable-state assertions). Past failure cited is this PR's own root cause.

## Design change ratified

This relaxes a tested invariant. `tests/test-zskills-paths.sh` Case 5 previously locked "both vars unset → fail loud everywhere." New contract splits into:
- **5a** (in a git repo) — fallback succeeds with WARN.
- **5b** (not in a git repo) — fail as before.

Analogous Tests 9a/9b/9c added to `tests/test-zskills-resolve-config.sh` (which had no coverage of the unset path). Test 9c locks the once-per-shell sentinel behavior.

## Test plan

- [x] Full local suite: 3074 → 3081 PASS (+7: new sub-assertions in Tests 9a/9b/9c + refactored Case 5).
- [x] Mirror byte-identity verified for `SKILL.md` and both helper scripts.
- [x] Skill `metadata.version` bumped `2026.05.13+a209b2` → `2026.05.15+7d4271`; recomputed hash matches.
- [x] Fresh verifier subagent (Read/Grep/Glob/Bash/Edit/Write tools) APPROVED with anchored evidence; verify-response-validate hook exit 0.
- [x] Conformance check (`tests/test-skill-conformance.sh`) unaffected by the fence-internal change — confirmed PASS in full suite.
- [ ] CI green on origin.
