### PR TITLE
fix(skills): lift dmi-true on /quickfix + /do; /fix-issues 5-way triage (closes #287)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: do
-disable-model-invocation: true
 argument-hint: "<description> [worktree] [push] [pr] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
@@ -8,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.15+8ed6a6"
+  version: "2026.05.15+210d28"
 ---
 
 # /do \<description> [worktree] [push] [pr] [every SCHEDULE] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.15+509e96"
+  version: "2026.05.15+d7d321"
 ---
 
 # /fix-issues N [focus] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -893,28 +893,62 @@ top, then the remaining slots filled by default priority.
 
 ### Triage: vague, complex, or interrelated issues
 
-While building the ranked list, classify each candidate:
+While building the ranked list, classify each candidate into ONE of the
+five routing tiers below. Picking the right tier is the whole point of
+triage — the wrong tier produces either a 1000-line plan for a 50-line
+fix (over-routing to `/draft-plan`) or an unreviewed PR for a subtle
+bug (under-routing to in-batch fix-agent).
 
-- **Clear and doable** — repro steps, expected behavior, affected files
-  identified. Include in the sprint.
+- **Clear and doable as one PR** — repro steps, expected behavior,
+  affected files identified, scope fits a single coherent commit.
+  Include in the sprint as an in-batch fix-agent dispatch. This is the
+  default and the cheapest path.
+
+- **Clear and doable as one PR, but needs review** — clear spec, single
+  PR scope, but the fix has multiple coordinate-with-discipline steps
+  (e.g., touches multiple files, requires version bumps, has subtle
+  scope-creep risk). Dispatch `/quickfix` for the issue, which adds
+  pre-execution plan-review (catches scope drift before commit) plus CI
+  poll + fix-cycle without you hand-orchestrating each step. Per-issue
+  /quickfix dispatch replaces the in-batch fix-agent for this category.
+
+- **Bug with unclear cause** — symptom is reported but no root-cause
+  hypothesis emerges from the issue body or research blurb. Don't guess.
+  Skip the issue with note: "Needs deeper investigation — could not
+  determine root cause in batch mode. Run `/investigate #NNN`." This is
+  a manual handoff (`/investigate` runs interactively, not in-batch).
+
+- **Plan-scale** — clear spec but would require 500+ lines across
+  multiple subsystems, multi-phase coordination, integration-point
+  design, or hook interactions. Not a batch-fix item.
+  - Interactive: report "this needs `/run-plan`, not `/fix-issues`"
+  - Auto: skip it, report as "Skipped: plan-scale, run /draft-plan"
+  - If `plans/PLAN_INDEX.md` exists, grep plan files for the issue
+    number (e.g., `#NNN`). If a plan already covers this issue, note
+    which plan in the skip reason. If no plan covers it, add to the
+    skip note: "Consider `/draft-plan` for #NNN."
+
 - **Too vague** — no repro steps, no expected behavior, body is empty or
   just "it's broken." You don't know WHAT to fix.
   - Interactive: flag it and ask the user for clarification
   - Auto: skip it, report as "Skipped: insufficient context" in
     $ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md
-- **Too complex** — clear spec but would require 500+ lines, major
-  refactoring, or architectural changes. Not a batch-fix item.
-  - Interactive: report "this needs `/run-plan`, not `/fix-issues`"
-  - Auto: skip it, report as "Skipped: too complex for batch fix"
-  - If `plans/PLAN_INDEX.md` exists, grep plan files for the issue number
-    (e.g., `#NNN`). If a plan already covers this issue, note which plan
-    in the skip reason. If no plan covers it, add to the skip note:
-    "Consider `/draft-plan` for #NNN."
 
 **"Too vague" means you don't know WHAT to do — not that you don't know
 HOW.** If the issue clearly describes the problem but the fix is hard,
 that's not vague — that's work. Never use "vague" as an excuse to skip
 hard issues.
+
+**Picking between in-batch fix-agent and `/quickfix`.** The in-batch
+fix-agent is appropriate when the fix is mechanical enough that
+post-execution diff review (which `/fix-issues` Phase 4 already
+dispatches) is sufficient. `/quickfix` is appropriate when *before* the
+fix, you want a second pair of eyes on the plan — typically when the
+issue has multiple discipline surfaces (version bumps + mirror, test
+updates + source change, doc update + behavior change). The
+`/quickfix` plan-reviewer's auto-REVISE on >4 Acceptance bullets is
+the mechanical signal that says "this is bigger than `/quickfix` —
+escalate to `/draft-plan`."
 
 ### Group by dependency and file overlap
 

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   requires execution.landing == "pr". No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.15+12451b"
+  version: "2026.05.15+abf853"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -43,23 +43,6 @@ the new feature branch.
 
 Pick `/quickfix` when the edit is small enough that leaving main is more
 ceremony than the change is worth, but a PR is still required.
-
-## Entry self-assertion (WI 1.1)
-
-At entry, when the SDK exposes `$SKILL_SELF` (path to this file), assert
-that the frontmatter still carries `disable-model-invocation: true`:
-
-```bash
-if [ -n "${SKILL_SELF:-}" ] && [ -f "$SKILL_SELF" ]; then
-  if ! grep -q '^disable-model-invocation: true$' "$SKILL_SELF"; then
-    echo "ERROR: /quickfix SKILL.md missing 'disable-model-invocation: true'" >&2
-    exit 1
-  fi
-fi
-# If $SKILL_SELF cannot be located (test-harness injection, older runtime),
-# the check is a no-op — the frontmatter grep in tests/run-all.sh still
-# enforces the invariant at CI time.
-```
 
 ## Argument parser (WI 1.2)
 

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: quickfix
-disable-model-invocation: true
 argument-hint: "[<description>] [auto] [--branch <name>] [--yes] [--from-here] [--skip-tests] [--force] [--rounds N]"
 description: >-
   Ship an in-flight edit (or short agent-authored fix) from main as a
@@ -11,7 +10,7 @@ description: >-
   requires execution.landing == "pr". No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.15+03e6a0"
+  version: "2026.05.15+12451b"
 ---
 
 # /quickfix — In-Flight Fix → PR

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: do
-disable-model-invocation: true
 argument-hint: "<description> [worktree] [push] [pr] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
@@ -8,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.15+8ed6a6"
+  version: "2026.05.15+210d28"
 ---
 
 # /do \<description> [worktree] [push] [pr] [every SCHEDULE] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.15+509e96"
+  version: "2026.05.15+d7d321"
 ---
 
 # /fix-issues N [focus] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -893,28 +893,62 @@ top, then the remaining slots filled by default priority.
 
 ### Triage: vague, complex, or interrelated issues
 
-While building the ranked list, classify each candidate:
+While building the ranked list, classify each candidate into ONE of the
+five routing tiers below. Picking the right tier is the whole point of
+triage — the wrong tier produces either a 1000-line plan for a 50-line
+fix (over-routing to `/draft-plan`) or an unreviewed PR for a subtle
+bug (under-routing to in-batch fix-agent).
 
-- **Clear and doable** — repro steps, expected behavior, affected files
-  identified. Include in the sprint.
+- **Clear and doable as one PR** — repro steps, expected behavior,
+  affected files identified, scope fits a single coherent commit.
+  Include in the sprint as an in-batch fix-agent dispatch. This is the
+  default and the cheapest path.
+
+- **Clear and doable as one PR, but needs review** — clear spec, single
+  PR scope, but the fix has multiple coordinate-with-discipline steps
+  (e.g., touches multiple files, requires version bumps, has subtle
+  scope-creep risk). Dispatch `/quickfix` for the issue, which adds
+  pre-execution plan-review (catches scope drift before commit) plus CI
+  poll + fix-cycle without you hand-orchestrating each step. Per-issue
+  /quickfix dispatch replaces the in-batch fix-agent for this category.
+
+- **Bug with unclear cause** — symptom is reported but no root-cause
+  hypothesis emerges from the issue body or research blurb. Don't guess.
+  Skip the issue with note: "Needs deeper investigation — could not
+  determine root cause in batch mode. Run `/investigate #NNN`." This is
+  a manual handoff (`/investigate` runs interactively, not in-batch).
+
+- **Plan-scale** — clear spec but would require 500+ lines across
+  multiple subsystems, multi-phase coordination, integration-point
+  design, or hook interactions. Not a batch-fix item.
+  - Interactive: report "this needs `/run-plan`, not `/fix-issues`"
+  - Auto: skip it, report as "Skipped: plan-scale, run /draft-plan"
+  - If `plans/PLAN_INDEX.md` exists, grep plan files for the issue
+    number (e.g., `#NNN`). If a plan already covers this issue, note
+    which plan in the skip reason. If no plan covers it, add to the
+    skip note: "Consider `/draft-plan` for #NNN."
+
 - **Too vague** — no repro steps, no expected behavior, body is empty or
   just "it's broken." You don't know WHAT to fix.
   - Interactive: flag it and ask the user for clarification
   - Auto: skip it, report as "Skipped: insufficient context" in
     $ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md
-- **Too complex** — clear spec but would require 500+ lines, major
-  refactoring, or architectural changes. Not a batch-fix item.
-  - Interactive: report "this needs `/run-plan`, not `/fix-issues`"
-  - Auto: skip it, report as "Skipped: too complex for batch fix"
-  - If `plans/PLAN_INDEX.md` exists, grep plan files for the issue number
-    (e.g., `#NNN`). If a plan already covers this issue, note which plan
-    in the skip reason. If no plan covers it, add to the skip note:
-    "Consider `/draft-plan` for #NNN."
 
 **"Too vague" means you don't know WHAT to do — not that you don't know
 HOW.** If the issue clearly describes the problem but the fix is hard,
 that's not vague — that's work. Never use "vague" as an excuse to skip
 hard issues.
+
+**Picking between in-batch fix-agent and `/quickfix`.** The in-batch
+fix-agent is appropriate when the fix is mechanical enough that
+post-execution diff review (which `/fix-issues` Phase 4 already
+dispatches) is sufficient. `/quickfix` is appropriate when *before* the
+fix, you want a second pair of eyes on the plan — typically when the
+issue has multiple discipline surfaces (version bumps + mirror, test
+updates + source change, doc update + behavior change). The
+`/quickfix` plan-reviewer's auto-REVISE on >4 Acceptance bullets is
+the mechanical signal that says "this is bigger than `/quickfix` —
+escalate to `/draft-plan`."
 
 ### Group by dependency and file overlap
 

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   requires execution.landing == "pr". No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.15+12451b"
+  version: "2026.05.15+abf853"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -43,23 +43,6 @@ the new feature branch.
 
 Pick `/quickfix` when the edit is small enough that leaving main is more
 ceremony than the change is worth, but a PR is still required.
-
-## Entry self-assertion (WI 1.1)
-
-At entry, when the SDK exposes `$SKILL_SELF` (path to this file), assert
-that the frontmatter still carries `disable-model-invocation: true`:
-
-```bash
-if [ -n "${SKILL_SELF:-}" ] && [ -f "$SKILL_SELF" ]; then
-  if ! grep -q '^disable-model-invocation: true$' "$SKILL_SELF"; then
-    echo "ERROR: /quickfix SKILL.md missing 'disable-model-invocation: true'" >&2
-    exit 1
-  fi
-fi
-# If $SKILL_SELF cannot be located (test-harness injection, older runtime),
-# the check is a no-op — the frontmatter grep in tests/run-all.sh still
-# enforces the invariant at CI time.
-```
 
 ## Argument parser (WI 1.2)
 

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: quickfix
-disable-model-invocation: true
 argument-hint: "[<description>] [auto] [--branch <name>] [--yes] [--from-here] [--skip-tests] [--force] [--rounds N]"
 description: >-
   Ship an in-flight edit (or short agent-authored fix) from main as a
@@ -11,7 +10,7 @@ description: >-
   requires execution.landing == "pr". No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.15+03e6a0"
+  version: "2026.05.15+12451b"
 ---
 
 # /quickfix — In-Flight Fix → PR

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -321,13 +321,17 @@ echo "=== quickfix — structural and algorithmic invariants ==="
 
 # ────────────────────────────────────────────────────────────────────
 # Case 1 — YAML frontmatter (WI 1.1)
+# Note: disable-model-invocation was lifted in #287 so the Skill-tool
+# can dispatch /quickfix from /fix-issues' middle-tier triage. The
+# previous assertion that the flag MUST be present is obsolete; the
+# new invariant is that the flag must be ABSENT (or not set true).
 # ────────────────────────────────────────────────────────────────────
-if grep -q '^disable-model-invocation: true$' "$SKILL" \
-   && grep -q '^name: quickfix$' "$SKILL" \
-   && grep -q '^argument-hint: "\[<description>\]' "$SKILL"; then
-  pass "1  frontmatter: name/disable-model-invocation/argument-hint present"
+if grep -q '^name: quickfix$' "$SKILL" \
+   && grep -q '^argument-hint: "\[<description>\]' "$SKILL" \
+   && ! grep -q '^disable-model-invocation: true$' "$SKILL"; then
+  pass "1  frontmatter: name/argument-hint present, dmi-true absent (per #287)"
 else
-  fail "1  frontmatter: missing one of name|disable-model-invocation|argument-hint"
+  fail "1  frontmatter: missing one of name|argument-hint, OR dmi-true still present"
 fi
 
 # ────────────────────────────────────────────────────────────────────
@@ -1002,16 +1006,10 @@ else
   fail "37 DIRTY_AFTER includes untracked: union-def missing or old exclusion wording still present"
 fi
 
-# ────────────────────────────────────────────────────────────────────
-# Case 38 — Entry self-assertion: disable-model-invocation check
-# block present (WI 1.1).
-# ────────────────────────────────────────────────────────────────────
-if grep -q 'SKILL_SELF' "$SKILL" \
-   && grep -q "missing 'disable-model-invocation: true'" "$SKILL"; then
-  pass "38 self-assertion: disable-model-invocation guard present"
-else
-  fail "38 self-assertion: disable-model-invocation guard missing"
-fi
+# Case 38 was removed in #287 — the entry self-assertion that grepped
+# for `disable-model-invocation: true` in the SKILL.md body was obsolete
+# after the dmi flag was lifted to make /quickfix Skill-tool-dispatchable.
+# Numbering preserved for continuity; the assertion itself does not exist.
 
 # ────────────────────────────────────────────────────────────────────
 # Case 39 — /tmp/zskills-tests test-output-dir idiom present (per


### PR DESCRIPTION
## Summary

Closes #287. Two coordinated changes that together fix the /fix-issues routing gap.

**Part 1 — Lift `disable-model-invocation` on /quickfix and /do.** Both skills documented agent-dispatched modes in their descriptions but the dmi-true frontmatter flag blocked Skill-tool dispatch from agent contexts. The flag contradicted the documented use case.

**Part 2 — /fix-issues Phase 2 5-way triage.** Replaces the binary "clear / too-complex" classification with explicit tiers:

| Tier | Vehicle | When |
|---|---|---|
| Clear, one PR | in-batch fix-agent | mechanical |
| Clear, needs review | `/quickfix` (NEW) | multi-step discipline / scope-creep risk |
| Bug, unclear cause | `/investigate` handoff (NEW) | no root-cause hypothesis |
| Plan-scale | `/draft-plan` | structural / multi-phase |
| Too vague | ask user | no spec |

The new middle tiers (`/quickfix` and `/investigate`) are reachable because Part 1 lifted the dmi-true flag.

## Files changed

- `skills/quickfix/SKILL.md` + mirror — removed dmi-true; version bump to `2026.05.15+12451b`
- `skills/do/SKILL.md` + mirror — removed dmi-true; version bump to `2026.05.15+210d28`
- `skills/fix-issues/SKILL.md` + mirror — Phase 2 triage rewrite; version bump to `2026.05.15+d7d321`

6 files total.

## Test plan

- [x] Conformance test: 404/404 PASS
- [x] Budget test: TOTAL 6795 chars, no WARN
- [x] Verifier subagent reviewed diff — APPROVE
- [x] dmi-true flag verified absent on /quickfix and /do
- [x] All 3 metadata.version values match recomputed content hashes
- [x] Mirror parity holds via `diff -q`
- [ ] CI green on this PR

## Follow-ups (filed separately)

- CLAUDE_TEMPLATE.md routing decision table
- /quickfix Phase 0a description-triage parity with /do
- /quickfix multi-mode support (drop PR-only constraint) — /draft-plan-shaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
