### PR TITLE
fix(hooks): close bash -c wrapper-bypass for destructive ops (#426)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -341,27 +341,53 @@ is_destruct_command_in_chain() {
   return 1
 }
 
-# git stash — command-boundary matching only. A bare `git[[:space:]]+stash`
-# match (anywhere in the command) overmatches on quoted strings (commit
-# messages, echo/printf/grep args that mention stash) and on the hook's own
-# error messages when they're ever echo'd. Gating on command-start or shell
-# separator (;, &, &&, ||, |, newline, backtick, $()) keeps the match scoped
-# to ACTUAL stash invocations.
+# git stash — wrapper-aware gate via is_git_subcommand_in_wrappers (#426,
+# completes #399). The prior regex-based STASH_BOUNDARY anchored
+# `git[[:space:]]+stash` to `^`, `;`, `&`, `&&`, `||`, `|`, backtick, or
+# `$(` — none of which precede the inner `git` inside wrapper forms like
+# `bash -c 'git stash drop'` / `eval 'git stash drop'` / `sh -c 'git
+# stash drop'`. Tokenize-then-walk via is_git_subcommand_in_wrappers
+# matches all those forms (and the existing chain/multi-segment cases)
+# and sets GIT_SUB_REST to the rest of the matching segment for flag
+# inspection — same idiom as the converted `add` / `commit` / `push`
+# gates further down.
 #
 # Allowed subcommands: apply, list, show, pop, create, store, branch (read
 # and recovery — never modify the working tree).
-# Destructive: drop, clear — block (prior behavior).
+# Destructive: drop, clear — block.
 # Create-stash: push, save, -u, bare — block (CLAUDE.md rule).
+#
+# Quoted-prose protection (overmatching on `echo "git stash drop"` etc.)
+# is preserved by the data-region redaction passes at the top of the
+# file (heredoc + -m/--message/--body/--title quoted-arg redaction). The
+# wrapper-aware gate runs AFTER redaction, so prose in commit messages
+# and gh body text no longer reaches the tokenizer.
 #
 # Past failure: a /commit pre-commit reviewer ran `stash -u && test && stash
 # pop`; the pop silently unstaged the caller's staged files.
-STASH_BOUNDARY='(^|[;&|`(]|&&|\|\||\$\()[[:space:]]*git[[:space:]]+stash'
-STASH_ALLOW_SUB="${STASH_BOUNDARY}[[:space:]]+(apply|list|show|pop|create|store|branch)([[:space:]]|\\\"|'|\\\\|\||;|\$)"
-STASH_DESTRUCTIVE="${STASH_BOUNDARY}[[:space:]]+(drop|clear)"
-if [[ "$COMMAND" =~ $STASH_DESTRUCTIVE ]]; then
-  block_with_reason "BLOCKED: git stash drop/clear destroys stashed work permanently (including untracked files saved with -u). If you need to drop a stash, ask the user to do it manually."
-elif [[ "$COMMAND" =~ $STASH_BOUNDARY ]] && [[ ! "$COMMAND" =~ $STASH_ALLOW_SUB ]]; then
-  block_with_reason "BLOCKED: git-stash write subcommand forbidden (modifies working tree). Allowed read/recovery: apply, list, show, pop. For cherry-pick protection, let git refuse on overlap."
+if is_git_subcommand_in_wrappers "$COMMAND" stash; then
+  # First token of GIT_SUB_REST is the stash subcommand (apply, drop, etc.)
+  # or absent (bare `git stash` = create-stash). Strip surrounding quotes
+  # that wrapper-unwrapped forms may leave (e.g. `bash -c 'git stash drop'`
+  # → GIT_SUB_REST="drop'" without the strip).
+  _stash_sub="${GIT_SUB_REST%% *}"
+  _stash_sub="${_stash_sub%\'}"; _stash_sub="${_stash_sub#\'}"
+  _stash_sub="${_stash_sub%\"}"; _stash_sub="${_stash_sub#\"}"
+  case "$_stash_sub" in
+    drop|clear)
+      block_with_reason "BLOCKED: git stash drop/clear destroys stashed work permanently (including untracked files saved with -u). If you need to drop a stash, ask the user to do it manually."
+      ;;
+    apply|list|show|pop|create|store|branch)
+      : # allowed read/recovery subcommands — no action
+      ;;
+    *)
+      # Includes: bare `git stash`, `git stash push`, `git stash save`,
+      # `git stash -u`, and any unknown form. All are create-stash or
+      # unrecognized — block.
+      block_with_reason "BLOCKED: git-stash write subcommand forbidden (modifies working tree). Allowed read/recovery: apply, list, show, pop. For cherry-pick protection, let git refuse on overlap."
+      ;;
+  esac
+  unset _stash_sub
 fi
 
 # git checkout -- (any file or blanket) — discards uncommitted changes permanently.
