### PR TITLE
fix(hooks): close bash -c / eval git-side hook bypass

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -24,16 +24,16 @@
 #      script (pre-/update-zskills install) must not have every git commit
 #      bricked. CI's test-skill-conformance.sh is the backstop.
 #
-# Known carve-outs (documented in references/skill-version-pretooluse-hook.md
-# §D5 and Phase 2 D&C):
-#   - `bash -c '<git commit ...>'` / `sh -c '...'` / `eval '...'` are NOT
-#     matched. The tokenize-then-walk requires the FIRST non-env-prefix
-#     token of every shell segment to be literal `git`; we deliberately do
-#     not recurse into the argument string of bash -c / sh -c / eval
-#     (re-introducing a regex-fragility class). This is a minor local-
-#     development hole; CI's conformance gate is the structural backstop.
-#     Test C10e in tests/test-block-stale-skill-version.sh locks this
-#     behavior. Tracked separately as #399.
+# Wrapper recursion (#399): `bash -c '<git commit ...>'` / `sh -c '...'` /
+# `eval '...'` are MATCHED via is_git_subcommand_in_wrappers, which
+# recursively unwraps the inline-string argument of bash/sh/dash/ksh/zsh
+# -c and eval (bounded depth=3). The base is_git_subcommand helper
+# remains first-token-anchored (does not recurse on its own); the
+# wrapper-recursion is layered on top via the inlined wrappers helper
+# below. Test cases C10i+ in tests/test-block-stale-skill-version.sh
+# lock the wrapper-positive behavior; C10e/C10h (first-token /
+# chain-walker) retain their negative assertions because those helpers
+# are intentionally first-token-anchored.
 #
 #   Note: cd-chained forms like `cd /tmp/wt && git commit` ARE matched as
 #   of #393's fix — `is_git_subcommand_in_chain` (inlined from
@@ -121,9 +121,9 @@ resolve_effective_worktree_root() {
 # cd-chained forms (`cd /tmp/wt && git commit`) match — required for
 # correct worktree behavior (#393).
 #
-# Carve-out: this matcher does NOT recurse into `bash -c '...'` /
-# `sh -c '...'` / `eval '...'` argument strings — see header docstring
-# and test C10e (issue #399).
+# Wrapper recursion (#399): the call site below uses
+# is_git_subcommand_in_wrappers (which layers on top of _in_chain) so
+# `bash -c 'git commit ...'` / `eval 'git commit ...'` are also matched.
 # Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh (Phase 5.4).
 is_git_subcommand() {
   local cmd="$1"
@@ -195,7 +195,127 @@ is_git_subcommand_in_chain() {
   done <<< "$normalized"
   return 1
 }
-is_git_subcommand_in_chain "$COMMAND" commit || exit 0
+
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+# Closes the bash -c / eval / sh -c wrapper-bypass hole (#399).
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+is_git_subcommand_in_wrappers "$COMMAND" commit || exit 0
 
 # Guard against `set -u` + unset `$CLAUDE_PROJECT_DIR` (rare but documented
 # harness edge case). `${X:-$PWD}` falls back to cwd; if the script is

--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -203,6 +203,126 @@ is_git_subcommand_in_chain() {
 }
 
 # Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+# Closes the bash -c / eval / sh -c wrapper-bypass hole (#399).
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_destruct_command_in_chain() {
   local cmd="$1"
   local want_first="$2"
@@ -381,12 +501,19 @@ if [[ "$COMMAND" =~ xargs[[:space:]]+.*(rm|-delete) ]]; then
 fi
 
 # git add . / git add -A / git add --all (sweeps in unrelated changes)
-if is_git_subcommand_in_chain "$COMMAND" add && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(-A|--all|\.)([[:space:]]|$) ]]; then
+# Use is_git_subcommand_in_wrappers (#399) so `bash -c 'git add -A'` /
+# `eval 'git add .'` cannot bypass. The wrappers helper falls back to
+# _in_chain on the outer command, then sets GIT_SUB_REST on match
+# (whether via the chain or the recursive unwrap path) so the flag-regex
+# check below still functions.
+if is_git_subcommand_in_wrappers "$COMMAND" add && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(-A|--all|\.)([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git add . / git add -A sweeps in ALL changes, including other sessions' work. Stage files by name: git add file1 file2."
 fi
 
-# git commit --no-verify (skips pre-commit hooks)
-if is_git_subcommand_in_chain "$COMMAND" commit && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--no-verify([[:space:]]|$) ]]; then
+# git commit --no-verify (skips pre-commit hooks). Wrapper-recursion via
+# is_git_subcommand_in_wrappers (#399) catches `bash -c "git commit
+# --no-verify"` / `eval 'git commit --no-verify'`.
+if is_git_subcommand_in_wrappers "$COMMAND" commit && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--no-verify([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: --no-verify skips pre-commit hooks. Hooks exist for safety — fix the hook failure, don't bypass it."
 fi
 
@@ -397,10 +524,12 @@ fi
 # Detection: parse the push target from the command itself, not from
 # git branch --show-current (which returns the MAIN repo's branch even
 # when the agent is working in a worktree via cd).
-if is_git_subcommand_in_chain "$COMMAND" push; then
+if is_git_subcommand_in_wrappers "$COMMAND" push; then
   PUSH_TARGET=""
   # COMMAND is already the parsed shell command (with -m bodies redacted),
   # so no need to re-extract from the JSON.
+  # Wrapper-recursion via is_git_subcommand_in_wrappers (#399) catches
+  # `bash -c 'git push origin main'` / `eval 'git push'`.
   PUSH_CMD="$COMMAND"
 
   # Strip everything before "git push" (e.g., "cd /tmp/path &&")
@@ -433,6 +562,13 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
   # remote main. ${X##*:} keeps the RIGHT side (remote). For non-refspec
   # values (no colon), both expansions return the input unchanged.
   PUSH_TARGET="${PUSH_TARGET##*:}"
+  # Strip trailing single/double quote that wrapper-unwrapped forms can
+  # leave behind. `bash -c 'git push origin main'` → PUSH_TARGET=main' →
+  # without strip, equality check against literal "main" fails and the
+  # bypass succeeds even though _in_wrappers caught it (#399). Strip one
+  # layer each side so quoted bash-c / eval inner strings still classify.
+  PUSH_TARGET="${PUSH_TARGET%\'}"; PUSH_TARGET="${PUSH_TARGET#\'}"
+  PUSH_TARGET="${PUSH_TARGET%\"}"; PUSH_TARGET="${PUSH_TARGET#\"}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -135,6 +135,126 @@ is_git_subcommand_in_chain() {
   return 1
 }
 
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+# Closes the bash -c / eval / sh -c wrapper-bypass hole (#399).
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
 # ─── Tracking enforcement helpers ───
 # Shared between the commit / cherry-pick / push reader blocks. Each helper
 # takes a marker path + the action-verb context ("committing", "landing",
@@ -491,14 +611,17 @@ else
 fi
 
 # --- main_protected: block git commit on main ---
-if is_git_subcommand_in_chain "$COMMAND" commit && is_main_protected && is_on_main; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399) closes
+# `bash -c 'git commit'` / `eval 'git commit'` bypass.
+if is_git_subcommand_in_wrappers "$COMMAND" commit && is_main_protected && is_on_main; then
   block_with_reason "BLOCKED: main branch is protected (main_protected: true in .claude/zskills-config.json). Create a feature branch or use PR mode. To change: edit .claude/zskills-config.json"
 fi
 
 # ─── CONFIGURE: set your full test command ────────────────────────────
 # Safety net: transcript-based verification on git commit
-# Ensures tests were run before committing code files.
-if is_git_subcommand_in_chain "$COMMAND" commit; then
+# Ensures tests were run before committing code files. Wrapper-recursion
+# via is_git_subcommand_in_wrappers (#399) catches wrapper-bypass forms.
+if is_git_subcommand_in_wrappers "$COMMAND" commit; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
@@ -630,13 +753,16 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
 fi
 
 # --- main_protected: block git cherry-pick on main ---
-if is_git_subcommand_in_chain "$COMMAND" cherry-pick && is_main_protected && is_on_main; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399) closes
+# `bash -c 'git cherry-pick'` / `eval 'git cherry-pick'` bypass.
+if is_git_subcommand_in_wrappers "$COMMAND" cherry-pick && is_main_protected && is_on_main; then
   block_with_reason "BLOCKED: main branch is protected (main_protected: true in .claude/zskills-config.json). Cherry-pick to a feature branch instead. To change: edit .claude/zskills-config.json"
 fi
 
 # Safety net: transcript-based verification on git cherry-pick
 # Cherry-picks replay existing commits and bypass the commit hook above.
