### PR TITLE
fix(update-zskills): scope Step 0.5 JSON extractions (#428)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.19+549aa0"
+  version: "2026.05.19+e6be98"
 ---
 
 # Update Z Skills Infrastructure
@@ -415,61 +415,98 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
 
 **If it exists:**
 1. Read the file content.
-2. Extract values using bash regex (pure bash, no external JSON tool):
+2. Extract values using bash regex (pure bash, no external JSON tool).
+
+   **IMPORTANT — parent-object scoping is mandatory for any field
+   that lives inside a parent block.** An unscoped regex like
+   `\"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"` matches the
+   FIRST occurrence of the field anywhere in the JSON, so a future
+   sibling block declaring its own same-named field will silently
+   shadow the intended one. The fix class addressed by issues #395
+   (`zskills-resolve-config.sh`) and #400 (`apply-preset.sh`) and
+   reproductively-broad issue #428 (this prose recipe) is the SAME
+   bug class: every field that lives inside `"<parent>": { ... }`
+   must scope its extraction under the parent. The canonical form
+   for a scoped string-value extraction is:
+
+   ```text
+   \"<parent>\"[[:space:]]*:[[:space:]]*\{[^}]*\"<field>\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"
+   ```
+
+   Top-level fields (`project_name`, `timezone`) have no parent
+   block and may be extracted directly. The mapping below annotates
+   every parent-scoped field with `# parent: <name>` next to its
+   regex.
+
    ```bash
    CONFIG_CONTENT=$(cat "$PROJECT_ROOT/.claude/zskills-config.json")
-   # Extract a string value (note: ([^\"]*) allows empty strings):
+   # Top-level string (no parent — direct extraction is safe):
    if [[ "$CONFIG_CONTENT" =~ \"project_name\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      PROJECT_NAME="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: testing  (sibling-shadow risk if unscoped — see #395)
+   if [[ "$CONFIG_CONTENT" =~ \"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      UNIT_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: testing
+   if [[ "$CONFIG_CONTENT" =~ \"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      FULL_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"output_file\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: testing
+   if [[ "$CONFIG_CONTENT" =~ \"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"output_file\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      OUTPUT_FILE="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: dev_server
+   if [[ "$CONFIG_CONTENT" =~ \"dev_server\"[[:space:]]*:[[:space:]]*\{[^}]*\"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      DEV_SERVER_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: dev_server
+   if [[ "$CONFIG_CONTENT" =~ \"dev_server\"[[:space:]]*:[[:space:]]*\{[^}]*\"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      MAIN_REPO_PATH="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"file_patterns\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: ui  (note: `file_patterns` also exists under `testing` as
+   # an array — scoping under `ui` disambiguates)
+   if [[ "$CONFIG_CONTENT" =~ \"ui\"[[:space:]]*:[[:space:]]*\{[^}]*\"file_patterns\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      UI_FILE_PATTERNS="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"auth_bypass\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: ui
+   if [[ "$CONFIG_CONTENT" =~ \"ui\"[[:space:]]*:[[:space:]]*\{[^}]*\"auth_bypass\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      AUTH_BYPASS="${BASH_REMATCH[1]}"
    fi
+   # Top-level string (no parent):
    if [[ "$CONFIG_CONTENT" =~ \"timezone\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      TIMEZONE="${BASH_REMATCH[1]}"
    fi
-   # Extract a boolean value:
-   if [[ "$CONFIG_CONTENT" =~ \"main_protected\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
+   # parent: execution  (boolean — sibling-shadow risk if unscoped, see #400)
+   if [[ "$CONFIG_CONTENT" =~ \"execution\"[[:space:]]*:[[:space:]]*\{[^}]*\"main_protected\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
      MAIN_PROTECTED="${BASH_REMATCH[1]}"
    fi
-   # Extract landing mode:
-   if [[ "$CONFIG_CONTENT" =~ \"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: execution  (landing mode)
+   if [[ "$CONFIG_CONTENT" =~ \"execution\"[[:space:]]*:[[:space:]]*\{[^}]*\"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      LANDING_MODE="${BASH_REMATCH[1]}"
    fi
-   # Extract branch prefix:
-   if [[ "$CONFIG_CONTENT" =~ \"branch_prefix\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: execution  (branch prefix)
+   if [[ "$CONFIG_CONTENT" =~ \"execution\"[[:space:]]*:[[:space:]]*\{[^}]*\"branch_prefix\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      BRANCH_PREFIX="${BASH_REMATCH[1]}"
    fi
-   # Extract CI config:
-   if [[ "$CONFIG_CONTENT" =~ \"auto_fix\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
+   # parent: ci  (boolean)
+   if [[ "$CONFIG_CONTENT" =~ \"ci\"[[:space:]]*:[[:space:]]*\{[^}]*\"auto_fix\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
      CI_AUTO_FIX="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"max_fix_attempts\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
+   # parent: ci  (integer)
+   if [[ "$CONFIG_CONTENT" =~ \"ci\"[[:space:]]*:[[:space:]]*\{[^}]*\"max_fix_attempts\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
      CI_MAX_ATTEMPTS="${BASH_REMATCH[1]}"
    fi
-   # Extract commit.co_author (optional — backfilled below if missing):
-   if [[ "$CONFIG_CONTENT" =~ \"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: commit  (optional — backfilled below if missing)
+   if [[ "$CONFIG_CONTENT" =~ \"commit\"[[:space:]]*:[[:space:]]*\{[^}]*\"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      CO_AUTHOR="${BASH_REMATCH[1]}"
    fi
    ```
+
+   The `[^}]*` between the parent key and the field key is what
+   constrains the match to inside that block. Do NOT replace it with
+   `.*` (which would match across blocks) and do NOT drop the parent
+   prefix to "simplify" the regex — that re-introduces the bug class.
 3. For each template placeholder, use the config value if non-empty.
 3.5. **Backfill `commit.co_author` if absent.** If the existing config
    does not contain a `"commit"` block with a `"co_author"` field (e.g.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.19+549aa0"
+  version: "2026.05.19+e6be98"
 ---
 
 # Update Z Skills Infrastructure
@@ -415,61 +415,98 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
 
 **If it exists:**
 1. Read the file content.
-2. Extract values using bash regex (pure bash, no external JSON tool):
+2. Extract values using bash regex (pure bash, no external JSON tool).
+
+   **IMPORTANT — parent-object scoping is mandatory for any field
+   that lives inside a parent block.** An unscoped regex like
+   `\"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"` matches the
+   FIRST occurrence of the field anywhere in the JSON, so a future
+   sibling block declaring its own same-named field will silently
+   shadow the intended one. The fix class addressed by issues #395
+   (`zskills-resolve-config.sh`) and #400 (`apply-preset.sh`) and
+   reproductively-broad issue #428 (this prose recipe) is the SAME
+   bug class: every field that lives inside `"<parent>": { ... }`
+   must scope its extraction under the parent. The canonical form
+   for a scoped string-value extraction is:
+
+   ```text
+   \"<parent>\"[[:space:]]*:[[:space:]]*\{[^}]*\"<field>\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"
+   ```
+
+   Top-level fields (`project_name`, `timezone`) have no parent
+   block and may be extracted directly. The mapping below annotates
+   every parent-scoped field with `# parent: <name>` next to its
+   regex.
+
    ```bash
    CONFIG_CONTENT=$(cat "$PROJECT_ROOT/.claude/zskills-config.json")
-   # Extract a string value (note: ([^\"]*) allows empty strings):
+   # Top-level string (no parent — direct extraction is safe):
    if [[ "$CONFIG_CONTENT" =~ \"project_name\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      PROJECT_NAME="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: testing  (sibling-shadow risk if unscoped — see #395)
+   if [[ "$CONFIG_CONTENT" =~ \"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"unit_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      UNIT_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: testing
+   if [[ "$CONFIG_CONTENT" =~ \"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"full_cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      FULL_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"output_file\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: testing
+   if [[ "$CONFIG_CONTENT" =~ \"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"output_file\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      OUTPUT_FILE="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: dev_server
+   if [[ "$CONFIG_CONTENT" =~ \"dev_server\"[[:space:]]*:[[:space:]]*\{[^}]*\"cmd\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      DEV_SERVER_CMD="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: dev_server
+   if [[ "$CONFIG_CONTENT" =~ \"dev_server\"[[:space:]]*:[[:space:]]*\{[^}]*\"main_repo_path\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      MAIN_REPO_PATH="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"file_patterns\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: ui  (note: `file_patterns` also exists under `testing` as
+   # an array — scoping under `ui` disambiguates)
+   if [[ "$CONFIG_CONTENT" =~ \"ui\"[[:space:]]*:[[:space:]]*\{[^}]*\"file_patterns\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      UI_FILE_PATTERNS="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"auth_bypass\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: ui
+   if [[ "$CONFIG_CONTENT" =~ \"ui\"[[:space:]]*:[[:space:]]*\{[^}]*\"auth_bypass\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      AUTH_BYPASS="${BASH_REMATCH[1]}"
    fi
+   # Top-level string (no parent):
    if [[ "$CONFIG_CONTENT" =~ \"timezone\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      TIMEZONE="${BASH_REMATCH[1]}"
    fi
-   # Extract a boolean value:
-   if [[ "$CONFIG_CONTENT" =~ \"main_protected\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
+   # parent: execution  (boolean — sibling-shadow risk if unscoped, see #400)
+   if [[ "$CONFIG_CONTENT" =~ \"execution\"[[:space:]]*:[[:space:]]*\{[^}]*\"main_protected\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
      MAIN_PROTECTED="${BASH_REMATCH[1]}"
    fi
-   # Extract landing mode:
-   if [[ "$CONFIG_CONTENT" =~ \"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: execution  (landing mode)
+   if [[ "$CONFIG_CONTENT" =~ \"execution\"[[:space:]]*:[[:space:]]*\{[^}]*\"landing\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      LANDING_MODE="${BASH_REMATCH[1]}"
    fi
-   # Extract branch prefix:
-   if [[ "$CONFIG_CONTENT" =~ \"branch_prefix\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: execution  (branch prefix)
+   if [[ "$CONFIG_CONTENT" =~ \"execution\"[[:space:]]*:[[:space:]]*\{[^}]*\"branch_prefix\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      BRANCH_PREFIX="${BASH_REMATCH[1]}"
    fi
-   # Extract CI config:
-   if [[ "$CONFIG_CONTENT" =~ \"auto_fix\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
+   # parent: ci  (boolean)
+   if [[ "$CONFIG_CONTENT" =~ \"ci\"[[:space:]]*:[[:space:]]*\{[^}]*\"auto_fix\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
      CI_AUTO_FIX="${BASH_REMATCH[1]}"
    fi
-   if [[ "$CONFIG_CONTENT" =~ \"max_fix_attempts\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
+   # parent: ci  (integer)
+   if [[ "$CONFIG_CONTENT" =~ \"ci\"[[:space:]]*:[[:space:]]*\{[^}]*\"max_fix_attempts\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
      CI_MAX_ATTEMPTS="${BASH_REMATCH[1]}"
    fi
-   # Extract commit.co_author (optional — backfilled below if missing):
-   if [[ "$CONFIG_CONTENT" =~ \"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
+   # parent: commit  (optional — backfilled below if missing)
+   if [[ "$CONFIG_CONTENT" =~ \"commit\"[[:space:]]*:[[:space:]]*\{[^}]*\"co_author\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
      CO_AUTHOR="${BASH_REMATCH[1]}"
    fi
    ```
+
+   The `[^}]*` between the parent key and the field key is what
+   constrains the match to inside that block. Do NOT replace it with
+   `.*` (which would match across blocks) and do NOT drop the parent
+   prefix to "simplify" the regex — that re-introduces the bug class.
 3. For each template placeholder, use the config value if non-empty.
 3.5. **Backfill `commit.co_author` if absent.** If the existing config
    does not contain a `"commit"` block with a `"co_author"` field (e.g.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2287,6 +2287,54 @@ check_fixed qe-audit "worked example: past failure #390"  'past failure #390'
 check_fixed qe-audit "bash-mode sweep echoes the rule"    'Ban caveats: the Commit Audit Step 6'
 
 echo ""
+echo "=== /update-zskills — Step 0.5 parent-scoped JSON extraction (issue #428) ==="
+# Issue #428: Step 0.5 "Read Config" in skills/update-zskills/SKILL.md
+# teaches a config-extraction recipe using bash regex on JSON. The
+# fields listed below all live INSIDE a parent object in
+# .claude/zskills-config.json — unscoped regex (the
+# `\"<field>\"[[:space:]]*:` form anchored at the start of the
+# pattern with no parent prefix) silently matches the first
+# occurrence regardless of which block declared it, exactly the
+# bug class fixed in scripts by PRs #422 (#400) and #423 (#395).
+# The prose recipe must use the parent-scoped form
+# (`\"<parent>\"[[:space:]]*:[[:space:]]*\{[^}]*\"<field>\"...`).
+# The negative check below greps for the unscoped pattern
+# (`=~ \"<field>\"` — i.e. `=~ ` directly followed by the field
+# key with no parent prefix). Scoped patterns will not match
+# because they begin with `=~ \"<parent>\"`.
+#
+# This tripwire fires on both the source and the .claude/ mirror so
+# any future regression on either side is caught.
+ZSKILLS_FIELDS_PARENTED=(
+  "unit_cmd"          # parent: testing  (#395)
+  "full_cmd"          # parent: testing  (#395)
+  "output_file"       # parent: testing  (#395)
+  "main_repo_path"    # parent: dev_server
+  "auth_bypass"       # parent: ui
+  "main_protected"    # parent: execution  (#400)
+  "landing"           # parent: execution  (#400)
+  "branch_prefix"     # parent: execution
+  "auto_fix"          # parent: ci
+  "max_fix_attempts"  # parent: ci
+  "co_author"         # parent: commit
+)
+for _zsk_field in "${ZSKILLS_FIELDS_PARENTED[@]}"; do
+  check_not_in_file update-zskills SKILL.md \
+    "Step 0.5 unscoped regex for parented field '$_zsk_field'" \
+    "=~ \\\\\"${_zsk_field}\\\\\""
+  check_not_in_file .claude/skills/update-zskills SKILL.md \
+    ".claude mirror: Step 0.5 unscoped regex for parented field '$_zsk_field'" \
+    "=~ \\\\\"${_zsk_field}\\\\\""
+done
+# Positive: at least one scoped extraction must be present so the
+# recipe still teaches the right pattern (catches accidental whole-
+# block deletion).
+check_fixed update-zskills "Step 0.5 scoped pattern (canonical form, testing.unit_cmd)" \
+  '\"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"unit_cmd\"'
+check_fixed .claude/skills/update-zskills ".claude mirror: scoped pattern present" \
+  '\"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"unit_cmd\"'
+
+echo ""
 echo "---"
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if [ $FAIL_COUNT -eq 0 ]; then


### PR DESCRIPTION
## Summary

Closes #428. `skills/update-zskills/SKILL.md` Step 0.5 ("Read Config") taught a config-extraction recipe using unscoped bash-regex on JSON — same class as the bugs PRs #422 (issue #400) and #423 (issue #395) just fixed in `apply-preset.sh` and `zskills-resolve-config.sh`. Sibling-blocks with same-named fields shadowed each other. The prose recipe is the canonical template skill authors copy from — leaving it broken means the bug class reproduces in every new author's extraction code.

## Approach

Per tracker blurb option (1): rewrite the 11 ambiguous extractions in Step 0.5 to parent-object-scoped form (`\"<parent>\"[[:space:]]*:[[:space:]]*\{[^}]*\"<field>\"...`), annotated with parent in a comment. Matches the canonical pattern at `.claude/skills/update-zskills/scripts/zskills-resolve-config.sh:88` (`dev_server.cmd`) and the `exec_field_replace`-style scope-awareness from PR #422.

Fields rewritten:
- `testing.unit_cmd`, `testing.full_cmd`, `testing.output_file` (#395 class)
- `execution.main_protected`, `execution.landing`, `execution.branch_prefix` (#400 class)
- `dev_server.cmd`, `dev_server.main_repo_path`
- `ui.file_patterns`, `ui.auth_bypass`
- `ci.auto_fix`, `ci.max_fix_attempts`
- `commit.co_author`

Top-level `project_name` and `timezone` left direct (no parent).

Option (2) — Python json helper — explicitly deferred per blurb (Larger-than-issue follow-up).

## Conformance tripwires

24 new assertions in `tests/test-skill-conformance.sh:2286-2333`: 22 negative (`grep` for unscoped form per field × {source, mirror}) + 2 positive (canonical scoped form present). Hand-traced; polarity correct.

## Test plan

- [x] Full suite: 3542/3542 passing (baseline 3518 from sprint-1 final + 24 new conformance assertions).
- [x] Mirror byte-equal (`diff` exits 0).
- [x] `metadata.version` bumped to `2026.05.19+e6be98` (was `+549aa0`); mirror version-equal; recomputed hash matches.