@@ -369,22 +395,31 @@ fi
 # whitespace or end-of-command. Otherwise benign long flags like --quiet,
 # --force, --orphan, --theirs, --ours would false-positive because their
 # leading `--` matched the bare regex.
-if is_git_subcommand_in_chain "$COMMAND" checkout && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(.*[[:space:]])?--([[:space:]]|$) ]]; then
+# Use is_git_subcommand_in_wrappers (#426, completes #399) so wrapper forms
+# like `bash -c 'git checkout -- file'` / `eval 'git checkout -- file'` /
+# `sh -c 'git checkout -- file'` cannot bypass. The wrappers helper falls
+# back to _in_chain on the outer command, then sets GIT_SUB_REST on match
+# (whether via the chain or the recursive unwrap path) so the flag-regex
+# check below still functions.
+if is_git_subcommand_in_wrappers "$COMMAND" checkout && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(.*[[:space:]])?--([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git checkout -- discards uncommitted changes permanently. This may destroy other sessions' work. If you need to undo your own change, use git diff to see what changed and edit it back manually."
 fi
 
 # git restore (any file or blanket) — modern equivalent of checkout --
-if is_git_subcommand_in_chain "$COMMAND" restore; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
+if is_git_subcommand_in_wrappers "$COMMAND" restore; then
   block_with_reason "BLOCKED: git restore discards uncommitted changes permanently. If you need to undo your own change, use git diff to see what changed and edit it back manually."
 fi
 
 # git clean -f (permanent file deletion)
-if is_git_subcommand_in_chain "$COMMAND" clean && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]]; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
+if is_git_subcommand_in_wrappers "$COMMAND" clean && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git clean -f permanently deletes untracked files. These cannot be recovered from git."
 fi
 
 # git reset --hard (discards everything)
-if is_git_subcommand_in_chain "$COMMAND" reset && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--hard([[:space:]]|$) ]]; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
+if is_git_subcommand_in_wrappers "$COMMAND" reset && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--hard([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git reset --hard discards all uncommitted changes and staged work. Use git reset (soft) or ask the user."
 fi
 

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -341,27 +341,53 @@ is_destruct_command_in_chain() {
   return 1
 }
 
-# git stash — command-boundary matching only. A bare `git[[:space:]]+stash`
-# match (anywhere in the command) overmatches on quoted strings (commit
-# messages, echo/printf/grep args that mention stash) and on the hook's own
-# error messages when they're ever echo'd. Gating on command-start or shell
-# separator (;, &, &&, ||, |, newline, backtick, $()) keeps the match scoped
-# to ACTUAL stash invocations.
+# git stash — wrapper-aware gate via is_git_subcommand_in_wrappers (#426,
+# completes #399). The prior regex-based STASH_BOUNDARY anchored
+# `git[[:space:]]+stash` to `^`, `;`, `&`, `&&`, `||`, `|`, backtick, or
+# `$(` — none of which precede the inner `git` inside wrapper forms like
+# `bash -c 'git stash drop'` / `eval 'git stash drop'` / `sh -c 'git
+# stash drop'`. Tokenize-then-walk via is_git_subcommand_in_wrappers
+# matches all those forms (and the existing chain/multi-segment cases)
+# and sets GIT_SUB_REST to the rest of the matching segment for flag
+# inspection — same idiom as the converted `add` / `commit` / `push`
+# gates further down.
 #
 # Allowed subcommands: apply, list, show, pop, create, store, branch (read
 # and recovery — never modify the working tree).
-# Destructive: drop, clear — block (prior behavior).
+# Destructive: drop, clear — block.
 # Create-stash: push, save, -u, bare — block (CLAUDE.md rule).
+#
+# Quoted-prose protection (overmatching on `echo "git stash drop"` etc.)
+# is preserved by the data-region redaction passes at the top of the
+# file (heredoc + -m/--message/--body/--title quoted-arg redaction). The
+# wrapper-aware gate runs AFTER redaction, so prose in commit messages
+# and gh body text no longer reaches the tokenizer.
 #
 # Past failure: a /commit pre-commit reviewer ran `stash -u && test && stash
 # pop`; the pop silently unstaged the caller's staged files.
-STASH_BOUNDARY='(^|[;&|`(]|&&|\|\||\$\()[[:space:]]*git[[:space:]]+stash'
-STASH_ALLOW_SUB="${STASH_BOUNDARY}[[:space:]]+(apply|list|show|pop|create|store|branch)([[:space:]]|\\\"|'|\\\\|\||;|\$)"
-STASH_DESTRUCTIVE="${STASH_BOUNDARY}[[:space:]]+(drop|clear)"
-if [[ "$COMMAND" =~ $STASH_DESTRUCTIVE ]]; then
-  block_with_reason "BLOCKED: git stash drop/clear destroys stashed work permanently (including untracked files saved with -u). If you need to drop a stash, ask the user to do it manually."
-elif [[ "$COMMAND" =~ $STASH_BOUNDARY ]] && [[ ! "$COMMAND" =~ $STASH_ALLOW_SUB ]]; then
-  block_with_reason "BLOCKED: git-stash write subcommand forbidden (modifies working tree). Allowed read/recovery: apply, list, show, pop. For cherry-pick protection, let git refuse on overlap."
+if is_git_subcommand_in_wrappers "$COMMAND" stash; then
+  # First token of GIT_SUB_REST is the stash subcommand (apply, drop, etc.)
+  # or absent (bare `git stash` = create-stash). Strip surrounding quotes
+  # that wrapper-unwrapped forms may leave (e.g. `bash -c 'git stash drop'`
+  # → GIT_SUB_REST="drop'" without the strip).
+  _stash_sub="${GIT_SUB_REST%% *}"
+  _stash_sub="${_stash_sub%\'}"; _stash_sub="${_stash_sub#\'}"
+  _stash_sub="${_stash_sub%\"}"; _stash_sub="${_stash_sub#\"}"
+  case "$_stash_sub" in
+    drop|clear)
+      block_with_reason "BLOCKED: git stash drop/clear destroys stashed work permanently (including untracked files saved with -u). If you need to drop a stash, ask the user to do it manually."
+      ;;
+    apply|list|show|pop|create|store|branch)
+      : # allowed read/recovery subcommands — no action
+      ;;
+    *)
+      # Includes: bare `git stash`, `git stash push`, `git stash save`,
+      # `git stash -u`, and any unknown form. All are create-stash or
+      # unrecognized — block.
+      block_with_reason "BLOCKED: git-stash write subcommand forbidden (modifies working tree). Allowed read/recovery: apply, list, show, pop. For cherry-pick protection, let git refuse on overlap."
+      ;;
+  esac
+  unset _stash_sub
 fi
 
 # git checkout -- (any file or blanket) — discards uncommitted changes permanently.
