### PR TITLE
chore(quickfix): drop --foo migration redirects (premature backcompat)

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.17+1167bf"
+  version: "2026.05.17+7aa3f0"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -64,11 +64,7 @@ at parse time — mode detection (WI 1.5) decides whether it is fatal.
 - **force** (optional) — bypass a triage REDIRECT verdict (WI 1.5.4) and
   proceed with `/quickfix` anyway.
 
-The legacy `--yes` / `-y` flag was removed; WI 1.5.5's confirmation
-prompt is bypassed when `AUTO_FLAG=1`. The legacy `--`-prefixed forms of
-`from-here`, `skip-tests`, `force` were converted to positional tokens;
-invoking them in the `--` form now hard-stops with a corrective error
-(see migration redirects in the parser case statement below).
+WI 1.5.5's confirmation prompt is bypassed when `AUTO_FLAG=1`.
 
 ```bash
 # Entry-point unset guard for the model-layer test seam. Without the
@@ -92,27 +88,6 @@ i=0
 while [ $i -lt ${#ARGS[@]} ]; do
   arg="${ARGS[$i]}"
   case "$arg" in
-    # --- Migration redirects (MUST be first; per WI 4.2 ordering invariant) ---
-    # These arms catch legacy `--`-prefixed forms that were removed (--yes)
-    # or converted to positional tokens (--from-here / --skip-tests / --force)
-    # in Phase 4. They MUST stay at the TOP of the case statement so the
-    # legacy invocations cannot fall through to `*)` and become silent
-    # description prose. Each redirect names the EXACT corrected invocation
-    # and exits 1. No deprecation grace period (per CLAUDE.md
-    # feedback_no_premature_backcompat.md).
-    --yes|-y)
-      echo "ERROR: /quickfix '--yes' / '-y' was removed. Re-invoke without --yes (use the positional 'auto' token to skip the WI 1.5.5 confirmation prompt)." >&2
-      exit 1 ;;
-    --from-here)
-      echo "ERROR: /quickfix '--from-here' was replaced by positional 'from-here'. Re-invoke as: /quickfix <description> from-here" >&2
-      exit 1 ;;
-    --skip-tests)
-      echo "ERROR: /quickfix '--skip-tests' was replaced by positional 'skip-tests'. Re-invoke as: /quickfix <description> skip-tests" >&2
-      exit 1 ;;
-    --force)
-      echo "ERROR: /quickfix '--force' was replaced by positional 'force'. Re-invoke as: /quickfix <description> force" >&2
-      exit 1 ;;
-    # --- Existing/new arms below ---
     --branch)
       i=$((i+1))
       BRANCH_OVERRIDE="${ARGS[$i]:-}"

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.17+1167bf"
+  version: "2026.05.17+7aa3f0"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -64,11 +64,7 @@ at parse time — mode detection (WI 1.5) decides whether it is fatal.
 - **force** (optional) — bypass a triage REDIRECT verdict (WI 1.5.4) and
   proceed with `/quickfix` anyway.
 
-The legacy `--yes` / `-y` flag was removed; WI 1.5.5's confirmation
-prompt is bypassed when `AUTO_FLAG=1`. The legacy `--`-prefixed forms of
-`from-here`, `skip-tests`, `force` were converted to positional tokens;
-invoking them in the `--` form now hard-stops with a corrective error
-(see migration redirects in the parser case statement below).
+WI 1.5.5's confirmation prompt is bypassed when `AUTO_FLAG=1`.
 
 ```bash
 # Entry-point unset guard for the model-layer test seam. Without the
