### PR TITLE
do: close worktree-blindness gap (#391, #393)

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -28,11 +28,20 @@
 # §D5 and Phase 2 D&C):
 #   - `bash -c '<git commit ...>'` / `sh -c '...'` / `eval '...'` are NOT
 #     matched. The tokenize-then-walk requires the FIRST non-env-prefix
-#     token to be literal `git`; we deliberately do not recurse into the
-#     argument string of bash -c / sh -c / eval (re-introducing a
-#     regex-fragility class). This is a minor local-development hole;
-#     CI's conformance gate is the structural backstop. Test C10e in
-#     tests/test-block-stale-skill-version.sh locks this behavior.
+#     token of every shell segment to be literal `git`; we deliberately do
+#     not recurse into the argument string of bash -c / sh -c / eval
+#     (re-introducing a regex-fragility class). This is a minor local-
+#     development hole; CI's conformance gate is the structural backstop.
+#     Test C10e in tests/test-block-stale-skill-version.sh locks this
+#     behavior. Tracked separately as #399.
+#
+#   Note: cd-chained forms like `cd /tmp/wt && git commit` ARE matched as
+#   of #393's fix — `is_git_subcommand_in_chain` (inlined from
+#   hooks/_lib/git-tokenwalk.sh) walks every shell segment, and the
+#   stage-check script is invoked in a subshell `cd`'d to the resolved
+#   effective worktree root so its `git -C "$REPO_ROOT" diff --cached`
+#   inspects the worktree's index, not the hook's ambient (main-repo)
+#   CWD.
 #
 # Pure bash at runtime (D4 in the reference doc) — no external JSON
 # parsers, no scripting-language interpreters. The unit-test harness MAY
@@ -53,6 +62,33 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 # hook remains defensive; no false-allows on the ALLOW path.
 [ -z "$COMMAND" ] && COMMAND="$INPUT"
 
+# Extract the cd target from the command (e.g., "cd /tmp/worktree && git commit").
+# Hooks run in the main repo CWD, not the agent's cd target. This helper lets
+# us run the stage-check script in a subshell `cd`'d to the worktree so its
+# `git -C "$REPO_ROOT" diff --cached` reflects the worktree's index, not the
+# hook's ambient (main-repo) CWD. Reads $INPUT (the stdin JSON envelope) —
+# safe because INPUT is captured at line 43 above.
+#
+# TODO(#401): consolidate extract_cd_target into hooks/_lib/
+# (`resolve-effective-worktree-root.sh`) alongside the three identical
+# LOCAL_ROOT-resolution sites in block-unsafe-project.sh.template.
+extract_cd_target() {
+  local cmd
+  # JSON wire format escapes embedded newlines as the two-character
+  # sequence `\n`. Decode here so `cd /tmp/wt\ngit commit` captures
+  # `/tmp/wt`, not `/tmp/wt\ngit`.
+  cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+    local target="${BASH_REMATCH[1]}"
+    # Remove surrounding quotes if present
+    target="${target%\"}"
+    target="${target#\"}"
+    if [ -d "$target" ]; then
+      echo "$target"
+    fi
+  fi
+}
+
 # Match `git commit` via two-stage tokenize-then-walk. Rationale: a single
 # regex that allows arbitrary git top-level flags (--no-pager, --git-dir=/x,
 # -P, -C path, -c k=v, --work-tree=/y, …) becomes a combinatorial mess and
@@ -62,11 +98,13 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 # walk past every `-…`/`--…` flag (consuming an extra token only for `-C`
 # and `-c`, which take a separate arg — all other top-level flags either
 # embed their value with `=` or take none) and check if the next token is
-# `commit`.
+# `commit`. `is_git_subcommand_in_chain` segment-walks the command so
+# cd-chained forms (`cd /tmp/wt && git commit`) match — required for
+# correct worktree behavior (#393).
 #
 # Carve-out: this matcher does NOT recurse into `bash -c '...'` /
 # `sh -c '...'` / `eval '...'` argument strings — see header docstring
-# and test C10e.
+# and test C10e (issue #399).
 # Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh (Phase 5.4).
 is_git_subcommand() {
   local cmd="$1"
@@ -115,7 +153,30 @@ is_git_subcommand() {
   GIT_SUB_REST="${rest# }"
   return 0
 }
-is_git_subcommand "$COMMAND" commit || exit 0
+
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+is_git_subcommand_in_chain() {
+  local cmd="$1"
+  local want_sub="$2"
+  # Replace shell-segment boundaries with newlines, then iterate.
+  # Handles: && || ; | (real boundaries), literal newline (multi-line
+  # commands), AND the JSON-escaped literal two-char `\n` (which arrives
+  # this way because the hook does not JSON-decode — sed-extracted
+  # values preserve the backslash-n).
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+    if is_git_subcommand "$seg" "$want_sub"; then
+      return 0
+    fi
+  done <<< "$normalized"
+  return 1
+}
+is_git_subcommand_in_chain "$COMMAND" commit || exit 0
 
 # Guard against `set -u` + unset `$CLAUDE_PROJECT_DIR` (rare but documented
 # harness edge case). `${X:-$PWD}` falls back to cwd; if the script is
@@ -125,8 +186,22 @@ is_git_subcommand "$COMMAND" commit || exit 0
 SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/skill-version-stage-check.sh"
 [ -x "$SCRIPT" ] || exit 0  # fail-open: script absent (consumer pre-/update-zskills)
 
-# Run script; capture stderr (the STOP message); discard stdout.
-STDERR=$(bash "$SCRIPT" 2>&1 >/dev/null) && exit 0  # rc=0 means clean
+# Resolve effective worktree root for the stage-check subshell.
+# Hooks run with the main repo as CWD (= $CLAUDE_PROJECT_DIR); when an
+# agent invokes `cd /tmp/wt && git commit` from a worktree, the script's
+# CWD must be the worktree, not main, so `git rev-parse --show-toplevel`
+# inside stage-check resolves to the worktree's index. Precedence:
+# extracted cd target → $CLAUDE_PROJECT_DIR → $PWD.
+CD_TARGET=$(extract_cd_target)
+if [ -n "$CD_TARGET" ] && [ -d "$CD_TARGET" ]; then
+  EFFECTIVE_REPO_ROOT="$CD_TARGET"
+else
+  EFFECTIVE_REPO_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+fi
+
+# Run script in a subshell `cd`'d to the effective root (subshell preserves
+# the hook's own CWD); capture stderr (the STOP message); discard stdout.
+STDERR=$(cd "$EFFECTIVE_REPO_ROOT" && bash "$SCRIPT" 2>&1 >/dev/null) && exit 0  # rc=0 means clean
 # Script exited non-zero — deny.
 
 json_escape() {

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -539,7 +539,16 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
   #   so sequential /run-plan invocations in the same session work correctly.
   #
   # Neither → unrelated session → skip enforcement → parallel work unblocked.
-  LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
+  # Same precedence as the push-block below: prefer cd target so worktree
+  # agents invoking `cd /tmp/wt && git commit` resolve to the worktree
+  # root, not the hook's ambient (main-repo) CWD.
+  CD_TARGET=$(extract_cd_target)
+  if [ -n "$CD_TARGET" ]; then
+    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
+  else
+    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  fi
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -565,7 +574,7 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
 
     # Check if any code files are being committed (skip check for content-only)
     if [ -z "$CODE_FILES" ]; then
-      DIFF_OUTPUT=$(git -C "$REPO_ROOT" diff --cached --name-only 2>/dev/null)
+      DIFF_OUTPUT=$(git -C "$LOCAL_ROOT" diff --cached --name-only 2>/dev/null)
       CODE_FILES=""
       while IFS= read -r line; do
         if [[ "$line" =~ \.(js|ts|json|css|html|rs|py|go|rb)$ ]]; then
@@ -630,7 +639,16 @@ if is_git_subcommand_in_chain "$COMMAND" cherry-pick; then
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
   # Pipeline association guard (same two-tier logic as commit block)
-  LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
+  # Same precedence as the push-block below: prefer cd target so worktree
+  # agents invoking `cd /tmp/wt && git cherry-pick` resolve to the worktree
+  # root, not the hook's ambient (main-repo) CWD.
+  CD_TARGET=$(extract_cd_target)
+  if [ -n "$CD_TARGET" ]; then
+    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
+  else
+    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  fi
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -692,6 +710,7 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
   # Pipeline association guard (same two-tier logic as commit/cherry-pick blocks)
   # Resolve LOCAL_ROOT: prefer cd target (worktree agents use "cd /tmp/wt && git push")
   # because the hook runs in the main repo CWD, not the agent's cd target.
+  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
   CD_TARGET=$(extract_cd_target)
   if [ -n "$CD_TARGET" ]; then
     LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"

--- a/docs/plans/DRAFT_PLAN_AUTO_WORKTREE.md
+++ b/docs/plans/DRAFT_PLAN_AUTO_WORKTREE.md
@@ -648,6 +648,26 @@ for those cases — see "Hook composition" below.
 
 #### Hook composition with `git -C` from foreign cwd (NEW — closes D-A / R-F12 / D-J)
 
+> **RESOLVED (issues #391 + #393).** The worktree-blindness described in
+> this section was closed by the PR that landed those two issues:
+>
+>   - `hooks/block-stale-skill-version.sh` now switches its matcher to
+>     `is_git_subcommand_in_chain` so `cd /tmp/wt && git commit` matches,
+>     inlines `extract_cd_target`, resolves an `EFFECTIVE_REPO_ROOT`, and
+>     invokes `scripts/skill-version-stage-check.sh` in a subshell `cd`'d
+>     to that root.
+>   - `scripts/skill-version-stage-check.sh` resolves `REPO_ROOT` via
+>     `git rev-parse --show-toplevel` (CWD-rooted), falling back to
+>     `$CLAUDE_PROJECT_DIR` then `$PWD` for backward compat.
+>   - `hooks/block-unsafe-project.sh.template` applies the same
+>     cd-target-precedence pattern to all three LOCAL_ROOT sites
+>     (commit / cherry-pick / push) so tracking-marker enforcement fires
+>     on worktree commits.
+>   - Worktree-fixture cases in `tests/test-skill-version-enforcement.sh`
+>     and `tests/test-tracking-integration.sh` lock the fix.
+>
+> The historical analysis below is preserved for context.
+
 `block-stale-skill-version.sh` (PreToolUse hook on every `git commit`)
 delegates to `scripts/skill-version-stage-check.sh`, which reads
 `REPO_ROOT="${CLAUDE_PROJECT_DIR:?...}"` and runs

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -28,11 +28,20 @@
 # §D5 and Phase 2 D&C):
 #   - `bash -c '<git commit ...>'` / `sh -c '...'` / `eval '...'` are NOT
 #     matched. The tokenize-then-walk requires the FIRST non-env-prefix
-#     token to be literal `git`; we deliberately do not recurse into the
-#     argument string of bash -c / sh -c / eval (re-introducing a
-#     regex-fragility class). This is a minor local-development hole;
-#     CI's conformance gate is the structural backstop. Test C10e in
-#     tests/test-block-stale-skill-version.sh locks this behavior.
+#     token of every shell segment to be literal `git`; we deliberately do
+#     not recurse into the argument string of bash -c / sh -c / eval
+#     (re-introducing a regex-fragility class). This is a minor local-
+#     development hole; CI's conformance gate is the structural backstop.
+#     Test C10e in tests/test-block-stale-skill-version.sh locks this
+#     behavior. Tracked separately as #399.
+#
+#   Note: cd-chained forms like `cd /tmp/wt && git commit` ARE matched as
+#   of #393's fix — `is_git_subcommand_in_chain` (inlined from
+#   hooks/_lib/git-tokenwalk.sh) walks every shell segment, and the
+#   stage-check script is invoked in a subshell `cd`'d to the resolved
+#   effective worktree root so its `git -C "$REPO_ROOT" diff --cached`
+#   inspects the worktree's index, not the hook's ambient (main-repo)
+#   CWD.
 #
 # Pure bash at runtime (D4 in the reference doc) — no external JSON
 # parsers, no scripting-language interpreters. The unit-test harness MAY
@@ -53,6 +62,33 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 # hook remains defensive; no false-allows on the ALLOW path.
 [ -z "$COMMAND" ] && COMMAND="$INPUT"
 
+# Extract the cd target from the command (e.g., "cd /tmp/worktree && git commit").
+# Hooks run in the main repo CWD, not the agent's cd target. This helper lets
+# us run the stage-check script in a subshell `cd`'d to the worktree so its
+# `git -C "$REPO_ROOT" diff --cached` reflects the worktree's index, not the
+# hook's ambient (main-repo) CWD. Reads $INPUT (the stdin JSON envelope) —
+# safe because INPUT is captured at line 43 above.
+#
+# TODO(#401): consolidate extract_cd_target into hooks/_lib/
+# (`resolve-effective-worktree-root.sh`) alongside the three identical
+# LOCAL_ROOT-resolution sites in block-unsafe-project.sh.template.
+extract_cd_target() {
+  local cmd
+  # JSON wire format escapes embedded newlines as the two-character
+  # sequence `\n`. Decode here so `cd /tmp/wt\ngit commit` captures
+  # `/tmp/wt`, not `/tmp/wt\ngit`.
+  cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+    local target="${BASH_REMATCH[1]}"
+    # Remove surrounding quotes if present
+    target="${target%\"}"
+    target="${target#\"}"
+    if [ -d "$target" ]; then
+      echo "$target"
+    fi
+  fi
+}
+
 # Match `git commit` via two-stage tokenize-then-walk. Rationale: a single
 # regex that allows arbitrary git top-level flags (--no-pager, --git-dir=/x,
 # -P, -C path, -c k=v, --work-tree=/y, …) becomes a combinatorial mess and
@@ -62,11 +98,13 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 # walk past every `-…`/`--…` flag (consuming an extra token only for `-C`
 # and `-c`, which take a separate arg — all other top-level flags either
 # embed their value with `=` or take none) and check if the next token is
-# `commit`.
+# `commit`. `is_git_subcommand_in_chain` segment-walks the command so
+# cd-chained forms (`cd /tmp/wt && git commit`) match — required for
+# correct worktree behavior (#393).
 #
 # Carve-out: this matcher does NOT recurse into `bash -c '...'` /
 # `sh -c '...'` / `eval '...'` argument strings — see header docstring
-# and test C10e.
+# and test C10e (issue #399).
 # Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh (Phase 5.4).
 is_git_subcommand() {
   local cmd="$1"
@@ -115,7 +153,30 @@ is_git_subcommand() {
   GIT_SUB_REST="${rest# }"
   return 0
 }
-is_git_subcommand "$COMMAND" commit || exit 0
+
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+is_git_subcommand_in_chain() {
+  local cmd="$1"
+  local want_sub="$2"
+  # Replace shell-segment boundaries with newlines, then iterate.
+  # Handles: && || ; | (real boundaries), literal newline (multi-line
+  # commands), AND the JSON-escaped literal two-char `\n` (which arrives
+  # this way because the hook does not JSON-decode — sed-extracted
+  # values preserve the backslash-n).
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+    if is_git_subcommand "$seg" "$want_sub"; then
+      return 0
+    fi
+  done <<< "$normalized"
+  return 1
+}
+is_git_subcommand_in_chain "$COMMAND" commit || exit 0
 
 # Guard against `set -u` + unset `$CLAUDE_PROJECT_DIR` (rare but documented
 # harness edge case). `${X:-$PWD}` falls back to cwd; if the script is
@@ -125,8 +186,22 @@ is_git_subcommand "$COMMAND" commit || exit 0
 SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/skill-version-stage-check.sh"
 [ -x "$SCRIPT" ] || exit 0  # fail-open: script absent (consumer pre-/update-zskills)
 
-# Run script; capture stderr (the STOP message); discard stdout.
-STDERR=$(bash "$SCRIPT" 2>&1 >/dev/null) && exit 0  # rc=0 means clean
+# Resolve effective worktree root for the stage-check subshell.
+# Hooks run with the main repo as CWD (= $CLAUDE_PROJECT_DIR); when an
+# agent invokes `cd /tmp/wt && git commit` from a worktree, the script's
+# CWD must be the worktree, not main, so `git rev-parse --show-toplevel`
+# inside stage-check resolves to the worktree's index. Precedence:
+# extracted cd target → $CLAUDE_PROJECT_DIR → $PWD.
+CD_TARGET=$(extract_cd_target)
+if [ -n "$CD_TARGET" ] && [ -d "$CD_TARGET" ]; then
+  EFFECTIVE_REPO_ROOT="$CD_TARGET"
+else
+  EFFECTIVE_REPO_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+fi
+
+# Run script in a subshell `cd`'d to the effective root (subshell preserves
+# the hook's own CWD); capture stderr (the STOP message); discard stdout.
+STDERR=$(cd "$EFFECTIVE_REPO_ROOT" && bash "$SCRIPT" 2>&1 >/dev/null) && exit 0  # rc=0 means clean
 # Script exited non-zero — deny.
 
 json_escape() {

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -539,7 +539,16 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
   #   so sequential /run-plan invocations in the same session work correctly.
   #
   # Neither → unrelated session → skip enforcement → parallel work unblocked.
-  LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
+  # Same precedence as the push-block below: prefer cd target so worktree
+  # agents invoking `cd /tmp/wt && git commit` resolve to the worktree
+  # root, not the hook's ambient (main-repo) CWD.
+  CD_TARGET=$(extract_cd_target)
+  if [ -n "$CD_TARGET" ]; then
+    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
+  else
+    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  fi
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -565,7 +574,7 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
 
     # Check if any code files are being committed (skip check for content-only)
     if [ -z "$CODE_FILES" ]; then
-      DIFF_OUTPUT=$(git -C "$REPO_ROOT" diff --cached --name-only 2>/dev/null)
+      DIFF_OUTPUT=$(git -C "$LOCAL_ROOT" diff --cached --name-only 2>/dev/null)
       CODE_FILES=""
       while IFS= read -r line; do
         if [[ "$line" =~ \.(js|ts|json|css|html|rs|py|go|rb)$ ]]; then
@@ -630,7 +639,16 @@ if is_git_subcommand_in_chain "$COMMAND" cherry-pick; then
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
   # Pipeline association guard (same two-tier logic as commit block)
-  LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
+  # Same precedence as the push-block below: prefer cd target so worktree
+  # agents invoking `cd /tmp/wt && git cherry-pick` resolve to the worktree
+  # root, not the hook's ambient (main-repo) CWD.
+  CD_TARGET=$(extract_cd_target)
+  if [ -n "$CD_TARGET" ]; then
+    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
+  else
+    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+  fi
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -692,6 +710,7 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
   # Pipeline association guard (same two-tier logic as commit/cherry-pick blocks)
   # Resolve LOCAL_ROOT: prefer cd target (worktree agents use "cd /tmp/wt && git push")
   # because the hook runs in the main repo CWD, not the agent's cd target.
+  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
   CD_TARGET=$(extract_cd_target)
   if [ -n "$CD_TARGET" ]; then
     LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"

--- a/scripts/skill-version-stage-check.sh
+++ b/scripts/skill-version-stage-check.sh
@@ -19,6 +19,17 @@
 #   0  no drift — caller proceeds.
 #   1  drift detected — caller halts with the printed STOP message.
 #
+# REPO_ROOT resolution: resolves from CWD via `git rev-parse --show-toplevel`.
+# Caller is responsible for `cd`-ing to the correct repo/worktree root before
+# invoking this script. Callers:
+#   - hooks/block-stale-skill-version.sh — runs the script in a subshell
+#     `cd`'d to the resolved effective worktree root (cd target extracted
+#     from the JSON command, falling back to $CLAUDE_PROJECT_DIR).
+#   - skills/commit/SKILL.md Phase 5 step 2.5 — invoked from the working
+#     directory (which is the worktree root in worktree mode and the main
+#     repo otherwise).
+# Falls back to $CLAUDE_PROJECT_DIR (backward compat) and finally $PWD.
+#
 # References:
 #   plans/SKILL_VERSIONING.md Phase 4.3
 #   references/skill-versioning.md §1.4 (point 2)
@@ -27,7 +38,11 @@
 
 set -u
 
-REPO_ROOT="${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR required}"
+# Resolve REPO_ROOT from CWD so the script works whether invoked from main
+# (via /commit) or from a worktree (via block-stale-skill-version.sh's
+# subshell cd). Fallback to CLAUDE_PROJECT_DIR for backward compat;
+# ultimate fallback to PWD.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "${CLAUDE_PROJECT_DIR:-$PWD}")"
 GET="$REPO_ROOT/scripts/frontmatter-get.sh"
 HASH="$REPO_ROOT/scripts/skill-content-hash.sh"
 

--- a/tests/test-block-stale-skill-version.sh
+++ b/tests/test-block-stale-skill-version.sh
@@ -106,6 +106,7 @@ load_hook_funcs() {
   tmp=$(mktemp)
   awk '
     /^is_git_subcommand\(\) \{$/,/^\}$/ {print}
+    /^is_git_subcommand_in_chain\(\) \{$/,/^\}$/ {print}
     /^json_escape\(\) \{$/,/^\}$/ {print}
   ' "$HOOK" > "$tmp"
   # shellcheck disable=SC1090
@@ -245,6 +246,28 @@ assert_no_match() {
   fi
 }
 
+# Chain-walker assertions — used for cd-chained forms (#393). The hook now
+# calls is_git_subcommand_in_chain on $COMMAND so worktree commits like
+# `cd /tmp/wt && git commit` match. Single-segment is_git_subcommand would
+# still return 1 (the FIRST token is `cd`, not `git`).
+assert_match_chain() {
+  local label="$1" cmd="$2"
+  if is_git_subcommand_in_chain "$cmd" commit; then
+    pass "$label: is_git_subcommand_in_chain('$cmd' commit) → match"
+  else
+    fail "$label: chain should match" "is_git_subcommand_in_chain returned 1 for: $cmd"
+  fi
+}
+
+assert_no_match_chain() {
+  local label="$1" cmd="$2"
+  if ! is_git_subcommand_in_chain "$cmd" commit; then
+    pass "$label: is_git_subcommand_in_chain('$cmd' commit) → no match"
+  else
+    fail "$label: chain should NOT match" "is_git_subcommand_in_chain returned 0 for: $cmd"
+  fi
+}
+
 # ─────────────────── C6 .. C11 — match assertions ────────────
 assert_match    "C6"   "git commit -am 'wip'"
 assert_match    "C7"   "git commit --amend"
@@ -262,6 +285,14 @@ assert_match    "C8"   "FOO=bar git commit -m msg"
 assert_match    "C9"   "   git commit"
 assert_no_match "C10"  'echo "git commit"'
 assert_no_match "C10e" "bash -c 'git commit -m foo'"
+# C10f / C10g — cd-chain forms now MATCH via is_git_subcommand_in_chain
+# (the hook's call site after #393's fix). is_git_subcommand alone would
+# return 1 (first token is `cd`), so we use the chain assertion to mirror
+# the hook's actual behavior. The bash -c carve-out (C10e) STAYS — it is
+# tracked separately as issue #399.
+assert_match_chain    "C10f" "cd /tmp/wt && git commit -m foo"
+assert_match_chain    "C10g" "cd /tmp/wt && cd subdir && git commit -m foo"
+assert_no_match_chain "C10h" "bash -c 'git commit -m foo'"
 assert_match    "C11"  "git commit && git push"
 
 # ─────────────────── C12: Script missing → fail-open ─────────

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -18,7 +18,7 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
   #   project hook              : is_git_subcommand,                  is_git_subcommand_in_chain
   #   generic hook              : is_git_subcommand, is_destruct_command,
   #                               is_git_subcommand_in_chain, is_destruct_command_in_chain
-  #   stale-skill-version hook  : is_git_subcommand
+  #   stale-skill-version hook  : is_git_subcommand, is_git_subcommand_in_chain
   #   block-bypassed-land-pr.sh : is_gh_pr_subcommand, is_gh_pr_subcommand_in_chain
   #     (Plan LAND_PR_BYPASS_HARDENING Phase 4 — 4th drift-gated hook)
   for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers; do
@@ -26,10 +26,9 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *stale-skill-version* ]] && continue
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *bypassed-land-pr* ]] && continue
-    # Chain wrappers are only inlined in the two block-unsafe hooks.
-    # Skip stale-skill-version (no chain wrapper needed — that hook's
-    # callers operate on the redacted single-segment COMMAND already).
-    [[ "$FN" == "is_git_subcommand_in_chain" && "$HOOK" == *stale-skill-version* ]] && continue
+    # Chain wrappers: now also inlined in stale-skill-version (#393's fix —
+    # cd-chained `cd /tmp/wt && git commit` must match for worktree commits).
+    # bypassed-land-pr still skips (uses gh-pr chain walker, not git).
     [[ "$FN" == "is_git_subcommand_in_chain" && "$HOOK" == *bypassed-land-pr* ]] && continue
     # is_destruct_command_in_chain is only inlined in the generic hook.
     [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *project* ]] && continue

--- a/tests/test-skill-version-enforcement.sh
+++ b/tests/test-skill-version-enforcement.sh
@@ -538,6 +538,67 @@ else
 fi
 
 # ----------------------------------------------------------------------
+# WORKTREE CASE — issue #393 closure.
+# ----------------------------------------------------------------------
+#
+# Proves the worktree-blind bug is closed: with a SKILL.md body edit
+# staged in a worktree (no version bump), the block-stale-skill-version
+# hook invoked with a `cd /tmp/wt && git commit` envelope must DENY.
+# Pre-fix, the hook ran stage-check with REPO_ROOT=$CLAUDE_PROJECT_DIR
+# (main repo), where nothing was staged → false-allow.
+
+echo ""
+echo "=== Worktree case (issue #393) ==="
+
+HOOK="$REPO_ROOT/hooks/block-stale-skill-version.sh"
+
+case_no=worktree-1
+sandbox=$(make_sandbox "$case_no")
+
+# Create a feature branch in the sandbox and a worktree on it. The sandbox
+# itself stays on main so the branch is free to be checked out in the
+# worktree (`git worktree add` rejects a branch already checked out elsewhere).
+worktree=$(mktemp -d)
+rm -rf "$worktree"
+(
+  cd "$sandbox"
+  # `make_sandbox` initialized the repo on its default branch. Create the
+  # feature branch as a ref pointing at HEAD without checking it out.
+  git branch -q feat/worktree-393
+  git worktree add -q "$worktree" feat/worktree-393
+)
+
+# Stage a SKILL.md body edit in the WORKTREE without bumping the version.
+echo "Worktree body edit." >> "$worktree/skills/foo/SKILL.md"
+(cd "$worktree" && git add skills/foo/SKILL.md)
+
+# Invoke the hook with a `cd /tmp/wt && git commit` envelope. The hook
+# must:
+#   1. match via is_git_subcommand_in_chain (cd-chained form)
+#   2. extract the cd target -> $worktree
+#   3. invoke stage-check in a subshell `cd`'d to $worktree
+#   4. stage-check resolves REPO_ROOT via `git rev-parse --show-toplevel`
+#      -> $worktree, finds the staged unbumped SKILL.md, emits STOP, exit 1
+#   5. hook wraps the STOP message into a deny envelope.
+ENVELOPE=$(printf '{"tool_name":"Bash","tool_input":{"command":"cd %s && git commit -m test"}}' "$worktree")
+HOOK_OUT=$(
+  CLAUDE_PROJECT_DIR="$sandbox" printf '%s' "$ENVELOPE" | bash "$HOOK"
+)
+HOOK_EXIT=$?
+
+if [ "$HOOK_EXIT" -eq 0 ] \
+   && [[ "$HOOK_OUT" == *'"permissionDecision":"deny"'* ]] \
+   && [[ "$HOOK_OUT" == *"STOP:"* ]]; then
+  pass "worktree-1: cd-chain commit in worktree with unbumped SKILL.md → DENY envelope"
+else
+  fail "worktree-1: expected deny envelope with STOP message, got exit=$HOOK_EXIT out=$HOOK_OUT"
+fi
+
+# Cleanup worktree.
+(cd "$sandbox" && git worktree remove --force "$worktree" 2>/dev/null) || true
+rm -rf "$worktree"
+
+# ----------------------------------------------------------------------
 # Summary.
 # ----------------------------------------------------------------------
 

--- a/tests/test-tracking-integration.sh
+++ b/tests/test-tracking-integration.sh
@@ -300,6 +300,87 @@ fi
 teardown_repo
 
 # ═══════════════════════════════════════════════════════════════════════
+# Test 3-cd-chain: Worktree enforcement via cd-chained command (#391)
+#
+# Pre-fix, the commit-block LOCAL_ROOT resolution was worktree-blind:
+# the hook ran with CWD=main_repo and used `git rev-parse --show-toplevel`,
+# so .zskills-tracked in the worktree was never read → tracking
+# enforcement silently no-op'd for worktree commits.
+#
+# After fix: the hook calls extract_cd_target on the JSON command. For
+# `cd /tmp/wt && git commit`, the cd target → LOCAL_ROOT → worktree's
+# .zskills-tracked is read → enforcement fires.
+# ═══════════════════════════════════════════════════════════════════════
+
+echo ""
+echo "=== Test 3-cd-chain: Worktree enforcement via cd-chained command (#391) ==="
+
+setup_repo
+
+# Create a branch + worktree.
+(cd "$TEST_TMPDIR" && git checkout -q -b worktree-branch-cdchain && git checkout -q master 2>/dev/null || git checkout -q main 2>/dev/null)
+WORKTREE_DIR=$(mktemp -d)
+rmdir "$WORKTREE_DIR"
+(cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" worktree-branch-cdchain 2>/dev/null)
+
+if [ ! -d "$WORKTREE_DIR" ]; then
+  fail "Test 3-cd-chain: could not create worktree, skipping"
+else
+  # Install hook script (mirrors what /update-zskills would do).
+  mkdir -p "$WORKTREE_DIR/.claude/hooks"
+  cp "$TEST_TMPDIR/.claude/hooks/block-unsafe-project.sh" "$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh"
+
+  # Write .zskills-tracked in the WORKTREE (Tier 1 source for LOCAL_ROOT).
+  PID="run-plan.cd-chain-pipeline"
+  printf '%s\n' "$PID" > "$WORKTREE_DIR/.zskills-tracked"
+
+  # Create an unfulfilled requires marker in the MAIN repo's per-pipeline subdir.
+  DIR_T=$(pipeline_subdir "$TEST_TMPDIR" "$PID")
+  touch "$DIR_T/requires.verify-changes.cd-chain"
+
+  # Transcript: test command present so transcript gate passes.
+  printf 'npm run test:all\n' > "$WORKTREE_DIR/.transcript"
+
+  # Stage a code file in the worktree.
+  (cd "$WORKTREE_DIR" && echo "var x = 1;" > thermal.js && git add thermal.js)
+
+  # Build the JSON envelope simulating the agent's cd-chained command.
+  # Critically: the bash script (hook) runs with CWD=$TEST_TMPDIR (main repo),
+  # NOT the worktree. The hook must extract the cd target to find
+  # .zskills-tracked in the worktree.
+  JSON="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $WORKTREE_DIR && git commit -m test\"},\"transcript_path\":\"$WORKTREE_DIR/.transcript\"}"
+
+  # Run hook from main repo CWD. No LOCAL_ROOT env override — the hook
+  # MUST resolve via extract_cd_target.
+  HOOK_OUTPUT=$(
+    echo "$JSON" | TRACKING_ROOT="$TEST_TMPDIR" bash -c "cd '$TEST_TMPDIR' && bash '$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null
+  )
+
+  if [[ "$HOOK_OUTPUT" == *"permissionDecision"*"deny"* ]] \
+     && [[ "$HOOK_OUTPUT" == *"verify-changes.cd-chain"* ]]; then
+    pass "Test 3-cd-chain-a: cd-chained worktree commit blocked by worktree's .zskills-tracked + main's unfulfilled marker"
+  else
+    fail "Test 3-cd-chain-a: cd-chained worktree commit should be blocked; got: $HOOK_OUTPUT"
+  fi
+
+  # Fulfill, then re-test → should allow.
+  touch "$DIR_T/fulfilled.verify-changes.cd-chain"
+  HOOK_OUTPUT=$(
+    echo "$JSON" | TRACKING_ROOT="$TEST_TMPDIR" bash -c "cd '$TEST_TMPDIR' && bash '$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null
+  )
+  if [[ "$HOOK_OUTPUT" == *"permissionDecision"*"deny"* ]]; then
+    fail "Test 3-cd-chain-b: cd-chained worktree commit should be allowed after fulfilling marker; got: $HOOK_OUTPUT"
+  else
+    pass "Test 3-cd-chain-b: cd-chained worktree commit allowed after fulfilling marker"
+  fi
+
+  # Clean up worktree
+  (cd "$TEST_TMPDIR" && git worktree remove --force "$WORKTREE_DIR" 2>/dev/null)
+fi
+
+teardown_repo
+
+# ═══════════════════════════════════════════════════════════════════════
 # Test 4: Content-only exemption
 # ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Closes #391
Closes #393

Fixes the worktree-blindness root cause shared by both issues: hooks and scripts that resolve REPO_ROOT via env (`CLAUDE_PROJECT_DIR` / bare `$REPO_ROOT`) missed the worktree the command actually `cd`-ed into, so tracking-marker enforcement (#391) and skill-version enforcement (#393) silently no-op'd for worktree commits. Plan doc at `docs/plans/DRAFT_PLAN_AUTO_WORKTREE.md:670` had acknowledged this gap.

## Changes

- `hooks/block-unsafe-project.sh.template` + mirror: apply cd-target precedence pattern (already in push-block 695-699) to commit-block (line 542) and cherry-pick-block (line 633); replace bare `$REPO_ROOT` at line 568 with `$LOCAL_ROOT`. TODO(#401) comments planted.
- `hooks/block-stale-skill-version.sh` + mirror: inline `extract_cd_target`, switch to `is_git_subcommand_in_chain`, resolve `EFFECTIVE_REPO_ROOT`, invoke script in subshell `cd`'d to that root. Docstring carve-out narrowed (bash -c miss STAYS — #399).
- `scripts/skill-version-stage-check.sh`: REPO_ROOT now resolves from CWD via `git rev-parse --show-toplevel`, falling back to `$CLAUDE_PROJECT_DIR` then `$PWD`.
- `tests/test-hook-helper-drift.sh`: skip-line for `is_git_subcommand_in_chain` × stale-skill-version deleted.
- `tests/test-block-stale-skill-version.sh`: C10e `bash -c` carve-out STAYS; added C10f/g (cd-chain match), C10h (chain-matcher carve-out lock).
- `tests/test-skill-version-enforcement.sh`: new worktree-fixture case proves #393 closed.
- `tests/test-tracking-integration.sh`: new cd-chain worktree case proves #391 closed.
- `docs/plans/DRAFT_PLAN_AUTO_WORKTREE.md`: section 649-670 annotated as resolved.

## Test plan

- [x] Full suite (`bash tests/run-all.sh`) passes — 3364 / 0
- [x] `test-hook-helper-drift.sh` — 11/11 (new coverage of chain helper in stale-skill-version)
- [x] `test-block-stale-skill-version.sh` — 30/30 (C10f/g/h added)
- [x] `test-tracking-integration.sh` — 24/24 (cd-chain cases added)
- [x] `test-skill-version-enforcement.sh` — 23/23 (worktree case added)
- [x] Manual repro 1: skill body edit in worktree without version bump → DENY envelope with version-bump STOP message (path correctly resolves to worktree)
- [x] Manual repro 2: `requires.*` marker without `fulfilled.*` + .js file staged in worktree → DENY envelope citing the marker
- [x] `diff hooks/block-unsafe-project.sh.template .claude/hooks/block-unsafe-project.sh` clean
- [x] `diff hooks/block-stale-skill-version.sh .claude/hooks/block-stale-skill-version.sh` clean

## Follow-up

#401 — extract `hooks/_lib/resolve-effective-worktree-root.sh` to consolidate the four cd-target + LOCAL_ROOT resolution sites (this PR planted TODO comments referencing #401).

#390 (warn-config-drift mirror staleness) and #399 (`bash -c 'git commit'` bypass) remain open — separate fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