@@ -369,22 +395,31 @@ fi
 # whitespace or end-of-command. Otherwise benign long flags like --quiet,
 # --force, --orphan, --theirs, --ours would false-positive because their
 # leading `--` matched the bare regex.
-if is_git_subcommand_in_chain "$COMMAND" checkout && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(.*[[:space:]])?--([[:space:]]|$) ]]; then
+# Use is_git_subcommand_in_wrappers (#426, completes #399) so wrapper forms
+# like `bash -c 'git checkout -- file'` / `eval 'git checkout -- file'` /
+# `sh -c 'git checkout -- file'` cannot bypass. The wrappers helper falls
+# back to _in_chain on the outer command, then sets GIT_SUB_REST on match
+# (whether via the chain or the recursive unwrap path) so the flag-regex
+# check below still functions.
+if is_git_subcommand_in_wrappers "$COMMAND" checkout && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(.*[[:space:]])?--([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git checkout -- discards uncommitted changes permanently. This may destroy other sessions' work. If you need to undo your own change, use git diff to see what changed and edit it back manually."
 fi
 
 # git restore (any file or blanket) — modern equivalent of checkout --
-if is_git_subcommand_in_chain "$COMMAND" restore; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
+if is_git_subcommand_in_wrappers "$COMMAND" restore; then
   block_with_reason "BLOCKED: git restore discards uncommitted changes permanently. If you need to undo your own change, use git diff to see what changed and edit it back manually."
 fi
 
 # git clean -f (permanent file deletion)
-if is_git_subcommand_in_chain "$COMMAND" clean && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]]; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
+if is_git_subcommand_in_wrappers "$COMMAND" clean && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git clean -f permanently deletes untracked files. These cannot be recovered from git."
 fi
 
 # git reset --hard (discards everything)
-if is_git_subcommand_in_chain "$COMMAND" reset && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--hard([[:space:]]|$) ]]; then
+# Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
+if is_git_subcommand_in_wrappers "$COMMAND" reset && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])--hard([[:space:]]|$) ]]; then
   block_with_reason "BLOCKED: git reset --hard discards all uncommitted changes and staged work. Use git reset (soft) or ask the user."
 fi
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -277,6 +277,33 @@ expect_deny "WB6: sh -c 'git commit --no-verify'" \
 expect_deny "WB7: nested bash -c 'sh -c \"git commit --no-verify\"'" \
   "bash -c 'sh -c \\\"git commit --no-verify -m hi\\\"'"
 
