### PR TITLE
do: fix-issues sprint-mode worktree gate (closes #325)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+5a0469"
+  version: "2026.05.17+c063df"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -781,7 +781,12 @@ implement the wrong fix. This has happened repeatedly.
 
 When mode is sprint (N provided), construct the per-sprint unique
 `$SPRINT_ID` and `$PIPELINE_ID` FIRST (before any other tracking write),
-then create the pipeline sentinel:
+then front-run the shared `ensure-worktree.sh` gate (mirror of standalone
+`## Sync` mode — closes #325), THEN create the pipeline sentinel. All
+subsequent Phase 1 writes (`ISSUES_PLAN.md` row-writer, tracker updates)
+land inside the worktree because `ZSKILLS_PATHS_ROOT` is re-anchored to
+the worktree root. Phase 5's `SPRINT_REPORT.md` append + commit + `/land-pr`
+dispatch also run inside the worktree.
 
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
@@ -792,6 +797,9 @@ mkdir -p "$MAIN_ROOT/.zskills/tracking"
 # fix-issues sessions from colliding on the literal "sprint" suffix. The
 # ISSUE_TITLE slug is a human-readable tag; the UTC timestamp guarantees
 # uniqueness across concurrent sprints on the same host.
+#
+# LIFTED above the ensure-worktree.sh preamble (closes #325) so the
+# preamble's `--pipeline-id "$PIPELINE_ID"` has a value to bind to.
 ISSUE_TITLE_SLUG=$(printf '%s' "${ISSUE_TITLE:-sprint}" | tr -cd 'a-z0-9' | head -c 8)
 [ -z "$ISSUE_TITLE_SLUG" ] && ISSUE_TITLE_SLUG="sprint"
 SPRINT_ID="sprint-$(date -u +%Y%m%d-%H%M%S)-$ISSUE_TITLE_SLUG"
@@ -800,7 +808,40 @@ PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/s
 # Recover SPRINT_ID after sanitization (strip the "fix-issues." prefix).
 SPRINT_ID="${PIPELINE_ID#fix-issues.}"
 mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+```
 
+**Worktree gate (sprint-mode parity with standalone `## Sync` — closes #325).**
+Before any Phase 1 write to a tracker file or `SPRINT_REPORT.md`, front-run
+`ensure-worktree.sh` so all subsequent writes land inside the worktree, not
+on `main`'s working tree. Mirrors the preamble at the top of `## Sync` above.
+
+```bash
+HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/ensure-worktree.sh"
+if [ ! -x "$HELPER" ]; then
+  echo "fix-issues: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
+  exit 11
+fi
+WT_PATH=$(bash "$HELPER" \
+  --prefix fix-issues \
+  --pipeline-id "$PIPELINE_ID" \
+  --purpose "fix-issues sprint; sprint=${SPRINT_ID}" \
+  "${SPRINT_ID}")
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  echo "ensure-worktree failed (rc=$RC) for /fix-issues sprint mode" >&2
+  exit "$RC"
+fi
+if [ -n "$WT_PATH" ]; then
+  cd "$WT_PATH" || { echo "fix-issues: cd $WT_PATH failed" >&2; exit 1; }
+  export ZSKILLS_PATHS_ROOT="$WT_PATH"  # R3-1 — re-anchor downstream path resolution
+fi
+```
+
+Now write the pipeline sentinel under `$MAIN_ROOT/.zskills/tracking/` —
+the sentinel is parent-scope tracking (by design) and stays on main_root
+regardless of which worktree the sprint executes from:
+
+```bash
 if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID" ]; then
   printf 'skill: fix-issues\nmode: sprint\ncount: %s\nfocus: %s\nstartedAt: %s\n' \
     "$N" "${FOCUS:-default}" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
@@ -1761,6 +1802,172 @@ The file starts with `# Sprint Report` (created once). Each sprint
 appends a new `## Sprint` section. `/fix-report` marks sections
 `[FINALIZED]` after review. **Use actual data** — real issue numbers,
 commit hashes, worktree paths, and test counts.
+
+### Commit sprint artifacts + dispatch `/land-pr` (closes #325)
+
+Phase 1 wrote tracker rows (`$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md` and any
+`*_ISSUES.md` files) and Phase 5 above appended the new `## Sprint —`
+section to `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`. Both writes landed in
+the worktree because the Phase 1 preamble re-anchored `ZSKILLS_PATHS_ROOT`.
+Now stage them, commit on the worktree's feature branch, and dispatch
+`/land-pr` to open the sprint PR. Sprint-mode landing is interactive
+(matches standalone `## Sync` convention) — no `auto` argument is appended
+to `LAND_ARGS`; per-issue auto-merge gating remains the responsibility of
+Phase 6 mode-specific dispatch.
+
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: filename basename suffixed onto $ZSKILLS_AUDIT_DIR (resolved via zskills-paths.sh); the basename token itself remains literal so the regex still flags the /SPRINT_REPORT.md tail -->
+```bash
+# Defensive cwd restore; WT_PATH set by the Phase 1 preamble.
+[ -n "${WT_PATH:-}" ] && cd "$WT_PATH" 2>/dev/null || true
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+TOPLEVEL=$(git rev-parse --show-toplevel)
+if [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+  # R3-1: re-anchor under the worktree so $ZSKILLS_AUDIT_DIR /
+  # $ZSKILLS_ISSUES_DIR resolve to TOPLEVEL/.zskills/audit and
+  # TOPLEVEL/<issues_dir>, not the main repo.
+  export ZSKILLS_PATHS_ROOT="$TOPLEVEL"
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+
+  ABS_FILE="$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md"
+  # Portable realpath (DA-R2-1; R3-6: adapted from warn-config-drift.sh:181-203).
+  SPRINT_REL=""
+  if SPRINT_REL=$(realpath --relative-to="$TOPLEVEL" "$ABS_FILE" 2>/dev/null) \
+       && [ -n "$SPRINT_REL" ]; then
+    case "$SPRINT_REL" in /*) SPRINT_REL="" ;; esac
+  fi
+  if [ -z "$SPRINT_REL" ]; then
+    ABS_FILE_CANON=$(cd "$(dirname "$ABS_FILE")" 2>/dev/null && pwd)/$(basename "$ABS_FILE")
+    case "$ABS_FILE_CANON" in
+      "$TOPLEVEL"/*) SPRINT_REL="${ABS_FILE_CANON#"$TOPLEVEL"/}" ;;
+      *) echo "fix-issues: cannot normalize $ABS_FILE vs $TOPLEVEL" >&2; exit 1 ;;
+    esac
+  fi
+  case "$SPRINT_REL" in
+    /*|../*) echo "fix-issues: $ABS_FILE is outside worktree $TOPLEVEL" >&2; exit 1 ;;
+  esac
+
+  # Stage SPRINT_REPORT.md plus any modified tracker files
+  # (`docs/issues/*ISSUES*.md` and `ISSUES_PLAN.md`) under
+  # $ZSKILLS_ISSUES_DIR. Tracker files are tracked in git.
+  git -C "$TOPLEVEL" add "$SPRINT_REL"
+  if [ -n "${ZSKILLS_ISSUES_DIR:-}" ] && [ -d "$ZSKILLS_ISSUES_DIR" ]; then
+    ISSUES_REL=$(realpath --relative-to="$TOPLEVEL" "$ZSKILLS_ISSUES_DIR" 2>/dev/null) || ISSUES_REL=""
+    if [ -n "$ISSUES_REL" ]; then
+      case "$ISSUES_REL" in /*|../*) ISSUES_REL="" ;; esac
+    fi
+    if [ -n "$ISSUES_REL" ]; then
+      git -C "$TOPLEVEL" add -A "$ISSUES_REL" 2>/dev/null || true
+    fi
+  fi
+  STAGED=$(git -C "$TOPLEVEL" diff --cached --name-only)
+  # Skip-if-empty guard: a sprint with no Phase 1 row-writer additions
+  # AND no Phase 5 sprint-section append leaves nothing staged — exit
+  # cleanly without erroring.
+  if [ -z "$STAGED" ]; then
+    echo "fix-issues: nothing to commit (empty sprint artifacts); skipping commit + /land-pr" >&2
+  else
+    UNEXPECTED=""
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      case "$f" in
+        "$SPRINT_REL") ;;
+        *)
+          if [ -n "${ISSUES_REL:-}" ]; then
+            case "$f" in
+              "$ISSUES_REL"/*) ;;
+              *) UNEXPECTED="$UNEXPECTED $f" ;;
+            esac
+          else
+            UNEXPECTED="$UNEXPECTED $f"
+          fi
+          ;;
+      esac
+    done <<EOF
+$STAGED
+EOF
+    if [ -n "$UNEXPECTED" ]; then
+      echo "fix-issues: unexpected staged files outside SPRINT_REPORT.md / $ISSUES_REL:$UNEXPECTED" >&2
+      exit 1
+    fi
+    if [ -n "$COMMIT_CO_AUTHOR" ]; then
+      git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" -m "docs(sprint): tracker rows + sprint report (sprint=$SPRINT_ID)"
+    else
+      git -C "$TOPLEVEL" commit -m "docs(sprint): tracker rows + sprint report (sprint=$SPRINT_ID)"
+    fi
+  fi
+fi
+```
+
+<!-- allow-hardcoded: TZ=America/New_York reason: SPRINT_TS is a user-facing wall-clock stamp on the PR title/body; matches the established sprint-mode idiom for human-readable dates. Per-skill $TIMEZONE migration is scoped to plans/SKILL_FILE_DRIFT_FIX.md, not this issue -->
+```bash
+# Dispatch /land-pr to open the sprint PR. The tracking marker is written
+# on main_root so /land-pr can satisfy it with a fulfilled.land-pr.<id>
+# marker on successful merge — mirrors standalone `## Sync` mode's
+# Step 5 sub-step 2 (and /run-plan PR mode).
+SPRINT_TS="${SPRINT_TS:-$(TZ=America/New_York date +%Y%m%d-%H%M%S)}"
+LAND_ID="fix-issues.sprint.${SPRINT_ID}"
+
+MAIN_ROOT="${MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir)/.." && pwd)}"
+mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+
+# Write the requires.land-pr marker on main_root BEFORE dispatch. The
+# matching fulfilled.land-pr.<LAND_ID> is written by /land-pr ONLY on
+# STATUS=merged (created/monitored do not fulfill — by design).
+printf 'skill: land-pr\nrequired-by: fix-issues-sprint\ndate: %s\n' \
+  "$(TZ=UTC date -Iseconds)" \
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${LAND_ID}"
+
+# Build the PR body file.
+RESULT_FILE=$(mktemp)
+BODY_FILE=$(mktemp)
+{
+  printf '## Summary\n`/fix-issues %s` sprint %s — tracker rows + sprint report.\n\n' \
+    "$N" "$SPRINT_ID"
+  printf '## Test plan\n- [x] Sprint artifacts reviewed by user before merge.\n'
+} > "$BODY_FILE"
+
+PR_TITLE="sprint: $(TZ=America/New_York date +%F) (${SPRINT_ID})"
+SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+
+# /land-pr arg vector. Mirrors standalone sync's invocation MINUS any
+# auto-merge flag — sprint-mode landing is interactive (matches sync
+# convention); Phase 6 mode-specific dispatch handles per-issue
+# auto-merge gating separately.
+LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$LAND_ID"
+
+# Transcript echo for PIPELINE_ID propagation (tier-2 idiom, matches
+# /do pr and standalone sync). Conformance test forbids the env-export
+# form — echo is the canonical channel.
+echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+
+# Dispatch /land-pr via the Skill tool. The Skill tool loads /land-pr's
+# prose into the current (orchestrator) context — its internal bash
+# blocks run here. After /land-pr returns, $RESULT_FILE is populated.
+#
+# Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+if [ ! -f "$RESULT_FILE" ]; then
+  echo "ERROR: /land-pr produced no result file at $RESULT_FILE" >&2
+  exit 1
+fi
+
+# Parse result-file via canonical allow-list pattern. Unknown keys WARN
+# but do not fail — forward-compatible with /land-pr schema additions.
+declare -A LP
+while IFS='=' read -r KEY VALUE; do
+  case "$KEY" in
+    STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
+    MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
+    CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      LP["$KEY"]="$VALUE" ;;
+    "") ;;
+    *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
+  esac
+done < "$RESULT_FILE"
+
+echo "Sprint PR: ${LP[PR_URL]:-(none)} — STATUS=${LP[STATUS]:-unknown}"
+```
 
 ### Post-report tracking
 

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+c063df"
+  version: "2026.05.17+42910a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -842,6 +842,7 @@ the sentinel is parent-scope tracking (by design) and stays on main_root
 regardless of which worktree the sprint executes from:
 
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID" ]; then
   printf 'skill: fix-issues\nmode: sprint\ncount: %s\nfocus: %s\nstartedAt: %s\n' \
     "$N" "${FOCUS:-default}" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
@@ -1816,6 +1817,7 @@ to `LAND_ARGS`; per-issue auto-merge gating remains the responsibility of
 Phase 6 mode-specific dispatch.
 
 <!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: filename basename suffixed onto $ZSKILLS_AUDIT_DIR (resolved via zskills-paths.sh); the basename token itself remains literal so the regex still flags the /SPRINT_REPORT.md tail -->
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /ISSUES_PLAN.md tail -->
 ```bash
 # Defensive cwd restore; WT_PATH set by the Phase 1 preamble.
 [ -n "${WT_PATH:-}" ] && cd "$WT_PATH" 2>/dev/null || true

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+5a0469"
+  version: "2026.05.17+c063df"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -781,7 +781,12 @@ implement the wrong fix. This has happened repeatedly.
 
 When mode is sprint (N provided), construct the per-sprint unique
 `$SPRINT_ID` and `$PIPELINE_ID` FIRST (before any other tracking write),
-then create the pipeline sentinel:
+then front-run the shared `ensure-worktree.sh` gate (mirror of standalone
+`## Sync` mode — closes #325), THEN create the pipeline sentinel. All
+subsequent Phase 1 writes (`ISSUES_PLAN.md` row-writer, tracker updates)
+land inside the worktree because `ZSKILLS_PATHS_ROOT` is re-anchored to
+the worktree root. Phase 5's `SPRINT_REPORT.md` append + commit + `/land-pr`
+dispatch also run inside the worktree.
 
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
@@ -792,6 +797,9 @@ mkdir -p "$MAIN_ROOT/.zskills/tracking"
 # fix-issues sessions from colliding on the literal "sprint" suffix. The
 # ISSUE_TITLE slug is a human-readable tag; the UTC timestamp guarantees
 # uniqueness across concurrent sprints on the same host.
+#
+# LIFTED above the ensure-worktree.sh preamble (closes #325) so the
+# preamble's `--pipeline-id "$PIPELINE_ID"` has a value to bind to.
 ISSUE_TITLE_SLUG=$(printf '%s' "${ISSUE_TITLE:-sprint}" | tr -cd 'a-z0-9' | head -c 8)
 [ -z "$ISSUE_TITLE_SLUG" ] && ISSUE_TITLE_SLUG="sprint"
 SPRINT_ID="sprint-$(date -u +%Y%m%d-%H%M%S)-$ISSUE_TITLE_SLUG"
@@ -800,7 +808,40 @@ PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/s
 # Recover SPRINT_ID after sanitization (strip the "fix-issues." prefix).
 SPRINT_ID="${PIPELINE_ID#fix-issues.}"
 mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+```
 
+**Worktree gate (sprint-mode parity with standalone `## Sync` — closes #325).**
+Before any Phase 1 write to a tracker file or `SPRINT_REPORT.md`, front-run
+`ensure-worktree.sh` so all subsequent writes land inside the worktree, not
+on `main`'s working tree. Mirrors the preamble at the top of `## Sync` above.
+
+```bash
+HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/ensure-worktree.sh"
+if [ ! -x "$HELPER" ]; then
+  echo "fix-issues: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
+  exit 11
+fi
+WT_PATH=$(bash "$HELPER" \
+  --prefix fix-issues \
+  --pipeline-id "$PIPELINE_ID" \
+  --purpose "fix-issues sprint; sprint=${SPRINT_ID}" \
+  "${SPRINT_ID}")
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  echo "ensure-worktree failed (rc=$RC) for /fix-issues sprint mode" >&2
+  exit "$RC"
+fi
+if [ -n "$WT_PATH" ]; then
+  cd "$WT_PATH" || { echo "fix-issues: cd $WT_PATH failed" >&2; exit 1; }
+  export ZSKILLS_PATHS_ROOT="$WT_PATH"  # R3-1 — re-anchor downstream path resolution
+fi
+```
+
+Now write the pipeline sentinel under `$MAIN_ROOT/.zskills/tracking/` —
+the sentinel is parent-scope tracking (by design) and stays on main_root
+regardless of which worktree the sprint executes from:
+
+```bash
 if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID" ]; then
   printf 'skill: fix-issues\nmode: sprint\ncount: %s\nfocus: %s\nstartedAt: %s\n' \
     "$N" "${FOCUS:-default}" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
@@ -1761,6 +1802,172 @@ The file starts with `# Sprint Report` (created once). Each sprint
 appends a new `## Sprint` section. `/fix-report` marks sections
 `[FINALIZED]` after review. **Use actual data** — real issue numbers,
 commit hashes, worktree paths, and test counts.
+
+### Commit sprint artifacts + dispatch `/land-pr` (closes #325)
+
+Phase 1 wrote tracker rows (`$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md` and any
+`*_ISSUES.md` files) and Phase 5 above appended the new `## Sprint —`
+section to `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`. Both writes landed in
+the worktree because the Phase 1 preamble re-anchored `ZSKILLS_PATHS_ROOT`.
+Now stage them, commit on the worktree's feature branch, and dispatch
+`/land-pr` to open the sprint PR. Sprint-mode landing is interactive
+(matches standalone `## Sync` convention) — no `auto` argument is appended
+to `LAND_ARGS`; per-issue auto-merge gating remains the responsibility of
+Phase 6 mode-specific dispatch.
+
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: filename basename suffixed onto $ZSKILLS_AUDIT_DIR (resolved via zskills-paths.sh); the basename token itself remains literal so the regex still flags the /SPRINT_REPORT.md tail -->
+```bash
+# Defensive cwd restore; WT_PATH set by the Phase 1 preamble.
+[ -n "${WT_PATH:-}" ] && cd "$WT_PATH" 2>/dev/null || true
+MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+TOPLEVEL=$(git rev-parse --show-toplevel)
+if [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+  # R3-1: re-anchor under the worktree so $ZSKILLS_AUDIT_DIR /
+  # $ZSKILLS_ISSUES_DIR resolve to TOPLEVEL/.zskills/audit and
+  # TOPLEVEL/<issues_dir>, not the main repo.
+  export ZSKILLS_PATHS_ROOT="$TOPLEVEL"
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+
+  ABS_FILE="$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md"
+  # Portable realpath (DA-R2-1; R3-6: adapted from warn-config-drift.sh:181-203).
+  SPRINT_REL=""
+  if SPRINT_REL=$(realpath --relative-to="$TOPLEVEL" "$ABS_FILE" 2>/dev/null) \
+       && [ -n "$SPRINT_REL" ]; then
+    case "$SPRINT_REL" in /*) SPRINT_REL="" ;; esac
+  fi
+  if [ -z "$SPRINT_REL" ]; then
+    ABS_FILE_CANON=$(cd "$(dirname "$ABS_FILE")" 2>/dev/null && pwd)/$(basename "$ABS_FILE")
+    case "$ABS_FILE_CANON" in
+      "$TOPLEVEL"/*) SPRINT_REL="${ABS_FILE_CANON#"$TOPLEVEL"/}" ;;
+      *) echo "fix-issues: cannot normalize $ABS_FILE vs $TOPLEVEL" >&2; exit 1 ;;
+    esac
+  fi
+  case "$SPRINT_REL" in
+    /*|../*) echo "fix-issues: $ABS_FILE is outside worktree $TOPLEVEL" >&2; exit 1 ;;
+  esac
+
+  # Stage SPRINT_REPORT.md plus any modified tracker files
+  # (`docs/issues/*ISSUES*.md` and `ISSUES_PLAN.md`) under
+  # $ZSKILLS_ISSUES_DIR. Tracker files are tracked in git.
+  git -C "$TOPLEVEL" add "$SPRINT_REL"
+  if [ -n "${ZSKILLS_ISSUES_DIR:-}" ] && [ -d "$ZSKILLS_ISSUES_DIR" ]; then
+    ISSUES_REL=$(realpath --relative-to="$TOPLEVEL" "$ZSKILLS_ISSUES_DIR" 2>/dev/null) || ISSUES_REL=""
+    if [ -n "$ISSUES_REL" ]; then
+      case "$ISSUES_REL" in /*|../*) ISSUES_REL="" ;; esac
+    fi
+    if [ -n "$ISSUES_REL" ]; then
+      git -C "$TOPLEVEL" add -A "$ISSUES_REL" 2>/dev/null || true
+    fi
+  fi
+  STAGED=$(git -C "$TOPLEVEL" diff --cached --name-only)
+  # Skip-if-empty guard: a sprint with no Phase 1 row-writer additions
+  # AND no Phase 5 sprint-section append leaves nothing staged — exit
+  # cleanly without erroring.
+  if [ -z "$STAGED" ]; then
+    echo "fix-issues: nothing to commit (empty sprint artifacts); skipping commit + /land-pr" >&2
+  else
+    UNEXPECTED=""
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      case "$f" in
+        "$SPRINT_REL") ;;
+        *)
+          if [ -n "${ISSUES_REL:-}" ]; then
+            case "$f" in
+              "$ISSUES_REL"/*) ;;
+              *) UNEXPECTED="$UNEXPECTED $f" ;;
+            esac
+          else
+            UNEXPECTED="$UNEXPECTED $f"
+          fi
+          ;;
+      esac
+    done <<EOF
+$STAGED
+EOF
+    if [ -n "$UNEXPECTED" ]; then
+      echo "fix-issues: unexpected staged files outside SPRINT_REPORT.md / $ISSUES_REL:$UNEXPECTED" >&2
+      exit 1
+    fi
+    if [ -n "$COMMIT_CO_AUTHOR" ]; then
+      git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" -m "docs(sprint): tracker rows + sprint report (sprint=$SPRINT_ID)"
+    else
+      git -C "$TOPLEVEL" commit -m "docs(sprint): tracker rows + sprint report (sprint=$SPRINT_ID)"
+    fi
+  fi
+fi
+```
+
+<!-- allow-hardcoded: TZ=America/New_York reason: SPRINT_TS is a user-facing wall-clock stamp on the PR title/body; matches the established sprint-mode idiom for human-readable dates. Per-skill $TIMEZONE migration is scoped to plans/SKILL_FILE_DRIFT_FIX.md, not this issue -->
+```bash
+# Dispatch /land-pr to open the sprint PR. The tracking marker is written
+# on main_root so /land-pr can satisfy it with a fulfilled.land-pr.<id>
+# marker on successful merge — mirrors standalone `## Sync` mode's
+# Step 5 sub-step 2 (and /run-plan PR mode).
+SPRINT_TS="${SPRINT_TS:-$(TZ=America/New_York date +%Y%m%d-%H%M%S)}"
+LAND_ID="fix-issues.sprint.${SPRINT_ID}"
+
+MAIN_ROOT="${MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir)/.." && pwd)}"
+mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+
+# Write the requires.land-pr marker on main_root BEFORE dispatch. The
+# matching fulfilled.land-pr.<LAND_ID> is written by /land-pr ONLY on
+# STATUS=merged (created/monitored do not fulfill — by design).
+printf 'skill: land-pr\nrequired-by: fix-issues-sprint\ndate: %s\n' \
+  "$(TZ=UTC date -Iseconds)" \
+  > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${LAND_ID}"
+
+# Build the PR body file.
+RESULT_FILE=$(mktemp)
+BODY_FILE=$(mktemp)
+{
+  printf '## Summary\n`/fix-issues %s` sprint %s — tracker rows + sprint report.\n\n' \
+    "$N" "$SPRINT_ID"
+  printf '## Test plan\n- [x] Sprint artifacts reviewed by user before merge.\n'
+} > "$BODY_FILE"
+
+PR_TITLE="sprint: $(TZ=America/New_York date +%F) (${SPRINT_ID})"
+SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+
+# /land-pr arg vector. Mirrors standalone sync's invocation MINUS any
+# auto-merge flag — sprint-mode landing is interactive (matches sync
+# convention); Phase 6 mode-specific dispatch handles per-issue
+# auto-merge gating separately.
+LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$LAND_ID"
+
+# Transcript echo for PIPELINE_ID propagation (tier-2 idiom, matches
+# /do pr and standalone sync). Conformance test forbids the env-export
+# form — echo is the canonical channel.
+echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+
+# Dispatch /land-pr via the Skill tool. The Skill tool loads /land-pr's
+# prose into the current (orchestrator) context — its internal bash
+# blocks run here. After /land-pr returns, $RESULT_FILE is populated.
+#
+# Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+if [ ! -f "$RESULT_FILE" ]; then
+  echo "ERROR: /land-pr produced no result file at $RESULT_FILE" >&2
+  exit 1
+fi
+
+# Parse result-file via canonical allow-list pattern. Unknown keys WARN
+# but do not fail — forward-compatible with /land-pr schema additions.
+declare -A LP
+while IFS='=' read -r KEY VALUE; do
+  case "$KEY" in
+    STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
+    MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
+    CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      LP["$KEY"]="$VALUE" ;;
+    "") ;;
+    *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
+  esac
+done < "$RESULT_FILE"
+
+echo "Sprint PR: ${LP[PR_URL]:-(none)} — STATUS=${LP[STATUS]:-unknown}"
+```
 
 ### Post-report tracking
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+c063df"
+  version: "2026.05.17+42910a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -842,6 +842,7 @@ the sentinel is parent-scope tracking (by design) and stays on main_root
 regardless of which worktree the sprint executes from:
 
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID" ]; then
   printf 'skill: fix-issues\nmode: sprint\ncount: %s\nfocus: %s\nstartedAt: %s\n' \
     "$N" "${FOCUS:-default}" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
@@ -1816,6 +1817,7 @@ to `LAND_ARGS`; per-issue auto-merge gating remains the responsibility of
 Phase 6 mode-specific dispatch.
 
 <!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: filename basename suffixed onto $ZSKILLS_AUDIT_DIR (resolved via zskills-paths.sh); the basename token itself remains literal so the regex still flags the /SPRINT_REPORT.md tail -->
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /ISSUES_PLAN.md tail -->
 ```bash
 # Defensive cwd restore; WT_PATH set by the Phase 1 preamble.
 [ -n "${WT_PATH:-}" ] && cd "$WT_PATH" 2>/dev/null || true

--- a/tests/test-fix-issues.sh
+++ b/tests/test-fix-issues.sh
@@ -344,6 +344,122 @@ test_dashboard_mutex_error_strings_present() {
   fi
 }
 
+# --- #325: sprint-mode worktree gate (Phase 1 preamble + Phase 5 land) ---
+#
+# Sprint mode previously wrote ISSUES_PLAN.md (Phase 1 row-writer) and
+# SPRINT_REPORT.md (Phase 5 append) directly to main's working tree when
+# main_protected: true. PR #252 fixed standalone `## Sync` with an
+# ensure-worktree.sh preamble; sprint mode was missed. These tests guard
+# the parity fix shipped for #325.
+
+test_325_sprint_phase1_has_ensure_worktree_preamble() {
+  # Locate the Phase 1 header. The preamble lives under "## Phase 1 —
+  # Preflight & Sync" inside the "### Sprint tracking sentinel" block.
+  local phase1_line phase1b_line preamble_line
+  phase1_line=$(grep -nE '^## Phase 1 — Preflight & Sync' "$SKILL" | head -1 | cut -d: -f1)
+  phase1b_line=$(grep -nE '^## Phase 1b' "$SKILL" | head -1 | cut -d: -f1)
+  if [ -z "$phase1_line" ] || [ -z "$phase1b_line" ]; then
+    fail "#325 Phase 1 has ensure-worktree.sh preamble" "Phase 1 / Phase 1b header not found"
+    return
+  fi
+  # The preamble's distinguishing signature: the helper-path assignment
+  # to the create-worktree ensure-worktree.sh script.
+  preamble_line=$(awk -v start="$phase1_line" -v end="$phase1b_line" \
+    'NR>=start && NR<end && /create-worktree\/scripts\/ensure-worktree\.sh/ { print NR; exit }' "$SKILL")
+  if [ -n "$preamble_line" ]; then
+    pass "#325 Phase 1 has ensure-worktree.sh preamble (line $preamble_line)"
+  else
+    fail "#325 Phase 1 has ensure-worktree.sh preamble" "ensure-worktree.sh not invoked between Phase 1 and Phase 1b"
+  fi
+
+  # The preamble must also pass --pipeline-id "$PIPELINE_ID" so the
+  # worktree's purpose tag is bound to the per-sprint scope. Look for
+  # the flag AFTER the helper line (so we don't accept a prose comment
+  # mentioning the flag as proof that the preamble passes it).
+  local pid_line
+  pid_line=$(awk -v start="$preamble_line" -v end="$phase1b_line" \
+    'NR>start && NR<end && /--pipeline-id "\$PIPELINE_ID"/ { print NR; exit }' "$SKILL")
+  if [ -n "$pid_line" ]; then
+    pass "#325 Phase 1 preamble passes --pipeline-id \"\$PIPELINE_ID\" (line $pid_line)"
+  else
+    fail "#325 Phase 1 preamble passes --pipeline-id \"\$PIPELINE_ID\"" "flag not found in preamble body (after helper line $preamble_line)"
+  fi
+}
+
+test_325_sprint_id_lifted_above_preamble() {
+  # The plan's correctness condition: SPRINT_ID/PIPELINE_ID must be
+  # constructed BEFORE the ensure-worktree.sh helper is invoked, because
+  # the helper consumes --pipeline-id "$PIPELINE_ID". A prior version
+  # of the sentinel block had the construction AFTER the (non-existent)
+  # preamble; lifting it above is the structural fix.
+  local sprint_id_line preamble_line
+  # Find the SPRINT_ID assignment line within Phase 1 (first occurrence
+  # of the canonical assignment idiom; sentinel block lifts it).
+  local phase1_line phase1b_line
+  phase1_line=$(grep -nE '^## Phase 1 — Preflight & Sync' "$SKILL" | head -1 | cut -d: -f1)
+  phase1b_line=$(grep -nE '^## Phase 1b' "$SKILL" | head -1 | cut -d: -f1)
+  if [ -z "$phase1_line" ] || [ -z "$phase1b_line" ]; then
+    fail "#325 SPRINT_ID lifted above preamble" "Phase 1 / Phase 1b header not found"
+    return
+  fi
+  sprint_id_line=$(awk -v start="$phase1_line" -v end="$phase1b_line" \
+    'NR>=start && NR<end && /^SPRINT_ID="sprint-\$\(date -u/ { print NR; exit }' "$SKILL")
+  preamble_line=$(awk -v start="$phase1_line" -v end="$phase1b_line" \
+    'NR>=start && NR<end && /create-worktree\/scripts\/ensure-worktree\.sh/ { print NR; exit }' "$SKILL")
+  if [ -z "$sprint_id_line" ]; then
+    fail "#325 SPRINT_ID lifted above preamble" "SPRINT_ID construction line not found in Phase 1"
+    return
+  fi
+  if [ -z "$preamble_line" ]; then
+    fail "#325 SPRINT_ID lifted above preamble" "ensure-worktree.sh preamble not found in Phase 1"
+    return
+  fi
+  if [ "$sprint_id_line" -lt "$preamble_line" ]; then
+    pass "#325 SPRINT_ID construction precedes preamble (lines $sprint_id_line < $preamble_line)"
+  else
+    fail "#325 SPRINT_ID construction precedes preamble" "SPRINT_ID at $sprint_id_line, preamble at $preamble_line — must be lifted above"
+  fi
+}
+
+test_325_phase5_has_commit_and_landpr_dispatch() {
+  # The Phase 5 commit + /land-pr dispatch block lives between the Phase 5
+  # header and the Phase 6 header. Two distinguishing signatures:
+  #  (a) a `docs(sprint): tracker rows + sprint report` commit message
+  #  (b) a `Skill: { skill: "land-pr"` dispatch comment with --landed-source=fix-issues-sprint
+  local phase5_line phase6_line commit_line dispatch_line
+  phase5_line=$(grep -nE '^## Phase 5 — Write Sprint Report' "$SKILL" | head -1 | cut -d: -f1)
+  phase6_line=$(grep -nE '^## Phase 6 — Land' "$SKILL" | head -1 | cut -d: -f1)
+  if [ -z "$phase5_line" ] || [ -z "$phase6_line" ]; then
+    fail "#325 Phase 5 has commit + /land-pr dispatch" "Phase 5 / Phase 6 header not found"
+    return
+  fi
+  commit_line=$(awk -v start="$phase5_line" -v end="$phase6_line" \
+    'NR>=start && NR<end && /docs\(sprint\): tracker rows \+ sprint report/ { print NR; exit }' "$SKILL")
+  dispatch_line=$(awk -v start="$phase5_line" -v end="$phase6_line" \
+    'NR>=start && NR<end && /Skill: \{ skill: "land-pr"/ && /\$LAND_ARGS/ { print NR; exit }' "$SKILL")
+  if [ -n "$commit_line" ]; then
+    pass "#325 Phase 5 has 'docs(sprint): tracker rows + sprint report' commit (line $commit_line)"
+  else
+    fail "#325 Phase 5 has 'docs(sprint): tracker rows + sprint report' commit" "commit message not found between Phase 5 and Phase 6"
+  fi
+  if [ -n "$dispatch_line" ]; then
+    pass "#325 Phase 5 has /land-pr Skill dispatch (line $dispatch_line)"
+  else
+    fail "#325 Phase 5 has /land-pr Skill dispatch" "Skill: { skill: \"land-pr\" ... \$LAND_ARGS } not found between Phase 5 and Phase 6"
+  fi
+
+  # The Phase 5 dispatch must NOT pass an auto-merge flag — sprint
+  # landing is interactive (matches standalone sync convention).
+  local auto_in_args
+  auto_in_args=$(awk -v start="$phase5_line" -v end="$phase6_line" \
+    'NR>=start && NR<end && /LAND_ARGS=/ && /--auto/ { print NR }' "$SKILL")
+  if [ -z "$auto_in_args" ]; then
+    pass "#325 Phase 5 /land-pr dispatch is interactive (no --auto)"
+  else
+    fail "#325 Phase 5 /land-pr dispatch is interactive (no --auto)" "found --auto in LAND_ARGS at line(s): $auto_in_args"
+  fi
+}
+
 # --- Mirror parity -------------------------------------------------------
 
 test_mirror_in_sync() {
@@ -356,7 +472,7 @@ test_mirror_in_sync() {
   fi
 }
 
-echo "=== /fix-issues sync-mode bundle (#280 #282 #300 #301) regression guards ==="
+echo "=== /fix-issues sync-mode + sprint-mode (#280 #282 #300 #301 #325) regression guards ==="
 test_301_regex_matches_markdown_bold_and_heading
 test_301_source_uses_qP_lookarounds
 test_282_success_set_is_merged_only
@@ -367,6 +483,9 @@ test_dashboard_token_recognized_in_phase0
 test_dashboard_phase2_branch_present
 test_dashboard_uses_python_json_not_bash_regex
 test_dashboard_mutex_error_strings_present
+test_325_sprint_phase1_has_ensure_worktree_preamble
+test_325_sprint_id_lifted_above_preamble
+test_325_phase5_has_commit_and_landpr_dispatch
 test_mirror_in_sync
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #325. `/fix-issues` sprint-mode now creates a sprint-level worktree at top of Phase 1 (mirroring the standalone `/fix-issues sync` mode pattern from PR #252), so the Phase 1 row-writer's `ISSUES_PLAN.md` append and the Phase 5 `SPRINT_REPORT.md` append both land inside the worktree instead of dirtying main.

## Change shape

**Phase 1 (top of skill):**
1. Source helper + resolve `MAIN_ROOT`
2. **Lifted** SPRINT_ID + PIPELINE_ID construction OUT of the sentinel block to a new block above the preamble (fixes round-1 reviewer's ordering bug: the preamble's `--pipeline-id "$PIPELINE_ID"` needs PIPELINE_ID set first)
3. **New** `ensure-worktree.sh` preamble (mirrors `## Sync` lines ~13-40) — sets `WT_PATH`, `cd`s in, exports `ZSKILLS_PATHS_ROOT`
4. Sentinel block continues — its tracking writes target `$MAIN_ROOT/.zskills/tracking/` by design (parent-scope tracking convention; unchanged)
5. All Phase 1 sync writes (`ISSUES_PLAN.md` row-writer, `SPRINT_REPORT.md` append) now resolve against `ZSKILLS_PATHS_ROOT` and land in the worktree

**Phase 5 (end of skill):**
- New commit + `/land-pr` dispatch block (mirrors `## Sync` Step 5 sub-step 2). Stages `SPRINT_REPORT.md` + tracker files, skip-if-empty guard, builds PR body, dispatches `/land-pr` via Skill tool (no `--auto` — sprint-mode sync is interactive, matching standalone-sync's convention).

**Phase 3 / Phase 6 unchanged.** Per-issue worktrees + landing modes resolve `MAIN_ROOT` via `git rev-parse --git-common-dir`. Linked worktrees share `git-dir` with the parent, so this works correctly whether the orchestrator's cwd is the sprint-level worktree or main.

**Out of scope:** `/fix-report` hardening — #325 body notes "worth bundling" but kept scope tight here (follow-up if needed).

## Test plan

- [x] Full suite: **3179/3179 PASS** (was 3173 pre-PR + 6 new asserts)
- [x] Targeted `tests/test-fix-issues.sh`: 31/31 PASS (was 25; +3 new test functions, 6 assertions covering preamble invocation, ordering, Phase 5 commit/dispatch block)
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: `2026.05.16+a8a3b2 → 2026.05.17+42910a` (matches recomputed content hash after conformance follow-up)
- [x] Plan reviewer: REVISE round 1 (caught ordering bug + Phase 3/6 concern) → APPROVE round 2
- [x] Fresh post-impl verifier: caught 2 conformance fixes (drift-checker tests) — both applied as a follow-up commit (squash-merges into one), full suite re-ran clean
- [ ] **Reviewer post-merge:** next `/fix-issues N` run should NOT dirty `SPRINT_REPORT.md` on main. The cron `d8921920` (`*/45 * * * *`) was the empirical source of dirtying during this session — its next fire should land any sprint report inside a sprint-level worktree and open a PR for it instead.

## Note

The dirty `SPRINT_REPORT.md` currently in main's working tree (from a pre-PR cron fire at 2026-05-17 02:36) is NOT cleaned up by this PR. The bug fix prevents NEW dirtying; existing dirty state needs a separate explicit commit (`/quickfix` against the dirty file). I'll ship that as a follow-up immediately after this PR lands.

🤖 Generated with /do (agent-dispatched, PR mode, auto-merge)