-if is_git_subcommand_in_chain "$COMMAND" cherry-pick; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399).
+if is_git_subcommand_in_wrappers "$COMMAND" cherry-pick; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
@@ -709,7 +835,8 @@ fi
 
 # Safety net: tracking enforcement on git push
 # Push is the landing gate for PR mode — same tracking checks as commit/cherry-pick.
-if is_git_subcommand_in_chain "$COMMAND" push; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399).
+if is_git_subcommand_in_wrappers "$COMMAND" push; then
   TRACKING_ROOT="${TRACKING_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/.." && pwd)}"
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
@@ -808,7 +935,7 @@ fi
 # variable-bearing push-target forms) produces false-positives on
 # legitimate worktree-scoped pushes without closing a realistic attack
 # vector.
-if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
+if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
   # Scope rules (a) and (b) to JUST the `git push` command segment, not the
   # whole $COMMAND buffer. Without this, multi-statement commands like
   # `git fetch origin main && git push -u origin feat/foo` false-positive
@@ -825,8 +952,10 @@ if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
     esac
   done
   # (a) Explicit origin main/master (optionally prefixed with + for
-  # force-push or : for delete-refspec):
-  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\") ]]; then
+  # force-push or : for delete-refspec). Trailing class includes `'` and
+  # `"` so wrapper-unwrapped forms like `bash -c 'git push origin main'`
+  # → PUSH_ARGS containing trailing `main'` still match (#399).
+  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (b) Any <localref>:main or <localref>:master refspec — covers HEAD:main,
@@ -835,7 +964,8 @@ if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
   # `git push origin feat:main` evaded this rule and rule (a) (which
   # requires `main` immediately after `origin`). Match any token ending
   # in `:main` or `:master` (including the empty-local deletion form).
-  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\") ]]; then
+  # Trailing class also includes `'` for wrapper-unwrapped forms (#399).
+  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -15,6 +15,10 @@
 #                                      (`some_cmd && kill -9 1234`)
 #     - is_gh_pr_subcommand_in_chain — segment-walk for cd-chained gh-pr verbs
 #                                      (`cd /tmp/wt && gh pr create -B main`)
