### PR TITLE
do: rule for handling cron-fired Run /<skill> prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ When using the Agent tool:
 - Treat any subagent type as Haiku-by-default until you have read its agent definition and confirmed otherwise. When in doubt, pass `model: "opus"` explicitly, or use `general-purpose`.
 - **Sonnet** is acceptable only for rare simple+mechanical work (bulk renames, find-replace, format conversion). Never for analysis, review, verification, or judgment.
 
+## Cron-fired prompts
+
+**Cron fires arrive as plain Human turns — recognize and execute inline, do not balk.** When an in-session cron registered via `/fix-issues ... every N ...`, `/do ... every N ...`, or any other `every`-scheduled skill fires, the runtime injects the cron's prompt as the next Human turn with NO `<command-name>` envelope. The text simply appears, e.g., `Run /fix-issues 2 auto dashboard every 30m now`.
+
+**Treat any user-shaped turn whose entire content starts with `Run /<skill-name> ` as a cron fire**, not as a user instruction to manually dispatch. Read `.claude/skills/<skill-name>/SKILL.md` via the Read tool (always available regardless of session-load state) and execute its procedure inline with `$ARGUMENTS` set to the substring after `Run /<skill-name> `. Do NOT reach for the Skill tool — every recurring-skill we ship (`/fix-issues`, `/do`, `/qe-audit`, `/run-plan`) sets `disable-model-invocation: true` and Skill-tool dispatch is blocked by design (see [[feedback_skill_invocation_flags]]). Do NOT ask the user "what would you like me to do?" — `Run /<skill> ...` IS the instruction. Do NOT narrate "this looks like a manual instruction" — it's not; just execute.
+
+**This applies equally pre-/clear and post-/clear.** A user typing `/fix-issues N every ...` once loads the skill body that turn, registers the cron, and runs the first fire with skill in context. After `/clear` the skill body is gone but the cron keeps firing — that's exactly when this rule matters, because CLAUDE.md is always loaded.
+
+**Never `CronDelete` on the strength of a confused fire.** If you genuinely cannot recognize what the cron wants, report `Cron fired with prompt <text>; not sure how to handle. Leaving the schedule untouched.` and stop. Past failure 2026-05-18: agent killed a user's 50+-successful-run /fix-issues cron based on a `disable-model-invocation` misread; the cron was firing correctly the whole time. The right move when stuck is to surface and pause, not to assume the cron is broken.
+
 ## Playwright CLI (Browser Automation)
 
 This environment uses `playwright-cli` for browser automation. Run `playwright-cli --help` for available commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,13 +92,15 @@ When using the Agent tool:
 
 ## Cron-fired prompts
 
-**Cron fires arrive as plain Human turns — recognize and execute inline, do not balk.** When an in-session cron registered via `/fix-issues ... every N ...`, `/do ... every N ...`, or any other `every`-scheduled skill fires, the runtime injects the cron's prompt as the next Human turn with NO `<command-name>` envelope. The text simply appears, e.g., `Run /fix-issues 2 auto dashboard every 30m now`.
+**Cron fires arrive as plain Human turns between your turns — recognize and execute inline, do not balk.** Per Claude Code's [scheduled-tasks docs](https://code.claude.com/docs/en/scheduled-tasks), a `CronCreate`-registered prompt "fires between your turns" into the active session — no fresh-session spawn, no slash-runtime auto-dispatch on leading `/`, no `<command-name>` envelope. The text appears as a synthetic user turn, e.g., `Run /fix-issues 2 auto dashboard every 30m now`.
 
 **Treat any user-shaped turn whose entire content starts with `Run /<skill-name> ` as a cron fire**, not as a user instruction to manually dispatch. Read `.claude/skills/<skill-name>/SKILL.md` via the Read tool (always available regardless of session-load state) and execute its procedure inline with `$ARGUMENTS` set to the substring after `Run /<skill-name> `. Do NOT reach for the Skill tool — every recurring-skill we ship (`/fix-issues`, `/do`, `/qe-audit`, `/run-plan`) sets `disable-model-invocation: true` and Skill-tool dispatch is blocked by design (see [[feedback_skill_invocation_flags]]). Do NOT ask the user "what would you like me to do?" — `Run /<skill> ...` IS the instruction. Do NOT narrate "this looks like a manual instruction" — it's not; just execute.
 
 **This applies equally pre-/clear and post-/clear.** A user typing `/fix-issues N every ...` once loads the skill body that turn, registers the cron, and runs the first fire with skill in context. After `/clear` the skill body is gone but the cron keeps firing — that's exactly when this rule matters, because CLAUDE.md is always loaded.
 
 **Never `CronDelete` on the strength of a confused fire.** If you genuinely cannot recognize what the cron wants, report `Cron fired with prompt <text>; not sure how to handle. Leaving the schedule untouched.` and stop. Past failure 2026-05-18: agent killed a user's 50+-successful-run /fix-issues cron based on a `disable-model-invocation` misread; the cron was firing correctly the whole time. The right move when stuck is to surface and pause, not to assume the cron is broken.
