### PR TITLE
fix(skills): HEAD-precondition guard at 3 mode-file rebase sites (#429)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.19+259d6a"
+  version: "2026.05.19+cd305b"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/direct.md
+++ b/.claude/skills/fix-issues/modes/direct.md
@@ -43,6 +43,16 @@ for issue in "${FIXED_ISSUES[@]}"; do
 
   # --- Rebase the worktree branch onto latest origin/main ---
   cd "$WORKTREE_PATH"
+  # HEAD precondition (symmetric to pr-rebase.sh:82-88; Issue #429).
+  # If CWD drifted (forgot a `cd`, wrong worktree active), `git rebase
+  # origin/main` would silently retarget the wrong branch and exit 0 —
+  # reporting success while $BRANCH_NAME is untouched. Same defense
+  # that #397 / pr-rebase.sh installs for the callable surface.
+  ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$ACTUAL_HEAD" != "$BRANCH_NAME" ]; then
+    echo "ERROR: fix-issues/direct: CWD is on '$ACTUAL_HEAD', expected '$BRANCH_NAME' — refusing to rebase the wrong branch" >&2
+    exit 14
+  fi
   git fetch origin main
   PRE_REBASE=$(git rev-parse HEAD)
   if ! git rebase origin/main; then

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.19+f7b4e6"
+  version: "2026.05.19+64d81c"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -15,6 +15,16 @@ impl agent:
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 cd "$WORKTREE_PATH"
+# HEAD precondition (symmetric to pr-rebase.sh:82-88; Issue #429).
+# If CWD drifted (forgot a `cd`, wrong worktree active), `git rebase
+# origin/main` would silently retarget the wrong branch and exit 0 —
+# reporting success while $BRANCH_NAME is untouched. Same defense
+# that #397 / pr-rebase.sh installs for the callable surface.
+ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)
+if [ "$ACTUAL_HEAD" != "$BRANCH_NAME" ]; then
+  echo "ERROR: run-plan/pr: CWD is on '$ACTUAL_HEAD', expected '$BRANCH_NAME' — refusing to rebase the wrong branch" >&2
+  exit 14
+fi
 git fetch origin main
 PRE_REBASE=$(git rev-parse HEAD)
 git rebase origin/main
@@ -111,6 +121,16 @@ After the LAST phase's verification agent commits, before pushing:
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 cd "$WORKTREE_PATH"
+# HEAD precondition (symmetric to pr-rebase.sh:82-88; Issue #429).
+# If CWD drifted (forgot a `cd`, wrong worktree active), `git rebase
+# origin/main` would silently retarget the wrong branch and exit 0 —
+# reporting success while $BRANCH_NAME is untouched. Same defense
+# that #397 / pr-rebase.sh installs for the callable surface.
+ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)
+if [ "$ACTUAL_HEAD" != "$BRANCH_NAME" ]; then
+  echo "ERROR: run-plan/pr: CWD is on '$ACTUAL_HEAD', expected '$BRANCH_NAME' — refusing to rebase the wrong branch" >&2
+  exit 14
+fi
 git fetch origin main
 PRE_REBASE=$(git rev-parse HEAD)
 git rebase origin/main

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.19+259d6a"
+  version: "2026.05.19+cd305b"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/direct.md
+++ b/skills/fix-issues/modes/direct.md
@@ -43,6 +43,16 @@ for issue in "${FIXED_ISSUES[@]}"; do
 
   # --- Rebase the worktree branch onto latest origin/main ---
   cd "$WORKTREE_PATH"