@@ -92,27 +88,6 @@ i=0
 while [ $i -lt ${#ARGS[@]} ]; do
   arg="${ARGS[$i]}"
   case "$arg" in
-    # --- Migration redirects (MUST be first; per WI 4.2 ordering invariant) ---
-    # These arms catch legacy `--`-prefixed forms that were removed (--yes)
-    # or converted to positional tokens (--from-here / --skip-tests / --force)
-    # in Phase 4. They MUST stay at the TOP of the case statement so the
-    # legacy invocations cannot fall through to `*)` and become silent
-    # description prose. Each redirect names the EXACT corrected invocation
-    # and exits 1. No deprecation grace period (per CLAUDE.md
-    # feedback_no_premature_backcompat.md).
-    --yes|-y)
-      echo "ERROR: /quickfix '--yes' / '-y' was removed. Re-invoke without --yes (use the positional 'auto' token to skip the WI 1.5.5 confirmation prompt)." >&2
-      exit 1 ;;
-    --from-here)
-      echo "ERROR: /quickfix '--from-here' was replaced by positional 'from-here'. Re-invoke as: /quickfix <description> from-here" >&2
-      exit 1 ;;
-    --skip-tests)
-      echo "ERROR: /quickfix '--skip-tests' was replaced by positional 'skip-tests'. Re-invoke as: /quickfix <description> skip-tests" >&2
-      exit 1 ;;
-    --force)
-      echo "ERROR: /quickfix '--force' was replaced by positional 'force'. Re-invoke as: /quickfix <description> force" >&2
-      exit 1 ;;
-    # --- Existing/new arms below ---
     --branch)
       i=$((i+1))
       BRANCH_OVERRIDE="${ARGS[$i]:-}"

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -337,24 +337,19 @@ fi
 
 # ────────────────────────────────────────────────────────────────────
 # Case 2 — Argument-parser flags (WI 1.2)
-# Post-Phase 4 (QUICKFIX_GRAMMAR_REDESIGN): --yes is REMOVED entirely;
-# --from-here / --skip-tests / --force are HARD-STOP migration redirects
-# (the bare `--`-form case arm exists, but it prints an error and exits
-# 1 rather than setting any flag); the working forms are the positional
-# bracket-class tokens.
+# Post-migration-redirect-removal: --yes / --from-here / --skip-tests /
+# --force migration arms were dropped entirely (per
+# feedback_no_premature_backcompat.md). Only positional bracket-class
+# tokens remain (plus --branch / --rounds value-takers).
 # ────────────────────────────────────────────────────────────────────
 if grep -q '[-][-]branch)' "$SKILL" \
-   && grep -q '[-][-]yes|[-]y)' "$SKILL" \
-   && grep -q '[-][-]from-here)' "$SKILL" \
-   && grep -q '[-][-]skip-tests)' "$SKILL" \
-   && grep -q '[-][-]force)' "$SKILL" \
    && grep -qE '^[[:space:]]*\[fF\]\[rR\]\[oO\]\[mM\]-\[hH\]\[eE\]\[rR\]\[eE\]\) FROM_HERE=1' "$SKILL" \
    && grep -qE '^[[:space:]]*\[sS\]\[kK\]\[iI\]\[pP\]-\[tT\]\[eE\]\[sS\]\[tT\]\[sS\]\) SKIP_TESTS=1' "$SKILL" \
    && grep -qE '^[[:space:]]*\[fF\]\[oO\]\[rR\]\[cC\]\[eE\]\) FORCE=1' "$SKILL" \
    && grep -qE '^[[:space:]]*\[aA\]\[uU\]\[tT\]\[oO\]\)' "$SKILL"; then
-  pass "2  argument parser: migration arms (--yes / --from-here / --skip-tests / --force) + positional from-here/skip-tests/force/auto (Phase 4 grammar)"
+  pass "2  argument parser: --branch + positional from-here/skip-tests/force/auto (Phase 4 grammar)"
 else
-  fail "2  argument parser: one or more arms missing (migration redirects + positional bracket-class tokens, Phase 4 grammar)"
+  fail "2  argument parser: one or more arms missing (--branch + positional bracket-class tokens)"
 fi
 
 # ────────────────────────────────────────────────────────────────────
@@ -752,9 +747,8 @@ rm -f -- "$ERR"
 # at branch creation), we assert that the preflight goes BEYOND the
 # unit_cmd gate — i.e., stderr does NOT contain 'requires
 # testing.unit_cmd'.
-# Phase 4 grammar (QUICKFIX_GRAMMAR_REDESIGN): the `--skip-tests` form
-# is a migration hard-stop; the positional `skip-tests` is the
-# working form.
+# Phase 4 grammar (QUICKFIX_GRAMMAR_REDESIGN): positional `skip-tests`
+# is the working form.
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c20 "" "")
 ERR=$(mktemp)
