### PR TITLE
fix(research-and-go): atomic Step 0+1 + step.* pointer (closes #278)

### DIFF
--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.15+e5bbe7"
+  version: "2026.05.16+087b59"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -55,6 +55,15 @@ Examples:
 ## Step 0 — Tracking Setup
 
 Before anything else, check whether another pipeline is already in progress.
+
+**On resume, also check `step.*` markers.** Child `/run-plan` invocations
+emit per-phase `step.<phase>.{implement,verify,report}` markers under
+their own pipeline subdirs (convention documented at
+`docs/tracking/TRACKING_NAMING.md:413-415`). If you are resuming an
+existing pipeline (sentinel already exists), inspect those `step.*`
+markers across the child pipelines' subdirs to determine which sub-plan
+phase last made progress before re-dispatching — they are the
+authoritative per-phase progress signal.
 
 ```bash
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
@@ -170,9 +179,25 @@ already exists and this is a deliberate re-run of the same goal:
    false positives).
 5. Overwrite the `pipeline.research-and-go.$SCOPE` sentinel with a fresh timestamp.
 
+### Atomicity gate — Step 0 → Step 1 ships in ONE response
+
+**Do NOT split Step 0's last bash and Step 1's Skill call across separate responses — interrupt-resilience requires they ship together.**
+
+The moment Step 0's final bash block completes (sentinel written, pipeline
+ID echoed, requirement marker written, and — on re-run — staleness
+touches done), the very next tool call in the SAME assistant response MUST
+be the `Skill` invocation in Step 1 below. Do not end your turn between
+Step 0 and Step 1. Do not narrate "now I will invoke /research-and-plan"
+and stop — actually invoke it, in this same response. This atomicity is
+the only thing protecting the pipeline against a user interrupt (e.g., a
+permissions prompt) that arrives between turns and leaves a tracking
+sentinel with no follow-through.
+
 ## Step 1 — Decompose and Draft
 
-Invoke `/research-and-plan` with `auto`, `parent=research-and-go`, and the full description:
+**This step MUST execute in the same response as Step 0's last bash block (see Atomicity gate above).**
+
+Invoke `/research-and-plan` (via the `Skill` tool) with `auto`, `parent=research-and-go`, and the full description:
 
 `/research-and-plan output $META_PLAN_PATH auto parent=research-and-go <description>`
 

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.15+e5bbe7"
+  version: "2026.05.16+087b59"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -55,6 +55,15 @@ Examples:
 ## Step 0 — Tracking Setup
 
 Before anything else, check whether another pipeline is already in progress.
+
+**On resume, also check `step.*` markers.** Child `/run-plan` invocations
+emit per-phase `step.<phase>.{implement,verify,report}` markers under
+their own pipeline subdirs (convention documented at
+`docs/tracking/TRACKING_NAMING.md:413-415`). If you are resuming an
+existing pipeline (sentinel already exists), inspect those `step.*`
+markers across the child pipelines' subdirs to determine which sub-plan
+phase last made progress before re-dispatching — they are the
+authoritative per-phase progress signal.
 
 ```bash
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
@@ -170,9 +179,25 @@ already exists and this is a deliberate re-run of the same goal:
    false positives).
 5. Overwrite the `pipeline.research-and-go.$SCOPE` sentinel with a fresh timestamp.
 
+### Atomicity gate — Step 0 → Step 1 ships in ONE response
+
+**Do NOT split Step 0's last bash and Step 1's Skill call across separate responses — interrupt-resilience requires they ship together.**
+
+The moment Step 0's final bash block completes (sentinel written, pipeline
+ID echoed, requirement marker written, and — on re-run — staleness
+touches done), the very next tool call in the SAME assistant response MUST
+be the `Skill` invocation in Step 1 below. Do not end your turn between
+Step 0 and Step 1. Do not narrate "now I will invoke /research-and-plan"
+and stop — actually invoke it, in this same response. This atomicity is
+the only thing protecting the pipeline against a user interrupt (e.g., a
+permissions prompt) that arrives between turns and leaves a tracking
+sentinel with no follow-through.
+
 ## Step 1 — Decompose and Draft
 
-Invoke `/research-and-plan` with `auto`, `parent=research-and-go`, and the full description:
+**This step MUST execute in the same response as Step 0's last bash block (see Atomicity gate above).**
+
+Invoke `/research-and-plan` (via the `Skill` tool) with `auto`, `parent=research-and-go`, and the full description:
 
 `/research-and-plan output $META_PLAN_PATH auto parent=research-and-go <description>`
 


### PR DESCRIPTION
## Summary
- Restructures `skills/research-and-go/SKILL.md` so Step 0's last bash and Step 1's `/research-and-plan` Skill call ship in the SAME response — interrupt-resilience (closes #278 Fix #1).
- Adds verbatim bolded guardrail sentence: "Do NOT split Step 0's last bash and Step 1's Skill call across separate responses — interrupt-resilience requires they ship together."
- Adds Step 1 cross-reference pointing back to the atomicity gate.
- Adds thin prose pointer to existing `step.*` marker convention (`docs/tracking/TRACKING_NAMING.md:413-415`) in Step 0's tracking-setup section (closes #278 Fix #4 — convention already exists; this just surfaces it).

**Fix #2 (PreCompact hook) and Fix #3 (SessionStart orphaned-pipeline detector) are explicitly DEFERRED** to `/draft-plan` when prioritized — plan-scale design work not in this PR's scope per the tracker blurb.

## Test plan
- [x] Verifier independently confirmed atomicity-gate prose joining Step 0 last bash and Step 1 Skill call into one response; guardrail sentence verbatim.
- [x] Confirmed Fix #2 and Fix #3 are NOT in the diff (`git diff --stat` shows only the two SKILL.md files).
- [x] Mirror byte-identical (`diff -u skills/research-and-go/SKILL.md .claude/skills/research-and-go/SKILL.md` empty).
- [x] `metadata.version` bumped to `2026.05.16+087b59` in source + mirror; stage-check exit 0.
- [x] Full suite: 3079/3080 pass (1 known parallel-test race in `test-briefing-parity.sh`; re-ran in isolation 21/21 PASS).
- [ ] Live `/research-and-go` invocation under user-interrupt conditions (interrupt during permissions debug between Step 0 and Step 1) confirms the agent resumes correctly. This is an integration test that requires triggering the original failure pattern — left for the next /research-and-go user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
