### PR TITLE
feat(cleanup-merged): --review flag for per-branch merit-based recommendations (#355)

### DIFF
--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[--dry-run | -n]"
+argument-hint: "[--dry-run | -n] [--review]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
   upstream is gone or whose PR has merged. Bails on a dirty tree; skips
-  branches with unpushed commits. --dry-run previews. Use after merging a
-  PR to catch local state up.
+  branches with unpushed commits. --dry-run previews. --review classifies
+  every local branch + worktree per merit rules and presents an
+  interactive picker for cleanup actions.
 metadata:
-  version: "2026.05.15+be2d31"
+  version: "2026.05.18+6491e2"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -28,6 +29,11 @@ never deletes a branch with unpushed commits.
 
 - `--dry-run` / `-n` — report what would happen without modifying
   anything. Useful to preview deletions on the first run.
+- `--review` — opt into per-branch merit-based classification.
+  Enumerates every local branch + worktree, classifies each per the rule
+  table (see Phase 7), and prompts the user for actions via an
+  alphabetized letter-keyed picker. Mutually exclusive with `--dry-run`
+  (review mode is interactive — dry-run has no meaning).
 
 ## Phase 1 — Preflight
 
@@ -50,15 +56,22 @@ fi
 
 ```bash
 DRY_RUN=0
+REVIEW=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run|-n) DRY_RUN=1 ;;
+    --review) REVIEW=1 ;;
     *)
-      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [--dry-run|-n]" >&2
+      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [--dry-run|-n] [--review]" >&2
       exit 2
       ;;
   esac
 done
+
+if [ "$DRY_RUN" -eq 1 ] && [ "$REVIEW" -eq 1 ]; then
+  echo "ERROR: --dry-run and --review are mutually exclusive (review is interactive)." >&2
+  exit 2
+fi
 ```
 
 ### WI 1.3 — Locate main-repo root and detect main branch
@@ -80,8 +93,12 @@ Untracked files count as dirty: `/cleanup-merged` will `git checkout
 main` and `git pull`, which would dump new untracked files back out or
 could conflict with an uncommitted edit the user hasn't saved yet.
 
+Review mode (`--review`) **does not** bail on a dirty tree — its job is
+to inspect and surface dirty worktrees. It still avoids any destructive
+operation on the dirty repo (no checkout, no pull, no auto-delete).
+
 ```bash
-if [ -n "$(git status --porcelain)" ]; then
+if [ "$REVIEW" -eq 0 ] && [ -n "$(git status --porcelain)" ]; then
   echo "ERROR: working tree is not clean. Commit, stash, or discard changes first." >&2
   git status --short >&2
   exit 3
@@ -113,13 +130,22 @@ merged branch is still held by a live worktree.
 
 If the current branch is not the main branch, check whether its PR is
 merged or its upstream is gone. If so, switch to main so we can delete
-the branch later.
+the branch later. Review mode skips this phase (and Phases 4–6) and
+jumps straight to Phase 7.
 
 ```bash
+if [ "$REVIEW" -eq 1 ]; then
+  # Review-mode skips Phases 3–6; jump to Phase 7 directly.
+  SWITCHED=0
+  ON_MAIN=0
+  DELETED=0
+  SKIPPED=0
+fi
+
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
 SWITCHED=0
 
-if [ "$CURRENT" != "$MAIN_BRANCH" ]; then
+if [ "$REVIEW" -eq 0 ] && [ "$CURRENT" != "$MAIN_BRANCH" ]; then
   UPSTREAM_GONE=0
   if git branch -vv | grep -qE "^\* $CURRENT .*: gone\]"; then
     UPSTREAM_GONE=1
@@ -149,13 +175,14 @@ fi
 ## Phase 4 — Pull main
 
 Only pull if we are on the main branch. A dry-run skips the pull
-because we promised not to modify anything.
+because we promised not to modify anything. Review mode skips this
+phase entirely.
 
 ```bash
 ON_MAIN=0
 [ "$(git rev-parse --abbrev-ref HEAD)" = "$MAIN_BRANCH" ] && ON_MAIN=1
 
-if [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+if [ "$REVIEW" -eq 0 ] && [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
   echo "Pulling $MAIN_BRANCH..."
   if ! git pull origin "$MAIN_BRANCH"; then
     echo "ERROR: git pull failed." >&2
@@ -165,6 +192,10 @@ fi
 ```
 
 ## Phase 5 — Scan and delete merged branches
+
+Review mode skips this phase — its per-branch action logic lives in
+Phase 7 instead (the `if [ "$REVIEW" -eq 1 ]; then : else …` guard
+below wraps the original loop).
 
 For every local branch other than the main branch and the currently
 checked-out branch, check the same two signals (upstream gone, PR
@@ -186,6 +217,9 @@ CURRENT=$(git rev-parse --abbrev-ref HEAD)
 DELETED=0
 SKIPPED=0
 
+if [ "$REVIEW" -eq 1 ]; then
+  : # Phase 5 main loop is bypassed in review mode (handled by Phase 7).
+else
 while IFS= read -r branch; do
   [ -z "$branch" ] && continue
   [ "$branch" = "$MAIN_BRANCH" ] && continue
@@ -284,33 +318,493 @@ while IFS= read -r branch; do
     fi
   fi
 done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+fi  # /REVIEW guard
 ```
 
 ## Phase 6 — Summary
 
+Review mode skips this phase; its summary is part of Phase 7's table
++ action report.
+
 ```bash
-echo ""
-if [ "$DRY_RUN" -eq 1 ]; then
-  echo "cleanup-merged (dry-run): would delete $DELETED, skip $SKIPPED. Nothing was modified."
-else
-  echo "cleanup-merged: deleted $DELETED branches, skipped $SKIPPED."
-  if [ "$SWITCHED" -eq 1 ]; then
-    echo "(switched to $MAIN_BRANCH and pulled.)"
-  elif [ "$ON_MAIN" -eq 1 ]; then
-    echo "(on $MAIN_BRANCH, pulled latest.)"
+if [ "$REVIEW" -eq 0 ]; then
+  echo ""
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "cleanup-merged (dry-run): would delete $DELETED, skip $SKIPPED. Nothing was modified."
+  else
+    echo "cleanup-merged: deleted $DELETED branches, skipped $SKIPPED."
+    if [ "$SWITCHED" -eq 1 ]; then
+      echo "(switched to $MAIN_BRANCH and pulled.)"
+    elif [ "$ON_MAIN" -eq 1 ]; then
+      echo "(on $MAIN_BRANCH, pulled latest.)"
+    fi
+  fi
+  exit 0
+fi
+```
+
+## Phase 7 — Review mode (--review)
+
+When `--review` is set, enumerate every local branch + worktree,
+classify each per the rule table below (first-match-wins), present an
+alphabetized table with letter IDs and verdicts, then prompt for action.
+
+### Classification rules (first-match wins)
+
+| # | Condition | Verdict | Rationale |
+|---|---|---|---|
+| 1 | Worktree is `locked` | **KEEP** | Live process; never touch |
+| 2 | Branch name matches `cleanup.long_running_patterns` config glob | **KEEP** | Explicitly preserved |
+| 3 | (upstream-gone OR PR=MERGED) AND worktree clean | **REMOVE** | Current `/cleanup-merged` default action |
+| 4 | (upstream-gone OR PR=MERGED) AND worktree dirty | **DECIDE** | Merged but uncommitted changes — inspect first |
+| 5 | Commits ahead AND PR=OPEN | **KEEP** | Active in-flight PR |
+| 6 | Commits ahead AND no PR AND clean | **MAYBE** | Drafted-but-not-pushed; review intent |
+| 7 | 0 commits ahead AND no PR AND clean AND `.landed status != landed` | **DECIDE** | Abandoned/failed sprint state |
+| 8 | 0 commits ahead AND no PR AND clean AND no `.landed` | **REMOVE** | Empty stub — typical orphaned cron artifact |
+| 9 | 0 commits ahead AND no PR AND tree dirty | **DECIDE** | Partial work or orphan; inspect diff |
+| 10 | Commits ahead AND tree dirty | **DECIDE** | Active uncommitted work |
+| — | (fallthrough) | **DECIDE** | Unclassified; manual review |
+
+### WI 7.1 — Load long_running_patterns from config
+
+Default empty array. Read via Python (zskills uses Python json, no jq).
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  CONFIG_FILE=".claude/zskills-config.json"
+  LONG_RUNNING_PATTERNS=()
+  if [ -f "$CONFIG_FILE" ]; then
+    PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+    if [ -n "$PYTHON" ]; then
+      while IFS= read -r p; do
+        [ -n "$p" ] && LONG_RUNNING_PATTERNS+=("$p")
+      done < <("$PYTHON" -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    pats = cfg.get("cleanup", {}).get("long_running_patterns", []) or []
+    for p in pats:
+        print(p)
+except Exception:
+    pass
+' "$CONFIG_FILE")
+    fi
   fi
 fi
-exit 0
+```
+
+### WI 7.2 — Enumerate branches + worktrees and classify
+
+Walk every local branch (`git for-each-ref refs/heads/`) and every
+worktree (`git worktree list --porcelain`). Build a unified row set
+keyed by `(worktree_path, branch_name)`. A worktree-less branch yields
+a row with `worktree=<none>`; a detached-HEAD worktree (no branch)
+yields a row with `branch=<detached>`.
+
+For each row, compute these signals:
+
+- `LOCKED` — worktree has a `locked` line in `git worktree list --porcelain`.
+- `AHEAD` — `git rev-list --count $MAIN_BRANCH..$branch` (0 if missing).
+- `UPSTREAM_GONE` — `git branch -vv` shows `: gone]` for the branch.
+- `PR_STATE` — `gh pr view $branch --json state` (empty if no PR).
+- `DIRTY` — `git -C $worktree status --porcelain` non-empty.
+- `LANDED_STATUS` — parse `status:` from `<worktree>/.landed`, or empty.
+
+Then walk the rule table top-to-bottom; the first matching rule sets
+`VERDICT` and `RULE_NUM`. `RULE_DESC` is a short one-liner from the
+table.
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  # Build worktree → (locked, branch) map via porcelain output.
+  # Format blocks: "worktree /path", then optional "HEAD <sha>",
+  # optional "branch refs/heads/<name>" OR "detached", optional "locked".
+  declare -A WT_BRANCH
+  declare -A WT_LOCKED
+  WT_PATHS=()
+
+  current_wt=""
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^worktree\ (.*)$ ]]; then
+      current_wt="${BASH_REMATCH[1]}"
+      WT_PATHS+=("$current_wt")
+      WT_BRANCH["$current_wt"]="<detached>"
+      WT_LOCKED["$current_wt"]=0
+    elif [[ "$line" =~ ^branch\ refs/heads/(.*)$ ]]; then
+      WT_BRANCH["$current_wt"]="${BASH_REMATCH[1]}"
+    elif [[ "$line" == "locked" || "$line" == locked\ * ]]; then
+      WT_LOCKED["$current_wt"]=1
+    fi
+  done < <(git worktree list --porcelain)
+
+  # Build branch → worktree reverse map.
+  declare -A BRANCH_WT
+  for wt in "${WT_PATHS[@]}"; do
+    br="${WT_BRANCH[$wt]}"
+    [ "$br" = "<detached>" ] && continue
+    BRANCH_WT["$br"]="$wt"
+  done
+
+  # Snapshot `git branch -vv` once for fast UPSTREAM_GONE lookup.
+  BRANCH_VV=$(git branch -vv)
+
+  # Glob-match a branch name against the long_running_patterns array.
+  # Uses bash's [[ "$name" == $pattern ]] glob (NOT regex).
+  matches_long_running() {
+    local name="$1" pat
+    for pat in "${LONG_RUNNING_PATTERNS[@]:-}"; do
+      [ -z "$pat" ] && continue
+      # shellcheck disable=SC2053
+      if [[ "$name" == $pat ]]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  # Classifier — given branch + worktree-path + signals, sets
+  # VERDICT and RULE_NUM and RULE_DESC.
+  classify() {
+    local branch="$1" wt="$2" locked="$3" ahead="$4" upstream_gone="$5"
+    local pr_state="$6" dirty="$7" landed_status="$8"
+
+    # Rule 1
+    if [ "$locked" = "1" ]; then
+      VERDICT="KEEP"; RULE_NUM=1
+      RULE_DESC="worktree locked; live process — never touch"
+      return
+    fi
+    # Rule 2
+    if [ "$branch" != "<detached>" ] && [ "$branch" != "<none>" ]; then
+      if matches_long_running "$branch"; then
+        VERDICT="KEEP"; RULE_NUM=2
+        RULE_DESC="matches cleanup.long_running_patterns"
+        return
+      fi
+    fi
+
+    local merged=0
+    if [ "$upstream_gone" = "1" ] || [ "$pr_state" = "MERGED" ]; then
+      merged=1
+    fi
+    local has_dirty=0
+    [ -n "$dirty" ] && has_dirty=1
+
+    # Rule 3
+    if [ "$merged" = "1" ] && [ "$has_dirty" = "0" ]; then
+      VERDICT="REMOVE"; RULE_NUM=3
+      RULE_DESC="merged (upstream-gone or PR=MERGED), worktree clean"
+      return
+    fi
+    # Rule 4
+    if [ "$merged" = "1" ] && [ "$has_dirty" = "1" ]; then
+      VERDICT="DECIDE"; RULE_NUM=4
+      RULE_DESC="merged but uncommitted changes — inspect first"
+      return
+    fi
+    # Rule 5
+    if [ "$ahead" -gt 0 ] && [ "$pr_state" = "OPEN" ]; then
+      VERDICT="KEEP"; RULE_NUM=5
+      RULE_DESC="active in-flight PR"
+      return
+    fi
+    # Rule 6
+    if [ "$ahead" -gt 0 ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ]; then
+      VERDICT="MAYBE"; RULE_NUM=6
+      RULE_DESC="drafted but not pushed — review intent"
+      return
+    fi
+    # Rule 7
+    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
+       && [ -n "$landed_status" ] && [ "$landed_status" != "landed" ] \
+       && [ "$landed_status" != "full" ]; then
+      VERDICT="DECIDE"; RULE_NUM=7
+      RULE_DESC="abandoned/failed sprint state (.landed=$landed_status)"
+      return
+    fi
+    # Rule 8
+    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
+       && [ -z "$landed_status" ]; then
+      VERDICT="REMOVE"; RULE_NUM=8
+      RULE_DESC="empty stub — typical orphaned cron artifact"
+      return
+    fi
+    # Rule 9
+    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "1" ]; then
+      VERDICT="DECIDE"; RULE_NUM=9
+      RULE_DESC="0-ahead + dirty — partial work or orphan; inspect diff"
+      return
+    fi
+    # Rule 10
+    if [ "$ahead" -gt 0 ] && [ "$has_dirty" = "1" ]; then
+      VERDICT="DECIDE"; RULE_NUM=10
+      RULE_DESC="commits ahead AND tree dirty — active uncommitted work"
+      return
+    fi
+    # Fallthrough
+    VERDICT="DECIDE"; RULE_NUM=0
+    RULE_DESC="unclassified; manual review"
+  }
+
+  # Build row list: every branch (with optional worktree) plus every
+  # detached worktree without a branch ref.
+  ROWS=()  # Each row: VERDICT|RULE_NUM|RULE_DESC|PATH|BRANCH|AHEAD|PR_STATE|DIRTY_COUNT|LANDED_STATUS
+  CLASSIFIED_BRANCHES=()
+
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    [ "$branch" = "$MAIN_BRANCH" ] && continue
+
+    wt="${BRANCH_WT[$branch]:-}"
+    locked=0
+    if [ -n "$wt" ]; then
+      locked="${WT_LOCKED[$wt]:-0}"
+    fi
+
+    ahead=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
+    [ -z "$ahead" ] && ahead=0
+
+    upstream_gone=0
+    if echo "$BRANCH_VV" | grep -qE "^[* ]+ ?$branch\b.*: gone\]"; then
+      upstream_gone=1
+    fi
+
+    pr_state=""
+    if [ "$HAVE_GH" -eq 1 ]; then
+      pr_state=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
+    fi
+
+    dirty=""
+    dirty_count=0
+    if [ -n "$wt" ]; then
+      dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
+      [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
+    fi
+
+    landed_status=""
+    if [ -n "$wt" ] && [ -f "$wt/.landed" ]; then
+      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
+        | head -1 | sed -E 's/^status:[[:space:]]*//')
+    fi
+
+    classify "$branch" "$wt" "$locked" "$ahead" "$upstream_gone" \
+             "$pr_state" "$dirty" "$landed_status"
+
+    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|${wt:-<no-worktree>}|$branch|$ahead|${pr_state:-none}|$dirty_count|${landed_status:-<none>}")
+    CLASSIFIED_BRANCHES+=("$branch")
+  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+
+  # Detached-HEAD worktrees: not represented by any branch, but still
+  # worth surfacing in the table.
+  for wt in "${WT_PATHS[@]}"; do
+    [ "${WT_BRANCH[$wt]}" != "<detached>" ] && continue
+    locked="${WT_LOCKED[$wt]:-0}"
+    dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
+    dirty_count=0
+    [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
+    landed_status=""
+    if [ -f "$wt/.landed" ]; then
+      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
+        | head -1 | sed -E 's/^status:[[:space:]]*//')
+    fi
+    classify "<detached>" "$wt" "$locked" 0 0 "" "$dirty" "$landed_status"
+    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|$wt|<detached>|0|none|$dirty_count|${landed_status:-<none>}")
+  done
+fi
+```
+
+### WI 7.3 — Render the alphabetized table
+
+Sort rows by worktree path (stable, deterministic), assign letter IDs
+A-Z then AA, AB, … for >26 rows. Print the verdict/path/details/rule
+table; then a one-line summary by verdict.
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  # Sort rows alphabetically by the PATH field (column 4 after the
+  # verb). We use Python sort for stable Unicode behaviour.
+  PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+  SORTED_ROWS=()
+  while IFS= read -r r; do
+    [ -n "$r" ] && SORTED_ROWS+=("$r")
+  done < <(printf '%s\n' "${ROWS[@]}" | "$PYTHON" -c '
+import sys
+rows = [l.rstrip("\n") for l in sys.stdin if l.strip()]
+rows.sort(key=lambda r: r.split("|")[3])
+for r in rows:
+    print(r)
+')
+
+  # Letter-ID generator: A, B, …, Z, AA, AB, …, AZ, BA, …
+  letter_for() {
+    local n="$1" out=""
+    while [ "$n" -ge 0 ]; do
+      out="$(printf "\\$(printf '%03o' $((65 + n % 26)))")$out"
+      n=$((n / 26 - 1))
+    done
+    printf '%s' "$out"
+  }
+
+  echo ""
+  echo "/cleanup-merged --review"
+  echo ""
+
+  declare -A ROW_BY_LETTER
+  declare -A SUGGESTED_BY_LETTER
+  KEEP_N=0; MAYBE_N=0; DECIDE_N=0; REMOVE_N=0
+  i=0
+  for row in "${SORTED_ROWS[@]}"; do
+    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
+    letter=$(letter_for "$i")
+    ROW_BY_LETTER["$letter"]="$row"
+    SUGGESTED_BY_LETTER["$letter"]="$verdict"
+
+    dirty_phrase="clean"
+    [ "$dirty_count" -gt 0 ] && dirty_phrase="dirty:${dirty_count} file$([ "$dirty_count" -ne 1 ] && echo s)"
+    pr_phrase="no PR"
+    [ "$pr_state" != "none" ] && pr_phrase="PR=$pr_state"
+
+    printf '  %s. %-6s %s\n' "$letter" "$verdict" "$path"
+    printf '       [%s, %s ahead, %s, %s' "$branch" "$ahead" "$pr_phrase" "$dirty_phrase"
+    [ "$landed_status" != "<none>" ] && printf ', .landed=%s' "$landed_status"
+    printf ']\n'
+    printf '       → rule %s: %s\n' "$rule_num" "$rule_desc"
+
+    case "$verdict" in
+      KEEP)   KEEP_N=$((KEEP_N+1)) ;;
+      MAYBE)  MAYBE_N=$((MAYBE_N+1)) ;;
+      DECIDE) DECIDE_N=$((DECIDE_N+1)) ;;
+      REMOVE) REMOVE_N=$((REMOVE_N+1)) ;;
+    esac
+    i=$((i+1))
+  done
+
+  TOTAL=${#SORTED_ROWS[@]}
+  echo ""
+  echo "$TOTAL total: $KEEP_N KEEP, $MAYBE_N MAYBE, $DECIDE_N DECIDE, $REMOVE_N REMOVE"
+fi
+```
+
+### WI 7.4 — Interactive picker
+
+Read one line of input from the user. Recognized forms:
+
+- blank (just Enter) OR `all-suggested` → apply all rows whose suggested
+  verdict is `REMOVE`. Other verdicts left alone.
+- `<letter>:<verb>` pairs separated by whitespace (e.g.,
+  `A:remove D:keep F:remove`) → per-row override. Recognized verbs:
+  `remove`, `keep`, `skip` (alias of `keep`). Unrecognized letters
+  produce a warning and are skipped.
+- `none` or empty stdin (e.g. pipe closed) → exit without action.
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  echo ""
+  echo "Pick action:"
+  echo "  [Enter] / all-suggested  apply suggested REMOVEs only"
+  echo "  <letter>:<verb> ...      per-row override (verbs: remove, keep, skip)"
+  echo "  none                     exit without action"
+  printf '  > '
+
+  USER_INPUT=""
+  if [ -t 0 ]; then
+    IFS= read -r USER_INPUT || USER_INPUT="none"
+  else
+    # Non-interactive (CI, pipe): default to dry-listing only.
+    USER_INPUT="none"
+  fi
+
+  USER_INPUT_TRIM=$(printf '%s' "$USER_INPUT" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
+
+  declare -A ACTION_BY_LETTER
+  if [ -z "$USER_INPUT_TRIM" ] || [ "$USER_INPUT_TRIM" = "all-suggested" ]; then
+    for letter in "${!SUGGESTED_BY_LETTER[@]}"; do
+      if [ "${SUGGESTED_BY_LETTER[$letter]}" = "REMOVE" ]; then
+        ACTION_BY_LETTER["$letter"]="remove"
+      fi
+    done
+  elif [ "$USER_INPUT_TRIM" = "none" ]; then
+    echo "Exiting without action."
+    exit 0
+  else
+    # Parse <letter>:<verb> pairs.
+    for token in $USER_INPUT_TRIM; do
+      if [[ "$token" =~ ^([A-Za-z]+):([a-z]+)$ ]]; then
+        letter="${BASH_REMATCH[1]}"
+        verb="${BASH_REMATCH[2]}"
+        letter=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
+        if [ -z "${ROW_BY_LETTER[$letter]:-}" ]; then
+          echo "  WARN: unknown letter '$letter' — skipped." >&2
+          continue
+        fi
+        case "$verb" in
+          remove) ACTION_BY_LETTER["$letter"]="remove" ;;
+          keep|skip) ACTION_BY_LETTER["$letter"]="keep" ;;
+          *)
+            echo "  WARN: unknown verb '$verb' for $letter — skipped." >&2
+            ;;
+        esac
+      else
+        echo "  WARN: malformed token '$token' (want <letter>:<verb>) — skipped." >&2
+      fi
+    done
+  fi
+
+  # Apply REMOVE actions. KEEP/skip are no-ops.
+  R_DONE=0
+  R_FAILED=0
+  for letter in "${!ACTION_BY_LETTER[@]}"; do
+    action="${ACTION_BY_LETTER[$letter]}"
+    [ "$action" != "remove" ] && continue
+    row="${ROW_BY_LETTER[$letter]}"
+    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
+
+    # Worktree removal — only if path is a registered worktree
+    # distinct from MAIN_ROOT. Dirty worktrees require --force or
+    # manual cleanup; for safety we skip them with a warning.
+    if [ "$path" != "<no-worktree>" ] && [ "$path" != "$MAIN_ROOT" ]; then
+      if [ "$dirty_count" -gt 0 ]; then
+        echo "  SKIP $letter: $path is dirty ($dirty_count file(s)); inspect manually." >&2
+        R_FAILED=$((R_FAILED+1))
+        continue
+      fi
+      if git worktree remove "$path"; then
+        echo "  REMOVED-WORKTREE $path"
+      else
+        echo "  FAILED to remove worktree $path" >&2
+        R_FAILED=$((R_FAILED+1))
+        continue
+      fi
+    fi
+
+    # Branch deletion (only if a real branch and not main / current).
+    if [ "$branch" != "<detached>" ] && [ "$branch" != "$MAIN_BRANCH" ] \
+       && [ "$branch" != "$(git rev-parse --abbrev-ref HEAD)" ]; then
+      if git branch -D "$branch" >/dev/null 2>&1; then
+        echo "  DELETED branch $branch"
+      else
+        echo "  WARN: could not delete branch $branch (may not exist locally)" >&2
+      fi
+    fi
+
+    R_DONE=$((R_DONE+1))
+  done
+
+  echo ""
+  echo "cleanup-merged --review: $R_DONE action(s) applied, $R_FAILED skipped/failed."
+  exit 0
+fi
 ```
 
 ## Exit codes
 
 | rc | Meaning |
 |----|---------|
-| 0 | Success (or dry-run complete) |
+| 0 | Success (or dry-run complete, or `--review` finished) |
 | 1 | Missing required tool (git) |
-| 2 | Bad argument |
-| 3 | Dirty working tree — refuses to proceed |
+| 2 | Bad argument (or mutually-exclusive flag combo) |
+| 3 | Dirty working tree — refuses to proceed (default mode only; `--review` tolerates) |
 | 4 | `git fetch` failed |
 | 5 | `git checkout` or `git pull` failed |
 

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -67,6 +67,19 @@
         }
       }
     },
+    "cleanup": {
+      "type": "object",
+      "description": "Per-project cleanup configuration for /cleanup-merged.",
+      "properties": {
+        "long_running_patterns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Branch-name glob patterns that /cleanup-merged --review treats as KEEP regardless of merge / push state. Use for explicitly long-lived branches (e.g., docs/run-order-guide, release/*). Empty by default. Matched via bash glob semantics (NOT regex).",
+          "examples": [["docs/run-order-guide", "release/*"]]
+        }
+      }
+    },
     "testing": {
       "type": "object",
       "description": "Test commands and patterns.",

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[--dry-run | -n]"
+argument-hint: "[--dry-run | -n] [--review]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
   upstream is gone or whose PR has merged. Bails on a dirty tree; skips
-  branches with unpushed commits. --dry-run previews. Use after merging a
-  PR to catch local state up.
+  branches with unpushed commits. --dry-run previews. --review classifies
+  every local branch + worktree per merit rules and presents an
+  interactive picker for cleanup actions.
 metadata:
-  version: "2026.05.15+be2d31"
+  version: "2026.05.18+6491e2"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -28,6 +29,11 @@ never deletes a branch with unpushed commits.
 
 - `--dry-run` / `-n` — report what would happen without modifying
   anything. Useful to preview deletions on the first run.
+- `--review` — opt into per-branch merit-based classification.
+  Enumerates every local branch + worktree, classifies each per the rule
+  table (see Phase 7), and prompts the user for actions via an
+  alphabetized letter-keyed picker. Mutually exclusive with `--dry-run`
+  (review mode is interactive — dry-run has no meaning).
 
 ## Phase 1 — Preflight
 
@@ -50,15 +56,22 @@ fi
 
 ```bash
 DRY_RUN=0
