### PR TITLE
docs(update-zskills): list block-bad-cron + block-main-edits in install list (Closes #505)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.20+78e88b"
+  version: "2026.05.20+45bef1"
 ---
 
 # Update Z Skills Infrastructure
@@ -1088,6 +1088,18 @@ Copy missing hooks from `$PORTABLE/hooks/` to `.claude/hooks/`.
   `bash .claude/hooks/verify-response-validate.sh ...` from skill
   prose.
 - For `block-stale-skill-version.sh`: copy as-is from `$PORTABLE/hooks/` to `.claude/hooks/`.
+- For `block-bad-cron.sh`: copy as-is from `$PORTABLE/hooks/` to
+  `.claude/hooks/`. Wired into `settings.json` as PreToolUse on the
+  `CronCreate` matcher (see canonical-triples table below). Rejects
+  one-shot crons whose next-fire is in the past or > 7 days out
+  (closes a TZ-confusion class of "the cron never fired" bugs; PR #456).
+- For `block-main-edits.sh`: copy as-is from `$PORTABLE/hooks/` to
+  `.claude/hooks/`. Wired into `settings.json` as PreToolUse on the
+  `Edit|Write|NotebookEdit` matcher (see canonical-triples table below).
+  Honors `execution.main_protected` from `.claude/zskills-config.json` —
+  denies edits to files inside the main repo working tree when
+  `main_protected: true`, with narrow allowlists for `.zskills/` and
+  gitignored worktree-state markers (issue #308).
 - For `scripts/test-all.sh`: copy as-is from
   `$PORTABLE/scripts/`. Reads `testing.unit_cmd` from
   `.claude/zskills-config.json` at runtime — no
@@ -1195,10 +1207,12 @@ not in this table is foreign and preserved untouched):
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-stale-skill-version.sh"`      |
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bypassed-land-pr.sh"`         |
 | PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`                   |
+| PreToolUse   | CronCreate | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bad-cron.sh"`              |
+| PreToolUse   | Edit\|Write\|NotebookEdit | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-edits.sh"` |
 | PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 | PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 
-All 7 rows carry `"type": "command"` and `"timeout": 5`. The
+All 9 rows carry `"type": "command"` and `"timeout": 5`. The
 `warn-config-drift.sh` hook lands in Phase 3 of
 `plans/DRIFT_ARCH_FIX.md`; the two PostToolUse rows become live once
 that hook is installed.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.20+78e88b"
+  version: "2026.05.20+45bef1"
 ---
 
 # Update Z Skills Infrastructure
@@ -1088,6 +1088,18 @@ Copy missing hooks from `$PORTABLE/hooks/` to `.claude/hooks/`.
   `bash .claude/hooks/verify-response-validate.sh ...` from skill
   prose.
 - For `block-stale-skill-version.sh`: copy as-is from `$PORTABLE/hooks/` to `.claude/hooks/`.
+- For `block-bad-cron.sh`: copy as-is from `$PORTABLE/hooks/` to
+  `.claude/hooks/`. Wired into `settings.json` as PreToolUse on the
+  `CronCreate` matcher (see canonical-triples table below). Rejects
+  one-shot crons whose next-fire is in the past or > 7 days out
+  (closes a TZ-confusion class of "the cron never fired" bugs; PR #456).
+- For `block-main-edits.sh`: copy as-is from `$PORTABLE/hooks/` to
+  `.claude/hooks/`. Wired into `settings.json` as PreToolUse on the
+  `Edit|Write|NotebookEdit` matcher (see canonical-triples table below).
+  Honors `execution.main_protected` from `.claude/zskills-config.json` —
+  denies edits to files inside the main repo working tree when
+  `main_protected: true`, with narrow allowlists for `.zskills/` and
+  gitignored worktree-state markers (issue #308).
 - For `scripts/test-all.sh`: copy as-is from
   `$PORTABLE/scripts/`. Reads `testing.unit_cmd` from
   `.claude/zskills-config.json` at runtime — no
@@ -1195,10 +1207,12 @@ not in this table is foreign and preserved untouched):
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-stale-skill-version.sh"`      |
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bypassed-land-pr.sh"`         |
 | PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`                   |
+| PreToolUse   | CronCreate | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bad-cron.sh"`              |
+| PreToolUse   | Edit\|Write\|NotebookEdit | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-edits.sh"` |
 | PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 | PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 
-All 7 rows carry `"type": "command"` and `"timeout": 5`. The
+All 9 rows carry `"type": "command"` and `"timeout": 5`. The
 `warn-config-drift.sh` hook lands in Phase 3 of
 `plans/DRIFT_ARCH_FIX.md`; the two PostToolUse rows become live once
 that hook is installed.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1239,6 +1239,18 @@ check_fixed update-zskills "Step C triples: PostToolUse Edit warn-config-drift" 
   'PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`'
 check_fixed update-zskills "Step C triples: PostToolUse Write warn-config-drift" \
   'PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`'
+# Issue #505 — block-bad-cron.sh (#456) and block-main-edits.sh (#308) were
+# wired into .claude/settings.json but missing from SKILL.md install bullets
+# AND canonical-triples table; fresh installs silently lacked both hooks.
+check_fixed update-zskills "Step C triples: PreToolUse CronCreate block-bad-cron (#505)" \
+  'PreToolUse   | CronCreate | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bad-cron.sh"`'
+check_fixed update-zskills "Step C triples: PreToolUse Edit|Write|NotebookEdit block-main-edits (#505)" \
+  'PreToolUse   | Edit\|Write\|NotebookEdit | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-edits.sh"`'
+# Install-bullet copies must also enumerate both hooks (Step C copy loop).
+check_fixed update-zskills "Step C install bullet: block-bad-cron.sh (#505)" \
+  'For `block-bad-cron.sh`: copy as-is from `$PORTABLE/hooks/` to'
+check_fixed update-zskills "Step C install bullet: block-main-edits.sh (#505)" \
+  'For `block-main-edits.sh`: copy as-is from `$PORTABLE/hooks/` to'
 
 # WI 2.7.3 — Preserve rule: never overwrite, never reorder top-level keys.
 check_fixed update-zskills "Step C preserve: never overwrite"         'never overwrite'


### PR DESCRIPTION
## Summary

Both `block-bad-cron.sh` (PR #456) and `block-main-edits.sh` (#308) exist on disk and are wired into the repo's own `.claude/settings.json`, but `skills/update-zskills/SKILL.md` Step C install list (1068-1101) and the canonical-triples table (1191-1199) never named either hook. Fresh consumers running `/update-zskills install` silently missed both protections.

Adds the missing entries:
- Step C install list — 2 bullets citing the source PRs + matchers
- Canonical-triples table — 2 rows: `block-bad-cron.sh` (matcher: `CronCreate`), `block-main-edits.sh` (matcher: `Edit|Write|NotebookEdit`)
- Sentinel: `All 7 rows` → `All 9 rows`
- 4 conformance assertions in `tests/test-skill-conformance.sh` lock the entries in place

Closes #505.

## Test plan

- [x] Full suite: 3657/3657 pass (delta +4 new conformance assertions).
- [x] All 4 new assertions verify the table rows + install bullets exist with expected matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
