### PR TITLE
do: fix-issues cap-check predicate + defer-path strand

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+987e2e"
+  version: "2026.05.17+64b77a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -803,6 +803,61 @@ PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/s
 SPRINT_ID="${PIPELINE_ID#fix-issues.}"
 ```
 
+### Live worktree count check (defer-all gate)
+
+**Run this BEFORE the sprint worktree gate below.** If the host is already
+at the live-worktree cap, defer the whole fire here — exit cleanly with no
+worktree created, no sentinel marker, no Phase 1 work. Co-located bugs from
+PR #320 (predicate over-counted because it didn't skip already-landed
+worktrees) and PR #329 (the cap-check used to run AFTER the sprint
+worktree gate, so a defer-all that appended to `SPRINT_REPORT.md` stranded
+the write in a worktree that never shipped — sprint-level `/land-pr` is in
+Phase 6, past the `exit 0`). Fix: move the gate up here and skip
+`.landed status: landed` worktrees from the count. The partial-dispatch
+arm (when 0 < SLOTS < N_REQUESTED) moves to its own spot in Phase 3 —
+it needs `TO_DISPATCH` which Phase 2 builds.
+
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: the SPRINT_REPORT.md basename appears only inside a comment explaining WHY the defer-all gate does NOT write to it (strand bug from #329); no actual `cat >> SPRINT_REPORT.md` heredoc lives in this fence — see tests/test-fix-issues-sprint-worktree-gate.sh assertion 8 -->
+```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+# $ZSKILLS_MAX_CONCURRENT_WORKTREES is now set (defaults to 3 when the
+# execution.max_concurrent_worktrees field is absent or malformed).
+
+# Count live fix/issue-* worktrees across the repo, SKIPPING any whose
+# `.landed` marker says `status: landed`. Done-but-uncleaned worktrees
+# (every PR that ever merged through /fix-issues whose dir wasn't swept
+# by /cleanup-merged yet) used to trip the cap; the awk/while shape
+# below filters them out. Both PR-mode (`fix/issue-NNN`) and
+# cherry-pick/direct mode (`fix-issue-NNN`) branches count via the
+# bracket alternation `fix[/-]issue-`. Each worktree contributes exactly
+# one `branch refs/heads/...` line in the porcelain output, preceded by
+# a `worktree <path>` line — awk pairs them.
+LIVE_COUNT=$(
+  git worktree list --porcelain \
+    | awk '/^worktree /{wt=$2} /^branch refs\/heads\/fix[/-]issue-/{print wt}' \
+    | while read -r wt; do
+        if [ -f "$wt/.landed" ] && grep -q '^status: landed' "$wt/.landed"; then
+          continue
+        fi
+        echo X
+      done \
+    | wc -l \
+    | tr -d ' '
+)
+
+CAP="$ZSKILLS_MAX_CONCURRENT_WORKTREES"
+if [ "$LIVE_COUNT" -ge "$CAP" ]; then
+  # All slots already taken — defer the entire fire BEFORE creating a
+  # worktree. No `cat >> SPRINT_REPORT.md` here: the audit-write would
+  # land in a worktree that never ships (sprint-level /land-pr is in
+  # Phase 6, past this exit). One stderr line is the whole audit trail
+  # — defer events are transient; the audit value is in real-dispatch
+  # sprints.
+  echo "fix-issues: live worktree count ($LIVE_COUNT) >= cap ($CAP); deferring sprint $PIPELINE_ID. Cron will retry on the next fire." >&2
+  exit 0
+fi
+```
+
 ### Sprint worktree gate
 
 **All sprint-mode work happens in a pre-created worktree.** Before
@@ -1396,9 +1451,11 @@ different problems and live at different scopes:
    makes the sprint defer new dispatches when live count is already at
    the cap, and waits for prior worktrees to land via cron retry.
 
-   See "Live worktree count check" below — this gate runs BEFORE the
-   dispatch loop and either reduces the batch size or defers the whole
-   fire.
+   See "Live worktree count check (defer-all gate)" in Phase 1 — that
+   block exits the sprint cleanly (no worktree, no markers) if all slots
+   are taken at entry. See "Live worktree count check (partial-dispatch
+   trim)" below — that block trims `TO_DISPATCH` if the available slots
+   are fewer than the batch size built in Phase 2.
 
 - **Interrelated issues** (same root cause or same files from Phase 2
   grouping) share one agent and one worktree. Tell the agent which
@@ -1407,59 +1464,57 @@ different problems and live at different scopes:
   issues into one agent — this caused a 4.5h bottleneck when one agent
   got 4 diverse issues sequentially.
 
-### Live worktree count check
+### Live worktree count check (partial-dispatch trim)
 
-Run this **before** the dispatch loop (cherry-pick / direct / PR mode all):
+Run this **before** the dispatch loop (cherry-pick / direct / PR mode all).
+The defer-all arm of this gate already ran in Phase 1 ("Live worktree count
+check (defer-all gate)") — if we reached this point, at least one slot was
+free at sprint entry. Here we only handle the partial-dispatch case: if
+the available slot count is now less than the batch the orchestrator built
+in Phase 2, trim `TO_DISPATCH` in place and re-prioritise the remainder on
+the next fire. We re-compute `LIVE_COUNT` because slots may have changed
+between Phase 1 and here (other concurrent pipelines, etc.).
 
-<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: filename basename suffixed onto $ZSKILLS_AUDIT_DIR (resolved via zskills-paths.sh); the basename token itself remains literal so the regex still flags the /SPRINT_REPORT.md tail -->
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: the SPRINT_REPORT.md basename appears only inside comments explaining WHY this trim does NOT write to it (symmetry with the Phase 1 defer-all gate); no actual `cat >> SPRINT_REPORT.md` heredoc lives in this fence — see tests/test-fix-issues-sprint-worktree-gate.sh assertion 8 -->
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 # $ZSKILLS_MAX_CONCURRENT_WORKTREES is now set (defaults to 3 when the
 # execution.max_concurrent_worktrees field is absent or malformed).
 
-# Count live fix/issue-* worktrees across the repo (resume detection is
-# directory-based, so this is the authoritative live-count). Both PR-mode
-# (branch fix/issue-NNN) and cherry-pick/direct mode (branch fix-issue-NNN)
-# branches are counted via two grep passes against `git worktree list
-# --porcelain`. Each worktree contributes exactly one `branch refs/heads/...`
-# line in the porcelain output.
-LIVE_COUNT=$(git worktree list --porcelain \
-  | grep -cE '^branch refs/heads/fix[/-]issue-')
+# Recount live fix/issue-* worktrees, skipping `.landed status: landed`
+# entries (same predicate as the Phase 1 defer-all gate — see that block
+# for the why; this is the symmetric per-batch trim).
+LIVE_COUNT=$(
+  git worktree list --porcelain \
+    | awk '/^worktree /{wt=$2} /^branch refs\/heads\/fix[/-]issue-/{print wt}' \
+    | while read -r wt; do
+        if [ -f "$wt/.landed" ] && grep -q '^status: landed' "$wt/.landed"; then
+          continue
+        fi
+        echo X
+      done \
+    | wc -l \
+    | tr -d ' '
+)
 
 CAP="$ZSKILLS_MAX_CONCURRENT_WORKTREES"
 N_REQUESTED="${#TO_DISPATCH[@]}"  # how many fix agents this sprint wants to dispatch
 SLOTS=$(( CAP - LIVE_COUNT ))
 if [ "$SLOTS" -le 0 ]; then
