### PR TITLE
Fix #293: /quickfix drop PR-only constraint (Approach A — soft redirect)

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -6,11 +6,12 @@ description: >-
   one-commit PR without a worktree. Two auto-detected modes: user-edited
   (dirty tree + description) and agent-dispatched (clean tree +
   description). Lifecycle: triage → review → commit → push → PR → CI poll
-  → fix cycle (dispatched via 'land-pr'). PR-only:
-  requires execution.landing == "pr". No .landed marker.
+  → fix cycle (dispatched via 'land-pr'). PR-lifecycle: when
+  execution.landing is 'worktree' or 'direct', soft-redirects to
+  '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.15+abf853"
+  version: "2026.05.16+7ea279"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -174,12 +175,27 @@ if [[ "$CONFIG_CONTENT" =~ \"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]];
 fi
 ```
 
-**Check 2 — landing == pr.**
+**Check 2 — landing == pr (soft redirect for non-PR modes).**
+
+`/quickfix` is PR-shaped end-to-end (push, PR creation, CI poll, fix
+cycle — all dispatched via `/land-pr`). When `execution.landing` is `worktree`
+or `direct`, we cannot meaningfully execute the lifecycle here — but
+emitting a hard error contradicts the project principle "all skills
+should work in all landing modes" (PR #290 review, issue #293). Instead,
+print a two-line redirect to the right skill for the configured landing
+mode and `exit 0` so the user can re-invoke the suggested skill. The
+redirect uses the same two-line printf template `/quickfix` uses for
+triage redirects (WI 1.5.4 — line 1 names the target + reason, line 2
+gives the exact re-invocation hint). `pr` (or unset) falls through and
+preserves the current PR-lifecycle behavior.
 
 ```bash
-if [ "$LANDING" != "pr" ]; then
-  echo "ERROR: /quickfix requires execution.landing == \"pr\" (got \"$LANDING\"). Use /commit or /do for non-PR landing." >&2
-  exit 1
+if [ "$LANDING" = "worktree" ]; then
+  printf 'Triage: redirecting to /do worktree. Reason: /quickfix requires execution.landing == "pr" (got "worktree").\nThe project is configured for worktree-based landing. Run `/do worktree <description>` instead — it creates an isolated worktree, lands via cherry-pick, and matches your config.\n'
+  exit 0
+elif [ "$LANDING" = "direct" ]; then
+  printf 'Triage: redirecting to /commit. Reason: /quickfix requires execution.landing == "pr" (got "direct").\nThe project is configured for direct-to-main landing. Run `/commit` instead — it commits in place without the PR scaffolding /quickfix layers on.\n'
+  exit 0
 fi
 ```
 
@@ -1346,8 +1362,8 @@ via `gh pr view` — there is no cherry-pick-landing step to attest to.
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success (PR created) or user-cancelled confirmation |
-| 1 | Config / environment error (landing, gh, not-on-main, fetch failed, unit_cmd unset, full_cmd mismatch, parallel in progress, ls-remote network) |
+| 0 | Success (PR created), user-cancelled confirmation, or soft-redirect on non-PR landing modes (`worktree` → `/do worktree`, `direct` → `/commit`) |
+| 1 | Config / environment error (gh, not-on-main, fetch failed, unit_cmd unset, full_cmd mismatch, parallel in progress, ls-remote network) |
 | 2 | Input error (no edits + no description; user-edited no description; branch exists local/remote; slug empty or contains slash) |
 | 4 | Test failure (`unit_cmd` non-zero) |
 | 5 | Commit / push / PR-create / agent failure |
@@ -1355,7 +1371,7 @@ via `gh pr view` — there is no cherry-pick-landing step to attest to.
 
 ## Key Rules
 
-- **PR-only.** `execution.landing != "pr"` → hard error; point to `/commit` or `/do`.
+- **PR-lifecycle (soft-redirect on non-PR landing).** `/quickfix` runs the PR lifecycle (push → PR creation → CI poll, all via `/land-pr`). When `execution.landing == "worktree"` it prints a two-line redirect to `/do worktree` and exits 0; when `== "direct"` it redirects to `/commit` and exits 0. `pr` (or unset) falls through. Hard-error replaced with redirect per issue #293 / PR #290 review.
 - **Aligned test-cmd.** `unit_cmd` set and (if `full_cmd` set) `unit_cmd == full_cmd`; otherwise the project pre-commit hook will block our commit.
 - **Dirty tree is input.** Show diff, optionally confirm, carry across via `git checkout -b`. Never stash.
 - **Never bypass the pre-commit hook.** Hooks exist for safety; fix the root cause.

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -6,11 +6,12 @@ description: >-
   one-commit PR without a worktree. Two auto-detected modes: user-edited
   (dirty tree + description) and agent-dispatched (clean tree +
   description). Lifecycle: triage → review → commit → push → PR → CI poll
-  → fix cycle (dispatched via 'land-pr'). PR-only:
-  requires execution.landing == "pr". No .landed marker.
+  → fix cycle (dispatched via 'land-pr'). PR-lifecycle: when
+  execution.landing is 'worktree' or 'direct', soft-redirects to
+  '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.15+abf853"
+  version: "2026.05.16+7ea279"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -174,12 +175,27 @@ if [[ "$CONFIG_CONTENT" =~ \"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]];
 fi
 ```
 
-**Check 2 — landing == pr.**
+**Check 2 — landing == pr (soft redirect for non-PR modes).**
+
+`/quickfix` is PR-shaped end-to-end (push, PR creation, CI poll, fix
+cycle — all dispatched via `/land-pr`). When `execution.landing` is `worktree`
+or `direct`, we cannot meaningfully execute the lifecycle here — but
+emitting a hard error contradicts the project principle "all skills
+should work in all landing modes" (PR #290 review, issue #293). Instead,
+print a two-line redirect to the right skill for the configured landing
+mode and `exit 0` so the user can re-invoke the suggested skill. The
+redirect uses the same two-line printf template `/quickfix` uses for
+triage redirects (WI 1.5.4 — line 1 names the target + reason, line 2
+gives the exact re-invocation hint). `pr` (or unset) falls through and
+preserves the current PR-lifecycle behavior.
 
 ```bash
-if [ "$LANDING" != "pr" ]; then
-  echo "ERROR: /quickfix requires execution.landing == \"pr\" (got \"$LANDING\"). Use /commit or /do for non-PR landing." >&2
-  exit 1
+if [ "$LANDING" = "worktree" ]; then
+  printf 'Triage: redirecting to /do worktree. Reason: /quickfix requires execution.landing == "pr" (got "worktree").\nThe project is configured for worktree-based landing. Run `/do worktree <description>` instead — it creates an isolated worktree, lands via cherry-pick, and matches your config.\n'
+  exit 0
+elif [ "$LANDING" = "direct" ]; then
+  printf 'Triage: redirecting to /commit. Reason: /quickfix requires execution.landing == "pr" (got "direct").\nThe project is configured for direct-to-main landing. Run `/commit` instead — it commits in place without the PR scaffolding /quickfix layers on.\n'
+  exit 0
 fi
 ```
 
@@ -1346,8 +1362,8 @@ via `gh pr view` — there is no cherry-pick-landing step to attest to.
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success (PR created) or user-cancelled confirmation |
-| 1 | Config / environment error (landing, gh, not-on-main, fetch failed, unit_cmd unset, full_cmd mismatch, parallel in progress, ls-remote network) |
+| 0 | Success (PR created), user-cancelled confirmation, or soft-redirect on non-PR landing modes (`worktree` → `/do worktree`, `direct` → `/commit`) |
+| 1 | Config / environment error (gh, not-on-main, fetch failed, unit_cmd unset, full_cmd mismatch, parallel in progress, ls-remote network) |
 | 2 | Input error (no edits + no description; user-edited no description; branch exists local/remote; slug empty or contains slash) |
 | 4 | Test failure (`unit_cmd` non-zero) |
 | 5 | Commit / push / PR-create / agent failure |
@@ -1355,7 +1371,7 @@ via `gh pr view` — there is no cherry-pick-landing step to attest to.
 
 ## Key Rules
 
-- **PR-only.** `execution.landing != "pr"` → hard error; point to `/commit` or `/do`.
+- **PR-lifecycle (soft-redirect on non-PR landing).** `/quickfix` runs the PR lifecycle (push → PR creation → CI poll, all via `/land-pr`). When `execution.landing == "worktree"` it prints a two-line redirect to `/do worktree` and exits 0; when `== "direct"` it redirects to `/commit` and exits 0. `pr` (or unset) falls through. Hard-error replaced with redirect per issue #293 / PR #290 review.
 - **Aligned test-cmd.** `unit_cmd` set and (if `full_cmd` set) `unit_cmd == full_cmd`; otherwise the project pre-commit hook will block our commit.
 - **Dirty tree is input.** Show diff, optionally confirm, carry across via `git checkout -b`. Never stash.
 - **Never bypass the pre-commit hook.** Hooks exist for safety; fix the root cause.

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -448,13 +448,21 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Case 6 — Landing gate wiring (WI 1.3 check 3)
+# Case 6 — Landing gate wiring (WI 1.3 check 3, soft-redirect form per #293)
+#
+# Post-#293: the hard error was replaced with a two-line redirect using
+# the WI 1.5.4 printf template. Wiring assertion: LANDING is read AND
+# both worktree → /do worktree AND direct → /commit redirect branches
+# are present in the bash check, AND each branch exits 0.
 # ────────────────────────────────────────────────────────────────────
 if grep -q 'execution.landing' "$SKILL" \
-   && grep -q 'requires execution.landing == "pr"' "$SKILL"; then
-  pass "6  landing gate: execution.landing read, \"pr\"-required error present"
+   && grep -qE '\[ "\$LANDING" = "worktree" \]' "$SKILL" \
+   && grep -qE '\[ "\$LANDING" = "direct" \]' "$SKILL" \
+   && grep -q 'redirecting to /do worktree' "$SKILL" \
+   && grep -q 'redirecting to /commit' "$SKILL"; then
+  pass "6  landing gate: execution.landing read; worktree → /do, direct → /commit soft-redirects present"
 else
-  fail "6  landing gate: wiring not found"
+  fail "6  landing gate: soft-redirect wiring not found"
 fi
 
 # ────────────────────────────────────────────────────────────────────
@@ -612,21 +620,64 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Case 15 — landing != pr exits 1 with landing-keyword stderr.
+# Case 15 — landing=direct soft-redirects to /commit and exits 0.
 # End-to-end against the preflight slice: config has
-# execution.landing=direct, we expect rc=1 and
-# 'requires execution.landing == "pr"' in stderr.
+# execution.landing=direct. Per issue #293, the hard error was
+# replaced with a two-line redirect (line 1 names target + reason,
+# line 2 gives re-invocation hint). We expect rc=0 and the
+# 'redirecting to /commit' phrase on stdout.
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c15 "true" "true" "direct" "quickfix/")
-ERR=$(mktemp)
-(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix something" >/dev/null 2>"$ERR")
+OUT=$(mktemp)
+(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix something" >"$OUT" 2>&1)
 RC=$?
-if [ "$RC" -eq 1 ] && grep -q 'requires execution.landing == "pr"' "$ERR"; then
-  pass "15 landing != pr: rc=1 + 'requires execution.landing' stderr"
+if [ "$RC" -eq 0 ] \
+   && grep -q 'redirecting to /commit' "$OUT" \
+   && grep -q 'Run `/commit`' "$OUT"; then
+  pass "15 landing=direct: rc=0 + /commit redirect on stdout (two-line template)"
 else
-  fail "15 landing != pr: rc=$RC stderr='$(cat "$ERR")'"
+  fail "15 landing=direct: rc=$RC out='$(cat "$OUT")'"
 fi
-rm -f -- "$ERR"
+rm -f -- "$OUT"
+
+# ────────────────────────────────────────────────────────────────────
+# Case 15b — landing=worktree soft-redirects to /do worktree and exits 0.
+# Sibling of case 15 covering the other non-PR mode.
+# ────────────────────────────────────────────────────────────────────
+FIX=$(make_fixture c15b "true" "true" "worktree" "quickfix/")
+OUT=$(mktemp)
+(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix something" >"$OUT" 2>&1)
+RC=$?
+if [ "$RC" -eq 0 ] \
+   && grep -q 'redirecting to /do worktree' "$OUT" \
+   && grep -q 'Run `/do worktree' "$OUT"; then
+  pass "15b landing=worktree: rc=0 + /do worktree redirect on stdout (two-line template)"
+else
+  fail "15b landing=worktree: rc=$RC out='$(cat "$OUT")'"
+fi
+rm -f -- "$OUT"
+
+# ────────────────────────────────────────────────────────────────────
+# Case 15c — landing=pr does NOT short-circuit at the landing check.
+# The preflight slice must proceed past the landing check (it may
+# still exit later on other gates the fixture doesn't satisfy — gh
+# is mocked, but the slice has additional checks downstream).
+# Assertion is purely that the landing-check redirect was NOT taken:
+# no 'redirecting to /commit' AND no 'redirecting to /do worktree' on
+# combined output. This guards fall-through.
+# ────────────────────────────────────────────────────────────────────
+FIX=$(make_fixture c15c "true" "true" "pr" "quickfix/")
+OUT=$(mktemp)
+(cd "$FIX" && PATH="$FIX/bin:$PATH" bash "$PREFLIGHT_SCRIPT" "fix something" >"$OUT" 2>&1)
+# We don't assert RC — the slice may exit non-zero on a later gate.
+# What matters: the landing redirect path was NOT taken.
+if ! grep -q 'redirecting to /commit' "$OUT" \
+   && ! grep -q 'redirecting to /do worktree' "$OUT"; then
+  pass "15c landing=pr: fall-through preserved (no landing redirect emitted)"
+else
+  fail "15c landing=pr: unexpected landing redirect — out='$(cat "$OUT")'"
+fi
+rm -f -- "$OUT"
 
 # ────────────────────────────────────────────────────────────────────
 # Case 16 — gh missing exits 1 with gh-keyword stderr.


### PR DESCRIPTION
Fixes #293

## Summary
`/quickfix` previously hard-errored when invoked in a project with `execution.landing != "pr"` or `execution.main_protected: false`, on the assumption that worktree-strict projects shouldn't use `/quickfix` at all. This PR replaces the hard error with a soft redirect ("Approach A"): emit a 2-line message pointing the agent at `/do worktree` (for `landing: worktree`) or `/commit` (for `landing: direct`), then `exit 0` so the orchestrator continues cleanly.

## Changes
- `skills/quickfix/SKILL.md`: replace hard error with landing-mode redirect block. `landing: pr` (or unset) falls through unchanged.
- `.claude/skills/quickfix/SKILL.md`: byte-identical mirror.
- `tests/test-quickfix.sh`: cases 15 (direct), 15b (worktree), 15c (pr fall-through) covering the new redirect behavior.
- `skills/quickfix/SKILL.md` `metadata.version` bumped to `2026.05.16+7ea279` per the skill-versioning rule.

## Test plan
- [x] Full test suite: 3137/3137 passing (post-rebase).
- [x] Three new redirect cases pass.
- [x] Source/mirror byte-identical; hash verified.
- [x] Rebase clean onto post-#281/#283/#284 main.

## Note on history
The fix commit was originally authored in a prior `/fix-issues` session that ended before verification. This PR rebases that commit (`28b2126` → `6e0feaf0`) onto current `origin/main` and adds verifier attestation via the sprint that's landing it.
