### PR TITLE
Fix #339: skill description budget test — relabel chars to bytes (LC_ALL=C semantics)

### DIFF
--- a/references/skill-description-budget.md
+++ b/references/skill-description-budget.md
@@ -29,15 +29,23 @@ Anthropic's published skill-development guidance suggests roughly
 to ~30 skills, that's ~3,000 words ≈ ~12,000 tokens ≈ ~6% of a 200k
 context.
 
-This project's chosen target is tighter: ~7,500 chars ≈ ~1,875 tokens
+This project's chosen target is tighter: ~7,500 bytes ≈ ~1,875 tokens
 ≈ <1% of context. The motivation is to leave headroom for skill growth
 (more skills, occasional necessary description expansion) without
 crossing the threshold where descriptions begin meaningfully crowding
 out task context.
 
-- **Hard cap: 7,500 chars** — test exits 1 above.
-- **Soft warn: 7,000 chars** — test prints WARN, exits 0 between 7,000
+- **Hard cap: 7,500 bytes** — test exits 1 above.
+- **Soft warn: 7,000 bytes** — test prints WARN, exits 0 between 7,000
   and 7,500.
+
+Units note: the budget and the enforcing test count BYTES, not
+characters. The test runs under `LC_ALL=C` and uses bash `${#var}`,
+which is a byte count in the C locale. Multibyte UTF-8 code points
+(e.g. em-dash U+2014 = 3 bytes) contribute more than one byte each.
+Bytes are the right proxy for token/context cost on the wire, and a
+byte count avoids an awk/python detour for what bash measures natively.
+See issue #339 for history.
 
 Both thresholds are project policy, not Anthropic mandates. The
 two-tier design (vs. a single hard cap) ensures that growth into the
@@ -46,15 +54,15 @@ hard-fails CI, giving authors one round of warning to trim.
 
 ## 3. Per-skill ceiling
 
-Normal-case skills aim for **≤ 350 chars** in their description.
+Normal-case skills aim for **≤ 350 bytes** in their description.
 Documented exceptions:
 
-- **`/land-pr` — 450 chars.** Helper-only contract from PR #173.
+- **`/land-pr` — 450 bytes.** Helper-only contract from PR #173.
   The description carries explicit "designed for agent dispatch /
   not for interactive human use" framing to prevent humans from
   invoking it directly; that framing is non-negotiable and pushes
   the description over the 350 default.
-- **`/quickfix` — 400 chars.** Full-lifecycle framing from PR #164.
+- **`/quickfix` — 400 bytes.** Full-lifecycle framing from PR #164.
   The description enumerates the multi-stage workflow (research →
   fix → land) to disambiguate quickfix from neighboring one-shot
   skills; the enumeration earns the additional budget.
@@ -98,7 +106,7 @@ Two tests in `tests/`:
   pure bash + awk; no jq. Extracts `description:` from every source
   SKILL.md, handling both block-scalar (`description: >-` + indented
   continuation) and single-line (`description: <text>`) forms.
-  Computes the total char count. Hard-fails above 7,500; soft-warns
+  Computes the total byte count. Hard-fails above 7,500; soft-warns
   between 7,000 and 7,500. Registered in `tests/run-all.sh` between
   the content-hash and version-compare entries.
 - **`tests/test-skill-conformance.sh`** — literal-grep checks for

--- a/tests/test-skill-description-budget.sh
+++ b/tests/test-skill-description-budget.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
-# Asserts total `description:` chars across all source SKILL.md files
+# Asserts total `description:` bytes across all source SKILL.md files
 # (skills/*/SKILL.md and block-diagram/*/SKILL.md, excluding screenshots/).
 # Two-tier budget: hard-fail above 7500, soft-warn between 7000 and 7500.
 # Per-skill breakdown emitted for diagnosis.
 #