-  # All slots already taken — defer the entire fire.
-  echo "Live worktree count ($LIVE_COUNT) >= cap ($CAP). Deferring this fire."
-  # Append a section to SPRINT_REPORT.md so the deferral is auditable.
-  cat >> "$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md" <<DEFER
-
-### Sprint deferred — at live-worktree cap
-
-Live count $LIVE_COUNT >= cap $CAP at $(TZ="${TIMEZONE:-UTC}" date -Iseconds).
-No fix agents dispatched this fire. \`execution.max_concurrent_worktrees\`
-in \`.claude/zskills-config.json\` controls the cap (default 3). Cron will
-retry on the next fire — by then prior worktrees should have landed (PR
-merged + worktree cleaned), opening slots.
-DEFER
+  # Edge case: slots vanished between the Phase 1 defer-all gate and now
+  # (concurrent pipeline filled the cap). Defer the whole batch — no
+  # audit-write to SPRINT_REPORT.md here either (defer events are
+  # transient; see Phase 1 defer-all gate comment).
+  echo "fix-issues: live count ($LIVE_COUNT) re-saturated cap ($CAP) before dispatch; deferring sprint $PIPELINE_ID. Cron will retry." >&2
   exit 0
 elif [ "$SLOTS" -lt "$N_REQUESTED" ]; then
   # Some slots, but not enough for the full batch. Dispatch the first SLOTS;
   # queue the rest for the next fire. The queued issues stay open and the
-  # next cron tick (or `/fix-issues next`) will re-prioritise them.
-  echo "Live count $LIVE_COUNT, cap $CAP — $SLOTS slots available, dispatching $SLOTS of $N_REQUESTED."
-  QUEUED=( "${TO_DISPATCH[@]:$SLOTS}" )
+  # next cron tick (or `/fix-issues next`) will re-prioritise them. No
+  # `cat >> SPRINT_REPORT.md` audit-write — symmetry with the defer-all
+  # gate above; the queued-subset signal lives on stderr.
+  echo "fix-issues: live count $LIVE_COUNT, cap $CAP — $SLOTS slots available, dispatching $SLOTS of $N_REQUESTED. Queued for next fire: ${TO_DISPATCH[*]:$SLOTS}" >&2
   TO_DISPATCH=( "${TO_DISPATCH[@]:0:$SLOTS}" )
-  # Note the deferred subset in the sprint report. The exact issue list
-  # comes from the orchestrator's batched-priority array.
-  cat >> "$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md" <<QUEUED_SEC
-
-### Sprint partially deferred — at live-worktree cap
-
-Live count $LIVE_COUNT, cap $CAP. Dispatched $SLOTS of $N_REQUESTED agents
-this fire; queued for next fire: ${QUEUED[*]}
-QUEUED_SEC
 fi
 # Otherwise SLOTS >= N_REQUESTED — proceed with the full dispatch loop below.
 # The per-message I/O contention cap (3) still applies inside the dispatch
@@ -1470,9 +1525,11 @@ Notes:
 - `TO_DISPATCH` is the array of issue numbers the orchestrator built in
   Phase 2's prioritisation. The cap-check truncates it in place; the
   dispatch loop below iterates `TO_DISPATCH` as usual.
-- The grep regex `^branch refs/heads/fix[/-]issue-` matches BOTH the PR-mode
-  pattern `fix/issue-NNN` and the cherry-pick/direct-mode pattern
-  `fix-issue-NNN`. Bracket alternation `[/-]` keeps it a single grep.
+- The awk/while predicate matches BOTH the PR-mode pattern
+  `fix/issue-NNN` and the cherry-pick/direct-mode pattern
+  `fix-issue-NNN` (bracket alternation `fix[/-]issue-`), and skips
+  any worktree whose `.landed` marker reads `status: landed` — those
+  are done-but-uncleaned cleanup artifacts, not live work.
 - The cap can be raised by editing `execution.max_concurrent_worktrees` in
   `.claude/zskills-config.json`. Raise above 3 only on hosts with ample
   CPU/memory/disk headroom — past containers OOMed at 8 concurrent live.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+987e2e"
+  version: "2026.05.17+64b77a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -803,6 +803,61 @@ PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/s
 SPRINT_ID="${PIPELINE_ID#fix-issues.}"
 ```
 