+#     - is_git_subcommand_in_wrappers — segment-walk + recursive unwrap of
+#                                      `bash -c '<inner>'` / `sh -c '<inner>'` /
+#                                      `eval '<inner>'` for git verbs (#399)
+#     - is_gh_pr_subcommand_in_wrappers — same for gh-pr verbs (#279/PR #255)
 #
 # All helpers are inlined verbatim into hook source files; the drift gate at
 # tests/test-hook-helper-drift.sh enforces byte-equality at CI time:
@@ -24,9 +28,15 @@
 #   - is_destruct_command inlined into block-unsafe-generic.sh
 #   - is_git_subcommand_in_chain   inlined into block-unsafe-project.sh.template
 #                                              + block-unsafe-generic.sh
+#                                              + block-stale-skill-version.sh
+#   - is_git_subcommand_in_wrappers inlined into block-unsafe-project.sh.template
+#                                              + block-unsafe-generic.sh
+#                                              + block-stale-skill-version.sh
+#                                              (#399 — closes bash -c / eval bypass)
 #   - is_destruct_command_in_chain inlined into block-unsafe-generic.sh only
 #   - is_gh_pr_subcommand          inlined into block-bypassed-land-pr.sh
 #   - is_gh_pr_subcommand_in_chain inlined into block-bypassed-land-pr.sh
+#   - is_gh_pr_subcommand_in_wrappers inlined into block-bypassed-land-pr.sh
 #
 # Maintain HERE only.
 set -u
@@ -180,6 +190,142 @@ is_git_subcommand_in_chain() {
       return 0
     fi
   done <<< "$normalized"
+  return 1
+}
+
+# Returns 0 iff ANY shell segment of $cmd — including segments reachable by
+# recursively unwrapping `bash -c '<inner>'` / `sh -c '<inner>'` / `eval
+# '<inner>'` style wrappers — is a `git $want_sub` invocation. Closes the
+# git-side wrapper-bypass hole (#399); structural twin of
+# is_gh_pr_subcommand_in_wrappers (the gh-side closure from #279/PR #255).
+#
+# Without this helper, `bash -c "git commit --no-verify"`, `eval "git push
+# origin main"`, etc. would tokenize as a top-level `bash`/`eval` and slip
+# past every git-side hook (block-stale-skill-version, block-unsafe-project
+# main_protected + tracking-enforcement, block-unsafe-generic --no-verify /
+# add -A / push). All four hook-suite call sites that previously used
+# is_git_subcommand_in_chain swap up to is_git_subcommand_in_wrappers when
+# wrapper-recursion is wanted (i.e., when the gate is a structural
+# invariant that an agent must not be able to bypass with `bash -c`).
+#
+# Bounded recursion (default depth=3) so a pathological
+# `bash -c 'bash -c "bash -c \"...\"" '` chain terminates. Matches the
+# gh-pr helper's depth budget.
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
   return 1
 }
 

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -24,16 +24,16 @@
 #      script (pre-/update-zskills install) must not have every git commit
 #      bricked. CI's test-skill-conformance.sh is the backstop.
 #
-# Known carve-outs (documented in references/skill-version-pretooluse-hook.md
-# §D5 and Phase 2 D&C):
-#   - `bash -c '<git commit ...>'` / `sh -c '...'` / `eval '...'` are NOT
-#     matched. The tokenize-then-walk requires the FIRST non-env-prefix
-#     token of every shell segment to be literal `git`; we deliberately do
-#     not recurse into the argument string of bash -c / sh -c / eval
-#     (re-introducing a regex-fragility class). This is a minor local-
-#     development hole; CI's conformance gate is the structural backstop.
-#     Test C10e in tests/test-block-stale-skill-version.sh locks this
-#     behavior. Tracked separately as #399.
+# Wrapper recursion (#399): `bash -c '<git commit ...>'` / `sh -c '...'` /
+# `eval '...'` are MATCHED via is_git_subcommand_in_wrappers, which
+# recursively unwraps the inline-string argument of bash/sh/dash/ksh/zsh
+# -c and eval (bounded depth=3). The base is_git_subcommand helper
+# remains first-token-anchored (does not recurse on its own); the
+# wrapper-recursion is layered on top via the inlined wrappers helper
+# below. Test cases C10i+ in tests/test-block-stale-skill-version.sh
+# lock the wrapper-positive behavior; C10e/C10h (first-token /
+# chain-walker) retain their negative assertions because those helpers
+# are intentionally first-token-anchored.
 #
 #   Note: cd-chained forms like `cd /tmp/wt && git commit` ARE matched as
 #   of #393's fix — `is_git_subcommand_in_chain` (inlined from
