### PR TITLE
fix(land-pr): pr-rebase asserts HEAD == $BRANCH before rebase

### DIFF
--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.18+908bf0"
+  version: "2026.05.19+a61d56"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/.claude/skills/land-pr/scripts/pr-rebase.sh
+++ b/.claude/skills/land-pr/scripts/pr-rebase.sh
@@ -23,6 +23,7 @@
 #   0  — clean rebase or already up to date
 #   10 — rebase conflicts (CONFLICT_FILES_LIST sidecar populated)
 #   11 — other failure (REASON populated)
+#   14 — wrong current branch (CWD's HEAD != $BRANCH; REASON=wrong-current-branch)
 #   2  — usage error
 
 set -u
@@ -69,6 +70,21 @@ if ! git rev-parse --verify "refs/heads/$BRANCH" >"$STDERR_LOG" 2>&1; then
     echo "REASON=branch-absent"
     exit 11
   fi
+fi
+
+# 2b. Verify CWD's current branch IS $BRANCH. `git rebase "origin/$BASE"`
+#     operates on whatever HEAD points to in the CWD; if a caller forgot
+#     to `cd` into the worktree (or the wrong worktree is active), the
+#     rebase silently retargets the wrong branch and exits 0 — reporting
+#     success while $BRANCH is untouched. This is the symmetric defense
+#     to pr-push-and-create.sh's Issue #188 post-push verification
+#     (which catches the dual case for `git push`). Issue #397.
+ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD 2>"$STDERR_LOG")
+if [ "$ACTUAL_HEAD" != "$BRANCH" ]; then
+  echo "ERROR: pr-rebase.sh: CWD is on '$ACTUAL_HEAD', expected '$BRANCH' — refusing to rebase the wrong branch" >&2
+  cat "$STDERR_LOG" >&2
+  echo "REASON=wrong-current-branch"
+  exit 14
 fi
 
 # 3. Fetch the base.

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.18+908bf0"
+  version: "2026.05.19+a61d56"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/skills/land-pr/scripts/pr-rebase.sh
+++ b/skills/land-pr/scripts/pr-rebase.sh
@@ -23,6 +23,7 @@
 #   0  — clean rebase or already up to date
 #   10 — rebase conflicts (CONFLICT_FILES_LIST sidecar populated)
 #   11 — other failure (REASON populated)
+#   14 — wrong current branch (CWD's HEAD != $BRANCH; REASON=wrong-current-branch)
 #   2  — usage error
 
 set -u
@@ -69,6 +70,21 @@ if ! git rev-parse --verify "refs/heads/$BRANCH" >"$STDERR_LOG" 2>&1; then
     echo "REASON=branch-absent"
     exit 11
   fi
+fi
+
+# 2b. Verify CWD's current branch IS $BRANCH. `git rebase "origin/$BASE"`
+#     operates on whatever HEAD points to in the CWD; if a caller forgot
+#     to `cd` into the worktree (or the wrong worktree is active), the
+#     rebase silently retargets the wrong branch and exits 0 — reporting
+#     success while $BRANCH is untouched. This is the symmetric defense
+#     to pr-push-and-create.sh's Issue #188 post-push verification
+#     (which catches the dual case for `git push`). Issue #397.
+ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD 2>"$STDERR_LOG")
+if [ "$ACTUAL_HEAD" != "$BRANCH" ]; then
+  echo "ERROR: pr-rebase.sh: CWD is on '$ACTUAL_HEAD', expected '$BRANCH' — refusing to rebase the wrong branch" >&2
+  cat "$STDERR_LOG" >&2
+  echo "REASON=wrong-current-branch"
+  exit 14
 fi
 
 # 3. Fetch the base.