+### Live worktree count check (defer-all gate)
+
+**Run this BEFORE the sprint worktree gate below.** If the host is already
+at the live-worktree cap, defer the whole fire here — exit cleanly with no
+worktree created, no sentinel marker, no Phase 1 work. Co-located bugs from
+PR #320 (predicate over-counted because it didn't skip already-landed
+worktrees) and PR #329 (the cap-check used to run AFTER the sprint
+worktree gate, so a defer-all that appended to `SPRINT_REPORT.md` stranded
+the write in a worktree that never shipped — sprint-level `/land-pr` is in
+Phase 6, past the `exit 0`). Fix: move the gate up here and skip
+`.landed status: landed` worktrees from the count. The partial-dispatch
+arm (when 0 < SLOTS < N_REQUESTED) moves to its own spot in Phase 3 —
+it needs `TO_DISPATCH` which Phase 2 builds.
+
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: the SPRINT_REPORT.md basename appears only inside a comment explaining WHY the defer-all gate does NOT write to it (strand bug from #329); no actual `cat >> SPRINT_REPORT.md` heredoc lives in this fence — see tests/test-fix-issues-sprint-worktree-gate.sh assertion 8 -->
+```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+# $ZSKILLS_MAX_CONCURRENT_WORKTREES is now set (defaults to 3 when the
+# execution.max_concurrent_worktrees field is absent or malformed).
+
+# Count live fix/issue-* worktrees across the repo, SKIPPING any whose
+# `.landed` marker says `status: landed`. Done-but-uncleaned worktrees
+# (every PR that ever merged through /fix-issues whose dir wasn't swept
+# by /cleanup-merged yet) used to trip the cap; the awk/while shape
+# below filters them out. Both PR-mode (`fix/issue-NNN`) and
+# cherry-pick/direct mode (`fix-issue-NNN`) branches count via the
+# bracket alternation `fix[/-]issue-`. Each worktree contributes exactly
+# one `branch refs/heads/...` line in the porcelain output, preceded by
+# a `worktree <path>` line — awk pairs them.
+LIVE_COUNT=$(
+  git worktree list --porcelain \
+    | awk '/^worktree /{wt=$2} /^branch refs\/heads\/fix[/-]issue-/{print wt}' \
+    | while read -r wt; do
+        if [ -f "$wt/.landed" ] && grep -q '^status: landed' "$wt/.landed"; then
+          continue
+        fi
+        echo X
+      done \
+    | wc -l \
+    | tr -d ' '
+)
+
+CAP="$ZSKILLS_MAX_CONCURRENT_WORKTREES"
+if [ "$LIVE_COUNT" -ge "$CAP" ]; then
+  # All slots already taken — defer the entire fire BEFORE creating a
+  # worktree. No `cat >> SPRINT_REPORT.md` here: the audit-write would
+  # land in a worktree that never ships (sprint-level /land-pr is in
+  # Phase 6, past this exit). One stderr line is the whole audit trail
+  # — defer events are transient; the audit value is in real-dispatch
+  # sprints.
+  echo "fix-issues: live worktree count ($LIVE_COUNT) >= cap ($CAP); deferring sprint $PIPELINE_ID. Cron will retry on the next fire." >&2
+  exit 0
+fi
+```
+
 ### Sprint worktree gate
 
 **All sprint-mode work happens in a pre-created worktree.** Before
@@ -1396,9 +1451,11 @@ different problems and live at different scopes:
    makes the sprint defer new dispatches when live count is already at
    the cap, and waits for prior worktrees to land via cron retry.
 
-   See "Live worktree count check" below — this gate runs BEFORE the
-   dispatch loop and either reduces the batch size or defers the whole
-   fire.
+   See "Live worktree count check (defer-all gate)" in Phase 1 — that
+   block exits the sprint cleanly (no worktree, no markers) if all slots
+   are taken at entry. See "Live worktree count check (partial-dispatch
+   trim)" below — that block trims `TO_DISPATCH` if the available slots
+   are fewer than the batch size built in Phase 2.
 
 - **Interrelated issues** (same root cause or same files from Phase 2
   grouping) share one agent and one worktree. Tell the agent which