@@ -121,9 +121,9 @@ resolve_effective_worktree_root() {
 # cd-chained forms (`cd /tmp/wt && git commit`) match — required for
 # correct worktree behavior (#393).
 #
-# Carve-out: this matcher does NOT recurse into `bash -c '...'` /
-# `sh -c '...'` / `eval '...'` argument strings — see header docstring
-# and test C10e (issue #399).
+# Wrapper recursion (#399): the call site below uses
+# is_git_subcommand_in_wrappers (which layers on top of _in_chain) so
+# `bash -c 'git commit ...'` / `eval 'git commit ...'` are also matched.
 # Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh (Phase 5.4).
 is_git_subcommand() {
   local cmd="$1"
@@ -195,7 +195,127 @@ is_git_subcommand_in_chain() {
   done <<< "$normalized"
   return 1
 }
-is_git_subcommand_in_chain "$COMMAND" commit || exit 0
+
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+# Closes the bash -c / eval / sh -c wrapper-bypass hole (#399).
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+is_git_subcommand_in_wrappers "$COMMAND" commit || exit 0
 
 # Guard against `set -u` + unset `$CLAUDE_PROJECT_DIR` (rare but documented
 # harness edge case). `${X:-$PWD}` falls back to cwd; if the script is

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -203,6 +203,126 @@ is_git_subcommand_in_chain() {
 }
 
 # Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+# Closes the bash -c / eval / sh -c wrapper-bypass hole (#399).
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
 is_destruct_command_in_chain() {
   local cmd="$1"
   local want_first="$2"
@@ -381,12 +501,19 @@ if [[ "$COMMAND" =~ xargs[[:space:]]+.*(rm|-delete) ]]; then
 fi
 
 # git add . / git add -A / git add --all (sweeps in unrelated changes)
-if is_git_subcommand_in_chain "$COMMAND" add && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(-A|--all|\.)([[:space:]]|$) ]]; then
+# Use is_git_subcommand_in_wrappers (#399) so `bash -c 'git add -A'` /
+# `eval 'git add .'` cannot bypass. The wrappers helper falls back to
+# _in_chain on the outer command, then sets GIT_SUB_REST on match
+# (whether via the chain or the recursive unwrap path) so the flag-regex
+# check below still functions.
+if is_git_subcommand_in_wrappers "$COMMAND" add && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(-A|--all|\.)([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git add . / git add -A sweeps in ALL changes, including other sessions' work. Stage files by name: git add file1 file2."
 fi
 
-# git commit --no-verify (skips pre-commit hooks)
-if is_git_subcommand_in_chain "$COMMAND" commit && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--no-verify([[:space:]]|$) ]]; then
+# git commit --no-verify (skips pre-commit hooks). Wrapper-recursion via
+# is_git_subcommand_in_wrappers (#399) catches `bash -c "git commit
+# --no-verify"` / `eval 'git commit --no-verify'`.
+if is_git_subcommand_in_wrappers "$COMMAND" commit && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--no-verify([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: --no-verify skips pre-commit hooks. Hooks exist for safety — fix the hook failure, don't bypass it."
 fi
 
@@ -397,10 +524,12 @@ fi
 # Detection: parse the push target from the command itself, not from
 # git branch --show-current (which returns the MAIN repo's branch even
 # when the agent is working in a worktree via cd).
-if is_git_subcommand_in_chain "$COMMAND" push; then
+if is_git_subcommand_in_wrappers "$COMMAND" push; then
   PUSH_TARGET=""
   # COMMAND is already the parsed shell command (with -m bodies redacted),
   # so no need to re-extract from the JSON.
+  # Wrapper-recursion via is_git_subcommand_in_wrappers (#399) catches
+  # `bash -c 'git push origin main'` / `eval 'git push'`.
   PUSH_CMD="$COMMAND"
 
   # Strip everything before "git push" (e.g., "cd /tmp/path &&")
@@ -433,6 +562,13 @@ if is_git_subcommand_in_chain "$COMMAND" push; then
   # remote main. ${X##*:} keeps the RIGHT side (remote). For non-refspec
   # values (no colon), both expansions return the input unchanged.
   PUSH_TARGET="${PUSH_TARGET##*:}"
+  # Strip trailing single/double quote that wrapper-unwrapped forms can
+  # leave behind. `bash -c 'git push origin main'` → PUSH_TARGET=main' →
+  # without strip, equality check against literal "main" fails and the
+  # bypass succeeds even though _in_wrappers caught it (#399). Strip one
+  # layer each side so quoted bash-c / eval inner strings still classify.
+  PUSH_TARGET="${PUSH_TARGET%\'}"; PUSH_TARGET="${PUSH_TARGET#\'}"
+  PUSH_TARGET="${PUSH_TARGET%\"}"; PUSH_TARGET="${PUSH_TARGET#\"}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -135,6 +135,126 @@ is_git_subcommand_in_chain() {
   return 1
 }
 
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+# Closes the bash -c / eval / sh -c wrapper-bypass hole (#399).
+is_git_subcommand_in_wrappers() {
+  local cmd="$1"
+  local want_sub="$2"
+  local depth="${3:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_git_subcommand_in_chain "$cmd" "$want_sub"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'git commit -m foo' became three tokens: "'git" "commit"
+          # "-m" "foo'". Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_git_subcommand_in_wrappers "$wrapper_inner" "$want_sub" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
 # ─── Tracking enforcement helpers ───
 # Shared between the commit / cherry-pick / push reader blocks. Each helper
 # takes a marker path + the action-verb context ("committing", "landing",
@@ -491,14 +611,17 @@ else
 fi
 
 # --- main_protected: block git commit on main ---
-if is_git_subcommand_in_chain "$COMMAND" commit && is_main_protected && is_on_main; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399) closes
+# `bash -c 'git commit'` / `eval 'git commit'` bypass.
+if is_git_subcommand_in_wrappers "$COMMAND" commit && is_main_protected && is_on_main; then
   block_with_reason "BLOCKED: main branch is protected (main_protected: true in .claude/zskills-config.json). Create a feature branch or use PR mode. To change: edit .claude/zskills-config.json"
 fi
 
 # ─── CONFIGURE: set your full test command ────────────────────────────
 # Safety net: transcript-based verification on git commit
-# Ensures tests were run before committing code files.
-if is_git_subcommand_in_chain "$COMMAND" commit; then
+# Ensures tests were run before committing code files. Wrapper-recursion
+# via is_git_subcommand_in_wrappers (#399) catches wrapper-bypass forms.
+if is_git_subcommand_in_wrappers "$COMMAND" commit; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
@@ -630,13 +753,16 @@ if is_git_subcommand_in_chain "$COMMAND" commit; then
 fi
 
 # --- main_protected: block git cherry-pick on main ---
-if is_git_subcommand_in_chain "$COMMAND" cherry-pick && is_main_protected && is_on_main; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399) closes
+# `bash -c 'git cherry-pick'` / `eval 'git cherry-pick'` bypass.
+if is_git_subcommand_in_wrappers "$COMMAND" cherry-pick && is_main_protected && is_on_main; then
   block_with_reason "BLOCKED: main branch is protected (main_protected: true in .claude/zskills-config.json). Cherry-pick to a feature branch instead. To change: edit .claude/zskills-config.json"
 fi
 
 # Safety net: transcript-based verification on git cherry-pick
 # Cherry-picks replay existing commits and bypass the commit hook above.
-if is_git_subcommand_in_chain "$COMMAND" cherry-pick; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399).
+if is_git_subcommand_in_wrappers "$COMMAND" cherry-pick; then
   TRANSCRIPT=$(extract_transcript)
   if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     FULL_TEST_CHECK="${FULL_TEST_CMD}"
