### PR TITLE
revert: tracker-PR always-auto (#356) — wrong content split

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+ba2b4f"
+  version: "2026.05.17+992d09"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -43,20 +43,13 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
   pattern: `/fix-issues 1 every 30m dashboard auto`.
 - **auto** (optional) — bypass confirmation gates for autonomous operation.
   Behavior depends on context:
-  - **Sprints:** skip Phase 2 issue list approval, and (in PR landing
-    mode) auto-merge the **per-issue fix PRs** dispatched in Phase 3 —
-    those carry real code changes that legitimately may want human
-    review. The **sprint-level tracker PR** dispatched in Phase 5 (tracker
-    row adds + SPRINT_REPORT section append; agent-facing markdown)
-    always auto-merges regardless of this flag. Does NOT close GH issues
-    or remove worktrees — those are `/fix-report` actions.
+  - **Sprints:** skip Phase 2 issue list approval, auto-land to main via
+    cherry-pick. Does NOT close GH issues or remove worktrees — those are
+    `/fix-report` actions.
   - **plan auto:** draft plans for all found issues without selection
     (see Plan section).
-  - **Sync — partially applicable.** The sync **tracker PR** itself
-    always auto-merges (agent-facing markdown, no human review value);
-    `auto` does not change that. The interactive bit referred to by
-    "sync is always interactive" is ONLY the subsequent `gh issue close`
-    step — closing issues on GitHub remains gated on human approval.
+  - **Not applicable to sync.** `sync` is always interactive — closing
+    issues on GitHub requires human approval.
 - **every SCHEDULE** (optional) — self-schedule recurring runs via cron:
   - Accepts intervals: `4h`, `2h`, `30m`, `12h`
   - Accepts time-of-day: `day at 9am`, `day at 14:00`, `weekday at 9am`
@@ -71,10 +64,8 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
 - **sync** — update all issue tracker files from GitHub, research new
   issues, AND verify/close issues that appear already fixed. Dispatches
   research agents that also check if open issues are already resolved in
-  the codebase. The tracker PR itself auto-merges (agent-facing
-  markdown); only the subsequent `gh issue close` step is interactive —
-  presents findings and asks before closing. See Sync section for the
-  full flow.
+  the codebase. Always interactive — presents findings and asks before
+  closing. See Sync section for the full flow.
 - **plan** — draft plans for issues previously skipped as "too complex."
   Scans `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md` for skipped items, dispatches `/draft-plan`
   for each. No fixing — just creates plans for `/run-plan` to execute later.
@@ -222,7 +213,7 @@ Examples:
 - `/fix-issues 5 auto every 4h now` — schedule every 4h + run immediately
 - `/fix-issues 10 auto every day at 9am` — schedule daily at 9am
 - `/fix-issues 10 auto every weekday at 9am now` — schedule + run now
-- `/fix-issues sync` — update trackers + verify/close fixed issues (tracker PR auto-merges; `gh issue close` step interactive)
+- `/fix-issues sync` — update trackers + verify/close fixed issues (always interactive)
 - `/fix-issues plan` — draft plans for issues skipped as "too complex"
 - `/fix-issues plan auto` — same, but plan all without selection
 - `/fix-issues stop` — cancel the recurring cron
@@ -550,22 +541,19 @@ EOF
    {
      printf '## Summary\n`/fix-issues sync` on %s updated trackers.\n\n' \
        "$(TZ=America/New_York date +%F)"
-     printf '## Test plan\n- [x] Tracker hygiene only (agent-facing markdown). Auto-merges on CI green.\n'
+     printf '## Test plan\n- [x] Tracker diff reviewed by user before merge.\n'
    } > "$BODY_FILE"
 
    PR_TITLE="sync: $(TZ=America/New_York date +%F)"
    SYNC_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
 
-   # /land-pr arg vector. Includes --auto unconditionally: the sync PR is
-   # pure tracker hygiene (research blurbs, ISSUES_PLAN row adds,
-   # SPRINT_REPORT section append) — agent-facing markdown the agent reads
-   # back, not user-facing artifacts warranting human review. The
-   # SUBSEQUENT "close approved issues on GitHub" sub-step (Step 5
-   # sub-step 3 below) is what remains interactive — that step requires
-   # human approval for the irreversible `gh issue close` calls. The
-   # CI-monitor-suppression flag is also omitted (CI monitoring is
-   # desired; the orchestrator awaits resting state).
-   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto"
+   # /land-pr arg vector. Mirrors run-plan PR mode (modes/pr.md:339-348)
+   # MINUS the auto-merge flag. Sync is always interactive — closing
+   # issues on GitHub requires human approval — so the auto-merge flag
+   # is intentionally omitted. The CI-monitor-suppression flag is also
+   # omitted (CI monitoring is desired; the orchestrator awaits resting
+   # state).
+   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID"
 
    # Echo the pipeline id for transcript-propagation (matches /do pr's
    # tier-2 idiom at `skills/do/modes/pr.md:203`). Do NOT env-export
@@ -2168,19 +2156,13 @@ if [ -n "${WT_PATH:-}" ]; then
     BODY_FILE=$(mktemp)
     {
       printf '## Summary\n`/fix-issues` sprint %s.\n\n' "$SPRINT_ID"
-      printf '## Test plan\n- [x] Sprint report (agent-facing log). Auto-merges on CI green.\n'
+      printf '## Test plan\n- [x] Sprint report content reviewed by user before merge.\n'
     } > "$BODY_FILE"
 
     PR_TITLE="sprint-report: $SPRINT_ID"
     SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
-    # Sprint-level tracker PR ALWAYS auto-merges, independent of the
-    # user's `auto` arg. The tracker PR carries tracker-row adds and
-    # SPRINT_REPORT updates — agent-facing markdown the agent reads
-    # back, not artifacts warranting human review. The user's `auto`
-    # arg continues to govern the per-issue Phase 3 fix-PR dispatches
-    # (which legitimately may want human review of code changes); only
-    # THIS sprint-level dispatch is unconditionally auto-merged.
-    LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+    LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID"
+    [ "${AUTO:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
 
     echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+ba2b4f"
+  version: "2026.05.17+992d09"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -43,20 +43,13 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
   pattern: `/fix-issues 1 every 30m dashboard auto`.
 - **auto** (optional) — bypass confirmation gates for autonomous operation.
   Behavior depends on context:
-  - **Sprints:** skip Phase 2 issue list approval, and (in PR landing
-    mode) auto-merge the **per-issue fix PRs** dispatched in Phase 3 —
-    those carry real code changes that legitimately may want human
-    review. The **sprint-level tracker PR** dispatched in Phase 5 (tracker
-    row adds + SPRINT_REPORT section append; agent-facing markdown)
-    always auto-merges regardless of this flag. Does NOT close GH issues
-    or remove worktrees — those are `/fix-report` actions.
+  - **Sprints:** skip Phase 2 issue list approval, auto-land to main via
+    cherry-pick. Does NOT close GH issues or remove worktrees — those are
+    `/fix-report` actions.
   - **plan auto:** draft plans for all found issues without selection
     (see Plan section).
-  - **Sync — partially applicable.** The sync **tracker PR** itself
-    always auto-merges (agent-facing markdown, no human review value);
-    `auto` does not change that. The interactive bit referred to by
-    "sync is always interactive" is ONLY the subsequent `gh issue close`
-    step — closing issues on GitHub remains gated on human approval.
+  - **Not applicable to sync.** `sync` is always interactive — closing
+    issues on GitHub requires human approval.
 - **every SCHEDULE** (optional) — self-schedule recurring runs via cron:
   - Accepts intervals: `4h`, `2h`, `30m`, `12h`
   - Accepts time-of-day: `day at 9am`, `day at 14:00`, `weekday at 9am`
@@ -71,10 +64,8 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
 - **sync** — update all issue tracker files from GitHub, research new
   issues, AND verify/close issues that appear already fixed. Dispatches
   research agents that also check if open issues are already resolved in
-  the codebase. The tracker PR itself auto-merges (agent-facing
-  markdown); only the subsequent `gh issue close` step is interactive —
-  presents findings and asks before closing. See Sync section for the
-  full flow.
+  the codebase. Always interactive — presents findings and asks before
+  closing. See Sync section for the full flow.
 - **plan** — draft plans for issues previously skipped as "too complex."
   Scans `$ZSKILLS_AUDIT_DIR/SPRINT_REPORT.md` for skipped items, dispatches `/draft-plan`
   for each. No fixing — just creates plans for `/run-plan` to execute later.
@@ -222,7 +213,7 @@ Examples:
 - `/fix-issues 5 auto every 4h now` — schedule every 4h + run immediately
 - `/fix-issues 10 auto every day at 9am` — schedule daily at 9am
 - `/fix-issues 10 auto every weekday at 9am now` — schedule + run now
-- `/fix-issues sync` — update trackers + verify/close fixed issues (tracker PR auto-merges; `gh issue close` step interactive)
+- `/fix-issues sync` — update trackers + verify/close fixed issues (always interactive)
 - `/fix-issues plan` — draft plans for issues skipped as "too complex"
 - `/fix-issues plan auto` — same, but plan all without selection
 - `/fix-issues stop` — cancel the recurring cron
@@ -550,22 +541,19 @@ EOF
    {
      printf '## Summary\n`/fix-issues sync` on %s updated trackers.\n\n' \
        "$(TZ=America/New_York date +%F)"
-     printf '## Test plan\n- [x] Tracker hygiene only (agent-facing markdown). Auto-merges on CI green.\n'
+     printf '## Test plan\n- [x] Tracker diff reviewed by user before merge.\n'
    } > "$BODY_FILE"
 
    PR_TITLE="sync: $(TZ=America/New_York date +%F)"
    SYNC_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
 
-   # /land-pr arg vector. Includes --auto unconditionally: the sync PR is
-   # pure tracker hygiene (research blurbs, ISSUES_PLAN row adds,
-   # SPRINT_REPORT section append) — agent-facing markdown the agent reads
-   # back, not user-facing artifacts warranting human review. The
-   # SUBSEQUENT "close approved issues on GitHub" sub-step (Step 5
-   # sub-step 3 below) is what remains interactive — that step requires
-   # human approval for the irreversible `gh issue close` calls. The
-   # CI-monitor-suppression flag is also omitted (CI monitoring is
-   # desired; the orchestrator awaits resting state).
-   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto"
+   # /land-pr arg vector. Mirrors run-plan PR mode (modes/pr.md:339-348)
+   # MINUS the auto-merge flag. Sync is always interactive — closing
+   # issues on GitHub requires human approval — so the auto-merge flag
+   # is intentionally omitted. The CI-monitor-suppression flag is also
+   # omitted (CI monitoring is desired; the orchestrator awaits resting
+   # state).
+   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID"
 
    # Echo the pipeline id for transcript-propagation (matches /do pr's
    # tier-2 idiom at `skills/do/modes/pr.md:203`). Do NOT env-export
@@ -2168,19 +2156,13 @@ if [ -n "${WT_PATH:-}" ]; then
     BODY_FILE=$(mktemp)
     {
       printf '## Summary\n`/fix-issues` sprint %s.\n\n' "$SPRINT_ID"
-      printf '## Test plan\n- [x] Sprint report (agent-facing log). Auto-merges on CI green.\n'
+      printf '## Test plan\n- [x] Sprint report content reviewed by user before merge.\n'
     } > "$BODY_FILE"
 
     PR_TITLE="sprint-report: $SPRINT_ID"
     SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
-    # Sprint-level tracker PR ALWAYS auto-merges, independent of the
-    # user's `auto` arg. The tracker PR carries tracker-row adds and
-    # SPRINT_REPORT updates — agent-facing markdown the agent reads
-    # back, not artifacts warranting human review. The user's `auto`
-    # arg continues to govern the per-issue Phase 3 fix-PR dispatches
-    # (which legitimately may want human review of code changes); only
-    # THIS sprint-level dispatch is unconditionally auto-merged.
-    LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+    LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID"
+    [ "${AUTO:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
 
     echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 

--- a/tests/test-fix-issues-sprint-land-pr.sh
+++ b/tests/test-fix-issues-sprint-land-pr.sh
@@ -372,21 +372,17 @@ test_A4_other_statuses_no_fulfilled() {
   fi
 }
 
-# Case A5: sprint-level tracker PR always includes --auto, regardless
-#  of $AUTO. Trace via a wrapper that captures LAND_ARGS into a file. We
-#  patch the block to additionally `printf '%s' "$LAND_ARGS" >
-#  $TMP_ROOT/A5.land_args` right after the `LAND_ARGS=...` assignment
-#  for landed-source=fix-issues-sprint.
+# Case A5: --auto conditional ON (AUTO=true) — LAND_ARGS contains --auto.
+#  Trace via a wrapper that captures LAND_ARGS into a file. We patch the
+#  block to additionally `printf '%s' "$LAND_ARGS" > $TMP_ROOT/A5.land_args`
+#  right after the `LAND_ARGS=...` assignment.
 # Helper: patch a block with an extra capture line that writes the
-# final $LAND_ARGS value to a file. The anchor is the sprint-land
-# `LAND_ARGS=...` assignment itself — after the tracker-auto decoupling
-# there is no AUTO conditional below it; the assignment is the
-# final-value line.
+# final $LAND_ARGS value to a file after the AUTO-conditional fires.
 patch_block_capturing_land_args() {
   local src="$1" out="$2" capture_file="$3"
   patch_block "$src" "$out"
   awk -v out="$capture_file" '
-    /^[[:space:]]*LAND_ARGS=.*landed-source=fix-issues-sprint/ {
+    /\[ "\$\{AUTO:-false\}" = "true" \] && LAND_ARGS=/ {
       print
       print "printf \"%s\" \"$LAND_ARGS\" > " out
       next
@@ -414,10 +410,8 @@ test_A5_auto_true_emits_flag() {
   unset AUTO WT_PATH ZSKILLS_AUDIT_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
 }
 
-# Case A6: AUTO=false — sprint-level tracker PR STILL contains --auto
-#   (tracker PRs always auto-merge, decoupled from caller's `auto` arg).
-#   This is the regression guard for the tracker-PR-always-auto behavior.
-test_A6_auto_false_still_has_flag() {
+# Case A6: AUTO=false — LAND_ARGS must NOT contain --auto.
+test_A6_auto_false_no_flag() {
   setup_case_a "6" "gnu"
   local patched="$CASE_DIR/block.sh"
   local cap="$TMP_ROOT/A6.land_args"
@@ -428,18 +422,18 @@ test_A6_auto_false_still_has_flag() {
   mk_result_file "$PREPARED_RESULT_FILE" "STATUS=merged"
   export AUTO="false"
   run_block "A-6cap" "$patched" "$CASE_DIR/bin"
-  if [ -f "$cap" ] && grep -q -- '--auto' "$cap"; then
-    pass "A6: AUTO=false → sprint LAND_ARGS still contains --auto (tracker PR always auto-merges)"
+  if [ -f "$cap" ] && ! grep -q -- '--auto' "$cap"; then
+    pass "A6: AUTO=false → LAND_ARGS does NOT contain --auto"
   else
-    fail "A6: AUTO=false → sprint LAND_ARGS still contains --auto" "captured=$(cat "$cap" 2>/dev/null || echo missing)"
+    fail "A6: AUTO=false → LAND_ARGS does NOT contain --auto" "captured=$(cat "$cap" 2>/dev/null || echo missing)"
   fi
   unset AUTO WT_PATH ZSKILLS_AUDIT_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
 }
 
-# Case A7: AUTO unset + `set -u` — block must NOT crash. Sprint LAND_ARGS
-#   contains --auto unconditionally (decoupling); since the AUTO-conditional
-#   was removed in the tracker-auto decoupling, the `set -u` unbound-variable
-#   risk from referencing $AUTO is also gone.
+# Case A7: AUTO unset + `set -u` — block must NOT crash, LAND_ARGS no --auto.
+#   This pins the fix from issue #337 secondary: `[ "${AUTO:-false}" = ... ]`
+#   defaults under set -u; the prior `[ "$AUTO" = "true" ]` would have
+#   triggered `unbound variable`.
 test_A7_auto_unset_no_crash() {
   setup_case_a "7" "gnu"
   local patched="$CASE_DIR/block.sh"
@@ -453,10 +447,10 @@ test_A7_auto_unset_no_crash() {
   run_block "A-7cap" "$patched" "$CASE_DIR/bin"
   local err; err=$(cat "$TMP_ROOT/A-7cap.err" 2>/dev/null || echo "")
   if [ "$LAST_RC" -eq 0 ] && ! echo "$err" | grep -qi 'unbound variable' \
-     && [ -f "$cap" ] && grep -q -- '--auto' "$cap"; then
-    pass "A7: AUTO unset + set -u → no 'unbound variable', sprint LAND_ARGS has --auto"
+     && [ -f "$cap" ] && ! grep -q -- '--auto' "$cap"; then
+    pass "A7: AUTO unset + set -u → no 'unbound variable', LAND_ARGS without --auto"
   else
-    fail "A7: AUTO unset + set -u → no crash + sprint --auto present" "rc=$LAST_RC err=$err captured=$(cat "$cap" 2>/dev/null || echo missing)"
+    fail "A7: AUTO unset + set -u → no crash" "rc=$LAST_RC err=$err captured=$(cat "$cap" 2>/dev/null || echo missing)"
   fi
   unset WT_PATH ZSKILLS_AUDIT_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
 }
@@ -653,7 +647,7 @@ test_A2_merged_fallback_realpath
 test_A3_created_no_fulfilled
 test_A4_other_statuses_no_fulfilled
 test_A5_auto_true_emits_flag
-test_A6_auto_false_still_has_flag
+test_A6_auto_false_no_flag
 test_A7_auto_unset_no_crash
 test_A8_unknown_key_warns_but_proceeds
 test_A9_missing_status_logs_left_open

--- a/tests/test-fix-issues.sh
+++ b/tests/test-fix-issues.sh
@@ -344,86 +344,6 @@ test_dashboard_mutex_error_strings_present() {
   fi
 }
 
-# --- tracker-PR-always-auto (decouple tracker from per-issue auto-merge) -
-#
-# The user's `auto` arg gates two distinct PR types:
-#   - Tracker PRs (sync Phase 5, sprint-mode Phase 5): agent-facing
-#     markdown the agent reads back. Auto-merge unconditionally.
-#   - Per-issue fix PRs (Phase 3 via modes/pr.md): real code changes,
-#     potentially worth human review. AUTO-gated conditional preserved.
-# These four tests guard the asymmetry.
-
-test_sync_land_args_unconditional_auto() {
-  # Case (a): the standalone sync Phase 5 LAND_ARGS line must end with
-  # --auto (no AUTO conditional gate above/below it).
-  local line
-  line=$(grep -n 'landed-source=fix-issues-sync' "$SKILL" | head -1 | cut -d: -f1)
-  if [ -z "$line" ]; then
-    fail "tracker-auto: sync LAND_ARGS line present" "not found"
-    return
-  fi
-  local content
-  content=$(sed -n "${line}p" "$SKILL")
-  case "$content" in
-    *'--auto"'*|*'--auto') pass "tracker-auto: sync LAND_ARGS contains --auto unconditionally (line $line)" ;;
-    *) fail "tracker-auto: sync LAND_ARGS contains --auto unconditionally" "line $line: $content" ;;
-  esac
-}
-
-test_sync_comment_no_intentionally_omitted() {
-  # Case (b): the conflated rationale "intentionally omitted" referring
-  # to the auto-merge flag must be gone. Regression tripwire.
-  if grep -qE 'is[[:space:]]+intentionally[[:space:]]+omitted' "$SKILL"; then
-    fail "tracker-auto: sync comment does NOT say 'intentionally omitted'" "phrase still present"
-  else
-    pass "tracker-auto: sync comment does NOT say 'intentionally omitted'"
-  fi
-}
-
-test_sprint_land_args_unconditional_auto() {
-  # Case (c): sprint-mode Phase 5 LAND_ARGS must end with --auto AND
-  # the immediately-following conditional `[ "${AUTO:-false}" = "true" ]`
-  # must be gone.
-  local line
-  line=$(grep -n 'landed-source=fix-issues-sprint' "$SKILL" | head -1 | cut -d: -f1)
-  if [ -z "$line" ]; then
-    fail "tracker-auto: sprint LAND_ARGS line present" "not found"
-    return
-  fi
-  local content
-  content=$(sed -n "${line}p" "$SKILL")
-  case "$content" in
-    *'--auto"'*|*'--auto') pass "tracker-auto: sprint LAND_ARGS contains --auto unconditionally (line $line)" ;;
-    *) fail "tracker-auto: sprint LAND_ARGS contains --auto unconditionally" "line $line: $content" ;;
-  esac
-
-  # The next non-blank line MUST NOT be the AUTO-conditional re-append.
-  local next_line
-  next_line=$(awk -v start=$((line+1)) 'NR>=start && NF>0 { print; exit }' "$SKILL")
-  case "$next_line" in
-    *'AUTO:-false'*'--auto'*)
-      fail "tracker-auto: sprint LAND_ARGS conditional re-append removed" "still present: $next_line" ;;
-    *)
-      pass "tracker-auto: sprint LAND_ARGS conditional re-append removed" ;;
-  esac
-}
-
-test_per_issue_conditional_pattern_preserved() {
-  # Case (d): the per-issue AUTO-gated conditional pattern must still
-  # appear AT LEAST ONCE in the file. After decoupling tracker PRs, the
-  # remaining occurrence is the `fix-issues-no-actionable` site (line
-  # ~1505 of SKILL.md). The per-issue Phase-3 dispatch itself lives in
-  # modes/pr.md; this test guards SKILL.md's surviving AUTO-conditional
-  # so future edits don't accidentally make ALL LAND_ARGS unconditional.
-  local hits
-  hits=$(grep -cE '\[ "\$\{AUTO:-false\}" = "true" \] && LAND_ARGS' "$SKILL")
-  if [ "$hits" -ge 1 ]; then
-    pass "tracker-auto: per-issue/non-tracker AUTO-conditional pattern preserved ($hits occurrence)"
-  else
-    fail "tracker-auto: per-issue/non-tracker AUTO-conditional pattern preserved" "0 occurrences — all LAND_ARGS now unconditional, contradicting decoupling intent"
-  fi
-}
-
 # --- Mirror parity -------------------------------------------------------
 
 test_mirror_in_sync() {
@@ -447,10 +367,6 @@ test_dashboard_token_recognized_in_phase0
 test_dashboard_phase2_branch_present
 test_dashboard_uses_python_json_not_bash_regex
 test_dashboard_mutex_error_strings_present
-test_sync_land_args_unconditional_auto
-test_sync_comment_no_intentionally_omitted
-test_sprint_land_args_unconditional_auto
-test_per_issue_conditional_pattern_preserved
 test_mirror_in_sync
 
 echo ""


### PR DESCRIPTION
## Summary

Reverts #356. That PR conflated two distinct tracker-PR content streams:

- **Sync-driven tracker updates** — agent-facing markdown the agent reads back; should always auto-merge regardless of user's `auto` arg.
- **Fix-work-driven tracker updates** (Phase 6 sprint-land's `SPRINT_REPORT.md`) — describes the sprint's actual fix work; should land WITH the fix work, honoring user's `auto`.

#356 made the Phase 6 sprint-land dispatch always auto-merge, which means a `/fix-issues 5` (no `auto`) now auto-merges a sprint-report PR describing 5 fix PRs that are still sitting open awaiting review. Backwards: the tracker (a meta-log of the work) should not auto-merge while the work itself doesn't.

#356 also touched standalone `/fix-issues sync`'s Phase 5 dispatch — that change was correct in isolation (sync produces only sync-driven content) — but is being reverted together to restart from a clean baseline. The follow-up PR will reapply only the correct changes (sync-only dispatch sites unconditional `--auto`) and add the missing fixes (sites 3 and 4: no-actionable always auto, dashboard-empty exits routed through ship-or-cleanup instead of stranding).

## Test plan

- [x] Clean `git revert` of squash-merge commit; tests pass (full suite, 3270/3270 — count matches pre-#356 baseline + the 4 tests added in #356 removed, as expected).
- [x] No new logic introduced.
- [ ] **Follow-up PR** will land the correct fix (sites 2/3/4 with right semantics; site 1 stays as it was before #356).

🤖 Generated with /do (PR mode, auto-merge)
