### PR TITLE
fix(zskills-dashboard): preserve queues when gh-list fails on cold start (#336)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.17+9ccab2"
+  version: "2026.05.18+aa228d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -48,6 +48,7 @@ SNAPSHOT_TOP_LEVEL_KEYS = {
     "queues",
     "state_file_path",
     "errors",
+    "issues_fetch_ok",
 }
 
 # Landing-mode hint regex (canonical, per plan Shared Schemas).
@@ -1074,17 +1075,27 @@ def list_issues(
     *,
     _now: Optional[float] = None,
     _runner: Optional[Any] = None,
-) -> List[Dict[str, Any]]:
+) -> Tuple[List[Dict[str, Any]], bool]:
     """Fetch open issues via `gh issue list`. 60s module-level cache.
 
     On gh failure: returns last cache (or `[]`) and appends to `errors[]`.
     Never raises.
 
+    Returns `(issues, ok)`. `ok` is True when the current fetch succeeded
+    OR was served from the 60s TTL cache (the last fetch was successful);
+    False when the current fetch failed (regardless of whether a cached
+    fallback was returned). The flag drives the client-side prune-guard
+    for issue #336 — `collect_snapshot` surfaces it as
+    `snapshot["issues_fetch_ok"]`, and the dashboard client skips queue
+    pruning when this is False to prevent monitor-state.json corruption
+    on the cold-start failure path.
+
     `_now` and `_runner` are test-only injection seams.
     """
     now = _now if _now is not None else time.time()
     if _ISSUE_CACHE["had_value"] and (now - _ISSUE_CACHE["ts"]) < ISSUE_CACHE_TTL_SECONDS:
-        return list(_ISSUE_CACHE["issues"])
+        # Cache hit: the most recent fetch succeeded; ok=True.
+        return list(_ISSUE_CACHE["issues"]), True
 
     try:
         runner = _runner or subprocess.run
@@ -1109,7 +1120,8 @@ def list_issues(
                 "source": "gh issue list",
                 "message": (getattr(result, "stderr", "") or "non-zero exit").strip(),
             })
-            return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            return cached, False
         try:
             data = json.loads(result.stdout)
         except Exception as exc:
@@ -1117,13 +1129,15 @@ def list_issues(
                 "source": "gh issue list",
                 "message": f"json parse error: {exc}",
             })
-            return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            return cached, False
         if not isinstance(data, list):
             errors.append({
                 "source": "gh issue list",
                 "message": "unexpected response shape",
             })
-            return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            return cached, False
         issues: List[Dict[str, Any]] = []
         for entry in data:
             if not isinstance(entry, dict):
@@ -1147,19 +1161,21 @@ def list_issues(
         _ISSUE_CACHE["ts"] = now
         _ISSUE_CACHE["issues"] = issues
         _ISSUE_CACHE["had_value"] = True
-        return list(issues)
+        return list(issues), True
     except FileNotFoundError as exc:
         errors.append({
             "source": "gh issue list",
             "message": f"gh not found: {exc}",
         })
-        return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        return cached, False
     except Exception as exc:
         errors.append({
             "source": "gh issue list",
             "message": str(exc),
         })
-        return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        return cached, False
 
 
 # ---------------------------------------------------------------------------
@@ -1379,8 +1395,12 @@ def collect_snapshot(
     state_updated_at = state.get("updated_at", "")
     _annotate_plans_queue(plans, state)
 
-    # Issues
-    issues = list_issues(errors, _runner=issue_runner)
+    # Issues. `issues_fetch_ok` is surfaced to the client (issue #336):
+    # when False, the dashboard skips its prune-against-live-issues pass
+    # in deepCloneQueues to prevent the cold-start corruption window
+    # (process restart + first gh-list failure + user drag → wiped
+    # monitor-state.json). Cache-hit within 60s TTL is treated as ok=True.
+    issues, issues_fetch_ok = list_issues(errors, _runner=issue_runner)
     _annotate_issues_queue(issues, state)
 
     # Worktrees + branches
@@ -1432,6 +1452,7 @@ def collect_snapshot(
         "queues": queues_block,
         "state_file_path": ".zskills/monitor-state.json",
         "errors": _finalize_errors(errors),
+        "issues_fetch_ok": issues_fetch_ok,
     }
     return snapshot
 
@@ -1543,6 +1564,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             },
             "state_file_path": ".zskills/monitor-state.json",
             "errors": _finalize_errors(errors),
+            # Fixture mode skips the gh fetch entirely; report ok=True so
+            # the snapshot's top-level-key contract stays stable (#336).
+            "issues_fetch_ok": True,
         }
     else:
         repo_root = args.repo_root or os.getcwd()

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -319,8 +319,17 @@ function applySnapshot(snap) {
   }
 
   // Capture last-known-good queues from snapshot.queues (server's view).