+REVIEW=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run|-n) DRY_RUN=1 ;;
+    --review) REVIEW=1 ;;
     *)
-      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [--dry-run|-n]" >&2
+      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [--dry-run|-n] [--review]" >&2
       exit 2
       ;;
   esac
 done
+
+if [ "$DRY_RUN" -eq 1 ] && [ "$REVIEW" -eq 1 ]; then
+  echo "ERROR: --dry-run and --review are mutually exclusive (review is interactive)." >&2
+  exit 2
+fi
 ```
 
 ### WI 1.3 — Locate main-repo root and detect main branch
@@ -80,8 +93,12 @@ Untracked files count as dirty: `/cleanup-merged` will `git checkout
 main` and `git pull`, which would dump new untracked files back out or
 could conflict with an uncommitted edit the user hasn't saved yet.
 
+Review mode (`--review`) **does not** bail on a dirty tree — its job is
+to inspect and surface dirty worktrees. It still avoids any destructive
+operation on the dirty repo (no checkout, no pull, no auto-delete).
+
 ```bash
-if [ -n "$(git status --porcelain)" ]; then
+if [ "$REVIEW" -eq 0 ] && [ -n "$(git status --porcelain)" ]; then
   echo "ERROR: working tree is not clean. Commit, stash, or discard changes first." >&2
   git status --short >&2
   exit 3
