### PR TITLE
do: add block-bad-cron PreToolUse hook for CronCreate

### DIFF
--- a/.claude/hooks/block-bad-cron.sh
+++ b/.claude/hooks/block-bad-cron.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# block-bad-cron.sh — PreToolUse hook for the CronCreate tool.
+#
+# Closes a class of "the cron never fired" bugs caused by structurally-wrong
+# cron expressions on the CronCreate tool. The recurring trap, observed on
+# 2026-05-19: an orchestrator typed `3 16 19 5 *` for CronCreate thinking
+# 4:03 PM ET. Container TZ is UTC, so the scheduler read it as 16:03 UTC =
+# 12:03 PM EDT — already past at scheduling. With no year field, the next
+# match is May 19 *2027*. One-shot crons whose match is far in the future
+# never fire within a single Claude Code session lifetime.
+#
+# Reject rules (deny with explanatory STOP message):
+#   - recurring=false AND no match in next 8 days  → today's past-time bug
+#   - recurring=false AND next-fire > 7 days from now → session-lifetime
+#   - delta < 0                                    → defensive past-time
+#
+# Allow with stderr WARN:
+#   - Cron expression fails to parse — let scheduler surface its own error.
+#
+# Allow (no warn):
+#   - recurring=true regardless (legitimate edge cases like Feb-31 exist).
+#   - Anything that passes the reject rules.
+#
+# Tool-name gate: filter early on `tool_name=CronCreate`. Anything else
+# exits 0. Pattern follows hooks/inject-bash-timeout.sh's `tool_name`
+# pre-filter (idiom: cheap startup cost on every Bash/PreToolUse call).
+#
+# TZ resolution ladder (display-TZ used in deny messages — container TZ is
+# always reported separately):
+#   1. top-level "timezone" field in .claude/zskills-config.json
+#   2. $TIMEZONE env var
+#   3. $TZ env var
+#   4. /etc/timezone
+#   5. UTC
+# NO hardcoded "America/New_York" anywhere — the deny-list scan in
+# tests/test-skill-conformance.sh enforces this.
+
+set -u
+
+INPUT=$(cat 2>/dev/null) || exit 0
+[ -z "$INPUT" ] && exit 0
+
+# ── Tool-name gate ─────────────────────────────────────────────────
+# Exit 0 for anything except CronCreate. Cheapest possible filter so
+# the hook adds near-zero cost to other PreToolUse paths.
+if [[ "$INPUT" != *'"tool_name":"CronCreate"'* ]] && [[ "$INPUT" != *'"tool_name": "CronCreate"'* ]]; then
+  exit 0
+fi
+
+# ── Resolve Python interpreter ─────────────────────────────────────
+# Same precedence as hooks/inject-bash-timeout.sh.
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+# ── Extract tool_input fields via bash regex ───────────────────────
+# tool_input.cron — 5-field cron expression
+CRON_EXPR=""
+if [[ "$INPUT" =~ \"cron\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  CRON_EXPR="${BASH_REMATCH[1]}"
+fi
+
+# If no cron in the envelope, allow (scheduler will reject; not our job).
+if [ -z "$CRON_EXPR" ]; then
+  exit 0
+fi
+
+# tool_input.recurring — bool, default true
+RECURRING="true"
+if [[ "$INPUT" =~ \"recurring\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
+  RECURRING="${BASH_REMATCH[1]}"
+fi
+
+# ── Resolve display TZ ─────────────────────────────────────────────
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+CONFIG_FILE="$REPO_ROOT/.claude/zskills-config.json"
+
+DISPLAY_TZ=""
+if [ -f "$CONFIG_FILE" ]; then
+  # Top-level "timezone" field — bash regex extraction.
+  if [[ "$(cat "$CONFIG_FILE")" =~ \"timezone\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    DISPLAY_TZ="${BASH_REMATCH[1]}"
+  fi
+fi
+if [ -z "$DISPLAY_TZ" ] && [ -n "${TIMEZONE:-}" ]; then
+  DISPLAY_TZ="$TIMEZONE"
+fi
+if [ -z "$DISPLAY_TZ" ] && [ -n "${TZ:-}" ]; then
+  DISPLAY_TZ="$TZ"
+fi
+if [ -z "$DISPLAY_TZ" ] && [ -f /etc/timezone ]; then
+  DISPLAY_TZ=$(tr -d '[:space:]' < /etc/timezone 2>/dev/null || true)
+fi
+if [ -z "$DISPLAY_TZ" ]; then
+  DISPLAY_TZ="UTC"
+fi
+
+# Container-local TZ — what the scheduler actually uses to evaluate
+# the cron expression. Read from /etc/timezone OR $TZ env. We DO NOT
+# fold this with DISPLAY_TZ — they may differ and the deny message
+# needs both to explain the most common bug (typing for the wrong TZ).
+CONTAINER_TZ=""
+if [ -n "${TZ:-}" ]; then
+  CONTAINER_TZ="$TZ"
+elif [ -f /etc/timezone ]; then
+  CONTAINER_TZ=$(tr -d '[:space:]' < /etc/timezone 2>/dev/null || true)
+fi
+if [ -z "$CONTAINER_TZ" ]; then
+  CONTAINER_TZ="UTC"
+fi
+
+# ── Compute next fire time (inline Python) ─────────────────────────
+# Python iterates minute-by-minute up to 8 days from NOW_EPOCH.
+# Returns:
+#   exit 0, stdout "<epoch> <iso-in-display-tz>" — found a match
+#   exit 1, stdout empty — no match in 8 days
+#   exit 2, stdout empty — parse error in cron expression
+#
+# Supports field forms: `*`, `*/N`, `A-B`, `A,B,C`, single integer.
+# Field order: minute(0-59) hour(0-23) day(1-31) month(1-12) dow(0-6).
+PY_OUT=$(
+  CRON_EXPR="$CRON_EXPR" \
+  DISPLAY_TZ="$DISPLAY_TZ" \
+  FAKE_NOW_EPOCH="${FAKE_NOW_EPOCH:-}" \
+  "$PYTHON" -c '
+import os, sys, time, datetime
+
+cron = os.environ["CRON_EXPR"].strip()
+display_tz = os.environ.get("DISPLAY_TZ", "UTC")
+fake_now = os.environ.get("FAKE_NOW_EPOCH", "").strip()
+
+def parse_field(spec, lo, hi):
+    """Return set of valid ints for one cron field."""
+    out = set()
+    for part in spec.split(","):
+        part = part.strip()
+        step = 1
+        if "/" in part:
+            base, step_s = part.split("/", 1)
+            step = int(step_s)
+            if step <= 0:
+                raise ValueError("step must be positive")
+        else:
+            base = part
+        if base == "*":
+            start, end = lo, hi
+        elif "-" in base:
+            a, b = base.split("-", 1)
+            start, end = int(a), int(b)
+        else:
+            start = end = int(base)
+        if start < lo or end > hi or start > end:
+            raise ValueError("field out of range")
+        for v in range(start, end + 1, step):
+            out.add(v)
+    if not out:
+        raise ValueError("empty field")
+    return out
+
+fields = cron.split()
+if len(fields) != 5:
+    sys.exit(2)
+
+try:
+    minutes = parse_field(fields[0], 0, 59)
+    hours   = parse_field(fields[1], 0, 23)
+    days    = parse_field(fields[2], 1, 31)
+    months  = parse_field(fields[3], 1, 12)
+    dows    = parse_field(fields[4], 0, 6)
+except Exception:
+    sys.exit(2)
+
+if fake_now:
+    now_epoch = int(fake_now)
+else:
+    now_epoch = int(time.time())
+
+# Iterate minute-by-minute in CONTAINER (system) TZ — this is what the
+# scheduler does. We start at the next whole minute >= now.
+# Use time.localtime to convert; the container TZ is honored implicitly.
+start = (now_epoch // 60) * 60
+if start < now_epoch:
+    start += 60
+
+# 8 days = 8 * 24 * 60 minutes
+limit = start + 8 * 24 * 60 * 60
+t = start
+found = None
+while t < limit:
+    lt = time.localtime(t)
+    if (lt.tm_min in minutes
+        and lt.tm_hour in hours
+        and lt.tm_mday in days
+        and lt.tm_mon in months
+        # cron dow: 0-6 Sun-Sat; Python tm_wday: 0-6 Mon-Sun
+        # Convert: cron_dow = (tm_wday + 1) % 7
+        and ((lt.tm_wday + 1) % 7) in dows):
+        found = t
+        break
+    t += 60
+
+if found is None:
+    sys.exit(1)
+
+# Format the found time in display TZ. Use ZoneInfo if available
+# (Python 3.9+); fall back to UTC label if not.
+try:
+    from zoneinfo import ZoneInfo
+    tz = ZoneInfo(display_tz)
+    dt = datetime.datetime.fromtimestamp(found, tz=tz)
+    iso = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+except Exception:
+    # Best-effort fall back: format as UTC.
+    dt = datetime.datetime.utcfromtimestamp(found)
+    iso = dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+sys.stdout.write("%d %s" % (found, iso))
+sys.exit(0)
+' 2>/dev/null
+)
+PY_RC=$?
+
+# ── Decide ─────────────────────────────────────────────────────────
+emit_deny() {
+  local reason="$1"
+  # JSON-escape: backslashes first, then quotes, then newlines.
+  local esc="${reason//\\/\\\\}"
+  esc="${esc//\"/\\\"}"
+  esc="${esc//$'\n'/\\n}"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$esc"
+  exit 0
+}
+
+# Helper: humanize a delta in seconds.
+human_delta() {
+  local delta="$1"
+  local sign=""
+  if [ "$delta" -lt 0 ]; then
+    sign="-"
+    delta=$(( -delta ))
+  fi
+  local days hours minutes
+  days=$(( delta / 86400 ))
+  hours=$(( (delta % 86400) / 3600 ))
+  minutes=$(( (delta % 3600) / 60 ))
+  if [ "$days" -gt 0 ]; then
+    printf '%s%dd %dh %dm' "$sign" "$days" "$hours" "$minutes"
+  elif [ "$hours" -gt 0 ]; then
+    printf '%s%dh %dm' "$sign" "$hours" "$minutes"
+  else
+    printf '%s%dm' "$sign" "$minutes"
+  fi
+}
+
+# Recovery hint shared across deny messages.
+RECOVERY_HINT='Recovery: container TZ is what the scheduler reads. If you wanted a different display TZ (e.g., ET), rebuild the cron expression with UTC offsets in mind, OR set top-level "timezone" in .claude/zskills-config.json to match the container.'
+
+case "$PY_RC" in
+  2)
+    # Parse error — allow, but WARN to stderr so the scheduler's
+    # own error path takes the surface.
+    echo "block-bad-cron: cron expression '$CRON_EXPR' failed to parse — allowing through; scheduler will surface its own parse error" >&2
+    exit 0
+    ;;
+  1)
+    # No match in 8 days. If recurring, allow (legitimate edge cases:
+    # 0 0 31 2 *, 0 0 29 2 * on non-leap years, etc).
+    if [ "$RECURRING" = "true" ]; then
+      exit 0
+    fi
+    # recurring=false → DENY.
+    NOW_EPOCH_FOR_MSG="${FAKE_NOW_EPOCH:-$(date +%s)}"
+    NOW_DISP=$(TZ="$DISPLAY_TZ" date -d "@$NOW_EPOCH_FOR_MSG" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "(now)")
+    REASON="STOP: CronCreate refused.
+
+  cron expression: $CRON_EXPR
+  recurring:       $RECURRING
+  container TZ:    $CONTAINER_TZ
+  display TZ:      $DISPLAY_TZ
+  now (display):   $NOW_DISP
+
+No match found within 8 days from now. For a one-shot cron (recurring=false), this means the next fire is so far away the Claude Code session will not survive to see it. Most common cause: the expression pins a day-of-month and month that have already passed for this year — cron with no year field rolls over to next year, so the cron sits in CronList for ~365 days and never fires.
+
+$RECOVERY_HINT"
+    emit_deny "$REASON"
+    ;;
+  0)
+    # Got a fire time. Read epoch + iso from PY_OUT.
+    FIRE_EPOCH=$(printf '%s' "$PY_OUT" | awk '{print $1}')
+    FIRE_ISO=$(printf '%s' "$PY_OUT" | cut -d' ' -f2-)
+    NOW_EPOCH_FOR_MSG="${FAKE_NOW_EPOCH:-$(date +%s)}"
+    DELTA=$(( FIRE_EPOCH - NOW_EPOCH_FOR_MSG ))
+    HUMAN=$(human_delta "$DELTA")
+    NOW_DISP=$(TZ="$DISPLAY_TZ" date -d "@$NOW_EPOCH_FOR_MSG" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "(now)")
+
+    # Defensive: delta < 0 (shouldn't be reachable with a forward iter,
+    # but guard anyway). Always deny.
+    if [ "$DELTA" -lt 0 ]; then
+      REASON="STOP: CronCreate refused.
+
+  cron expression: $CRON_EXPR
+  recurring:       $RECURRING
+  container TZ:    $CONTAINER_TZ
+  display TZ:      $DISPLAY_TZ
+  now (display):   $NOW_DISP
+  next fire:       $FIRE_ISO ($HUMAN from now)
+
+Computed next-fire time is in the past. This is a defensive guard against an iterator bug — should not be reachable. Re-check the expression and the system clock.
+
+$RECOVERY_HINT"
+      emit_deny "$REASON"
+    fi
+
+    # recurring=false AND fire > 7 days out → session-lifetime deny.
+    if [ "$RECURRING" = "false" ]; then
+      SEVEN_DAYS=$(( 7 * 24 * 60 * 60 ))
+      if [ "$DELTA" -gt "$SEVEN_DAYS" ]; then
+        REASON="STOP: CronCreate refused.
+
+  cron expression: $CRON_EXPR
+  recurring:       $RECURRING
+  container TZ:    $CONTAINER_TZ
+  display TZ:      $DISPLAY_TZ
+  now (display):   $NOW_DISP
+  next fire:       $FIRE_ISO ($HUMAN from now)
+
+For a one-shot cron (recurring=false), the next fire is more than 7 days from now. Claude Code session lifetime will not reach it. If you intended this fire time, switch to recurring=true. Otherwise, rebuild the cron expression to fire within 7 days.
+
+$RECOVERY_HINT"
+        emit_deny "$REASON"
+      fi
+    fi
+
+    # All checks passed → allow.
+    exit 0
+    ;;
+  *)
+    # Python died for an unexpected reason. Fail-open with a WARN.
+    echo "block-bad-cron: unexpected Python exit code $PY_RC — allowing through" >&2
+    exit 0
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,16 @@
         ]
       },
       {
+        "matcher": "CronCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-bad-cron.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|NotebookEdit",
         "hooks": [
           {

--- a/hooks/block-bad-cron.sh
+++ b/hooks/block-bad-cron.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# block-bad-cron.sh — PreToolUse hook for the CronCreate tool.
+#
+# Closes a class of "the cron never fired" bugs caused by structurally-wrong
+# cron expressions on the CronCreate tool. The recurring trap, observed on
+# 2026-05-19: an orchestrator typed `3 16 19 5 *` for CronCreate thinking
+# 4:03 PM ET. Container TZ is UTC, so the scheduler read it as 16:03 UTC =
+# 12:03 PM EDT — already past at scheduling. With no year field, the next
+# match is May 19 *2027*. One-shot crons whose match is far in the future
+# never fire within a single Claude Code session lifetime.
+#
+# Reject rules (deny with explanatory STOP message):
+#   - recurring=false AND no match in next 8 days  → today's past-time bug
+#   - recurring=false AND next-fire > 7 days from now → session-lifetime
+#   - delta < 0                                    → defensive past-time
+#
+# Allow with stderr WARN:
+#   - Cron expression fails to parse — let scheduler surface its own error.
+#
+# Allow (no warn):
+#   - recurring=true regardless (legitimate edge cases like Feb-31 exist).
+#   - Anything that passes the reject rules.
+#
+# Tool-name gate: filter early on `tool_name=CronCreate`. Anything else
+# exits 0. Pattern follows hooks/inject-bash-timeout.sh's `tool_name`
+# pre-filter (idiom: cheap startup cost on every Bash/PreToolUse call).
+#
+# TZ resolution ladder (display-TZ used in deny messages — container TZ is
+# always reported separately):
+#   1. top-level "timezone" field in .claude/zskills-config.json
+#   2. $TIMEZONE env var
+#   3. $TZ env var
+#   4. /etc/timezone
+#   5. UTC
+# NO hardcoded "America/New_York" anywhere — the deny-list scan in
+# tests/test-skill-conformance.sh enforces this.
+
+set -u
+
+INPUT=$(cat 2>/dev/null) || exit 0
+[ -z "$INPUT" ] && exit 0
+
+# ── Tool-name gate ─────────────────────────────────────────────────
+# Exit 0 for anything except CronCreate. Cheapest possible filter so
+# the hook adds near-zero cost to other PreToolUse paths.
+if [[ "$INPUT" != *'"tool_name":"CronCreate"'* ]] && [[ "$INPUT" != *'"tool_name": "CronCreate"'* ]]; then
+  exit 0
+fi
+
+# ── Resolve Python interpreter ─────────────────────────────────────
+# Same precedence as hooks/inject-bash-timeout.sh.
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+# ── Extract tool_input fields via bash regex ───────────────────────
+# tool_input.cron — 5-field cron expression
+CRON_EXPR=""
+if [[ "$INPUT" =~ \"cron\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+  CRON_EXPR="${BASH_REMATCH[1]}"
+fi
+
+# If no cron in the envelope, allow (scheduler will reject; not our job).
+if [ -z "$CRON_EXPR" ]; then
+  exit 0
+fi
+
+# tool_input.recurring — bool, default true
+RECURRING="true"
+if [[ "$INPUT" =~ \"recurring\"[[:space:]]*:[[:space:]]*(true|false) ]]; then
+  RECURRING="${BASH_REMATCH[1]}"
+fi
+
+# ── Resolve display TZ ─────────────────────────────────────────────
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+CONFIG_FILE="$REPO_ROOT/.claude/zskills-config.json"
+
+DISPLAY_TZ=""
+if [ -f "$CONFIG_FILE" ]; then
+  # Top-level "timezone" field — bash regex extraction.
+  if [[ "$(cat "$CONFIG_FILE")" =~ \"timezone\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    DISPLAY_TZ="${BASH_REMATCH[1]}"
+  fi
+fi
+if [ -z "$DISPLAY_TZ" ] && [ -n "${TIMEZONE:-}" ]; then
+  DISPLAY_TZ="$TIMEZONE"
+fi
+if [ -z "$DISPLAY_TZ" ] && [ -n "${TZ:-}" ]; then
+  DISPLAY_TZ="$TZ"
+fi
+if [ -z "$DISPLAY_TZ" ] && [ -f /etc/timezone ]; then
+  DISPLAY_TZ=$(tr -d '[:space:]' < /etc/timezone 2>/dev/null || true)
+fi
+if [ -z "$DISPLAY_TZ" ]; then
+  DISPLAY_TZ="UTC"
+fi
+
+# Container-local TZ — what the scheduler actually uses to evaluate
+# the cron expression. Read from /etc/timezone OR $TZ env. We DO NOT
+# fold this with DISPLAY_TZ — they may differ and the deny message
+# needs both to explain the most common bug (typing for the wrong TZ).
+CONTAINER_TZ=""
+if [ -n "${TZ:-}" ]; then
+  CONTAINER_TZ="$TZ"
+elif [ -f /etc/timezone ]; then
+  CONTAINER_TZ=$(tr -d '[:space:]' < /etc/timezone 2>/dev/null || true)
+fi
+if [ -z "$CONTAINER_TZ" ]; then
+  CONTAINER_TZ="UTC"
+fi
+
+# ── Compute next fire time (inline Python) ─────────────────────────
+# Python iterates minute-by-minute up to 8 days from NOW_EPOCH.
+# Returns:
+#   exit 0, stdout "<epoch> <iso-in-display-tz>" — found a match
+#   exit 1, stdout empty — no match in 8 days
+#   exit 2, stdout empty — parse error in cron expression
+#
+# Supports field forms: `*`, `*/N`, `A-B`, `A,B,C`, single integer.
+# Field order: minute(0-59) hour(0-23) day(1-31) month(1-12) dow(0-6).
+PY_OUT=$(
+  CRON_EXPR="$CRON_EXPR" \
+  DISPLAY_TZ="$DISPLAY_TZ" \
+  FAKE_NOW_EPOCH="${FAKE_NOW_EPOCH:-}" \
+  "$PYTHON" -c '
+import os, sys, time, datetime
+
+cron = os.environ["CRON_EXPR"].strip()
+display_tz = os.environ.get("DISPLAY_TZ", "UTC")
+fake_now = os.environ.get("FAKE_NOW_EPOCH", "").strip()
+
+def parse_field(spec, lo, hi):
+    """Return set of valid ints for one cron field."""
+    out = set()
+    for part in spec.split(","):
+        part = part.strip()
+        step = 1
+        if "/" in part:
+            base, step_s = part.split("/", 1)
+            step = int(step_s)
+            if step <= 0:
+                raise ValueError("step must be positive")
+        else:
+            base = part
+        if base == "*":
+            start, end = lo, hi
+        elif "-" in base:
+            a, b = base.split("-", 1)
+            start, end = int(a), int(b)
+        else:
+            start = end = int(base)
+        if start < lo or end > hi or start > end:
+            raise ValueError("field out of range")
+        for v in range(start, end + 1, step):
+            out.add(v)
+    if not out:
+        raise ValueError("empty field")
+    return out
+
+fields = cron.split()
+if len(fields) != 5:
+    sys.exit(2)
+
+try:
+    minutes = parse_field(fields[0], 0, 59)
+    hours   = parse_field(fields[1], 0, 23)
+    days    = parse_field(fields[2], 1, 31)
+    months  = parse_field(fields[3], 1, 12)
+    dows    = parse_field(fields[4], 0, 6)
+except Exception:
+    sys.exit(2)
+
+if fake_now:
+    now_epoch = int(fake_now)
+else:
+    now_epoch = int(time.time())
+
+# Iterate minute-by-minute in CONTAINER (system) TZ — this is what the
+# scheduler does. We start at the next whole minute >= now.
+# Use time.localtime to convert; the container TZ is honored implicitly.
+start = (now_epoch // 60) * 60
+if start < now_epoch:
+    start += 60
+
+# 8 days = 8 * 24 * 60 minutes
+limit = start + 8 * 24 * 60 * 60
+t = start
+found = None
+while t < limit:
+    lt = time.localtime(t)
+    if (lt.tm_min in minutes
+        and lt.tm_hour in hours
+        and lt.tm_mday in days
+        and lt.tm_mon in months
+        # cron dow: 0-6 Sun-Sat; Python tm_wday: 0-6 Mon-Sun
+        # Convert: cron_dow = (tm_wday + 1) % 7
+        and ((lt.tm_wday + 1) % 7) in dows):
+        found = t
+        break
+    t += 60
+
+if found is None:
+    sys.exit(1)
+
+# Format the found time in display TZ. Use ZoneInfo if available
+# (Python 3.9+); fall back to UTC label if not.
+try:
+    from zoneinfo import ZoneInfo
+    tz = ZoneInfo(display_tz)
+    dt = datetime.datetime.fromtimestamp(found, tz=tz)
+    iso = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+except Exception:
+    # Best-effort fall back: format as UTC.
+    dt = datetime.datetime.utcfromtimestamp(found)
+    iso = dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+sys.stdout.write("%d %s" % (found, iso))
+sys.exit(0)
+' 2>/dev/null
+)
+PY_RC=$?
+
+# ── Decide ─────────────────────────────────────────────────────────
+emit_deny() {
+  local reason="$1"
+  # JSON-escape: backslashes first, then quotes, then newlines.
+  local esc="${reason//\\/\\\\}"
+  esc="${esc//\"/\\\"}"
+  esc="${esc//$'\n'/\\n}"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$esc"
+  exit 0
+}
+
+# Helper: humanize a delta in seconds.
+human_delta() {
+  local delta="$1"
+  local sign=""
+  if [ "$delta" -lt 0 ]; then
+    sign="-"
+    delta=$(( -delta ))
+  fi
+  local days hours minutes
+  days=$(( delta / 86400 ))
+  hours=$(( (delta % 86400) / 3600 ))
+  minutes=$(( (delta % 3600) / 60 ))
+  if [ "$days" -gt 0 ]; then
+    printf '%s%dd %dh %dm' "$sign" "$days" "$hours" "$minutes"
+  elif [ "$hours" -gt 0 ]; then
+    printf '%s%dh %dm' "$sign" "$hours" "$minutes"
+  else
+    printf '%s%dm' "$sign" "$minutes"
+  fi
+}
+
+# Recovery hint shared across deny messages.
+RECOVERY_HINT='Recovery: container TZ is what the scheduler reads. If you wanted a different display TZ (e.g., ET), rebuild the cron expression with UTC offsets in mind, OR set top-level "timezone" in .claude/zskills-config.json to match the container.'
+
+case "$PY_RC" in
+  2)
+    # Parse error — allow, but WARN to stderr so the scheduler's
+    # own error path takes the surface.
+    echo "block-bad-cron: cron expression '$CRON_EXPR' failed to parse — allowing through; scheduler will surface its own parse error" >&2
+    exit 0
+    ;;
+  1)
+    # No match in 8 days. If recurring, allow (legitimate edge cases:
+    # 0 0 31 2 *, 0 0 29 2 * on non-leap years, etc).
+    if [ "$RECURRING" = "true" ]; then
+      exit 0
+    fi
+    # recurring=false → DENY.
+    NOW_EPOCH_FOR_MSG="${FAKE_NOW_EPOCH:-$(date +%s)}"
+    NOW_DISP=$(TZ="$DISPLAY_TZ" date -d "@$NOW_EPOCH_FOR_MSG" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "(now)")
+    REASON="STOP: CronCreate refused.
+
+  cron expression: $CRON_EXPR
+  recurring:       $RECURRING
+  container TZ:    $CONTAINER_TZ
+  display TZ:      $DISPLAY_TZ
+  now (display):   $NOW_DISP
+
+No match found within 8 days from now. For a one-shot cron (recurring=false), this means the next fire is so far away the Claude Code session will not survive to see it. Most common cause: the expression pins a day-of-month and month that have already passed for this year — cron with no year field rolls over to next year, so the cron sits in CronList for ~365 days and never fires.
+
+$RECOVERY_HINT"
+    emit_deny "$REASON"
+    ;;
+  0)
+    # Got a fire time. Read epoch + iso from PY_OUT.
+    FIRE_EPOCH=$(printf '%s' "$PY_OUT" | awk '{print $1}')
+    FIRE_ISO=$(printf '%s' "$PY_OUT" | cut -d' ' -f2-)
+    NOW_EPOCH_FOR_MSG="${FAKE_NOW_EPOCH:-$(date +%s)}"
+    DELTA=$(( FIRE_EPOCH - NOW_EPOCH_FOR_MSG ))
+    HUMAN=$(human_delta "$DELTA")
+    NOW_DISP=$(TZ="$DISPLAY_TZ" date -d "@$NOW_EPOCH_FOR_MSG" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "(now)")
+
+    # Defensive: delta < 0 (shouldn't be reachable with a forward iter,
+    # but guard anyway). Always deny.
+    if [ "$DELTA" -lt 0 ]; then
+      REASON="STOP: CronCreate refused.
+
+  cron expression: $CRON_EXPR
+  recurring:       $RECURRING
+  container TZ:    $CONTAINER_TZ
+  display TZ:      $DISPLAY_TZ
+  now (display):   $NOW_DISP
+  next fire:       $FIRE_ISO ($HUMAN from now)
+
+Computed next-fire time is in the past. This is a defensive guard against an iterator bug — should not be reachable. Re-check the expression and the system clock.
+
+$RECOVERY_HINT"
+      emit_deny "$REASON"
+    fi
+
+    # recurring=false AND fire > 7 days out → session-lifetime deny.
+    if [ "$RECURRING" = "false" ]; then
+      SEVEN_DAYS=$(( 7 * 24 * 60 * 60 ))
+      if [ "$DELTA" -gt "$SEVEN_DAYS" ]; then
+        REASON="STOP: CronCreate refused.
+
+  cron expression: $CRON_EXPR
+  recurring:       $RECURRING
+  container TZ:    $CONTAINER_TZ
+  display TZ:      $DISPLAY_TZ
+  now (display):   $NOW_DISP
+  next fire:       $FIRE_ISO ($HUMAN from now)
+
+For a one-shot cron (recurring=false), the next fire is more than 7 days from now. Claude Code session lifetime will not reach it. If you intended this fire time, switch to recurring=true. Otherwise, rebuild the cron expression to fire within 7 days.
+
+$RECOVERY_HINT"
+        emit_deny "$REASON"
+      fi
+    fi
+
+    # All checks passed → allow.
+    exit 0
+    ;;
+  *)
+    # Python died for an unexpected reason. Fail-open with a WARN.
+    echo "block-bad-cron: unexpected Python exit code $PY_RC — allowing through" >&2
+    exit 0
+    ;;
+esac

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -72,6 +72,7 @@ run_suite "test-run-plan-sync-pr-body-progress.sh" "tests/test-run-plan-sync-pr-
 run_suite "test-runplan-defer-backoff.sh" "tests/test-runplan-defer-backoff.sh"
 run_suite "test-scope-halt.sh" "tests/test-scope-halt.sh"
 run_suite "test-canary-failures.sh" "tests/test-canary-failures.sh"
+run_suite "test-block-bad-cron.sh" "tests/test-block-bad-cron.sh"
 run_suite "test-block-stale-skill-version.sh" "tests/test-block-stale-skill-version.sh"
 run_suite "test-block-stale-skill-version-sandbox.sh" "tests/test-block-stale-skill-version-sandbox.sh"
 run_suite "test-block-bypassed-land-pr.sh" "tests/test-block-bypassed-land-pr.sh"

--- a/tests/test-block-bad-cron.sh
+++ b/tests/test-block-bad-cron.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Tests for hooks/block-bad-cron.sh
+# Run from repo root: bash tests/test-block-bad-cron.sh
+#
+# Coverage:
+#   T1  Allow: recurring=true future fire (*/5 * * * *)
+#   T2  Allow: recurring=false fire ~2h ahead
+#   T3  DENY: synthetic repro of 2026-05-19 bug — `3 16 19 5 *` recurring=false,
+#       FAKE_NOW = 2026-05-19 16:31:00 UTC (cron evaluated by scheduler in
+#       container UTC, next match is 2027) → no-match-in-8-days reason
+#   T4  DENY: recurring=false with fire >7 days out
+#   T5  Allow w/ WARN: garbage cron expression
+#   T6  Allow: recurring=true 0 0 31 2 * (Feb 31 never matches)
+#   T7  Fallthrough: tool_name=Bash → exit 0, no stdout (early filter)
+#   T8a TZ resolution: TMPDIR config with "timezone":"Europe/London" → deny
+#       message contains 'Europe/London'
+#   T8b TZ resolution fallback: no config → does NOT contain 'America/New_York'
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/block-bad-cron.sh"
+
+TEST_OUT="/tmp/zskills-tests/$(basename "$REPO_ROOT")-block-bad-cron"
+mkdir -p "$TEST_OUT"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  printf '\033[32m  PASS\033[0m %s\n' "$1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+fail() {
+  printf '\033[31m  FAIL\033[0m %s\n' "$1"
+  printf '    %s\n' "$2"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+echo "=== block-bad-cron.sh ==="
+
+# Default CLAUDE_PROJECT_DIR to repo root for cases that don't override.
+export CLAUDE_PROJECT_DIR="$REPO_ROOT"
+
+# Helper — invoke the hook with stdin envelope; capture stdout/stderr/exit.
+run_hook() {
+  local input="$1"
+  local _err
+  _err=$(mktemp -p /tmp zskills-cronhook-err-XXXX)
+  HOOK_OUT=$(printf '%s' "$input" | bash "$HOOK" 2>"$_err")
+  HOOK_EXIT=$?
+  HOOK_ERR=$(cat "$_err")
+  rm -f "$_err"
+}
+
+# Helper — set FAKE_NOW_EPOCH from a UTC time string.
+fake_now() {
+  TZ=UTC date -d "$1" +%s
+}
+
+# ─────────────── T1: recurring=true future fire → allow ───────────
+export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 12:00:00")
+run_hook '{"tool_name":"CronCreate","tool_input":{"cron":"*/5 * * * *","recurring":true,"prompt":"hi"}}'
+if [ "$HOOK_EXIT" -eq 0 ] && [ -z "$HOOK_OUT" ]; then
+  pass "T1: recurring=true future fire → allow (empty stdout, exit 0)"
+else
+  fail "T1: recurring=true should allow" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+unset FAKE_NOW_EPOCH
+
+# ─────────────── T2: recurring=false fire 2h ahead → allow ────────
+# FAKE_NOW=2026-05-19 12:00 UTC, cron=0 14 19 5 * → fires 14:00 UTC same day.
+export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 12:00:00")
+run_hook '{"tool_name":"CronCreate","tool_input":{"cron":"0 14 19 5 *","recurring":false,"prompt":"hi"}}'
+if [ "$HOOK_EXIT" -eq 0 ] && [ -z "$HOOK_OUT" ]; then
+  pass "T2: recurring=false +2h → allow"
+else
+  fail "T2: recurring=false +2h should allow" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+unset FAKE_NOW_EPOCH
+
+# ─────────────── T3: SYNTHETIC REPRO 2026-05-19 BUG ───────────────
+# cron=3 16 19 5 *, recurring=false, FAKE_NOW=2026-05-19 16:31:00 UTC.
+# 16:03 UTC has already passed for May 19 at 16:31. No year field → next
+# match is May 19 2027 → no match in 8 days → DENY.
+export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 16:31:00")
+run_hook '{"tool_name":"CronCreate","tool_input":{"cron":"3 16 19 5 *","recurring":false,"prompt":"hi"}}'
+T3_OK=1
+[ "$HOOK_EXIT" -eq 0 ] || T3_OK=0
+[[ "$HOOK_OUT" == *'"permissionDecision":"deny"'* ]] || T3_OK=0
+[[ "$HOOK_OUT" == *'STOP:'* ]] || T3_OK=0
+[[ "$HOOK_OUT" == *'container TZ'* ]] || T3_OK=0
+[[ "$HOOK_OUT" == *'8 days'* ]] || T3_OK=0
+# Valid JSON envelope.
+if command -v python3 >/dev/null; then
+  python3 -c 'import json,sys; json.loads(sys.stdin.read())' <<< "$HOOK_OUT" >/dev/null 2>&1 || T3_OK=0
+fi
+if [ "$T3_OK" -eq 1 ]; then
+  pass "T3: synthetic 2026-05-19 repro → DENY w/ container-TZ + 8-day reason"
+else
+  fail "T3: synthetic repro must deny" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+unset FAKE_NOW_EPOCH
+
+# ─────────────── T4: recurring=false fire >7 days out → DENY ──────
+# now=2026-05-19 00:00 UTC, cron=0 12 26 5 * → fires 7.5 days later (within 8)
+export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 00:00:00")
+run_hook '{"tool_name":"CronCreate","tool_input":{"cron":"0 12 26 5 *","recurring":false,"prompt":"hi"}}'
+T4_OK=1
+[ "$HOOK_EXIT" -eq 0 ] || T4_OK=0
+[[ "$HOOK_OUT" == *'"permissionDecision":"deny"'* ]] || T4_OK=0
+[[ "$HOOK_OUT" == *'7 days'* ]] || T4_OK=0
+if [ "$T4_OK" -eq 1 ]; then
+  pass "T4: recurring=false fire >7 days → DENY w/ session-lifetime reason"
+else
+  fail "T4: fire >7d should deny" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+unset FAKE_NOW_EPOCH
+
+# ─────────────── T5: garbage cron → allow + WARN to stderr ────────
+run_hook '{"tool_name":"CronCreate","tool_input":{"cron":"not a cron","recurring":false,"prompt":"hi"}}'
+T5_OK=1
+[ "$HOOK_EXIT" -eq 0 ] || T5_OK=0
+[ -z "$HOOK_OUT" ] || T5_OK=0
+[[ "$HOOK_ERR" == *parse* ]] || T5_OK=0
+if [ "$T5_OK" -eq 1 ]; then
+  pass "T5: garbage cron → allow + 'parse' WARN on stderr"
+else
+  fail "T5: garbage should allow w/ WARN" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+
+# ─────────────── T6: recurring=true 0 0 31 2 * → allow ────────────
+# Feb-31 never matches (no Feb 31st exists). With recurring=true, the
+# no-match rule must NOT fire.
+export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 00:00:00")
+run_hook '{"tool_name":"CronCreate","tool_input":{"cron":"0 0 31 2 *","recurring":true,"prompt":"hi"}}'
+if [ "$HOOK_EXIT" -eq 0 ] && [ -z "$HOOK_OUT" ]; then
+  pass "T6: recurring=true Feb-31 → allow (no-match rule must not fire on recurring)"
+else
+  fail "T6: recurring=true Feb-31 should allow" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+unset FAKE_NOW_EPOCH
+
+# ─────────────── T7: tool_name=Bash → fallthrough ─────────────────
+run_hook '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}'
+if [ "$HOOK_EXIT" -eq 0 ] && [ -z "$HOOK_OUT" ]; then
+  pass "T7: tool_name=Bash → fallthrough, no stdout, exit 0"
+else
+  fail "T7: Bash should fall through" "exit=$HOOK_EXIT stdout=$HOOK_OUT err=$HOOK_ERR"
+fi
+
+# ─────────────── T8a: TZ resolution from TMPDIR config ────────────
+T8_TMP=$(mktemp -d -p /tmp zskills-cronhook-T8-XXXX)
+mkdir -p "$T8_TMP/.claude"
+cat > "$T8_TMP/.claude/zskills-config.json" <<'CFG_EOF'
+{"timezone":"Europe/London"}
+CFG_EOF
+(
+  export CLAUDE_PROJECT_DIR="$T8_TMP"
+  export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 16:31:00")
+  printf '%s' '{"tool_name":"CronCreate","tool_input":{"cron":"3 16 19 5 *","recurring":false,"prompt":"hi"}}' | bash "$HOOK"
+) > "$TEST_OUT/t8a.out" 2>"$TEST_OUT/t8a.err"
+T8A_OUT=$(cat "$TEST_OUT/t8a.out")
+if [[ "$T8A_OUT" == *'"permissionDecision":"deny"'* ]] && [[ "$T8A_OUT" == *'Europe/London'* ]]; then
+  pass "T8a: TMPDIR config 'Europe/London' → deny msg contains Europe/London"
+else
+  fail "T8a: TMPDIR London config" "out=$T8A_OUT err=$(cat "$TEST_OUT/t8a.err")"
+fi
+rm -rf "$T8_TMP"
+
+# ─────────────── T8b: TZ resolution fallback (no config) ──────────
+# Goal: prove America/New_York is NOT hardcoded. With config absent, the
+# fallback ladder is $TIMEZONE → $TZ → /etc/timezone → "UTC". On this
+# devcontainer /etc/timezone is "Etc/UTC", so the deny message MUST NOT
+# contain "America/New_York".
+T8B_TMP=$(mktemp -d -p /tmp zskills-cronhook-T8b-XXXX)
+mkdir -p "$T8B_TMP/.claude"
+# No config file written.
+(
+  export CLAUDE_PROJECT_DIR="$T8B_TMP"
+  unset TIMEZONE
+  unset TZ
+  export FAKE_NOW_EPOCH=$(fake_now "2026-05-19 16:31:00")
+  printf '%s' '{"tool_name":"CronCreate","tool_input":{"cron":"3 16 19 5 *","recurring":false,"prompt":"hi"}}' | bash "$HOOK"
+) > "$TEST_OUT/t8b.out" 2>"$TEST_OUT/t8b.err"
+T8B_OUT=$(cat "$TEST_OUT/t8b.out")
+if [[ "$T8B_OUT" == *'"permissionDecision":"deny"'* ]] && [[ "$T8B_OUT" != *'America/New_York'* ]]; then
+  pass "T8b: no config → fallback NOT America/New_York (drift PR UTC convention honored)"
+else
+  fail "T8b: fallback should NOT be America/New_York" "out=$T8B_OUT err=$(cat "$TEST_OUT/t8b.err")"
+fi
+rm -rf "$T8B_TMP"
+
+echo ""
+echo "---"
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

New PreToolUse hook `block-bad-cron.sh` (+ mirror) gates `CronCreate` calls against past-time / wrong-TZ bugs. Closes the bug class that bit us on 2026-05-19.

**Rejects (deny):**
- `recurring=false` AND no match in next 8 days — catches the past-time-rolling-to-next-year bug
- `recurring=false` AND next-fire > 7 days — session-only crons can't survive
- delta < 0 — defensive past-time guard

**Allows with stderr WARN:**
- Parse errors on the cron expression — lets the scheduler surface its own error

**Allows (no warn):**
- `recurring=true` regardless (legitimate edge cases like `0 0 31 * *` exist)
- Anything that passes the reject rules
- Missing Python interpreter or unexpected helper exit code — fails open with noise, never silent deny

**Design:**
- Inline Python via `"$PYTHON" -c '...'` (ZSKILLS_PYTHON precedence per `inject-bash-timeout.sh`). NO `_lib/` file (consumers don't get `_lib/`).
- Display TZ from `.claude/zskills-config.json` top-level `"timezone"`, fallback ladder `$TIMEZONE` → `$TZ` → container-local → UTC. No hardcoded `America/New_York`.
- Deny message cites cron expression, recurring flag, container TZ, display TZ, next-fire time, delta from now, and a recovery hint (rebuild expression in UTC, or set `timezone` config to match the container).

**Today's bug verified denied:** synthetic repro (`3 16 19 5 *`, recurring=false, FAKE_NOW=2026-05-19 16:31 UTC) → DENY with deny message citing container TZ + no-match-in-8-days.

## Why

2026-05-19: orchestrator typed `3 16 19 5 *` intending 4:03 PM ET. Container TZ is UTC, so scheduler read 16:03 UTC = 12:03 PM EDT — past at scheduling. With no year field, next match is May 19 *2027* — a year away, never fires within session. The "eyeball it" workaround was fragile (depends on every future agent remembering); this hook makes the bug class mechanically impossible to commit.

## Test plan

- [x] `bash tests/run-all.sh` → 3596/3596 passed, 0 failed
- [x] 9 hook test cases (8 required + T8 TZ-resolution split into config-present + config-absent)
- [x] Synthetic repro of 2026-05-19 bug denied with expected reasons
- [x] Independent verifier confirmed: hook bites motivating bug, tests strong + isolated, edge cases fail-open safely
- [x] Source/.claude mirrors byte-equal (test-hooks-mirror-parity.sh 21/21)
- [x] `.claude/settings.json` diff: exactly one new matcher block under PreToolUse for CronCreate
- [x] No hardcoded `America/New_York` in hook source (drift-PR's extended deny-list scope verified)

