### PR TITLE
fix(dashboard): TTL-cache collect_snapshot fan-out (Closes #514)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.20+8f02a6"
+  version: "2026.05.20+7d9f9d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -97,6 +97,19 @@ ERRORS_CAP = 100
 # gh issue cache TTL (seconds).
 ISSUE_CACHE_TTL_SECONDS = 60
 
+# Per-subsystem collect_snapshot fan-out TTLs (seconds). Tuned to each
+# subsystem's natural change frequency vs the 2Hz client poll cadence.
+# See issue #514 for the latency analysis that motivated this.
+#
+# `time.monotonic()` is the TTL clock — NOT `time.time()` — because wall
+# clock can jump on NTP sync. Monotonic guarantees a non-decreasing tick
+# regardless of wall-time corrections.
+SNAPSHOT_CACHE_TTL_WORKTREES = 5.0       # git worktree list
+SNAPSHOT_CACHE_TTL_BRANCHES = 5.0        # git for-each-ref
+SNAPSHOT_CACHE_TTL_GIT_HISTORY = 10.0    # git log
+SNAPSHOT_CACHE_TTL_PLANS = 3.0           # parse_plan + parse_report + landing-mode
+SNAPSHOT_CACHE_TTL_TRACKING = 3.0        # .zskills/tracking/ walk + PR-number scan
+
 
 # ---------------------------------------------------------------------------
 # Module-level cache (per-Python-process; documented limitation per DA-14)
@@ -108,12 +121,56 @@ _ISSUE_CACHE: Dict[str, Any] = {
     "had_value": False,
 }
 
+# Per-subsystem snapshot cache: maps (kind, main_root_str) →
+# (monotonic_ts, value, errors_from_that_call). On cache hit, the
+# captured errors are re-extended onto the new caller's errors list so
+# the per-snapshot errors block stays accurate.
+_SNAPSHOT_CACHE: Dict[Tuple[str, str], Tuple[float, Any, List[Dict[str, str]]]] = {}
+
 
 def _reset_issue_cache_for_tests() -> None:
     """Reset the module-level cache (test-only helper)."""
     _ISSUE_CACHE["ts"] = 0.0
     _ISSUE_CACHE["issues"] = []
     _ISSUE_CACHE["had_value"] = False
+
+
+def _reset_snapshot_cache_for_tests() -> None:
+    """Reset the per-subsystem snapshot cache (test-only helper)."""
+    _SNAPSHOT_CACHE.clear()
+
+
+def _cached_subsystem(
+    kind: str,
+    main_root: pathlib.Path,
+    ttl: float,
+    fn: Any,
+    errors: List[Dict[str, str]],
+    *,
+    _now: Optional[float] = None,
+) -> Any:
+    """Cache the result of `fn(local_errors)` keyed by (kind, main_root).
+
+    `fn` is called with a fresh `local_errors` list so cached error
+    records can be replayed without double-counting on cache hits. If
+    `fn` raises, the cache is NOT updated — fail-loud, no stale value
+    poisoning. The monotonic clock is used (NTP-safe). TTL of 0 disables
+    caching entirely (always re-fetch).
+    """
+    now = _now if _now is not None else time.monotonic()
+    key = (kind, str(main_root))
+    cached = _SNAPSHOT_CACHE.get(key)
+    if cached is not None and ttl > 0 and (now - cached[0]) < ttl:
+        _ts, value, cached_errors = cached
+        if cached_errors:
+            errors.extend(cached_errors)
+        return value
+    local_errors: List[Dict[str, str]] = []
+    value = fn(local_errors)
+    _SNAPSHOT_CACHE[key] = (now, value, list(local_errors))
+    if local_errors:
+        errors.extend(local_errors)
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -1605,14 +1662,19 @@ def collect_snapshot(
         main_root = _resolve_main_root(repo_root)
     errors: List[Dict[str, str]] = []
 
-    plans_dir = _resolve_paths(main_root)["plans_dir"]
-    plans: List[Dict[str, Any]] = []
-    if plans_dir.is_dir():
+    # Plans + reports — TTL-cached per subsystem (#514). The plan files
+    # change on /run-plan phase ticks (minutes, not seconds); a 3s TTL
+    # absorbs ~7 of every 10 polls without showing stale phase state.
+    def _build_plans(local_errors: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+        plans_dir = _resolve_paths(main_root)["plans_dir"]
+        out: List[Dict[str, Any]] = []
+        if not plans_dir.is_dir():
+            return out
         try:
             plan_files = sorted(plans_dir.glob("*.md"))
         except Exception as exc:
             plan_files = []
-            errors.append({
+            local_errors.append({
                 "source": "plans scan",
                 "message": str(exc),
             })
@@ -1621,7 +1683,9 @@ def collect_snapshot(
             if parsed is None:
                 continue
             content = parsed.pop("_content", "")
-            parsed["landing_mode"] = _resolve_landing_mode(content, main_root, errors)
+            parsed["landing_mode"] = _resolve_landing_mode(
+                content, main_root, local_errors,
+            )
             # Report enrichment
             report = parse_report(parsed["slug"], main_root)
             parsed["has_report"] = report is not None
@@ -1633,9 +1697,23 @@ def collect_snapshot(
                 parsed["file"] = str(rel)
             except Exception:
                 pass
-            plans.append(parsed)
+            out.append(parsed)
+        return out
 
-    # State file merge (drives queue annotations + queues block)
+    plans = _cached_subsystem(
+        "plans", main_root, SNAPSHOT_CACHE_TTL_PLANS, _build_plans, errors,
+    )
+    # Defensive shallow copy: caller _annotate_plans_queue mutates each
+    # plan dict in place, but those mutations are state-file-derived
+    # (queue position, column) and the same state file is read fresh
+    # every poll — so re-annotation produces a deterministic result. We
+    # copy the OUTER list so re-orderings don't leak, but trust the
+    # per-plan dicts to be re-annotated to a consistent state.
+    plans = list(plans)
+
+    # State file merge (drives queue annotations + queues block).
+    # Uncached — sub-ms read; staleness here would break the live-source
+    # invariant for queue annotations.
     state = _read_state_file(main_root, errors)
     state_updated_at = state.get("updated_at", "")
     _annotate_plans_queue(plans, state)
@@ -1648,18 +1726,41 @@ def collect_snapshot(
     issues, issues_fetch_ok = list_issues(errors, _runner=issue_runner)
     _annotate_issues_queue(issues, state, main_root)
 
-    # Worktrees + branches
-    worktrees = _list_worktrees(main_root, errors)
-    branches = _list_branches(main_root, errors)
+    # Worktrees + branches — TTL-cached subsystems (#514). Both run git
+    # subprocesses; both change at human-action cadence (worktree create
+    # / branch checkout), not 2Hz polls.
+    worktrees = _cached_subsystem(
+        "worktrees", main_root, SNAPSHOT_CACHE_TTL_WORKTREES,
+        lambda e: _list_worktrees(main_root, e), errors,
+    )
+    branches = _cached_subsystem(
+        "branches", main_root, SNAPSHOT_CACHE_TTL_BRANCHES,
+        lambda e: _list_branches(main_root, e), errors,
+    )
 
     # Tracking activity + git-history events (commits with no marker).
     # Tracking markers are richer (skill, id, pipeline) so they win on
     # dedup; commits whose trailing `(#N)` matches a fulfilled.land-pr.*
-    # marker's PR number are dropped.
-    marker_activity = _scan_tracking_markers(main_root, errors)
-    fulfilled_prs = _extract_pr_numbers_from_markers(main_root)
-    git_activity = _scan_git_history(
-        main_root, errors, fulfilled_pr_numbers=fulfilled_prs,
+    # marker's PR number are dropped. Tracking markers + their PR-number
+    # extraction are grouped under one "tracking" subsystem (#514) —
+    # they walk the same `.zskills/tracking/` tree.
+    def _build_tracking(
+        local_errors: List[Dict[str, str]],
+    ) -> Tuple[List[Dict[str, Any]], set]:
+        marker_activity = _scan_tracking_markers(main_root, local_errors)
+        fulfilled_prs = _extract_pr_numbers_from_markers(main_root)
+        return marker_activity, fulfilled_prs
+
+    marker_activity, fulfilled_prs = _cached_subsystem(
+        "tracking", main_root, SNAPSHOT_CACHE_TTL_TRACKING,
+        _build_tracking, errors,
+    )
+    git_activity = _cached_subsystem(
+        "git_history", main_root, SNAPSHOT_CACHE_TTL_GIT_HISTORY,
+        lambda e: _scan_git_history(
+            main_root, e, fulfilled_pr_numbers=fulfilled_prs,
+        ),
+        errors,
     )
     activity = marker_activity + git_activity
 

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.20+8f02a6"
+  version: "2026.05.20+7d9f9d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -97,6 +97,19 @@ ERRORS_CAP = 100
 # gh issue cache TTL (seconds).
 ISSUE_CACHE_TTL_SECONDS = 60
 
+# Per-subsystem collect_snapshot fan-out TTLs (seconds). Tuned to each
+# subsystem's natural change frequency vs the 2Hz client poll cadence.
+# See issue #514 for the latency analysis that motivated this.
+#
+# `time.monotonic()` is the TTL clock — NOT `time.time()` — because wall
+# clock can jump on NTP sync. Monotonic guarantees a non-decreasing tick
+# regardless of wall-time corrections.
+SNAPSHOT_CACHE_TTL_WORKTREES = 5.0       # git worktree list
+SNAPSHOT_CACHE_TTL_BRANCHES = 5.0        # git for-each-ref
+SNAPSHOT_CACHE_TTL_GIT_HISTORY = 10.0    # git log
+SNAPSHOT_CACHE_TTL_PLANS = 3.0           # parse_plan + parse_report + landing-mode
+SNAPSHOT_CACHE_TTL_TRACKING = 3.0        # .zskills/tracking/ walk + PR-number scan
+
 
 # ---------------------------------------------------------------------------
 # Module-level cache (per-Python-process; documented limitation per DA-14)
@@ -108,12 +121,56 @@ _ISSUE_CACHE: Dict[str, Any] = {
     "had_value": False,
 }
 
+# Per-subsystem snapshot cache: maps (kind, main_root_str) →
+# (monotonic_ts, value, errors_from_that_call). On cache hit, the
+# captured errors are re-extended onto the new caller's errors list so
+# the per-snapshot errors block stays accurate.
+_SNAPSHOT_CACHE: Dict[Tuple[str, str], Tuple[float, Any, List[Dict[str, str]]]] = {}
+
 
 def _reset_issue_cache_for_tests() -> None:
     """Reset the module-level cache (test-only helper)."""
     _ISSUE_CACHE["ts"] = 0.0
     _ISSUE_CACHE["issues"] = []
     _ISSUE_CACHE["had_value"] = False
+
+
+def _reset_snapshot_cache_for_tests() -> None:
+    """Reset the per-subsystem snapshot cache (test-only helper)."""
+    _SNAPSHOT_CACHE.clear()
+
+
+def _cached_subsystem(
+    kind: str,
+    main_root: pathlib.Path,
+    ttl: float,
+    fn: Any,
+    errors: List[Dict[str, str]],
+    *,
+    _now: Optional[float] = None,
+) -> Any:
+    """Cache the result of `fn(local_errors)` keyed by (kind, main_root).
+
+    `fn` is called with a fresh `local_errors` list so cached error
+    records can be replayed without double-counting on cache hits. If
+    `fn` raises, the cache is NOT updated — fail-loud, no stale value
+    poisoning. The monotonic clock is used (NTP-safe). TTL of 0 disables
+    caching entirely (always re-fetch).
+    """
+    now = _now if _now is not None else time.monotonic()
+    key = (kind, str(main_root))
+    cached = _SNAPSHOT_CACHE.get(key)
+    if cached is not None and ttl > 0 and (now - cached[0]) < ttl:
+        _ts, value, cached_errors = cached
+        if cached_errors:
+            errors.extend(cached_errors)
+        return value
+    local_errors: List[Dict[str, str]] = []
+    value = fn(local_errors)
+    _SNAPSHOT_CACHE[key] = (now, value, list(local_errors))
+    if local_errors:
+        errors.extend(local_errors)
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -1605,14 +1662,19 @@ def collect_snapshot(
         main_root = _resolve_main_root(repo_root)
     errors: List[Dict[str, str]] = []
 
-    plans_dir = _resolve_paths(main_root)["plans_dir"]
-    plans: List[Dict[str, Any]] = []
-    if plans_dir.is_dir():
+    # Plans + reports — TTL-cached per subsystem (#514). The plan files
+    # change on /run-plan phase ticks (minutes, not seconds); a 3s TTL
+    # absorbs ~7 of every 10 polls without showing stale phase state.
+    def _build_plans(local_errors: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+        plans_dir = _resolve_paths(main_root)["plans_dir"]
+        out: List[Dict[str, Any]] = []
+        if not plans_dir.is_dir():
+            return out
         try:
             plan_files = sorted(plans_dir.glob("*.md"))
         except Exception as exc:
             plan_files = []
-            errors.append({
+            local_errors.append({
                 "source": "plans scan",
                 "message": str(exc),
             })
@@ -1621,7 +1683,9 @@ def collect_snapshot(
             if parsed is None:
                 continue
             content = parsed.pop("_content", "")
-            parsed["landing_mode"] = _resolve_landing_mode(content, main_root, errors)
+            parsed["landing_mode"] = _resolve_landing_mode(
+                content, main_root, local_errors,
+            )
             # Report enrichment
             report = parse_report(parsed["slug"], main_root)
             parsed["has_report"] = report is not None
@@ -1633,9 +1697,23 @@ def collect_snapshot(
                 parsed["file"] = str(rel)
             except Exception:
                 pass
-            plans.append(parsed)
+            out.append(parsed)
+        return out
 
-    # State file merge (drives queue annotations + queues block)
+    plans = _cached_subsystem(
+        "plans", main_root, SNAPSHOT_CACHE_TTL_PLANS, _build_plans, errors,
+    )
+    # Defensive shallow copy: caller _annotate_plans_queue mutates each
+    # plan dict in place, but those mutations are state-file-derived
+    # (queue position, column) and the same state file is read fresh
+    # every poll — so re-annotation produces a deterministic result. We
+    # copy the OUTER list so re-orderings don't leak, but trust the
+    # per-plan dicts to be re-annotated to a consistent state.
+    plans = list(plans)
+
+    # State file merge (drives queue annotations + queues block).
+    # Uncached — sub-ms read; staleness here would break the live-source
+    # invariant for queue annotations.
     state = _read_state_file(main_root, errors)
     state_updated_at = state.get("updated_at", "")
     _annotate_plans_queue(plans, state)
@@ -1648,18 +1726,41 @@ def collect_snapshot(
     issues, issues_fetch_ok = list_issues(errors, _runner=issue_runner)
     _annotate_issues_queue(issues, state, main_root)
 
-    # Worktrees + branches
-    worktrees = _list_worktrees(main_root, errors)
-    branches = _list_branches(main_root, errors)
+    # Worktrees + branches — TTL-cached subsystems (#514). Both run git
+    # subprocesses; both change at human-action cadence (worktree create
+    # / branch checkout), not 2Hz polls.
+    worktrees = _cached_subsystem(
+        "worktrees", main_root, SNAPSHOT_CACHE_TTL_WORKTREES,
+        lambda e: _list_worktrees(main_root, e), errors,
+    )
+    branches = _cached_subsystem(
+        "branches", main_root, SNAPSHOT_CACHE_TTL_BRANCHES,
+        lambda e: _list_branches(main_root, e), errors,
+    )
 
     # Tracking activity + git-history events (commits with no marker).
     # Tracking markers are richer (skill, id, pipeline) so they win on
     # dedup; commits whose trailing `(#N)` matches a fulfilled.land-pr.*
-    # marker's PR number are dropped.
-    marker_activity = _scan_tracking_markers(main_root, errors)
-    fulfilled_prs = _extract_pr_numbers_from_markers(main_root)
-    git_activity = _scan_git_history(
-        main_root, errors, fulfilled_pr_numbers=fulfilled_prs,
+    # marker's PR number are dropped. Tracking markers + their PR-number
+    # extraction are grouped under one "tracking" subsystem (#514) —
+    # they walk the same `.zskills/tracking/` tree.
+    def _build_tracking(
+        local_errors: List[Dict[str, str]],
+    ) -> Tuple[List[Dict[str, Any]], set]:
+        marker_activity = _scan_tracking_markers(main_root, local_errors)
+        fulfilled_prs = _extract_pr_numbers_from_markers(main_root)
+        return marker_activity, fulfilled_prs
+
+    marker_activity, fulfilled_prs = _cached_subsystem(
+        "tracking", main_root, SNAPSHOT_CACHE_TTL_TRACKING,
+        _build_tracking, errors,
+    )
+    git_activity = _cached_subsystem(
+        "git_history", main_root, SNAPSHOT_CACHE_TTL_GIT_HISTORY,
+        lambda e: _scan_git_history(
+            main_root, e, fulfilled_pr_numbers=fulfilled_prs,
+        ),
+        errors,
     )
     activity = marker_activity + git_activity
 

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -1091,6 +1091,121 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# AC (#514): per-subsystem snapshot cache — _cached_subsystem hit/miss/expire
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Issue #514: per-subsystem snapshot cache TTL ==="
+
+SCACHE_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+# Hit/miss invariants on a deterministic _now clock.
+c._reset_snapshot_cache_for_tests()
+calls = []
+def fn(errs):
+    calls.append("X")
+    errs.append({"source": "test", "message": "boom"})
+    return ["value"]
+
+root = pathlib.Path("/fake/main")
+errs1 = []
+v1 = c._cached_subsystem("kind1", root, 5.0, fn, errs1, _now=100.0)
+v2 = c._cached_subsystem("kind1", root, 5.0, fn, errs1, _now=102.0)  # within TTL — hit
+v3 = c._cached_subsystem("kind1", root, 5.0, fn, errs1, _now=104.99)  # still hit
+v4 = c._cached_subsystem("kind1", root, 5.0, fn, errs1, _now=105.5)  # past TTL — miss
+print("calls_after_4=" + str(len(calls)))  # expect 2
+print("value_stable=" + str(v1 == v2 == v3 == v4))
+print("errors_replayed=" + str(len(errs1)))  # 4
+
+# Different kind doesn t collide.
+errs2 = []
+c._cached_subsystem("kind2", root, 5.0, fn, errs2, _now=100.0)
+print("calls_after_kind2=" + str(len(calls)))  # 3
+
+# Different main_root doesn t collide.
+c._cached_subsystem("kind1", pathlib.Path("/other/main"), 5.0, fn, errs2, _now=100.0)
+print("calls_after_otherroot=" + str(len(calls)))  # 4
+
+# Fail-loud: if fn raises, cache is NOT updated.
+c._reset_snapshot_cache_for_tests()
+def boom_fn(errs):
+    raise RuntimeError("intentional")
+try:
+    c._cached_subsystem("k", root, 5.0, boom_fn, [], _now=100.0)
+except RuntimeError:
+    pass
+print("cache_size_after_raise=" + str(len(c._SNAPSHOT_CACHE)))  # 0
+')
+if printf '%s\n' "$SCACHE_RES" | grep -q "calls_after_4=2" \
+    && printf '%s\n' "$SCACHE_RES" | grep -q "value_stable=True" \
+    && printf '%s\n' "$SCACHE_RES" | grep -q "errors_replayed=4" \
+    && printf '%s\n' "$SCACHE_RES" | grep -q "calls_after_kind2=3" \
+    && printf '%s\n' "$SCACHE_RES" | grep -q "calls_after_otherroot=4" \
+    && printf '%s\n' "$SCACHE_RES" | grep -q "cache_size_after_raise=0"; then
+  pass "snapshot cache: hit within TTL, miss past TTL, kind+root keying, fail-loud on raise"
+else
+  fail "snapshot cache TTL: got '$SCACHE_RES'"
+fi
+
+# Integration: collect_snapshot does NOT re-invoke fan-out helpers within TTL.
+SCACHE_INT=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys, pathlib, tempfile
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+c._reset_snapshot_cache_for_tests()
+c._reset_issue_cache_for_tests()
+
+counts = {"wt": 0, "br": 0, "hist": 0, "mk": 0, "extract_pr": 0}
+def wt(root, errs):
+    counts["wt"] += 1
+    return []
+def br(root, errs):
+    counts["br"] += 1
+    return []
+def hist(root, errs, **kw):
+    counts["hist"] += 1
+    return []
+def mk(root, errs):
+    counts["mk"] += 1
+    return []
+def extract_pr(root):
+    counts["extract_pr"] += 1
+    return set()
+c._list_worktrees = wt
+c._list_branches = br
+c._scan_git_history = hist
+c._scan_tracking_markers = mk
+c._extract_pr_numbers_from_markers = extract_pr
+
+class FakeResult:
+    returncode = 0
+    stdout = "[]"
+    stderr = ""
+def runner(*a, **kw):
+    return FakeResult()
+
+with tempfile.TemporaryDirectory() as td:
+    root = pathlib.Path(td)
+    c.collect_snapshot(root, pre_resolved=True, issue_runner=runner)
+    print("after_first wt=" + str(counts["wt"]) + " br=" + str(counts["br"]) + " hist=" + str(counts["hist"]) + " mk=" + str(counts["mk"]) + " extract_pr=" + str(counts["extract_pr"]))
+    c.collect_snapshot(root, pre_resolved=True, issue_runner=runner)
+    print("after_second wt=" + str(counts["wt"]) + " br=" + str(counts["br"]) + " hist=" + str(counts["hist"]) + " mk=" + str(counts["mk"]) + " extract_pr=" + str(counts["extract_pr"]))
+    c._reset_snapshot_cache_for_tests()
+    c.collect_snapshot(root, pre_resolved=True, issue_runner=runner)
+    print("after_reset wt=" + str(counts["wt"]) + " br=" + str(counts["br"]) + " hist=" + str(counts["hist"]) + " mk=" + str(counts["mk"]) + " extract_pr=" + str(counts["extract_pr"]))
+')
+if printf '%s\n' "$SCACHE_INT" | grep -q "after_first wt=1 br=1 hist=1 mk=1 extract_pr=1" \
+    && printf '%s\n' "$SCACHE_INT" | grep -q "after_second wt=1 br=1 hist=1 mk=1 extract_pr=1" \
+    && printf '%s\n' "$SCACHE_INT" | grep -q "after_reset wt=2 br=2 hist=2 mk=2 extract_pr=2"; then
+  pass "collect_snapshot: fan-out helpers cached within TTL, re-invoked on cache reset"
+else
+  fail "collect_snapshot cache integration: got '$SCACHE_INT'"
+fi
+
+# ---------------------------------------------------------------------------
 # AC: Test registered in tests/run-all.sh (verified by the test runner if
 # we're invoked via run-all.sh; here we just sanity-check this file is
 # referenced).


### PR DESCRIPTION
## Summary

`/api/state` median latency was ~6s vs `/api/work-state` at ~2s. `collect_snapshot()` synchronously ran 3 git subprocesses + directory walks + per-marker parses on every 2Hz poll — none of which change at that cadence.

Adds per-subsystem TTL caching in `collect.py` keyed by `(kind, main_root)`:

| Subsystem | TTL | Why |
|---|---|---|
| worktrees / branches | 5s | Worktree creation/removal is bursty but rare |
| git_history | 10s | Commits land at low frequency |
| plans + reports | 3s | User edits + sprint-report appends |
| tracking_markers | 3s | Skill-driven; bursty but bounded |
| state-file read | uncached | Sub-ms; no win |

Uses `time.monotonic()` (NTP-jump safe).

**Empirical note:** On a worktree with 82 active git worktrees + 68 plans, helpers can exceed their TTL (cache misses every poll). Production-typical repos with fewer worktrees should see the structural improvement. TTL retune deferred to follow-up if dogfooding surfaces it.

Closes #514.

## Test plan

- [x] Full suite: 3669/3669 pass (delta +2 for new cache TTL invariants).
- [x] Verified 190x speedup measured by overriding TTLs to 100s (~6.7s → ~35ms).
- [x] Skill version bumped; pre-commit hook clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
