### PR TITLE
do: tracker-PR auto-merge follows content stream

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+992d09"
+  version: "2026.05.17+29284f"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -43,13 +43,23 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
   pattern: `/fix-issues 1 every 30m dashboard auto`.
 - **auto** (optional) — bypass confirmation gates for autonomous operation.
   Behavior depends on context:
-  - **Sprints:** skip Phase 2 issue list approval, auto-land to main via
-    cherry-pick. Does NOT close GH issues or remove worktrees — those are
+  - **Sprints:** skip Phase 2 issue list approval, auto-land per-issue
+    fix PRs, AND auto-merge the Phase 6 sprint-report PR (its content
+    describes the sprint's fix work, so it follows your `auto` choice).
+    Does NOT close GH issues or remove worktrees — those are
     `/fix-report` actions.
+  - **Sync-only tracker PRs always auto-merge regardless of `auto`.**
+    Three dispatch sites ship sync-driven tracker updates ONLY (no fix
+    work): the standalone `/fix-issues sync` PR, the sprint
+    no-actionable ship branch, and the dashboard-empty ship branch.
+    Those PRs contain agent-facing markdown that the agent reads back,
+    not user-facing artifacts warranting human review.
   - **plan auto:** draft plans for all found issues without selection
     (see Plan section).
-  - **Not applicable to sync.** `sync` is always interactive — closing
-    issues on GitHub requires human approval.
+  - **Sync `gh issue close` step is still interactive.** `auto` does NOT
+    bypass the human-approval gate on the irreversible `gh issue close`
+    sub-step in standalone sync (Step 5 sub-step 3); only the tracker-PR
+    auto-merge is unconditional.
 - **every SCHEDULE** (optional) — self-schedule recurring runs via cron:
   - Accepts intervals: `4h`, `2h`, `30m`, `12h`
   - Accepts time-of-day: `day at 9am`, `day at 14:00`, `weekday at 9am`
@@ -541,19 +551,23 @@ EOF
    {
      printf '## Summary\n`/fix-issues sync` on %s updated trackers.\n\n' \
        "$(TZ=America/New_York date +%F)"
-     printf '## Test plan\n- [x] Tracker diff reviewed by user before merge.\n'
+     printf '## Test plan\n- [x] Sync-only diff: agent-facing tracker markdown; auto-merge.\n'
    } > "$BODY_FILE"
 
    PR_TITLE="sync: $(TZ=America/New_York date +%F)"
    SYNC_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
 
-   # /land-pr arg vector. Mirrors run-plan PR mode (modes/pr.md:339-348)
-   # MINUS the auto-merge flag. Sync is always interactive — closing
-   # issues on GitHub requires human approval — so the auto-merge flag
-   # is intentionally omitted. The CI-monitor-suppression flag is also
+   # /land-pr arg vector. Always includes --auto: this dispatch ships
+   # sync-driven tracker updates ONLY (research blurbs, ISSUES_PLAN row
+   # adds, SPRINT_REPORT section append from sync). That content is
+   # agent-facing markdown the agent reads back, not user-facing artifacts
+   # warranting human review. The SUBSEQUENT "close approved issues on
+   # GitHub" sub-step (Step 5 sub-step 3 below) is what remains
+   # interactive — that requires human approval for the irreversible
+   # `gh issue close` calls. The CI-monitor-suppression flag remains
    # omitted (CI monitoring is desired; the orchestrator awaits resting
    # state).
-   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID"
+   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto"
 
    # Echo the pipeline id for transcript-propagation (matches /do pr's
    # tier-2 idiom at `skills/do/modes/pr.md:203`). Do NOT env-export
@@ -1217,8 +1231,100 @@ arrays — same discipline as Phase 1's row-writer).
 
 ```bash
 if [ "$DASHBOARD_MODE" = "1" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
   MAIN_ROOT="${MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir)/.." && pwd)}"
   MONITOR_STATE="$MAIN_ROOT/.zskills/monitor-state.json"
+
+  # Helper: ship-or-cleanup. Called from each of the two dashboard-empty
+  # exits below. If $WT_PATH is set and the worktree has uncommitted
+  # changes from Phase 1a sync, stage + commit + dispatch /land-pr --auto
+  # (sync-only content, same rationale as the no-actionable ship branch
+  # at `### If no actionable issues found`). If clean, remove the empty
+  # worktree. Inlined rather than function-shared with the no-actionable
+  # site because those live in separate bash fences — bash functions do
+  # not span skill fences.
+  ship_sync_only_or_cleanup() {
+    [ -z "${WT_PATH:-}" ] && return 0
+    cd "$WT_PATH" || { echo "fix-issues: cd $WT_PATH failed (dashboard-empty)" >&2; return 1; }
+    local TOPLEVEL
+    TOPLEVEL=$(git rev-parse --show-toplevel)
+    if [ -n "$(git -C "$TOPLEVEL" status --porcelain)" ]; then
+      echo "fix-issues dashboard-empty: Phase 1a sync wrote updates; shipping sync-only PR" >&2
+      git -C "$TOPLEVEL" add -A
+      local STAGED
+      STAGED=$(git -C "$TOPLEVEL" diff --cached --name-only)
+      if [ -z "$STAGED" ]; then
+        echo "fix-issues dashboard-empty: status reported dirty but nothing staged — removing worktree" >&2
+        cd "$MAIN_ROOT" && git worktree remove --force "$WT_PATH"
+        return 0
+      fi
+      if [ -n "${COMMIT_CO_AUTHOR:-}" ]; then
+        git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" \
+          -m "docs(sync): tracker refresh from /fix-issues fire $SPRINT_ID"
+      else
+        git -C "$TOPLEVEL" commit -m "docs(sync): tracker refresh from /fix-issues fire $SPRINT_ID"
+      fi
+
+      local SPRINT_LAND_ID="fix-issues.dashboard-sync.${SPRINT_ID}"
+      mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+      printf 'skill: land-pr\nrequired-by: fix-issues-dashboard-empty\ndate: %s\n' \
+        "$(TZ=UTC date -Iseconds)" \
+        > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${SPRINT_LAND_ID}"
+
+      local RESULT_FILE BODY_FILE PR_TITLE SPRINT_BRANCH LAND_ARGS
+      RESULT_FILE=$(mktemp)
+      BODY_FILE=$(mktemp)
+      {
+        printf '## Summary\n`/fix-issues` dashboard fire %s: Ready queue empty; Phase 1a sync produced tracker updates that ship here.\n\n' "$SPRINT_ID"
+        printf '## Test plan\n- [x] Sync-only diff; no per-issue work executed this fire.\n'
+      } > "$BODY_FILE"
+
+      PR_TITLE="sync: tracker refresh from /fix-issues dashboard fire $SPRINT_ID"
+      SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+      # This dispatch fires when the dashboard Ready queue is empty but
+      # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
+      # content (`git add -A` against the worktree after sync ran), so it
+      # ALWAYS auto-merges regardless of user's `auto` arg — same rationale
+      # as standalone sync's Phase 5 dispatch and the no-actionable ship
+      # branch later in this skill.
+      LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-dashboard-empty --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+
+      echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+
+      # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+      if [ ! -f "$RESULT_FILE" ]; then
+        echo "ERROR: /land-pr (dashboard-empty sync-land) produced no result file at $RESULT_FILE" >&2
+      else
+        local -A LP_DASH
+        local KEY VALUE
+        while IFS='=' read -r KEY VALUE; do
+          case "$KEY" in
+            STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
+            MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
+            CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+              LP_DASH["$KEY"]="$VALUE" ;;
+            "") ;;
+            *) printf 'WARN: /land-pr (dashboard-empty sync-land) result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
+          esac
+        done < "$RESULT_FILE"
+        case "${LP_DASH[STATUS]:-}" in
+          merged)
+            printf 'skill: land-pr\nid: %s\npr: %s\nbranch: %s\ndate: %s\n' \
+              "$SPRINT_LAND_ID" "${LP_DASH[PR_URL]:-}" "$SPRINT_BRANCH" \
+              "$(TZ=UTC date -Iseconds)" \
+              > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.land-pr.$SPRINT_LAND_ID"
+            ;;
+          *)
+            echo "fix-issues dashboard-empty sync-land: /land-pr STATUS=${LP_DASH[STATUS]:-unknown} — sync PR left open" >&2
+            ;;
+        esac
+      fi
+    else
+      echo "fix-issues dashboard-empty: no sync updates; cleaning up empty worktree" >&2
+      cd "$MAIN_ROOT" && git worktree remove --force "$WT_PATH"
+    fi
+  }
 
   # Reuse the cached OPEN_NUMS array fetched in Phase 1's sync step (gh
   # issue list --state open ...). If for some reason it is not set in
