### PR TITLE
fix(land-pr): pr-rebase.sh dirty-tree precondition with dedicated exit code 16 (Closes #481)

### DIFF
--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.20+5abdda"
+  version: "2026.05.20+2dee67"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -282,6 +282,17 @@ if [ -z "$PR_RESUME" ]; then
     # rebase-failed so the orchestrator surfaces the classification
     # instead of falling through to STATUS="" and proceeding silently.
     # REASON is already captured to wrong-current-branch above.
+    # Jump to step 9.
+  elif [ "$REBASE_RC" -eq 16 ]; then
+    STATUS="rebase-failed"
+    # Issue #481: pr-rebase.sh exits 16 when the working tree has
+    # uncommitted changes (REASON=dirty-working-tree). Pre-#481 the
+    # dirty-tree case fell through to the generic exit-11 terminus,
+    # surfacing as REASON=rebase-failed and indistinguishable from real
+    # conflicts, network failures, or abort failures. Map to
+    # rebase-failed (same terminus class) but preserve REASON=
+    # dirty-working-tree so the orchestrator can tell users "commit or
+    # stash first" instead of misdiagnosing as a real rebase failure.
     # Jump to step 9.
   fi
 fi

--- a/.claude/skills/land-pr/scripts/pr-rebase.sh
+++ b/.claude/skills/land-pr/scripts/pr-rebase.sh
@@ -24,6 +24,7 @@
 #   10 — rebase conflicts (CONFLICT_FILES_LIST sidecar populated)
 #   11 — other failure (REASON populated)
 #   14 — wrong current branch (CWD's HEAD != $BRANCH; REASON=wrong-current-branch)
+#   16 — dirty working tree (uncommitted changes; REASON=dirty-working-tree)
 #   2  — usage error
 
 set -u
@@ -85,6 +86,21 @@ if [ "$ACTUAL_HEAD" != "$BRANCH" ]; then
   cat "$STDERR_LOG" >&2
   echo "REASON=wrong-current-branch"
   exit 14
+fi
+
+# 2c. Verify the working tree is clean. `git rebase` itself would refuse on
+#     dirty state, but the surfaced failure mode is indistinguishable from
+#     a real conflict / network error / abort failure when funnelled
+#     through the generic exit-11 terminus below. Categorize the
+#     dirty-tree case explicitly so /land-pr Step 3 can map it to a
+#     dedicated REASON (Issue #481, sibling of #420). Symmetric to the
+#     #420 wrong-current-branch guard above. CLAUDE.md "Protect untracked
+#     files before git operations" applies to rebase here.
+DIRTY=$(git status --porcelain)
+if [ -n "$DIRTY" ]; then
+  echo "ERROR: pr-rebase.sh: working tree has uncommitted changes — refusing to rebase. Commit or stash first." >&2
+  echo "REASON=dirty-working-tree"
+  exit 16
 fi
 
 # 3. Fetch the base.

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.20+5abdda"
+  version: "2026.05.20+2dee67"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -282,6 +282,17 @@ if [ -z "$PR_RESUME" ]; then
     # rebase-failed so the orchestrator surfaces the classification
     # instead of falling through to STATUS="" and proceeding silently.
     # REASON is already captured to wrong-current-branch above.
+    # Jump to step 9.
+  elif [ "$REBASE_RC" -eq 16 ]; then
+    STATUS="rebase-failed"
+    # Issue #481: pr-rebase.sh exits 16 when the working tree has
+    # uncommitted changes (REASON=dirty-working-tree). Pre-#481 the
+    # dirty-tree case fell through to the generic exit-11 terminus,
+    # surfacing as REASON=rebase-failed and indistinguishable from real
+    # conflicts, network failures, or abort failures. Map to
+    # rebase-failed (same terminus class) but preserve REASON=
+    # dirty-working-tree so the orchestrator can tell users "commit or
+    # stash first" instead of misdiagnosing as a real rebase failure.
     # Jump to step 9.
   fi
 fi

--- a/skills/land-pr/scripts/pr-rebase.sh
+++ b/skills/land-pr/scripts/pr-rebase.sh
@@ -24,6 +24,7 @@
 #   10 — rebase conflicts (CONFLICT_FILES_LIST sidecar populated)
 #   11 — other failure (REASON populated)
 #   14 — wrong current branch (CWD's HEAD != $BRANCH; REASON=wrong-current-branch)
+#   16 — dirty working tree (uncommitted changes; REASON=dirty-working-tree)
 #   2  — usage error
 
 set -u
@@ -85,6 +86,21 @@ if [ "$ACTUAL_HEAD" != "$BRANCH" ]; then
   cat "$STDERR_LOG" >&2
   echo "REASON=wrong-current-branch"
   exit 14
+fi
+
+# 2c. Verify the working tree is clean. `git rebase` itself would refuse on
+#     dirty state, but the surfaced failure mode is indistinguishable from
+#     a real conflict / network error / abort failure when funnelled
+#     through the generic exit-11 terminus below. Categorize the
+#     dirty-tree case explicitly so /land-pr Step 3 can map it to a
+#     dedicated REASON (Issue #481, sibling of #420). Symmetric to the
+#     #420 wrong-current-branch guard above. CLAUDE.md "Protect untracked
+#     files before git operations" applies to rebase here.
+DIRTY=$(git status --porcelain)
+if [ -n "$DIRTY" ]; then
+  echo "ERROR: pr-rebase.sh: working tree has uncommitted changes — refusing to rebase. Commit or stash first." >&2
+  echo "REASON=dirty-working-tree"
+  exit 16
 fi
 
 # 3. Fetch the base.

--- a/tests/test-land-pr-rebase-rc14-parser.sh
+++ b/tests/test-land-pr-rebase-rc14-parser.sh
@@ -43,7 +43,9 @@ for anchor in \
   'if [ "$REBASE_RC" -eq 10 ]; then' \
   'elif [ "$REBASE_RC" -eq 11 ]; then' \
   'elif [ "$REBASE_RC" -eq 14 ]; then' \
-  'Issue #420: pr-rebase.sh exits 14 when CWD'"'"'s HEAD != $BRANCH'
+  'elif [ "$REBASE_RC" -eq 16 ]; then' \
+  'Issue #420: pr-rebase.sh exits 14 when CWD'"'"'s HEAD != $BRANCH' \
+  'Issue #481: pr-rebase.sh exits 16 when the working tree has'
 do
   if ! grep -qF "$anchor" "$SKILL_FILE"; then
     fail "[anchor] SKILL.md missing Step 3 RC parser anchor: $anchor" "(Issue #420 regression)"
@@ -101,6 +103,8 @@ run_step3_parser() {
     STATUS="rebase-failed"
   elif [ "$REBASE_RC" -eq 14 ]; then
     STATUS="rebase-failed"
+  elif [ "$REBASE_RC" -eq 16 ]; then
+    STATUS="rebase-failed"
   fi
 
   echo "STATUS=$STATUS"
@@ -154,15 +158,30 @@ else
   fail "[case4] RC 14 (Issue #420)" "STATUS='$S' REASON='$R' (expected STATUS=rebase-failed REASON=wrong-current-branch)"
 fi
 
-# ===== Case 5: unknown RC (e.g., 99) → STATUS empty (explicit fall-through).
-# Documents that the parser is closed on {10, 11, 14}; any new pr-rebase.sh
-# exit code added in the future needs its own mapping (same pattern as #420).
+# ===== Case 5: RC 16 dirty-working-tree → STATUS=rebase-failed, REASON=dirty-working-tree
+# This is the Issue #481 case. Pre-fix the dirty-tree case fell through to
+# the generic exit-11 terminus, surfacing as REASON=rebase-failed and
+# indistinguishable from real conflicts, network failures, abort failures.
+REBASE_STDOUT=$'REASON=dirty-working-tree'
+REBASE_RC=16
+OUT=$(run_step3_parser)
+S=$(echo "$OUT" | grep '^STATUS=' | cut -d= -f2-)
+R=$(echo "$OUT" | grep '^REASON=' | cut -d= -f2-)
+if [ "$S" = "rebase-failed" ] && [ "$R" = "dirty-working-tree" ]; then
+  pass "[case5] RC 16 (dirty-working-tree) → STATUS=rebase-failed + REASON=dirty-working-tree (Issue #481)"
+else
+  fail "[case5] RC 16 (Issue #481)" "STATUS='$S' REASON='$R' (expected STATUS=rebase-failed REASON=dirty-working-tree)"
+fi
+
+# ===== Case 6: unknown RC (e.g., 99) → STATUS empty (explicit fall-through).
+# Documents that the parser is closed on {10, 11, 14, 16}; any new pr-rebase.sh
+# exit code added in the future needs its own mapping (same pattern as #420/#481).
 REBASE_STDOUT="" REBASE_RC=99 OUT=$(run_step3_parser)
 S=$(echo "$OUT" | grep '^STATUS=' | cut -d= -f2-)
 if [ -z "$S" ]; then
-  pass "[case5] unknown RC 99 → STATUS empty (documents closed mapping set; add new RC explicitly)"
+  pass "[case6] unknown RC 99 → STATUS empty (documents closed mapping set; add new RC explicitly)"
 else
-  fail "[case5] unknown RC fall-through" "STATUS='$S' (expected empty)"
+  fail "[case6] unknown RC fall-through" "STATUS='$S' (expected empty)"
 fi
 
 echo ""

--- a/tests/test-land-pr-scripts.sh
+++ b/tests/test-land-pr-scripts.sh
@@ -103,6 +103,8 @@ counter() {
 #   call 1: rev-parse --is-inside-work-tree → exit 0
 #   call 2: rev-parse --verify refs/heads/<branch> → exit 0
 #   call 3: rev-parse --abbrev-ref HEAD → stdout=<branch> (Issue #397 guard)
+#   call 1: status --porcelain → stdout="" (Issue #481 dirty-tree guard;
+#          empty = clean tree, proceed)
 #   call 1: fetch origin <base> → exit 0
 prep_rebase_preflight_ok() {
   local sd="$1"
@@ -110,6 +112,7 @@ prep_rebase_preflight_ok() {
   prep_git "$sd" rev-parse 1 exit 0
   prep_git "$sd" rev-parse 2 exit 0
   prep_git "$sd" rev-parse 3 stdout "$branch"
+  prep_git "$sd" status    1 stdout ""
   prep_git "$sd" fetch     1 exit 0
 }
 
@@ -174,6 +177,7 @@ F=$(new_fixture mode3)
 prep_git "$F/state-git" rev-parse 1 exit 0
 prep_git "$F/state-git" rev-parse 2 exit 0
 prep_git "$F/state-git" rev-parse 3 stdout 'feat/x'
+prep_git "$F/state-git" status    1 stdout ""
 prep_git "$F/state-git" fetch     1 exit 1
 prep_git "$F/state-git" fetch     1 stderr 'fatal: could not resolve hostname'
 run_sut "$F" bash "$SCRIPTS_DIR/pr-rebase.sh" --branch feat/x --base main
@@ -524,6 +528,40 @@ cleanup_fixture "$F"
 # in [mode1]/[mode2]/[idem1]/[slug] above — those tests would fail-loud
 # (mock-git exit 99 "no canned response") if the script bypassed the
 # HEAD call.
+
+# ----------------------------------------------------------------------
+# Issue #481 regression: pr-rebase.sh asserts a clean working tree
+# BEFORE calling git rebase. Pre-fix code fell through to the generic
+# line-130 failure terminus emitting REASON=rebase-failed exit 11 for
+# ALL of: dirty working tree, network failure, abort failure, real
+# rebase conflict — overloaded across 4 distinct failure modes.
+# /land-pr Step 3 couldn't distinguish.
+# Assertion: when `git status --porcelain` returns non-empty, pr-rebase.sh
+# exits 16 with REASON=dirty-working-tree, no fetch, no rebase.
+# ----------------------------------------------------------------------
+F=$(new_fixture issue481_dirty_tree)
+prep_git "$F/state-git" rev-parse 1 exit 0
+prep_git "$F/state-git" rev-parse 2 exit 0
+prep_git "$F/state-git" rev-parse 3 stdout 'feat/x'
+# git status --porcelain returns non-empty → dirty tree.
+prep_git "$F/state-git" status 1 stdout $' M src/foo.js\n?? new-untracked.txt'
+run_sut "$F" bash "$SCRIPTS_DIR/pr-rebase.sh" --branch feat/x --base main
+if [ "$SUT_RC" -eq 16 ] \
+   && [[ "$SUT_OUT" == *"REASON=dirty-working-tree"* ]] \
+   && [[ "$SUT_ERR" == *"uncommitted changes"* ]] \
+   && [ "$(counter "$F/state-git" fetch)" = "0" ] \
+   && [ "$(counter "$F/state-git" rebase)" = "0" ]; then
+  pass "[issue481] pr-rebase refuses dirty working tree (exit 16, no fetch, no rebase)"
+else
+  fail "[issue481] pr-rebase dirty-tree guard" "rc=$SUT_RC out=$SUT_OUT err=$SUT_ERR fetch=$(counter "$F/state-git" fetch) rebase=$(counter "$F/state-git" rebase)"
+fi
+cleanup_fixture "$F"
+
+# Companion: the dirty-tree-check happy-path uses `git status --porcelain`
+# returning empty; rebase proceeds. The prep_rebase_preflight_ok helper
+# below MUST be updated to prep the status call as exit 0 (empty stdout),
+# else [mode1]/[mode2]/[idem1]/[slug]/[mode3..] would fail-loud (mock-git
+# exit 99 "no canned response").
 
 # ----------------------------------------------------------------------
 # Issue #188 regression: pr-push-and-create.sh must push $BRANCH


### PR DESCRIPTION
## Summary

`pr-rebase.sh` previously fell through to the generic line-130 failure terminus emitting `REASON=rebase-failed` exit 11 for ALL of: dirty working tree, network failure, abort-failed, generic rebase failure. `/land-pr` Step 3 couldn't distinguish — exit 11 was overloaded across 4 failure modes.

Adds a `git status --porcelain` precondition before the rebase invocation. On dirty tree: exits 16 with `REASON=dirty-working-tree` and a clear stderr message. `/land-pr` Step 3 maps exit 16 to `STATUS=rebase-failed REASON=dirty-working-tree`, preserving the rebase-failed terminus while surfacing the specific cause.

Closes #481.

## Test plan

- [x] Full suite: 3633/3633 pass (delta +5).
- [x] Script-level test mocks dirty tree → asserts exit 16, REASON, no fetch, no rebase.
- [x] Parser test asserts exit 16 maps cleanly through /land-pr Step 3 to STATUS/REASON.
- [x] Existing happy-path tests still pass (helper prepped with empty `git status` response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