@@ -1407,59 +1464,57 @@ different problems and live at different scopes:
   issues into one agent — this caused a 4.5h bottleneck when one agent
   got 4 diverse issues sequentially.
 
-### Live worktree count check
+### Live worktree count check (partial-dispatch trim)
 
-Run this **before** the dispatch loop (cherry-pick / direct / PR mode all):
+Run this **before** the dispatch loop (cherry-pick / direct / PR mode all).
+The defer-all arm of this gate already ran in Phase 1 ("Live worktree count
+check (defer-all gate)") — if we reached this point, at least one slot was
+free at sprint entry. Here we only handle the partial-dispatch case: if
+the available slot count is now less than the batch the orchestrator built
+in Phase 2, trim `TO_DISPATCH` in place and re-prioritise the remainder on
+the next fire. We re-compute `LIVE_COUNT` because slots may have changed
+between Phase 1 and here (other concurrent pipelines, etc.).
 
-<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: filename basename suffixed onto $ZSKILLS_AUDIT_DIR (resolved via zskills-paths.sh); the basename token itself remains literal so the regex still flags the /SPRINT_REPORT.md tail -->
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])SPRINT_REPORT\.md reason: the SPRINT_REPORT.md basename appears only inside comments explaining WHY this trim does NOT write to it (symmetry with the Phase 1 defer-all gate); no actual `cat >> SPRINT_REPORT.md` heredoc lives in this fence — see tests/test-fix-issues-sprint-worktree-gate.sh assertion 8 -->
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 # $ZSKILLS_MAX_CONCURRENT_WORKTREES is now set (defaults to 3 when the
 # execution.max_concurrent_worktrees field is absent or malformed).
 
-# Count live fix/issue-* worktrees across the repo (resume detection is
-# directory-based, so this is the authoritative live-count). Both PR-mode
-# (branch fix/issue-NNN) and cherry-pick/direct mode (branch fix-issue-NNN)
-# branches are counted via two grep passes against `git worktree list
-# --porcelain`. Each worktree contributes exactly one `branch refs/heads/...`
-# line in the porcelain output.
-LIVE_COUNT=$(git worktree list --porcelain \
-  | grep -cE '^branch refs/heads/fix[/-]issue-')
+# Recount live fix/issue-* worktrees, skipping `.landed status: landed`
+# entries (same predicate as the Phase 1 defer-all gate — see that block
+# for the why; this is the symmetric per-batch trim).
+LIVE_COUNT=$(
+  git worktree list --porcelain \
+    | awk '/^worktree /{wt=$2} /^branch refs\/heads\/fix[/-]issue-/{print wt}' \
+    | while read -r wt; do
+        if [ -f "$wt/.landed" ] && grep -q '^status: landed' "$wt/.landed"; then
+          continue
+        fi
+        echo X
+      done \
+    | wc -l \
+    | tr -d ' '
+)
 
 CAP="$ZSKILLS_MAX_CONCURRENT_WORKTREES"
 N_REQUESTED="${#TO_DISPATCH[@]}"  # how many fix agents this sprint wants to dispatch
 SLOTS=$(( CAP - LIVE_COUNT ))
 if [ "$SLOTS" -le 0 ]; then
