### PR TITLE
fix(hooks): close +main bypasses surviving #465 — project hook regex + refs/heads strip (Closes #470)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -611,6 +611,13 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # like `+HEAD:main` (already reduced to "main") and `+main` (reduced to
   # "+main") both classify correctly.
   PUSH_TARGET="${PUSH_TARGET#+}"
+  # Strip leading 'refs/heads/' prefix. `git push origin refs/heads/main` is
+  # the fully-qualified branch ref spelling that Git accepts as equivalent
+  # to `main`; without this strip, PUSH_TARGET="refs/heads/main" falls
+  # through the equality check against literal "main" and the rule doesn't
+  # fire (#470). Strip after the '+' strip so `+refs/heads/main` also
+  # normalizes to "main".
+  PUSH_TARGET="${PUSH_TARGET#refs/heads/}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -1029,10 +1029,12 @@ if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
     esac
   done
   # (a) Explicit origin main/master (optionally prefixed with + for
-  # force-push or : for delete-refspec). Trailing class includes `'` and
-  # `"` so wrapper-unwrapped forms like `bash -c 'git push origin main'`
-  # → PUSH_ARGS containing trailing `main'` still match (#399).
-  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\"|\') ]]; then
+  # force-push or : for delete-refspec, and optionally fully-qualified as
+  # refs/heads/main). Trailing class includes `'` and `"` so
+  # wrapper-unwrapped forms like `bash -c 'git push origin main'` →
+  # PUSH_ARGS containing trailing `main'` still match (#399). The optional
+  # `refs/heads/` prefix closes the fully-qualified-ref bypass (#470).
+  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(refs/heads/)?(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (b) Any <localref>:main or <localref>:master refspec — covers HEAD:main,
@@ -1042,7 +1044,11 @@ if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
   # requires `main` immediately after `origin`). Match any token ending
   # in `:main` or `:master` (including the empty-local deletion form).
   # Trailing class also includes `'` for wrapper-unwrapped forms (#399).
-  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\"|\') ]]; then
+  # `[+]?` allows the force-prefix `:+main` form (#470 — pre-fix
+  # `feat:+main` slipped this rule because `+` was not optional after `:`).
+  # `(refs/heads/)?` allows the fully-qualified form `feat:refs/heads/main`
+  # (#470).
+  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:[+]?(refs/heads/)?(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -611,6 +611,13 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # like `+HEAD:main` (already reduced to "main") and `+main` (reduced to
   # "+main") both classify correctly.
   PUSH_TARGET="${PUSH_TARGET#+}"
+  # Strip leading 'refs/heads/' prefix. `git push origin refs/heads/main` is
+  # the fully-qualified branch ref spelling that Git accepts as equivalent
+  # to `main`; without this strip, PUSH_TARGET="refs/heads/main" falls
+  # through the equality check against literal "main" and the rule doesn't
+  # fire (#470). Strip after the '+' strip so `+refs/heads/main` also
+  # normalizes to "main".
+  PUSH_TARGET="${PUSH_TARGET#refs/heads/}"
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -1029,10 +1029,12 @@ if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
     esac
   done
   # (a) Explicit origin main/master (optionally prefixed with + for
-  # force-push or : for delete-refspec). Trailing class includes `'` and
-  # `"` so wrapper-unwrapped forms like `bash -c 'git push origin main'`
-  # → PUSH_ARGS containing trailing `main'` still match (#399).
-  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(main|master)([[:space:]]|$|\"|\') ]]; then
+  # force-push or : for delete-refspec, and optionally fully-qualified as
+  # refs/heads/main). Trailing class includes `'` and `"` so
+  # wrapper-unwrapped forms like `bash -c 'git push origin main'` →
+  # PUSH_ARGS containing trailing `main'` still match (#399). The optional
+  # `refs/heads/` prefix closes the fully-qualified-ref bypass (#470).
+  if [[ "$PUSH_ARGS" =~ origin[[:space:]]+[+:]?(refs/heads/)?(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (b) Any <localref>:main or <localref>:master refspec — covers HEAD:main,
@@ -1042,7 +1044,11 @@ if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
   # requires `main` immediately after `origin`). Match any token ending
   # in `:main` or `:master` (including the empty-local deletion form).
   # Trailing class also includes `'` for wrapper-unwrapped forms (#399).
-  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:(main|master)([[:space:]]|$|\"|\') ]]; then
+  # `[+]?` allows the force-prefix `:+main` form (#470 — pre-fix
+  # `feat:+main` slipped this rule because `+` was not optional after `:`).
+  # `(refs/heads/)?` allows the fully-qualified form `feat:refs/heads/main`
+  # (#470).
+  if [[ "$PUSH_ARGS" =~ (^|[[:space:]])[^[:space:]]*:[+]?(refs/heads/)?(main|master)([[:space:]]|$|\"|\') ]]; then
     block_with_reason "BLOCKED: Cannot push to main (main_protected: true in .claude/zskills-config.json). Push a feature branch instead. To change: edit .claude/zskills-config.json"
   fi
   # (c) Naked push (no origin arg) while on main — based on PUSH_ARGS,

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -381,6 +381,17 @@ expect_deny "git push origin +main (force-prefix — #457)" "git push origin +ma
 expect_deny "git push origin +master (force-prefix master — #457)" "git push origin +master"
 expect_deny "git push origin +HEAD:main (force-prefix with refspec — #457)" "git push origin +HEAD:main"
 
+# Issue #470: fully-qualified refs/heads/main — Git accepts this as
+# equivalent to `main` but pre-fix neither hook stripped the `refs/heads/`
+# prefix, so PUSH_TARGET stayed "refs/heads/main" and the equality check
+# against literal "main" missed. Strip after the '+' strip so combined
+# forms (+refs/heads/main, refs/heads/+main, feat:refs/heads/main) all
+# normalize.
+expect_deny "git push origin refs/heads/main (fully-qualified — #470)" "git push origin refs/heads/main"
+expect_deny "git push origin refs/heads/master (fully-qualified master — #470)" "git push origin refs/heads/master"
+expect_deny "git push origin +refs/heads/main (force + fully-qualified — #470)" "git push origin +refs/heads/main"
+expect_deny "git push origin feat:refs/heads/main (refspec + fully-qualified — #470)" "git push origin feat:refs/heads/main"
+
 echo ""
 echo "=== Push: BLOCK_MAIN_PUSH preset toggle ==="
 
@@ -1448,6 +1459,51 @@ if [[ "$RESULT" == *"Cannot push to main"* ]]; then
   pass "main_protected: push origin abc123:master (#392) blocked"
 else
   fail "main_protected: push origin abc123:master should be blocked, got: $RESULT"
+fi
+
+# Issue #470: project-hook rule (b) — `feat:+main` slipped because the regex
+# didn't allow an optional `+` between `:` and `main`. Generic hook caught
+# this via the `${X##*:}` + `${X#+}` layered normalization, but the project
+# hook (active under main_protected: true) didn't.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin feat:+main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin feat:+main (#470 — force after refspec colon) blocked"
+else
+  fail "main_protected: push origin feat:+main should be blocked, got: $RESULT"
+fi
+
+# Issue #470: project-hook rule (a) — `refs/heads/main` slipped because
+# neither rule allowed the fully-qualified `refs/heads/` prefix. Git accepts
+# this as equivalent to `main`.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin refs/heads/main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin refs/heads/main (#470 — fully-qualified ref) blocked"
+else
+  fail "main_protected: push origin refs/heads/main should be blocked, got: $RESULT"
+fi
+
+# Issue #470: project-hook rule (a) — `refs/heads/master` equivalent.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin refs/heads/master")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin refs/heads/master (#470) blocked"
+else
+  fail "main_protected: push origin refs/heads/master should be blocked, got: $RESULT"
+fi
+
+# Issue #470: combined force + fully-qualified.
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin +refs/heads/main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin +refs/heads/main (#470 — force + fully-qualified) blocked"
+else
+  fail "main_protected: push origin +refs/heads/main should be blocked, got: $RESULT"
+fi
+
+# Issue #470: combined refspec + fully-qualified — rule (b).
+RESULT=$(run_main_protected_test "feat/test" '{"execution": {"main_protected": true}}' "git push origin feat:refs/heads/main")
+if [[ "$RESULT" == *"Cannot push to main"* ]]; then
+  pass "main_protected: push origin feat:refs/heads/main (#470 — refspec + fully-qualified) blocked"
+else
+  fail "main_protected: push origin feat:refs/heads/main should be blocked, got: $RESULT"
 fi
 
 # Regression guard: rule (b)'s broadened regex must NOT trip on a legitimate


### PR DESCRIPTION
## Summary

PR #465 closed `+main` on the generic hook via `${X#+}` strip after colon-RHS extraction. Two surfaces survived:

1. **Project hook rule (b)** at `hooks/block-unsafe-project.sh.template` lacked `[+]?` between `:` and `main` — so `feat:+main` slipped under `main_protected: true`.
2. **Neither hook stripped `refs/heads/`** — so `refs/heads/main` slipped both hooks.

Adds `[+]?` and `(refs/heads/)?` to the project-hook rule (a) + (b) regex, and a `${PUSH_TARGET#refs/heads/}` strip to the generic-hook normalization. 9 new test cases cover the surviving bypasses + defense-in-depth.

Closes #470.

## Test plan

- [x] Full suite: 3617/3617 pass (delta +9 from new tests).
- [x] Regex verified live: rule (a) matches `origin main` / `origin refs/heads/main` / `origin +main` / `origin +refs/heads/main`; rule (b) matches `feat:main` / `feat:+main` / `feat:refs/heads/main`.
- [x] No false positives on legitimate paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
