### PR TITLE
do: add mutex-error-string regression test to /fix-issues

### DIFF
--- a/tests/test-fix-issues.sh
+++ b/tests/test-fix-issues.sh
@@ -314,6 +314,36 @@ test_dashboard_uses_python_json_not_bash_regex() {
   fi
 }
 
+# --- dashboard mutex: 5 verbatim ERROR strings present ------------------
+#
+# PR #313 added mutual-exclusion guards between `dashboard` and each of
+# focus/sync/plan/stop/next modes. Each guard emits a specific
+# user-facing ERROR string. This test asserts all 5 strings exist
+# verbatim in SKILL.md so a future edit can't silently drop or rename
+# one of them without tripping a regression.
+
+test_dashboard_mutex_error_strings_present() {
+  local EXPECTED_MUTEX_ERRORS=(
+    "ERROR: dashboard is incompatible with focus mode"
+    "ERROR: dashboard is incompatible with sync mode"
+    "ERROR: dashboard is incompatible with plan mode"
+    "ERROR: dashboard is incompatible with stop mode"
+    "ERROR: dashboard is incompatible with next mode"
+  )
+  local missing=()
+  local s
+  for s in "${EXPECTED_MUTEX_ERRORS[@]}"; do
+    if ! grep -qF "$s" "$SKILL"; then
+      missing+=("$s")
+    fi
+  done
+  if [ "${#missing[@]}" -eq 0 ]; then
+    pass "dashboard mutex: all 5 verbatim ERROR strings present (focus/sync/plan/stop/next)"
+  else
+    fail "dashboard mutex: all 5 verbatim ERROR strings present" "missing: ${missing[*]}"
+  fi
+}
+
 # --- Mirror parity -------------------------------------------------------
 
 test_mirror_in_sync() {
@@ -336,6 +366,7 @@ test_280_python_json_handles_escaped_quotes
 test_dashboard_token_recognized_in_phase0
 test_dashboard_phase2_branch_present
 test_dashboard_uses_python_json_not_bash_regex
+test_dashboard_mutex_error_strings_present
 test_mirror_in_sync
 
 echo ""


### PR DESCRIPTION
## Summary

Closes the residual test-coverage gap flagged by the PR #313 post-merge verifier: `/fix-issues`'s 5 mutual-exclusion error paths (`dashboard` + `focus`/`sync`/`plan`/`stop`/`next`) were not directly covered by regression tests. They're string-literal branches that would be obvious if regressed, but a grep-assertion is cheap insurance.

## Change

One new test function `test_dashboard_mutex_error_strings_present` in `tests/test-fix-issues.sh` (~31 lines including comment + registration). It defines an array of the 5 verbatim strings and `grep -qF`s each against `skills/fix-issues/SKILL.md`. On any missing string → FAIL with a diagnostic listing what's missing. On all present → PASS.

No skill prose was modified — this PR only adds the test. Skill version was correctly NOT bumped (tests/ is outside `skills/fix-issues/`).

## Test plan

- [x] `tests/test-fix-issues.sh`: 25/25 PASS (was 24, +1 new)
- [x] Full suite: **3173/3173 PASS**, exit 0
- [x] Scope check: ONE file in diff (`tests/test-fix-issues.sh +31`). CLAUDE.md, CLAUDE_TEMPLATE.md, and `skills/fix-issues/SKILL.md` untouched
- [x] Verbatim string match verified: 5 strings present in SKILL.md exactly as the test expects
- [x] Fresh A+ verifier including negative-test code-walk (proves a missing string would cause the test to fail)
- [ ] **Reviewer post-merge:** none needed — pure test addition, no behavior change

🤖 Generated with /do (agent-dispatched, PR mode, auto-merge)