+  // `issues_fetch_ok` (issue #336): server signals whether the most recent
+  // `gh issue list` succeeded. When false, deepCloneQueues skips its
+  // prune-against-live-issues pass so a transient cold-start fetch failure
+  // doesn't wipe the user's persisted ordering on the next POST. Missing
+  // key (older snapshot shape) is treated as true to preserve current
+  // steady-state behavior.
   const queues = snap.queues || { plans: {}, issues: {}, default_mode: "phase" };
-  lastGoodQueues = deepCloneQueues(queues, snap.plans || [], snap.issues || []);
+  const issuesFetchOk = snap.issues_fetch_ok !== false;
+  lastGoodQueues = deepCloneQueues(
+    queues, snap.plans || [], snap.issues || [], issuesFetchOk,
+  );
   lastGoodDefaultMode = queues.default_mode || "phase";
 
   const dmFp = String(lastGoodDefaultMode);
@@ -372,7 +381,17 @@ function applyWorkState(ws) {
 // Build a queues dict that contains every plan/issue, populated from
 // state where present and inferred from snapshot column hints otherwise.
 // This is the local "source of truth" the UI POSTs back on every drag.
-function deepCloneQueues(queues, plans, issues) {
+//
+// `issuesFetchOk` (issue #336): when false, the server's `issues` array
+// is NOT a reliable picture of live GitHub state — the most recent
+// `gh issue list` failed. In that case the prune-against-live-issues
+// pass below would drop EVERY queued number on a cold-start failure
+// (empty `issues` + populated state-file queues), and a subsequent
+// drag-POST would persist the wiped queues. Skip the prune; preserve
+// the state-file's queues verbatim until a successful fetch lands.
+// Defaults to true so older snapshots (pre-#336 server) still prune.
+function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
+  if (issuesFetchOk === undefined) issuesFetchOk = true;
   const out = {
     default_mode: queues.default_mode || "phase",
     plans: {},
@@ -406,6 +425,9 @@ function deepCloneQueues(queues, plans, issues) {
   // GitHub owns issue existence; this file only owns ordering. Drop any
   // queue entry whose number isn't in the live `issues` array so closed
   // issues self-prune from monitor-state.json on the next POST.
+  // Issue #336: only enforce this when `issuesFetchOk` — otherwise the
+  // "live" array is unreliable (gh fetch failed) and pruning would wipe
+  // the user's ordering on the next drag-POST.
   const liveIssueNumbers = new Set();
   for (const it of issues) {
     if (typeof it.number === "number") liveIssueNumbers.add(it.number);
@@ -416,7 +438,7 @@ function deepCloneQueues(queues, plans, issues) {
     for (const n of arr) {
       const num = parseInt(n, 10);
       if (!Number.isFinite(num) || seenNums.has(num)) continue;
-      if (!liveIssueNumbers.has(num)) continue;
+      if (issuesFetchOk && !liveIssueNumbers.has(num)) continue;
       seenNums.add(num);
       out.issues[c].push(num);
     }

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.17+9ccab2"
+  version: "2026.05.18+aa228d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -48,6 +48,7 @@ SNAPSHOT_TOP_LEVEL_KEYS = {
     "queues",
     "state_file_path",
     "errors",
+    "issues_fetch_ok",
 }
 
 # Landing-mode hint regex (canonical, per plan Shared Schemas).
@@ -1074,17 +1075,27 @@ def list_issues(
     *,
     _now: Optional[float] = None,
     _runner: Optional[Any] = None,
-) -> List[Dict[str, Any]]:
+) -> Tuple[List[Dict[str, Any]], bool]:
     """Fetch open issues via `gh issue list`. 60s module-level cache.
 
     On gh failure: returns last cache (or `[]`) and appends to `errors[]`.
     Never raises.
 
+    Returns `(issues, ok)`. `ok` is True when the current fetch succeeded
+    OR was served from the 60s TTL cache (the last fetch was successful);
+    False when the current fetch failed (regardless of whether a cached
+    fallback was returned). The flag drives the client-side prune-guard
+    for issue #336 — `collect_snapshot` surfaces it as
+    `snapshot["issues_fetch_ok"]`, and the dashboard client skips queue
+    pruning when this is False to prevent monitor-state.json corruption
+    on the cold-start failure path.
+
     `_now` and `_runner` are test-only injection seams.
     """
     now = _now if _now is not None else time.time()
     if _ISSUE_CACHE["had_value"] and (now - _ISSUE_CACHE["ts"]) < ISSUE_CACHE_TTL_SECONDS:
-        return list(_ISSUE_CACHE["issues"])
+        # Cache hit: the most recent fetch succeeded; ok=True.
+        return list(_ISSUE_CACHE["issues"]), True
 
     try:
         runner = _runner or subprocess.run
@@ -1109,7 +1120,8 @@ def list_issues(
                 "source": "gh issue list",
                 "message": (getattr(result, "stderr", "") or "non-zero exit").strip(),
             })
-            return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            return cached, False
         try:
             data = json.loads(result.stdout)
         except Exception as exc:
@@ -1117,13 +1129,15 @@ def list_issues(
                 "source": "gh issue list",
                 "message": f"json parse error: {exc}",
             })
-            return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            return cached, False
         if not isinstance(data, list):
             errors.append({
                 "source": "gh issue list",
                 "message": "unexpected response shape",
             })
-            return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+            return cached, False
         issues: List[Dict[str, Any]] = []
         for entry in data:
             if not isinstance(entry, dict):
@@ -1147,19 +1161,21 @@ def list_issues(
         _ISSUE_CACHE["ts"] = now
         _ISSUE_CACHE["issues"] = issues
         _ISSUE_CACHE["had_value"] = True
-        return list(issues)
+        return list(issues), True
     except FileNotFoundError as exc:
         errors.append({
             "source": "gh issue list",
             "message": f"gh not found: {exc}",
         })
-        return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        return cached, False
     except Exception as exc:
         errors.append({
             "source": "gh issue list",
             "message": str(exc),
         })
-        return list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        cached = list(_ISSUE_CACHE["issues"]) if _ISSUE_CACHE["had_value"] else []
+        return cached, False
 
 
 # ---------------------------------------------------------------------------
@@ -1379,8 +1395,12 @@ def collect_snapshot(
     state_updated_at = state.get("updated_at", "")
     _annotate_plans_queue(plans, state)
 
-    # Issues
-    issues = list_issues(errors, _runner=issue_runner)
+    # Issues. `issues_fetch_ok` is surfaced to the client (issue #336):
+    # when False, the dashboard skips its prune-against-live-issues pass
+    # in deepCloneQueues to prevent the cold-start corruption window
+    # (process restart + first gh-list failure + user drag → wiped
+    # monitor-state.json). Cache-hit within 60s TTL is treated as ok=True.
+    issues, issues_fetch_ok = list_issues(errors, _runner=issue_runner)
     _annotate_issues_queue(issues, state)
 
     # Worktrees + branches
@@ -1432,6 +1452,7 @@ def collect_snapshot(
         "queues": queues_block,
         "state_file_path": ".zskills/monitor-state.json",
         "errors": _finalize_errors(errors),
+        "issues_fetch_ok": issues_fetch_ok,
     }
     return snapshot
 
@@ -1543,6 +1564,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             },
             "state_file_path": ".zskills/monitor-state.json",
             "errors": _finalize_errors(errors),
+            # Fixture mode skips the gh fetch entirely; report ok=True so
+            # the snapshot's top-level-key contract stays stable (#336).
+            "issues_fetch_ok": True,
         }
     else:
         repo_root = args.repo_root or os.getcwd()

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -319,8 +319,17 @@ function applySnapshot(snap) {
   }
 
   // Capture last-known-good queues from snapshot.queues (server's view).
+  // `issues_fetch_ok` (issue #336): server signals whether the most recent
+  // `gh issue list` succeeded. When false, deepCloneQueues skips its
+  // prune-against-live-issues pass so a transient cold-start fetch failure
+  // doesn't wipe the user's persisted ordering on the next POST. Missing
+  // key (older snapshot shape) is treated as true to preserve current
+  // steady-state behavior.
   const queues = snap.queues || { plans: {}, issues: {}, default_mode: "phase" };
-  lastGoodQueues = deepCloneQueues(queues, snap.plans || [], snap.issues || []);
+  const issuesFetchOk = snap.issues_fetch_ok !== false;
+  lastGoodQueues = deepCloneQueues(
+    queues, snap.plans || [], snap.issues || [], issuesFetchOk,
+  );
   lastGoodDefaultMode = queues.default_mode || "phase";
 
   const dmFp = String(lastGoodDefaultMode);
@@ -372,7 +381,17 @@ function applyWorkState(ws) {
 // Build a queues dict that contains every plan/issue, populated from
 // state where present and inferred from snapshot column hints otherwise.
 // This is the local "source of truth" the UI POSTs back on every drag.
-function deepCloneQueues(queues, plans, issues) {
+//
+// `issuesFetchOk` (issue #336): when false, the server's `issues` array
+// is NOT a reliable picture of live GitHub state — the most recent
+// `gh issue list` failed. In that case the prune-against-live-issues
+// pass below would drop EVERY queued number on a cold-start failure
+// (empty `issues` + populated state-file queues), and a subsequent
+// drag-POST would persist the wiped queues. Skip the prune; preserve
+// the state-file's queues verbatim until a successful fetch lands.
+// Defaults to true so older snapshots (pre-#336 server) still prune.
+function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
+  if (issuesFetchOk === undefined) issuesFetchOk = true;
   const out = {
     default_mode: queues.default_mode || "phase",
     plans: {},
@@ -406,6 +425,9 @@ function deepCloneQueues(queues, plans, issues) {
   // GitHub owns issue existence; this file only owns ordering. Drop any
   // queue entry whose number isn't in the live `issues` array so closed
   // issues self-prune from monitor-state.json on the next POST.
+  // Issue #336: only enforce this when `issuesFetchOk` — otherwise the
+  // "live" array is unreliable (gh fetch failed) and pruning would wipe
+  // the user's ordering on the next drag-POST.
   const liveIssueNumbers = new Set();
   for (const it of issues) {
     if (typeof it.number === "number") liveIssueNumbers.add(it.number);
@@ -416,7 +438,7 @@ function deepCloneQueues(queues, plans, issues) {
     for (const n of arr) {
       const num = parseInt(n, 10);
       if (!Number.isFinite(num) || seenNums.has(num)) continue;
-      if (!liveIssueNumbers.has(num)) continue;
+      if (issuesFetchOk && !liveIssueNumbers.has(num)) continue;
       seenNums.add(num);
       out.issues[c].push(num);
     }

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -62,7 +62,7 @@ else
   fail "CLI --fixture minimal exits 0 (rc=$RC, output: $OUT)"
 fi
 
-EXPECTED_KEYS="activity branches errors issues plans queues repo_root repo_url state_file_path state_updated_at updated_at version worktrees"
+EXPECTED_KEYS="activity branches errors issues issues_fetch_ok plans queues repo_root repo_url state_file_path state_updated_at updated_at version worktrees"
 ACTUAL_KEYS=$(printf '%s' "$OUT" | python3 -c '
 import json,sys
 print(" ".join(sorted(json.load(sys.stdin).keys())))
@@ -498,13 +498,96 @@ c._reset_issue_cache_for_tests()
 def boom(*a, **kw):
     raise FileNotFoundError("gh: not found")
 errs = []
-issues = c.list_issues(errs, _now=1.0, _runner=boom)
-print(len(issues), len(errs), errs[0]["source"] if errs else "")
+issues, ok = c.list_issues(errs, _now=1.0, _runner=boom)
+print(len(issues), len(errs), errs[0]["source"] if errs else "", ok)
 ')
-if [ "$GH_MISSING" = "0 1 gh issue list" ]; then
-  pass "missing gh: issues=[] + 'gh issue list' error, no exception"
+if [ "$GH_MISSING" = "0 1 gh issue list False" ]; then
+  pass "missing gh: issues=[] + 'gh issue list' error + ok=False, no exception"
 else
   fail "missing gh: got '$GH_MISSING'"
+fi
+
+# ---------------------------------------------------------------------------
+# AC (issue #336): cold-start gh-list failure → snapshot.issues_fetch_ok=False
+# AND queues block remains populated from state file (no client-side prune).
+# Reproduces the cold-start window: empty issue cache + mocked gh failure
+# + monitor-state.json with N issue entries → snapshot must carry the flag
+# so the dashboard client preserves the user's ordering on the next POST.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Phase 4 AC: cold-start gh-list failure (#336) ==="
+
+COLD_START=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import json, sys, tempfile, pathlib
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._reset_issue_cache_for_tests()
+
+# Fixture: monitor-state.json with 3 queued issue numbers in "triage".
+tmp = pathlib.Path(tempfile.mkdtemp())
+(tmp / ".zskills").mkdir()
+state_doc = {
+    "version": "1.1",
+    "default_mode": "phase",
+    "plans": {},
+    "issues": {"triage": [101, 202, 303]},
+    "updated_at": "2026-05-18T00:00:00+00:00",
+}
+(tmp / ".zskills" / "monitor-state.json").write_text(json.dumps(state_doc))
+
+# Mock gh issue list as a non-zero exit (transient failure on cold start).
+class BoomResult:
+    returncode = 1
+    stdout = ""
+    stderr = "gh: rate limit exceeded"
+def runner(*a, **kw):
+    return BoomResult()
+
+snap = c.collect_snapshot(tmp, issue_runner=runner, pre_resolved=True)
+print("issues_fetch_ok=" + repr(snap.get("issues_fetch_ok")))
+print("issues_len=" + str(len(snap.get("issues", []))))
+print("queue_triage=" + json.dumps(snap.get("queues", {}).get("issues", {}).get("triage", [])))
+errs = [e for e in snap.get("errors", []) if e.get("source") == "gh issue list"]
+print("error_reported=" + ("yes" if errs else "no"))
+')
+if printf '%s\n' "$COLD_START" | grep -q "^issues_fetch_ok=False$" \
+    && printf '%s\n' "$COLD_START" | grep -q "^issues_len=0$" \
+    && printf '%s\n' "$COLD_START" | grep -q "^queue_triage=\[101, 202, 303\]$" \
+    && printf '%s\n' "$COLD_START" | grep -q "^error_reported=yes$"; then
+  pass "cold-start gh failure: issues_fetch_ok=False + queues preserved + error logged (#336)"
+else
+  fail "cold-start gh failure (#336): got '$COLD_START'"
+fi
+
+# Steady-state mirror: successful gh fetch → issues_fetch_ok=True.
+STEADY_OK=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import json, sys, tempfile, pathlib
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._reset_issue_cache_for_tests()
+
+tmp = pathlib.Path(tempfile.mkdtemp())
+(tmp / ".zskills").mkdir()
+(tmp / ".zskills" / "monitor-state.json").write_text(json.dumps({
+    "version": "1.1", "default_mode": "phase",
+    "plans": {}, "issues": {},
+    "updated_at": "2026-05-18T00:00:00+00:00",
+}))
+
+class OkResult:
+    returncode = 0
+    stdout = "[]"
+    stderr = ""
+def runner(*a, **kw):
+    return OkResult()
+
+snap = c.collect_snapshot(tmp, issue_runner=runner, pre_resolved=True)
+print(snap.get("issues_fetch_ok"))
+')
+if [ "$STEADY_OK" = "True" ]; then
+  pass "steady-state gh success: issues_fetch_ok=True (#336)"
+else
+  fail "steady-state ok flag wrong: got '$STEADY_OK'"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -528,6 +528,33 @@ else
   fail "AC: applySnapshot must call fingerprintIssues with lastGoodQueues, not raw queues — fingerprint drift on new issues"
 fi
 
+# AC (issue #336): deepCloneQueues gates the prune-against-live-issues
+# pass on the `issuesFetchOk` parameter, and applySnapshot passes
+# `snap.issues_fetch_ok !== false` (defaulting to true) when calling it.
+# Without this gate, a cold-start gh-list failure (issues=[]) triggers
+# the prune block to drop every queued number, and the next drag-POST
+# persists the wiped queues — corrupting user-set ordering.
+DEEPCLONE_BODY=$(awk '
+  /^function deepCloneQueues\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$DEEPCLONE_BODY" | grep -qE 'function deepCloneQueues\(.*issuesFetchOk\)'; then
+  pass "AC: deepCloneQueues accepts issuesFetchOk parameter (#336)"
+else
+  fail "AC: deepCloneQueues signature missing issuesFetchOk param (#336)"
+fi
+if echo "$DEEPCLONE_BODY" | grep -qF 'issuesFetchOk && !liveIssueNumbers.has(num)'; then
+  pass "AC: deepCloneQueues prune-pass gated on issuesFetchOk (#336)"
+else
+  fail "AC: deepCloneQueues prune pass not gated on issuesFetchOk — cold-start corruption regression (#336)"
+fi
+if echo "$APPLY_BODY" | grep -qF 'snap.issues_fetch_ok !== false'; then
+  pass "AC: applySnapshot reads snap.issues_fetch_ok (#336)"
+else
+  fail "AC: applySnapshot does not consume snap.issues_fetch_ok — fix not wired (#336)"
+fi
+
 # AC: Reconciliation suppress window present (1500ms).
 if grep -q 'POST_RECONCILE_SUPPRESS_MS' "$APP_JS" && grep -q '1500' "$APP_JS"; then
   pass "AC: reconciliation suppress window 1500ms present"


### PR DESCRIPTION
## Summary

Fixes #336 — dashboard cold-start corruption when first `gh issue list` fails.

**Bug:** PR #294 made the dashboard self-normalize queues against the live GitHub issue list. On cold start with a failed first fetch, `issues` was `[]` and `deepCloneQueues` pruned everything as "dead." A user drag during that window would POST a wiped state, destroying ordering.

**Fix (server-side, single source of truth):**
- `collect.py`: `list_issues` now returns `(issues, ok_bool)`. All 5 failure paths return `ok=False`. `collect_snapshot` surfaces `snapshot.issues_fetch_ok` at the top level. Backward-compat: missing key defaults to `true`.
- `app.js`: `applySnapshot` reads `snap.issues_fetch_ok !== false` and passes it into `deepCloneQueues`. The prune-against-live block becomes `if (issuesFetchOk && !liveIssueNumbers.has(num)) continue` — bypassed when `false`, state-file queues preserved.

Secondary card-counter concern from the issue body verified obsolete: `renderPlans` and `renderIssues` already read from `lastGoodQueues.length`, so stale-good fallback is in place.

## Test plan
- [x] 5 new + 1 updated tests in `tests/test_zskills_monitor_collect.sh` (cold-start preserves queues, flag=False; steady-state flag=True; error logged)
- [x] 3 new static-grep tests in `tests/test_zskills_monitor_dashboard_ui.sh` (deepCloneQueues signature, prune-gate text, applySnapshot consumer)
- [x] Full suite: `bash tests/run-all.sh` → 3332/3332 passed
- [x] Mirror parity clean; skill version bumped to `2026.05.18+aa228d`
- [x] Live synthetic cold-start sanity check (collect_snapshot with mocked-failed list_issues) confirms `issues_fetch_ok=False` and queues preserved
- [ ] Real-world: stop dashboard, delete monitor-state.json cache, shim `gh` to exit 1, restart dashboard, hit GET / + POST a queue update, confirm saved state preserves prior ordering (deferred — verify post-merge)

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)
