### PR TITLE
Fix #335: /fix-issues sync Step 5 git add -A fails loud (drop || true)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+9dcfe6"
+  version: "2026.05.17+f1cb8a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -482,7 +482,13 @@ auto-merge completes will close them.
        fi
        if [ -n "$ISSUES_REL" ]; then
          # Add only modified/new tracker files; -A scoped to the issues dir.
-         git -C "$TOPLEVEL" add -A "$ISSUES_REL" 2>/dev/null || true
+         # Fail loud: if git add fails (permissions, repo corruption, race
+         # against another writer), the tracker would desync from the
+         # working tree and sync would silently proceed — abort instead.
+         if ! git -C "$TOPLEVEL" add -A "$ISSUES_REL"; then
+           echo "fix-issues: git add -A $ISSUES_REL failed under $TOPLEVEL — aborting sync." >&2
+           exit 1
+         fi
        fi
      fi
      STAGED=$(git -C "$TOPLEVEL" diff --cached --name-only)

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+9dcfe6"
+  version: "2026.05.17+f1cb8a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -482,7 +482,13 @@ auto-merge completes will close them.
        fi
        if [ -n "$ISSUES_REL" ]; then
          # Add only modified/new tracker files; -A scoped to the issues dir.
-         git -C "$TOPLEVEL" add -A "$ISSUES_REL" 2>/dev/null || true
+         # Fail loud: if git add fails (permissions, repo corruption, race
+         # against another writer), the tracker would desync from the
+         # working tree and sync would silently proceed — abort instead.
+         if ! git -C "$TOPLEVEL" add -A "$ISSUES_REL"; then
+           echo "fix-issues: git add -A $ISSUES_REL failed under $TOPLEVEL — aborting sync." >&2
+           exit 1
+         fi
        fi
      fi
      STAGED=$(git -C "$TOPLEVEL" diff --cached --name-only)

--- a/tests/test-fix-issues-sprint-worktree-gate.sh
+++ b/tests/test-fix-issues-sprint-worktree-gate.sh
@@ -367,6 +367,34 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────
+# Assertion 11: sync Step 5 `git add -A "$ISSUES_REL"` must fail
+# loud (issue #335). The original pattern
+#   `git -C "$TOPLEVEL" add -A "$ISSUES_REL" 2>/dev/null || true`
+# suppressed both stderr AND the exit status, so a real failure
+# (permissions, repo corruption, race) silently desynced the
+# tracker from the working tree while sync proceeded as if nothing
+# happened — direct violation of CLAUDE.md's "never suppress
+# errors on operations you need to verify" rule.
+# Pin: the literal suppression pattern is GONE, and the line is
+# now guarded by an `if ! git ... add -A "$ISSUES_REL"; then ...
+# exit 1; fi` block.
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== sync Step 5 git add -A fails loud (issue #335) ==="
+
+if grep -E 'git -C "\$TOPLEVEL" add -A "\$ISSUES_REL" 2>/dev/null \|\| true' "$FI_SKILL" >/dev/null; then
+  fail "sync Step 5 still uses suppressed 'git add -A ... 2>/dev/null || true' pattern (#335 regression)"
+else
+  pass "sync Step 5 no longer suppresses 'git add -A \$ISSUES_REL' errors"
+fi
+
+if grep -E 'if ! git -C "\$TOPLEVEL" add -A "\$ISSUES_REL"; then' "$FI_SKILL" >/dev/null; then
+  pass "sync Step 5 guards 'git add -A \$ISSUES_REL' with 'if ! ...; then exit 1; fi'"
+else
+  fail "sync Step 5 missing 'if ! git ... add -A \$ISSUES_REL; then ... fi' fail-loud guard"
+fi
+
+# ─────────────────────────────────────────────────────────────────
 # Source/mirror parity (general invariant; pinned here so a broken
 # mirror surfaces in THIS test too, not only the conformance test).
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #335

## Summary
`skills/fix-issues/SKILL.md:485` had `git -C "$TOPLEVEL" add -A "$ISSUES_REL" 2>/dev/null || true` — a clean CLAUDE.md "Never suppress errors on operations you need to verify" violation.

## Changes
- `skills/fix-issues/SKILL.md` (+ mirror): replace the suppression with an explicit guard:
  ```bash
  if ! git -C "$TOPLEVEL" add -A "$ISSUES_REL"; then
    echo "fix-issues: git add -A $ISSUES_REL failed under $TOPLEVEL — aborting sync." >&2
    exit 1
  fi
  ```
- Preceding lines (479-482) already validate `$ISSUES_REL` is non-empty + a relative path inside `$TOPLEVEL`, so a failure here is a real signal (permissions, repo corruption, race with another writer) — abort instead of swallowing.
- `tests/test-fix-issues-sprint-worktree-gate.sh`: Assertion 11 (2 sub-asserts) pins the fix — literal `|| true` pattern absent + new guard present.
- `metadata.version` bumped to `2026.05.17+f1cb8a`.

## Out-of-scope (flagged)
- Line 445 (`cd "$WT_PATH" 2>/dev/null || true`): defensive cwd preamble; different class.
- Line 1508 (bare `git add -A` in no-actionable arm): already fails loud.
- Realpath portability concerns: existing code has explicit fallback variables, not suppression.

## Test plan
- [x] Full suite: 3283/3283 passing **pre AND post-commit** (Tier-1 + case 6c invariants check committed state — local-vs-CI parity).
- [x] Schema test: 22/22 (was 20).
- [x] Source/mirror byte-identical; hash `f1cb8a` matches `metadata.version`.
