### PR TITLE
test(dashboard-ui): tighten renderIssues regression-guard grep (#378)

### DIFF
--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -497,7 +497,7 @@ RENDER_ISSUES_BODY=$(awk '
   flag { print }
   flag && /^}$/ { exit }
 ' "$APP_JS")
-if echo "$RENDER_ISSUES_BODY" | grep -qE 'queues\.issues'; then
+if echo "$RENDER_ISSUES_BODY" | grep -qE 'queues\.issues\[c\]|queues && queues\.issues'; then
   pass "AC: renderIssues references queues.issues (optimistic-render contract)"
 else
   fail "AC: renderIssues does not reference queues.issues — regression of optimistic-render bug"


### PR DESCRIPTION
## Summary

Fixes #378. Tightens a brittle string-presence-only regression-guard grep in `tests/test_zskills_monitor_dashboard_ui.sh`:

```diff
-if echo "$RENDER_ISSUES_BODY" | grep -qE 'queues\.issues'; then
+if echo "$RENDER_ISSUES_BODY" | grep -qE 'queues\.issues\[c\]|queues && queues\.issues'; then
```

The original pattern matched any text occurrence including a comment (`// uses queues.issues someday`) or dead expression (`void queues.issues;`). The new pattern requires either bracket-indexed access (`queues.issues[c]`) or the guard-chain prefix (`queues && queues.issues`), matching the actual fix shape at `app.js:920`: `(queues && queues.issues && queues.issues[c]) || []`.

## Test plan
- [x] Full suite: 3332/3332 passed
- [x] Target AC `renderIssues references queues.issues` PASS with new pattern
- [x] Verifier A+ (structurally rejects comment-only and dead-expression refs)

Closes #378