-  # All slots already taken — defer the entire fire.
-  echo "Live worktree count ($LIVE_COUNT) >= cap ($CAP). Deferring this fire."
-  # Append a section to SPRINT_REPORT.md so the deferral is auditable.
-  cat >> "$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md" <<DEFER
-
-### Sprint deferred — at live-worktree cap
-
-Live count $LIVE_COUNT >= cap $CAP at $(TZ="${TIMEZONE:-UTC}" date -Iseconds).
-No fix agents dispatched this fire. \`execution.max_concurrent_worktrees\`
-in \`.claude/zskills-config.json\` controls the cap (default 3). Cron will
-retry on the next fire — by then prior worktrees should have landed (PR
-merged + worktree cleaned), opening slots.
-DEFER
+  # Edge case: slots vanished between the Phase 1 defer-all gate and now
+  # (concurrent pipeline filled the cap). Defer the whole batch — no
+  # audit-write to SPRINT_REPORT.md here either (defer events are
+  # transient; see Phase 1 defer-all gate comment).
+  echo "fix-issues: live count ($LIVE_COUNT) re-saturated cap ($CAP) before dispatch; deferring sprint $PIPELINE_ID. Cron will retry." >&2
   exit 0
 elif [ "$SLOTS" -lt "$N_REQUESTED" ]; then
   # Some slots, but not enough for the full batch. Dispatch the first SLOTS;
   # queue the rest for the next fire. The queued issues stay open and the
-  # next cron tick (or `/fix-issues next`) will re-prioritise them.
-  echo "Live count $LIVE_COUNT, cap $CAP — $SLOTS slots available, dispatching $SLOTS of $N_REQUESTED."
-  QUEUED=( "${TO_DISPATCH[@]:$SLOTS}" )
+  # next cron tick (or `/fix-issues next`) will re-prioritise them. No
+  # `cat >> SPRINT_REPORT.md` audit-write — symmetry with the defer-all
+  # gate above; the queued-subset signal lives on stderr.
+  echo "fix-issues: live count $LIVE_COUNT, cap $CAP — $SLOTS slots available, dispatching $SLOTS of $N_REQUESTED. Queued for next fire: ${TO_DISPATCH[*]:$SLOTS}" >&2
   TO_DISPATCH=( "${TO_DISPATCH[@]:0:$SLOTS}" )
-  # Note the deferred subset in the sprint report. The exact issue list
-  # comes from the orchestrator's batched-priority array.
-  cat >> "$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md" <<QUEUED_SEC
-
-### Sprint partially deferred — at live-worktree cap
-
-Live count $LIVE_COUNT, cap $CAP. Dispatched $SLOTS of $N_REQUESTED agents
-this fire; queued for next fire: ${QUEUED[*]}
-QUEUED_SEC
 fi
 # Otherwise SLOTS >= N_REQUESTED — proceed with the full dispatch loop below.
 # The per-message I/O contention cap (3) still applies inside the dispatch
@@ -1470,9 +1525,11 @@ Notes:
 - `TO_DISPATCH` is the array of issue numbers the orchestrator built in
   Phase 2's prioritisation. The cap-check truncates it in place; the
   dispatch loop below iterates `TO_DISPATCH` as usual.
-- The grep regex `^branch refs/heads/fix[/-]issue-` matches BOTH the PR-mode
-  pattern `fix/issue-NNN` and the cherry-pick/direct-mode pattern
-  `fix-issue-NNN`. Bracket alternation `[/-]` keeps it a single grep.
+- The awk/while predicate matches BOTH the PR-mode pattern
+  `fix/issue-NNN` and the cherry-pick/direct-mode pattern
+  `fix-issue-NNN` (bracket alternation `fix[/-]issue-`), and skips
+  any worktree whose `.landed` marker reads `status: landed` — those
+  are done-but-uncleaned cleanup artifacts, not live work.
 - The cap can be raised by editing `execution.max_concurrent_worktrees` in
   `.claude/zskills-config.json`. Raise above 3 only on hosts with ample
   CPU/memory/disk headroom — past containers OOMed at 8 concurrent live.

--- a/tests/test-fix-issues-sprint-worktree-gate.sh
+++ b/tests/test-fix-issues-sprint-worktree-gate.sh
@@ -139,6 +139,153 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────
+# Assertion 6: cap-check defer-all gate runs BEFORE the sprint
+# worktree gate (issue #329 follow-up — co-located bugs from #320).
+# If the cap-check ran AFTER the worktree gate, the defer-path's
+# `cat >> SPRINT_REPORT.md` would strand in a worktree that never
+# ships (Phase 6's sprint-level /land-pr is past the `exit 0`).
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== fix-issues cap-check ordering + predicate (issue #329 follow-up) ==="
+
+CAP_DEFER_LINE=$(grep -n '^### Live worktree count check (defer-all gate)' "$FI_SKILL" | head -1 | cut -d: -f1)
+CAP_PARTIAL_LINE=$(grep -n '^### Live worktree count check (partial-dispatch trim)' "$FI_SKILL" | head -1 | cut -d: -f1)
+if [ -z "$CAP_DEFER_LINE" ]; then
+  fail "fix-issues: '### Live worktree count check (defer-all gate)' missing (cap-check must run before worktree gate)"
+elif [ -z "$SPRINT_GATE_LINE" ]; then
+  fail "fix-issues: '### Sprint worktree gate' missing (cannot verify ordering)"
+elif [ "$CAP_DEFER_LINE" -ge "$SPRINT_GATE_LINE" ]; then
+  fail "fix-issues: defer-all gate at line $CAP_DEFER_LINE must precede sprint worktree gate at line $SPRINT_GATE_LINE (defer-path would strand SPRINT_REPORT.md write otherwise)"
+else
+  pass "fix-issues: defer-all gate (line $CAP_DEFER_LINE) precedes sprint worktree gate (line $SPRINT_GATE_LINE)"
+fi
+
+if [ -z "$CAP_PARTIAL_LINE" ]; then
+  fail "fix-issues: '### Live worktree count check (partial-dispatch trim)' missing (partial-batch trim needs its own block in Phase 3)"
+elif [ -z "$SPRINT_GATE_LINE" ]; then
+  : # already failed above
+elif [ "$CAP_PARTIAL_LINE" -le "$SPRINT_GATE_LINE" ]; then
+  fail "fix-issues: partial-dispatch trim at line $CAP_PARTIAL_LINE must FOLLOW sprint worktree gate at line $SPRINT_GATE_LINE (it needs TO_DISPATCH from Phase 2)"
+else
+  pass "fix-issues: partial-dispatch trim (line $CAP_PARTIAL_LINE) follows sprint worktree gate (line $SPRINT_GATE_LINE)"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Assertion 7: behavioural — the cap-check predicate must SKIP
+# worktrees whose `.landed` marker reads `status: landed`. We
+# extract the predicate code block from the SKILL.md, build a
+# fake `git worktree list --porcelain` fixture with three entries
+# (one landed, one un-landed, one not-fix-issue), eval the
+# predicate against it, and assert LIVE_COUNT == 1.
+#
+# This locks the EXACT predicate behaviour, not just structural
+# presence — the reviewer-flagged gap from the bug report.
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== predicate behaviour: skip .landed status: landed ==="
+
+# Extract the awk/while predicate block from the SKILL.md (defer-all
+# gate). Pull the lines between `LIVE_COUNT=$(` and the matching `)`.
+PRED_START=$(awk '/^### Live worktree count check \(defer-all gate\)/{found=1} found && /^LIVE_COUNT=\$\($/{print NR; exit}' "$FI_SKILL")
+if [ -z "$PRED_START" ]; then
+  fail "could not locate LIVE_COUNT=( in defer-all gate (cannot run predicate behaviour test)"
+else
+  # Capture lines from PRED_START through the next standalone `)` line.
+  PRED_END=$(awk -v start="$PRED_START" 'NR>=start && /^\)$/{print NR; exit}' "$FI_SKILL")
+  if [ -z "$PRED_END" ]; then
+    fail "could not locate closing ) of LIVE_COUNT predicate"
+  else
+    PRED_BODY=$(sed -n "${PRED_START},${PRED_END}p" "$FI_SKILL")
+
+    # Build a temp dir with three fake worktrees:
+    #   wt-landed   — fix-issue-1, .landed says `status: landed` (SKIP)
+    #   wt-active   — fix-issue-2, no .landed                    (COUNT)
+    #   wt-other    — feature/foo, not a fix branch              (SKIP)
+    TMP_PRED=$(mktemp -d /tmp/cap-predicate-test.XXXXXX)
+    trap 'rm -rf "$TMP_PRED"' EXIT
+
+    mkdir -p "$TMP_PRED/wt-landed" "$TMP_PRED/wt-active" "$TMP_PRED/wt-other"
+    printf 'status: landed\ndate: 2026-05-17\n' > "$TMP_PRED/wt-landed/.landed"
+    # wt-active has no .landed file
+    # wt-other has no .landed file
+
+    # Stub `git worktree list --porcelain` to print our fixture.
+    cat > "$TMP_PRED/git" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "worktree" ] && [ "\$2" = "list" ] && [ "\$3" = "--porcelain" ]; then
+  cat <<PORC
+worktree $TMP_PRED/wt-landed
+branch refs/heads/fix/issue-1
+
+worktree $TMP_PRED/wt-active
+branch refs/heads/fix-issue-2
+
+worktree $TMP_PRED/wt-other
+branch refs/heads/feature/foo
+
+PORC
+  exit 0
+fi
+exec /usr/bin/git "\$@"
+EOF
+    chmod +x "$TMP_PRED/git"
+
+    # Run the predicate with our stub git on PATH.
+    ACTUAL=$(PATH="$TMP_PRED:$PATH" bash -c "$PRED_BODY"$'\necho "$LIVE_COUNT"' 2>&1 | tail -1)
+
+    if [ "$ACTUAL" = "1" ]; then
+      pass "predicate excludes .landed status: landed (LIVE_COUNT=1 from fixture: 1 landed + 1 active + 1 non-fix)"
+    else
+      fail "predicate behaviour wrong: expected LIVE_COUNT=1, got '$ACTUAL' (fixture: 1 landed fix-issue + 1 active fix-issue + 1 non-fix branch)"
+    fi
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Assertion 8: defer-all gate does NOT `cat >> SPRINT_REPORT.md`.
+# The strand bug was: defer-all wrote audit content into the
+# sprint-level worktree's SPRINT_REPORT.md, then `exit 0` skipped
+# Phase 6's /land-pr. Even after moving the gate earlier (so no
+# worktree exists yet), keep the predicate negative — any future
+# refactor that re-introduces a `cat >>` here re-opens the strand
+# if someone moves the gate back.
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== defer-all gate does not append to SPRINT_REPORT.md ==="
+
+# Slice from "### Live worktree count check (defer-all gate)" up to
+# the next "### " heading.
+DEFER_BLOCK=$(awk '
+  /^### Live worktree count check \(defer-all gate\)/{capture=1; next}
+  capture && /^### /{exit}
+  capture {print}
+' "$FI_SKILL")
+
+# Match an actual shell heredoc: `cat >> "...SPRINT_REPORT.md" <<TAG`,
+# not prose commentary like `# No 'cat >> SPRINT_REPORT.md' here`. The
+# leading `# ` in a code-comment line is the disambiguator.
+if echo "$DEFER_BLOCK" | grep -E '^[[:space:]]*cat[[:space:]]+>>.*SPRINT_REPORT\.md.*<<' >/dev/null; then
+  fail "defer-all gate contains 'cat >> ...SPRINT_REPORT.md <<TAG' heredoc — re-opens the strand bug from #329"
+else
+  pass "defer-all gate has no 'cat >> SPRINT_REPORT.md <<' heredoc (strand bug from #329 stays closed)"
+fi
+
+# Same check for the partial-dispatch trim — kept symmetric per the
+# bug report's lean: defer events shouldn't go in SPRINT_REPORT.md.
+PARTIAL_BLOCK=$(awk '
+  /^### Live worktree count check \(partial-dispatch trim\)/{capture=1; next}
+  capture && /^### /{exit}
+  capture && /^## /{exit}
+  capture {print}
+' "$FI_SKILL")
+
+if echo "$PARTIAL_BLOCK" | grep -E '^[[:space:]]*cat[[:space:]]+>>.*SPRINT_REPORT\.md.*<<' >/dev/null; then
+  fail "partial-dispatch trim contains 'cat >> ...SPRINT_REPORT.md <<TAG' heredoc — should stay stderr-only for symmetry with defer-all"
+else
+  pass "partial-dispatch trim has no 'cat >> SPRINT_REPORT.md <<' heredoc (symmetric with defer-all)"
+fi
+
+# ─────────────────────────────────────────────────────────────────
 # Source/mirror parity (general invariant; pinned here so a broken
 # mirror surfaces in THIS test too, not only the conformance test).
 # ─────────────────────────────────────────────────────────────────

--- a/tests/test-fix-issues-worktree-cap.sh
+++ b/tests/test-fix-issues-worktree-cap.sh
@@ -205,23 +205,45 @@ if grep -qF 'git worktree list --porcelain' "$SKILL"; then
 else
   fail "Test 5c: gate uses worktree porcelain" "not found"
 fi
-if grep -qF 'branch refs/heads/fix[/-]issue-' "$SKILL"; then
-  pass "Test 5d: gate regex matches both fix/issue-NNN and fix-issue-NNN"
+# Gate regex — matches BOTH fix/issue-NNN and fix-issue-NNN. The shape
+# changed in the #329 follow-up from a single `grep -cE` to an
+# `awk`-then-`while` pipeline that also filters out `.landed status:
+# landed` worktrees, but the bracket-alternation literal that selects
+# the fix-branch lines is preserved.
+if grep -qF 'refs\/heads\/fix[/-]issue-' "$SKILL" || grep -qF 'refs/heads/fix[/-]issue-' "$SKILL"; then
+  pass "Test 5d: gate regex matches both fix/issue-NNN and fix-issue-NNN (awk or grep variant)"
 else
-  fail "Test 5d: gate regex" "not found"
+  fail "Test 5d: gate regex" "neither awk-escaped nor grep-form bracket alternation found"
 fi
 
-# Deferral path must append to SPRINT_REPORT.md (auditable) — match the
-# section heading literal.
+# Defer-path no longer writes to SPRINT_REPORT.md. The #329 follow-up
+# moved the cap-check ahead of the sprint worktree gate so a defer-all
+# exits before the worktree is created — appending to SPRINT_REPORT.md
+# from there would strand the write (Phase 6's sprint-level /land-pr
+# is past `exit 0`). The partial-dispatch trim drops the audit-write
+# for symmetry. Both paths are now stderr-only; the section-heading
+# literals from the old shape are negative pinned here.
 if grep -qF 'Sprint deferred — at live-worktree cap' "$SKILL"; then
-  pass "Test 5e: defer-all path writes auditable section to SPRINT_REPORT.md"
+  fail "Test 5e: defer-all path still writes 'Sprint deferred' to SPRINT_REPORT.md" "should have been dropped in the #329 follow-up (strand bug)"
 else
-  fail "Test 5e: defer-all SPRINT_REPORT.md write" "not found"
+  pass "Test 5e: defer-all path no longer appends to SPRINT_REPORT.md (strand bug from #329 closed)"
 fi
 if grep -qF 'Sprint partially deferred — at live-worktree cap' "$SKILL"; then
-  pass "Test 5f: partial-defer path writes auditable section to SPRINT_REPORT.md"
+  fail "Test 5f: partial-defer path still writes 'Sprint partially deferred' to SPRINT_REPORT.md" "should have been dropped for symmetry with defer-all"
 else
-  fail "Test 5f: partial-defer SPRINT_REPORT.md write" "not found"
+  pass "Test 5f: partial-defer path no longer appends to SPRINT_REPORT.md (symmetric with defer-all)"
+fi
+
+# Test 5g (new): predicate skips `.landed status: landed` worktrees.
+# This is the load-bearing behavioural change from #329 follow-up —
+# done-but-uncleaned worktrees no longer trip the cap. The schema
+# test/test-fix-issues-sprint-worktree-gate.sh has the full fixture
+# eval; here we pin the literal presence of the `.landed`-skip
+# branch in the predicate body.
+if grep -qF "grep -q '^status: landed'" "$SKILL"; then
+  pass "Test 5g: predicate skips '.landed status: landed' worktrees (cap-over-count bug from #320 closed)"
+else
+  fail "Test 5g: predicate skips '.landed status: landed' worktrees" "the grep against \$wt/.landed for 'status: landed' is missing — done-but-uncleaned worktrees will over-count toward the cap"
 fi
 
 # --- Test 6: two-cap distinction documented ---------------------------------


### PR DESCRIPTION
## Summary

Two co-located bugs in `skills/fix-issues/SKILL.md` sprint-mode cap-check (line ~1410 in the prior layout). Bug A introduced by PR #320 (closes #295), Bug B is a design-hole exposed by PR #329 (closes #325) — surfaced when the very first deferred sprint under #329's new gate stranded its SPRINT_REPORT.md write in a temporary worktree.

## Bugs

**Bug A — `LIVE_COUNT` over-counts.** Predicate counted ALL `fix/issue-*` worktrees regardless of `.landed status`. Post-merge worktrees that `/cleanup-merged` hadn't swept tripped the cap as if they were active work. Symptom: cap fires at `LIVE_COUNT=3` when actual active work is 0.

**Bug B — Defer-path strands `SPRINT_REPORT.md` write.** `if [ "$SLOTS" -le 0 ]` did `cat >> "$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md"` + `exit 0` AFTER the sprint-level worktree gate (line ~806) had created a worktree. The `$ZSKILLS_AUDIT_DIR` resolves into THAT worktree, so the append lands inside it. Phase 6's sprint-level `/land-pr` (added by #325) is past the `exit 0` — the worktree never ships. Violates #329's contract that all `SPRINT_REPORT.md` updates land via PR.

## Fix (Option A per user choice)

1. **Refined `LIVE_COUNT` predicate** — `awk` extracts each `fix[/-]issue-*` worktree's path; inner `while read` checks `$wt/.landed` for `^status: landed` and skips matches. Both PR-mode (`fix/issue-N`) and cherry-pick/direct-mode (`fix-issue-N`) branches covered. No `jq` (per project convention).

2. **Cap-check moved BEFORE the worktree gate.** Sprint-identity (line ~780) sets `PIPELINE_ID`; new "Live worktree count check (defer-all gate)" block runs at line 806, BEFORE `### Sprint worktree gate` at line 860. Defer-all exits with no worktree, no sentinel, no Phase 1 work.

3. **Partial-dispatch trim stays in Phase 3.** `SLOTS < N_REQUESTED but > 0` needs `TO_DISPATCH` (set by Phase 2 prioritization), so it splits off into a "Live worktree count check (partial-dispatch trim)" block at line ~1466. Cross-references in the Phase 3 paragraph updated.

4. **Both defer-arms drop the `cat >> SPRINT_REPORT.md` heredoc.** Stderr-only output (one line per defer). Defer events are transient; audit value is in real-dispatch sprints.

5. **Schema test updated** (`tests/test-fix-issues-sprint-worktree-gate.sh`):
   - Assertion 6: defer-all precedes the worktree gate; partial-dispatch trim follows it.
   - Assertion 7: fixture-driven `eval` of the new predicate against a 3-worktree fixture (1 landed, 1 active, 1 non-fix) confirms `LIVE_COUNT=1`.
   - Assertion 8: heredoc-grep verifies the dropped `cat >> SPRINT_REPORT.md` in both blocks.

6. **Sister test updated** (`tests/test-fix-issues-worktree-cap.sh`): scope-expansion the impl agent surfaced honestly. Tests 5d (regex-shape tolerant of new awk/grep idiom), 5e/5f (negative-pinned the dropped section headings), 5g new (positive-pinned the `grep -q '^status: landed'` literal). 19/19 PASS.

7. **`metadata.version` bump** `2026.05.17+64b77a`. Source/mirror byte-identical.

## Test plan

- [x] Full suite: **3191/3191 PASS** (`bash tests/run-all.sh`, exit 0).
- [x] Conformance: **404/404 PASS**; `fix-issues` rows green, hash match.
- [x] Gate-test fixture proves predicate skips a `status: landed` worktree.
- [x] Negative assertion proves defer-path no longer writes to SPRINT_REPORT.md.
- [x] No CLAUDE.md / docs / plans / other-skill changes.

## Related

- #295 — original framing of the aggregate-load cap (closed by PR #320).
- #325 — sprint-mode worktree-gate hole (closed by PR #329).
- The stranded-write incident: a deferred sprint earlier in this session created `/tmp/zskills-fix-issues-sprint-20260517-071039-cap` and left its 39-line deferral note unshipped. That worktree can now be removed manually (`git worktree remove --force`); this PR prevents the recurrence.