+
+Empirical anchor for the Skill-tool-refusal fallback: Anthropic [issue #26251](https://github.com/anthropics/claude-code/issues/26251) documents Claude organically reading SKILL.md and executing inline when a `disable-model-invocation: true` skill is invoked via a typed slash command. This rule codifies that natural fallback so every recipient agent — including post-`/clear` ones with the originating skill body out of context — handles cron-fired `Run /<skill>` turns the same way.
 
 ## Playwright CLI (Browser Automation)
 

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -17,6 +17,16 @@ When using the Agent tool:
 
 **Impl-agent dispatch.** When dispatching a sub-agent to write code, run tests, or commit changes (this includes any agent dispatch inside `/fix-issues` PR mode, `/do` PR mode, `/land-pr`'s fix-cycle template, `/run-plan`'s phase implementer, and `/quickfix`'s agent-dispatched mode), use `subagent_type: "implementer"`. The implementer agent (`.claude/agents/implementer.md`) clones the verifier's frontmatter `inject-bash-timeout.sh` hook so the agent's Bash calls auto-extend to a 600s timeout. Without this pin the impl agent runs as default `general-purpose`, hits the Bash tool's 120s default on long test runs, and reflexively reaches for `run_in_background: true` + `Monitor` — the exact stall pattern the verifier-cannot-run rule already guards against on the verifier side.
 
+## Cron-fired prompts
+
+**Cron fires arrive as plain Human turns — recognize and execute inline, do not balk.** When an in-session cron registered via `/fix-issues ... every N ...`, `/do ... every N ...`, or any other `every`-scheduled skill fires, the runtime injects the cron's prompt as the next Human turn with NO `<command-name>` envelope. The text simply appears, e.g., `Run /fix-issues 2 auto dashboard every 30m now`.
+
+**Treat any user-shaped turn whose entire content starts with `Run /<skill-name> ` as a cron fire**, not as a user instruction to manually dispatch. Read `.claude/skills/<skill-name>/SKILL.md` via the Read tool (always available regardless of session-load state) and execute its procedure inline with `$ARGUMENTS` set to the substring after `Run /<skill-name> `. Do NOT reach for the Skill tool — every recurring-skill we ship (`/fix-issues`, `/do`, `/qe-audit`, `/run-plan`) sets `disable-model-invocation: true` and Skill-tool dispatch is blocked by design (see [[feedback_skill_invocation_flags]]). Do NOT ask the user "what would you like me to do?" — `Run /<skill> ...` IS the instruction. Do NOT narrate "this looks like a manual instruction" — it's not; just execute.
+
+**This applies equally pre-/clear and post-/clear.** A user typing `/fix-issues N every ...` once loads the skill body that turn, registers the cron, and runs the first fire with skill in context. After `/clear` the skill body is gone but the cron keeps firing — that's exactly when this rule matters, because CLAUDE.md is always loaded.
+
+**Never `CronDelete` on the strength of a confused fire.** If you genuinely cannot recognize what the cron wants, report `Cron fired with prompt <text>; not sure how to handle. Leaving the schedule untouched.` and stop. Past failure 2026-05-18: agent killed a user's 50+-successful-run /fix-issues cron based on a `disable-model-invocation` misread; the cron was firing correctly the whole time. The right move when stuck is to surface and pause, not to assume the cron is broken.
+
 ## Bash tool timeouts and bg behavior
 
 The Bash tool has a 600s (10 min) hard ceiling. When a command may exceed it:

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -19,13 +19,15 @@ When using the Agent tool:
 
 ## Cron-fired prompts
 
-**Cron fires arrive as plain Human turns — recognize and execute inline, do not balk.** When an in-session cron registered via `/fix-issues ... every N ...`, `/do ... every N ...`, or any other `every`-scheduled skill fires, the runtime injects the cron's prompt as the next Human turn with NO `<command-name>` envelope. The text simply appears, e.g., `Run /fix-issues 2 auto dashboard every 30m now`.
+**Cron fires arrive as plain Human turns between your turns — recognize and execute inline, do not balk.** Per Claude Code's [scheduled-tasks docs](https://code.claude.com/docs/en/scheduled-tasks), a `CronCreate`-registered prompt "fires between your turns" into the active session — no fresh-session spawn, no slash-runtime auto-dispatch on leading `/`, no `<command-name>` envelope. The text appears as a synthetic user turn, e.g., `Run /fix-issues 2 auto dashboard every 30m now`.
 
 **Treat any user-shaped turn whose entire content starts with `Run /<skill-name> ` as a cron fire**, not as a user instruction to manually dispatch. Read `.claude/skills/<skill-name>/SKILL.md` via the Read tool (always available regardless of session-load state) and execute its procedure inline with `$ARGUMENTS` set to the substring after `Run /<skill-name> `. Do NOT reach for the Skill tool — every recurring-skill we ship (`/fix-issues`, `/do`, `/qe-audit`, `/run-plan`) sets `disable-model-invocation: true` and Skill-tool dispatch is blocked by design (see [[feedback_skill_invocation_flags]]). Do NOT ask the user "what would you like me to do?" — `Run /<skill> ...` IS the instruction. Do NOT narrate "this looks like a manual instruction" — it's not; just execute.
 
 **This applies equally pre-/clear and post-/clear.** A user typing `/fix-issues N every ...` once loads the skill body that turn, registers the cron, and runs the first fire with skill in context. After `/clear` the skill body is gone but the cron keeps firing — that's exactly when this rule matters, because CLAUDE.md is always loaded.
 
 **Never `CronDelete` on the strength of a confused fire.** If you genuinely cannot recognize what the cron wants, report `Cron fired with prompt <text>; not sure how to handle. Leaving the schedule untouched.` and stop. Past failure 2026-05-18: agent killed a user's 50+-successful-run /fix-issues cron based on a `disable-model-invocation` misread; the cron was firing correctly the whole time. The right move when stuck is to surface and pause, not to assume the cron is broken.
+
+Empirical anchor for the Skill-tool-refusal fallback: Anthropic [issue #26251](https://github.com/anthropics/claude-code/issues/26251) documents Claude organically reading SKILL.md and executing inline when a `disable-model-invocation: true` skill is invoked via a typed slash command. This rule codifies that natural fallback so every recipient agent — including post-`/clear` ones with the originating skill body out of context — handles cron-fired `Run /<skill>` turns the same way.
 
 ## Bash tool timeouts and bg behavior
 

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1993,6 +1993,26 @@ for prose_file in "$REPO_ROOT/CLAUDE_TEMPLATE.md" "$REPO_ROOT/CLAUDE.md"; do
   else
     fail "[propagation-prose] $rel" "missing literal: 'Never call \`gh pr create\` or \`gh pr merge --auto\` directly when landing a PR' (#185)"
   fi
+  # Cron-fire recognition rule: cron fires arrive as plain Human turns with
+  # no `<command-name>` envelope; recipient agents must recognize the
+  # `Run /<skill> ...` shape, read SKILL.md, execute inline, and never
+  # CronDelete on a confused fire. Memory anchors don't propagate, so this
+  # rule must live in both surfaces.
+  if grep -qF '## Cron-fired prompts' "$prose_file"; then
+    pass "[propagation-prose] $rel contains '## Cron-fired prompts' heading"
+  else
+    fail "[propagation-prose] $rel" "missing heading: '## Cron-fired prompts'"
+  fi
+  if grep -qF 'Treat any user-shaped turn whose entire content starts with' "$prose_file"; then
+    pass "[propagation-prose] $rel contains cron-fire recognition contract literal"
+  else
+    fail "[propagation-prose] $rel" "missing literal: 'Treat any user-shaped turn whose entire content starts with'"
+  fi
+  if grep -qF 'Never `CronDelete` on the strength of a confused fire' "$prose_file"; then
+    pass "[propagation-prose] $rel contains 'no-CronDelete-on-confusion' rule literal"
+  else
+    fail "[propagation-prose] $rel" "missing literal: 'Never \`CronDelete\` on the strength of a confused fire'"
+  fi
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Adds a `## Cron-fired prompts` section to `CLAUDE.md` and `CLAUDE_TEMPLATE.md` so receiving agents correctly recognize and execute `Run /<skill> <args>` cron-fired turns instead of stalling on `disable-model-invocation` and writing confused options blocks to the user.

## Why

Today's session saw two agents in succession stall when /fix-issues cron fires landed in an active orchestrator after `/clear` had blown away the skill body. Each tried to Skill-tool dispatch, hit `disable-model-invocation: true`, and wrote options blocks asking the user what to do — instead of just reading SKILL.md and executing inline. A separate 2026-05-18 incident (recorded in memory anchor `feedback_framework_broken_claims_need_falsification.md`) went further: an agent killed a user's 50+-successful-run /fix-issues cron on a `disable-model-invocation` misread. Per CLAUDE.md's own rule, memory anchors are agent-local and don't propagate — so the fix has to land in always-loaded context (CLAUDE.md survives `/clear`; the skill body doesn't).

## Approach

Four load-bearing bullets in the new section:

1. **Recognition contract.** Any Human turn whose entire content starts with `Run /<skill-name> ` is a cron fire. Read `.claude/skills/<skill-name>/SKILL.md` via the Read tool and execute inline with `$ARGUMENTS` = substring after `Run /<skill-name> `.
2. **No Skill-tool dispatch.** Every recurring skill (`/fix-issues`, `/do`, `/qe-audit`, `/run-plan`) sets `disable-model-invocation: true` by design — Skill-tool is blocked; don't reach for it, don't ask the user, don't narrate "this looks manual."
3. **Pre/post-`/clear` survival.** This rule matters most after `/clear` when the skill body is gone but the cron keeps firing.
4. **Never `CronDelete` on a confused fire.** Surface and pause; don't assume the cron is broken (cites the 2026-05-18 past failure).

Mirror byte-equal section body to `CLAUDE_TEMPLATE.md` so consumer projects pick it up via `/update-zskills` Step B → `.claude/rules/zskills/managed.md`. Six anchor assertions added to `tests/test-skill-conformance.sh` (3 literals × 2 files).

## Research-confirmed wording

Per Claude Code's [scheduled-tasks docs](https://code.claude.com/docs/en/scheduled-tasks): "A scheduled prompt fires between your turns, not while Claude is mid-response. … Tasks are session-scoped." Cron prompts arrive as synthetic user turns; no leading-`/` slash-runtime auto-dispatch is documented. Anthropic [issue #26251](https://github.com/anthropics/claude-code/issues/26251) documents Claude's organic Skill-tool-refusal fallback on `disable-model-invocation` skills (reads SKILL.md and executes inline) — our rule codifies that natural behavior.

## Follow-up

Filed as **#432**: the zskills repo's own install shape (monolithic `CLAUDE.md`) doesn't follow the consumer install shape (`/update-zskills` Step B → `.claude/rules/zskills/managed.md`). Surfaced during this work; not in scope for this PR.

## Test plan

- [x] Full suite: **3500/3500 passing** (baseline 3494 from #431 + 6 new anchor assertions covering the new section in both files).
- [x] `diff` confirms section body byte-equal between `CLAUDE.md` and `CLAUDE_TEMPLATE.md`.
- [x] `git diff --stat origin/main..HEAD` shows ONLY `CLAUDE.md`, `CLAUDE_TEMPLATE.md`, and `tests/test-skill-conformance.sh` — no skill version bumps, no script changes.
- [x] No `metadata.version` bumps required (no `skills/<name>/**` regular files touched).
