### PR TITLE
fix(hooks): block-main-edits deny msg recommends /do pr (was /quickfix; no-worktree contradicts main_protected)

### DIFF
--- a/.claude/hooks/block-main-edits.sh
+++ b/.claude/hooks/block-main-edits.sh
@@ -147,10 +147,16 @@ Target: $REL
 Edits to the main repo working tree bypass the worktree discipline. Move
 this change into a worktree:
 
-  - Light, one-commit fix in flight: \\\`/quickfix\\\` (dirty tree on main → PR)
-  - Standard task with review: \\\`/do\\\` (worktree → PR)
+  - Standard task with review: \\\`/do pr\\\` (worktree → PR)
   - Plan-driven work: \\\`/run-plan\\\` (worktree per phase)
   - Manual: \\\`/create-worktree\\\` then operate inside the returned path
+
+\\\`/quickfix\\\` is NOT a valid alternative here: it is no-worktree by
+design (operates on main via \\\`git checkout -b\\\`), so an agent-dispatched
+\\\`/quickfix\\\` invocation would hit this same hook on its first Edit/Write.
+Humans driving \\\`/quickfix\\\` interactively can still use it — their dirty
+edits exist on disk before \\\`/quickfix\\\` runs and are not subject to this
+gate — but agents must route through a worktree.
 
 Allowed on main (not blocked): paths under \\\`.zskills/\\\` (tracking,
 audit, issues, dev-server state), and the gitignored worktree-state markers

--- a/hooks/block-main-edits.sh
+++ b/hooks/block-main-edits.sh
@@ -147,10 +147,16 @@ Target: $REL
 Edits to the main repo working tree bypass the worktree discipline. Move
 this change into a worktree:
 
-  - Light, one-commit fix in flight: \\\`/quickfix\\\` (dirty tree on main → PR)
-  - Standard task with review: \\\`/do\\\` (worktree → PR)
+  - Standard task with review: \\\`/do pr\\\` (worktree → PR)
   - Plan-driven work: \\\`/run-plan\\\` (worktree per phase)
   - Manual: \\\`/create-worktree\\\` then operate inside the returned path
+
+\\\`/quickfix\\\` is NOT a valid alternative here: it is no-worktree by
+design (operates on main via \\\`git checkout -b\\\`), so an agent-dispatched
+\\\`/quickfix\\\` invocation would hit this same hook on its first Edit/Write.
+Humans driving \\\`/quickfix\\\` interactively can still use it — their dirty
+edits exist on disk before \\\`/quickfix\\\` runs and are not subject to this
+gate — but agents must route through a worktree.
 
 Allowed on main (not blocked): paths under \\\`.zskills/\\\` (tracking,
 audit, issues, dev-server state), and the gitignored worktree-state markers

--- a/tests/test-block-main-edits.sh
+++ b/tests/test-block-main-edits.sh
@@ -236,10 +236,31 @@ assert_deny "C16: Edit hooks/x.sh on main → DENY" "$HOOK_OUT"
 # ── C17: CLAUDE.md on main → DENY (already in C1, but assert deny envelope
 # contains a worktree alternative recommendation per the STOP message contract) ─
 run_hook "$SANDBOX" "$(mkenv_edit "$SANDBOX/CLAUDE.md")"
-if [[ "$HOOK_OUT" == *'/quickfix'* ]] || [[ "$HOOK_OUT" == *'/do'* ]] || [[ "$HOOK_OUT" == *'worktree'* ]]; then
+if [[ "$HOOK_OUT" == *'/do'* ]] && [[ "$HOOK_OUT" == *'worktree'* ]]; then
   pass "C17: STOP message recommends worktree alternative"
 else
   fail "C17: STOP message recommends worktree alternative" "envelope=$HOOK_OUT"
+fi
+
+# ── C18: deny message must lead with /do pr, NOT /quickfix (issue #398) ──
+# /quickfix is no-worktree by design, so recommending it as the primary
+# alternative for an agent-dispatched edit creates a denial loop. The deny
+# message must (a) recommend /do pr as the primary worktree-routed alt,
+# and (b) if /quickfix is mentioned at all, qualify it as user-edited-only.
+run_hook "$SANDBOX" "$(mkenv_edit "$SANDBOX/CLAUDE.md")"
+if [[ "$HOOK_OUT" == *'/do pr'* ]]; then
+  pass "C18a: STOP message recommends /do pr (issue #398)"
+else
+  fail "C18a: STOP message recommends /do pr (issue #398)" "envelope=$HOOK_OUT"
+fi
+# If /quickfix appears, it must appear with a qualifier — never as a bare
+# "Light, one-commit fix in flight: /quickfix" recommendation. We assert
+# either /quickfix is absent OR the message also contains the words
+# "no-worktree" or "NOT a valid" near it, indicating the qualification.
+if [[ "$HOOK_OUT" != *'/quickfix'* ]] || [[ "$HOOK_OUT" == *'no-worktree'* ]] || [[ "$HOOK_OUT" == *'NOT a valid'* ]]; then
+  pass "C18b: STOP message does not recommend /quickfix as a bare alternative (issue #398)"
+else
+  fail "C18b: STOP message does not recommend /quickfix as a bare alternative (issue #398)" "envelope=$HOOK_OUT"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix #398: `hooks/block-main-edits.sh` deny message recommended `/quickfix` as the alternative, but `/quickfix` is no-worktree by design — agent-dispatched `/quickfix` invocations hit this same hook on their first Edit/Write. Rewrite the message to lead with `/do pr` (worktree → PR) and qualify `/quickfix` as user-edit-only per the blurb's scope subtlety (human-driven `/quickfix` works because dirty edits exist on disk before /quickfix runs and aren't subject to this gate).

## Changes (3 files)

1. `hooks/block-main-edits.sh` — deny message rewritten:
   - **Primary:** `/do pr` (worktree → PR)
   - **Plan-driven:** `/run-plan` (worktree per phase)
   - **Manual:** `/create-worktree` then operate inside the returned path
   - **`/quickfix` explanation:** "NOT a valid alternative here: it is no-worktree by design... agent-dispatched `/quickfix` invocation would hit this same hook on its first Edit/Write. Humans driving `/quickfix` interactively can still use it — their dirty edits exist on disk before `/quickfix` runs and are not subject to this gate — but agents must route through a worktree."
2. `.claude/hooks/block-main-edits.sh` — mirror (byte-equal)
3. `tests/test-block-main-edits.sh`:
   - C17 tightened: was `*'/quickfix'* || *'/do'* || *'worktree'*` (passed on /quickfix alone); now `*'/do'* && *'worktree'*` (regression-blocking)
   - C18a (new): asserts `/do pr` exact phrase in deny message
   - C18b (new): asserts `/quickfix` either absent OR qualified with `no-worktree`/`NOT a valid`

## Test plan

- [x] Full suite: 3478/3478 passing (baseline 3476 post-#419 + 2 new)
- [x] Mirror byte-equality
- [x] C17 regression-blocking: a deny message that dropped `/do pr` and mentioned only `/quickfix` would now fail C17
- [x] C18a + C18b lock the new behavioral contract
- [x] Scope clean: 3 files, no CLAUDE.md / unrelated / skill-source edits
- [x] No skill-versioning bump (hook at top-level `hooks/`, not under any `skills/<name>/`)

Closes #398
