### PR TITLE
fix(hooks): sync warn-config-drift mirror + add mirror-parity conformance test

### DIFF
--- a/.claude/hooks/warn-config-drift.sh
+++ b/.claude/hooks/warn-config-drift.sh
@@ -59,7 +59,10 @@ fi
 # `^skills/...`), but NOT `.claude/skills/...` mirrors. Editing the source
 # skills/ file is the canonical path; the mirror gets cp-batched, so warning
 # twice would spam every Edit→cp pair.
-if [[ "$FILE_PATH" =~ (^|/)skills/[^/]+/.*\.md$ ]] && [[ "$FILE_PATH" != *.claude/skills/* ]]; then
+if [[ "$FILE_PATH" =~ (^|/)(skills|block-diagram)/[^/]+/.*\.md$ ]] && [[ "$FILE_PATH" != *.claude/skills/* ]] \
+   && [ -n "${CLAUDE_PROJECT_DIR:-}" ] \
+   && [ -r "$CLAUDE_PROJECT_DIR/tests/fixtures/forbidden-literals.txt" ] \
+   && [ -r "$FILE_PATH" ]; then
   # Resolve fixture path. CLAUDE_PROJECT_DIR is set by Claude Code at
   # hook fire time. Graceful no-op when fixture absent — downstream
   # installs that bypass /update-zskills will hit this. The deny-list
@@ -67,10 +70,12 @@ if [[ "$FILE_PATH" =~ (^|/)skills/[^/]+/.*\.md$ ]] && [[ "$FILE_PATH" != *.claud
   # shipped skills; this hook is a zskills-CI-only nudge for in-repo
   # edits (see plans/SKILL_FILE_DRIFT_FIX.md Phase 4 Design &
   # Constraints "Downstream coverage scope").
-  [ -n "${CLAUDE_PROJECT_DIR:-}" ] || exit 0
+  #
+  # Pre-conditions are folded into the if-chain above (was a series of
+  # `... || exit 0` lines pre-Phase-4) so a missing fixture skips Branch
+  # 2 only, leaving Branch 3 (below) free to run. Previous form
+  # short-circuited the entire hook.
   FIXTURE_PATH="$CLAUDE_PROJECT_DIR/tests/fixtures/forbidden-literals.txt"
-  [ -r "$FIXTURE_PATH" ] || exit 0
-  [ -r "$FILE_PATH" ] || exit 0
 
   while IFS= read -r entry; do
     [ -z "$entry" ] && continue
@@ -138,6 +143,117 @@ if [[ "$FILE_PATH" =~ (^|/)skills/[^/]+/.*\.md$ ]] && [[ "$FILE_PATH" != *.claud
         "$FILE_PATH" "$hit_line_no" "$allow_key" >&2
     done < <(grep "${grep_args[@]}" "$match_term" "$FILE_PATH" 2>/dev/null || true)
   done < "$FIXTURE_PATH"
+fi
+
+# --- Branch 3: skill version not bumped --------------------------------------
+# Fires on Edit/Write of any regular file under (skills|block-diagram)/<name>/
+# (parent SKILL.md OR child files in modes/, references/, scripts/, fixtures/,
+# stubs/, etc — every file in the §1.1 projection). Compares the parent
+# skill's recomputed projection hash against HEAD's metadata.version hash; if
+# the hash drifted but the version line is unchanged, emit an asymmetric
+# WARN. If the version was bumped but the projection is unchanged, emit a
+# symmetric WARN (revert / no-op edit).
+#
+# Trailing `[^/]+` requires a path segment AFTER the skill name — keeps
+# top-level docs like `block-diagram/README.md` and asset-only paths like
+# `block-diagram/screenshots/foo.png` from matching this branch unless
+# their parent has a SKILL.md (the [ -f "$skill_md" ] || exit 0 check
+# downstream is the load-bearing guard). refine-plan F-DA-9.
+if [[ "$FILE_PATH" =~ (^|/)(skills|block-diagram)/([^/]+)/[^/]+ ]] \
+   && [[ "$FILE_PATH" != *.claude/skills/* ]]; then
+  REPO_ROOT="${CLAUDE_PROJECT_DIR:-}"
+  if [ -n "$REPO_ROOT" ]; then
+    HASH_HELPER="$REPO_ROOT/scripts/skill-content-hash.sh"
+    GET_HELPER="$REPO_ROOT/scripts/frontmatter-get.sh"
+    if [ -x "$HASH_HELPER" ] && [ -x "$GET_HELPER" ]; then
+      skill_root_kind="${BASH_REMATCH[2]}"
+      skill_name="${BASH_REMATCH[3]}"
+      skill_dir="$REPO_ROOT/$skill_root_kind/$skill_name"
+      skill_md="$skill_dir/SKILL.md"
+      if [ -f "$skill_md" ]; then
+        # Normalise $FILE_PATH to repo-relative form. Probe `realpath
+        # --relative-to` by INVOCATION (BSD realpath exists at
+        # /usr/bin/realpath but lacks the flag; the `command -v realpath`
+        # probe alone misclassifies BSD as supported — refine-plan
+        # F-DA-R2-1). On fallback failure, surface a WARN diagnostic so
+        # the silent no-op is observable (refine-plan F-R2-1).
+        FILE_PATH_REL=""
+        if FILE_PATH_REL=$(realpath --relative-to="$REPO_ROOT" "$FILE_PATH" 2>/dev/null) \
+             && [ -n "$FILE_PATH_REL" ]; then
+          case "$FILE_PATH_REL" in
+            /*) FILE_PATH_REL="" ;;
+          esac
+        fi
+        skip_branch3=0
+        if [ -z "$FILE_PATH_REL" ]; then
+          # Fallback: textual prefix strip. Works when $FILE_PATH and
+          # $REPO_ROOT share a literal prefix; fails on symlink
+          # divergence (e.g., /var/folders/.../X vs /private/var/.../X
+          # on macOS, where REPO_ROOT may be one form and FILE_PATH the
+          # other after symlink resolution).
+          FILE_PATH_REL="${FILE_PATH#$REPO_ROOT/}"
+          case "$FILE_PATH_REL" in
+            /*)
+              printf 'WARN: warn-config-drift: could not normalize %s relative to %s — staged-file gate skipped\n' \
+                "$FILE_PATH" "$REPO_ROOT" >&2
+              skip_branch3=1
+              ;;
+          esac
+        fi
+
+        if [ "$skip_branch3" -eq 0 ]; then
+          # Staged-file gate. `grep -Fqx` (fixed-string, full-line) — paths
+          # may contain regex metacharacters (e.g., a skill named `a.b` or
+          # `a+b`); plain `grep -qx` would treat them as a regex pattern
+          # (refine-plan F-DA-R2-5). `git diff` uses 2>/dev/null because
+          # "no git tree" is a legitimate signal "no staged set" — see the
+          # plan §4.1 audit of the four operational sites that suppress
+          # stderr.
+          if git -C "$REPO_ROOT" diff --cached --name-only 2>/dev/null \
+             | grep -Fqx "$FILE_PATH_REL"; then
+            # Subject = parent SKILL.md (NOT the edited child file). The
+            # body-diff check operates on the parent's projection.
+            on_disk_ver=$(bash "$GET_HELPER" "$skill_md" metadata.version) || on_disk_ver=""
+
+            # HEAD version line. `git show HEAD:<path>` failure (file not
+            # yet in HEAD) is the legitimate "first migration commit"
+            # signal — see §4.1 audit.
+            head_blob=$(git -C "$REPO_ROOT" show "HEAD:${skill_md#$REPO_ROOT/}" 2>/dev/null) \
+              || head_blob=""
+            head_ver=""
+            if [ -n "$head_blob" ]; then
+              # `2>/dev/null` here is the legitimate "first migration"
+              # signal — HEAD's SKILL.md may predate metadata.version
+              # (frontmatter-get exits 1 with "key not found" stderr).
+              # We do NOT suppress stderr on the on-disk get above
+              # because that one signals a real bug if it fails.
+              head_ver=$(printf '%s' "$head_blob" | bash "$GET_HELPER" - metadata.version 2>/dev/null) \
+                || head_ver=""
+            fi
+
+            cur_hash=$(bash "$HASH_HELPER" "$skill_dir")
+            stored_hash="${on_disk_ver##*+}"
+            head_hash="${head_ver##*+}"
+
+            # Asymmetric warn: hash drifted but version line unchanged.
+            if [ -n "$on_disk_ver" ] && [ "$on_disk_ver" = "$head_ver" ] \
+               && [ "$cur_hash" != "$stored_hash" ]; then
+              today=$(TZ="${TIMEZONE:-America/New_York}" date +%Y.%m.%d)
+              printf 'WARN: %s — skill content changed (hash %s → %s) but metadata.version unchanged. Bump to %s+%s before commit.\n' \
+                "$skill_md" "$stored_hash" "$cur_hash" "$today" "$cur_hash" >&2
+            fi
+
+            # Symmetric warn: version bumped but content unchanged.
+            if [ -n "$on_disk_ver" ] && [ "$on_disk_ver" != "$head_ver" ] \
+               && [ "$cur_hash" = "$head_hash" ]; then
+              printf 'WARN: %s — metadata.version bumped (%s → %s) but content unchanged. Revert version line or land a real edit.\n' \
+                "$skill_md" "$head_ver" "$on_disk_ver" >&2
+            fi
+          fi
+        fi
+      fi
+    fi
+  fi
 fi
 
 exit 0

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -38,6 +38,7 @@ run_suite() {
 run_suite "test-hooks.sh" "tests/test-hooks.sh"
 run_suite "test-tokenize-then-walk.sh" "tests/test-tokenize-then-walk.sh"
 run_suite "test-hook-helper-drift.sh" "tests/test-hook-helper-drift.sh"
+run_suite "test-hooks-mirror-parity.sh" "tests/test-hooks-mirror-parity.sh"
 run_suite "test-inject-bash-timeout.sh" "tests/test-inject-bash-timeout.sh"
 run_suite "test-verify-response-validate.sh" "tests/test-verify-response-validate.sh"
 run_suite "canary-verifier-agent-discovery-part1.sh" "tests/canary-verifier-agent-discovery-part1.sh"

--- a/tests/test-hooks-mirror-parity.sh
+++ b/tests/test-hooks-mirror-parity.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# tests/test-hooks-mirror-parity.sh
+#
+# Asserts byte-equality between every hook source under `hooks/` and its
+# installed mirror under `.claude/hooks/`. Closes the "mirror-bypassed-tests"
+# class of bug (issue #390): every test in `tests/test-skill-version-*` and
+# friends targets the source `hooks/*.sh`, but `.claude/settings.json` wires
+# the mirror under `.claude/hooks/*.sh`. When the source is updated without
+# refreshing the mirror, CI stays green while production is silently inert.
+#
+# Mapping rules (per skills/update-zskills/SKILL.md "Copy missing hooks"):
+#   hooks/<X>.sh                      -> .claude/hooks/<X>.sh           (byte-equal)
+#   hooks/<X>.sh.template             -> .claude/hooks/<X>.sh           (byte-equal,
+#                                                                       no install-time
+#                                                                       placeholder fill)
+# Exclusions:
+#   hooks/_lib/*       — source-of-truth helpers inlined into hooks, never installed.
+#   hooks/canary3-bad.sh — deliberately-broken syntax-error fixture for canary tests;
+#                          not a real hook, not installed.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { echo "PASS $*"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { echo "FAIL $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# Excluded basenames (not real hooks / not installed).
+EXCLUDE_BASENAMES=(
+  "canary3-bad.sh"
+)
+
+is_excluded() {
+  local bn="$1"
+  for x in "${EXCLUDE_BASENAMES[@]}"; do
+    [[ "$bn" == "$x" ]] && return 0
+  done
+  return 1
+}
+
+# Collect candidate source hooks: top-level `hooks/*.sh` and `hooks/*.sh.template`.
+# (Subdirectories like `hooks/_lib/` are intentionally not globbed.)
+shopt -s nullglob
+SOURCES=( hooks/*.sh hooks/*.sh.template )
+shopt -u nullglob
+
+if [[ ${#SOURCES[@]} -eq 0 ]]; then
+  fail "no hook sources matched hooks/*.sh{,.template} — glob likely broken"
+fi
+
+for SRC in "${SOURCES[@]}"; do
+  bn="$(basename "$SRC")"
+  if is_excluded "$bn"; then
+    pass "skip (excluded fixture): $SRC"
+    continue
+  fi
+
+  # Map source basename to expected mirror basename:
+  #   <name>.sh.template -> <name>.sh
+  #   <name>.sh          -> <name>.sh
+  if [[ "$bn" == *.sh.template ]]; then
+    mirror_bn="${bn%.template}"
+  else
+    mirror_bn="$bn"
+  fi
+  MIRROR=".claude/hooks/$mirror_bn"
+
+  if [[ ! -f "$MIRROR" ]]; then
+    fail "mirror missing: $SRC has no mirror at $MIRROR"
+    continue
+  fi
+
+  if cmp -s "$SRC" "$MIRROR"; then
+    pass "mirror parity: $SRC == $MIRROR"
+  else
+    fail "mirror drift: $SRC and $MIRROR differ (run: cp '$SRC' '$MIRROR')"
+  fi
+done
+
+# Reverse check: every `.claude/hooks/*.sh` must have a source under `hooks/`
+# (either same name, or with a `.template` suffix). This catches the case
+# where a mirror exists but no source — implying a stale install that would
+# never be regenerated.
+shopt -s nullglob
+MIRRORS=( .claude/hooks/*.sh )
+shopt -u nullglob
+
+for MIR in "${MIRRORS[@]}"; do
+  bn="$(basename "$MIR")"
+  if [[ -f "hooks/$bn" || -f "hooks/${bn}.template" ]]; then
+    pass "reverse: mirror $MIR has a source under hooks/"
+  else
+    fail "reverse: mirror $MIR has no corresponding source under hooks/"
+  fi
+done
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+exit $FAIL_COUNT


### PR DESCRIPTION
## Summary

Fix #390: `.claude/hooks/warn-config-drift.sh` was the pre-#175 form (143 lines) while source had grown to 259 lines (Branch 3 added + Branch 2 regex widened to cover `block-diagram`). `.claude/settings.json:56,66` wire the mirror, so Layer 1 of the documented 3-point skill-version enforcement (Edit-time WARN) was silently inert in every Claude Code session. CI stayed green because `tests/test-skill-version-enforcement.sh:17` pins the source path — classic mirror-bypassed-tests.

## Changes

1. `.claude/hooks/warn-config-drift.sh` — synced byte-equal to source (+124 lines: Branch 3 skill-content-hash drift WARN + widened Branch 2 regex)
2. `tests/test-hooks-mirror-parity.sh` — new conformance test, 19 byte-equality checks (10 forward + 9 reverse), handles `.sh.template` → `.sh` install-time rendering, excludes `canary3-bad.sh` fixture
3. `tests/run-all.sh` — registered new suite

## Test plan

- [x] Full suite: 3401/3401 passed (baseline 3382 + 19 new)
- [x] Mirror byte-equal: `diff -q hooks/warn-config-drift.sh .claude/hooks/warn-config-drift.sh` clean
- [x] Branch 3 + widened Branch 2 confirmed present in mirror via grep
- [x] Negative test by verifier: artificial drift to mirror produces FAIL with copy-pasteable `cp` remediation; restore returns to PASS
- [x] Scope clean: 3 files, no source-skill / CLAUDE.md edits

Closes #390
