### PR TITLE
do: renderIssues now honors queues arg (optimistic drop)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.17+8ff082"
+  version: "2026.05.17+03cbc6"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -878,31 +878,19 @@ function renderIssues(issues, queues) {
   const numToIssue = {};
   for (const it of issues) numToIssue[it.number] = it;
 
-  // GitHub owns issue existence; we render one card per live issue and
-  // group by its annotated queue.column. Queue-only entries are never
-  // rendered, so closed issues stop producing blank cards.
-  const UNQUEUED = Number.MAX_SAFE_INTEGER;
-  const grouped = {};
-  for (const c of ISSUE_COLUMNS) grouped[c] = [];
-  for (const it of issues) {
-    if (typeof it.number !== "number") continue;
-    const col = (it.queue && it.queue.column) || "triage";
-    if (ISSUE_COLUMNS.indexOf(col) < 0) continue;
-    let idx = (it.queue && typeof it.queue.index === "number") ? it.queue.index : -1;
-    if (idx < 0) idx = UNQUEUED;
-    grouped[col].push({ num: it.number, idx });
-  }
-  for (const c of ISSUE_COLUMNS) {
-    grouped[c].sort((a, b) => (a.idx - b.idx) || (b.num - a.num));
-  }
-
+  // Mirror renderPlans: column membership and order come from the
+  // `queues` argument (typically lastGoodQueues.issues), NOT from the
+  // per-issue server annotation. This lets commitQueueChange's
+  // optimistic lastGoodQueues update render the dragged card in its
+  // new column immediately, before the next poll arrives.
   const cols = el("div", { cls: "columns columns-2" });
   for (const c of ISSUE_COLUMNS) {
     const colDiv = el("div", { cls: "column" });
     const headId = "issues-col-" + c;
     const head = el("div", { cls: "column-head", attrs: { id: headId } });
     head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
-    head.appendChild(el("span", { cls: "muted", text: String(grouped[c].length) }));
+    const arr = (queues && queues.issues && queues.issues[c]) || [];
+    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -914,9 +902,10 @@ function renderIssues(issues, queues) {
         "aria-labelledby": headId,
       },
     });
