### PR TITLE
fix(land-pr): pr-monitor.sh post-force-push grace period — sleep+re-poll on first-poll fail (Closes #482)

### DIFF
--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.20+2dee67"
+  version: "2026.05.20+e3cf3d"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/.claude/skills/land-pr/scripts/pr-monitor.sh
+++ b/.claude/skills/land-pr/scripts/pr-monitor.sh
@@ -112,9 +112,27 @@ fi
 
 # Step 5 — Re-check (per fix 87af82a). `gh pr checks` (no --watch) DOES
 # signal pass/fail/pending via exit code: 0=pass, 1=fail, 8=pending.
+#
+# Post-force-push grace (Closes #482). Step 6b's auto-rebase loop force-
+# pushes then immediately invokes pr-monitor.sh; GitHub takes ~5s to
+# register the new check run, so a first-poll rc=1 often reflects the
+# stale prior run (which failed) rather than the new run. Memory anchor
+# `feedback_pr_monitor_false_fail.md` documents 3+ false-fail observations
+# in a single 2026-05-17 session. Mitigation: on first-poll rc=1, sleep
+# 5s and re-run ONCE — the second result wins. Adds at most 5s to a real
+# CI failure (negligible vs. the 600s --watch budget) and eliminates the
+# documented race. Single re-poll (not a generic retry loop) — bounded
+# and cheap.
 set +e
 gh pr checks "$PR_NUMBER" >/dev/null 2>"$STDERR_LOG"
 RECHECK_RC=$?
+if [ "$RECHECK_RC" -eq 1 ]; then
+  # ${PR_MONITOR_RECHECK_SLEEP:-5} — test seam: tests can set 0 to skip
+  # the wall-clock wait while still exercising the retry path.
+  sleep "${PR_MONITOR_RECHECK_SLEEP:-5}"
+  gh pr checks "$PR_NUMBER" >/dev/null 2>"$STDERR_LOG"
+  RECHECK_RC=$?
+fi
 set -e
 
 CI_STATUS="unknown"

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.20+2dee67"
+  version: "2026.05.20+e3cf3d"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/skills/land-pr/scripts/pr-monitor.sh
+++ b/skills/land-pr/scripts/pr-monitor.sh
@@ -112,9 +112,27 @@ fi
 
 # Step 5 — Re-check (per fix 87af82a). `gh pr checks` (no --watch) DOES
 # signal pass/fail/pending via exit code: 0=pass, 1=fail, 8=pending.
+#
+# Post-force-push grace (Closes #482). Step 6b's auto-rebase loop force-
+# pushes then immediately invokes pr-monitor.sh; GitHub takes ~5s to
+# register the new check run, so a first-poll rc=1 often reflects the
+# stale prior run (which failed) rather than the new run. Memory anchor
+# `feedback_pr_monitor_false_fail.md` documents 3+ false-fail observations
+# in a single 2026-05-17 session. Mitigation: on first-poll rc=1, sleep
+# 5s and re-run ONCE — the second result wins. Adds at most 5s to a real
+# CI failure (negligible vs. the 600s --watch budget) and eliminates the
+# documented race. Single re-poll (not a generic retry loop) — bounded
+# and cheap.
 set +e
 gh pr checks "$PR_NUMBER" >/dev/null 2>"$STDERR_LOG"
 RECHECK_RC=$?
+if [ "$RECHECK_RC" -eq 1 ]; then
+  # ${PR_MONITOR_RECHECK_SLEEP:-5} — test seam: tests can set 0 to skip
+  # the wall-clock wait while still exercising the retry path.
+  sleep "${PR_MONITOR_RECHECK_SLEEP:-5}"
+  gh pr checks "$PR_NUMBER" >/dev/null 2>"$STDERR_LOG"
+  RECHECK_RC=$?
+fi
 set -e
 
 CI_STATUS="unknown"

--- a/tests/test-land-pr-scripts.sh
+++ b/tests/test-land-pr-scripts.sh
@@ -326,6 +326,85 @@ fi
 cleanup_fixture "$F"
 
 # ----------------------------------------------------------------------
+# Issue #482 — post-force-push grace: first-poll rc=1 + second rc=0 →
+# CI_STATUS=pass (NOT fail). After Step 6b's force-push, GitHub takes
+# ~5s to register the new check run; pr-monitor.sh Step 5 retries once
+# on rc=1 so the stale prior failed run doesn't surface as a false fail.
+# PR_MONITOR_RECHECK_SLEEP=0 skips the wall-clock wait for testing.
+#
+# Sequence:
+#   auth_status   → 0
+#   pr_checks   1 → stdout=[{...}] (CHECK_COUNT=1, success)
+#   pr_checks   2 → exit 0 (timeout-watch returns 0, not 124)
+#   pr_checks   3 → exit 1 (first re-check: stale prior-run still fail)
+#   pr_checks   4 → exit 0 (second re-check after grace: new run passes)
+# ----------------------------------------------------------------------
+F=$(new_fixture issue482_grace)
+mkdir -p "$F/work"
+prep_gh "$F/state-gh" auth_status 1 exit 0
+prep_gh "$F/state-gh" pr_checks   1 stdout '[{"name":"build"}]'
+prep_gh "$F/state-gh" pr_checks   2 exit 0
+prep_gh "$F/state-gh" pr_checks   3 exit 1
+prep_gh "$F/state-gh" pr_checks   4 exit 0
+SUT_OUT_FILE="$F/sut.stdout"
+SUT_ERR_FILE="$F/sut.stderr"
+set +e
+PATH="$F/bin:$PATH" \
+  MOCK_GH_STATE_DIR="$F/state-gh" \
+  MOCK_GIT_STATE_DIR="$F/state-git" \
+  PR_MONITOR_RECHECK_SLEEP=0 \
+  bash "$SCRIPTS_DIR/pr-monitor.sh" --pr 42 --timeout 1 --log-out "$F/work/ci.log" \
+  >"$SUT_OUT_FILE" 2>"$SUT_ERR_FILE"
+SUT_RC=$?
+set -e
+SUT_OUT=$(cat "$SUT_OUT_FILE")
+SUT_ERR=$(cat "$SUT_ERR_FILE")
+# Expect: CI_STATUS=pass (second poll wins), AND pr_checks was called 4
+# times total (the retry happened).
+if [ "$SUT_RC" -eq 0 ] \
+   && [[ "$SUT_OUT" == *"CI_STATUS=pass"* ]] \
+   && [ "$(counter "$F/state-gh" pr_checks)" = "4" ]; then
+  pass "[issue482] monitor-post-force-push-grace: fail-then-pass → CI_STATUS=pass (4 pr_checks calls)"
+else
+  fail "[issue482] monitor-post-force-push-grace" "rc=$SUT_RC out=$SUT_OUT pr_checks_count=$(counter "$F/state-gh" pr_checks)"
+fi
+cleanup_fixture "$F"
+
+# Companion: both polls return rc=1 → still CI_STATUS=fail (real failure,
+# retry doesn't mask). Ensures the retry isn't a license to ignore
+# persistent failures.
+F=$(new_fixture issue482_persistent_fail)
+mkdir -p "$F/work"
+prep_gh "$F/state-gh" auth_status 1 exit 0
+prep_gh "$F/state-gh" pr_checks   1 stdout '[{"name":"build"}]'
+prep_gh "$F/state-gh" pr_checks   2 exit 0
+prep_gh "$F/state-gh" pr_checks   3 exit 1
+prep_gh "$F/state-gh" pr_checks   4 exit 1
+# After CI_STATUS=fail, the script attempts to fetch run id for log capture
+# (Step 6). It calls `gh pr checks --json link` once and `gh run view` once.
+prep_gh "$F/state-gh" pr_checks   5 stdout '[]'
+SUT_OUT_FILE="$F/sut.stdout"
+SUT_ERR_FILE="$F/sut.stderr"
+set +e
+PATH="$F/bin:$PATH" \
+  MOCK_GH_STATE_DIR="$F/state-gh" \
+  MOCK_GIT_STATE_DIR="$F/state-git" \
+  PR_MONITOR_RECHECK_SLEEP=0 \
+  bash "$SCRIPTS_DIR/pr-monitor.sh" --pr 42 --timeout 1 --log-out "$F/work/ci.log" \
+  >"$SUT_OUT_FILE" 2>"$SUT_ERR_FILE"
+SUT_RC=$?
+set -e
+SUT_OUT=$(cat "$SUT_OUT_FILE")
+if [ "$SUT_RC" -eq 0 ] \
+   && [[ "$SUT_OUT" == *"CI_STATUS=fail"* ]] \
+   && [ "$(counter "$F/state-gh" pr_checks)" = "5" ]; then
+  pass "[issue482] monitor-persistent-fail: fail-then-fail → CI_STATUS=fail (retry attempted, both failed)"
+else
+  fail "[issue482] monitor-persistent-fail" "rc=$SUT_RC out=$SUT_OUT pr_checks_count=$(counter "$F/state-gh" pr_checks)"
+fi
+cleanup_fixture "$F"
+
+# ----------------------------------------------------------------------
 # Failure mode #9 — auto-merge-disabled-on-repo (benign, exit 0)
 # ----------------------------------------------------------------------
 F=$(new_fixture mode9)


### PR DESCRIPTION
## Summary

After Step 6b's auto-rebase-BEHIND force-push, GitHub takes ~5s to register the new check run. `pr-monitor.sh` trusted the first `gh pr checks` exit code with zero grace, so the stale prior run's `rc=1` surfaced as a false `CI_STATUS=fail`. Memory anchor `feedback_pr_monitor_false_fail.md` documented repeated incidents.

Adds a single inline retry: if first poll returns `rc=1`, sleep 5s then re-run once; second result wins. Fix lives in the script so Step 6b inherits the corrected contract for free — no SKILL.md prose changes needed. Sleep duration is env-overrideable via `PR_MONITOR_RECHECK_SLEEP` for test seam (defaults to 5s in production).

Closes #482.

## Test plan

- [x] Full suite: 3631/3631 pass.
- [x] Two new test cases: (1) fail-then-pass mock → CI_STATUS=pass (retry works); (2) persistent fail → CI_STATUS=fail (retry doesn't mask real failures).
- [x] Env-overrideable sleep means tests run instantly without the 5s wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