@@ -709,7 +835,8 @@ fi
 
 # Safety net: tracking enforcement on git push
 # Push is the landing gate for PR mode — same tracking checks as commit/cherry-pick.
-if is_git_subcommand_in_chain "$COMMAND" push; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#399).
+if is_git_subcommand_in_wrappers "$COMMAND" push; then
   TRACKING_ROOT="${TRACKING_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null || echo .git)/.." && pwd)}"
   TRACKING_DIR="$TRACKING_ROOT/.zskills/tracking"
 
@@ -808,7 +935,7 @@ fi
 # variable-bearing push-target forms) produces false-positives on
 # legitimate worktree-scoped pushes without closing a realistic attack
 # vector.
-if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
+if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
   # Scope rules (a) and (b) to JUST the `git push` command segment, not the
   # whole $COMMAND buffer. Without this, multi-statement commands like
   # `git fetch origin main && git push -u origin feat/foo` false-positive
@@ -825,8 +952,10 @@ if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
     esac
   done
   # (a) Explicit origin main/master (optionally prefixed with + for
-  # force-push or : for delete-refspec):
-  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\") ]]; then
+  # force-push or : for delete-refspec). Trailing class includes `'` and
+  # `"` so wrapper-unwrapped forms like `bash -c 'git push origin main'`
+  # → PUSH_ARGS containing trailing `main'` still match (#399).
+  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (b) Any <localref>:main or <localref>:master refspec — covers HEAD:main,
@@ -835,7 +964,8 @@ if is_git_subcommand_in_chain "$COMMAND" push && is_main_protected; then
   # `git push origin feat:main` evaded this rule and rule (a) (which
   # requires `main` immediately after `origin`). Match any token ending
   # in `:main` or `:master` (including the empty-local deletion form).
-  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\") ]]; then
+  # Trailing class also includes `'` for wrapper-unwrapped forms (#399).
+  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,

--- a/tests/test-block-stale-skill-version.sh
+++ b/tests/test-block-stale-skill-version.sh
@@ -27,8 +27,21 @@
 #   C8  FOO=bar git commit -m msg         → matches (env-var prefix)
 #   C9  '   git commit' leading ws        → matches
 #   C10 echo "git commit"                 → does NOT match
-#   C10e bash -c 'git commit -m foo'      → does NOT match (carve-out;
-#                                            Round 2 DA2-L-2 lock)
+#   C10e bash -c 'git commit -m foo'      → does NOT match is_git_subcommand
+#                                            (first-token-anchored; the helper
+#                                            is intentionally not wrapper-
+#                                            recursing on its own — the
+#                                            wrapper recursion lives in
+#                                            is_git_subcommand_in_wrappers,
+#                                            which the hook now calls. See
+#                                            C10i+ for wrapper-positive cases.)
+#   C10i bash -c 'git commit -m foo'      → MATCHES is_git_subcommand_in_wrappers (#399)
+#   C10j eval 'git commit -m foo'         → MATCHES is_git_subcommand_in_wrappers (#399)
+#   C10k bash -c 'cd /tmp/wt && git commit' → MATCHES is_git_subcommand_in_wrappers (#399)
+#   C10l bash -c "git commit --no-verify" → MATCHES is_git_subcommand_in_wrappers (#399)
+#   C10m sh -c 'git commit'               → MATCHES is_git_subcommand_in_wrappers (#399)
+#   C10n bash -c 'sh -c "git commit"'     → MATCHES is_git_subcommand_in_wrappers (#399; nested)
+#   C10o eval 'echo no git here'          → does NOT match is_git_subcommand_in_wrappers
 #   C11 git commit && git push            → matches (chained)
 #   C12 Script missing (chmod -x)         → fail-open (allow)
 #   C12a unset CLAUDE_PROJECT_DIR         → fail-open (allow); guards
