### PR TITLE
fix(hook): support ZSKILLS_PYTHON env override (closes #288)

### DIFF
--- a/.claude/hooks/inject-bash-timeout.sh
+++ b/.claude/hooks/inject-bash-timeout.sh
@@ -14,9 +14,11 @@
 #
 # Implementation note: the `command` field can contain arbitrary quotes,
 # backslashes, and newlines that are awkward to round-trip through pure
-# bash regex. We use python3 for the JSON parse + reserialize to keep the
+# bash regex. We use Python for the JSON parse + reserialize to keep the
 # escaping correct. Per zskills convention: no jq; python is acceptable
-# in hook scripts when bash JSON construction would be brittle.
+# in hook scripts when bash JSON construction would be brittle. The
+# interpreter is resolved via $ZSKILLS_PYTHON (env override, for
+# Windows / non-standard distros) → `python3` → `python`.
 #
 # Stdin shape: PreToolUse harness envelopes vary. Two supported shapes —
 #   1. The full envelope `{"tool_name":"Bash","tool_input":{...},...}`
@@ -26,6 +28,12 @@
 # hook usable from both the live harness and direct unit tests.
 
 set -u
+
+# Resolve Python interpreter once. Override via ZSKILLS_PYTHON for
+# Windows / non-standard distros where only `python` exists. Default
+# precedence: python3 (POSIX-standard zskills target), then python.
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
 
 INPUT=$(cat)
 MIN_TIMEOUT=600000
@@ -48,7 +56,7 @@ fi
 # Need to inject. Round-trip via python3 for correct JSON escaping.
 # We pass MIN_TIMEOUT as an env var (stdin must stay free for the JSON
 # envelope; argv-vs-stdin separation is what `python3 -c` gets us).
-PY_OUT=$(printf '%s' "$INPUT" | MIN_TIMEOUT="$MIN_TIMEOUT" python3 -c '
+PY_OUT=$(printf '%s' "$INPUT" | MIN_TIMEOUT="$MIN_TIMEOUT" "$PYTHON" -c '
 import json, os, sys
 min_timeout = int(os.environ["MIN_TIMEOUT"])
 raw = sys.stdin.read()
@@ -70,7 +78,7 @@ sys.stdout.write(json.dumps(out))
 ' 2>/dev/null)
 
 if [ -z "$PY_OUT" ]; then
-  # python failed (missing python3 / parse error / unexpected). Permissive
+  # python failed (parse error / unexpected; missing interpreter exits earlier). Permissive
   # fallback: allow as-is. Layer 3 (verify-response-validate.sh) catches
   # any downstream verifier failure regardless.
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,23 @@ issues, dev-server.{pid,log}) — not just `.zskills/tracking/` — so the
 ZSKILLS_PATH_CONFIG migration's audit + issues subtrees are equally
 guarded against accidental recursive deletion.
 
+## Python is required
+
+zskills depends on Python 3 for JSON round-tripping in hooks and helper scripts where bash regex would be brittle (notably `hooks/inject-bash-timeout.sh` — Layer 0 of the verifier-cannot-run defense). Per project convention there is **no jq** — Python's stdlib `json` is the supported parser.
+
+The interpreter is resolved via this precedence (in `hooks/inject-bash-timeout.sh` and any script that adopts the same idiom):
+
+```
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+```
+
+- Default is `python3` (POSIX-standard zskills target).
+- Falls back to `python` for Windows / distros where only `python` exists (pointing at Python 3).
+- `ZSKILLS_PYTHON` overrides both — set it explicitly when both `python3` and `python` exist but you want a specific interpreter (e.g. a venv).
+
+Python 2 is unsupported. Scripts may assume Python 3 stdlib without a version check.
+
 ## Skill versioning
 
 **Skill versioning.** Every source skill under `skills/<name>/SKILL.md` and `block-diagram/<name>/SKILL.md` carries a `metadata.version: "YYYY.MM.DD+HHHHHH"` field — date in `America/New_York` plus a 6-char content hash. Edits to a skill body, frontmatter (other than `metadata.version` itself), or any regular file under the skill directory (mode files, references, scripts, fixtures, stubs, etc.) MUST bump this field; the date refreshes to today, the hash is recomputed via `scripts/skill-content-hash.sh`. Pure typo / formatting / whitespace edits do not require a bump (the hash naturally absorbs them since the canonical projection normalizes whitespace; see `references/skill-versioning.md` §3). Enforcement fires at three points: `warn-config-drift.sh` (Edit-time warn, fires only when the file is staged), `/commit` Phase 5 step 2.5 (commit-time hard stop), `test-skill-conformance.sh` (CI gate). The repo-level zskills version (`YYYY.MM.N`) lives in git tags and is mirrored into `.claude/zskills-config.json` by `/update-zskills`.

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -15,6 +15,23 @@ When using the Agent tool:
 - Treat any subagent type as Haiku-by-default until you have read its agent definition and confirmed otherwise. When in doubt, pass `model: "opus"` explicitly, or use `general-purpose`.
 - **Sonnet** is acceptable only for rare simple+mechanical work (bulk renames, find-replace, format conversion). Never for analysis, review, verification, or judgment.
 
+## Python is required
+
+zskills hooks and helper scripts depend on Python 3 for JSON round-tripping where bash regex would be brittle (notably `hooks/inject-bash-timeout.sh` — Layer 0 of the verifier-cannot-run defense). Per project convention there is **no jq** — Python's stdlib `json` is the supported parser.
+
+The interpreter is resolved via this precedence:
+
+```
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+```
+
+- Default is `python3` (POSIX-standard zskills target).
+- Falls back to `python` for Windows / distros where only `python` exists (pointing at Python 3).
+- Set `ZSKILLS_PYTHON` to override both — useful when both binaries exist but you need a specific interpreter (e.g. a venv).
+
+Python 2 is unsupported.
+
 ## Dev Server
 
 Run `bash scripts/start-dev.sh` to start the dev server and `bash scripts/stop-dev.sh` to stop it. Both ship as failing stubs that the consumer customizes (see in-file comments for the contract). The pairing: `start-dev.sh` runs `{{DEV_SERVER_CMD}}` and writes each spawned child PID (one per line) to `.zskills/dev-server.pid`; `stop-dev.sh` reads `.zskills/dev-server.pid` and SIGTERMs each. `.zskills/` is gitignored.

--- a/hooks/inject-bash-timeout.sh
+++ b/hooks/inject-bash-timeout.sh
@@ -14,9 +14,11 @@
 #
 # Implementation note: the `command` field can contain arbitrary quotes,
 # backslashes, and newlines that are awkward to round-trip through pure
-# bash regex. We use python3 for the JSON parse + reserialize to keep the
+# bash regex. We use Python for the JSON parse + reserialize to keep the
 # escaping correct. Per zskills convention: no jq; python is acceptable
-# in hook scripts when bash JSON construction would be brittle.
+# in hook scripts when bash JSON construction would be brittle. The
+# interpreter is resolved via $ZSKILLS_PYTHON (env override, for
+# Windows / non-standard distros) → `python3` → `python`.
 #
 # Stdin shape: PreToolUse harness envelopes vary. Two supported shapes —
 #   1. The full envelope `{"tool_name":"Bash","tool_input":{...},...}`
@@ -26,6 +28,12 @@
 # hook usable from both the live harness and direct unit tests.
 
 set -u
+
+# Resolve Python interpreter once. Override via ZSKILLS_PYTHON for
+# Windows / non-standard distros where only `python` exists. Default
+# precedence: python3 (POSIX-standard zskills target), then python.
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
 
 INPUT=$(cat)
 MIN_TIMEOUT=600000
@@ -48,7 +56,7 @@ fi
 # Need to inject. Round-trip via python3 for correct JSON escaping.
 # We pass MIN_TIMEOUT as an env var (stdin must stay free for the JSON
 # envelope; argv-vs-stdin separation is what `python3 -c` gets us).
-PY_OUT=$(printf '%s' "$INPUT" | MIN_TIMEOUT="$MIN_TIMEOUT" python3 -c '
+PY_OUT=$(printf '%s' "$INPUT" | MIN_TIMEOUT="$MIN_TIMEOUT" "$PYTHON" -c '
 import json, os, sys
 min_timeout = int(os.environ["MIN_TIMEOUT"])
 raw = sys.stdin.read()
@@ -70,7 +78,7 @@ sys.stdout.write(json.dumps(out))
 ' 2>/dev/null)
 
 if [ -z "$PY_OUT" ]; then
-  # python failed (missing python3 / parse error / unexpected). Permissive
+  # python failed (parse error / unexpected; missing interpreter exits earlier). Permissive
   # fallback: allow as-is. Layer 3 (verify-response-validate.sh) catches
   # any downstream verifier failure regardless.
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'


### PR DESCRIPTION
## Summary
- Resolves Python binary at hook top via `$ZSKILLS_PYTHON` env override with `command -v python3 || command -v python` fallback; swaps the one `python3 -c` call to `"$PYTHON" -c` (closes #288).
- Documents Python policy in `CLAUDE.md` and `CLAUDE_TEMPLATE.md` (auto-propagates to consumers via `/update-zskills` Step B).
- **Narrow scope per tracker blurb:** hook + docs only. No `PYTHON_CMD` helper, no test sed-sweep, no `scripts/zskills-resolve-config.sh` edit.

## Test plan
- [x] Verifier ran full suite foreground: 3080/3080 PASS.
- [x] Hook smoke test confirms `timeout=600000` still injects on default invocation + `ZSKILLS_PYTHON=python3` env-override invocation.
- [x] Source `hooks/inject-bash-timeout.sh` byte-identical to mirror `.claude/hooks/inject-bash-timeout.sh`.
- [x] Files modified are exactly the 4 expected (hook + mirror + 2 doc files); no scope creep.
- [ ] On a Windows / distro where only `python` (not `python3`) exists, set `ZSKILLS_PYTHON=python` and confirm hook still injects timeout. Project's CI environment has python3; behavior on python-only systems is what this PR enables but cannot test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
