### PR TITLE
fix(dashboard): plan-activity filter uses canonical `pipeline` key (Closes #473)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.20+7861fd"
+  version: "2026.05.20+8f02a6"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -837,7 +837,7 @@ class MonitorHandler(BaseHTTPRequestHandler):
         # Activity scoped to this plan (best-effort filter on slug field).
         all_activity = _collect._scan_tracking_markers(main_root, errors=[])
         parsed["activity"] = [
-            a for a in all_activity if slug in str(a.get("pipeline_id", ""))
+            a for a in all_activity if slug in str(a.get("pipeline", ""))
         ]
         self._send_json(200, parsed)
 

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.20+7861fd"
+  version: "2026.05.20+8f02a6"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -837,7 +837,7 @@ class MonitorHandler(BaseHTTPRequestHandler):
         # Activity scoped to this plan (best-effort filter on slug field).
         all_activity = _collect._scan_tracking_markers(main_root, errors=[])
         parsed["activity"] = [
-            a for a in all_activity if slug in str(a.get("pipeline_id", ""))
+            a for a in all_activity if slug in str(a.get("pipeline", ""))
         ]
         self._send_json(200, parsed)
 

--- a/tests/test_zskills_monitor_server.sh
+++ b/tests/test_zskills_monitor_server.sh
@@ -338,6 +338,26 @@ if start_server "$MR5" "$PORT_D"; then
     fail "/api/plan body missing slug"
   fi
 
+  # #473: activity[] filter must match the canonical `pipeline` key
+  # (not the old `pipeline_id`). Seed a tracking marker under a pipeline
+  # subdir whose name contains the plan slug, then verify activity[]
+  # picks it up.
+  mkdir -p "$MR5/.zskills/tracking/run-sample-plan-001"
+  cat >"$MR5/.zskills/tracking/run-sample-plan-001/fulfilled.test" <<'MARKER'
+date: 2026-05-20T10:00:00-04:00
+skill: test
+status: ok
+output: /dev/null
+MARKER
+  PLAN_BODY=$(curl -sf -m 3 "http://127.0.0.1:$PORT_D/api/plan/sample-plan")
+  # activity[] must be non-empty AND contain the seeded pipeline name.
+  if printf '%s' "$PLAN_BODY" | grep -q '"activity":[[:space:]]*\[[[:space:]]*{' \
+     && printf '%s' "$PLAN_BODY" | grep -q '"pipeline":[[:space:]]*"run-sample-plan-001"'; then
+    pass "/api/plan activity[] filters on canonical 'pipeline' key (#473)"
+  else
+    fail "/api/plan activity[] empty or missing seeded marker (#473); body: $PLAN_BODY"
+  fi
+
   # 404 for unknown slug
   CODE=$(curl -s -o /dev/null -w '%{http_code}' \
     "http://127.0.0.1:$PORT_D/api/plan/does-not-exist")


### PR DESCRIPTION
## Summary

`server.py:840` filtered tracking-marker records on the key `pipeline_id`, but the canonical key emitted by `collect.py` (3 sites: 727/763/918) is `pipeline` — same as the `.zskills/tracking/$PIPELINE_ID/` directory naming convention. Result: filter always returned empty `activity[]` for plan-detail pages.

One-line rename of the filter key on the broken side (the filter is the lone outlier; data side has 3 sites + matches the directory convention). Adds a regression test that seeds a tracking marker and asserts non-empty `activity[]`.

Closes #473.

## Test plan

- [x] Full suite: 3624/3624 pass.
- [x] Regression test exercises the end-to-end filter: seed marker → call `/api/plan/<slug>` → assert `activity[]` contains the seeded pipeline.
- [x] All 3 collect.py emit sites verified to use `pipeline` (not `pipeline_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
