### PR TITLE
do: fix /fix-issues Phase 0c cron-prompt token drop (#362)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.18+fb745e"
+  version: "2026.05.18+642c20"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -784,11 +784,22 @@ If `$ARGUMENTS` contains `every <schedule>`:
    # gates must be skipped non-interactively). Default-on regardless of
    # $AUTO_FLAG.
    CRON_TOKENS="$CRON_TOKENS auto"
+   # Propagate `dashboard` source-of-truth (issue #362) — without this, cron
+   # fire #2+ loses the dashboard-Ready source and falls back to the
+   # model-layer priority rubric.
+   [ "$DASHBOARD_MODE" = "1" ] && CRON_TOKENS="$CRON_TOKENS dashboard"
+   # Propagate explicit landing mode so subsequent cron fires reproduce the
+   # user's pr/direct choice (config default is re-resolved per-fire when
+   # the token is absent, matching current behavior).
+   case "$LANDING_MODE" in
+     pr) CRON_TOKENS="$CRON_TOKENS pr" ;;
+     direct) CRON_TOKENS="$CRON_TOKENS direct" ;;
+   esac
    CRON_PROMPT="Run /fix-issues $N${FOCUS:+ $FOCUS}$CRON_TOKENS every $SCHEDULE now"
    ```
    Default new-cron shape:
    ```
-   Run /fix-issues <N> [focus] auto every <schedule> now
+   Run /fix-issues <N> [focus] auto [dashboard] [pr|direct] every <schedule> now
    ```
 
 4. **Create the cron** — use `CronCreate`:

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.18+fb745e"
+  version: "2026.05.18+642c20"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -784,11 +784,22 @@ If `$ARGUMENTS` contains `every <schedule>`:
    # gates must be skipped non-interactively). Default-on regardless of
    # $AUTO_FLAG.
    CRON_TOKENS="$CRON_TOKENS auto"
+   # Propagate `dashboard` source-of-truth (issue #362) — without this, cron
+   # fire #2+ loses the dashboard-Ready source and falls back to the
+   # model-layer priority rubric.
+   [ "$DASHBOARD_MODE" = "1" ] && CRON_TOKENS="$CRON_TOKENS dashboard"
+   # Propagate explicit landing mode so subsequent cron fires reproduce the
+   # user's pr/direct choice (config default is re-resolved per-fire when
+   # the token is absent, matching current behavior).
+   case "$LANDING_MODE" in
+     pr) CRON_TOKENS="$CRON_TOKENS pr" ;;
+     direct) CRON_TOKENS="$CRON_TOKENS direct" ;;
+   esac
    CRON_PROMPT="Run /fix-issues $N${FOCUS:+ $FOCUS}$CRON_TOKENS every $SCHEDULE now"
    ```
    Default new-cron shape:
    ```
-   Run /fix-issues <N> [focus] auto every <schedule> now
+   Run /fix-issues <N> [focus] auto [dashboard] [pr|direct] every <schedule> now
    ```
 
 4. **Create the cron** — use `CronCreate`:

--- a/tests/test-fix-issues.sh
+++ b/tests/test-fix-issues.sh
@@ -314,6 +314,40 @@ test_dashboard_uses_python_json_not_bash_regex() {
   fi
 }
 
+# --- dashboard + landing-mode tokens propagate to cron prompt (#362) ----
+#
+# Phase 0c step 3 builds CRON_TOKENS for the self-perpetuating cron prompt.
+# Issue #362: the original block only appended `auto`, silently dropping
+# `dashboard` and explicit landing-mode tokens (`pr`/`direct`). Cron fire
+# #2+ then lost the dashboard-Ready source-of-truth and fell back to the
+# model-layer priority rubric.
+#
+# This test guards two propagation lines in skills/fix-issues/SKILL.md:
+#   (1) A DASHBOARD_MODE conditional appending `dashboard` to CRON_TOKENS.
+#   (2) A LANDING_MODE case statement appending `pr` or `direct`.
+
+test_dashboard_token_propagates_to_cron_prompt() {
+  # (1) DASHBOARD_MODE → CRON_TOKENS dashboard propagation.
+  if grep -qE 'DASHBOARD_MODE.*=.*"?1"?.*CRON_TOKENS.*dashboard' "$SKILL"; then
+    pass "CRON_TOKENS propagates dashboard when DASHBOARD_MODE=1 (#362)"
+  else
+    fail "CRON_TOKENS propagates dashboard when DASHBOARD_MODE=1 (#362)" \
+      "no DASHBOARD_MODE-guarded 'CRON_TOKENS=...dashboard' line found in Phase 0c"
+  fi
+
+  # (2) LANDING_MODE case statement assigning pr/direct to CRON_TOKENS.
+  # We look for the `case "$LANDING_MODE"` header plus both arm tokens
+  # near a CRON_TOKENS append.
+  if grep -qE 'case[[:space:]]+"\$LANDING_MODE"' "$SKILL" \
+     && grep -qE 'pr\)[[:space:]]*CRON_TOKENS=.*pr' "$SKILL" \
+     && grep -qE 'direct\)[[:space:]]*CRON_TOKENS=.*direct' "$SKILL"; then
+    pass "CRON_TOKENS propagates pr/direct via LANDING_MODE case (#362)"
+  else
+    fail "CRON_TOKENS propagates pr/direct via LANDING_MODE case (#362)" \
+      "LANDING_MODE case statement assigning pr/direct to CRON_TOKENS not found"
+  fi
+}
+
 # --- dashboard mutex: 5 verbatim ERROR strings present ------------------
 #
 # PR #313 added mutual-exclusion guards between `dashboard` and each of
@@ -513,6 +547,7 @@ test_280_python_json_handles_escaped_quotes
 test_dashboard_token_recognized_in_phase0
 test_dashboard_phase2_branch_present
 test_dashboard_uses_python_json_not_bash_regex
+test_dashboard_token_propagates_to_cron_prompt
 test_dashboard_mutex_error_strings_present
 test_site2_sync_phase5_unconditional_auto
 test_site3_no_actionable_unconditional_auto


### PR DESCRIPTION
## Summary

Fixes #362 — `/fix-issues` Phase 0c CRON_TOKENS build dropped `dashboard` and explicit landing-mode tokens, so recurring crons (`/fix-issues 1 every 30m dashboard auto`) lost the Ready-queue source after the first fire and fell back to the model-layer priority rubric.

The fix adds two propagation segments to the CRON_TOKENS build:
- `DASHBOARD_MODE` propagation: `[ "$DASHBOARD_MODE" = "1" ] && CRON_TOKENS="$CRON_TOKENS dashboard"`
- `LANDING_MODE` case statement propagating explicit `pr`/`direct` tokens
- Updates the "Default new-cron shape" doc-block to reflect the new tokens

Also adds a regression test (`test_dashboard_token_propagates_to_cron_prompt`) asserting both propagation lines are present in the SKILL.md CRON_TOKENS block.

## Test plan

- [x] Per-skill: `bash tests/test-fix-issues.sh` → 35 passed / 0 failed (both new assertions green)
- [x] Full suite: `bash tests/run-all.sh` → 3293 passed / 0 failed / 0 skipped
- [x] Mirror parity: `diff -rq skills/fix-issues/ .claude/skills/fix-issues/` reports clean
- [x] metadata.version bumped to 2026.05.18+642c20 via `frontmatter-set.sh`
- [ ] End-to-end queue-worker validation: `/fix-issues 1 every 30m dashboard auto` registers a cron prompt containing `dashboard` and survives cron-fire #2+ (post-merge, in a fresh session)

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
