### PR TITLE
do: add Under Construction badge to dashboard title bar

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.15+a63bc3"
+  version: "2026.05.16+7c1a88"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -47,6 +47,8 @@ code, pre, .mono {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 16px 24px;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
@@ -60,6 +62,20 @@ code, pre, .mono {
   letter-spacing: 0.02em;
   color: var(--accent);
   font-weight: 600;
+}
+
+.under-construction {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 12px;
+  margin-right: auto;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  color: var(--accent2);
+  border: 1px solid var(--accent2);
+  border-radius: 999px;
+  white-space: nowrap;
+  cursor: help;
 }
 
 .topbar-meta {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -9,6 +9,7 @@
 <body>
   <header class="topbar">
     <h1>Z Skills Dashboard</h1>
+    <span class="under-construction" title="Z Skills Dashboard is an early build — features are in flux">🚧 Under Construction</span>
     <div class="topbar-meta">
       <span id="updated-at" class="muted" aria-live="polite"></span>
     </div>

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.15+a63bc3"
+  version: "2026.05.16+7c1a88"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -47,6 +47,8 @@ code, pre, .mono {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 16px 24px;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
@@ -60,6 +62,20 @@ code, pre, .mono {
   letter-spacing: 0.02em;
   color: var(--accent);
   font-weight: 600;
+}
+
+.under-construction {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 12px;
+  margin-right: auto;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  color: var(--accent2);
+  border: 1px solid var(--accent2);
+  border-radius: 999px;
+  white-space: nowrap;
+  cursor: help;
 }
 
 .topbar-meta {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -9,6 +9,7 @@
 <body>
   <header class="topbar">
     <h1>Z Skills Dashboard</h1>
+    <span class="under-construction" title="Z Skills Dashboard is an early build — features are in flux">🚧 Under Construction</span>
     <div class="topbar-meta">
       <span id="updated-at" class="muted" aria-live="polite"></span>
     </div>


### PR DESCRIPTION
Task: Add an "Under Construction" indicator to the Z Skills Dashboard title bar to make it clear the dashboard isn't fully functional yet.

The badge is a small purple-outlined pill (🚧 Under Construction) placed immediately after the H1 inside `<header class="topbar">`. Styled with `var(--accent2)` text+border at 0.8rem, rounded-pill (border-radius 999px), 4px/10px padding, 12px left margin. `.topbar` gained `flex-wrap: wrap; gap: 8px` so the badge wraps below the h1 on narrow viewports rather than overflowing.

Verifier graded A+:
- Diff scoped to HTML/CSS + skill version + mirror (no server-side Python)
- Mirror parity clean (only __pycache__)
- Skill version: `2026.05.16+7c1a88` (matches recomputed content hash)
- Full suite: 3080/3080 PASS, exit 0
- Live functional smoke: `.under-construction` element present, visible, inside `.topbar`, immediately after `<h1>`; text "🚧 Under Construction"
- Screenshot inspection: badge subtle, aligned with h1, legible without dominating

Worktree: /tmp/zskills-do-under-construction-badge
Commits: 81ee998 do: add Under Construction badge to dashboard title bar

Note: /do does not currently support the positional `auto` token (issue #297). Auto-merge will be requested manually via `gh pr merge --auto --squash` after PR creation.
