### PR TITLE
fix(hooks): wrapper-recursive extract_cd_target (#427)

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -82,6 +82,83 @@ extract_cd_target() {
   # same spirit as the existing `\"` decoding. `\n` is the only escape
   # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  # Wrapper unwrap (#427): if the command's first non-env-prefix token is
+  # a shell wrapper (bash/sh/dash/ash/ksh/zsh -c '<inner>') or `eval
+  # '<inner>'`, peel one layer and re-inspect the inner string. Mirrors
+  # is_git_subcommand_in_wrappers's recursion: PR #417 made the classify
+  # check wrapper-aware but left this resolver one-level, so wrapped
+  # commits like `bash -c 'cd /tmp/wt && git commit'` fired the hook on
+  # the OUTER command (starts with `bash`, not `cd`) → empty extraction
+  # → fallback to $CLAUDE_PROJECT_DIR (main repo) → stage-check and
+  # tracking-marker enforcement silently passed against MAIN's empty
+  # index. Bounded depth (3) matches the wrapper-helper convention.
+  local depth=3
+  while [ "$depth" -gt 0 ]; do
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$cmd"
+    local i=0 n=${#TOKENS[@]}
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    local first="${TOKENS[$i]:-}"
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+    local inner=""
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+        fi
+        ;;
+      eval)
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        ;;
+    esac
+    if [ -n "$inner" ]; then
+      cmd="$inner"
+      ((depth--))
+      continue
+    fi
+    break
+  done
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
     # Remove surrounding quotes if present

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -331,6 +331,83 @@ extract_cd_target() {
   # same spirit as the existing `\"` decoding. `\n` is the only escape
   # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  # Wrapper unwrap (#427): if the command's first non-env-prefix token is
+  # a shell wrapper (bash/sh/dash/ash/ksh/zsh -c '<inner>') or `eval
+  # '<inner>'`, peel one layer and re-inspect the inner string. Mirrors
+  # is_git_subcommand_in_wrappers's recursion: PR #417 made the classify
+  # check wrapper-aware but left this resolver one-level, so wrapped
+  # commits like `bash -c 'cd /tmp/wt && git commit'` fired the hook on
+  # the OUTER command (starts with `bash`, not `cd`) → empty extraction
+  # → fallback to $CLAUDE_PROJECT_DIR (main repo) → stage-check and
+  # tracking-marker enforcement silently passed against MAIN's empty
+  # index. Bounded depth (3) matches the wrapper-helper convention.
+  local depth=3
+  while [ "$depth" -gt 0 ]; do
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$cmd"
+    local i=0 n=${#TOKENS[@]}
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    local first="${TOKENS[$i]:-}"
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+    local inner=""
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+        fi
+        ;;
+      eval)
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        ;;
+    esac
+    if [ -n "$inner" ]; then
+      cmd="$inner"
+      ((depth--))
+      continue
+    fi
+    break
+  done
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
     # Remove surrounding quotes if present

--- a/hooks/_lib/resolve-effective-worktree-root.sh
+++ b/hooks/_lib/resolve-effective-worktree-root.sh
@@ -57,6 +57,83 @@ extract_cd_target() {
   # same spirit as the existing `\"` decoding. `\n` is the only escape
   # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  # Wrapper unwrap (#427): if the command's first non-env-prefix token is
+  # a shell wrapper (bash/sh/dash/ash/ksh/zsh -c '<inner>') or `eval
+  # '<inner>'`, peel one layer and re-inspect the inner string. Mirrors
+  # is_git_subcommand_in_wrappers's recursion: PR #417 made the classify
+  # check wrapper-aware but left this resolver one-level, so wrapped
+  # commits like `bash -c 'cd /tmp/wt && git commit'` fired the hook on
+  # the OUTER command (starts with `bash`, not `cd`) → empty extraction
+  # → fallback to $CLAUDE_PROJECT_DIR (main repo) → stage-check and
+  # tracking-marker enforcement silently passed against MAIN's empty
+  # index. Bounded depth (3) matches the wrapper-helper convention.
+  local depth=3
+  while [ "$depth" -gt 0 ]; do
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$cmd"
+    local i=0 n=${#TOKENS[@]}
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    local first="${TOKENS[$i]:-}"
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+    local inner=""
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+        fi
+        ;;
+      eval)
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        ;;
+    esac
+    if [ -n "$inner" ]; then
+      cmd="$inner"
+      ((depth--))
+      continue
+    fi
+    break
+  done
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
     # Remove surrounding quotes if present

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -82,6 +82,83 @@ extract_cd_target() {
   # same spirit as the existing `\"` decoding. `\n` is the only escape
   # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  # Wrapper unwrap (#427): if the command's first non-env-prefix token is
+  # a shell wrapper (bash/sh/dash/ash/ksh/zsh -c '<inner>') or `eval
+  # '<inner>'`, peel one layer and re-inspect the inner string. Mirrors
+  # is_git_subcommand_in_wrappers's recursion: PR #417 made the classify
+  # check wrapper-aware but left this resolver one-level, so wrapped
+  # commits like `bash -c 'cd /tmp/wt && git commit'` fired the hook on
+  # the OUTER command (starts with `bash`, not `cd`) → empty extraction
+  # → fallback to $CLAUDE_PROJECT_DIR (main repo) → stage-check and
+  # tracking-marker enforcement silently passed against MAIN's empty
+  # index. Bounded depth (3) matches the wrapper-helper convention.
+  local depth=3
+  while [ "$depth" -gt 0 ]; do
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$cmd"
+    local i=0 n=${#TOKENS[@]}
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    local first="${TOKENS[$i]:-}"
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+    local inner=""
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+        fi
+        ;;
+      eval)
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        ;;
+    esac
+    if [ -n "$inner" ]; then
+      cmd="$inner"
+      ((depth--))
+      continue
+    fi
+    break
+  done
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
     # Remove surrounding quotes if present

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -331,6 +331,83 @@ extract_cd_target() {
   # same spirit as the existing `\"` decoding. `\n` is the only escape
   # we currently see in practice from Claude Code's wire format.
   cmd=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' | sed 's/\\"/"/g; s/\\n/\n/g')
+  # Wrapper unwrap (#427): if the command's first non-env-prefix token is
+  # a shell wrapper (bash/sh/dash/ash/ksh/zsh -c '<inner>') or `eval
+  # '<inner>'`, peel one layer and re-inspect the inner string. Mirrors
+  # is_git_subcommand_in_wrappers's recursion: PR #417 made the classify
+  # check wrapper-aware but left this resolver one-level, so wrapped
+  # commits like `bash -c 'cd /tmp/wt && git commit'` fired the hook on
+  # the OUTER command (starts with `bash`, not `cd`) → empty extraction
+  # → fallback to $CLAUDE_PROJECT_DIR (main repo) → stage-check and
+  # tracking-marker enforcement silently passed against MAIN's empty
+  # index. Bounded depth (3) matches the wrapper-helper convention.
+  local depth=3
+  while [ "$depth" -gt 0 ]; do
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$cmd"
+    local i=0 n=${#TOKENS[@]}
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    local first="${TOKENS[$i]:-}"
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+    local inner=""
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+        fi
+        ;;
+      eval)
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        ;;
+    esac
+    if [ -n "$inner" ]; then
+      cmd="$inner"
+      ((depth--))
+      continue
+    fi
+    break
+  done
   if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
     local target="${BASH_REMATCH[1]}"
     # Remove surrounding quotes if present

--- a/tests/test-skill-version-enforcement.sh
+++ b/tests/test-skill-version-enforcement.sh
@@ -599,6 +599,84 @@ fi
 rm -rf "$worktree"
 
 # ----------------------------------------------------------------------
+# WRAPPER-CD CASE — issue #427 closure.
+# ----------------------------------------------------------------------
+#
+# Proves the wrapper-cd worktree-blind bug is closed: PR #417 made the
+# classify check wrapper-aware via is_git_subcommand_in_wrappers, so the
+# hook *triggers* on `bash -c 'cd /tmp/wt && git commit'` and `eval 'cd
+# /tmp/wt && git commit'`. But before #427, extract_cd_target only
+# looked at the OUTER command (first token = bash/eval, not cd) →
+# returned empty → EFFECTIVE_REPO_ROOT fell back to $CLAUDE_PROJECT_DIR
+# (main repo), where nothing was staged → stage-check exit 0 → silent
+# false-allow. Each wrapper case below stages an unbumped SKILL.md edit
+# in a worktree and asserts the hook DENIES.
+#
+# Three wrapper shapes:
+#   wrapper-cd-1: bash -c 'cd <wt> && git commit'   (single-quoted)
+#   wrapper-cd-2: sh   -c "cd <wt> && git commit"   (double-quoted, sh)
+#   wrapper-cd-3: eval 'cd <wt> && git commit'      (eval)
+
+echo ""
+echo "=== Wrapper-cd cases (issue #427) ==="
+
+for wrapper_case in bash-c sh-c eval; do
+  case_no="wrapper-cd-$wrapper_case"
+  sandbox=$(make_sandbox "$case_no")
+
+  worktree=$(mktemp -d)
+  rm -rf "$worktree"
+  (
+    cd "$sandbox"
+    git branch -q "feat/wrapper-$wrapper_case"
+    git worktree add -q "$worktree" "feat/wrapper-$wrapper_case"
+  )
+
+  # Stage a SKILL.md body edit in the worktree without bumping the version.
+  echo "Worktree wrapper-cd body edit." >> "$worktree/skills/foo/SKILL.md"
+  (cd "$worktree" && git add skills/foo/SKILL.md)
+
+  # Build a wrapper-cd envelope that wraps `cd <wt> && git commit` in an
+  # outer shell (bash -c / sh -c / eval). The hook's classify check
+  # (is_git_subcommand_in_wrappers, #399/#417) detects the wrapped git
+  # commit and fires; extract_cd_target (post-#427) must recursively
+  # unwrap one layer and resolve the cd target to $worktree so
+  # stage-check runs against the worktree's index (where the unbumped
+  # SKILL.md edit lives) and emits STOP.
+  case "$wrapper_case" in
+    bash-c)
+      inner="cd $worktree && git commit -m test"
+      outer="bash -c '$inner'"
+      ;;
+    sh-c)
+      inner="cd $worktree && git commit -m test"
+      outer="sh -c \\\"$inner\\\""
+      ;;
+    eval)
+      inner="cd $worktree && git commit -m test"
+      outer="eval '$inner'"
+      ;;
+  esac
+
+  ENVELOPE=$(printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$outer")
+  HOOK_OUT=$(
+    CLAUDE_PROJECT_DIR="$sandbox" printf '%s' "$ENVELOPE" | bash "$HOOK"
+  )
+  HOOK_EXIT=$?
+
+  if [ "$HOOK_EXIT" -eq 0 ] \
+     && [[ "$HOOK_OUT" == *'"permissionDecision":"deny"'* ]] \
+     && [[ "$HOOK_OUT" == *"STOP:"* ]]; then
+    pass "$case_no: wrapper-cd commit in worktree with unbumped SKILL.md → DENY envelope"
+  else
+    fail "$case_no: expected deny envelope with STOP, got exit=$HOOK_EXIT out=$HOOK_OUT"
+  fi
+
+  (cd "$sandbox" && git worktree remove --force "$worktree" 2>/dev/null) || true
+  rm -rf "$worktree"
+done
+
+# ----------------------------------------------------------------------
 # Summary.
 # ----------------------------------------------------------------------
 

--- a/tests/test-tracking-integration.sh
+++ b/tests/test-tracking-integration.sh
@@ -381,6 +381,94 @@ fi
 teardown_repo
 
 # ═══════════════════════════════════════════════════════════════════════
+# Test 3-wrapper-cd: Worktree enforcement via wrapper-cd envelope (#427)
+#
+# Pre-#427, PR #417 made classify wrapper-aware (the hook fires on
+# `bash -c 'cd /tmp/wt && git commit'`) but extract_cd_target still
+# only inspected the OUTER command (first token = bash/eval, not cd).
+# So LOCAL_ROOT fell back to the hook's ambient main-repo CWD; the
+# worktree's .zskills-tracked was never read; tracking-marker
+# enforcement silently no-op'd for wrapped worktree commits.
+#
+# After #427: extract_cd_target recursively unwraps one wrapper layer
+# (bounded depth 3) and resolves the inner `cd <wt>` target. LOCAL_ROOT
+# → worktree → .zskills-tracked read → enforcement fires.
+#
+# Three wrapper shapes covered: bash -c '<inner>', sh -c "<inner>",
+# eval '<inner>'.
+# ═══════════════════════════════════════════════════════════════════════
+
+echo ""
+echo "=== Test 3-wrapper-cd: Worktree enforcement via wrapper-cd envelope (#427) ==="
+
+for wrapper_case in bash-c sh-c eval; do
+  setup_repo
+
+  (cd "$TEST_TMPDIR" && git checkout -q -b "wrapper-branch-$wrapper_case" && git checkout -q master 2>/dev/null || git checkout -q main 2>/dev/null)
+  WORKTREE_DIR=$(mktemp -d)
+  rmdir "$WORKTREE_DIR"
+  (cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" "wrapper-branch-$wrapper_case" 2>/dev/null)
+
+  if [ ! -d "$WORKTREE_DIR" ]; then
+    fail "Test 3-wrapper-cd-$wrapper_case: could not create worktree, skipping"
+    teardown_repo
+    continue
+  fi
+
+  mkdir -p "$WORKTREE_DIR/.claude/hooks"
+  cp "$TEST_TMPDIR/.claude/hooks/block-unsafe-project.sh" "$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh"
+
+  PID="run-plan.wrapper-$wrapper_case-pipeline"
+  printf '%s\n' "$PID" > "$WORKTREE_DIR/.zskills-tracked"
+
+  DIR_T=$(pipeline_subdir "$TEST_TMPDIR" "$PID")
+  touch "$DIR_T/requires.verify-changes.wrapper-$wrapper_case"
+
+  printf 'npm run test:all\n' > "$WORKTREE_DIR/.transcript"
+
+  (cd "$WORKTREE_DIR" && echo "var x = 1;" > thermal.js && git add thermal.js)
+
+  # Build the wrapper-cd envelope. The hook (running with CWD=main_repo)
+  # must (1) classify the wrapped git commit via
+  # is_git_subcommand_in_wrappers, then (2) extract the cd target from
+  # the inner `cd <wt> && git commit` via the wrapper-recursive
+  # extract_cd_target (#427), then (3) read .zskills-tracked from the
+  # worktree, then (4) find the unfulfilled marker → DENY.
+  case "$wrapper_case" in
+    bash-c) INNER="cd $WORKTREE_DIR && git commit -m test"; OUTER="bash -c '$INNER'" ;;
+    sh-c)   INNER="cd $WORKTREE_DIR && git commit -m test"; OUTER="sh -c \\\"$INNER\\\"" ;;
+    eval)   INNER="cd $WORKTREE_DIR && git commit -m test"; OUTER="eval '$INNER'" ;;
+  esac
+
+  JSON="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$OUTER\"},\"transcript_path\":\"$WORKTREE_DIR/.transcript\"}"
+
+  HOOK_OUTPUT=$(
+    echo "$JSON" | TRACKING_ROOT="$TEST_TMPDIR" bash -c "cd '$TEST_TMPDIR' && bash '$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null
+  )
+
+  if [[ "$HOOK_OUTPUT" == *"permissionDecision"*"deny"* ]] \
+     && [[ "$HOOK_OUTPUT" == *"verify-changes.wrapper-$wrapper_case"* ]]; then
+    pass "Test 3-wrapper-cd-$wrapper_case-a: wrapper-cd worktree commit blocked by worktree's .zskills-tracked + main's unfulfilled marker"
+  else
+    fail "Test 3-wrapper-cd-$wrapper_case-a: wrapper-cd worktree commit should be blocked; got: $HOOK_OUTPUT"
+  fi
+
+  # Fulfill, then re-test → should allow.
+  touch "$DIR_T/fulfilled.verify-changes.wrapper-$wrapper_case"
+  HOOK_OUTPUT=$(
+    echo "$JSON" | TRACKING_ROOT="$TEST_TMPDIR" bash -c "cd '$TEST_TMPDIR' && bash '$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh'" 2>/dev/null
+  )
+  if [[ "$HOOK_OUTPUT" == *"permissionDecision"*"deny"* ]]; then
+    fail "Test 3-wrapper-cd-$wrapper_case-b: wrapper-cd commit should be allowed after fulfilling marker; got: $HOOK_OUTPUT"
+  else
+    pass "Test 3-wrapper-cd-$wrapper_case-b: wrapper-cd commit allowed after fulfilling marker"
+  fi
+
+  (cd "$TEST_TMPDIR" && git worktree remove --force "$WORKTREE_DIR" 2>/dev/null)
+  teardown_repo
+done
+
+# ═══════════════════════════════════════════════════════════════════════
 # Test 4: Content-only exemption
 # ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Closes #427. PR #417 made the classify check wrapper-aware via `is_git_subcommand_in_wrappers`, but left `extract_cd_target` in `hooks/_lib/resolve-effective-worktree-root.sh` one-level — it sed-extracted a leading `cd <target>` from the OUTER command string only. Result: `bash -c 'cd /tmp/wt && git commit'` and `eval 'cd /tmp/wt && git commit'` fired the hook (classify post-#417 worked) but `EFFECTIVE_REPO_ROOT` fell back to `$CLAUDE_PROJECT_DIR` (= main), so stage-check / tracking-marker enforcement ran against MAIN's empty index and silently passed. Same shape as #391/#393 worktree-blindness, scoped to wrapper-cd envelopes.

## Approach

- `extract_cd_target` made wrapper-recursive in place: while-loop with `depth=3` bound (matches `is_git_subcommand_in_wrappers` convention), handles `bash|sh|dash|ash|ksh|zsh -c '<inner>'` (combined-short-flag forms `-lc`/`-ic`/`-cx` supported, `--` end-of-options supported) plus `eval '<inner>'`, strips one outer quote layer (single OR double) per iteration, skips env-var prefixes (`FOO=bar`) and explicit `env` token.
- Drift-propagated byte-equal to 4 inlined call sites: `hooks/block-unsafe-project.sh.template` (3 sites) and `hooks/block-stale-skill-version.sh` (1 site). Drift gate (`tests/test-hook-helper-drift.sh`) confirms 18/18.
- Mirrored to `.claude/hooks/block-unsafe-project.sh` and `.claude/hooks/block-stale-skill-version.sh` (`.template` suffix dropped in `.claude/` per established pattern; `.claude/hooks/_lib/` deliberately NOT created — see `skills/update-zskills/SKILL.md:1028` "inlined into each hook; do not install separately").
- 9 new wrapper-cd test cases: 3 in `tests/test-skill-version-enforcement.sh` (3 wrapper shapes), 6 in `tests/test-tracking-integration.sh` (3 shapes × 2 sub-cases each for deny/allow).

## Quote handling

- Outer quotes stripped one layer for either single (`'…'`) or double (`"…"`) — mirrors the existing gh/git wrapper helpers.
- Inner `cd <target>` quotes peeled by the existing `target%\"` / `target#\"` logic.
- `bash -c "cd /tmp/wt && git commit"` and `bash -c 'cd /tmp/wt && git commit'` both correctly resolve.

## Test plan

- [x] Full suite: 3509/3509 passing at baseline (3500 from #433 + 9 new wrapper-cd assertions in this branch). After #426 lands and this branch rebases, expected pass count = 3518.
- [x] Drift gate 18/18.
- [x] Source / `.claude/` mirror pairs byte-equal.
- [x] No skill `metadata.version` bumps (hooks aren't skill-versioned).