+  # HEAD precondition (symmetric to pr-rebase.sh:82-88; Issue #429).
+  # If CWD drifted (forgot a `cd`, wrong worktree active), `git rebase
+  # origin/main` would silently retarget the wrong branch and exit 0 —
+  # reporting success while $BRANCH_NAME is untouched. Same defense
+  # that #397 / pr-rebase.sh installs for the callable surface.
+  ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$ACTUAL_HEAD" != "$BRANCH_NAME" ]; then
+    echo "ERROR: fix-issues/direct: CWD is on '$ACTUAL_HEAD', expected '$BRANCH_NAME' — refusing to rebase the wrong branch" >&2
+    exit 14
+  fi
   git fetch origin main
   PRE_REBASE=$(git rev-parse HEAD)
   if ! git rebase origin/main; then

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.19+f7b4e6"
+  version: "2026.05.19+64d81c"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -15,6 +15,16 @@ impl agent:
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 cd "$WORKTREE_PATH"
+# HEAD precondition (symmetric to pr-rebase.sh:82-88; Issue #429).
+# If CWD drifted (forgot a `cd`, wrong worktree active), `git rebase
+# origin/main` would silently retarget the wrong branch and exit 0 —
+# reporting success while $BRANCH_NAME is untouched. Same defense
+# that #397 / pr-rebase.sh installs for the callable surface.
+ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)
+if [ "$ACTUAL_HEAD" != "$BRANCH_NAME" ]; then
+  echo "ERROR: run-plan/pr: CWD is on '$ACTUAL_HEAD', expected '$BRANCH_NAME' — refusing to rebase the wrong branch" >&2
+  exit 14
+fi
 git fetch origin main
 PRE_REBASE=$(git rev-parse HEAD)
 git rebase origin/main
@@ -111,6 +121,16 @@ After the LAST phase's verification agent commits, before pushing:
 ```bash
 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 cd "$WORKTREE_PATH"
+# HEAD precondition (symmetric to pr-rebase.sh:82-88; Issue #429).
+# If CWD drifted (forgot a `cd`, wrong worktree active), `git rebase
+# origin/main` would silently retarget the wrong branch and exit 0 —
+# reporting success while $BRANCH_NAME is untouched. Same defense
+# that #397 / pr-rebase.sh installs for the callable surface.
+ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)
+if [ "$ACTUAL_HEAD" != "$BRANCH_NAME" ]; then
+  echo "ERROR: run-plan/pr: CWD is on '$ACTUAL_HEAD', expected '$BRANCH_NAME' — refusing to rebase the wrong branch" >&2
+  exit 14
+fi
 git fetch origin main
 PRE_REBASE=$(git rev-parse HEAD)
 git rebase origin/main

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2334,6 +2334,50 @@ check_fixed update-zskills "Step 0.5 scoped pattern (canonical form, testing.uni
 check_fixed .claude/skills/update-zskills ".claude mirror: scoped pattern present" \
   '\"testing\"[[:space:]]*:[[:space:]]*\{[^}]*\"unit_cmd\"'
 
