### PR TITLE
fix(dashboard): self-normalize issue queue against GitHub

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.15+1556ea"
+  version: "2026.05.15+a63bc3"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -383,12 +383,20 @@ function deepCloneQueues(queues, plans, issues) {
     out.plans[col].push({ slug: p.slug });
   }
 
+  // GitHub owns issue existence; this file only owns ordering. Drop any
+  // queue entry whose number isn't in the live `issues` array so closed
+  // issues self-prune from monitor-state.json on the next POST.
+  const liveIssueNumbers = new Set();
+  for (const it of issues) {
+    if (typeof it.number === "number") liveIssueNumbers.add(it.number);
+  }
   const seenNums = new Set();
   for (const c of ISSUE_COLUMNS) {
     const arr = (queues.issues && queues.issues[c]) || [];
     for (const n of arr) {
       const num = parseInt(n, 10);
       if (!Number.isFinite(num) || seenNums.has(num)) continue;
+      if (!liveIssueNumbers.has(num)) continue;
       seenNums.add(num);
       out.issues[c].push(num);
     }
@@ -847,7 +855,7 @@ function renderIssues(issues, queues) {
   const body = $("issues-body");
   const empty = $("issues-empty");
   clear(body);
-  if (!issues.length && allColumnsEmpty(queues.issues, ISSUE_COLUMNS)) {
+  if (!issues.length) {
     empty.hidden = false;
     return;
   }
@@ -856,14 +864,31 @@ function renderIssues(issues, queues) {
   const numToIssue = {};
   for (const it of issues) numToIssue[it.number] = it;
 
+  // GitHub owns issue existence; we render one card per live issue and
+  // group by its annotated queue.column. Queue-only entries are never
+  // rendered, so closed issues stop producing blank cards.
+  const UNQUEUED = Number.MAX_SAFE_INTEGER;
+  const grouped = {};
+  for (const c of ISSUE_COLUMNS) grouped[c] = [];
+  for (const it of issues) {
+    if (typeof it.number !== "number") continue;
+    const col = (it.queue && it.queue.column) || "triage";
+    if (ISSUE_COLUMNS.indexOf(col) < 0) continue;
+    let idx = (it.queue && typeof it.queue.index === "number") ? it.queue.index : -1;
+    if (idx < 0) idx = UNQUEUED;
+    grouped[col].push({ num: it.number, idx });
+  }
+  for (const c of ISSUE_COLUMNS) {
+    grouped[c].sort((a, b) => (a.idx - b.idx) || (b.num - a.num));
+  }
+
   const cols = el("div", { cls: "columns columns-2" });
   for (const c of ISSUE_COLUMNS) {
     const colDiv = el("div", { cls: "column" });
     const headId = "issues-col-" + c;
     const head = el("div", { cls: "column-head", attrs: { id: headId } });
     head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
-    const arr = (lastGoodQueues && lastGoodQueues.issues[c]) || [];
-    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    head.appendChild(el("span", { cls: "muted", text: String(grouped[c].length) }));
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -875,10 +900,8 @@ function renderIssues(issues, queues) {
         "aria-labelledby": headId,
       },
     });
-    for (const num of arr) {
-      const n = parseInt(num, 10);
-      if (!Number.isFinite(n)) continue;
-      const card = buildIssueCard(numToIssue[n] || null, n, c);
+    for (const entry of grouped[c]) {
+      const card = buildIssueCard(numToIssue[entry.num], entry.num, c);
       ul.appendChild(card);
     }
     colDiv.appendChild(ul);

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.15+1556ea"
+  version: "2026.05.15+a63bc3"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -383,12 +383,20 @@ function deepCloneQueues(queues, plans, issues) {
     out.plans[col].push({ slug: p.slug });
   }
 
+  // GitHub owns issue existence; this file only owns ordering. Drop any
+  // queue entry whose number isn't in the live `issues` array so closed
+  // issues self-prune from monitor-state.json on the next POST.
+  const liveIssueNumbers = new Set();
+  for (const it of issues) {
+    if (typeof it.number === "number") liveIssueNumbers.add(it.number);
+  }
   const seenNums = new Set();
   for (const c of ISSUE_COLUMNS) {
     const arr = (queues.issues && queues.issues[c]) || [];
     for (const n of arr) {
       const num = parseInt(n, 10);
       if (!Number.isFinite(num) || seenNums.has(num)) continue;
+      if (!liveIssueNumbers.has(num)) continue;
       seenNums.add(num);
       out.issues[c].push(num);
     }
@@ -847,7 +855,7 @@ function renderIssues(issues, queues) {
   const body = $("issues-body");
   const empty = $("issues-empty");
   clear(body);
-  if (!issues.length && allColumnsEmpty(queues.issues, ISSUE_COLUMNS)) {
+  if (!issues.length) {
     empty.hidden = false;
     return;
   }
@@ -856,14 +864,31 @@ function renderIssues(issues, queues) {
   const numToIssue = {};
   for (const it of issues) numToIssue[it.number] = it;
 
+  // GitHub owns issue existence; we render one card per live issue and
+  // group by its annotated queue.column. Queue-only entries are never
+  // rendered, so closed issues stop producing blank cards.
+  const UNQUEUED = Number.MAX_SAFE_INTEGER;
+  const grouped = {};
+  for (const c of ISSUE_COLUMNS) grouped[c] = [];
+  for (const it of issues) {
+    if (typeof it.number !== "number") continue;
+    const col = (it.queue && it.queue.column) || "triage";
+    if (ISSUE_COLUMNS.indexOf(col) < 0) continue;
+    let idx = (it.queue && typeof it.queue.index === "number") ? it.queue.index : -1;
+    if (idx < 0) idx = UNQUEUED;
+    grouped[col].push({ num: it.number, idx });
+  }
+  for (const c of ISSUE_COLUMNS) {
+    grouped[c].sort((a, b) => (a.idx - b.idx) || (b.num - a.num));
+  }
+
   const cols = el("div", { cls: "columns columns-2" });
   for (const c of ISSUE_COLUMNS) {
     const colDiv = el("div", { cls: "column" });
     const headId = "issues-col-" + c;
     const head = el("div", { cls: "column-head", attrs: { id: headId } });
     head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
-    const arr = (lastGoodQueues && lastGoodQueues.issues[c]) || [];
-    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    head.appendChild(el("span", { cls: "muted", text: String(grouped[c].length) }));
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -875,10 +900,8 @@ function renderIssues(issues, queues) {
         "aria-labelledby": headId,
       },
     });
-    for (const num of arr) {
-      const n = parseInt(num, 10);
-      if (!Number.isFinite(n)) continue;
-      const card = buildIssueCard(numToIssue[n] || null, n, c);
+    for (const entry of grouped[c]) {
+      const card = buildIssueCard(numToIssue[entry.num], entry.num, c);
       ul.appendChild(card);
     }
     colDiv.appendChild(ul);


### PR DESCRIPTION
## Summary

The dashboard's Triage column rendered blank cards for closed-issue numbers (e.g., #266 / #267 / #231) because those numbers lingered in `.zskills/monitor-state.json` after `/fix-issues sync` closed them via `gh issue close`. The root cause is architectural: `monitor-state.json` was conflating issue **existence** (which GitHub owns) with **ordering** (which the state file owns). The client also rendered one card per queue entry instead of per live issue, so dead numbers surfaced as blank cards.

This PR makes the state file purely derivative: GitHub-owns-existence; state-file-owns-ordering.

Two surgical edits in `skills/zskills-dashboard/scripts/zskills_monitor/static/app.js`:

1. **`renderIssues(issues, queues)`** — flipped from iterating queue columns to iterating the live `issues` array. Each live issue is grouped by its annotated `queue.column` (default `"triage"`) and ordered by `queue.index` (with `Number.MAX_SAFE_INTEGER` sentinel for unqueued, descending-number tiebreak so newest issues appear first within unqueued group). Cards are always built with `numToIssue[entry.num]` — always defined since iteration is over live issues. Closed-issue numbers simply have no live issue to anchor to, so they produce no card.

2. **`deepCloneQueues(queues, plans, issues)`** — built a `liveIssueNumbers` Set from the live `issues` argument; queue entries whose numbers aren't in that set are skipped during pre-populate. This makes `monitor-state.json` self-normalize on the next POST: the round-trip drops closed-issue numbers from the state file without any explicit prune step.

No server-side changes. `_annotate_issues_queue` in `collect.py` already populates `queue.column` / `queue.index` on every live issue.

## Test plan

- [x] Full suite: **3081/3081 PASS**, exit 0
- [x] Live smoke: started worktree-bound dashboard on :19985, confirmed bug condition (stale 231/266/267 in state file's triage list, 17 vs 14 live), then validated post-fix DOM: `total_cards: 14, blank_cards: 0, number_only_cards: 0` — every rendered card has a non-empty title
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: → `2026.05.15+a63bc3` (matches recomputed content hash)
- [x] Fresh verifier subagent: **A+** (7/7 checks; dedup interaction verified by code-walk — filter only in pre-populate loop, second loop unfiltered so live-but-unqueued issues still flow through)
- [ ] **Reviewer post-merge:** restart your dashboard (`/zskills-dashboard restart`), open `#issues` — the three blank cards (#266, #267, #231) should be gone. After your next drag/drop or other queue interaction, `monitor-state.json` will self-normalize and the stale numbers will be removed from disk.

🤖 Generated with /quickfix (agent-dispatched)