@@ -790,8 +784,7 @@ rm -f -- "$ERR"
 # ────────────────────────────────────────────────────────────────────
 # Case 22 — positional from-here overrides the main-required gate:
 # feature branch + from-here proceeds past the branch check.
-# Phase 4 grammar (QUICKFIX_GRAMMAR_REDESIGN): the legacy `--from-here`
-# form is a hard-stop migration redirect; the positional `from-here`
+# Phase 4 grammar (QUICKFIX_GRAMMAR_REDESIGN): positional `from-here`
 # is the working form.
 # ────────────────────────────────────────────────────────────────────
 FIX=$(make_fixture c22)
@@ -1266,8 +1259,7 @@ fi
 # Exercises WI 1.2's parser fence in isolation (no preflight side
 # effects). Asserts the new positional `[fF][oO][rR][cC][eE]) FORCE=1`
 # arm sets FORCE=1 and does not consume any positional arg as a value.
-# Phase 4 grammar: the legacy `--force` form is a hard-stop migration
-# redirect; this case uses the working positional form.
+# Phase 4 grammar: positional `force` is the working form.
 # ────────────────────────────────────────────────────────────────────
 OUT=$(bash "$PARSER_SCRIPT" force "fix typo")
 if echo "$OUT" | grep -q '^FORCE=1$' \
@@ -1776,51 +1768,36 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Cases 60–69 — WI 4.7 smoke tests (Phase 4 grammar): migration
-# redirects exit 1 with the corrective error; new positional tokens
-# set the corresponding flag (case-insensitive); `--branch` still
-# consumes its next arg verbatim; `--rounds` greedy-fallthrough on
-# non-numeric arg leaves description/force token semantics intact.
-#
-# Each migration-redirect case re-uses $PARSER_SCRIPT (the extracted
-# parser fence wrapped to emit FLAG=VALUE lines). For the migration
-# redirects we capture stderr separately and assert rc=1 + the
-# expected error stem.
+# Cases 62a–69 — WI 4.7 smoke tests (Phase 4 grammar): legacy
+# `--`-prefixed forms fall through to DESCRIPTION as prose (migration
+# redirects deleted per feedback_no_premature_backcompat.md); new
+# positional tokens set the corresponding flag (case-insensitive);
+# `--branch` still consumes its next arg verbatim; `--rounds`
+# greedy-fallthrough on non-numeric arg leaves description/force token
+# semantics intact.
 # ────────────────────────────────────────────────────────────────────
 
-# Case 60 — --yes migration: hard-stop with corrective error (AC4.1).
-ERR60=$(mktemp)
-bash "$PARSER_SCRIPT" --yes 2>"$ERR60" >/dev/null
-RC60=$?
-if [ "$RC60" -eq 1 ] && grep -q "'--yes' / '-y' was removed" "$ERR60"; then
-  pass "60 migration: --yes exits 1 with WI 4.2 corrective error"
-else
-  fail "60 migration: --yes rc=$RC60 stderr=$(tr '\n' '|' <"$ERR60")"
-fi
-rm -f -- "$ERR60"
+# Cases 60-62 — DELETED: previously asserted --yes / --from-here /
+# --skip-tests / --force hard-stop with corrective error. The migration
+# redirects were removed per feedback_no_premature_backcompat.md; legacy
+# `--`-prefixed tokens now fall through to DESCRIPTION as prose (see new
+# Case 62a below).
 
-# Case 61 — --from-here migration: hard-stop (AC4.2).
-ERR61=$(mktemp)
-bash "$PARSER_SCRIPT" --from-here 2>"$ERR61" >/dev/null
-RC61=$?
-if [ "$RC61" -eq 1 ] && grep -q "'--from-here' was replaced by positional 'from-here'" "$ERR61"; then
-  pass "61 migration: --from-here exits 1 with corrective error pointing to positional"
+# Case 62a — positive fallthrough: `--from-here` (legacy `--`-prefixed
+# form) is no longer a recognized arm; it falls through to DESCRIPTION
+# as user-prose. Exit code is 0 and the token appears in DESCRIPTION.
+# Locks in the post-removal behavior.
+ERR62a=$(mktemp)
+OUT62a=$(bash "$PARSER_SCRIPT" --from-here 2>"$ERR62a")
+RC62a=$?
+if [ "$RC62a" -eq 0 ] \
+   && echo "$OUT62a" | grep -q '^FROM_HERE=0$' \
+   && echo "$OUT62a" | grep -q '^DESCRIPTION=--from-here$'; then
+  pass "62a positive fallthrough: --from-here exits 0, treated as DESCRIPTION prose (FROM_HERE=0)"
 else
