### PR TITLE
fix(tests): extend test-skill-conformance.sh deny-list scanner to scan block-diagram/ (Closes #458)

### DIFF
--- a/.claude/skills/add-block/SKILL.md
+++ b/.claude/skills/add-block/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Step-by-step guide for adding new block types. Use when the user asks to
   "add a block", "create a new block", or "implement a block".
 metadata:
-  version: "2026.05.20+21a0f9"
+  version: "2026.05.20+0d78b5"
 ---
 
 # Adding Block Types
@@ -414,7 +414,12 @@ describe('NameBlock', () => {
 ### Run tests
 
 ```bash
-npm run test:all
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$FULL_TEST_CMD" ]; then
+  echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+$FULL_TEST_CMD
 ```
 
 All existing tests must continue to pass (unit, E2E, and codegen suites).
@@ -571,6 +576,7 @@ handled by `/add-example` (Step 7), not here.
 
 After codegen is implemented:
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.codegen"
 ```
@@ -595,6 +601,7 @@ Create a GitHub issue and add an entry to `$ZSKILLS_ISSUES_DIR/BUILD_ISSUES.md` 
 
 After deferring codegen, create the deferred marker with the GitHub issue number:
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 printf 'block: %s\ndeferred: true\nissue: #%s\ndate: %s\n' \
   "$BLOCK_NAME" "$ISSUE_NUMBER" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.codegen-deferred"
@@ -705,7 +712,14 @@ variants) exist.
 
 ### Self-audit checklist
 
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])BUILD_ISSUES\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /BUILD_ISSUES.md tail (mirrors skills/fix-issues/SKILL.md:1050 exemption for ISSUES_PLAN.md) -->
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$FULL_TEST_CMD" ]; then
+  echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+
 # 1. Block registered?
 grep "type: 'BlockType'" src/library/block-registry.js
 
@@ -732,7 +746,7 @@ grep '"BlockType"' runtime/src/blocks/mod.rs || \
 grep "BlockType" $ZSKILLS_ISSUES_DIR/BUILD_ISSUES.md
 
 # 9. Tests pass?
-npm run test:all
+$FULL_TEST_CMD
 ```
 
 If ANY check returns nothing (except #4 which is conditional and #8 which

--- a/.claude/skills/add-example/SKILL.md
+++ b/.claude/skills/add-example/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   verification.
 argument-hint: "<block-type(s)> [concept hint]"
 metadata:
-  version: "2026.05.20+7e9e3c"
+  version: "2026.05.20+a1f9b7"
 ---
 
 # Add Example Model
@@ -266,7 +266,12 @@ printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ="${TIMEZONE:-UTC}" date -Isecon
 
 Start dev server if not running:
 ```bash
-npm start &
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$DEV_SERVER_CMD" ]; then
+  echo "ERROR: dev_server.cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+$DEV_SERVER_CMD &
 ```
 
 Use `playwright-cli` to:
@@ -310,7 +315,12 @@ wrong param name produced wrong output. The test passed but the model was broken
 ### 4d. Run all test suites
 
 ```bash
-npm run test:all
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$FULL_TEST_CMD" ]; then
+  echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+$FULL_TEST_CMD
 ```
 
 All 3 suites must pass (unit, e2e, codegen). Report each suite's result.

--- a/block-diagram/add-block/SKILL.md
+++ b/block-diagram/add-block/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Step-by-step guide for adding new block types. Use when the user asks to
   "add a block", "create a new block", or "implement a block".
 metadata:
-  version: "2026.05.20+21a0f9"
+  version: "2026.05.20+0d78b5"
 ---
 
 # Adding Block Types
@@ -414,7 +414,12 @@ describe('NameBlock', () => {
 ### Run tests
 
 ```bash
-npm run test:all
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$FULL_TEST_CMD" ]; then
+  echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+$FULL_TEST_CMD
 ```
 
 All existing tests must continue to pass (unit, E2E, and codegen suites).
@@ -571,6 +576,7 @@ handled by `/add-example` (Step 7), not here.
 
 After codegen is implemented:
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 printf 'block: %s\ncompleted: %s\n' "$BLOCK_NAME" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.codegen"
 ```
@@ -595,6 +601,7 @@ Create a GitHub issue and add an entry to `$ZSKILLS_ISSUES_DIR/BUILD_ISSUES.md` 
 
 After deferring codegen, create the deferred marker with the GitHub issue number:
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 printf 'block: %s\ndeferred: true\nissue: #%s\ndate: %s\n' \
   "$BLOCK_NAME" "$ISSUE_NUMBER" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.add-block.${BLOCK_SLUG}.codegen-deferred"
@@ -705,7 +712,14 @@ variants) exist.
 
 ### Self-audit checklist
 
+<!-- allow-hardcoded: (^|[^A-Za-z0-9_])BUILD_ISSUES\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /BUILD_ISSUES.md tail (mirrors skills/fix-issues/SKILL.md:1050 exemption for ISSUES_PLAN.md) -->
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$FULL_TEST_CMD" ]; then
+  echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+
 # 1. Block registered?
 grep "type: 'BlockType'" src/library/block-registry.js
 
@@ -732,7 +746,7 @@ grep '"BlockType"' runtime/src/blocks/mod.rs || \
 grep "BlockType" $ZSKILLS_ISSUES_DIR/BUILD_ISSUES.md
 
 # 9. Tests pass?
-npm run test:all
+$FULL_TEST_CMD
 ```
 
 If ANY check returns nothing (except #4 which is conditional and #8 which

--- a/block-diagram/add-example/SKILL.md
+++ b/block-diagram/add-example/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   verification.
 argument-hint: "<block-type(s)> [concept hint]"
 metadata:
-  version: "2026.05.20+7e9e3c"
+  version: "2026.05.20+a1f9b7"
 ---
 
 # Add Example Model
@@ -266,7 +266,12 @@ printf 'name: %s\ncompleted: %s\n' "$NAME" "$(TZ="${TIMEZONE:-UTC}" date -Isecon
 
 Start dev server if not running:
 ```bash
-npm start &
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$DEV_SERVER_CMD" ]; then
+  echo "ERROR: dev_server.cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+$DEV_SERVER_CMD &
 ```
 
 Use `playwright-cli` to:
@@ -310,7 +315,12 @@ wrong param name produced wrong output. The test passed but the model was broken
 ### 4d. Run all test suites
 
 ```bash
-npm run test:all
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+if [ -z "$FULL_TEST_CMD" ]; then
+  echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+  exit 1
+fi
+$FULL_TEST_CMD
 ```
 
 All 3 suites must pass (unit, e2e, codegen). Report each suite's result.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1759,7 +1759,7 @@ else
         fi
       done
     done < "$skill_file"
-  done < <(find "$REPO_ROOT/skills" -name '*.md' | sort)
+  done < <(find "$REPO_ROOT/skills" "$REPO_ROOT/block-diagram" -name '*.md' | sort)
 
   if [ "$DRIFT_FAIL" -eq 0 ]; then
     pass "no skill-file drift hardcodes (deny-list clean against tests/fixtures/forbidden-literals.txt)"
@@ -1768,6 +1768,29 @@ else
     for h in "${DRIFT_HITS[@]}"; do
       printf '    %s\n' "$h" >&2
     done
+  fi
+
+  # Regression fixture (#458): the three deny-list/positive-side/coverage
+  # scanner roots MUST cover both skills/ AND block-diagram/. Without this,
+  # the #454 sweep's regression mode (re-injecting TZ=America/New_York or
+  # `npm run test:all` into a block-diagram SKILL.md) silently passes
+  # conformance. Inspect the live scanner source for the dual-root find
+  # invocation. Fails closed if a future edit drops `block-diagram` from
+  # any of the three sites.
+  SELF="$REPO_ROOT/tests/test-skill-conformance.sh"
+  bd_root_hits=$(grep -cE 'find "\$REPO_ROOT/skills" "\$REPO_ROOT/block-diagram"' "$SELF" 2>/dev/null || echo 0)
+  # Also count the positive-side scanner's `extra_root` plumbing (a 4th-arg
+  # variant that passes the second root through the helper function).
+  bd_extra_root_hits=$(grep -cE 'scan_positive_side "\$REPO_ROOT/skills".*"\$REPO_ROOT/block-diagram"' "$SELF" 2>/dev/null || echo 0)
+  # Expected: 2 dual-root find invocations (deny-list at ~line 1762, prose-
+  # imperative coverage at ~line 2408) + 1 scan_positive_side with extra_root
+  # (real-tree case). Total >= 3 references to block-diagram across the
+  # three scanner-root sites.
+  bd_total=$((bd_root_hits + bd_extra_root_hits))
+  if [ "$bd_total" -ge 3 ]; then
+    pass "deny-list/positive-side/coverage scanners all scope block-diagram/ (#458 regression fixture: found $bd_total of 3 expected block-diagram scan-root references)"
+  else
+    fail "deny-list scanner scope regression" "expected 3 block-diagram scan-root references in $SELF (2 dual-root find + 1 scan_positive_side extra_root), got $bd_total — at least one of the three scanner roots has regressed to skills/-only (#458)"
   fi
 fi
 
@@ -1943,9 +1966,13 @@ POS_DRIFT_HITS=()
 POS_VAR_RE='\$\{?(UNIT_TEST_CMD|FULL_TEST_CMD|TIMEZONE|DEV_SERVER_CMD|TEST_OUTPUT_FILE|COMMIT_CO_AUTHOR)\}?'
 
 scan_positive_side() {
+  # First positional arg is a single root (kept for callers that pass one
+  # root); additional roots may be passed as a comma-separated list via
+  # the 4th positional (root2) — caller convenience for two-root scans.
   local target_root="$1"
   local fail_var_name="$2"
   local hits_var_name="$3"
+  local extra_root="${4:-}"
   local local_fail=0
   local -a local_hits=()
   while IFS= read -r skill_file; do
@@ -2037,7 +2064,13 @@ scan_positive_side() {
         fi
       fi
     done < "$skill_file"
-  done < <(find "$target_root" -name '*.md' | sort)
+  done < <(
+    if [ -n "$extra_root" ]; then
+      find "$target_root" "$extra_root" -name '*.md' | sort
+    else
+      find "$target_root" -name '*.md' | sort
+    fi
+  )
   # Export results via name-refs.
   printf -v "$fail_var_name" '%s' "$local_fail"
   if [ "$local_fail" -eq 1 ]; then
@@ -2092,10 +2125,14 @@ fi
 
 rm -rf "$POS_FIXTURE_DIR"
 
-# Real-tree case: scan current skills/ — expect 0 drift after Phase 2 migration.
+# Real-tree case: scan current skills/ AND block-diagram/ — expect 0 drift
+# after Phase 2 migration. block-diagram/ added under #458 closure (the
+# companion deny-list scanner above already extends to block-diagram/; the
+# positive-side scanner extends here for symmetry — same surface PR #454
+# swept).
 REAL_POS_FAIL=0
 REAL_POS_HITS=()
-scan_positive_side "$REPO_ROOT/skills" REAL_POS_FAIL REAL_POS_HITS
+scan_positive_side "$REPO_ROOT/skills" REAL_POS_FAIL REAL_POS_HITS "$REPO_ROOT/block-diagram"
 if [ "$REAL_POS_FAIL" -eq 0 ]; then
   pass "positive-side real-tree: every fence using a config-var also sources zskills-resolve-config.sh"
 else
@@ -2405,7 +2442,7 @@ while IFS= read -r skill_file; do
       fi
     fi
   done
-done < <(find "$REPO_ROOT/skills" -name '*.md' | sort)
+done < <(find "$REPO_ROOT/skills" "$REPO_ROOT/block-diagram" -name '*.md' | sort)
 
 # Guard against vacuous pass: if zero sites were detected, the regex broke.
 # Plan enumerates 9 PROSE-IMPERATIVE sites (8 test-cmd + 1 dev-server).


### PR DESCRIPTION
## Summary

Extends `tests/test-skill-conformance.sh`'s 3 deny-list/positive-side/prose-imperative scanner roots to scan both `$REPO_ROOT/skills` AND `$REPO_ROOT/block-diagram`. The hardcoded `skills`-only roots left `block-diagram/`'s SKILL.md files invisible to the CI gate — exactly the surface PR #454 explicitly migrated 17 TZ hits across.

The extended scope surfaced more pre-existing block-diagram drift than the issue body originally claimed (3 → 7 hits). All handled:

| File | Site | Resolution |
|---|---|---|
| `block-diagram/add-block/SKILL.md` | `npm run test:all` fences (417, 740) | Migrated to `$FULL_TEST_CMD` + preamble |
| `block-diagram/add-block/SKILL.md` | `TIMEZONE` fences (578, 602) | Added helper-source preamble |
| `block-diagram/add-block/SKILL.md` | `BUILD_ISSUES.md` basename (743) | Added `<!-- allow-hardcoded: ... -->` marker (path IS resolved; basename is genuine anchor) |
| `block-diagram/add-example/SKILL.md` | `npm start &` (269) | Migrated to `$DEV_SERVER_CMD &` + preamble |
| `block-diagram/add-example/SKILL.md` | `npm run test:all` (313) | Migrated to `$FULL_TEST_CMD` + preamble |

Adds a regression-fixture test that inspects the live scanner source to assert all three roots include `block-diagram`, failing closed if the scope ever regresses.

Closes #458.

## Test plan

- [x] Full suite passes: 3597/3597, 0 failed.
- [x] Pre-fix branch had 2 failures (the extended scope surfaced pre-existing block-diagram drift); fix brings to clean pass.
- [x] Regression-fixture test inspects live scanner source — fails closed if any of the 3 find invocations regresses to `skills`-only.
- [x] All 2 modified block-diagram skills get metadata.version bumps; pre-commit hook accepts the commit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