-    for (const entry of grouped[c]) {
-      const card = buildIssueCard(numToIssue[entry.num], entry.num, c);
-      ul.appendChild(card);
+    for (const num of arr) {
+      const issue = numToIssue[num];
+      if (!issue) continue;
+      ul.appendChild(buildIssueCard(issue, num, c));
     }
     colDiv.appendChild(ul);
     cols.appendChild(colDiv);

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.17+8ff082"
+  version: "2026.05.17+03cbc6"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -878,31 +878,19 @@ function renderIssues(issues, queues) {
   const numToIssue = {};
   for (const it of issues) numToIssue[it.number] = it;
 
-  // GitHub owns issue existence; we render one card per live issue and
-  // group by its annotated queue.column. Queue-only entries are never
-  // rendered, so closed issues stop producing blank cards.
-  const UNQUEUED = Number.MAX_SAFE_INTEGER;
-  const grouped = {};
-  for (const c of ISSUE_COLUMNS) grouped[c] = [];
-  for (const it of issues) {
-    if (typeof it.number !== "number") continue;
-    const col = (it.queue && it.queue.column) || "triage";
-    if (ISSUE_COLUMNS.indexOf(col) < 0) continue;
-    let idx = (it.queue && typeof it.queue.index === "number") ? it.queue.index : -1;
-    if (idx < 0) idx = UNQUEUED;
-    grouped[col].push({ num: it.number, idx });
-  }
-  for (const c of ISSUE_COLUMNS) {
-    grouped[c].sort((a, b) => (a.idx - b.idx) || (b.num - a.num));
-  }
-
+  // Mirror renderPlans: column membership and order come from the
+  // `queues` argument (typically lastGoodQueues.issues), NOT from the
+  // per-issue server annotation. This lets commitQueueChange's
+  // optimistic lastGoodQueues update render the dragged card in its
+  // new column immediately, before the next poll arrives.
   const cols = el("div", { cls: "columns columns-2" });
   for (const c of ISSUE_COLUMNS) {
     const colDiv = el("div", { cls: "column" });
     const headId = "issues-col-" + c;
     const head = el("div", { cls: "column-head", attrs: { id: headId } });
     head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
-    head.appendChild(el("span", { cls: "muted", text: String(grouped[c].length) }));
+    const arr = (queues && queues.issues && queues.issues[c]) || [];
+    head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -914,9 +902,10 @@ function renderIssues(issues, queues) {
         "aria-labelledby": headId,
       },
     });
-    for (const entry of grouped[c]) {
-      const card = buildIssueCard(numToIssue[entry.num], entry.num, c);
-      ul.appendChild(card);
+    for (const num of arr) {
+      const issue = numToIssue[num];
+      if (!issue) continue;
+      ul.appendChild(buildIssueCard(issue, num, c));
     }
     colDiv.appendChild(ul);
     cols.appendChild(colDiv);

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -487,6 +487,22 @@ else
   fail "AC: column constants missing"
 fi
 
+# AC: renderIssues honors its `queues` argument for column membership
+# (mirrors renderPlans). Without this, optimistic drag-and-drop renders
+# from the stale per-issue server annotation `it.queue.column` and the
+# card snaps back until the next poll. Regression guard for the
+# renderIssues-ignores-queues bug.
+RENDER_ISSUES_BODY=$(awk '
+  /^function renderIssues\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$RENDER_ISSUES_BODY" | grep -qE 'queues\.issues'; then
+  pass "AC: renderIssues references queues.issues (optimistic-render contract)"
+else
+  fail "AC: renderIssues does not reference queues.issues — regression of optimistic-render bug"
+fi
+
 # AC: Reconciliation suppress window present (1500ms).
 if grep -q 'POST_RECONCILE_SUPPRESS_MS' "$APP_JS" && grep -q '1500' "$APP_JS"; then
   pass "AC: reconciliation suppress window 1500ms present"


### PR DESCRIPTION
## Summary

Follow-up to #344. After #344 closed the in-flight-GET race, the user still saw "drop → card snaps back → page reload reveals the move." Investigation found the optimistic UI never actually applied: `renderIssues` ignored its `queues` argument and grouped cards by the per-issue server annotation `it.queue.column`, so `commitQueueChange`'s optimistic `lastGoodQueues` update was discarded at render time.

## Root cause

`renderIssues(issues, queues)` accepted a `queues` parameter but never read it. Card-to-column membership came from `snap.issues[i].queue.column` — the server's pre-POST annotation. `renderPlans` (line 656) gets this right: it iterates `lastGoodQueues.plans[c]` directly. This PR brings `renderIssues` into the same shape.

## Fix

Rewrite `renderIssues` body:
- Iterate `(queues && queues.issues && queues.issues[c]) || []` for column membership.
- Look up each number in `numToIssue` (built from `snap.issues`); skip if not present (closed/missing — self-prunes).
- Drop the `grouped[col]` accumulator, `it.queue.column` grouping loop, `UNQUEUED` sentinel, and per-column sort. `deepCloneQueues` already produces an exhaustive ordered `lastGoodQueues.issues`.

Both call sites unchanged: `applySnapshot` passes `snap.queues` (server's view); `commitQueueChange` passes `lastGoodQueues` (local view with optimistic edits applied). Same code path, correct source-of-truth in each case.

## Why #344's guards stay

PR #344's `state_updated_at` (state-file-anchored stale guard) and `pendingPosts` counter remain correct and active. They closed the in-flight-GET race so an arriving stale snapshot can't overwrite the optimistic state. This PR closes the orthogonal bug that there was no optimistic state to overwrite in the first place.

## Files

- `skills/zskills-dashboard/scripts/zskills_monitor/static/app.js` — `renderIssues` rewrite (~lines 868–910); −33 +24 net.
- `skills/zskills-dashboard/SKILL.md` — version bump → `2026.05.17+03cbc6`.
- `tests/test_zskills_monitor_dashboard_ui.sh` — regression assertion that the rewritten `renderIssues` body references `queues.issues`. Fails if someone reintroduces the annotation-grouping pattern.
- `.claude/skills/zskills-dashboard/*` — mirror regenerated.

## Test plan

- [x] Plan-confirmation agent: APPROVE — verified plan structure, scope discipline, and that the renderPlans pattern is the correct model.
- [x] Full suite: **3271/3271 PASS**.
- [x] Scope check: `git show --stat` touches 5 files (4 source/test + 1 mirror set).
- [x] Mirror clean: `diff -rq` shows only `__pycache__`.
- [x] Skill version bumped: `→ 2026.05.17+03cbc6`.
- [ ] **Reviewer post-merge:** restart dashboard, drag an issue between Triage and Ready while `/fix-issues` cron is active — card should visibly move to target column the instant you release the mouse, before any poll arrives, and stay there.

🤖 Generated with /do (agent-dispatched, PR mode, auto-merge)