@@ -113,13 +130,22 @@ merged branch is still held by a live worktree.
 
 If the current branch is not the main branch, check whether its PR is
 merged or its upstream is gone. If so, switch to main so we can delete
-the branch later.
+the branch later. Review mode skips this phase (and Phases 4–6) and
+jumps straight to Phase 7.
 
 ```bash
+if [ "$REVIEW" -eq 1 ]; then
+  # Review-mode skips Phases 3–6; jump to Phase 7 directly.
+  SWITCHED=0
+  ON_MAIN=0
+  DELETED=0
+  SKIPPED=0
+fi
+
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
 SWITCHED=0
 
-if [ "$CURRENT" != "$MAIN_BRANCH" ]; then
+if [ "$REVIEW" -eq 0 ] && [ "$CURRENT" != "$MAIN_BRANCH" ]; then
   UPSTREAM_GONE=0
   if git branch -vv | grep -qE "^\* $CURRENT .*: gone\]"; then
     UPSTREAM_GONE=1
@@ -149,13 +175,14 @@ fi
 ## Phase 4 — Pull main
 
 Only pull if we are on the main branch. A dry-run skips the pull
-because we promised not to modify anything.
+because we promised not to modify anything. Review mode skips this
+phase entirely.
 
 ```bash
 ON_MAIN=0
 [ "$(git rev-parse --abbrev-ref HEAD)" = "$MAIN_BRANCH" ] && ON_MAIN=1
 