-# Background: ~7500 chars ≈ 1875 tokens ≈ <1% of 200k context. The
+# Units note: the script runs under LC_ALL=C and uses bash `${#var}`,
+# which counts BYTES (not characters) in the C locale. Multibyte UTF-8
+# code points (e.g. em-dash U+2014 = 3 bytes) therefore contribute more
+# than one to the total. We report and budget in bytes — both because
+# bytes are what bash measures cheaply without an awk/python detour and
+# because byte-count is the right proxy for token-context cost on the
+# wire. A future trimmer chasing a budget overage should think in bytes,
+# not characters. See issue #339.
+#
+# Background: ~7500 bytes ≈ 1875 tokens ≈ <1% of 200k context. The
 # project's design target chosen to honor the published Anthropic
 # skill-development guidance of ~100 words/skill, scaled to ~30 skills,
 # leaving headroom in the 200k context budget for descriptions. This is
@@ -79,20 +88,20 @@ for f in $(find skills block-diagram -mindepth 2 -maxdepth 2 -name SKILL.md | so
   TOTAL=$((TOTAL + n))
 done
 
-# Emit per-skill breakdown sorted by chars desc.
-echo "# skill-description-budget per-skill breakdown"
+# Emit per-skill breakdown sorted by bytes desc.
+echo "# skill-description-budget per-skill breakdown (bytes)"
 for name in "${!PER_SKILL[@]}"; do
   printf '%5d  %s\n' "${PER_SKILL[$name]}" "$name"
 done | sort -nr
 
 echo "----"
-echo "TOTAL: $TOTAL chars (warn_at: $WARN_AT, hard_cap: $CAP)"
+echo "TOTAL: $TOTAL bytes (warn_at: $WARN_AT, hard_cap: $CAP)"
 
 if (( TOTAL > CAP )); then
-  echo "FAIL: total description chars $TOTAL exceeds hard cap $CAP" >&2
+  echo "FAIL: total description bytes $TOTAL exceeds hard cap $CAP" >&2
   exit 1
 fi
 if (( TOTAL > WARN_AT )); then
-  echo "WARN: total description chars $TOTAL is between warn-at $WARN_AT and hard cap $CAP — trim before next addition" >&2
+  echo "WARN: total description bytes $TOTAL is between warn-at $WARN_AT and hard cap $CAP — trim before next addition" >&2
 fi
 echo "PASS"


### PR DESCRIPTION
Fixes #339

## Summary
`tests/test-skill-description-budget.sh` uses `LC_ALL=C` + bash `${#var}` (which natively count bytes), but labelled output as "chars". Multibyte characters (em-dashes etc.) reported as 3 bytes instead of 1 char, inflating per-skill and total counts in the test report.

## Choice: relabel "chars" → "bytes" (cheaper fix)
Per the issue body: "labelling is the cheaper fix and matches the implementation reality." Byte count is the right proxy for context cost anyway (shipped JSON has byte limits, not char limits). No counting-mechanism change.

## Changes
- `tests/test-skill-description-budget.sh`: header comment, output lines (`per-skill breakdown (bytes)`, `TOTAL: $TOTAL bytes (...)`), FAIL/WARN messages all relabelled chars → bytes. Added Units note explaining `LC_ALL=C` + `${#var}` byte semantics, citing this issue.
- `references/skill-description-budget.md`: §2 thresholds (7,500 chars → 7,500 bytes), §3 per-skill ceilings (350/450/400 chars → bytes), §5 wording ("total char count" → "total byte count"). Added Units paragraph.

## Numeric values unchanged
- Per-skill counts: same.
- TOTAL: `6874 bytes (warn_at: 7000, hard_cap: 7500)` — same as before, just relabelled.

## Out-of-scope
The issue's "Bonus" section suggests adding `tests/test-skill-trigger-keywords.sh`. Not done here; it's a separate test addition the issue marks as a future suggestion.

## Test plan
- [x] Full suite: 3281/3281 passing.
- [x] Isolated test PASS with new labels.
- [x] `references/skill-description-budget.md` is at repo root (NOT under any skill dir) — no SKILL.md cascade, no version bump needed.
