### PR TITLE
do: dashboard applySnapshot uses lastGoodQueues (fix #353)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.17+03cbc6"
+  version: "2026.05.17+9ccab2"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -341,10 +341,16 @@ function applySnapshot(snap) {
     renderBranches(snap.branches || [], snap.worktrees || []);
   }
 
-  const issuesFp = fingerprintIssues(snap.issues || [], queues);
+  // Use lastGoodQueues (deepCloneQueues output, includes inferred entries
+  // for new GH issues not yet in monitor-state.json's queue arrays), NOT
+  // raw snap.queues. Post-#353 renderIssues honors its queues arg and
+  // only renders cards present in queues.issues[c] — a new issue that
+  // gh returned but monitor-state.json hasn't seen yet would otherwise
+  // never appear. Mirror commitQueueChange's pattern (lines 1182-1202).
+  const issuesFp = fingerprintIssues(snap.issues || [], lastGoodQueues);
   if (issuesFp !== lastFingerprint.issues) {
     lastFingerprint.issues = issuesFp;
-    renderIssues(snap.issues || [], queues);
+    renderIssues(snap.issues || [], lastGoodQueues);
   }
 
   const actFp = fingerprintActivity(snap.activity || []);

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.17+03cbc6"
+  version: "2026.05.17+9ccab2"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -341,10 +341,16 @@ function applySnapshot(snap) {
     renderBranches(snap.branches || [], snap.worktrees || []);
   }
 
-  const issuesFp = fingerprintIssues(snap.issues || [], queues);
+  // Use lastGoodQueues (deepCloneQueues output, includes inferred entries
+  // for new GH issues not yet in monitor-state.json's queue arrays), NOT
+  // raw snap.queues. Post-#353 renderIssues honors its queues arg and
+  // only renders cards present in queues.issues[c] — a new issue that
+  // gh returned but monitor-state.json hasn't seen yet would otherwise
+  // never appear. Mirror commitQueueChange's pattern (lines 1182-1202).
+  const issuesFp = fingerprintIssues(snap.issues || [], lastGoodQueues);
   if (issuesFp !== lastFingerprint.issues) {
     lastFingerprint.issues = issuesFp;
-    renderIssues(snap.issues || [], queues);
+    renderIssues(snap.issues || [], lastGoodQueues);
   }
 
   const actFp = fingerprintActivity(snap.activity || []);

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -503,6 +503,31 @@ else
   fail "AC: renderIssues does not reference queues.issues — regression of optimistic-render bug"
 fi
 
+# AC: applySnapshot passes lastGoodQueues (not raw `queues`) to renderIssues
+# and fingerprintIssues, so new GH issues present in snap.issues but absent
+# from monitor-state.json's queue arrays (deepCloneQueues adds inferred
+# entries) still render. Regression guard for the new-issue auto-pickup bug
+# introduced when PR #353 made renderIssues honor its queues argument.
+# Scoped to applySnapshot's body (commitQueueChange uses same function names
+# but a different pattern, so a whole-file grep would false-positive).
+APPLY_BODY=$(awk '
+  /^function applySnapshot\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$APPLY_BODY" | grep -qF 'renderIssues(snap.issues || [], lastGoodQueues)' \
+   && ! echo "$APPLY_BODY" | grep -qF 'renderIssues(snap.issues || [], queues)'; then
+  pass "AC: applySnapshot calls renderIssues with lastGoodQueues (not raw queues)"
+else
+  fail "AC: applySnapshot must call renderIssues with lastGoodQueues, not raw queues — new-issue auto-pickup regression"
+fi
+if echo "$APPLY_BODY" | grep -qF 'fingerprintIssues(snap.issues || [], lastGoodQueues)' \
+   && ! echo "$APPLY_BODY" | grep -qF 'fingerprintIssues(snap.issues || [], queues)'; then
+  pass "AC: applySnapshot calls fingerprintIssues with lastGoodQueues (not raw queues)"
+else
+  fail "AC: applySnapshot must call fingerprintIssues with lastGoodQueues, not raw queues — fingerprint drift on new issues"
+fi
+
 # AC: Reconciliation suppress window present (1500ms).
 if grep -q 'POST_RECONCILE_SUPPRESS_MS' "$APP_JS" && grep -q '1500' "$APP_JS"; then
   pass "AC: reconciliation suppress window 1500ms present"


### PR DESCRIPTION
## Summary

Regression from PR #353. `applySnapshot` at lines 344/347 of the dashboard's `app.js` passed raw `snap.queues` to `fingerprintIssues` and `renderIssues` instead of the augmented `lastGoodQueues` that was just computed two lines earlier via `deepCloneQueues`. Result: new GH issues present in `snap.issues` but absent from `monitor-state.json`'s queue arrays (like #355 today) never rendered in the dashboard. The drag path was fine (`commitQueueChange` already passed `lastGoodQueues`); only the poll path was broken.

## Root cause

Pre-#353, `renderIssues` ignored its `queues` argument and grouped by each issue's `it.queue.column` annotation (default triage). New GH issues showed up naturally. Post-#353, `renderIssues` correctly honors the argument — but the poll-path call site was never updated to pass the augmented source. `deepCloneQueues` builds `lastGoodQueues.issues[c]` by walking `snap.queues.issues[c]` AND adding inferred entries (with triage fallback) for any live issue not yet in those arrays. `applySnapshot` line 323 captures that augmented value into `lastGoodQueues` — but the very next lines 344 and 347 ignored it and used the raw `queues` variable.

## The fix

Two-line change in `applySnapshot`, mirroring `commitQueueChange`'s already-correct pattern (lines 1182, 1184, 1200, 1202):

```diff
- const issuesFp = fingerprintIssues(snap.issues || [], queues);
+ const issuesFp = fingerprintIssues(snap.issues || [], lastGoodQueues);
  if (issuesFp !== lastFingerprint.issues) {
    lastFingerprint.issues = issuesFp;
-   renderIssues(snap.issues || [], queues);
+   renderIssues(snap.issues || [], lastGoodQueues);
  }
```

Plus a 6-line comment explaining the rationale.

## Tests

Two new bidirectional regression assertions in `tests/test_zskills_monitor_dashboard_ui.sh` (mirrors the brace-extraction idiom used by the renderIssues regression test from PR #353):
- `applySnapshot` body contains `renderIssues(snap.issues || [], lastGoodQueues)` AND does NOT contain `renderIssues(snap.issues || [], queues)`.
- `applySnapshot` body contains `fingerprintIssues(snap.issues || [], lastGoodQueues)` AND does NOT contain `fingerprintIssues(snap.issues || [], queues)`.

Scoped to `applySnapshot`'s function body (not whole-file), so `commitQueueChange`'s call sites aren't accidentally affected.

## Test plan

- [x] Plan-confirmation agent: APPROVE (4 acceptance bullets, scrutinized stale-render risk, stale-snapshot guard interaction, regression-test scoping, downstream fingerprint impact — all cleared)
- [x] Full suite: **3279/3279 PASS**
- [x] Mirror clean: `diff -rq` shows only `__pycache__`
- [x] Skill version bumped: `→ 2026.05.17+9ccab2`
- [x] Scope check: 5 files (skill + mirror + 1 test)
- [ ] **Reviewer post-merge:** restart dashboard, confirm #355 (or any new GH issue not in monitor-state.json) renders in Triage on next poll without needing a drag-and-drop to materialize it.

🤖 Generated with /do (agent-dispatched, PR mode, auto-merge)
