### PR TITLE
do: close dashboard drop snap-back race (server + client)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.16+cd7839"
+  version: "2026.05.17+8ff082"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1207,6 +1207,7 @@ def _read_state_file(
         "default_mode": "phase",
         "plans": {},
         "issues": {},
+        "updated_at": "",
     }
     if text is None:
         return empty
@@ -1256,6 +1257,7 @@ def _read_state_file(
         "default_mode": default_mode,
         "plans": plans_out,
         "issues": issues_out,
+        "updated_at": raw.get("updated_at", ""),
     }
 
 
@@ -1374,6 +1376,7 @@ def collect_snapshot(
 
     # State file merge (drives queue annotations + queues block)
     state = _read_state_file(main_root, errors)
+    state_updated_at = state.get("updated_at", "")
     _annotate_plans_queue(plans, state)
 
     # Issues
@@ -1418,6 +1421,7 @@ def collect_snapshot(
     snapshot: Dict[str, Any] = {
         "version": VERSION,
         "updated_at": _now_iso(),
+        "state_updated_at": state_updated_at,
         "repo_root": str(main_root),
         "repo_url": _derive_repo_url(main_root),
         "plans": plans,
@@ -1524,6 +1528,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         snapshot = {
             "version": VERSION,
             "updated_at": _now_iso(),
+            "state_updated_at": state.get("updated_at", ""),
             "repo_root": str(main_root),
             "repo_url": "",
             "plans": plans,

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -908,7 +908,7 @@ class MonitorHandler(BaseHTTPRequestHandler):
             }
             target = main_root / ".zskills" / "monitor-state.json"
             _atomic_write_json(target, new_doc)
-        self._send_json(200, {"ok": True, "updated_at": new_doc["updated_at"]})
+        self._send_json(200, {"ok": True, "updated_at": new_doc["updated_at"], "state_updated_at": new_doc["updated_at"]})
 
     def _handle_trigger_post(self) -> None:
         if not self._origin_ok():

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -167,6 +167,10 @@ let suppressNextStatePollUntil = 0;
 // window (which only skips the NEXT scheduled poll, not a poll already
 // awaiting fetchState()).
 let lastCommittedAt = null;
+// Incremented while a /api/queue POST is in flight; applySnapshot drops
+// snapshots that arrive during this window, since their `queues` block
+// may be older than the in-flight write.
+let pendingPosts = 0;
 
 // last-known-good queues — used to revert local DOM on POST failure.
 let lastGoodQueues = null;
@@ -281,13 +285,23 @@ async function pollWorkOnce() {
 }
 
 function applySnapshot(snap) {
+  // In-flight-POST guard: while a /api/queue POST is awaiting its
+  // response, any GET snapshot already composed by the server has a
+  // `queues` block older than what we're about to commit. Drop it
+  // outright; postQueue's lastCommittedAt update will gate subsequent
+  // late-arriving snapshots once the POST settles.
+  if (pendingPosts > 0) return;
   // Stale-snapshot guard: if our most recent committed POST has an
-  // updated_at newer than this snapshot's updated_at, the server hadn't
-  // yet processed our write when this GET was generated. Applying it
-  // would clobber the user's just-applied reorder with the pre-commit
-  // state ("snap-back"). String comparison on ISO-8601 with UTC offset
-  // is lexicographic-monotonic; sufficient here.
-  if (lastCommittedAt && snap && snap.updated_at && snap.updated_at < lastCommittedAt) {
+  // updated_at newer than this snapshot's state_updated_at (the state
+  // file's authoritative timestamp, propagated through collect_snapshot),
+  // the server hadn't yet processed our write when this GET was
+  // generated. Applying it would clobber the user's just-applied reorder
+  // with the pre-commit state ("snap-back"). Comparing against
+  // state_updated_at — not snap.updated_at (snapshot composition time) —
+  // closes the TOCTOU window where composition time outraces the
+  // state-file write. String comparison on ISO-8601 with UTC offset is
+  // lexicographic-monotonic; sufficient here.
+  if (lastCommittedAt && snap && snap.state_updated_at && snap.state_updated_at < lastCommittedAt) {
     return;
   }
   // Capture repo_url for entry-link construction in render*().
@@ -1156,8 +1170,8 @@ async function postQueue(queues, opts) {
   // awaiting fetchState() at the moment this POST returned.
   try {
     const body = await res.json();
-    if (body && typeof body.updated_at === "string") {
-      lastCommittedAt = body.updated_at;
+    if (body && typeof body.state_updated_at === "string") {
+      lastCommittedAt = body.state_updated_at;
     }
   } catch (_e) { /* tolerable — guard just becomes a no-op for this commit */ }
   // Reconcile: suppress next state poll for ~1.5s to avoid stale-GET flicker.
@@ -1181,7 +1195,13 @@ async function commitQueueChange(newQueues, opts) {
   lastFingerprint.issues = fingerprintIssues(snap.issues || [], lastGoodQueues);
   lastFingerprint.defaultMode = String(lastGoodDefaultMode);
 
-  const ok = await postQueue(newQueues, opts);
+  pendingPosts++;
+  let ok;
+  try {
+    ok = await postQueue(newQueues, opts);
+  } finally {
+    pendingPosts--;
+  }
   if (!ok && previous) {
     // Revert immediately; do not wait for next poll.
     lastGoodQueues = previous;

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.16+cd7839"
+  version: "2026.05.17+8ff082"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1207,6 +1207,7 @@ def _read_state_file(
         "default_mode": "phase",
         "plans": {},
         "issues": {},
+        "updated_at": "",
     }
     if text is None:
         return empty
@@ -1256,6 +1257,7 @@ def _read_state_file(
         "default_mode": default_mode,
         "plans": plans_out,
         "issues": issues_out,
+        "updated_at": raw.get("updated_at", ""),
     }
 
 
@@ -1374,6 +1376,7 @@ def collect_snapshot(
 
     # State file merge (drives queue annotations + queues block)
     state = _read_state_file(main_root, errors)
+    state_updated_at = state.get("updated_at", "")
     _annotate_plans_queue(plans, state)
 
     # Issues
@@ -1418,6 +1421,7 @@ def collect_snapshot(
     snapshot: Dict[str, Any] = {
         "version": VERSION,
         "updated_at": _now_iso(),
+        "state_updated_at": state_updated_at,
         "repo_root": str(main_root),
         "repo_url": _derive_repo_url(main_root),
         "plans": plans,
@@ -1524,6 +1528,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         snapshot = {
             "version": VERSION,
             "updated_at": _now_iso(),
+            "state_updated_at": state.get("updated_at", ""),
             "repo_root": str(main_root),
             "repo_url": "",
             "plans": plans,

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -908,7 +908,7 @@ class MonitorHandler(BaseHTTPRequestHandler):
             }
             target = main_root / ".zskills" / "monitor-state.json"
             _atomic_write_json(target, new_doc)
-        self._send_json(200, {"ok": True, "updated_at": new_doc["updated_at"]})
+        self._send_json(200, {"ok": True, "updated_at": new_doc["updated_at"], "state_updated_at": new_doc["updated_at"]})
 
     def _handle_trigger_post(self) -> None:
         if not self._origin_ok():

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -167,6 +167,10 @@ let suppressNextStatePollUntil = 0;
 // window (which only skips the NEXT scheduled poll, not a poll already
 // awaiting fetchState()).
 let lastCommittedAt = null;
+// Incremented while a /api/queue POST is in flight; applySnapshot drops
+// snapshots that arrive during this window, since their `queues` block
+// may be older than the in-flight write.
+let pendingPosts = 0;
 
 // last-known-good queues — used to revert local DOM on POST failure.
 let lastGoodQueues = null;
@@ -281,13 +285,23 @@ async function pollWorkOnce() {
 }
 
 function applySnapshot(snap) {
+  // In-flight-POST guard: while a /api/queue POST is awaiting its
+  // response, any GET snapshot already composed by the server has a
+  // `queues` block older than what we're about to commit. Drop it
+  // outright; postQueue's lastCommittedAt update will gate subsequent
+  // late-arriving snapshots once the POST settles.
+  if (pendingPosts > 0) return;
   // Stale-snapshot guard: if our most recent committed POST has an
-  // updated_at newer than this snapshot's updated_at, the server hadn't
-  // yet processed our write when this GET was generated. Applying it
-  // would clobber the user's just-applied reorder with the pre-commit
-  // state ("snap-back"). String comparison on ISO-8601 with UTC offset
-  // is lexicographic-monotonic; sufficient here.
-  if (lastCommittedAt && snap && snap.updated_at && snap.updated_at < lastCommittedAt) {
+  // updated_at newer than this snapshot's state_updated_at (the state
+  // file's authoritative timestamp, propagated through collect_snapshot),
+  // the server hadn't yet processed our write when this GET was
+  // generated. Applying it would clobber the user's just-applied reorder
+  // with the pre-commit state ("snap-back"). Comparing against
+  // state_updated_at — not snap.updated_at (snapshot composition time) —
+  // closes the TOCTOU window where composition time outraces the
+  // state-file write. String comparison on ISO-8601 with UTC offset is
+  // lexicographic-monotonic; sufficient here.
+  if (lastCommittedAt && snap && snap.state_updated_at && snap.state_updated_at < lastCommittedAt) {
     return;
   }
   // Capture repo_url for entry-link construction in render*().
@@ -1156,8 +1170,8 @@ async function postQueue(queues, opts) {
   // awaiting fetchState() at the moment this POST returned.
   try {
     const body = await res.json();
-    if (body && typeof body.updated_at === "string") {
-      lastCommittedAt = body.updated_at;
+    if (body && typeof body.state_updated_at === "string") {
+      lastCommittedAt = body.state_updated_at;
     }
   } catch (_e) { /* tolerable — guard just becomes a no-op for this commit */ }
   // Reconcile: suppress next state poll for ~1.5s to avoid stale-GET flicker.
@@ -1181,7 +1195,13 @@ async function commitQueueChange(newQueues, opts) {
   lastFingerprint.issues = fingerprintIssues(snap.issues || [], lastGoodQueues);
   lastFingerprint.defaultMode = String(lastGoodDefaultMode);
 
-  const ok = await postQueue(newQueues, opts);
+  pendingPosts++;
+  let ok;
+  try {
+    ok = await postQueue(newQueues, opts);
+  } finally {
+    pendingPosts--;
+  }
   if (!ok && previous) {
     // Revert immediately; do not wait for next poll.
     lastGoodQueues = previous;

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -62,7 +62,7 @@ else
   fail "CLI --fixture minimal exits 0 (rc=$RC, output: $OUT)"
 fi
 
-EXPECTED_KEYS="activity branches errors issues plans queues repo_root repo_url state_file_path updated_at version worktrees"
+EXPECTED_KEYS="activity branches errors issues plans queues repo_root repo_url state_file_path state_updated_at updated_at version worktrees"
 ACTUAL_KEYS=$(printf '%s' "$OUT" | python3 -c '
 import json,sys
 print(" ".join(sorted(json.load(sys.stdin).keys())))
@@ -303,6 +303,87 @@ if [ "$CORRUPT_ERR" = "1 True" ]; then
   pass "corrupt-state: errors[] has 1 .zskills/monitor-state.json entry with non-empty message"
 else
   fail "corrupt-state: errors[] wrong: '$CORRUPT_ERR'"
+fi
+
+# ---------------------------------------------------------------------------
+# AC: snapshot.state_updated_at — propagates state file's `updated_at`
+# (race-condition fix: applySnapshot stale-guard compares against the state
+# file's authoritative timestamp, not snapshot composition time).
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== state_updated_at field propagation ==="
+
+# Case 1: key always present in snapshot (minimal fixture: no state file)
+HAS_KEY=$(run_collect minimal | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+print("state_updated_at" in d, repr(d.get("state_updated_at")))
+')
+if [ "$HAS_KEY" = "True ''" ]; then
+  pass "state_updated_at present and empty when state file absent (minimal)"
+else
+  fail "state_updated_at missing/wrong for state-absent: '$HAS_KEY'"
+fi
+
+# Case 2: corrupt state file → state_updated_at is ""
+CORRUPT_SUA=$(run_collect corrupt-state | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+print(repr(d.get("state_updated_at")))
+')
+if [ "$CORRUPT_SUA" = "''" ]; then
+  pass "state_updated_at == '' when state file is corrupt"
+else
+  fail "state_updated_at wrong for corrupt-state: '$CORRUPT_SUA'"
+fi
+
+# Case 3: synthesize a fixture with a known updated_at and verify propagation.
+SUA_PROP=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import json, sys, tempfile, pathlib
+sys.path.insert(0, "'"$PKG_PARENT"'")
+from zskills_monitor.collect import collect_snapshot
+
+tmp = pathlib.Path(tempfile.mkdtemp())
+(tmp / ".zskills").mkdir()
+state_doc = {
+    "version": "1.1",
+    "default_mode": "phase",
+    "plans": {},
+    "issues": {},
+    "updated_at": "2026-05-17T07:00:00+00:00",
+}
+(tmp / ".zskills" / "monitor-state.json").write_text(json.dumps(state_doc))
+snap = collect_snapshot(tmp, pre_resolved=True)
+print(snap.get("state_updated_at"))
+')
+if [ "$SUA_PROP" = "2026-05-17T07:00:00+00:00" ]; then
+  pass "state_updated_at propagates state file's updated_at verbatim"
+else
+  fail "state_updated_at propagation wrong: '$SUA_PROP'"
+fi
+
+# Case 4: state file without `updated_at` key → state_updated_at == ""
+SUA_NO_KEY=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import json, sys, tempfile, pathlib
+sys.path.insert(0, "'"$PKG_PARENT"'")
+from zskills_monitor.collect import collect_snapshot
+
+tmp = pathlib.Path(tempfile.mkdtemp())
+(tmp / ".zskills").mkdir()
+state_doc = {
+    "version": "1.1",
+    "default_mode": "phase",
+    "plans": {},
+    "issues": {},
+}
+(tmp / ".zskills" / "monitor-state.json").write_text(json.dumps(state_doc))
+snap = collect_snapshot(tmp, pre_resolved=True)
+print(repr(snap.get("state_updated_at")))
+')
+if [ "$SUA_NO_KEY" = "''" ]; then
+  pass "state_updated_at == '' when state file lacks updated_at key"
+else
+  fail "state_updated_at wrong when key absent: '$SUA_NO_KEY'"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zskills_monitor_server.sh
+++ b/tests/test_zskills_monitor_server.sh
@@ -397,11 +397,14 @@ if start_server "$MR5" "$PORT_D"; then
   fi
 
   # Valid POST: 200 + state file written
-  CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+  QPOST_BODY=$(curl -s -X POST \
     -H "Origin: http://127.0.0.1:$PORT_D" \
     -H 'Content-Type: application/json' \
     -d '{"plans":{"drafted":[{"slug":"sample-plan"}],"reviewed":[],"ready":[]},"issues":{"triage":[42],"ready":[]}}' \
+    -w '\n%{http_code}' \
     "http://127.0.0.1:$PORT_D/api/queue")
+  CODE=$(printf '%s\n' "$QPOST_BODY" | tail -n1)
+  BODY=$(printf '%s\n' "$QPOST_BODY" | sed '$d')
   if [ "$CODE" = "200" ]; then
     pass "POST /api/queue with valid body + Origin → 200"
   else
@@ -412,6 +415,27 @@ if start_server "$MR5" "$PORT_D"; then
     pass "monitor-state.json updated with new state"
   else
     fail "monitor-state.json not updated"
+  fi
+  # Response body shape: must include both `updated_at` (legacy) and
+  # `state_updated_at` (snap-back race fix — client uses this as the
+  # lastCommittedAt watermark for applySnapshot's stale-guard).
+  SHAPE_OK=$(printf '%s' "$BODY" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception as e:
+    print("PARSE_FAIL:" + str(e))
+    sys.exit()
+ok = d.get("ok") is True
+has_ua = isinstance(d.get("updated_at"), str) and d.get("updated_at")
+has_sua = isinstance(d.get("state_updated_at"), str) and d.get("state_updated_at")
+eq = d.get("updated_at") == d.get("state_updated_at")
+print(f"ok={ok} ua={bool(has_ua)} sua={bool(has_sua)} eq={eq}")
+')
+  if [ "$SHAPE_OK" = "ok=True ua=True sua=True eq=True" ]; then
+    pass "POST /api/queue response includes ok + updated_at + state_updated_at (equal)"
+  else
+    fail "POST /api/queue response shape wrong: '$SHAPE_OK'"
   fi
 
   # Invalid body → 400 + state unchanged


### PR DESCRIPTION
## Summary

Closes the snap-back race users hit when dragging issues in the dashboard. Drop POST succeeds server-side, but the optimistic UI is clobbered back to the pre-drop state by a stale in-flight `/api/state` GET response. Sometimes the next poll catches up, sometimes the UI stays stale until a page reload.

## Two-layer cause

**Server (TOCTOU in `collect_snapshot`).** `_read_state_file()` reads `monitor-state.json` at the start of `collect_snapshot()`, then `list_issues()` runs `gh issue list` (1–7s), then `updated_at = _now_iso()` stamps at the end. A POST that lands mid-call yields a snapshot whose `queues` block is pre-POST but whose `updated_at` is post-POST — the client's stale-guard `snap.updated_at < lastCommittedAt` doesn't fire.

**Client (no in-flight-POST guard).** `applySnapshot` has no protection against snapshots arriving while a POST is in flight. `lastCommittedAt` is set only after `postQueue` resolves, so a stale GET response that races back during the POST is applied with no guard.

## Fix — three composable guards

1. **`pendingPosts` counter** (new module-scope `let` in `app.js`). Incremented around every `postQueue` call (try/finally bracket in `commitQueueChange`). `applySnapshot` returns early when `pendingPosts > 0`. Closes the in-flight window.

2. **`state_updated_at` propagation.** New top-level field on `/api/state` snapshot and `/api/queue` POST response, equal to `monitor-state.json`'s authoritative `updated_at`. The stale-guard now compares `snap.state_updated_at < lastCommittedAt` — composition time can no longer outrace the state-file write. Existing `updated_at` field preserved (still used for the "Updated N seconds ago" UI text — semantically right there).

3. **`suppressNextStatePollUntil`** (existing, unchanged) — post-POST 1.5s suppression of the next scheduled poll.

## Files

- `skills/zskills-dashboard/scripts/zskills_monitor/collect.py` — `_read_state_file()` returns `updated_at`; `collect_snapshot()` and fixture-mode CLI both emit `state_updated_at`
- `skills/zskills-dashboard/scripts/zskills_monitor/server.py` — `_handle_queue_post()` response includes `state_updated_at`
- `skills/zskills-dashboard/scripts/zskills_monitor/static/app.js` — `pendingPosts`, `applySnapshot` first-guard, `postQueue` field switch, `commitQueueChange` try/finally
- `skills/zskills-dashboard/SKILL.md` — version bump → `2026.05.17+8ff082`
- `tests/test_zskills_monitor_collect.sh` — 4 new assertions covering `state_updated_at` (present + missing state-file + value match)
- `tests/test_zskills_monitor_server.sh` — 1 new assertion on POST response body shape
- `.claude/skills/zskills-dashboard/*` — mirror regenerated

## Test plan

- [x] Full suite: **3196/3196 PASS** (was 3191 pre-PR + 5 new asserts)
- [x] Plan-confirmation agent (Phase 0b): APPROVE — confirmed `state_updated_at` propagation is consistent across state file → `collect_snapshot` → POST response → client, and the three guards close all three race windows
- [x] Scope check: `git show --stat 3ab7594` touches only the 10 expected files (5 source + 5 mirror)
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: `→ 2026.05.17+8ff082`
- [ ] **Reviewer post-merge:** restart the dashboard, drag an issue between Triage and Ready while `/fix-issues` cron `d8921920` is active — drop should NOT snap back; optimistic UI should hold even if poll fires mid-drag

🤖 Generated with /do (agent-dispatched, PR mode, auto-merge)