-  fail "61 migration: --from-here rc=$RC61 stderr=$(tr '\n' '|' <"$ERR61")"
+  fail "62a positive fallthrough: rc=$RC62a out=$(echo "$OUT62a" | tr '\n' '|') stderr=$(tr '\n' '|' <"$ERR62a")"
 fi
-rm -f -- "$ERR61"
-
-# Case 62 — --skip-tests / --force migration (AC4.3).
-ERR62a=$(mktemp); ERR62b=$(mktemp)
-bash "$PARSER_SCRIPT" --skip-tests 2>"$ERR62a" >/dev/null; RC62a=$?
-bash "$PARSER_SCRIPT" --force 2>"$ERR62b" >/dev/null; RC62b=$?
-if [ "$RC62a" -eq 1 ] && grep -q "'--skip-tests' was replaced by positional 'skip-tests'" "$ERR62a" \
-   && [ "$RC62b" -eq 1 ] && grep -q "'--force' was replaced by positional 'force'" "$ERR62b"; then
-  pass "62 migration: --skip-tests & --force both exit 1 with corrective errors"
-else
-  fail "62 migration: skip-tests rc=$RC62a force rc=$RC62b"
-fi
-rm -f -- "$ERR62a" "$ERR62b"
+rm -f -- "$ERR62a"
 
 # Case 63 — positional from-here sets FROM_HERE=1, DESCRIPTION unchanged (AC4.4).
 OUT63=$(bash "$PARSER_SCRIPT" "fix broken docs link" from-here 2>&1)
@@ -1884,12 +1861,11 @@ else
   fail "68 fromhere boundary: $(echo "$OUT68" | tr '\n' '|')"
 fi
 
-# Case 69 — argument-hint shape (AC4.9): exact new hint with legacy
-# --yes/--from-here/--skip-tests/--force brackets ABSENT.
+# Case 69 — argument-hint shape (AC4.9): exact positional hint.
 HINT=$(grep '^argument-hint' "$SKILL" | sed -E 's/^argument-hint: "(.*)"$/\1/')
 EXPECTED='[<description>] [auto] [from-here] [skip-tests] [force] [--branch <name>] [--rounds N]'
 if [ "$HINT" = "$EXPECTED" ]; then
-  pass "69 argument-hint (AC4.9, AC4.12): new Phase 4 positional shape; legacy --yes/[--from-here]/[--skip-tests]/[--force] brackets removed (len=${#HINT})"
+  pass "69 argument-hint (AC4.9, AC4.12): positional shape (len=${#HINT})"
 else
   fail "69 argument-hint: got='$HINT' expected='$EXPECTED'"
 fi


### PR DESCRIPTION
## Summary

Removes premature-backcompat migration redirects from `/quickfix`'s parser. The 4 case arms (`--yes|-y`, `--from-here`, `--skip-tests`, `--force` → exit 1 with corrective error) exist only to be helpful to hypothetical users with stale invocations. Per `feedback_no_premature_backcompat.md`, zskills has no external consumers.

After: type `--from-here` and it falls through to user-description prose. Visible weirdness once, adapt, done.

Spec: `/tmp/plan-a-drop-migration-redirects.md` (reviewed and tightened).

## Changes
- `skills/quickfix/SKILL.md` + mirror: remove 4 migration-redirect case arms + obsolete ordering-invariant comment + any redundant explanatory prose
- `tests/test-quickfix.sh`: remove Cases 60-62 (migration-exit-1 tests); update Case 2 to drop the 4 `grep -q '[-][-]...)'` arm-existence assertions; sweep "migration hard-stop" prose; add positive fallthrough assertion
- Bump `/quickfix` metadata.version + re-mirror

## Test plan
- [x] Full suite green (verified by impl + verifier)
- [x] No migration-redirect arms in /quickfix parser
- [x] Case 2 no longer asserts removed arms
- [x] Mirror byte-identical
- [x] Stage-check exit 0
- [ ] CI: validate post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