--- a/tests/test-land-pr-scripts.sh
+++ b/tests/test-land-pr-scripts.sh
@@ -102,11 +102,14 @@ counter() {
 # Standard prep for the rebase happy-path prefix:
 #   call 1: rev-parse --is-inside-work-tree → exit 0
 #   call 2: rev-parse --verify refs/heads/<branch> → exit 0
+#   call 3: rev-parse --abbrev-ref HEAD → stdout=<branch> (Issue #397 guard)
 #   call 1: fetch origin <base> → exit 0
 prep_rebase_preflight_ok() {
   local sd="$1"
+  local branch="${2:-feat/x}"
   prep_git "$sd" rev-parse 1 exit 0
   prep_git "$sd" rev-parse 2 exit 0
+  prep_git "$sd" rev-parse 3 stdout "$branch"
   prep_git "$sd" fetch     1 exit 0
 }
 
@@ -170,6 +173,7 @@ cleanup_fixture "$F"
 F=$(new_fixture mode3)
 prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" rev-parse 2 exit 0
+prep_git "$F/state-git" rev-parse 3 stdout 'feat/x'
 prep_git "$F/state-git" fetch     1 exit 1
 prep_git "$F/state-git" fetch     1 stderr 'fatal: could not resolve hostname'
 run_sut "$F" bash "$SCRIPTS_DIR/pr-rebase.sh" --branch feat/x --base main
@@ -470,7 +474,7 @@ cleanup_fixture "$F"
 # Any sidecar path emitted should have NO `/` after `land-pr-…-`.
 # ----------------------------------------------------------------------
 F=$(new_fixture slug)
-prep_rebase_preflight_ok "$F/state-git"
+prep_rebase_preflight_ok "$F/state-git" 'smoke/foo'
 prep_git "$F/state-git" rebase 1 exit 1
 prep_git "$F/state-git" diff_unmerged 1 stdout 'a.js'
 prep_git "$F/state-git" rebase_abort 1 exit 0
@@ -488,6 +492,38 @@ else
   fail "[slug] branch-slash sanitized" "rc=$SUT_RC out=$SUT_OUT"
 fi
 cleanup_fixture "$F"
+
+# ----------------------------------------------------------------------
+# Issue #397 regression: pr-rebase.sh asserts CWD's HEAD == $BRANCH.
+# Pre-fix code rebased whatever HEAD pointed to in the caller's CWD — if
+# the caller forgot to `cd` into the worktree (HEAD on `main` or another
+# branch), the rebase silently retargeted the wrong branch and exited 0.
+# Symmetric defense to pr-push-and-create's Issue #188 fix.
+# Assertion: when `git rev-parse --abbrev-ref HEAD` returns a branch
+# different from --branch, pr-rebase.sh exits 14 with REASON=wrong-current-branch.
+# ----------------------------------------------------------------------
+F=$(new_fixture issue397_wrong_branch)
+prep_git "$F/state-git" rev-parse 1 exit 0
+prep_git "$F/state-git" rev-parse 2 exit 0
+# HEAD reports a DIFFERENT branch — script must refuse.
+prep_git "$F/state-git" rev-parse 3 stdout 'main'
+run_sut "$F" bash "$SCRIPTS_DIR/pr-rebase.sh" --branch feat/x --base main
+if [ "$SUT_RC" -eq 14 ] \
+   && [[ "$SUT_OUT" == *"REASON=wrong-current-branch"* ]] \
+   && [[ "$SUT_ERR" == *"expected 'feat/x'"* ]] \
+   && [ "$(counter "$F/state-git" fetch)" = "0" ] \
+   && [ "$(counter "$F/state-git" rebase)" = "0" ]; then
+  pass "[issue397] pr-rebase refuses when CWD HEAD != \$BRANCH (exit 14, no fetch, no rebase)"
+else
+  fail "[issue397] pr-rebase wrong-branch guard" "rc=$SUT_RC out=$SUT_OUT err=$SUT_ERR fetch=$(counter "$F/state-git" fetch) rebase=$(counter "$F/state-git" rebase)"
+fi
+cleanup_fixture "$F"
+
+# Companion: the HEAD-check happy-path uses `rev-parse --abbrev-ref HEAD`
+# returning $BRANCH; rebase proceeds. Asserted via prep_rebase_preflight_ok
+# in [mode1]/[mode2]/[idem1]/[slug] above — those tests would fail-loud
+# (mock-git exit 99 "no canned response") if the script bypassed the
+# HEAD call.
 
 # ----------------------------------------------------------------------
 # Issue #188 regression: pr-push-and-create.sh must push $BRANCH


### PR DESCRIPTION
## Summary

Fix #397: `pr-rebase.sh` accepted `--branch <name>` for existence checks (lines 65-72) but the actual `git rebase "origin/$BASE"` at line 83 ran against current HEAD with no assertion. If CWD's HEAD was somehow on a different branch, the wrong branch would be silently rebased. Symmetric port from `pr-push-and-create.sh:104-122` (Issue #188 pattern).

## Changes (5 files)

1. `skills/land-pr/scripts/pr-rebase.sh` — HEAD guard inserted between step 2 (branch-exists) and step 3 (fetch). Uses `git rev-parse --abbrev-ref HEAD`. On mismatch: `REASON=wrong-current-branch` to stdout, `expected '$BRANCH'` to stderr, exit 14. Header doc-block updated with new exit code.
2. `.claude/skills/land-pr/scripts/pr-rebase.sh` — mirror (byte-equal)
3-4. `skills/land-pr/SKILL.md` + mirror — version bumped to `2026.05.19+a61d56`
5. `tests/test-land-pr-scripts.sh`:
   - New `[issue397]` test: preps `rev-parse 3 stdout 'main'`, passes `--branch feat/x`, asserts exit 14 + `REASON=wrong-current-branch` + `expected 'feat/x'` stderr + fetch_count=0 + rebase_count=0 (guard fires BEFORE any side effect)
   - `prep_rebase_preflight_ok` helper extended with optional `<branch>` arg + 3rd `rev-parse` prep
   - 4 existing happy-path tests now exercise the guard via the updated helper

## Test plan

- [x] Full suite: 3476/3476 passing (baseline 3475 post-#418 + 1 new)
- [x] Conformance: 431/431
- [x] Negative test: confirmed guard fires before fetch+rebase (both mock counters 0)
- [x] Mirror byte-equality
- [x] Version hash matches content
- [x] Exit code 14 chosen (next gap after existing 0/2/10/11). Note: sibling script `pr-push-and-create.sh` also exits 14 for a different invariant; scripts are sibling-isolated (callers parse each separately).

## Known follow-up (NON-blocking)

Verifier flagged: `/land-pr` SKILL.md Step 3 result-parser maps RC 10 and 11 only. With pr-rebase.sh now able to exit 14, the parser falls through to STATUS-empty. **The script-level guard still prevents the wrong-branch rebase** that #397 reported; the orchestrator just misclassifies the failure (no `.landed status: rebase-failed` written). A separate follow-up issue can extend Step 3 with `elif [ "$REBASE_RC" -eq 14 ]; then STATUS="rebase-failed"; REASON="wrong-current-branch"; fi`. Not in scope for #397.

Closes #397
