### PR TITLE
do: fix-issues drop no-actionable strand + 3-empty-runs nag

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+64b77a"
+  version: "2026.05.17+b03c6e"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -1389,15 +1389,19 @@ If ALL candidates are too vague, too complex, or already attempted:
 
    **Only sync once per sprint.** If still empty after, proceed to step 2.
 
-2. **If still no actionable issues after refresh:**
-   - Write a minimal sprint section to `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`: `## Sprint —
-     YYYY-MM-DD HH:MM [UNFINALIZED]` with "No actionable issues found
-     (synced twice)" and the skip reasons.
-   - **Do NOT kill the cron** — new issues may be filed before the next run.
-   - After **3 consecutive empty runs**, add a note: "3 consecutive runs
-     with no actionable issues. Run `/fix-issues stop` if no new issues
-     are expected." Do NOT auto-stop — that's the user's call.
-   - **Exit.** Skip Phases 3-6.
+2. **If still no actionable issues after refresh:** emit one stderr
+   notice and exit 0 — the cron retries on the next fire. **Do NOT**
+   write to `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md` here (mirrors the
+   defer-all arm's stderr-only shape — Phase 5's sprint worktree gate
+   has not run yet at this point, but symmetry with the defer-all arm
+   from #331 keeps no-actionable events out of the report regardless).
+   The user decides when to stop the cron from cron list + recent PR
+   history signals; no nag counter, no marker, no read-back.
+
+   ```bash
+   echo "fix-issues: no actionable issues this fire (open=$OPEN_COUNT); cron will retry on next fire." >&2
+   exit 0
+   ```
 
 ### Post-prioritize tracking
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+64b77a"
+  version: "2026.05.17+b03c6e"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -1389,15 +1389,19 @@ If ALL candidates are too vague, too complex, or already attempted:
 
    **Only sync once per sprint.** If still empty after, proceed to step 2.
 
-2. **If still no actionable issues after refresh:**
-   - Write a minimal sprint section to `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md`: `## Sprint —
-     YYYY-MM-DD HH:MM [UNFINALIZED]` with "No actionable issues found
-     (synced twice)" and the skip reasons.
-   - **Do NOT kill the cron** — new issues may be filed before the next run.
-   - After **3 consecutive empty runs**, add a note: "3 consecutive runs
-     with no actionable issues. Run `/fix-issues stop` if no new issues
-     are expected." Do NOT auto-stop — that's the user's call.
-   - **Exit.** Skip Phases 3-6.
+2. **If still no actionable issues after refresh:** emit one stderr
+   notice and exit 0 — the cron retries on the next fire. **Do NOT**
+   write to `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md` here (mirrors the
+   defer-all arm's stderr-only shape — Phase 5's sprint worktree gate
+   has not run yet at this point, but symmetry with the defer-all arm
+   from #331 keeps no-actionable events out of the report regardless).
+   The user decides when to stop the cron from cron list + recent PR
+   history signals; no nag counter, no marker, no read-back.
+
+   ```bash
+   echo "fix-issues: no actionable issues this fire (open=$OPEN_COUNT); cron will retry on next fire." >&2
+   exit 0
+   ```
 
 ### Post-prioritize tracking
 

--- a/tests/test-fix-issues-sprint-worktree-gate.sh
+++ b/tests/test-fix-issues-sprint-worktree-gate.sh
@@ -286,6 +286,41 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────
+# Assertion 9: no-actionable arm does NOT `cat >> SPRINT_REPORT.md`.
+# Sibling strand bug to the defer-all arm (Assertion 8): the
+# no-actionable branch under `### If no actionable issues found`
+# previously wrote a `## Sprint — ... [UNFINALIZED]` section to
+# SPRINT_REPORT.md and `exit 0`. After PR #329's sprint worktree
+# gate, that write strands inside the sprint-level worktree and
+# never ships (Phase 6's sprint-level /land-pr is past the exit).
+# Pin the predicate negative so a future refactor cannot re-open
+# the strand. Also pins the "no nag counter" decision: any
+# `consecutive` / `empty run` references in the block would
+# indicate the dropped nag mechanism crept back in.
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== no-actionable arm does not append to SPRINT_REPORT.md (and no nag counter) ==="
+
+NO_ACT_BLOCK=$(awk '
+  /^### If no actionable issues found/{capture=1; next}
+  capture && /^### /{exit}
+  capture && /^## /{exit}
+  capture {print}
+' "$FI_SKILL")
+
+if echo "$NO_ACT_BLOCK" | grep -E '^[[:space:]]*cat[[:space:]]+>>.*SPRINT_REPORT\.md.*<<' >/dev/null; then
+  fail "no-actionable arm contains 'cat >> ...SPRINT_REPORT.md <<TAG' heredoc — re-opens the strand bug sibling to #331"
+else
+  pass "no-actionable arm has no 'cat >> SPRINT_REPORT.md <<' heredoc (strand bug sibling to #331 stays closed)"
+fi
+
+if echo "$NO_ACT_BLOCK" | grep -iE 'consecutive|empty run' >/dev/null; then
+  fail "no-actionable arm contains 'consecutive' / 'empty run' — the dropped 3-empty-runs nag mechanism crept back in"
+else
+  pass "no-actionable arm has no nag counter / 'consecutive empty runs' logic (per-user-judgment: commit noise)"
+fi
+
+# ─────────────────────────────────────────────────────────────────
 # Source/mirror parity (general invariant; pinned here so a broken
 # mirror surfaces in THIS test too, not only the conformance test).
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Sibling to PR #331's cap-defer strand fix. After PR #329's sprint-level worktree gate, `/fix-issues` Phase 2's no-actionable arm at `skills/fix-issues/SKILL.md:1392-1400` directed the agent to `cat >> $ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md` + `exit 0` — but the gate had already created a sprint-level worktree, so the write would land inside it and Phase 6's sprint-level `/land-pr` (past the `exit 0`) would never ship it. Identical shape to the cap-defer strand #331 closed.

## What changed

Per-user-judgment that no-actionable sections are commit noise:

- **Dropped the `cat >> SPRINT_REPORT.md` write entirely.** Replaced with one stderr line per fire:
  ```bash
  echo "fix-issues: no actionable issues this fire (open=$OPEN_COUNT); cron will retry on next fire." >&2
  exit 0
  ```
- **Removed the "3 consecutive empty runs → consider `/fix-issues stop`" nag.** Was a prose directive to count `## Sprint — ... no actionable` sections in SPRINT_REPORT.md and surface a hint. Counts the same skip-class items every fire (noise); user can read cron list + recent PR history to decide when to stop the cron.

## Test additions (`tests/test-fix-issues-sprint-worktree-gate.sh`)

- **Assertion 10**: no-actionable arm has no `cat >>.*SPRINT_REPORT.md.*<<` heredoc (mirrors Assertion 8's cap-defer pattern from PR #331).
- **Assertion 11**: no-actionable arm has no `consecutive` / `empty run` references (pins the dropped nag).
- Schema test total: 16 assertions, was 14.

## Test plan

- [x] Full suite: 3193/3193 passing both pre-commit AND post-commit (caught local-vs-CI parity gap from PR #332's CI bite — running post-commit makes Tier-1 drift + case 6c invariants visible locally).
- [x] Conformance: `metadata.version=2026.05.17+b03c6e`, hash match, source/mirror byte-identical.
- [x] Scope: 3 files (SKILL.md + mirror + schema test). No CLAUDE.md/docs/plans/other-skill changes.
- [x] No `--no-verify`.

## Related

- PR #331 — cap-defer strand fix (canonical pattern this mirrors).
- PR #329 — sprint-mode worktree gate that introduced the strand failure mode.
- The 2 stranded sprint-level worktrees from this session (`/tmp/zskills-fix-issues-sprint-20260517-{071039-cap,080452-326}`) document the same failure mode the no-actionable arm would otherwise produce.
