### PR TITLE
chore(do): 3 hygiene nits from post-#354 audit

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,10 +7,10 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.17+0b6de4"
+  version: "2026.05.17+18f7d9"
 ---
 
-# /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or autonomous landing. Can be scheduled for recurring maintenance
@@ -216,8 +216,11 @@ fi
 # Issue #297: positional `auto` token (case-insensitive, anywhere in the
 # args) opts /do pr into /land-pr's auto-merge path. Mirrors /quickfix,
 # /run-plan, /fix-issues. Pre-parsed here so Phase 1.5's strip chain and
-# Phase 2 mode dispatch both see AUTO_FLAG. No-op for non-PR modes (only
-# modes/pr.md reads AUTO_FLAG).
+# Phase 2 mode dispatch both see AUTO_FLAG.
+# AUTO_FLAG is consumed by:
+#   - modes/pr.md to inject --auto into LAND_ARGS for /land-pr (PR mode)
+#   - Phase 3 to dispatch /verify-changes (direct/worktree modes)
+#   - Phase 4 (Land) as the gate to push/cherry-pick+push (direct/worktree modes)
 AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1

--- a/docs/plans/QUICKFIX_GRAMMAR_REDESIGN.md
+++ b/docs/plans/QUICKFIX_GRAMMAR_REDESIGN.md
@@ -5,6 +5,8 @@ created: 2026-05-16
 status: complete
 ---
 
+> **⚠ SUPERSEDED.** This plan was executed via /run-plan (landed PR #342), then largely reverted in PR #349 because the `auto`/`unattended` split was over-engineering per `feedback_no_premature_backcompat.md`. Subsequent cleanup in PRs #352 + #354 finalized the simpler design. Retained as historical record. Anyone grepping `unattended` lands here — that's expected; the token does not exist anywhere else in the codebase.
+
 # Plan: /quickfix argument-grammar redesign + cross-skill `auto`/`unattended` alignment
 
 > **Landing mode: PR** — This plan targets PR-based landing. All phases use worktree isolation with a named feature branch.

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,10 +7,10 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.17+0b6de4"
+  version: "2026.05.17+18f7d9"
 ---
 
-# /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or autonomous landing. Can be scheduled for recurring maintenance
@@ -216,8 +216,11 @@ fi
 # Issue #297: positional `auto` token (case-insensitive, anywhere in the
 # args) opts /do pr into /land-pr's auto-merge path. Mirrors /quickfix,
 # /run-plan, /fix-issues. Pre-parsed here so Phase 1.5's strip chain and
-# Phase 2 mode dispatch both see AUTO_FLAG. No-op for non-PR modes (only
-# modes/pr.md reads AUTO_FLAG).
+# Phase 2 mode dispatch both see AUTO_FLAG.
+# AUTO_FLAG is consumed by:
+#   - modes/pr.md to inject --auto into LAND_ARGS for /land-pr (PR mode)
+#   - Phase 3 to dispatch /verify-changes (direct/worktree modes)
+#   - Phase 4 (Land) as the gate to push/cherry-pick+push (direct/worktree modes)
 AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1


### PR DESCRIPTION
## Summary

3 cosmetic hygiene nits flagged by independent audit at HEAD `5ce2e9e` (post-PRs #342 → #349 → #352 → #354). No behavior change; all visual/documentation cleanups.

No CHANGELOG entry — sub-cosmetic.

## Changes

1. **`skills/do/SKILL.md:219-220` stale comment** — said `"No-op for non-PR modes (only modes/pr.md reads AUTO_FLAG)"`. This was wrong post-#354: Phase 3 (verifier dispatch) and Phase 4 (Land gate) both consume AUTO_FLAG in direct/worktree modes. Rewritten as an accurate 3-line consumer list:
   ```
   # AUTO_FLAG is consumed by:
   #   - modes/pr.md to inject --auto into LAND_ARGS for /land-pr (PR mode)
   #   - Phase 3 to dispatch /verify-changes (direct/worktree modes)
   #   - Phase 4 (Land) as the gate to push/cherry-pick+push (direct/worktree modes)
   ```

2. **`skills/do/SKILL.md:13` H1 drift** — was missing `[now]` between `[every SCHEDULE]` and `[--force]`; line 3 `argument-hint` had it. Synced. `[push]` was already gone (#354 caught it).

3. **`docs/plans/QUICKFIX_GRAMMAR_REDESIGN.md` SUPERSEDED header** — the historical plan has 175 `unattended` mentions (zero elsewhere in the codebase). Anyone repo-grepping the token lands here. Prepended a `> **⚠ SUPERSEDED.**` blockquote pointing at PRs #342/#349/#352/#354 + `feedback_no_premature_backcompat.md`.

## Test plan
- [x] Full suite: 3277/3277 pass at branch HEAD (foreground confirmed)
- [x] `/do` `metadata.version` bumped to `2026.05.17+18f7d9`; mirror byte-identical
- [x] Stage-check exit 0
- [x] Scope: exactly 3 files staged
- [ ] CI: validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
