### PR TITLE
fix(verifier): scope-creep AC must use commit-only/merge-base diff (#448)

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -25,4 +25,15 @@ $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
 
 Read the file when the call returns.
 
+## Scope-creep AC checks
+
+When checking AC-style "no scope creep" criteria, prefer one of:
+
+- `git show HEAD --stat` — shows ONLY the commit's diff (no comparison; rebase-staleness can't apply).
+- `git diff $(git merge-base origin/main HEAD)..HEAD --stat` — merge-base diff (what HEAD has that the branch-base didn't).
+
+**Avoid bare `git diff origin/main..HEAD --stat`.** That command shows the SYMMETRIC file-set diff — including files in `origin/main` that aren't in `HEAD`. If `origin/main` advances past your branch's merge-base during the verification run (common at active-landing cadence, where the full suite takes 3-4 min and sibling PRs land mid-flight), files added on origin appear as "deletions" in HEAD's diff. The verifier reads those phantom deletions as scope creep and REJECTs with a confident, destructive recovery path: if followed, the recovery overwrites the in-flight commit with origin/main's content and rolls back another sprint's work.
+
+**Past failures (anchor, not theoretical):** this exact false-positive fired TWICE on 2026-05-19/20 — once during the PR #447 landing window (recovery path would have undone PR #446), once with a sibling agent the same evening. Both recovered only because the recipient happened to recognize the merge-base gotcha. Use the two preferred commands above and the failure mode goes away.
+
 **You cannot dispatch sub-subagents.** Subagents categorically lack the `Agent` tool (per Anthropic's documented design at https://code.claude.com/docs/en/sub-agents). If your task requires fresh-agent fanout, that's the orchestrator's job — do the work inline and report the freshness mode in your verification output.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -557,6 +557,23 @@ else
   fail "[.claude/agents/implementer.md] hooks inject-bash-timeout.sh" "Layer 0 hook reference missing"
 fi
 
+# Verifier agent scope-creep AC check guidance (Issue #448).
+# Bare `git diff origin/main..HEAD --stat` shows symmetric file-set diff;
+# when origin/main advances past the branch merge-base mid-verification
+# (active-landing cadence), files added on origin appear as "deletions"
+# in HEAD's diff and the verifier REJECTs with a destructive recovery
+# path. The agent prose recommends commit-only or merge-base forms.
+if grep -qF 'git show HEAD --stat' "$REPO_ROOT/.claude/agents/verifier.md" 2>/dev/null; then
+  pass "[.claude/agents/verifier.md] scope-creep: git show HEAD --stat"
+else
+  fail "[.claude/agents/verifier.md] scope-creep: git show HEAD --stat" "commit-only diff form missing"
+fi
+if grep -qF 'merge-base origin/main HEAD' "$REPO_ROOT/.claude/agents/verifier.md" 2>/dev/null; then
+  pass "[.claude/agents/verifier.md] scope-creep: merge-base form"
+else
+  fail "[.claude/agents/verifier.md] scope-creep: merge-base form" "merge-base diff form missing"
+fi
+
 echo ""
 echo "=== Cross-skill PR-landing tripwires (PR_LANDING_UNIFICATION Phase 6 WI 6.1) ==="
 # Drift-prevention assertions catching any future re-introduction of inline


### PR DESCRIPTION
## Summary

Closes #448. Verifier subagents used `git diff origin/main..HEAD --stat` for scope-creep AC validation. That command shows the **symmetric** file-set diff — including files in `origin/main` that aren't in `HEAD`. During active-landing cadence (3-4 min full-suite + sibling PRs landing mid-verification), recently-landed-on-origin files appeared as "deletions in HEAD," and the verifier REJECTed with a confident, destructive recovery path that — if followed — would overwrite the in-flight commit with origin/main's content and roll back another sprint's work.

Observed TWICE on 2026-05-19/20 (PR #447 landing window + a sibling agent same evening). Both occurrences recovered only because the recipient happened to recognize the merge-base gotcha.

## Approach (Option A per issue body)

Pure-addition prose to `.claude/agents/verifier.md` (the file had zero prior scope-creep guidance — confirmed by reviewer's `grep -c` returning 0 for `--stat`, `origin/main..HEAD`, and `scope creep`). New "Scope-creep AC checks" subsection recommends:

- `git show HEAD --stat` — commit-only, no comparison; rebase-staleness can't apply.
- `git diff $(git merge-base origin/main HEAD)..HEAD --stat` — merge-base diff (what HEAD has that the branch-base didn't).

Warning against bare `origin/main..HEAD --stat` includes the symmetric-diff reason and cites the 2026-05-19/20 past failures inline so future agents don't treat the warning as theoretical.

## Conformance tripwire

Added 2 assertions in `tests/test-skill-conformance.sh` (after the existing implementer.md frontmatter checks) asserting both preferred commands appear in `verifier.md` prose. Catches accidental regressions where a future edit reverts to the bare pattern.

## Out of scope

- **Option B (verifier pre-flight rebase)** — explicitly deferred per issue body. Mention here as the next step if Option A doesn't stick.
- **Skill version bump** — `.claude/agents/` is NOT under `skills/<name>/**`; skill-versioning rule doesn't apply.

## Test plan

- [x] Full suite: 3578/3578 passing (baseline 3576 post-#451 + 2 new conformance tripwires).
- [x] `grep -F "git show HEAD --stat" .claude/agents/verifier.md` matches.
- [x] `grep -F "merge-base origin/main HEAD" .claude/agents/verifier.md` matches.
- [x] No `.claude/agents/` mirror needed (single home).