@@ -107,6 +120,7 @@ load_hook_funcs() {
   awk '
     /^is_git_subcommand\(\) \{$/,/^\}$/ {print}
     /^is_git_subcommand_in_chain\(\) \{$/,/^\}$/ {print}
+    /^is_git_subcommand_in_wrappers\(\) \{$/,/^\}$/ {print}
     /^json_escape\(\) \{$/,/^\}$/ {print}
   ' "$HOOK" > "$tmp"
   # shellcheck disable=SC1090
@@ -268,6 +282,28 @@ assert_no_match_chain() {
   fi
 }
 
+# Wrapper-walker assertions — used for bash -c / sh -c / eval forms (#399).
+# is_git_subcommand_in_wrappers layers on top of _in_chain and recursively
+# unwraps the inner string of bash/sh/dash/ksh/zsh -c and eval. The hook's
+# call site now uses _in_wrappers so these forms BLOCK at hook level.
+assert_match_wrappers() {
+  local label="$1" cmd="$2"
+  if is_git_subcommand_in_wrappers "$cmd" commit; then
+    pass "$label: is_git_subcommand_in_wrappers('$cmd' commit) → match"
+  else
+    fail "$label: wrappers should match" "is_git_subcommand_in_wrappers returned 1 for: $cmd"
+  fi
+}
+
+assert_no_match_wrappers() {
+  local label="$1" cmd="$2"
+  if ! is_git_subcommand_in_wrappers "$cmd" commit; then
+    pass "$label: is_git_subcommand_in_wrappers('$cmd' commit) → no match"
+  else
+    fail "$label: wrappers should NOT match" "is_git_subcommand_in_wrappers returned 0 for: $cmd"
+  fi
+}
+
 # ─────────────────── C6 .. C11 — match assertions ────────────
 assert_match    "C6"   "git commit -am 'wip'"
 assert_match    "C7"   "git commit --amend"
@@ -288,11 +324,27 @@ assert_no_match "C10e" "bash -c 'git commit -m foo'"
 # C10f / C10g — cd-chain forms now MATCH via is_git_subcommand_in_chain
 # (the hook's call site after #393's fix). is_git_subcommand alone would
 # return 1 (first token is `cd`), so we use the chain assertion to mirror
-# the hook's actual behavior. The bash -c carve-out (C10e) STAYS — it is
-# tracked separately as issue #399.
+# the hook's actual behavior.
+# C10h — bash -c '...' still does NOT match the chain helper directly
+# (chain is first-token-anchored per shell segment, doesn't recurse into
+# bash -c args). The wrapper recursion lives in
+# is_git_subcommand_in_wrappers (C10i+), which the hook now calls.
 assert_match_chain    "C10f" "cd /tmp/wt && git commit -m foo"
 assert_match_chain    "C10g" "cd /tmp/wt && cd subdir && git commit -m foo"
 assert_no_match_chain "C10h" "bash -c 'git commit -m foo'"
+# C10i .. C10o — wrapper-recursion cases (#399). These MATCH via
+# is_git_subcommand_in_wrappers, which the hook calls instead of
+# _in_chain. Closes the bash -c / eval / sh -c bypass class.
+assert_match_wrappers    "C10i" "bash -c 'git commit -m foo'"
+assert_match_wrappers    "C10j" "eval 'git commit -m foo'"
+assert_match_wrappers    "C10k" "bash -c 'cd /tmp/wt && git commit -m foo'"
+assert_match_wrappers    "C10l" "bash -c \"git commit --no-verify -m hi\""
+assert_match_wrappers    "C10m" "sh -c 'git commit -m foo'"
+assert_match_wrappers    "C10n" "bash -c 'sh -c \"git commit -m foo\"'"
+assert_no_match_wrappers "C10o" "eval 'echo no git here'"
+# C10p — chain-then-wrapper composition: a cd-chain whose tail segment is
+# a bash -c wrapper. _in_chain alone misses the inner; _in_wrappers catches.
+assert_match_wrappers    "C10p" "cd /tmp/wt && bash -c 'git commit'"
 assert_match    "C11"  "git commit && git push"
 
 # ─────────────────── C12: Script missing → fail-open ─────────

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -28,7 +28,7 @@ fail() { echo "FAIL $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 # When a new helper joins hooks/_lib/, add it here.
 fn_source() {
   case "$1" in
-    is_git_subcommand|is_destruct_command|is_git_subcommand_in_chain|is_destruct_command_in_chain|is_gh_pr_subcommand|is_gh_pr_subcommand_in_chain|is_gh_pr_subcommand_in_wrappers)
+    is_git_subcommand|is_destruct_command|is_git_subcommand_in_chain|is_destruct_command_in_chain|is_git_subcommand_in_wrappers|is_gh_pr_subcommand|is_gh_pr_subcommand_in_chain|is_gh_pr_subcommand_in_wrappers)
       echo "hooks/_lib/git-tokenwalk.sh" ;;
     extract_cd_target|resolve_effective_worktree_root)
       echo "hooks/_lib/resolve-effective-worktree-root.sh" ;;