@@ -1243,6 +1349,7 @@ for it in json.load(sys.stdin):
   # default rubric. Do NOT error.
   if [ ! -f "$MONITOR_STATE" ]; then
     echo "Dashboard Ready is empty — nothing to do"
+    ship_sync_only_or_cleanup
     exit 0
   fi
 
@@ -1291,6 +1398,7 @@ print(" ".join(str(p) for p in picks))
 
   if [ -z "$DASHBOARD_PICKS" ]; then
     echo "Dashboard Ready is empty — nothing to do"
+    ship_sync_only_or_cleanup
     exit 0
   fi
 
@@ -1501,8 +1609,13 @@ If ALL candidates are too vague, too complex, or already attempted:
 
          PR_TITLE="sync: tracker refresh from /fix-issues fire $SPRINT_ID"
          SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
-         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID"
-         [ "${AUTO:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+         # This dispatch fires when Phase 2 found no actionable issues but
+         # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
+         # content (`git add -A` against the worktree after sync ran, before any
+         # fix work), so it ALWAYS auto-merges regardless of user's `auto` arg —
+         # same rationale as standalone sync's Phase 5 dispatch at the top of
+         # this skill.
+         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
 
          echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.17+992d09"
+  version: "2026.05.17+29284f"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -43,13 +43,23 @@ report, and optionally auto-lands to main. Can self-schedule for recurring runs.
   pattern: `/fix-issues 1 every 30m dashboard auto`.
 - **auto** (optional) — bypass confirmation gates for autonomous operation.
   Behavior depends on context:
-  - **Sprints:** skip Phase 2 issue list approval, auto-land to main via
-    cherry-pick. Does NOT close GH issues or remove worktrees — those are
+  - **Sprints:** skip Phase 2 issue list approval, auto-land per-issue
+    fix PRs, AND auto-merge the Phase 6 sprint-report PR (its content
+    describes the sprint's fix work, so it follows your `auto` choice).
+    Does NOT close GH issues or remove worktrees — those are
     `/fix-report` actions.
+  - **Sync-only tracker PRs always auto-merge regardless of `auto`.**
+    Three dispatch sites ship sync-driven tracker updates ONLY (no fix
+    work): the standalone `/fix-issues sync` PR, the sprint
+    no-actionable ship branch, and the dashboard-empty ship branch.
+    Those PRs contain agent-facing markdown that the agent reads back,
+    not user-facing artifacts warranting human review.
   - **plan auto:** draft plans for all found issues without selection
     (see Plan section).
-  - **Not applicable to sync.** `sync` is always interactive — closing
-    issues on GitHub requires human approval.
+  - **Sync `gh issue close` step is still interactive.** `auto` does NOT
+    bypass the human-approval gate on the irreversible `gh issue close`
+    sub-step in standalone sync (Step 5 sub-step 3); only the tracker-PR
+    auto-merge is unconditional.
 - **every SCHEDULE** (optional) — self-schedule recurring runs via cron:
   - Accepts intervals: `4h`, `2h`, `30m`, `12h`
   - Accepts time-of-day: `day at 9am`, `day at 14:00`, `weekday at 9am`
@@ -541,19 +551,23 @@ EOF
    {
      printf '## Summary\n`/fix-issues sync` on %s updated trackers.\n\n' \
        "$(TZ=America/New_York date +%F)"
-     printf '## Test plan\n- [x] Tracker diff reviewed by user before merge.\n'
+     printf '## Test plan\n- [x] Sync-only diff: agent-facing tracker markdown; auto-merge.\n'
    } > "$BODY_FILE"
 
    PR_TITLE="sync: $(TZ=America/New_York date +%F)"
    SYNC_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
 
-   # /land-pr arg vector. Mirrors run-plan PR mode (modes/pr.md:339-348)
-   # MINUS the auto-merge flag. Sync is always interactive — closing
-   # issues on GitHub requires human approval — so the auto-merge flag
-   # is intentionally omitted. The CI-monitor-suppression flag is also
+   # /land-pr arg vector. Always includes --auto: this dispatch ships
+   # sync-driven tracker updates ONLY (research blurbs, ISSUES_PLAN row
+   # adds, SPRINT_REPORT section append from sync). That content is
+   # agent-facing markdown the agent reads back, not user-facing artifacts
+   # warranting human review. The SUBSEQUENT "close approved issues on
+   # GitHub" sub-step (Step 5 sub-step 3 below) is what remains
+   # interactive — that requires human approval for the irreversible
+   # `gh issue close` calls. The CI-monitor-suppression flag remains
    # omitted (CI monitoring is desired; the orchestrator awaits resting
    # state).
-   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID"
+   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto"
 
    # Echo the pipeline id for transcript-propagation (matches /do pr's
    # tier-2 idiom at `skills/do/modes/pr.md:203`). Do NOT env-export
@@ -1217,8 +1231,100 @@ arrays — same discipline as Phase 1's row-writer).
 
 ```bash
 if [ "$DASHBOARD_MODE" = "1" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
   MAIN_ROOT="${MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir)/.." && pwd)}"
   MONITOR_STATE="$MAIN_ROOT/.zskills/monitor-state.json"
+
+  # Helper: ship-or-cleanup. Called from each of the two dashboard-empty
+  # exits below. If $WT_PATH is set and the worktree has uncommitted
+  # changes from Phase 1a sync, stage + commit + dispatch /land-pr --auto
+  # (sync-only content, same rationale as the no-actionable ship branch
+  # at `### If no actionable issues found`). If clean, remove the empty
+  # worktree. Inlined rather than function-shared with the no-actionable
+  # site because those live in separate bash fences — bash functions do
+  # not span skill fences.
+  ship_sync_only_or_cleanup() {
+    [ -z "${WT_PATH:-}" ] && return 0
+    cd "$WT_PATH" || { echo "fix-issues: cd $WT_PATH failed (dashboard-empty)" >&2; return 1; }
+    local TOPLEVEL
+    TOPLEVEL=$(git rev-parse --show-toplevel)
+    if [ -n "$(git -C "$TOPLEVEL" status --porcelain)" ]; then
+      echo "fix-issues dashboard-empty: Phase 1a sync wrote updates; shipping sync-only PR" >&2
+      git -C "$TOPLEVEL" add -A
+      local STAGED
+      STAGED=$(git -C "$TOPLEVEL" diff --cached --name-only)
+      if [ -z "$STAGED" ]; then
+        echo "fix-issues dashboard-empty: status reported dirty but nothing staged — removing worktree" >&2
+        cd "$MAIN_ROOT" && git worktree remove --force "$WT_PATH"
+        return 0
+      fi
+      if [ -n "${COMMIT_CO_AUTHOR:-}" ]; then
+        git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" \
+          -m "docs(sync): tracker refresh from /fix-issues fire $SPRINT_ID"
+      else
+        git -C "$TOPLEVEL" commit -m "docs(sync): tracker refresh from /fix-issues fire $SPRINT_ID"
+      fi
+
+      local SPRINT_LAND_ID="fix-issues.dashboard-sync.${SPRINT_ID}"
+      mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+      printf 'skill: land-pr\nrequired-by: fix-issues-dashboard-empty\ndate: %s\n' \
+        "$(TZ=UTC date -Iseconds)" \
+        > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${SPRINT_LAND_ID}"
+
+      local RESULT_FILE BODY_FILE PR_TITLE SPRINT_BRANCH LAND_ARGS
+      RESULT_FILE=$(mktemp)
+      BODY_FILE=$(mktemp)
+      {
+        printf '## Summary\n`/fix-issues` dashboard fire %s: Ready queue empty; Phase 1a sync produced tracker updates that ship here.\n\n' "$SPRINT_ID"
+        printf '## Test plan\n- [x] Sync-only diff; no per-issue work executed this fire.\n'
+      } > "$BODY_FILE"
+
+      PR_TITLE="sync: tracker refresh from /fix-issues dashboard fire $SPRINT_ID"
+      SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+      # This dispatch fires when the dashboard Ready queue is empty but
+      # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
+      # content (`git add -A` against the worktree after sync ran), so it
+      # ALWAYS auto-merges regardless of user's `auto` arg — same rationale
+      # as standalone sync's Phase 5 dispatch and the no-actionable ship
+      # branch later in this skill.
+      LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-dashboard-empty --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+
+      echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+
+      # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+      if [ ! -f "$RESULT_FILE" ]; then
+        echo "ERROR: /land-pr (dashboard-empty sync-land) produced no result file at $RESULT_FILE" >&2
+      else
+        local -A LP_DASH
+        local KEY VALUE
+        while IFS='=' read -r KEY VALUE; do
+          case "$KEY" in
+            STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
+            MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
+            CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+              LP_DASH["$KEY"]="$VALUE" ;;
+            "") ;;
+            *) printf 'WARN: /land-pr (dashboard-empty sync-land) result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
+          esac
+        done < "$RESULT_FILE"
+        case "${LP_DASH[STATUS]:-}" in
+          merged)
+            printf 'skill: land-pr\nid: %s\npr: %s\nbranch: %s\ndate: %s\n' \
+              "$SPRINT_LAND_ID" "${LP_DASH[PR_URL]:-}" "$SPRINT_BRANCH" \
+              "$(TZ=UTC date -Iseconds)" \
+              > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.land-pr.$SPRINT_LAND_ID"
+            ;;
+          *)
+            echo "fix-issues dashboard-empty sync-land: /land-pr STATUS=${LP_DASH[STATUS]:-unknown} — sync PR left open" >&2
+            ;;
+        esac
+      fi
+    else
+      echo "fix-issues dashboard-empty: no sync updates; cleaning up empty worktree" >&2
+      cd "$MAIN_ROOT" && git worktree remove --force "$WT_PATH"
+    fi
+  }
 
   # Reuse the cached OPEN_NUMS array fetched in Phase 1's sync step (gh
   # issue list --state open ...). If for some reason it is not set in
