### PR TITLE
fix(hooks): block force-prefix push to main (`+main` bypass) (Closes #457)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -604,6 +604,13 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # layer each side so quoted bash-c / eval inner strings still classify.
   PUSH_TARGET="${PUSH_TARGET%\'}"; PUSH_TARGET="${PUSH_TARGET#\'}"
   PUSH_TARGET="${PUSH_TARGET%\"}"; PUSH_TARGET="${PUSH_TARGET#\"}"
+  # Strip leading '+' from force-prefix refspec form. `git push origin +main`
+  # is the no-colon force-push spelling; without this strip, PUSH_TARGET=+main
+  # falls through the equality check against literal "main" and the rule
+  # doesn't fire (#457). Strip after the colon-RHS normalization so forms
+  # like `+HEAD:main` (already reduced to "main") and `+main` (reduced to
+  # "+main") both classify correctly.
+  PUSH_TARGET="${PUSH_TARGET#+}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -604,6 +604,13 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # layer each side so quoted bash-c / eval inner strings still classify.
   PUSH_TARGET="${PUSH_TARGET%\'}"; PUSH_TARGET="${PUSH_TARGET#\'}"
   PUSH_TARGET="${PUSH_TARGET%\"}"; PUSH_TARGET="${PUSH_TARGET#\"}"
+  # Strip leading '+' from force-prefix refspec form. `git push origin +main`
+  # is the no-colon force-push spelling; without this strip, PUSH_TARGET=+main
+  # falls through the equality check against literal "main" and the rule
+  # doesn't fire (#457). Strip after the colon-RHS normalization so forms
+  # like `+HEAD:main` (already reduced to "main") and `+main` (reduced to
+  # "+main") both classify correctly.
+  PUSH_TARGET="${PUSH_TARGET#+}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -374,6 +374,13 @@ expect_deny "git push origin :main (deletion attempt — #392)" "git push origin
 expect_deny "git push origin abc123:master (sha:master refspec — #392)" "git push origin abc123:master"
 expect_deny "git push -u origin feat:main (upstream + refspec — #392)" "git push -u origin feat:main"
 
+# Issue #457: force-prefix refspec (+main) — no colon, leading '+'. Pre-fix
+# normalization stripped colon-LHS and quotes but not '+', so PUSH_TARGET
+# stayed "+main" and the equality check against literal "main" missed.
+expect_deny "git push origin +main (force-prefix — #457)" "git push origin +main"
+expect_deny "git push origin +master (force-prefix master — #457)" "git push origin +master"
+expect_deny "git push origin +HEAD:main (force-prefix with refspec — #457)" "git push origin +HEAD:main"
+
 echo ""
 echo "=== Push: BLOCK_MAIN_PUSH preset toggle ==="
 


### PR DESCRIPTION
## Summary

`block-unsafe-generic.sh`'s BLOCK_MAIN_PUSH check normalized refspec-LHS and quotes before equality-checking against `"main"`, but never stripped a leading `+`. So the force-prefix form `git push origin +main` (no colon, no quote) fell straight through to `exit 0`. Strip the leading `+` during normalization so `+main`/`+master`/`+HEAD:main` are caught the same as bare `main`/`master`.

Adds 3 test cases to `tests/test-hooks.sh` covering the force-prefix forms, placed adjacent to the existing #392 refspec block.

Closes #457.

## Test plan

- [x] Full suite passes: 3604/3604.
- [x] New test cases assert deny for `+main`, `+master`, `+HEAD:main`.
- [x] Existing positive cases (`git push origin main`, etc.) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
