### PR TITLE
Fix #283: Dashboard server helpers (collect.py): new aggregation logic shipped without targeted unit tests

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.16+d429b8"
+  version: "2026.05.16+cd7839"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -872,11 +872,16 @@ def _scan_git_history(
         })
         return []
     if result.returncode != 0:
-        # Empty repo / no commits in window is not an error here.
-        if result.stderr.strip():
+        # Empty repo / no commits in window is not an error here. Recognise
+        # the canonical "fatal: your current branch ... does not have any
+        # commits yet" message so a brand-new repo doesn't show up as a
+        # collection error.
+        stderr = result.stderr.strip()
+        benign = (not stderr) or ("does not have any commits yet" in stderr)
+        if not benign:
             errors.append({
                 "source": "git history",
-                "message": f"git log rc={result.returncode}: {result.stderr.strip()[:200]}",
+                "message": f"git log rc={result.returncode}: {stderr[:200]}",
             })
         return []
 
@@ -919,10 +924,15 @@ def _scan_git_history(
 
 
 def _extract_pr_numbers_from_markers(
-    activity: List[Dict[str, Any]],
     main_root: pathlib.Path,
 ) -> set:
-    """Walk fulfilled.land-pr.* markers to collect PR numbers for dedup."""
+    """Walk fulfilled.land-pr.* markers to collect PR numbers for dedup.
+
+    Reads markers directly from disk (both flat `.zskills/tracking/` and
+    per-pipeline subdirs) rather than from the in-memory activity list,
+    because the activity list strips the raw `pr` field — it's flattened
+    into the `output` slot and may be elided.
+    """
     nums: set = set()
     base = main_root / ".zskills" / "tracking"
     if not base.is_dir():
@@ -1379,7 +1389,7 @@ def collect_snapshot(
     # dedup; commits whose trailing `(#N)` matches a fulfilled.land-pr.*
     # marker's PR number are dropped.
     marker_activity = _scan_tracking_markers(main_root, errors)
-    fulfilled_prs = _extract_pr_numbers_from_markers(marker_activity, main_root)
+    fulfilled_prs = _extract_pr_numbers_from_markers(main_root)
     git_activity = _scan_git_history(
         main_root, errors, fulfilled_pr_numbers=fulfilled_prs,
     )

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.16+d429b8"
+  version: "2026.05.16+cd7839"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -872,11 +872,16 @@ def _scan_git_history(
         })
         return []
     if result.returncode != 0:
-        # Empty repo / no commits in window is not an error here.
-        if result.stderr.strip():
+        # Empty repo / no commits in window is not an error here. Recognise
+        # the canonical "fatal: your current branch ... does not have any
+        # commits yet" message so a brand-new repo doesn't show up as a
+        # collection error.
+        stderr = result.stderr.strip()
+        benign = (not stderr) or ("does not have any commits yet" in stderr)
+        if not benign:
             errors.append({
                 "source": "git history",
-                "message": f"git log rc={result.returncode}: {result.stderr.strip()[:200]}",
+                "message": f"git log rc={result.returncode}: {stderr[:200]}",
             })
         return []
 
@@ -919,10 +924,15 @@ def _scan_git_history(
 
 
 def _extract_pr_numbers_from_markers(
-    activity: List[Dict[str, Any]],
     main_root: pathlib.Path,
 ) -> set:
-    """Walk fulfilled.land-pr.* markers to collect PR numbers for dedup."""
+    """Walk fulfilled.land-pr.* markers to collect PR numbers for dedup.
+
+    Reads markers directly from disk (both flat `.zskills/tracking/` and
+    per-pipeline subdirs) rather than from the in-memory activity list,
+    because the activity list strips the raw `pr` field — it's flattened
+    into the `output` slot and may be elided.
+    """
     nums: set = set()
     base = main_root / ".zskills" / "tracking"
     if not base.is_dir():
@@ -1379,7 +1389,7 @@ def collect_snapshot(
     # dedup; commits whose trailing `(#N)` matches a fulfilled.land-pr.*
     # marker's PR number are dropped.
     marker_activity = _scan_tracking_markers(main_root, errors)
-    fulfilled_prs = _extract_pr_numbers_from_markers(marker_activity, main_root)
+    fulfilled_prs = _extract_pr_numbers_from_markers(main_root)
     git_activity = _scan_git_history(
         main_root, errors, fulfilled_pr_numbers=fulfilled_prs,
     )

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -547,6 +547,386 @@ fi
 trap - EXIT
 
 # ---------------------------------------------------------------------------
+# Issue #283: targeted coverage for activity helpers added in PR #274 + #277
+# ---------------------------------------------------------------------------
+# These tests exercise `_derive_repo_url`, `_scan_git_history`,
+# `_extract_pr_numbers_from_markers`, and the dedup/cap/sort logic in
+# `_collect_activity` directly via REPL imports (the fixtures don't carry
+# a real `.git`, so these helpers no-op against fixtures).
+echo ""
+echo "=== Issue #283: dashboard activity-helper coverage ==="
+
+# --- _derive_repo_url: regex unit cases ---------------------------------
+# Drive the URL-translation logic via a stub that replaces git invocation
+# with a hardcoded stdout. This exercises every branch of _GIT_HTTPS_RE,
+# _GIT_SSH_RE, and the missing/empty-remote early-returns.
+URL_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib, tempfile, subprocess
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+# We use a tmp dir with a stub .git so the existence guard passes; the
+# git subprocess output is mocked via monkeypatch of subprocess.run.
+tmp = pathlib.Path(tempfile.mkdtemp())
+(tmp / ".git").mkdir()
+
+class FakeResult:
+    def __init__(self, rc, stdout):
+        self.returncode = rc
+        self.stdout = stdout
+        self.stderr = ""
+
+cases = [
+    # (remote-stdout, expected-derived-url, label)
+    ("https://github.com/foo/bar.git",      "https://github.com/foo/bar", "https_with_dot_git"),
+    ("https://github.com/foo/bar",          "https://github.com/foo/bar", "https_no_dot_git"),
+    ("https://github.com/foo/bar/",         "https://github.com/foo/bar", "https_trailing_slash"),
+    ("https://github.com/foo/bar.git/",     "https://github.com/foo/bar", "https_dot_git_trailing_slash"),
+    ("http://gitea.local/foo/bar.git",      "https://gitea.local/foo/bar", "http_self_hosted"),
+    ("git@github.com:foo/bar.git",          "https://github.com/foo/bar", "ssh_with_dot_git"),
+    ("git@github.com:foo/bar",              "https://github.com/foo/bar", "ssh_no_dot_git"),
+    ("git@gitlab.example.com:org/proj.git", "https://gitlab.example.com/org/proj", "ssh_custom_host"),
+    ("ftp://nope.example/foo/bar",          "",                          "unknown_protocol"),
+    ("",                                     "",                          "empty_remote_stdout"),
+    ("not a url at all",                     "",                          "malformed_remote"),
+]
+
+results = []
+for stdout, expected, label in cases:
+    def fake_run(cmd, **kw):
+        return FakeResult(0, stdout)
+    orig = subprocess.run
+    subprocess.run = fake_run
+    try:
+        got = c._derive_repo_url(tmp)
+    finally:
+        subprocess.run = orig
+    ok = got == expected
+    results.append((label, ok, expected, got))
+
+# Missing-remote rc=1 path
+def fake_run_rc1(cmd, **kw):
+    return FakeResult(128, "")
+orig = subprocess.run
+subprocess.run = fake_run_rc1
+try:
+    got = c._derive_repo_url(tmp)
+finally:
+    subprocess.run = orig
+results.append(("nonzero_rc_yields_empty", got == "", "", got))
+
+# Missing `.git` dir entirely
+tmp2 = pathlib.Path(tempfile.mkdtemp())
+got = c._derive_repo_url(tmp2)
+results.append(("no_git_dir_yields_empty", got == "", "", got))
+
+# Timeout path
+def fake_run_timeout(cmd, **kw):
+    raise subprocess.TimeoutExpired(cmd, 2)
+subprocess.run = fake_run_timeout
+try:
+    got = c._derive_repo_url(tmp)
+finally:
+    subprocess.run = orig
+results.append(("timeout_yields_empty", got == "", "", got))
+
+# OSError path (e.g., git binary missing)
+def fake_run_oserror(cmd, **kw):
+    raise OSError("git: not found")
+subprocess.run = fake_run_oserror
+try:
+    got = c._derive_repo_url(tmp)
+finally:
+    subprocess.run = orig
+results.append(("oserror_yields_empty", got == "", "", got))
+
+bad = [r for r in results if not r[1]]
+if bad:
+    for label, _, exp, got in bad:
+        print(f"FAIL {label}: expected={exp!r} got={got!r}")
+    print("STATUS=BAD")
+else:
+    print(f"STATUS=OK count={len(results)}")
+')
+if printf '%s\n' "$URL_RES" | grep -q "^STATUS=OK"; then
+  N=$(printf '%s\n' "$URL_RES" | grep -oE "count=[0-9]+" | cut -d= -f2)
+  pass "_derive_repo_url: all ${N} URL forms (SSH/HTTPS/.git/trailing/empty/rc!=0/timeout/OSError) translate correctly"
+else
+  fail "_derive_repo_url: at least one case wrong: $URL_RES"
+fi
+
+# --- _scan_git_history: real-git fixture --------------------------------
+# Build a real throwaway git repo with deliberately tricky commit subjects
+# so we exercise the regex anchors directly. The fixtures dir is read-only
+# (no .git), so we materialize a tmpdir for this case.
+HIST_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib, tempfile, subprocess, json
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+tmp = pathlib.Path(tempfile.mkdtemp())
+def git(*args):
+    subprocess.run(["git", "-C", str(tmp), *args], check=True,
+                   capture_output=True, text=True,
+                   env={"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+                        "PATH": "/usr/bin:/bin:/usr/local/bin"})
+git("init", "--quiet", "-b", "main")
+git("commit", "--allow-empty", "-m", "fix: trailing PR ref (#100)")
+git("commit", "--allow-empty", "-m", "docs: inline body ref (#999) and trailer (#101)")
+git("commit", "--allow-empty", "-m", "chore: closes #200 with no PR trailer")
+git("commit", "--allow-empty", "-m", "feat(scope): subject with no refs at all")
+git("commit", "--allow-empty", "-m", "fix: ref #300 followed by PR trailer (#102)")
+# This commit also gets dedup-skipped (its trailing (#101) is in fulfilled_prs).
+
+errors = []
+rows = c._scan_git_history(tmp, errors, since_hours=720, max_commits=200,
+                           fulfilled_pr_numbers={"101"})
+
+if errors:
+    print("ERRORS:", errors)
+# Index by subject suffix for clarity
+by_sub = {r["subject"]: r for r in rows}
+
+checks = []
+# (#100) trailer extracted
+r = by_sub.get("fix: trailing PR ref (#100)")
+checks.append(("trailer_extracted", r is not None and r["pr"] == "100" and r["issue"] == ""))
+# (#101) trailer commit should be DROPPED via dedup
+checks.append(("dedup_drops_101", "docs: inline body ref (#999) and trailer (#101)" not in by_sub))
+# closes #200 — issue extracted, pr empty
+r = by_sub.get("chore: closes #200 with no PR trailer")
+checks.append(("issue_only_no_pr", r is not None and r["pr"] == "" and r["issue"] == "200"))
+# bare subject — both empty
+r = by_sub.get("feat(scope): subject with no refs at all")
+checks.append(("bare_subject_empty", r is not None and r["pr"] == "" and r["issue"] == ""))
+# inline #300 + trailer (#102) — pr=102, issue=300 (different group)
+r = by_sub.get("fix: ref #300 followed by PR trailer (#102)")
+checks.append(("inline_plus_trailer", r is not None and r["pr"] == "102" and r["issue"] == "300"))
+# shape: every record has location=git, kind=commit, sha set, id=sha[:7]
+shape_ok = all(r["location"] == "git" and r["kind"] == "commit"
+               and len(r["sha"]) >= 7 and r["id"] == r["sha"][:7] for r in rows)
+checks.append(("record_shape", shape_ok))
+# timestamp is ISO-8601 (contains T) on every row
+ts_ok = all("T" in r["timestamp"] for r in rows)
+checks.append(("timestamp_iso", ts_ok))
+
+# Edge: empty repo
+tmp2 = pathlib.Path(tempfile.mkdtemp())
+subprocess.run(["git", "-C", str(tmp2), "init", "--quiet", "-b", "main"], check=True,
+               capture_output=True, text=True)
+errs2 = []
+rows2 = c._scan_git_history(tmp2, errs2, since_hours=720, max_commits=200)
+checks.append(("empty_repo_yields_empty", rows2 == [] and errs2 == []))
+
+# Edge: no .git at all
+tmp3 = pathlib.Path(tempfile.mkdtemp())
+errs3 = []
+rows3 = c._scan_git_history(tmp3, errs3, since_hours=720, max_commits=200)
+checks.append(("no_git_yields_empty", rows3 == [] and errs3 == []))
+
+# Edge: malformed git log output (mock subprocess to return non-\x1f data)
+class FakeResult:
+    returncode = 0
+    stdout = "this is\nnot the\nright format\n"
+    stderr = ""
+orig = subprocess.run
+def fake_run(cmd, **kw):
+    return FakeResult()
+subprocess.run = fake_run
+try:
+    errs4 = []
+    rows4 = c._scan_git_history(tmp, errs4, since_hours=720, max_commits=200)
+finally:
+    subprocess.run = orig
+checks.append(("malformed_lines_dropped", rows4 == [] and errs4 == []))
+
+bad = [name for name, ok in checks if not ok]
+if bad:
+    for r in rows:
+        print("  row:", repr(r.get("subject")), "pr=", repr(r.get("pr")), "issue=", repr(r.get("issue")))
+    print("FAILED:", bad)
+else:
+    print("STATUS=OK count=" + str(len(checks)))
+' 2>&1)
+if printf '%s\n' "$HIST_RES" | grep -q "^STATUS=OK"; then
+  N=$(printf '%s\n' "$HIST_RES" | grep -oE "count=[0-9]+" | cut -d= -f2)
+  pass "_scan_git_history: ${N} cases (trailer/inline/dedup/empty/no-git/malformed/shape)"
+else
+  fail "_scan_git_history: $HIST_RES"
+fi
+
+# --- _extract_pr_numbers_from_markers: real marker dir ------------------
+PR_MARKER_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib, tempfile
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+root = pathlib.Path(tempfile.mkdtemp())
+tr = root / ".zskills" / "tracking"
+tr.mkdir(parents=True)
+
+# Case 1: flat marker with a github.com PR URL
+(tr / "fulfilled.land-pr.aaa").write_text(
+    "skill: land-pr\nstatus: complete\ndate: 2026-05-01T00:00:00-04:00\n"
+    "pr: https://github.com/foo/bar/pull/100\n",
+    encoding="utf-8",
+)
+# Case 2: subdir marker with a different PR URL
+(tr / "pipe1").mkdir()
+(tr / "pipe1" / "fulfilled.land-pr.bbb").write_text(
+    "skill: land-pr\nstatus: complete\ndate: 2026-05-02T00:00:00-04:00\n"
+    "pr: https://github.com/foo/bar/pull/200\n",
+    encoding="utf-8",
+)
+# Case 3: marker with NO pr field — must not crash, contributes nothing
+(tr / "fulfilled.land-pr.ccc").write_text(
+    "skill: land-pr\nstatus: complete\ndate: 2026-05-03T00:00:00-04:00\n",
+    encoding="utf-8",
+)
+# Case 4: marker that is NOT a land-pr kind — must be ignored
+(tr / "fulfilled.run-plan.xxx").write_text(
+    "skill: run-plan\nstatus: complete\ndate: 2026-05-04T00:00:00-04:00\n"
+    "pr: https://github.com/foo/bar/pull/999\n",
+    encoding="utf-8",
+)
+# Case 5: pr field that is plain text not a URL — must be ignored
+(tr / "fulfilled.land-pr.ddd").write_text(
+    "skill: land-pr\nstatus: complete\ndate: 2026-05-05T00:00:00-04:00\n"
+    "pr: just some text without a URL\n",
+    encoding="utf-8",
+)
+
+nums = c._extract_pr_numbers_from_markers(root)
+print("nums=" + ",".join(sorted(nums)))
+
+# Edge: tracking dir missing entirely
+root2 = pathlib.Path(tempfile.mkdtemp())
+nums2 = c._extract_pr_numbers_from_markers(root2)
+print("missing_dir=" + str(nums2 == set()))
+
+# Edge: tracking is a file, not a dir
+root3 = pathlib.Path(tempfile.mkdtemp())
+(root3 / ".zskills").mkdir()
+(root3 / ".zskills" / "tracking").write_text("oops", encoding="utf-8")
+nums3 = c._extract_pr_numbers_from_markers(root3)
+print("tracking_is_file=" + str(nums3 == set()))
+' 2>&1)
+if printf '%s\n' "$PR_MARKER_RES" | grep -q "^nums=100,200$" \
+    && printf '%s\n' "$PR_MARKER_RES" | grep -q "^missing_dir=True$" \
+    && printf '%s\n' "$PR_MARKER_RES" | grep -q "^tracking_is_file=True$"; then
+  pass "_extract_pr_numbers_from_markers: collects flat+subdir PR URLs, ignores non-land-pr kinds + missing fields + non-URL pr text + missing tracking dir"
+else
+  fail "_extract_pr_numbers_from_markers: $PR_MARKER_RES"
+fi
+
+# --- Dedup integration: marker-PR vs history (#N) trailer ---------------
+# Construct one real git repo + tracking dir, then run _scan_git_history
+# with fulfilled_prs computed via _extract_pr_numbers_from_markers. The
+# commit whose trailer matches the marker MUST be dropped from history.
+DEDUP_INT_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib, tempfile, subprocess
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+root = pathlib.Path(tempfile.mkdtemp())
+env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+       "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+       "PATH": "/usr/bin:/bin:/usr/local/bin"}
+def git(*args):
+    subprocess.run(["git", "-C", str(root), *args], check=True,
+                   capture_output=True, text=True, env=env)
+git("init", "--quiet", "-b", "main")
+git("commit", "--allow-empty", "-m", "fix: tracked (#500)")    # has marker — drop
+git("commit", "--allow-empty", "-m", "feat: untracked (#501)")  # no marker — keep
+git("commit", "--allow-empty", "-m", "docs: nothing trailing")  # no PR ref — keep
+
+# Marker dir referencing only PR 500.
+tr = root / ".zskills" / "tracking"
+tr.mkdir(parents=True)
+(tr / "fulfilled.land-pr.x").write_text(
+    "skill: land-pr\nstatus: complete\ndate: 2026-05-10T00:00:00-04:00\n"
+    "pr: https://github.com/foo/bar/pull/500\n",
+    encoding="utf-8",
+)
+
+fulfilled = c._extract_pr_numbers_from_markers(root)
+errs = []
+rows = c._scan_git_history(root, errs, since_hours=720, max_commits=200,
+                           fulfilled_pr_numbers=fulfilled)
+subjects = sorted(r["subject"] for r in rows)
+prs = sorted(r["pr"] for r in rows if r["pr"])
+print("subjects=" + "|".join(subjects))
+print("prs=" + ",".join(prs))
+print("fulfilled=" + ",".join(sorted(fulfilled)))
+' 2>&1)
+if printf '%s\n' "$DEDUP_INT_RES" | grep -q "^fulfilled=500$" \
+    && printf '%s\n' "$DEDUP_INT_RES" | grep -q "^prs=501$" \
+    && printf '%s\n' "$DEDUP_INT_RES" | grep -q "docs: nothing trailing" \
+    && printf '%s\n' "$DEDUP_INT_RES" | grep -q "feat: untracked" \
+    && ! printf '%s\n' "$DEDUP_INT_RES" | grep -q "fix: tracked"; then
+  pass "history+marker dedup: commit whose (#N) trailer matches a fulfilled.land-pr.* marker is dropped"
+else
+  fail "history+marker dedup: $DEDUP_INT_RES"
+fi
+
+# --- collect_snapshot activity sort + cap-at-200 ------------------------
+# Build a marker dir of 250 markers; resulting activity must be sorted
+# descending by timestamp and capped at 200.
+CAP_SORT_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib, tempfile
+sys.path.insert(0, "'"$PKG_PARENT"'")
+from zskills_monitor.collect import collect_snapshot
+
+root = pathlib.Path(tempfile.mkdtemp())
+tr = root / ".zskills" / "tracking"
+tr.mkdir(parents=True)
+# 250 markers; ids 0..249. Older ids get older timestamps, so the top-200
+# should be ids 50..249.
+for i in range(250):
+    ts = f"2026-01-01T00:00:{i:02d}-04:00" if i < 60 else f"2026-01-01T{(i//60):02d}:{(i%60):02d}:00-04:00"
+    (tr / f"fulfilled.run-plan.id{i:03d}").write_text(
+        f"skill: run-plan\nstatus: complete\ndate: {ts}\noutput: row{i:03d}\n",
+        encoding="utf-8",
+    )
+
+# We also drop a plans dir to keep the snapshot well-formed.
+(root / "plans").mkdir()
+
+snap = collect_snapshot(root)
+activity = snap["activity"]
+print("len=" + str(len(activity)))
+# Sorted desc → first ts must be the LARGEST one.
+ts_list = [a["timestamp"] for a in activity]
+print("sorted_desc=" + str(ts_list == sorted(ts_list, reverse=True)))
+# Top entry should be id249 (latest).
+print("top_id=" + activity[0]["id"])
+' 2>&1)
+if printf '%s\n' "$CAP_SORT_RES" | grep -q "^len=200$" \
+    && printf '%s\n' "$CAP_SORT_RES" | grep -q "^sorted_desc=True$" \
+    && printf '%s\n' "$CAP_SORT_RES" | grep -q "^top_id=run-plan.id249$"; then
+  pass "_collect_activity: cap-at-200 + sort-desc-by-timestamp invariants hold"
+else
+  fail "_collect_activity cap/sort: $CAP_SORT_RES"
+fi
+
+# --- Dead-arg cleanup: _extract_pr_numbers_from_markers signature -------
+# Per issue #283 bonus: the obsolete `activity` parameter must be gone.
+SIG_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, inspect
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+sig = inspect.signature(c._extract_pr_numbers_from_markers)
+params = list(sig.parameters.keys())
+print("params=" + ",".join(params))
+')
+if [ "$SIG_RES" = "params=main_root" ]; then
+  pass "_extract_pr_numbers_from_markers signature is (main_root,) — dead 'activity' arg removed"
+else
+  fail "_extract_pr_numbers_from_markers signature wrong: $SIG_RES"
+fi
+
+# ---------------------------------------------------------------------------
 # AC: Test registered in tests/run-all.sh (verified by the test runner if
 # we're invoked via run-all.sh; here we just sanity-check this file is
 # referenced).


### PR DESCRIPTION
Fixes #283

## Summary
Targeted test coverage for `skills/zskills-dashboard/scripts/zskills_monitor/collect.py` — the new activity helpers (`_scan_git_history`, `_extract_pr_numbers_from_markers`, `_derive_repo_url`) shipped in PRs #274 / #277 without test cases. Adds ~380 lines exercising SSH/HTTPS/.git/trailing-slash URL parsing, edge-case commit subjects, marker dir cases, history+marker dedup, and `_collect_activity` cap-at-200 + sort-desc semantics.

## Changes
- `tests/test_zskills_monitor_collect.sh`: +380 lines under new "Issue #283: dashboard activity-helper coverage" section.
  - `_derive_repo_url` (15 cases): SSH +/- .git, HTTPS +/- .git +/- trailing slash, self-hosted, custom-host SSH, unknown protocol, empty stdout, malformed, nonzero rc, missing `.git` dir, `TimeoutExpired`, `OSError`.
  - `_scan_git_history` (10 cases): trailing `(#N)` extracted, inline + trailing dedup, bare `closes #200`, bare subject, record shape, ISO timestamps, empty repo, no-`.git`, malformed log dropped.
  - `_extract_pr_numbers_from_markers`: flat + subdir markers, ignores non-`land-pr` kinds and missing/non-URL `pr` fields, missing tracking dir, tracking-as-file (3 negative cases).
  - History+marker dedup integration test.
  - `_collect_activity`: 250-marker fixture exercises cap-at-200 + sort-desc-by-timestamp.
- `skills/zskills-dashboard/scripts/zskills_monitor/collect.py`: dead `activity` parameter removed from `_extract_pr_numbers_from_markers` (was unused); sole caller updated. Also: `_scan_git_history` empty-repo stderr ("does not have any commits yet") now recognised as benign rather than emitting a spurious error.
- `skills/zskills-dashboard/SKILL.md` `metadata.version` bumped (hash recomputed after rebase if conflicts on top of #281); mirror updated byte-identically.

## Test plan
- [x] Full test suite: 3104/3104 passing (verifier confirmed pre-rebase).
- [x] Source/mirror byte-identical.
- [x] Dead-arg removal verified at sole call site via grep.
- [x] Empty-repo stderr filter is narrow (only canonical string).
- [x] Scope clean: no CLAUDE.md / docs / plans edits.