@@ -1243,6 +1349,7 @@ for it in json.load(sys.stdin):
   # default rubric. Do NOT error.
   if [ ! -f "$MONITOR_STATE" ]; then
     echo "Dashboard Ready is empty — nothing to do"
+    ship_sync_only_or_cleanup
     exit 0
   fi
 
@@ -1291,6 +1398,7 @@ print(" ".join(str(p) for p in picks))
 
   if [ -z "$DASHBOARD_PICKS" ]; then
     echo "Dashboard Ready is empty — nothing to do"
+    ship_sync_only_or_cleanup
     exit 0
   fi
 
@@ -1501,8 +1609,13 @@ If ALL candidates are too vague, too complex, or already attempted:
 
          PR_TITLE="sync: tracker refresh from /fix-issues fire $SPRINT_ID"
          SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
-         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID"
-         [ "${AUTO:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+         # This dispatch fires when Phase 2 found no actionable issues but
+         # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
+         # content (`git add -A` against the worktree after sync ran, before any
+         # fix work), so it ALWAYS auto-merges regardless of user's `auto` arg —
+         # same rationale as standalone sync's Phase 5 dispatch at the top of
+         # this skill.
+         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
 
          echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 

--- a/tests/test-fix-issues-dashboard.sh
+++ b/tests/test-fix-issues-dashboard.sh
@@ -100,8 +100,11 @@ test_empty_missing_state_file() {
 # Also assert the bash guard is wired (defense in depth for the missing
 # file case, which short-circuits before invoking Python).
 test_bash_guard_missing_file_exits_zero() {
+  # The guard's block grew from 2 lines (echo + exit) to 3 lines
+  # (echo + ship_sync_only_or_cleanup call + exit) when the dashboard-empty
+  # ship-or-cleanup routing landed. Widen the context window to -A3.
   if grep -qE 'if \[ ! -f "\$MONITOR_STATE" \]; then' "$SKILL" \
-     && grep -A2 'if \[ ! -f "\$MONITOR_STATE" \]; then' "$SKILL" | grep -qF 'exit 0'; then
+     && grep -A3 'if \[ ! -f "\$MONITOR_STATE" \]; then' "$SKILL" | grep -qF 'exit 0'; then
     pass "bash guard: missing state file -> echo + exit 0"
   else
     fail "bash guard: missing state file -> echo + exit 0" "guard or 'exit 0' not found near missing-file check"

--- a/tests/test-fix-issues.sh
+++ b/tests/test-fix-issues.sh
@@ -344,6 +344,153 @@ test_dashboard_mutex_error_strings_present() {
   fi
 }
 
+# --- tracker-PR auto-merge content-stream semantics (post-PR #357 revert) -
+#
+# Four dispatch sites in /fix-issues open tracker-style PRs via /land-pr.
+# Their `--auto` semantics follow what each PR commits, NOT what the user
+# said:
+#   Site 1 (Phase 6 sprint-land):     fix-work content → follows user's `auto`
+#   Site 2 (standalone sync Phase 5): sync-only content → unconditional --auto
+#   Site 3 (sprint no-actionable):    sync-only content → unconditional --auto
+#   Site 4 (dashboard-empty exits):   route through ship-or-cleanup (sync-only
+#                                      content → unconditional --auto)
+#
+# The PR #356 attempt over-corrected and dropped the `auto` honor on the
+# Phase 6 sprint-land PR too — content-stream-blind. PR #357 reverted it;
+# this regression bundle pins the corrected asymmetry.
+
+test_site2_sync_phase5_unconditional_auto() {
+  # The standalone sync Phase 5 LAND_ARGS line must end with `--auto`.
+  # Identified by --landed-source=fix-issues-sync (site 2 only).
+  local line
+  line=$(grep -nF 'landed-source=fix-issues-sync ' "$SKILL" \
+         | grep -F 'LAND_ARGS=' | head -1 | cut -d: -f1)
+  if [ -z "$line" ]; then
+    fail "site 2: standalone sync LAND_ARGS line found" "no LAND_ARGS line with landed-source=fix-issues-sync"
+    return
+  fi
+  local content
+  content=$(awk -v n="$line" 'NR==n { print }' "$SKILL")
+  if echo "$content" | grep -qE -- '--auto"?$'; then
+    pass "site 2: standalone sync LAND_ARGS ends with --auto (unconditional)"
+  else
+    fail "site 2: standalone sync LAND_ARGS ends with --auto" "line $line does not end --auto: [$content]"
+  fi
+}
+
+test_site3_no_actionable_unconditional_auto() {
+  # The sprint no-actionable LAND_ARGS line must end with `--auto`.
+  # Identified by --landed-source=fix-issues-no-actionable (site 3 only).
+  local line
+  line=$(grep -nF 'landed-source=fix-issues-no-actionable ' "$SKILL" \
+         | grep -F 'LAND_ARGS=' | head -1 | cut -d: -f1)
+  if [ -z "$line" ]; then
+    fail "site 3: no-actionable LAND_ARGS line found" "no LAND_ARGS line with landed-source=fix-issues-no-actionable"
+    return
+  fi
+  local content
+  content=$(awk -v n="$line" 'NR==n { print }' "$SKILL")
+  if echo "$content" | grep -qE -- '--auto"?$'; then
+    pass "site 3: no-actionable LAND_ARGS ends with --auto (unconditional)"
+  else
+    fail "site 3: no-actionable LAND_ARGS ends with --auto" "line $line does not end --auto: [$content]"
+  fi
+
+  # And the AUTO-conditional must NOT appear immediately after the
+  # no-actionable LAND_ARGS line (would re-introduce content-stream
+  # confusion).
+  local next
+  next=$(awk -v n="$line" 'NR==n+1 { print }' "$SKILL")
+  if echo "$next" | grep -qE '\[\s*"\$\{AUTO:-false\}"\s*=\s*"true"\s*\]\s*&&\s*LAND_ARGS='; then
+    fail "site 3: no AUTO-conditional after no-actionable LAND_ARGS" "found on line $((line+1)): [$next]"
+  else
+    pass "site 3: no AUTO-conditional immediately after no-actionable LAND_ARGS"
+  fi
+}
+
+test_site1_sprint_land_honors_auto() {
+  # CRITICAL INVARIANT from PR #357 revert: the Phase 6 sprint-land
+  # LAND_ARGS must NOT have unconditional --auto, and the AUTO-conditional
+  # MUST be present immediately after it. Identified by
+  # --landed-source=fix-issues-sprint (site 1 only).
+  local line
+  line=$(grep -nF 'landed-source=fix-issues-sprint ' "$SKILL" \
+         | grep -F 'LAND_ARGS=' | head -1 | cut -d: -f1)
+  if [ -z "$line" ]; then
+    fail "site 1: Phase 6 sprint-land LAND_ARGS line found" "no LAND_ARGS line with landed-source=fix-issues-sprint"
+    return
+  fi
+  local content
+  content=$(awk -v n="$line" 'NR==n { print }' "$SKILL")
+  if echo "$content" | grep -qE -- '--auto"?$'; then
+    fail "site 1: Phase 6 sprint-land LAND_ARGS must NOT end --auto" "PR #356 regression: line $line ends --auto unconditionally: [$content]"
+  else
+    pass "site 1: Phase 6 sprint-land LAND_ARGS does NOT end --auto (honors user's auto)"
+  fi
+
+  # The AUTO-conditional MUST be on the very next line.
+  local next
+  next=$(awk -v n="$line" 'NR==n+1 { print }' "$SKILL")
+  if echo "$next" | grep -qE '\[\s*"\$\{AUTO:-false\}"\s*=\s*"true"\s*\]\s*&&\s*LAND_ARGS='; then
+    pass "site 1: AUTO-conditional present immediately after sprint-land LAND_ARGS"
+  else
+    fail "site 1: AUTO-conditional present immediately after sprint-land LAND_ARGS" \
+         "PR #356 regression — line $((line+1)) is not the AUTO-conditional: [$next]"
+  fi
+}
+
+test_site4_dashboard_empty_exits_route_through_ship_or_cleanup() {
+  # The two dashboard-empty exits must route through ship-or-cleanup
+  # (Option A: function call) instead of bare `exit 0` immediately after
+  # the "Dashboard Ready is empty" echo. Phase 1a sync may have written
+  # tracker updates to the worktree; bare `exit 0` would strand them.
+  #
+  # Locate both echo lines and assert the line BEFORE `exit 0` is the
+  # ship_sync_only_or_cleanup call (Option A) — not a bare echo + exit.
+  local echo_lines
+  echo_lines=$(grep -nF 'Dashboard Ready is empty — nothing to do' "$SKILL" | cut -d: -f1)
+  local n_lines
+  n_lines=$(printf '%s\n' "$echo_lines" | wc -l)
+  if [ "$n_lines" -lt 2 ]; then
+    fail "site 4: both dashboard-empty echo lines present" "found $n_lines, expected 2"
+    return
+  fi
+
+  local missing=0
+  for el in $echo_lines; do
+    # The line immediately after the echo should be the ship_sync_only_or_cleanup
+    # call (not exit 0 directly).
+    local next_line
+    next_line=$(awk -v n="$el" 'NR==n+1 { print }' "$SKILL")
+    if ! echo "$next_line" | grep -qE 'ship_sync_only_or_cleanup'; then
+      fail "site 4: dashboard-empty echo at line $el routes through ship-or-cleanup" \
+           "next line is not ship_sync_only_or_cleanup: [$next_line]"
+      missing=1
+    fi
+  done
+  if [ "$missing" -eq 0 ]; then
+    pass "site 4: both dashboard-empty exits route through ship_sync_only_or_cleanup ($n_lines sites)"
+  fi
+
+  # And ship_sync_only_or_cleanup must be defined somewhere in the file.
+  if grep -qE '^\s*ship_sync_only_or_cleanup\s*\(\s*\)\s*\{' "$SKILL"; then
+    pass "site 4: ship_sync_only_or_cleanup() helper defined"
+  else
+    fail "site 4: ship_sync_only_or_cleanup() helper defined" "function definition not found"
+  fi
+}
+
+test_no_intentionally_omitted_rationale() {
+  # The deprecated "intentionally omitted" rationale was tied to the old
+  # claim that sync is always interactive at the PR level. With unconditional
+  # --auto on site 2, that prose is wrong and must be removed.
+  if grep -qF 'intentionally omitted' "$SKILL"; then
+    fail "deprecated 'intentionally omitted' rationale removed" "still present"
+  else
+    pass "deprecated 'intentionally omitted' rationale removed"
+  fi
+}
+
 # --- Mirror parity -------------------------------------------------------
 
 test_mirror_in_sync() {
@@ -367,6 +514,11 @@ test_dashboard_token_recognized_in_phase0
 test_dashboard_phase2_branch_present
 test_dashboard_uses_python_json_not_bash_regex
 test_dashboard_mutex_error_strings_present
+test_site2_sync_phase5_unconditional_auto
+test_site3_no_actionable_unconditional_auto
+test_site1_sprint_land_honors_auto
+test_site4_dashboard_empty_exits_route_through_ship_or_cleanup
+test_no_intentionally_omitted_rationale
 test_mirror_in_sync
 
 echo ""


### PR DESCRIPTION
## Summary

Correct version of the tracker-PR auto-merge semantics. Supersedes #356 (reverted in #357). The rule is: `--auto` gating follows what each PR commits, not what the user typed.

## The principle

`/fix-issues` opens tracker-style PRs from four distinct dispatch sites. Each one's content has a different origin and therefore a different review surface:

| # | Site | Commits | Auto-merge rule |
|---|------|---------|-----------------|
| 1 | Sprint Phase 6 sprint-land | `SPRINT_REPORT.md` (fix-work log) | Honor user's `auto` — **UNCHANGED** |
| 2 | Standalone `/fix-issues sync` Phase 5 | Sync's tracker updates only | **Always `--auto`** |
| 3 | Sprint no-actionable ship branch | Sync's tracker updates only (no fix work ran) | **Always `--auto`** |
| 4 | Dashboard-empty exits | (was bare `exit 0`, stranded sync output) | **Route through site 3's ship-or-cleanup** |

## Why this is right where #356 was wrong

#356 made sites 1 AND 2 always auto-merge uniformly. That broke site 1: the Phase 6 sprint-report PR describes the sprint's actual fix work. If the user runs `/fix-issues 5` without `auto`, they want to review the 5 fix PRs before the sprint-report log lands; #356 inverted that. This PR keeps site 1 honoring `auto` and only flips the sites that ship sync-only content.

## Implementation

- **Site 1** (~Phase 6 sprint-land): untouched. Restored by #357's revert; this PR doesn't re-touch it.
- **Site 2** (~standalone sync Phase 5, line 556): LAND_ARGS gets unconditional `--auto`; comment rewritten to attribute interactivity to the subsequent `gh issue close` sub-step, not the tracker PR.
- **Site 3** (~no-actionable ship branch, line 1517): LAND_ARGS gets unconditional `--auto`; the conditional `[ "${AUTO:-false}" = "true" ] && ...` line removed.
- **Site 4** (~dashboard-empty exits at lines 1258 + 1306): bare `exit 0` replaced with a call to a new bash helper `ship_sync_only_or_cleanup` (defined once at top of the dashboard fence). The helper mirrors the no-actionable path's commit-or-cleanup logic: if `$TOPLEVEL` is dirty after Phase 1a sync, commit + `/land-pr --auto`; if clean, `git worktree remove --force`. Dashboard-empty cron fires now produce either a clean PR or a clean worktree teardown — never strand.

## Tests

5 new regression-grep tests in `tests/test-fix-issues.sh`:
1. Site 2 LAND_ARGS unconditional `--auto`.
2. Site 3 LAND_ARGS unconditional `--auto` + no following AUTO-conditional line.
3. Site 1 LAND_ARGS preserves the AUTO-conditional pattern (critical invariant — catches future regressions like #356).
4. Site 4 dashboard-empty exits route through `ship_sync_only_or_cleanup` (no bare `exit 0` after the "Dashboard Ready is empty" echo).
5. Phrase "intentionally omitted" no longer appears anywhere in skills/fix-issues/SKILL.md.

One adjacent test (`tests/test-fix-issues-dashboard.sh` — `test_bash_guard_missing_file_exits_zero`) had a brittle `-A2` context-window assertion that became insufficient with the helper call inserted between echo and exit. Widened to `-A3`. Same test, same intent, more robust grep.

## Test plan

- [x] Full suite: **3277/3277 PASS**
- [x] Plan-confirmation agent (Phase 0b): APPROVE
- [x] Scope check: 4 files (skill + mirror + 2 tests); no CLAUDE.md / hooks / other-skill touch
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: `→ 2026.05.17+29284f`
- [ ] **Post-merge end-to-end verifier agent** to trace every tracker-PR dispatch site and confirm the four-site invariant holds.
- [ ] **User test:** `/fix-issues 1 dashboard` with empty Ready → either ships a sync-only PR (auto-merges) or cleans up the worktree. Drag #67 to Ready, re-run → fix PR for #67 sits at pr-ready awaiting review; sprint-report PR sits at pr-ready too (correct — it's fix-work-driven). Add `auto`: both PRs auto-merge.

🤖 Generated with /do (agent-dispatched, PR mode, auto-merge)