-if [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+if [ "$REVIEW" -eq 0 ] && [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
   echo "Pulling $MAIN_BRANCH..."
   if ! git pull origin "$MAIN_BRANCH"; then
     echo "ERROR: git pull failed." >&2
@@ -165,6 +192,10 @@ fi
 ```
 
 ## Phase 5 — Scan and delete merged branches
+
+Review mode skips this phase — its per-branch action logic lives in
+Phase 7 instead (the `if [ "$REVIEW" -eq 1 ]; then : else …` guard
+below wraps the original loop).
 
 For every local branch other than the main branch and the currently
 checked-out branch, check the same two signals (upstream gone, PR
@@ -186,6 +217,9 @@ CURRENT=$(git rev-parse --abbrev-ref HEAD)
 DELETED=0
 SKIPPED=0
 
+if [ "$REVIEW" -eq 1 ]; then
+  : # Phase 5 main loop is bypassed in review mode (handled by Phase 7).
+else
 while IFS= read -r branch; do
   [ -z "$branch" ] && continue
   [ "$branch" = "$MAIN_BRANCH" ] && continue
@@ -284,33 +318,493 @@ while IFS= read -r branch; do
     fi
   fi
 done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+fi  # /REVIEW guard
 ```
 
 ## Phase 6 — Summary
 
+Review mode skips this phase; its summary is part of Phase 7's table
++ action report.
+
 ```bash
-echo ""
-if [ "$DRY_RUN" -eq 1 ]; then
-  echo "cleanup-merged (dry-run): would delete $DELETED, skip $SKIPPED. Nothing was modified."
-else
-  echo "cleanup-merged: deleted $DELETED branches, skipped $SKIPPED."
-  if [ "$SWITCHED" -eq 1 ]; then
-    echo "(switched to $MAIN_BRANCH and pulled.)"
-  elif [ "$ON_MAIN" -eq 1 ]; then
-    echo "(on $MAIN_BRANCH, pulled latest.)"
+if [ "$REVIEW" -eq 0 ]; then
+  echo ""
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "cleanup-merged (dry-run): would delete $DELETED, skip $SKIPPED. Nothing was modified."
+  else
+    echo "cleanup-merged: deleted $DELETED branches, skipped $SKIPPED."
+    if [ "$SWITCHED" -eq 1 ]; then
+      echo "(switched to $MAIN_BRANCH and pulled.)"
+    elif [ "$ON_MAIN" -eq 1 ]; then
+      echo "(on $MAIN_BRANCH, pulled latest.)"
+    fi
+  fi
+  exit 0
+fi
+```
+
+## Phase 7 — Review mode (--review)
+
+When `--review` is set, enumerate every local branch + worktree,
+classify each per the rule table below (first-match-wins), present an
+alphabetized table with letter IDs and verdicts, then prompt for action.
+
+### Classification rules (first-match wins)
+
+| # | Condition | Verdict | Rationale |
+|---|---|---|---|
+| 1 | Worktree is `locked` | **KEEP** | Live process; never touch |
+| 2 | Branch name matches `cleanup.long_running_patterns` config glob | **KEEP** | Explicitly preserved |
+| 3 | (upstream-gone OR PR=MERGED) AND worktree clean | **REMOVE** | Current `/cleanup-merged` default action |
+| 4 | (upstream-gone OR PR=MERGED) AND worktree dirty | **DECIDE** | Merged but uncommitted changes — inspect first |
+| 5 | Commits ahead AND PR=OPEN | **KEEP** | Active in-flight PR |
+| 6 | Commits ahead AND no PR AND clean | **MAYBE** | Drafted-but-not-pushed; review intent |
+| 7 | 0 commits ahead AND no PR AND clean AND `.landed status != landed` | **DECIDE** | Abandoned/failed sprint state |
+| 8 | 0 commits ahead AND no PR AND clean AND no `.landed` | **REMOVE** | Empty stub — typical orphaned cron artifact |
+| 9 | 0 commits ahead AND no PR AND tree dirty | **DECIDE** | Partial work or orphan; inspect diff |
+| 10 | Commits ahead AND tree dirty | **DECIDE** | Active uncommitted work |
+| — | (fallthrough) | **DECIDE** | Unclassified; manual review |
+
+### WI 7.1 — Load long_running_patterns from config
+
+Default empty array. Read via Python (zskills uses Python json, no jq).
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  CONFIG_FILE=".claude/zskills-config.json"
+  LONG_RUNNING_PATTERNS=()
+  if [ -f "$CONFIG_FILE" ]; then
+    PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+    if [ -n "$PYTHON" ]; then
+      while IFS= read -r p; do
+        [ -n "$p" ] && LONG_RUNNING_PATTERNS+=("$p")
+      done < <("$PYTHON" -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    pats = cfg.get("cleanup", {}).get("long_running_patterns", []) or []
+    for p in pats:
+        print(p)
+except Exception:
+    pass
+' "$CONFIG_FILE")
+    fi
   fi
 fi
-exit 0
+```
+
+### WI 7.2 — Enumerate branches + worktrees and classify
+
+Walk every local branch (`git for-each-ref refs/heads/`) and every
+worktree (`git worktree list --porcelain`). Build a unified row set
+keyed by `(worktree_path, branch_name)`. A worktree-less branch yields
+a row with `worktree=<none>`; a detached-HEAD worktree (no branch)
+yields a row with `branch=<detached>`.
+
+For each row, compute these signals:
+
+- `LOCKED` — worktree has a `locked` line in `git worktree list --porcelain`.
+- `AHEAD` — `git rev-list --count $MAIN_BRANCH..$branch` (0 if missing).
+- `UPSTREAM_GONE` — `git branch -vv` shows `: gone]` for the branch.
+- `PR_STATE` — `gh pr view $branch --json state` (empty if no PR).
+- `DIRTY` — `git -C $worktree status --porcelain` non-empty.
+- `LANDED_STATUS` — parse `status:` from `<worktree>/.landed`, or empty.
+
+Then walk the rule table top-to-bottom; the first matching rule sets
+`VERDICT` and `RULE_NUM`. `RULE_DESC` is a short one-liner from the
+table.
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  # Build worktree → (locked, branch) map via porcelain output.
+  # Format blocks: "worktree /path", then optional "HEAD <sha>",
+  # optional "branch refs/heads/<name>" OR "detached", optional "locked".
+  declare -A WT_BRANCH
+  declare -A WT_LOCKED
+  WT_PATHS=()
+
+  current_wt=""
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^worktree\ (.*)$ ]]; then
+      current_wt="${BASH_REMATCH[1]}"
+      WT_PATHS+=("$current_wt")
+      WT_BRANCH["$current_wt"]="<detached>"
+      WT_LOCKED["$current_wt"]=0
+    elif [[ "$line" =~ ^branch\ refs/heads/(.*)$ ]]; then
+      WT_BRANCH["$current_wt"]="${BASH_REMATCH[1]}"
+    elif [[ "$line" == "locked" || "$line" == locked\ * ]]; then
+      WT_LOCKED["$current_wt"]=1
+    fi
+  done < <(git worktree list --porcelain)
+
+  # Build branch → worktree reverse map.
+  declare -A BRANCH_WT
+  for wt in "${WT_PATHS[@]}"; do
+    br="${WT_BRANCH[$wt]}"
+    [ "$br" = "<detached>" ] && continue
+    BRANCH_WT["$br"]="$wt"
+  done
+
+  # Snapshot `git branch -vv` once for fast UPSTREAM_GONE lookup.
+  BRANCH_VV=$(git branch -vv)
+
+  # Glob-match a branch name against the long_running_patterns array.
+  # Uses bash's [[ "$name" == $pattern ]] glob (NOT regex).
+  matches_long_running() {
+    local name="$1" pat
+    for pat in "${LONG_RUNNING_PATTERNS[@]:-}"; do
+      [ -z "$pat" ] && continue
+      # shellcheck disable=SC2053
+      if [[ "$name" == $pat ]]; then
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  # Classifier — given branch + worktree-path + signals, sets
+  # VERDICT and RULE_NUM and RULE_DESC.
+  classify() {
+    local branch="$1" wt="$2" locked="$3" ahead="$4" upstream_gone="$5"
+    local pr_state="$6" dirty="$7" landed_status="$8"
+
+    # Rule 1
+    if [ "$locked" = "1" ]; then
+      VERDICT="KEEP"; RULE_NUM=1
+      RULE_DESC="worktree locked; live process — never touch"
+      return
+    fi
+    # Rule 2
+    if [ "$branch" != "<detached>" ] && [ "$branch" != "<none>" ]; then
+      if matches_long_running "$branch"; then
+        VERDICT="KEEP"; RULE_NUM=2
+        RULE_DESC="matches cleanup.long_running_patterns"
+        return
+      fi
+    fi
+
+    local merged=0
+    if [ "$upstream_gone" = "1" ] || [ "$pr_state" = "MERGED" ]; then
+      merged=1
+    fi
+    local has_dirty=0
+    [ -n "$dirty" ] && has_dirty=1
+
+    # Rule 3
+    if [ "$merged" = "1" ] && [ "$has_dirty" = "0" ]; then
+      VERDICT="REMOVE"; RULE_NUM=3
+      RULE_DESC="merged (upstream-gone or PR=MERGED), worktree clean"
+      return
+    fi
+    # Rule 4
+    if [ "$merged" = "1" ] && [ "$has_dirty" = "1" ]; then
+      VERDICT="DECIDE"; RULE_NUM=4
+      RULE_DESC="merged but uncommitted changes — inspect first"
+      return
+    fi
+    # Rule 5
+    if [ "$ahead" -gt 0 ] && [ "$pr_state" = "OPEN" ]; then
+      VERDICT="KEEP"; RULE_NUM=5
+      RULE_DESC="active in-flight PR"
+      return
+    fi
+    # Rule 6
+    if [ "$ahead" -gt 0 ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ]; then
+      VERDICT="MAYBE"; RULE_NUM=6
+      RULE_DESC="drafted but not pushed — review intent"
+      return
+    fi
+    # Rule 7
+    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
+       && [ -n "$landed_status" ] && [ "$landed_status" != "landed" ] \
+       && [ "$landed_status" != "full" ]; then
+      VERDICT="DECIDE"; RULE_NUM=7
+      RULE_DESC="abandoned/failed sprint state (.landed=$landed_status)"
+      return
+    fi
+    # Rule 8
+    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
+       && [ -z "$landed_status" ]; then
+      VERDICT="REMOVE"; RULE_NUM=8
+      RULE_DESC="empty stub — typical orphaned cron artifact"
+      return
+    fi
+    # Rule 9
+    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "1" ]; then
+      VERDICT="DECIDE"; RULE_NUM=9
+      RULE_DESC="0-ahead + dirty — partial work or orphan; inspect diff"
+      return
+    fi
+    # Rule 10
+    if [ "$ahead" -gt 0 ] && [ "$has_dirty" = "1" ]; then
+      VERDICT="DECIDE"; RULE_NUM=10
+      RULE_DESC="commits ahead AND tree dirty — active uncommitted work"
+      return
+    fi
+    # Fallthrough
+    VERDICT="DECIDE"; RULE_NUM=0
+    RULE_DESC="unclassified; manual review"
+  }
+
+  # Build row list: every branch (with optional worktree) plus every
+  # detached worktree without a branch ref.
+  ROWS=()  # Each row: VERDICT|RULE_NUM|RULE_DESC|PATH|BRANCH|AHEAD|PR_STATE|DIRTY_COUNT|LANDED_STATUS
+  CLASSIFIED_BRANCHES=()
+
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    [ "$branch" = "$MAIN_BRANCH" ] && continue
+
+    wt="${BRANCH_WT[$branch]:-}"
+    locked=0
+    if [ -n "$wt" ]; then
+      locked="${WT_LOCKED[$wt]:-0}"
+    fi
+
+    ahead=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
+    [ -z "$ahead" ] && ahead=0
+
+    upstream_gone=0
+    if echo "$BRANCH_VV" | grep -qE "^[* ]+ ?$branch\b.*: gone\]"; then
+      upstream_gone=1
+    fi
+
+    pr_state=""
+    if [ "$HAVE_GH" -eq 1 ]; then
+      pr_state=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
+    fi
+
+    dirty=""
+    dirty_count=0
+    if [ -n "$wt" ]; then
+      dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
+      [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
+    fi
+
+    landed_status=""
+    if [ -n "$wt" ] && [ -f "$wt/.landed" ]; then
+      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
+        | head -1 | sed -E 's/^status:[[:space:]]*//')
+    fi
+
+    classify "$branch" "$wt" "$locked" "$ahead" "$upstream_gone" \
+             "$pr_state" "$dirty" "$landed_status"
+
+    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|${wt:-<no-worktree>}|$branch|$ahead|${pr_state:-none}|$dirty_count|${landed_status:-<none>}")
+    CLASSIFIED_BRANCHES+=("$branch")
+  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+
+  # Detached-HEAD worktrees: not represented by any branch, but still
+  # worth surfacing in the table.
+  for wt in "${WT_PATHS[@]}"; do
+    [ "${WT_BRANCH[$wt]}" != "<detached>" ] && continue
+    locked="${WT_LOCKED[$wt]:-0}"
+    dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
+    dirty_count=0
+    [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
+    landed_status=""
+    if [ -f "$wt/.landed" ]; then
+      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
+        | head -1 | sed -E 's/^status:[[:space:]]*//')
+    fi
+    classify "<detached>" "$wt" "$locked" 0 0 "" "$dirty" "$landed_status"
+    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|$wt|<detached>|0|none|$dirty_count|${landed_status:-<none>}")
+  done
+fi
+```
+
+### WI 7.3 — Render the alphabetized table
+
+Sort rows by worktree path (stable, deterministic), assign letter IDs
+A-Z then AA, AB, … for >26 rows. Print the verdict/path/details/rule
+table; then a one-line summary by verdict.
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  # Sort rows alphabetically by the PATH field (column 4 after the
+  # verb). We use Python sort for stable Unicode behaviour.
+  PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+  SORTED_ROWS=()
+  while IFS= read -r r; do
+    [ -n "$r" ] && SORTED_ROWS+=("$r")
+  done < <(printf '%s\n' "${ROWS[@]}" | "$PYTHON" -c '
+import sys
+rows = [l.rstrip("\n") for l in sys.stdin if l.strip()]
+rows.sort(key=lambda r: r.split("|")[3])
+for r in rows:
+    print(r)
+')
+
+  # Letter-ID generator: A, B, …, Z, AA, AB, …, AZ, BA, …
+  letter_for() {
+    local n="$1" out=""
+    while [ "$n" -ge 0 ]; do
+      out="$(printf "\\$(printf '%03o' $((65 + n % 26)))")$out"
+      n=$((n / 26 - 1))
+    done
+    printf '%s' "$out"
+  }
+
+  echo ""
+  echo "/cleanup-merged --review"
+  echo ""
+
+  declare -A ROW_BY_LETTER
+  declare -A SUGGESTED_BY_LETTER
+  KEEP_N=0; MAYBE_N=0; DECIDE_N=0; REMOVE_N=0
+  i=0
+  for row in "${SORTED_ROWS[@]}"; do
+    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
+    letter=$(letter_for "$i")
+    ROW_BY_LETTER["$letter"]="$row"
+    SUGGESTED_BY_LETTER["$letter"]="$verdict"
+
+    dirty_phrase="clean"
+    [ "$dirty_count" -gt 0 ] && dirty_phrase="dirty:${dirty_count} file$([ "$dirty_count" -ne 1 ] && echo s)"
+    pr_phrase="no PR"
+    [ "$pr_state" != "none" ] && pr_phrase="PR=$pr_state"
+
+    printf '  %s. %-6s %s\n' "$letter" "$verdict" "$path"
+    printf '       [%s, %s ahead, %s, %s' "$branch" "$ahead" "$pr_phrase" "$dirty_phrase"
+    [ "$landed_status" != "<none>" ] && printf ', .landed=%s' "$landed_status"
+    printf ']\n'
+    printf '       → rule %s: %s\n' "$rule_num" "$rule_desc"
+
+    case "$verdict" in
+      KEEP)   KEEP_N=$((KEEP_N+1)) ;;
+      MAYBE)  MAYBE_N=$((MAYBE_N+1)) ;;
+      DECIDE) DECIDE_N=$((DECIDE_N+1)) ;;
+      REMOVE) REMOVE_N=$((REMOVE_N+1)) ;;
+    esac
+    i=$((i+1))
+  done
+
+  TOTAL=${#SORTED_ROWS[@]}
+  echo ""
+  echo "$TOTAL total: $KEEP_N KEEP, $MAYBE_N MAYBE, $DECIDE_N DECIDE, $REMOVE_N REMOVE"
+fi
+```
+
+### WI 7.4 — Interactive picker
+
+Read one line of input from the user. Recognized forms:
+
+- blank (just Enter) OR `all-suggested` → apply all rows whose suggested
+  verdict is `REMOVE`. Other verdicts left alone.
+- `<letter>:<verb>` pairs separated by whitespace (e.g.,
+  `A:remove D:keep F:remove`) → per-row override. Recognized verbs:
+  `remove`, `keep`, `skip` (alias of `keep`). Unrecognized letters
+  produce a warning and are skipped.
+- `none` or empty stdin (e.g. pipe closed) → exit without action.
+
+```bash
+if [ "$REVIEW" -eq 1 ]; then
+  echo ""
+  echo "Pick action:"
+  echo "  [Enter] / all-suggested  apply suggested REMOVEs only"
+  echo "  <letter>:<verb> ...      per-row override (verbs: remove, keep, skip)"
+  echo "  none                     exit without action"
+  printf '  > '
+
+  USER_INPUT=""
+  if [ -t 0 ]; then
+    IFS= read -r USER_INPUT || USER_INPUT="none"
+  else
+    # Non-interactive (CI, pipe): default to dry-listing only.
+    USER_INPUT="none"
+  fi
+
+  USER_INPUT_TRIM=$(printf '%s' "$USER_INPUT" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
+
+  declare -A ACTION_BY_LETTER
+  if [ -z "$USER_INPUT_TRIM" ] || [ "$USER_INPUT_TRIM" = "all-suggested" ]; then
+    for letter in "${!SUGGESTED_BY_LETTER[@]}"; do
+      if [ "${SUGGESTED_BY_LETTER[$letter]}" = "REMOVE" ]; then
+        ACTION_BY_LETTER["$letter"]="remove"
+      fi
+    done
+  elif [ "$USER_INPUT_TRIM" = "none" ]; then
+    echo "Exiting without action."
+    exit 0
+  else
+    # Parse <letter>:<verb> pairs.
+    for token in $USER_INPUT_TRIM; do
+      if [[ "$token" =~ ^([A-Za-z]+):([a-z]+)$ ]]; then
+        letter="${BASH_REMATCH[1]}"
+        verb="${BASH_REMATCH[2]}"
+        letter=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
+        if [ -z "${ROW_BY_LETTER[$letter]:-}" ]; then
+          echo "  WARN: unknown letter '$letter' — skipped." >&2
+          continue
+        fi
+        case "$verb" in
+          remove) ACTION_BY_LETTER["$letter"]="remove" ;;
+          keep|skip) ACTION_BY_LETTER["$letter"]="keep" ;;
+          *)
+            echo "  WARN: unknown verb '$verb' for $letter — skipped." >&2
+            ;;
+        esac
+      else
+        echo "  WARN: malformed token '$token' (want <letter>:<verb>) — skipped." >&2
+      fi
+    done
+  fi
+
+  # Apply REMOVE actions. KEEP/skip are no-ops.
+  R_DONE=0
+  R_FAILED=0
+  for letter in "${!ACTION_BY_LETTER[@]}"; do
+    action="${ACTION_BY_LETTER[$letter]}"
+    [ "$action" != "remove" ] && continue
+    row="${ROW_BY_LETTER[$letter]}"
+    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
+
+    # Worktree removal — only if path is a registered worktree
+    # distinct from MAIN_ROOT. Dirty worktrees require --force or
+    # manual cleanup; for safety we skip them with a warning.
+    if [ "$path" != "<no-worktree>" ] && [ "$path" != "$MAIN_ROOT" ]; then
+      if [ "$dirty_count" -gt 0 ]; then
+        echo "  SKIP $letter: $path is dirty ($dirty_count file(s)); inspect manually." >&2
+        R_FAILED=$((R_FAILED+1))
+        continue
+      fi
+      if git worktree remove "$path"; then
+        echo "  REMOVED-WORKTREE $path"
+      else
+        echo "  FAILED to remove worktree $path" >&2
+        R_FAILED=$((R_FAILED+1))
+        continue
+      fi
+    fi
+
+    # Branch deletion (only if a real branch and not main / current).
+    if [ "$branch" != "<detached>" ] && [ "$branch" != "$MAIN_BRANCH" ] \
+       && [ "$branch" != "$(git rev-parse --abbrev-ref HEAD)" ]; then
+      if git branch -D "$branch" >/dev/null 2>&1; then
+        echo "  DELETED branch $branch"
+      else
+        echo "  WARN: could not delete branch $branch (may not exist locally)" >&2
+      fi
+    fi
+
+    R_DONE=$((R_DONE+1))
+  done
+
+  echo ""
+  echo "cleanup-merged --review: $R_DONE action(s) applied, $R_FAILED skipped/failed."
+  exit 0
+fi
 ```
 
 ## Exit codes
 
 | rc | Meaning |
 |----|---------|
-| 0 | Success (or dry-run complete) |
+| 0 | Success (or dry-run complete, or `--review` finished) |
 | 1 | Missing required tool (git) |
-| 2 | Bad argument |
-| 3 | Dirty working tree — refuses to proceed |
+| 2 | Bad argument (or mutually-exclusive flag combo) |
+| 3 | Dirty working tree — refuses to proceed (default mode only; `--review` tolerates) |
 | 4 | `git fetch` failed |
 | 5 | `git checkout` or `git pull` failed |
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -89,6 +89,7 @@ run_suite "test-update-zskills-agent-install" "tests/test-update-zskills-agent-i
 run_suite "test-update-zskills-paths-migration.sh" "tests/test-update-zskills-paths-migration.sh"
 run_suite "test-update-zskills-rerender.sh" "tests/test-update-zskills-rerender.sh"
 run_suite "test-mirror-skill.sh" "tests/test-mirror-skill.sh"
+run_suite "test-cleanup-merged-review.sh" "tests/test-cleanup-merged-review.sh"
 run_suite "test-land-pr-scripts.sh" "tests/test-land-pr-scripts.sh"
 run_suite "test-land-pr-worktree-detect.sh" "tests/test-land-pr-worktree-detect.sh"
 run_suite "test-land-pr-post-merge-ff.sh" "tests/test-land-pr-post-merge-ff.sh"

--- a/tests/test-cleanup-merged-review.sh
+++ b/tests/test-cleanup-merged-review.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# Tests for skills/cleanup-merged/SKILL.md --review flag (issue #355).
+#
+# Coverage:
+#   Static (skill-source assertions):
+#     1.  argument-hint contains --review
+#     2.  --review flag accepted by Phase 1.2 case statement
+#     3.  --dry-run + --review mutual-exclusion check present
+#     4.  Phase 7 heading present
+#     5.  All 10 rule numbers (1–10) appear in the rule table
+#     6.  Long-running-patterns loaded from cleanup.long_running_patterns
+#     7.  Interactive picker recognizes all-suggested / none / <letter>:<verb>
+#     8.  Mirror sync: skills/cleanup-merged/ == .claude/skills/cleanup-merged/
+#     9.  Existing --dry-run semantics still intact (Phase 5 loop preserved)
+#    10.  Schema: cleanup.long_running_patterns array field present
+#
+#   Dynamic (classifier behaviour via extracted function):
+#    R1. locked worktree → KEEP rule 1
+#    R2. branch matching pattern → KEEP rule 2
+#    R3. PR=MERGED + clean → REMOVE rule 3
+#    R4. PR=MERGED + dirty → DECIDE rule 4
+#    R5. commits ahead + PR=OPEN → KEEP rule 5
+#    R6. commits ahead + no PR + clean → MAYBE rule 6
+#    R7. 0 ahead + no PR + clean + .landed=partial → DECIDE rule 7
+#    R8. 0 ahead + no PR + clean + no .landed → REMOVE rule 8
+#    R9. 0 ahead + no PR + dirty → DECIDE rule 9
+#    R10. commits ahead + dirty → DECIDE rule 10
+#
+# Run from repo root: bash tests/test-cleanup-merged-review.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$REPO_ROOT/skills/cleanup-merged/SKILL.md"
+SCHEMA="$REPO_ROOT/config/zskills-config.schema.json"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+echo "=== cleanup-merged --review tests ==="
+
+# ── Static checks ────────────────────────────────────────────────────
+
+# 1. argument-hint contains --review
+if grep -qE '^argument-hint:.*--review' "$SKILL"; then
+  pass "argument-hint advertises --review"
+else
+  fail "argument-hint missing --review"
+fi
+
+# 2. --review accepted in arg parse
+if grep -q -- '--review) REVIEW=1' "$SKILL"; then
+  pass "Phase 1.2: --review case branch present"
+else
+  fail "Phase 1.2: --review case branch missing"
+fi
+
+# 3. --dry-run + --review mutual exclusion
+if grep -q 'mutually exclusive' "$SKILL"; then
+  pass "mutual-exclusion check between --dry-run and --review"
+else
+  fail "mutual-exclusion check missing"
+fi
+
+# 4. Phase 7 heading present
+if grep -qE '^## Phase 7 — Review mode' "$SKILL"; then
+  pass "Phase 7 heading present"
+else
+  fail "Phase 7 heading missing"
+fi
+
+# 5. All 10 rules present in rule table
+for n in 1 2 3 4 5 6 7 8 9 10; do
+  if grep -qE "^\| $n \|" "$SKILL"; then
+    pass "rule table row $n present"
+  else
+    fail "rule table row $n missing"
+  fi
+done
+
+# 6. long_running_patterns config consumed
+if grep -q 'cleanup.long_running_patterns' "$SKILL" \
+   && grep -q 'LONG_RUNNING_PATTERNS' "$SKILL"; then
+  pass "cleanup.long_running_patterns wired into classifier"
+else
+  fail "cleanup.long_running_patterns not wired"
+fi
+
+# 7. Picker recognizes all-suggested / none / letter:verb
+if grep -q 'all-suggested' "$SKILL" \
+   && grep -q '"none"' "$SKILL" \
+   && grep -q '\[A-Za-z\]+):(\[a-z\]+)' "$SKILL"; then
+  pass "picker accepts all-suggested, none, and <letter>:<verb>"
+else
+  fail "picker forms incomplete"
+fi
+
+# 8. Mirror sync
+MIRROR="$REPO_ROOT/.claude/skills/cleanup-merged"
+if [ -d "$MIRROR" ]; then
+  if diff -q "$SKILL" "$MIRROR/SKILL.md" >/dev/null; then
+    pass "mirror sync: skills/cleanup-merged/SKILL.md == .claude mirror"
+  else
+    fail "mirror drift: skills/ vs .claude/skills/ differ"
+  fi
+else
+  fail "mirror directory .claude/skills/cleanup-merged absent"
+fi
+
+# 9. --dry-run path preserved (Phase 5 unchanged for non-review)
+if grep -q 'WOULD-DELETE' "$SKILL" && grep -q 'WOULD-REMOVE-WORKTREE' "$SKILL"; then
+  pass "Phase 5 dry-run output strings preserved"
+else
+  fail "Phase 5 dry-run output regressed"
+fi
+
+# 10. Schema field
+if grep -q '"long_running_patterns"' "$SCHEMA" \
+   && grep -q '"cleanup"' "$SCHEMA"; then
+  pass "schema: cleanup.long_running_patterns defined"
+else
+  fail "schema: cleanup.long_running_patterns missing"
+fi
+
+# ── Dynamic checks (extract classify() and exercise each rule) ───────
+#
+# The classify() function is embedded inside the Phase 7 WI 7.2 bash
+# fence. Extract it into a temporary shim script, source it, and call
+# it with synthetic signal values for each of the 10 rules.
+
+WORK="/tmp/zskills-tests/$(basename "$REPO_ROOT")/cleanup-merged-review"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+CLASSIFIER_SHIM="$WORK/classifier-shim.sh"
+
+# AWK extracts everything from the `# Classifier — given branch ...`
+# comment line through the closing `}` of the function.
+awk '
+  /^  # Classifier — given branch/ { capturing = 1 }
+  capturing { print }
+  capturing && /^  \}$/ { exit }
+' "$SKILL" > "$WORK/classify-fn-body.txt"
+
+# matches_long_running helper is also needed — extract it the same way.
+awk '
+  /^  matches_long_running\(\) \{/ { capturing = 1 }
+  capturing { print }
+  capturing && /^  \}$/ { count++; if (count >= 1) exit }
+' "$SKILL" > "$WORK/matches-fn-body.txt"
+
+{
+  echo "#!/bin/bash"
+  echo "set -u"
+  echo "LONG_RUNNING_PATTERNS=(\"\${@:1}\")"
+  # Source the matches_long_running fn body.
+  cat "$WORK/matches-fn-body.txt"
+  # Source the classify fn body.
+  cat "$WORK/classify-fn-body.txt"
+  echo ""
+  # Reset positional args before invoking classify (re-used via env).
+  echo "VERDICT=\"\"; RULE_NUM=\"\"; RULE_DESC=\"\""
+  echo "classify \"\$BR\" \"\$WT\" \"\$LK\" \"\$AH\" \"\$UG\" \"\$PR\" \"\$DT\" \"\$LS\""
+  echo "echo \"VERDICT=\$VERDICT RULE_NUM=\$RULE_NUM\""
+} > "$CLASSIFIER_SHIM"
+chmod +x "$CLASSIFIER_SHIM"
+
+# Sanity: the extracted classify body must contain `VERDICT=` assignments.
+if ! grep -q 'VERDICT="KEEP"' "$WORK/classify-fn-body.txt"; then
+  fail "extracted classify() body looks empty/malformed — aborting dynamic checks"
+  echo ""
+  echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+  [ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1
+fi
+
+# Helper to call the shim with named signal vars.
+run_classify() {
+  local desc="$1" want_v="$2" want_n="$3"
+  shift 3
+  local out
+  out=$("$@" bash "$CLASSIFIER_SHIM" 2>&1)
+  if echo "$out" | grep -q "VERDICT=$want_v RULE_NUM=$want_n"; then
+    pass "rule $want_n: $desc → $want_v"
+  else
+    fail "rule $want_n: $desc → expected $want_v/$want_n, got: $out"
+  fi
+}
+
+# Rule 1: locked worktree → KEEP rule 1
+run_classify "locked worktree" "KEEP" "1" \
+  env BR="feat/x" WT="/tmp/x" LK="1" AH="0" UG="0" PR="" DT="" LS=""
+
+# Rule 2: branch matches long_running pattern (docs/run-order-guide)
+LRP=("docs/run-order-guide" "release/*")
+out=$(env BR="docs/run-order-guide" WT="/tmp/x" LK="0" AH="5" UG="0" PR="" DT="" LS="" \
+  bash "$CLASSIFIER_SHIM" "${LRP[@]}" 2>&1)
+if echo "$out" | grep -q "VERDICT=KEEP RULE_NUM=2"; then
+  pass "rule 2: long_running_patterns exact match → KEEP"
+else
+  fail "rule 2: expected KEEP/2, got: $out"
+fi
+out=$(env BR="release/1.2" WT="/tmp/x" LK="0" AH="5" UG="0" PR="" DT="" LS="" \
+  bash "$CLASSIFIER_SHIM" "${LRP[@]}" 2>&1)
+if echo "$out" | grep -q "VERDICT=KEEP RULE_NUM=2"; then
+  pass "rule 2: long_running_patterns glob match (release/*) → KEEP"
+else
+  fail "rule 2 glob: expected KEEP/2, got: $out"
+fi
+
+# Rule 3: PR=MERGED + clean
+run_classify "PR=MERGED + clean" "REMOVE" "3" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="3" UG="0" PR="MERGED" DT="" LS=""
+# Rule 3 via upstream-gone
+run_classify "upstream-gone + clean" "REMOVE" "3" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="3" UG="1" PR="" DT="" LS=""
+
+# Rule 4: merged + dirty
+run_classify "PR=MERGED + dirty" "DECIDE" "4" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="3" UG="0" PR="MERGED" DT="M f.txt" LS=""
+
+# Rule 5: commits ahead + PR=OPEN
+run_classify "commits ahead + PR=OPEN" "KEEP" "5" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="OPEN" DT="" LS=""
+
+# Rule 6: commits ahead + no PR + clean
+run_classify "ahead + no PR + clean" "MAYBE" "6" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="" DT="" LS=""
+
+# Rule 7: 0 ahead + no PR + clean + .landed=partial
+run_classify "0 ahead + .landed=partial" "DECIDE" "7" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS="partial"
+
+# Rule 8: 0 ahead + no PR + clean + no .landed
+run_classify "0 ahead + no PR + clean + no .landed" "REMOVE" "8" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS=""
+
+# Rule 9: 0 ahead + no PR + dirty
+run_classify "0 ahead + dirty" "DECIDE" "9" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="M f.txt" LS=""
+
+# Rule 10: commits ahead + dirty (no OPEN PR — rule 5 takes priority otherwise)
+run_classify "ahead + dirty" "DECIDE" "10" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="" DT="M f.txt" LS=""
+# Wait — rule 6 (ahead + no PR + clean) is "MAYBE", but ahead + no PR + dirty
+# falls through 6 (dirty), 7 (ahead>0), 8 (ahead>0), 9 (ahead>0), to 10. Good.
+
+# Bonus: rule 5 + dirty should still hit rule 5 (PR=OPEN beats dirty).
+run_classify "rule 5 wins over dirty (PR=OPEN + dirty)" "KEEP" "5" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="OPEN" DT="M f.txt" LS=""
+
+# .landed=landed: rule 7 doesn't fire (condition is `!= landed`); rule 8
+# requires absence of .landed → so this falls through to DECIDE/0.
+# This is safe-by-design: an unrecognised .landed value is surfaced for
+# manual review rather than silently removed.
+run_classify ".landed=landed → fallthrough DECIDE" "DECIDE" "0" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS="landed"
+
+# .landed=full: similar — rule 7 skips (we treat 'full' like 'landed' as
+# a success marker), rule 8 needs empty .landed, so this also DECIDEs.
+run_classify ".landed=full → fallthrough DECIDE" "DECIDE" "0" \
+  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS="full"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Adds `/cleanup-merged --review` — a merit-based, per-branch classification mode that enumerates every local branch + worktree, applies the 10-rule classification table, and presents an alphabetized verdict table with an interactive picker.

10 first-match-wins rules cover: locked worktrees, long-running config patterns, merged+clean (REMOVE), merged+dirty (DECIDE), PR=OPEN+ahead (KEEP), drafted-not-pushed (MAYBE), abandoned/failed sprints (DECIDE), empty stubs (REMOVE), 0-ahead+dirty (DECIDE), and ahead+dirty (DECIDE). Default verdict on unclassified states: DECIDE (safe).

New config field `cleanup.long_running_patterns` (array of branch-name globs, default `[]`) added to `config/zskills-config.schema.json` for per-project KEEP safe-list.

## Test plan
- [x] 34-case test fixture covering all 10 rules + mutual-exclusion + mirror sync + schema (`tests/test-cleanup-merged-review.sh`)
- [x] Full suite: `bash tests/run-all.sh` → 3327/3327 passed
- [x] Mirror parity: `diff -rq skills/cleanup-merged/ .claude/skills/cleanup-merged/` clean
- [x] Skill version bumped to `2026.05.18+6491e2`
- [x] Existing `--dry-run` semantics preserved (Phase 1.4 dirty-tree bail relaxed only when `--review` is set)
- [ ] Real-world dogfood: run `/cleanup-merged --review` against current 10+ trailing worktrees from today's session, confirm verdicts match operator judgment

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
