### PR TITLE
fix(qe-audit): ban audit-not-done caveats; require validating evidence for cross-cutting concerns

### DIFF
--- a/.claude/skills/qe-audit/SKILL.md
+++ b/.claude/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.18+7dfae6"
+  version: "2026.05.19+f11c5f"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -220,6 +220,60 @@ Run when `bash` is NOT present in arguments.
    severity, which commit introduced it, and the verification command/result
    from Step 5.
 
+   **Ban caveats: no "audit-not-done" hedges in filed bodies.** If a finding
+   identifies a wider concern beyond the immediate defect — a pattern that
+   "might exist elsewhere," a structural framing like "Larger-than-issue,"
+   a suggestion that "a repo-wide sweep would help" — the agent MUST verify
+   before filing, not publish the deferred research as a caveat:
+
+   - **Run the audit yourself.** Audits identified by a finding are usually
+     cheap — one `grep`, one `diff`, one `git show`. Do them. If the finding
+     body says "run `grep -rn 'pattern' tests/` to enumerate similar cases,"
+     run that grep before filing. The caveat-as-published is banned; the
+     concrete result is required.
+   - **Record concrete results in the body.** "Verified: `grep -n 'pattern'
+     file` → matches at lines X, Y, Z" or "Verified: 3 other instances at
+     files A, B, C" or "Verified: no other instances (`grep -rn ... tests/`
+     returned zero matches outside the cited file)."
+   - **If verification confirms a wider concern AND the wider fix is
+     genuinely high-value** (touches multiple files in production code,
+     blocks releases, structural risk with concrete instances), file a
+     SEPARATE issue with the validating evidence inline. The separate
+     issue carries the concrete instances; it is NOT a speculative "this
+     might be a bigger problem."
+   - **If verification disconfirms** (no other instances, framing was
+     theoretical), drop the concern entirely. Do not include it in the
+     immediate-fix issue's body. Do not file a separate speculative issue.
+
+   **Bar for filing a structural / cross-cutting issue:** verified concrete
+   instances + judgment that the wider fix is genuinely high-value.
+   Speculation alone ("this might exist elsewhere") never earns a filed
+   issue. Cross-cutting concerns folded into a single-defect issue body
+   are banned; they belong in a separate issue with evidence, or nowhere.
+
+   **Worked examples (right vs wrong shape):**
+
+   - **Wrong (past failure #380):** "Audit-not-done: only these two tests
+     have been audited as committed-state-dependent. A repo-wide sweep
+     would help — run something like `grep -rn 'git ls-tree HEAD' tests/`
+     to enumerate similar tests before deciding the fix's scope." The
+     audit is literally the cited grep. The caveat publishes deferred
+     research; `/fix-issues` triage over-tiered the issue to `/draft-plan`
+     and stalled the queue.
+   - **Right (the same finding, audited):** "Verified scope: ran
+     `grep -rn 'git ls-tree HEAD\|git log.*--pretty=format:%H' tests/`,
+     found 2 committed-state-dependent tests — both cited above. No
+     other instances. Fix is sized to the 2 known tests."
+   - **Wrong (past failure #390):** "Larger-than-issue: mirror discipline
+     is a structural risk." No audit of whether other `hooks/` ↔
+     `.claude/hooks/` pairs are drifted; the framing is speculation.
+   - **Right (the same finding, audited):** "Verified: `diff -rq hooks/
+     .claude/hooks/` shows 0 drifted pairs other than the one cited. No
+     wider structural risk. Fix is the single pair." OR — if drift is
+     actually found — "Verified: `diff -rq` shows 3 additional drifted
+     pairs (hook-A.sh, hook-B.sh, hook-C.sh). Filed separate issue #NNN
+     for the structural fix with full pair list inline."
+
 7. **Update tracker** — Edit `the QE issues tracker (e.g., `$ZSKILLS_ISSUES_DIR/QE_ISSUES.md`)`.
    The Step 5 verification gate applies before any tracker mutation — do not
    move issues to "Resolved" on agent-only claims; re-verify with `git show`
@@ -285,6 +339,12 @@ Run when `bash` IS present in arguments.
      full verification discipline (file:line grep, negative-claim recheck,
      `git show` for "fixed by" claims). Findings that don't reproduce are
      logged as "Unverified findings," not filed as issues.
+     **Ban caveats: the Commit Audit Step 6 "no audit-not-done hedges"
+     rule applies here too.** A parallel-sweep finding that says "this
+     might generalize across other models" must be verified (run the
+     sweep) before being filed as a wider concern. Cross-cutting framings
+     without concrete instances stay out of filed bodies; file a separate
+     issue only with verified evidence.
 
    **c. Adversarial unit tests** (for all areas):
    - Edge cases (empty inputs, zero values, NaN, Infinity, negative numbers)
@@ -316,6 +376,13 @@ Run when `bash` IS present in arguments.
    - Include: what was tested, expected vs actual behavior, test code,
      severity rating, suggested fix
    - Tag with appropriate labels
+   - **Ban caveats: no "audit-not-done" hedges.** See Commit Audit Step 6
+     for the full rule. If a bash finding identifies a wider concern
+     ("this edge case might affect other features," "Larger-than-issue:
+     structural"), verify it inline before filing — run the additional
+     test, sweep the additional area, cite concrete results. Drop
+     unvalidated cross-cutting framings; file a separate issue only with
+     verified evidence.
 
 6. **Update `the QE issues tracker (e.g., `$ZSKILLS_ISSUES_DIR/QE_ISSUES.md`)`** with new findings.
    The verification gate from Commit Audit Step 5 applies here too — do not

--- a/skills/qe-audit/SKILL.md
+++ b/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.18+7dfae6"
+  version: "2026.05.19+f11c5f"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -220,6 +220,60 @@ Run when `bash` is NOT present in arguments.
    severity, which commit introduced it, and the verification command/result
    from Step 5.
 
+   **Ban caveats: no "audit-not-done" hedges in filed bodies.** If a finding
+   identifies a wider concern beyond the immediate defect — a pattern that
+   "might exist elsewhere," a structural framing like "Larger-than-issue,"
+   a suggestion that "a repo-wide sweep would help" — the agent MUST verify
+   before filing, not publish the deferred research as a caveat:
+
+   - **Run the audit yourself.** Audits identified by a finding are usually
+     cheap — one `grep`, one `diff`, one `git show`. Do them. If the finding
+     body says "run `grep -rn 'pattern' tests/` to enumerate similar cases,"
+     run that grep before filing. The caveat-as-published is banned; the
+     concrete result is required.
+   - **Record concrete results in the body.** "Verified: `grep -n 'pattern'
+     file` → matches at lines X, Y, Z" or "Verified: 3 other instances at
+     files A, B, C" or "Verified: no other instances (`grep -rn ... tests/`
+     returned zero matches outside the cited file)."
+   - **If verification confirms a wider concern AND the wider fix is
+     genuinely high-value** (touches multiple files in production code,
+     blocks releases, structural risk with concrete instances), file a
+     SEPARATE issue with the validating evidence inline. The separate
+     issue carries the concrete instances; it is NOT a speculative "this
+     might be a bigger problem."
+   - **If verification disconfirms** (no other instances, framing was
+     theoretical), drop the concern entirely. Do not include it in the
+     immediate-fix issue's body. Do not file a separate speculative issue.
+
+   **Bar for filing a structural / cross-cutting issue:** verified concrete
+   instances + judgment that the wider fix is genuinely high-value.
+   Speculation alone ("this might exist elsewhere") never earns a filed
+   issue. Cross-cutting concerns folded into a single-defect issue body
+   are banned; they belong in a separate issue with evidence, or nowhere.
+
+   **Worked examples (right vs wrong shape):**
+
+   - **Wrong (past failure #380):** "Audit-not-done: only these two tests
+     have been audited as committed-state-dependent. A repo-wide sweep
+     would help — run something like `grep -rn 'git ls-tree HEAD' tests/`
+     to enumerate similar tests before deciding the fix's scope." The
+     audit is literally the cited grep. The caveat publishes deferred
+     research; `/fix-issues` triage over-tiered the issue to `/draft-plan`
+     and stalled the queue.
+   - **Right (the same finding, audited):** "Verified scope: ran
+     `grep -rn 'git ls-tree HEAD\|git log.*--pretty=format:%H' tests/`,
+     found 2 committed-state-dependent tests — both cited above. No
+     other instances. Fix is sized to the 2 known tests."
+   - **Wrong (past failure #390):** "Larger-than-issue: mirror discipline
+     is a structural risk." No audit of whether other `hooks/` ↔
+     `.claude/hooks/` pairs are drifted; the framing is speculation.
+   - **Right (the same finding, audited):** "Verified: `diff -rq hooks/
+     .claude/hooks/` shows 0 drifted pairs other than the one cited. No
+     wider structural risk. Fix is the single pair." OR — if drift is
+     actually found — "Verified: `diff -rq` shows 3 additional drifted
+     pairs (hook-A.sh, hook-B.sh, hook-C.sh). Filed separate issue #NNN
+     for the structural fix with full pair list inline."
+
 7. **Update tracker** — Edit `the QE issues tracker (e.g., `$ZSKILLS_ISSUES_DIR/QE_ISSUES.md`)`.
    The Step 5 verification gate applies before any tracker mutation — do not
    move issues to "Resolved" on agent-only claims; re-verify with `git show`
@@ -285,6 +339,12 @@ Run when `bash` IS present in arguments.
      full verification discipline (file:line grep, negative-claim recheck,
      `git show` for "fixed by" claims). Findings that don't reproduce are
      logged as "Unverified findings," not filed as issues.
+     **Ban caveats: the Commit Audit Step 6 "no audit-not-done hedges"
+     rule applies here too.** A parallel-sweep finding that says "this
+     might generalize across other models" must be verified (run the
+     sweep) before being filed as a wider concern. Cross-cutting framings
+     without concrete instances stay out of filed bodies; file a separate
+     issue only with verified evidence.
 
    **c. Adversarial unit tests** (for all areas):
    - Edge cases (empty inputs, zero values, NaN, Infinity, negative numbers)
@@ -316,6 +376,13 @@ Run when `bash` IS present in arguments.
    - Include: what was tested, expected vs actual behavior, test code,
      severity rating, suggested fix
    - Tag with appropriate labels
+   - **Ban caveats: no "audit-not-done" hedges.** See Commit Audit Step 6
+     for the full rule. If a bash finding identifies a wider concern
+     ("this edge case might affect other features," "Larger-than-issue:
+     structural"), verify it inline before filing — run the additional
+     test, sweep the additional area, cite concrete results. Drop
+     unvalidated cross-cutting framings; file a separate issue only with
+     verified evidence.
 
 6. **Update `the QE issues tracker (e.g., `$ZSKILLS_ISSUES_DIR/QE_ISSUES.md`)`** with new findings.
    The verification gate from Commit Audit Step 5 applies here too — do not

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2252,6 +2252,21 @@ else
 fi
 
 echo ""
+echo "=== /qe-audit — ban audit-not-done caveats (issue #404) ==="
+# Issue #404: /qe-audit-filed issue bodies trend conservative with
+# "Audit-not-done" / "Larger-than-issue" framings instead of running
+# the cheap inline audit. The SKILL.md prose must explicitly ban those
+# caveats and require validating evidence before filing cross-cutting
+# concerns. These checks lock the prose anchor + the bar-for-filing
+# language so future edits can't silently drop the rule.
+check_fixed qe-audit "ban-caveats heading"                'Ban caveats: no "audit-not-done" hedges in filed bodies'
+check_fixed qe-audit "bar-for-filing structural rule"     'Bar for filing a structural / cross-cutting issue'
+check_fixed qe-audit "speculation never earns a filing"   'Speculation alone'
+check_fixed qe-audit "worked example: past failure #380"  'past failure #380'
+check_fixed qe-audit "worked example: past failure #390"  'past failure #390'
+check_fixed qe-audit "bash-mode sweep echoes the rule"    'Ban caveats: the Commit Audit Step 6'
+
+echo ""
 echo "---"
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if [ $FAIL_COUNT -eq 0 ]; then


### PR DESCRIPTION
## Summary

Fix #404: `/qe-audit`-filed issue bodies were trending toward conservative "audit-not-done" caveats that caused downstream triage conflation, queue stalls, and over-tiering to `/draft-plan`. New prose at Commit Audit Step 6 bans those hedges and requires validating evidence for any cross-cutting / "Larger-than-issue" framing in a filed body. Bash mode 3b (parallel-sweep) and Bash mode 5 (file GitHub issues) carry back-references to the canonical Step 6 location.

## Approach (per blurb)

- New prose inserted as a sibling rule to Step 6's existing "verify before filing" discipline (PR #338-era) — clean structural fit, no disturbance to existing rules.
- 4 bullets describe the audit-now-or-don't-file discipline: run-the-audit / record-concrete-results / separate-issue-if-confirmed / drop-if-disconfirmed.
- Bar-for-filing rule explicitly forbids speculation: *"Speculation alone ('this might exist elsewhere') never earns a filed issue."*
- Worked examples cite #380 (test false-PASS — the cheap grep was literally the audit) and #390 (mirror discipline framing without `diff -rq`) as past-failure calibration.

## Changes (3 files)

1. `skills/qe-audit/SKILL.md` — Step 6 ban-caveats block + Bash mode 3b + Bash mode 5 back-references. `metadata.version` bumped to `2026.05.19+f11c5f`.
2. `.claude/skills/qe-audit/SKILL.md` — mirror (byte-equal)
3. `tests/test-skill-conformance.sh` — 6 new anchor checks: ban-caveats heading, bar-for-filing rule, "Speculation alone", past failure #380, past failure #390, bash-mode rule echo

## Test plan

- [x] Full suite: 3487/3487 passing (baseline 3486 post-#423 + 1 net since rebase; 6 new conformance checks absorbed in existing test counts via test-skill-conformance.sh growth)
- [x] Conformance test (test-skill-conformance.sh) alone: 437/437 (was 431, +6 = exact match for the 6 new anchors)
- [x] Mirror byte-equality
- [x] Version hash matches content (`f11c5f`)
- [x] Prose anchors greppable in actual SKILL.md (verifier independently confirmed each `check_fixed` greppable exactly once)

Closes #404
