### PR TITLE
fix(fix-report): replace literal `npm run test:all` with $FULL_TEST_CMD (Closes #477)

### DIFF
--- a/.claude/skills/fix-report/SKILL.md
+++ b/.claude/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.18+5b806e"
+  version: "2026.05.20+c8b30f"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -448,7 +448,9 @@ not "3 fixes in category" but one per fix.
   synthetic event limitations)
 - **Pre-existing Bugs Discovered** — bugs found during verification,
   not related to sprint fixes (Bug, Found During, Location, Severity)
-- **Test Suite Status** — `Command: npm run test:all` + per-suite counts
+- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via
+  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
+  if not already in environment) + per-suite counts
 
 **Append, don't overwrite** — new items go at the top of each domain
 section. Already-verified items stay as `✅`. Returning from a fix

--- a/skills/fix-report/SKILL.md
+++ b/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.18+5b806e"
+  version: "2026.05.20+c8b30f"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -448,7 +448,9 @@ not "3 fixes in category" but one per fix.
   synthetic event limitations)
 - **Pre-existing Bugs Discovered** — bugs found during verification,
   not related to sprint fixes (Bug, Found During, Location, Severity)
-- **Test Suite Status** — `Command: npm run test:all` + per-suite counts
+- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via
+  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
+  if not already in environment) + per-suite counts
 
 **Append, don't overwrite** — new items go at the top of each domain
 section. Already-verified items stay as `✅`. Returning from a fix


### PR DESCRIPTION
## Summary

`skills/fix-report/SKILL.md:451` contained literal `` `Command: npm run test:all` `` in a bullet whose label-prefix ("Test Suite Status") didn't match the deny-list scanner's prose-imperative gate (which requires Run/Execute/Invoke prefix), so the literal slipped through despite being a deny-list pattern.

Fix is the authoring side (option 1 from the issue body): replace with `$FULL_TEST_CMD` placeholder, plus required substitution-discipline annotation (`(resolve via . ".../zskills-resolve-config.sh" if not already in environment)`) per the canonical form already used in `skills/do/modes/direct.md:18` and `skills/run-plan/SKILL.md:1479`.

Scanner-coverage gap (broaden imperative-verb gate to also cover label-prefix forms) deferred as a separate judgment-class follow-up.

Closes #477.

## Test plan

- [x] Full suite: 3652/3652 pass.
- [x] PROSE-IMPERATIVE substitution-discipline coverage check now passes (was the constraint that forced the annotation form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