+echo '=== Mode-file `git rebase origin/main` HEAD precondition (issue #429) ==='
+# Issue #429: PR #419 added a `HEAD == \$BRANCH` precondition to
+# scripts/pr-rebase.sh:82-88 (exit 14, REASON=wrong-current-branch) so
+# the callable helper can't silently rebase the wrong branch on CWD
+# drift. But agent-prose mode files run their OWN inline `git rebase
+# origin/main` that bypasses that helper — same #397 symptom resurfaces
+# if the guard isn't ported inline. This check asserts: every literal
+# bash `git rebase origin/main` invocation in a `skills/**/modes/*.md`
+# file is preceded (within the prior 20 lines) by a HEAD check
+# (`rev-parse --abbrev-ref HEAD` or `symbolic-ref`).
+#
+# Excluded by design (these are NOT bash invocations the agent runs
+# inline — they are echoed recovery instructions or prose commentary):
+#   - lines starting with `echo` / `printf` (user-facing recovery hints)
+#   - lines beginning with `#` (comments / agent prompt prose)
+MODE_FILES=$(find "$REPO_ROOT/skills" -path '*/modes/*.md' -type f 2>/dev/null)
+GUARD_VIOLATIONS=0
+for mf in $MODE_FILES; do
+  # Find every line that contains `git rebase origin/main` as an actual
+  # bash invocation. Strip leading whitespace before deciding whether
+  # the line is a comment / echo / printf.
+  while IFS=: read -r MATCH_LN _; do
+    [ -z "$MATCH_LN" ] && continue
+    LINE=$(sed -n "${MATCH_LN}p" "$mf")
+    # Strip leading whitespace.
+    STRIPPED="${LINE#"${LINE%%[![:space:]]*}"}"
+    case "$STRIPPED" in
+      \#*|echo*|printf*|\"*|\'*) continue ;;  # comment, echo, printf, or string literal — not an invocation
+    esac
+    # Compute the start of the 20-line preceding window.
+    START=$((MATCH_LN - 20))
+    [ "$START" -lt 1 ] && START=1
+    END=$((MATCH_LN - 1))
+    [ "$END" -lt 1 ] && END=1
+    WINDOW=$(sed -n "${START},${END}p" "$mf")
+    if echo "$WINDOW" | grep -qE 'rev-parse --abbrev-ref HEAD|symbolic-ref'; then
+      pass "$(basename "$(dirname "$(dirname "$mf")")")/modes/$(basename "$mf"):${MATCH_LN} HEAD guard present"
+    else
+      fail "$(basename "$(dirname "$(dirname "$mf")")")/modes/$(basename "$mf"):${MATCH_LN} missing HEAD guard before \`git rebase origin/main\`" "rev-parse --abbrev-ref HEAD within preceding 20 lines"
+      GUARD_VIOLATIONS=$((GUARD_VIOLATIONS + 1))
+    fi
+  done < <(grep -n 'git rebase origin/main' "$mf" 2>/dev/null)
+done
+
 echo ""
 echo "---"
 TOTAL=$((PASS_COUNT + FAIL_COUNT))


### PR DESCRIPTION
## Summary

Closes #429. PR #419 (closes #397) added a `HEAD == $BRANCH` precondition to `scripts/pr-rebase.sh:82-88` (exit 14, `REASON=wrong-current-branch`) to prevent rebasing the wrong branch on agent CWD drift. But three agent-prose mode files ran their OWN inline `git rebase origin/main` that bypassed that helper:

- `skills/fix-issues/modes/direct.md` (line 48 pre-fix)
- `skills/run-plan/modes/pr.md` (lines 20 + 116 pre-fix)

Pre-fix, grep returned zero hits for `git rev-parse --abbrev-ref HEAD` or `git symbolic-ref` in either mode file's prose. The #397 symptom remained reachable through the 3 inline sites.

## Approach

Per tracker blurb: port the `pr-rebase.sh:82-88` HEAD-precondition guard inline at each site. Each guard now captures `ACTUAL_HEAD=$(git rev-parse --abbrev-ref HEAD)`, compares to the surrounding branch variable (`$BRANCH_NAME` in all cases), and exits with a clear `REASON=wrong-current-branch` error on mismatch — symmetric to the helper.

Skills version-bumped:
- `skills/fix-issues/SKILL.md`: `metadata.version: "2026.05.19+cd305b"`
- `skills/run-plan/SKILL.md`: `metadata.version: "2026.05.19+64d81c"`

Mirrors byte-equal across 4 source/mirror pairs.

## Conformance assertion

New section in `tests/test-skill-conformance.sh` iterates every `skills/**/modes/*.md`, finds each literal `git rebase origin/main`, excludes comment/echo/printf/quoted-string lines, asserts a `rev-parse --abbrev-ref HEAD` or `symbolic-ref` appears within the preceding 20 lines. Verified the assertion fires correctly when a guard is removed.

## Test plan

- [x] Full suite: 3545/3545 passing (baseline post-#437 = 3542 + 3 new assertions).
- [x] All 3 sites guarded; preceding-20-line window contains the HEAD check.
- [x] Source/mirror byte-equal across 4 pairs.
- [x] Version-bumped (2 skills × 2 = 4 SKILL.md edits, all version-equal).