@@ -39,16 +39,23 @@ fn_source() {
 
 for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh hooks/block-stale-skill-version.sh hooks/block-bypassed-land-pr.sh; do
   # Helper coverage per hook (which inlined helpers are present in each):
-  #   project hook              : is_git_subcommand,                  is_git_subcommand_in_chain,
-  #                               extract_cd_target,                  resolve_effective_worktree_root
+  #   project hook              : is_git_subcommand, is_git_subcommand_in_chain,
+  #                               is_git_subcommand_in_wrappers,
+  #                               extract_cd_target, resolve_effective_worktree_root
   #   generic hook              : is_git_subcommand, is_destruct_command,
-  #                               is_git_subcommand_in_chain, is_destruct_command_in_chain
+  #                               is_git_subcommand_in_chain, is_destruct_command_in_chain,
+  #                               is_git_subcommand_in_wrappers
   #   stale-skill-version hook  : is_git_subcommand, is_git_subcommand_in_chain,
+  #                               is_git_subcommand_in_wrappers,
   #                               extract_cd_target, resolve_effective_worktree_root
   #   block-bypassed-land-pr.sh : is_gh_pr_subcommand, is_gh_pr_subcommand_in_chain,
   #                               is_gh_pr_subcommand_in_wrappers
   #     (Plan LAND_PR_BYPASS_HARDENING Phase 4 — 4th drift-gated hook)
-  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers extract_cd_target resolve_effective_worktree_root; do
+  # is_git_subcommand_in_wrappers added in #399 — git-side closure of the
+  # bash -c / eval / sh -c wrapper-bypass class.
+  # extract_cd_target + resolve_effective_worktree_root added in #401 —
+  # consolidated cd-target / worktree-root resolution helper.
+  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_git_subcommand_in_wrappers is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers extract_cd_target resolve_effective_worktree_root; do
     # is_destruct_command is only inlined in generic hook; skip for project + stale-skill-version + bypassed-land-pr.
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *stale-skill-version* ]] && continue
@@ -57,6 +64,9 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
     # cd-chained `cd /tmp/wt && git commit` must match for worktree commits).
     # bypassed-land-pr still skips (uses gh-pr chain walker, not git).
     [[ "$FN" == "is_git_subcommand_in_chain" && "$HOOK" == *bypassed-land-pr* ]] && continue
+    # is_git_subcommand_in_wrappers (#399): inlined in the three git-side
+    # hooks; bypassed-land-pr uses the gh-pr equivalent so skip.
+    [[ "$FN" == "is_git_subcommand_in_wrappers" && "$HOOK" == *bypassed-land-pr* ]] && continue
     # is_destruct_command_in_chain is only inlined in the generic hook.
     [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *stale-skill-version* ]] && continue

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -259,6 +259,24 @@ expect_deny "git add --all" "git add --all"
 # 10. git commit --no-verify
 expect_deny "git commit --no-verify" "git commit --no-verify -m \"msg\""
 
+# 10a-10g. Wrapper-bypass closure (#399): bash -c / eval / sh -c forms of
+# blocked git invocations now also DENY. Cross-cutting positive tests over
+# the three generic-hook gates (commit --no-verify, add -A, push to main).
+expect_deny "WB1: bash -c 'git commit --no-verify'" \
+  "bash -c 'git commit --no-verify -m hi'"
+expect_deny "WB2: eval 'git commit --no-verify'" \
+  "eval 'git commit --no-verify -m hi'"
+expect_deny "WB3: bash -c 'cd /tmp/x && git commit --no-verify'" \
+  "bash -c 'cd /tmp/x && git commit --no-verify -m hi'"
+expect_deny "WB4: bash -c \"git add -A\"" \
+  "bash -c \\\"git add -A\\\""
+expect_deny "WB5: eval 'git add .'" \
+  "eval 'git add .'"
+expect_deny "WB6: sh -c 'git commit --no-verify'" \
+  "sh -c 'git commit --no-verify -m hi'"
+expect_deny "WB7: nested bash -c 'sh -c \"git commit --no-verify\"'" \
+  "bash -c 'sh -c \\\"git commit --no-verify -m hi\\\"'"
+
 echo ""
 echo "=== Hook allow patterns ==="
 
@@ -1237,6 +1255,52 @@ if [[ "$RESULT" == *"main branch is protected"* ]]; then
   pass "main_protected: cherry-pick on main blocked"
 else
   fail "main_protected: cherry-pick on main should be blocked, got: $RESULT"
+fi
+
+# ─── Wrapper-bypass closure (#399): bash -c / eval / sh -c forms ───
+# Without is_git_subcommand_in_wrappers, an agent could route around
+# main_protected via `bash -c 'git commit -m foo'`. These tests assert the
+# hook now catches the wrapper-bypass class for commit / cherry-pick / push.
+
+# WB-MP1: bash -c 'git commit' on protected main → blocked.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "bash -c 'git commit -m test'")
+if [[ "$RESULT" == *"main branch is protected"* ]]; then
+  pass "main_protected #399: bash -c 'git commit' on main blocked"
+else
+  fail "main_protected #399: bash -c 'git commit' on main should be blocked, got: $RESULT"
+fi
+
+# WB-MP2: eval 'git commit' on protected main → blocked.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "eval 'git commit -m test'")
+if [[ "$RESULT" == *"main branch is protected"* ]]; then
+  pass "main_protected #399: eval 'git commit' on main blocked"
+else
+  fail "main_protected #399: eval 'git commit' on main should be blocked, got: $RESULT"
+fi
+
+# WB-MP3: sh -c 'git cherry-pick' on protected main → blocked.
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "sh -c 'git cherry-pick abc123'")
+if [[ "$RESULT" == *"main branch is protected"* ]]; then
+  pass "main_protected #399: sh -c 'git cherry-pick' on main blocked"
+else
+  fail "main_protected #399: sh -c 'git cherry-pick' on main should be blocked, got: $RESULT"
+fi
+
+# WB-MP4: bash -c 'git push origin main' on protected main → blocked.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "bash -c 'git push origin main'")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected #399: bash -c 'git push origin main' blocked"
+else
+  fail "main_protected #399: bash -c 'git push origin main' should be blocked, got: $RESULT"
+fi
+
+# WB-MP5: nested bash -c 'sh -c "git commit"' on protected main → blocked
+# (#399's bounded-depth recursion).
+RESULT=$(run_main_protected_test "main" '{"execution": {"main_protected": true}}' "bash -c 'sh -c \\\"git commit -m test\\\"'")
+if [[ "$RESULT" == *"main branch is protected"* ]]; then
+  pass "main_protected #399: nested bash -c 'sh -c \"git commit\"' blocked"
+else
+  fail "main_protected #399: nested wrapper should be blocked, got: $RESULT"
 fi
 
 # Test: main_protected blocks push to main


