### PR TITLE
fix(hooks): block destructive `git switch` flags (Closes #478)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -411,6 +411,19 @@ if is_git_subcommand_in_wrappers "$COMMAND" restore; then
   block_with_reason "BLOCKED: git restore discards uncommitted changes permanently. If you need to undo your own change, use git diff to see what changed and edit it back manually."
 fi
 
+# git switch with destructive flags — modern analog of `git checkout --`.
+# `git switch --discard-changes` and `git switch -f` / `git switch --force`
+# all destroy unstaged working-tree changes (per `git help switch`). Plain
+# `git switch <branch>` and `git switch -c new-branch` are allowed; git
+# itself refuses on dirty trees without the destructive opt-in flag.
+# `git rebase` is intentionally NOT blocked here — reflog + `--abort` make
+# rebases recoverable, and a blanket block would false-positive on the
+# `-X theirs` rescue patterns CLAUDE.md teaches. Wrapper-recursion via
+# is_git_subcommand_in_wrappers (#478, completes #426).
+if is_git_subcommand_in_wrappers "$COMMAND" switch && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(--discard-changes|--force|-f)([[:space:]]|$) ]]; then
+  block_with_reason "BLOCKED: git switch --discard-changes / -f / --force discards uncommitted changes permanently (modern analog of git checkout --). If you need to switch branches with dirty state, commit or stash first; if you genuinely want to discard, ask the user."
+fi
+
 # git clean -f (permanent file deletion)
 # Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
 if is_git_subcommand_in_wrappers "$COMMAND" clean && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]]; then

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -411,6 +411,19 @@ if is_git_subcommand_in_wrappers "$COMMAND" restore; then
   block_with_reason "BLOCKED: git restore discards uncommitted changes permanently. If you need to undo your own change, use git diff to see what changed and edit it back manually."
 fi
 
+# git switch with destructive flags — modern analog of `git checkout --`.
+# `git switch --discard-changes` and `git switch -f` / `git switch --force`
+# all destroy unstaged working-tree changes (per `git help switch`). Plain
+# `git switch <branch>` and `git switch -c new-branch` are allowed; git
+# itself refuses on dirty trees without the destructive opt-in flag.
+# `git rebase` is intentionally NOT blocked here — reflog + `--abort` make
+# rebases recoverable, and a blanket block would false-positive on the
+# `-X theirs` rescue patterns CLAUDE.md teaches. Wrapper-recursion via
+# is_git_subcommand_in_wrappers (#478, completes #426).
+if is_git_subcommand_in_wrappers "$COMMAND" switch && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])(--discard-changes|--force|-f)([[:space:]]|$) ]]; then
+  block_with_reason "BLOCKED: git switch --discard-changes / -f / --force discards uncommitted changes permanently (modern analog of git checkout --). If you need to switch branches with dirty state, commit or stash first; if you genuinely want to discard, ask the user."
+fi
+
 # git clean -f (permanent file deletion)
 # Wrapper-recursion via is_git_subcommand_in_wrappers (#426).
 if is_git_subcommand_in_wrappers "$COMMAND" clean && [[ "$GIT_SUB_REST" =~ (^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$) ]]; then

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -103,6 +103,18 @@ expect_allow "git checkout -b feat/foo"         "git checkout -b feat/foo"
 # 3. git restore file
 expect_deny "git restore file" "git restore file.js"
 
+# 3a. git switch with destructive flags (modern analog of `git checkout --`).
+# #478: discard-changes / -f / --force destroy unstaged work; plain switch
+# and `-c` (create-new-branch) remain allowed because git refuses on dirty
+# tree without the opt-in flag.
+expect_deny  "git switch --discard-changes"       "git switch --discard-changes my-branch"
+expect_deny  "git switch -f"                      "git switch -f main"
+expect_deny  "git switch --force"                 "git switch --force feat/x"
+expect_allow "git switch <branch> (plain)"        "git switch main"
+expect_allow "git switch -c new-branch"           "git switch -c new-branch"
+# Defense-in-depth: wrapper-aware match via is_git_subcommand_in_wrappers
+expect_deny  "WB-switch: bash -c 'git switch -f'" "bash -c 'git switch -f main'"
+
 # 4. git clean -fd
 expect_deny "git clean -fd" "git clean -fd"
 


### PR DESCRIPTION
## Summary

The existing hook blocks `git checkout -- <file>` (destructive working-tree restore) but has no analog for the modern equivalents. Adds deny coverage for:

- `git switch --discard-changes` — explicit destructive flag
- `git switch -f` / `git switch --force` — force-switch discards unstaged changes

Excludes `git rebase` (recoverable via reflog + `--abort`; a blanket block would false-positive on the `-X theirs` rescue patterns CLAUDE.md teaches). Uses the wrapper-aware helper so `bash -c 'git switch -f ...'` is also covered.

Closes #478.

## Test plan

- [x] Full suite: 3614/3614 pass (delta +6).
- [x] Wrapper coverage verified: `bash -c 'git switch -f main'` denies via `is_git_subcommand_in_wrappers`.
- [x] Allow cases verified: plain `git switch main` and `git switch -c new-branch` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