+# WB8-WB16. Wrapper-bypass closure for the 4 destructive-op gates + stash
+# (#426, completes #399). PR #417 threaded is_git_subcommand_in_wrappers
+# through commit/cherry-pick/push/add but left the 4 destructive-op gates
+# (checkout --, restore, clean -f, reset --hard) and STASH_BOUNDARY on the
+# original _in_chain tokenizer / first-token regex. Wrapper forms like
+# `bash -c 'git reset --hard HEAD~5'` slipped past and silently destroyed
+# uncommitted state.
+expect_deny "WB8: bash -c 'git reset --hard'" \
+  "bash -c 'git reset --hard HEAD~5'"
+expect_deny "WB9: eval 'git clean -fd'" \
+  "eval 'git clean -fd'"
+expect_deny "WB10: sh -c 'git checkout -- file'" \
+  "sh -c 'git checkout -- file.js'"
+expect_deny "WB11: bash -c 'git restore file'" \
+  "bash -c 'git restore file.js'"
+expect_deny "WB12: bash -c 'git stash drop'" \
+  "bash -c 'git stash drop'"
+expect_deny "WB13: eval 'git stash clear'" \
+  "eval 'git stash clear'"
+expect_deny "WB14: sh -c 'git stash push -u'" \
+  "sh -c 'git stash push -u'"
+expect_deny "WB15: bash -c 'git stash' (bare create-stash)" \
+  "bash -c 'git stash'"
+# Wrapper-aware stash gate must still ALLOW the read/recovery subcommands.
+expect_allow "WB16: bash -c 'git stash list' (allowed read)" \
+  "bash -c 'git stash list'"
+
 echo ""
 echo "=== Hook allow patterns ==="
 


### PR DESCRIPTION
## Summary

Closes #426. PR #417 (closed #399) threaded `is_git_subcommand_in_wrappers` through 9 add/commit/push gates but left 4 destructive-op gates in `hooks/block-unsafe-generic.sh` (lines 372 `checkout --`, 377 `restore`, 382 `clean -f`, 387 `reset --hard`) on the older `is_git_subcommand_in_chain` tokenizer — that tokenizer required the first non-env token to be literal `git`, so wrapper forms (`bash -c 'git reset --hard'`, `eval 'git clean -fd'`, `sh -c 'git checkout -- file'`) slipped past all four gates and silently destroyed uncommitted state. `STASH_BOUNDARY` (lines 358-365) was independently exposed via the same shape.

## Approach

- Swap tokenizer at the 4 destructive-op gates: `is_git_subcommand_in_chain` → `is_git_subcommand_in_wrappers`. Match the calling convention of the converted commit/cherry-pick/push gates (lines 509/516/527).
- `STASH_BOUNDARY` converted to wrapper-aware form (Option B): `is_git_subcommand_in_wrappers "$COMMAND" stash` then flag-style case-stmt on `$GIT_SUB_REST` first token (destructive: `drop|clear|push|save|-u`; allow: `apply|list|show|pop|create|store|branch`). Mirrors the existing converted-gate pattern.
- Mirror byte-equal to `.claude/hooks/block-unsafe-generic.sh`.
- 9 new wrapper-bypass test cases (WB8-WB16) in `tests/test-hooks.sh` near the existing #399 block: 4 destructive-op deny cases × 3 wrapper shapes (bash/sh/eval) + STASH variations + 1 allow case for read-only `bash -c 'git stash list'`.

## Audit

Remaining `is_git_subcommand_in_chain` references audited:
- `hooks/block-stale-skill-version.sh` (4 hits): all helper-definition / commentary / base-case recursion inside `is_git_subcommand_in_wrappers` itself. External gate at line 318 already uses `_in_wrappers`. No misses.
- `hooks/block-unsafe-project.sh.template` (2 hits): helper definition + base-case recursion. External gates already converted. No misses.

## Test plan

- [x] Full suite: 3509/3509 passing (baseline 3500 from #433 + 9 new WB cases).
- [x] Wrapper forms now denied at all 4 destructive-op gates and the STASH boundary.
- [x] Single read-only `bash -c 'git stash list'` allowed (asymmetry preserved).
- [x] Source / `.claude/` mirror byte-equal (`diff` exits 0).
- [x] No skill `metadata.version` bumps (hooks aren't skill-versioned per CLAUDE.md skill-versioning rule).