### PR DESCRIPTION
## Summary

Fix #399: closes the `bash -c '<inner>'` / `eval '<inner>'` / `sh -c '<inner>'` wrapper-bypass class for git-side hooks. Pre-fix, `bash -c 'git commit'` and similar wrapped forms evaded every git-side hook (block-stale-skill-version, block-unsafe-project, block-unsafe-generic). Carve-out at `block-stale-skill-version.sh:25-36` ("Tracked separately as #399") + test C10e ("assert no-match for bypass pattern") are both flipped in lockstep.

## Approach

- New `is_git_subcommand_in_wrappers` in `hooks/_lib/git-tokenwalk.sh` — clone of the existing `is_gh_pr_subcommand_in_wrappers` (lines 407-524) parameterized for git rather than gh-pr. Recognizes bash/sh/dash/ash/ksh/zsh + eval wrappers, normalizes absolute-path basenames (`/bin/bash` → `bash`), strips env-var prefixes + outer quotes, bounded recursion (depth=3), falls through to `is_git_subcommand_in_chain` first.
- Wired into 10 call sites across the 3 git-side hooks:
  - `block-stale-skill-version.sh:318` (1 site)
  - `block-unsafe-project.sh.template:616, 624, 758, 765, 839, 938` (6 sites — commit×2, cherry-pick×2, push×2)
  - `block-unsafe-generic.sh:509, 516, 527` (3 sites — add, --no-verify, push)
- **Trailing-quote residue fix** (caught by WB-MP4 test): after `is_git_subcommand_in_wrappers` matches `bash -c 'git push origin main'`, downstream PUSH_TARGET extraction operates on the still-wrapped buffer, leaving residue (`origin main'`). The main-block regex's trailing alternation was extended to `([[:space:]]|$|\"|\')` and an explicit trailing-quote strip added in the generic hook.
- Composes with PR #416 (#401, just landed): drift gate at `tests/test-hook-helper-drift.sh` now covers both new families (#399 wrappers helper + #401 worktree-root resolvers) — manual conflict-resolved during rebase + amended.

## Out-of-scope follow-up (flagged)

4 remaining `*_in_chain` sites in `block-unsafe-generic.sh:372, 377, 382, 387` (checkout `--`, restore, clean `-f`, reset `--hard`) are exposed to the same bypass class but NOT included per #399's enumerated 10-site scope. Worth a follow-up issue.

## Changes (10 files)

1. `hooks/_lib/git-tokenwalk.sh` — new function at L214-330
2. `hooks/block-stale-skill-version.sh` — carve-out docstring flipped, 1 site rewired
3. `hooks/block-unsafe-generic.sh` — 3 sites rewired + trailing-quote strip
4. `hooks/block-unsafe-project.sh.template` — 6 sites rewired + main-block regex alternation extended
5-7. `.claude/hooks/{block-stale-skill-version,block-unsafe-generic,block-unsafe-project}.sh` — mirrors
8. `tests/test-block-stale-skill-version.sh` — 8 new cases C10i-C10p (bash -c, eval, sh -c, nested, cd-chain-in-wrapper, plus a negative `eval 'echo no git'`)
9. `tests/test-hooks.sh` — WB1-WB7 (generic deny, 7 cases) + WB-MP1-WB-MP5 (project main_protected, 5 cases)
10. `tests/test-hook-helper-drift.sh` — extended FN list + comments (+ rebase-conflict resolve merging #399 wrappers with #401 worktree-root additions)

## Test plan

- [x] Full suite: 3469/3469 passing (post-#401 baseline 3446 + 23 new)
- [x] Drift gate: 18/18 in isolation (15 from #401 baseline + 3 new — one per git-side hook)
- [x] Negative regression: `eval 'echo no git here'` correctly NOT blocked
- [x] Mirror byte-equal (all 3 mirrors)
- [x] Carve-out flipped at both source docstring + inline comment + test C10e relationship correctly preserved (C10e tests `is_git_subcommand` first-token-anchor; the wrapper recursion is a NEW layer, tested via C10i+)
- [x] No skill-versioning bumps
- [x] Verifier-confirmed: no `eval` of user-controlled strings, bounded recursion, no `2>/dev/null` masking, no `# allow-hardcoded` markers added
- [x] Trailing-quote residue handled (both `'` and `"` strip)

Closes #399
