### PR TITLE
fix(hooks): correct refspec-strip direction + close localref:main push bypass

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -425,8 +425,14 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
     PUSH_TARGET=$(git branch --show-current 2>/dev/null)
   fi
 
-  # Strip remote-side of refspec if present (e.g., local:remote)
-  PUSH_TARGET="${PUSH_TARGET%%:*}"
+  # Strip local-side of refspec if present (e.g., local:remote). The
+  # destination/remote-side after the colon is what determines whether the
+  # push targets main/master. Past bug (#392): ${X%%:*} kept the LEFT side
+  # (local), so `git push origin feat:main` resolved PUSH_TARGET=feat and
+  # the rule below let the push through, force-shipping local feat to
+  # remote main. ${X##*:} keeps the RIGHT side (remote). For non-refspec
+  # values (no colon), both expansions return the input unchanged.
+  PUSH_TARGET="${PUSH_TARGET##*:}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -828,8 +828,13 @@ if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
   if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
-  # (b) HEAD:main or HEAD:master refspec:
-  if [[ "$PUSH_ARGS" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
+  # (b) Any <localref>:main or <localref>:master refspec — covers HEAD:main,
+  # feat:main, abc123:main, HEAD~3:main, and the deletion form :main.
+  # Past bug (#392): the old regex required `HEAD:` literal prefix, so
+  # `git push origin feat:main` evaded this rule and rule (a) (which
+  # requires `main` immediately after `origin`). Match any token ending
+  # in `:main` or `:master` (including the empty-local deletion form).
+  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -425,8 +425,14 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
     PUSH_TARGET=$(git branch --show-current 2>/dev/null)
   fi
 
-  # Strip remote-side of refspec if present (e.g., local:remote)
-  PUSH_TARGET="${PUSH_TARGET%%:*}"
+  # Strip local-side of refspec if present (e.g., local:remote). The
+  # destination/remote-side after the colon is what determines whether the
+  # push targets main/master. Past bug (#392): ${X%%:*} kept the LEFT side
+  # (local), so `git push origin feat:main` resolved PUSH_TARGET=feat and
+  # the rule below let the push through, force-shipping local feat to
+  # remote main. ${X##*:} keeps the RIGHT side (remote). For non-refspec
+  # values (no colon), both expansions return the input unchanged.
+  PUSH_TARGET="${PUSH_TARGET##*:}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -828,8 +828,13 @@ if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
   if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
-  # (b) HEAD:main or HEAD:master refspec:
-  if [[ "$PUSH_ARGS" =~ HEAD:(main|master)([[:space:]]|$|\") ]]; then
+  # (b) Any <localref>:main or <localref>:master refspec — covers HEAD:main,
+  # feat:main, abc123:main, HEAD~3:main, and the deletion form :main.
+  # Past bug (#392): the old regex required `HEAD:` literal prefix, so
+  # `git push origin feat:main` evaded this rule and rule (a) (which
+  # requires `main` immediately after `origin`). Match any token ending
+  # in `:main` or `:master` (including the empty-local deletion form).
+  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\") ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -318,6 +318,17 @@ bare_push_test "allow: git push (bare, on feature branch)" "feat/test" "allow"
 expect_deny "git push origin main" "git push origin main"
 expect_deny "git push -u origin main" "git push -u origin main"
 
+# Issue #392: <localref>:main refspec — generic hook's BLOCK_MAIN_PUSH path
+# must parse the REMOTE side of the colon. Pre-fix ${X%%:*} kept the local
+# side ("feat"), so the rule didn't match and the push went through. Post-fix
+# ${X##*:} keeps the destination ("main") and the rule fires.
+expect_deny "git push origin feat:main (refspec, local:remote — #392)" "git push origin feat:main"
+expect_deny "git push origin localbranch:main (refspec — #392)" "git push origin localbranch:main"
+expect_deny "git push origin HEAD:main (refspec — regression)" "git push origin HEAD:main"
+expect_deny "git push origin :main (deletion attempt — #392)" "git push origin :main"
+expect_deny "git push origin abc123:master (sha:master refspec — #392)" "git push origin abc123:master"
+expect_deny "git push -u origin feat:main (upstream + refspec — #392)" "git push -u origin feat:main"
+
 echo ""
 echo "=== Push: BLOCK_MAIN_PUSH preset toggle ==="
 
@@ -1307,6 +1318,48 @@ if [[ "$RESULT" == *"Cannot push to main"* ]]; then
   pass "main_protected: push origin HEAD:master (refspec) blocked"
 else
   fail "main_protected: push origin HEAD:master should be blocked, got: $RESULT"
+fi
+
+# Issue #392: <localref>:main refspec — main_protected must broaden rule (b)
+# beyond HEAD:main to catch arbitrary local-side names. Pre-fix the regex
+# required a literal "HEAD:" prefix; "feat:main" evaded both rule (a)
+# (which requires main immediately after origin) and rule (b).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin feat:main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin feat:main (#392) blocked"
+else
+  fail "main_protected: push origin feat:main should be blocked, got: $RESULT"
+fi
+
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin localbranch:main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin localbranch:main (#392) blocked"
+else
+  fail "main_protected: push origin localbranch:main should be blocked, got: $RESULT"
+fi
+
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin :main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin :main (deletion attempt — #392) blocked"
+else
+  fail "main_protected: push origin :main should be blocked, got: $RESULT"
+fi
+
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin abc123:master")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin abc123:master (#392) blocked"
+else
+  fail "main_protected: push origin abc123:master should be blocked, got: $RESULT"
+fi
+
+# Regression guard: rule (b)'s broadened regex must NOT trip on a legitimate
+# feature-branch refspec (no `:main` / `:master` suffix). Pairs with the
+# existing literal feature-branch refspec test for rule (a).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin feat/test:feat/test")
+if [[ "$RESULT" != *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin feat/test:feat/test (refspec, non-main remote) allowed"
+else
+  fail "main_protected: push origin feat/test:feat/test should be allowed, got: $RESULT"
 fi
 
 # Test: main_protected blocks naked `git push` while on main (rule (c) — the


### PR DESCRIPTION
## Summary

Fix #392: `hooks/block-unsafe-generic.sh:429` had `${PUSH_TARGET%%:*}` (strip RIGHT, keep LEFT) but the comment said "Strip remote-side." Wrong direction: kept the local-side, so `git push origin <local>:main` evaded the main-push block. Companion bug in `hooks/block-unsafe-project.sh.template:828-833` — rule (b) regex required literal `HEAD:` prefix, letting `feat:main` / `abc123:main` / `:main` evade `main_protected` entirely.

## Changes

1. `hooks/block-unsafe-generic.sh` — `${PUSH_TARGET%%:*}` → `${PUSH_TARGET##*:}` (keep RIGHT side after colon = remote target). Comment updated. Non-refspec inputs (no colon) → expansion is identity (regression-safe).
2. `hooks/block-unsafe-project.sh.template` — rule (b) regex broadened from `HEAD:(main|master)...` to `(^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\")`. Matches `feat:main`, `HEAD:main` (regression), `abc123:main`, `HEAD~3:main`, `:main` (deletion form). Does NOT match `feat/test:feat/test` (non-main destination regression-guarded).
3. `.claude/hooks/block-unsafe-generic.sh` + `.claude/hooks/block-unsafe-project.sh` — mirror sync (template→rendered copy per install path).
4. `tests/test-hooks.sh` — 11 new cases (6 generic, 5 project) including deletion form and non-main allow-regression guard.

## Test plan

- [x] Full suite: 3393/3393 passed (this worktree's baseline + 11 new); after rebase onto current main (which now includes #390/#412's 19 new tests) the count will compose to 3412
- [x] Direct shell-regex test: all 8 patterns route correctly (5 block, 3 allow including regressions)
- [x] Mirror byte-equality: clean for both files
- [x] Scope clean: 5 files, no source-skill / CLAUDE.md edits
- [x] Verifier independently confirmed fix direction by reading surrounding `awk '{print $2}'` extractor

Closes #392
