### PR TITLE
sync: tracker blurb for #432 + sprint-report (research-only)

### DIFF
--- a/docs/issues/ISSUES_PLAN.md
+++ b/docs/issues/ISSUES_PLAN.md
@@ -380,6 +380,23 @@ Created by `/fix-issues sync` on 2026-05-15 for issues not covered by domain-spe
 
 ---
 
+### #432 — zskills install shape: own repo doesn't follow consumer pattern (CLAUDE.md monolithic vs `.claude/rules/zskills/managed.md`)
+
+**Labels:** (none) | **Verdict:** NOT FIXED — `.claude/rules/zskills/` does not exist in this repo (confirmed `ls`); root `./CLAUDE.md` is monolithic (266 lines, 11 `^## ` sections); `CLAUDE_TEMPLATE.md` is 362 lines / 15 sections; 8 sections are shared by name (`Architecture`, `Subagent Dispatch`, `Cron-fired prompts`, `Playwright CLI`, `Worktree Rules`, `Git Rules`, `Migration scripts`, `Python is required`) — and the recently-landed `## Cron-fired prompts` rule (commit `452e9c7`, PR #433) was dual-written verbatim into both files. `skills/update-zskills/SKILL.md:938-947` documents the consumer pattern (Step B renders template → `.claude/rules/zskills/managed.md`, auto-loaded recursively, never cross-writes root `./CLAUDE.md`) — a pattern this repo does not eat.
+
+**Problem.** zskills ships consumers an install where `CLAUDE_TEMPLATE.md` is the source-of-truth and consumers' root `./CLAUDE.md` stays user-owned. The zskills repo itself stores those same rules in its monolithic root `./CLAUDE.md` AND in `CLAUDE_TEMPLATE.md`. Every shared-rules edit is a manual dual-write with no tooling guard — PR #433 already had to verify byte-equal section bodies via `diff` post-hoc. Future shared edits (anything in the 8 overlapping sections) accumulate latent drift. CLAUDE.md also has 3 zskills-author-only sections (`Tracking markers`, `Skill versioning`, `Verifier-cannot-run rule`) that legitimately don't belong in the consumer template — so the fix can't be a naive "delete CLAUDE.md, render from template."
+
+**Three options in body (mutually divergent designs, not refinements).**
+1. **Self-install** — populate `.claude/rules/zskills/managed.md` from our own `CLAUDE_TEMPLATE.md`, gitignore the rendered file, add a contributor render step. Removes dual-write; requires `/update-zskills` to be re-runnable against zskills's own clone (Step 0 source-locator already supports the repo-clone branch at `skills/update-zskills/SKILL.md:99,142`); root `./CLAUDE.md` shrinks to the 3 author-only sections + a pointer to the rendered file.
+2. **Accept the difference, document it** — annotate the duplication in `CLAUDE.md` / contributor docs as upstream-self-hosting. XS effort; latent drift persists.
+3. **Strip shared content from `CLAUDE.md`, source-of-truth in `CLAUDE_TEMPLATE.md`, regenerate-on-demand** — small render script + gitignore + contributor discipline. Slightly cheaper than option 1 because no Step B execution against ourselves, but redundant if option 1 already works.
+
+**Fix outline.** None pre-decision — option choice is author-level (durability vs effort vs self-install discipline). If option 1: bounded plan covering gitignore entry, contributor render hook or `/update-zskills` self-run docs, root `./CLAUDE.md` split (keep author-only sections, point to rendered file), migration of pre-existing dual-writes, plus a drift-detection conformance test (`tests/test-claude-rules-mirror-parity.sh` asserting the 8 shared sections in `CLAUDE_TEMPLATE.md` render byte-equal into `.claude/rules/zskills/managed.md`). If option 2: a few-line note in `CLAUDE.md` plus optionally a drift test that asserts the 8 shared section bodies match between `CLAUDE.md` and `CLAUDE_TEMPLATE.md`. If option 3: a render script + the same drift test, scoped to the single direction. The drift-detection conformance test is common to all three actionable variants and is the smallest immediate win — could be filed as a follow-up issue regardless of option choice.
+
+**Complexity:** M-L for option 1 (multi-step: gitignore + split CLAUDE.md + contributor docs + migration + conformance test, with self-install correctness risk), XS for option 2, M for option 3. **Action now:** none — author decision needed on which option (or defer entirely). If author picks option 1 or 3, escalate to `/draft-plan`. If option 2, single `/do pr`. A standalone follow-up issue for the drift-detection conformance test (covering whichever shape lands) is a low-risk parallel track regardless.
+
+---
+
 ### #429 — Mode files embed `git rebase origin/main` without HEAD precondition — symmetric to fixed #397
 
 **Labels:** (none) | **Verdict:** NOT FIXED — 3 embedded rebase sites have no HEAD guard; grep for `git rev-parse --abbrev-ref HEAD` / `git symbolic-ref` in either mode file returns zero hits.

--- a/docs/reports/SPRINT_REPORT.md
+++ b/docs/reports/SPRINT_REPORT.md
@@ -1037,3 +1037,20 @@ Per-issue `/land-pr --auto` for #337, then sprint-level `/land-pr --auto` for th
 - N=2 requested; partial-fill expected once #432 filtered. Sprint dispatched 1 (the researched candidate).
 - #420 was XS complexity (`/do pr` per blurb). Implementer added a more thorough test file (11 assertions covering the full RC mapping table, not just RC 14) — appropriate over-coverage; absorbed.
 - Pass count ratcheted: 3545 → 3556 (+11 from #441).
+
+## Sprint — 2026-05-19 17:26 UTC [UNFINALIZED]
+
+**Mode:** auto | dashboard | **Sprint ID:** sprint-20260519-172642-sprint
+
+### Fixed
+(none — research-only sprint)
+
+### Skipped — Author decision needed
+| # | Title | Why |
+|---|-------|-----|
+| #432 | zskills install shape — own repo doesn't follow consumer pattern | Tracker blurb added this sprint (commit `05f7a21`). Independent sizing call: **`Action now: none — author decision needed`**. The 3 options in the body (self-install / document / render-from-template) are mutually divergent designs, not refinements of one fix. Choice is durability-vs-effort and depends on whether zskills should self-install. Suggested follow-up regardless of option choice: a drift-detection conformance test asserting the 8 shared sections in CLAUDE.md vs CLAUDE_TEMPLATE.md match — that's the low-risk parallel track. |
+
+### Triage notes
+- Ready ∩ open = [432] (only); N=2 requested, partial-fill to 0 fix-dispatches.
+- Research agent invested ~95s reading the actual files (CLAUDE.md, CLAUDE_TEMPLATE.md, update-zskills Step B) and verifying claims (file existence, line counts, section overlap) before writing the blurb. Evidence-anchored independent sizing per `/qe-audit` discipline.
+- Sync ship: this sprint produces a single-file research blurb commit. The blurb's the artifact.


### PR DESCRIPTION
## Summary

`/fix-issues 2 auto dashboard every 30m now` sprint at 2026-05-19 17:26 UTC. Ready ∩ open = [432]; the only actionable candidate had no tracker blurb, so the sprint dispatched a research agent and skipped fix-dispatch.

**Fixed:** (none — research-only)

**Skipped:** #432 — research agent's independent sizing call: `Action now: none — author decision needed`. The 3 options in the issue body are mutually divergent designs (self-install / document / render-from-template), not refinements of one fix. The choice is durability-vs-effort and depends on whether zskills should self-install its own pattern. Tracker blurb written (commit `05f7a21`) with full evidence-anchored analysis: 11 sections in CLAUDE.md, 15 in CLAUDE_TEMPLATE.md, 8 shared by name (verified by `^## ` grep), 3 zskills-author-only that can't move to template, dual-write established by PR #433. Per-option complexity sized (M-L / XS / M).

**Suggested low-risk parallel track regardless of option choice:** a drift-detection conformance test asserting the 8 shared sections in CLAUDE.md vs CLAUDE_TEMPLATE.md match. File as a follow-up issue if you want.

## Test plan

- [x] Sync-only PR — agent-facing tracker markdown + sprint report. Auto-merge per "sync ship" convention.
- [x] No code changes; full suite not run (per skill's content-only rule).
