### PR TITLE
test(fidelity): tighten 3 assertions to catch the regressions they claim to (Closes #517)

### DIFF
--- a/tests/test-briefing-parity.sh
+++ b/tests/test-briefing-parity.sh
@@ -50,29 +50,79 @@ fi
 TEST_TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
-# Smoke test all subcommands with python3
-# Note: "report" writes files, so redirect its output to the temp dir
+# Smoke test all subcommands with python3. Each subcommand asserts a
+# stable expected substring in its actual output — NOT "exit 0 + any
+# output" (issue #517: that latter form is tautological because every
+# non-zero-exit and every empty-stdout-but-stderr-warning case passes,
+# masking real "subcommand handler returned empty string" regressions).
+# Note: "report" writes files, so its stdout includes the "Report
+# written to: <path>" confirmation line + the file body.
+#
+# Per-subcommand expected substring (rationale):
+#   summary     — top-of-output banner is always "BRIEFING — <date>"
+#   report      — emits "Report written to:" then markdown header begins
+#                 with "# Briefing Report —"; check for the file header
+#                 in the OUTPUT FILE rather than stdout (stdout is the
+#                 single confirmation line).
+#   verify      — emits one of "VERIFICATION NEEDED" / "NO VERIFICATION
+#                 NEEDED" depending on plan-report state. Match either.
+#   current     — top header is "CURRENTLY IN FLIGHT —"
+#   worktrees   — emits a JSON array; the first object always has
+#                 `"path":` (every worktree has a path). Match `"path":`.
+#   commits     — emits a JSON array; every commit object has `"hash":`.
+#   checkboxes  — emits a JSON array; objects have `"file":` keys. Empty
+#                 array `[]` is also valid (no plan reports = no checkboxes),
+#                 so accept either `"file":` OR a literal `[]` whole-output.
 smoke_cmds=(
-  "summary"
-  "report --since=24h --output=$TEST_TMPDIR/briefing-test.md"
-  "verify"
-  "current"
-  "worktrees"
-  "commits --since=24h"
-  "checkboxes"
+  "summary|BRIEFING —"
+  "report --since=24h --output=$TEST_TMPDIR/briefing-test.md|Report written to:"
+  "verify|VERIFICATION"
+  "current|CURRENTLY IN FLIGHT"
+  "worktrees|\"path\":"
+  "commits --since=24h|\"hash\":"
+  "checkboxes|"  # custom-matched below (allow empty-array)
 )
 
-for cmd in "${smoke_cmds[@]}"; do
+for entry in "${smoke_cmds[@]}"; do
+  cmd="${entry%%|*}"
+  expected="${entry#*|}"
   # shellcheck disable=SC2086
   output=$(cd "$REPO_ROOT" && python3 "$REPO_ROOT/skills/briefing/scripts/briefing.py" $cmd 2>&1)
   exit_code=$?
-  if [[ $exit_code -eq 0 && -n "$output" ]]; then
-    pass "python3 briefing.py $cmd"
-  elif [[ $exit_code -eq 0 && -z "$output" ]]; then
-    # Some subcommands may produce empty output legitimately (e.g. no checkboxes)
-    pass "python3 briefing.py $cmd (empty but exit 0)"
-  else
+  if [[ $exit_code -ne 0 ]]; then
     fail "python3 briefing.py $cmd (exit=$exit_code)"
+    continue
+  fi
+
+  if [[ "$cmd" == "checkboxes" ]]; then
+    # checkboxes: accept either non-empty JSON-array-with-"file": OR a
+    # literal empty array "[]" (legitimate when no plan reports exist).
+    trimmed=$(printf '%s' "$output" | tr -d '[:space:]')
+    if [[ "$trimmed" == "[]" ]] || printf '%s' "$output" | grep -q '"file":'; then
+      pass "python3 briefing.py $cmd (JSON array)"
+    else
+      fail "python3 briefing.py $cmd (expected '\"file\":' key or '[]'; got: $output)"
+    fi
+    continue
+  fi
+
+  if [[ "$cmd" == report* ]]; then
+    # report: stdout has "Report written to:"; ALSO verify the written
+    # file contains the "# Briefing Report —" header (catches a regression
+    # where the handler prints the confirmation but emits an empty file).
+    if printf '%s' "$output" | grep -qF "$expected" \
+       && grep -qF '# Briefing Report —' "$TEST_TMPDIR/briefing-test.md"; then
+      pass "python3 briefing.py $cmd"
+    else
+      fail "python3 briefing.py $cmd (stdout missing '$expected' or output file missing '# Briefing Report —' header)"
+    fi
+    continue
+  fi
+
+  if printf '%s' "$output" | grep -qF "$expected"; then
+    pass "python3 briefing.py $cmd"
+  else
+    fail "python3 briefing.py $cmd (expected '$expected' in output; got first 200 chars: $(printf '%s' "$output" | head -c 200))"
   fi
 done
 

--- a/tests/test-briefing-parity.sh
+++ b/tests/test-briefing-parity.sh
@@ -67,9 +67,14 @@ trap 'rm -rf "$TEST_TMPDIR"' EXIT
 #   verify      — emits one of "VERIFICATION NEEDED" / "NO VERIFICATION
 #                 NEEDED" depending on plan-report state. Match either.
 #   current     — top header is "CURRENTLY IN FLIGHT —"
-#   worktrees   — emits a JSON array; the first object always has
-#                 `"path":` (every worktree has a path). Match `"path":`.
-#   commits     — emits a JSON array; every commit object has `"hash":`.
+#   worktrees   — emits a JSON array (possibly empty in fresh CI clones
+#                 with no live worktrees). Custom-matched below: output must
+#                 begin with `[` AND, when non-empty, contain `"path":`.
+#                 The `return 0` mutation produces empty stdout — neither
+#                 condition holds, so the assertion still fails it.
+#   commits     — emits a JSON array (possibly empty when no commits land
+#                 in the --since window). Same shape as worktrees: output
+#                 begins with `[`, and non-empty arrays contain `"hash":`.
 #   checkboxes  — emits a JSON array; objects have `"file":` keys. Empty
 #                 array `[]` is also valid (no plan reports = no checkboxes),
 #                 so accept either `"file":` OR a literal `[]` whole-output.
@@ -78,8 +83,8 @@ smoke_cmds=(
   "report --since=24h --output=$TEST_TMPDIR/briefing-test.md|Report written to:"
   "verify|VERIFICATION"
   "current|CURRENTLY IN FLIGHT"
-  "worktrees|\"path\":"
-  "commits --since=24h|\"hash\":"
+  "worktrees|"  # custom-matched below (stateful-env-agnostic JSON-array)
+  "commits --since=24h|"  # custom-matched below (stateful-env-agnostic JSON-array)
   "checkboxes|"  # custom-matched below (allow empty-array)
 )
 
@@ -102,6 +107,35 @@ for entry in "${smoke_cmds[@]}"; do
       pass "python3 briefing.py $cmd (JSON array)"
     else
       fail "python3 briefing.py $cmd (expected '\"file\":' key or '[]'; got: $output)"
+    fi
+    continue
+  fi
+
+  if [[ "$cmd" == "worktrees" || "$cmd" == "commits"* ]]; then
+    # worktrees / commits: emit a JSON array via json.dumps(list, indent=2).
+    # In fresh CI clones with no live worktrees / no in-window commits the
+    # array is empty (`[]`); locally it has entries. Stateful-env-agnostic
+    # check: output (trimmed of leading whitespace) MUST start with `[`.
+    # The regression this guards (`def cmd(): return 0` / removed print)
+    # produces empty stdout — fails this check. When the array IS non-empty
+    # we additionally assert the expected key (`"path":` / `"hash":`)
+    # appears — preserves the tighter check on populated envs.
+    if [[ "$cmd" == "worktrees" ]]; then
+      key='"path":'
+    else
+      key='"hash":'
+    fi
+    trimmed_lead=$(printf '%s' "$output" | sed -e 's/^[[:space:]]*//')
+    trimmed_all=$(printf '%s' "$output" | tr -d '[:space:]')
+    if [[ "$trimmed_lead" != \[* ]]; then
+      fail "python3 briefing.py $cmd (expected JSON array — output to begin with '['; got first 200 chars: $(printf '%s' "$output" | head -c 200))"
+    elif [[ "$trimmed_all" == "[]" ]]; then
+      # Empty array — legitimate in CI / clean envs.
+      pass "python3 briefing.py $cmd (empty JSON array — no data in this env)"
+    elif printf '%s' "$output" | grep -qF "$key"; then
+      pass "python3 briefing.py $cmd (JSON array with $key entries)"
+    else
+      fail "python3 briefing.py $cmd (non-empty JSON array missing expected '$key' key; got first 200 chars: $(printf '%s' "$output" | head -c 200))"
     fi
     continue
   fi

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -110,6 +110,53 @@ check_in_file() {
   fi
 }
 
+# check_in_file_near <skill> <relative-path> <label> <pattern> <context-pattern> [window-lines]
+# Like check_in_file, but requires <pattern> AND <context-pattern> to
+# appear within <window-lines> of each other (default 10; pass 0 for
+# "same line"). Used for impl-dispatch pin checks (issue #517): the
+# literal `subagent_type: "implementer"` must appear ON THE SAME LINE
+# as the `Agent` keyword (i.e. on the actual dispatch directive line),
+# not in an unrelated comment or footnote. Whole-file `grep -E` would
+# let a demoted dispatch site (e.g. subagent_type: "general-purpose")
+# pass as long as ANY mention of the pin literal survives elsewhere —
+# a comment like `<!-- TODO: re-pin subagent_type: "implementer" -->`
+# would satisfy the assertion.
+check_in_file_near() {
+  local skill="$1" relpath="$2" label="$3" pattern="$4" ctx="$5" window="${6:-10}"
+  local target
+  if [[ "$skill" == */* ]]; then
+    target="$REPO_ROOT/$skill/$relpath"
+  else
+    target="$REPO_ROOT/skills/$skill/$relpath"
+  fi
+  if [ ! -f "$target" ]; then
+    fail "[$skill/$relpath] $label" "file does not exist"
+    return
+  fi
+  # awk: track the last line numbers at which $pattern and $ctx each
+  # matched; pass if they are ever within $window lines of each other.
+  if awk -v pat="$pattern" -v ctx="$ctx" -v win="$window" '
+    {
+      if (index($0, pat))  pat_lines[++pn] = NR
+      if (index($0, ctx))  ctx_lines[++cn] = NR
+    }
+    END {
+      for (i = 1; i <= pn; i++) {
+        for (j = 1; j <= cn; j++) {
+          d = pat_lines[i] - ctx_lines[j]
+          if (d < 0) d = -d
+          if (d <= win) exit 0
+        }
+      }
+      exit 1
+    }
+  ' "$target"; then
+    pass "[$skill/$relpath] $label"
+  else
+    fail "[$skill/$relpath] $label" "no '$pattern' within $window lines of '$ctx'"
+  fi
+}
+
 # check_not_in_file <skill> <relative-path> <label> <pattern>
 # Inverted check_in_file.
 check_not_in_file() {
@@ -529,16 +576,20 @@ echo "=== implementer subagent — impl-dispatch site pins (Verifier-cannot-run 
 # auto-extend to 600s and never trigger the bg+Monitor stall pattern that
 # hangs the dispatch at "Tests are running. Let me wait for the monitor."
 #
-# Scoped per-file (check_in_file) so adding the directive to an unrelated
-# file inside the skill tree doesn't satisfy the assertion — each
-# dispatch site is verified independently.
-check_in_file run-plan    "SKILL.md"                   "impl-dispatch pins implementer" 'subagent_type: "implementer"'
-check_in_file run-plan    "modes/pr.md"                "fix-cycle pins implementer"     'subagent_type: "implementer"'
-check_in_file fix-issues  "SKILL.md"                   "fix-agent pins implementer"     'subagent_type: "implementer"'
-check_in_file fix-issues  "modes/pr.md"                "fix-cycle pins implementer"     'subagent_type: "implementer"'
-check_in_file land-pr     "references/fix-cycle-agent-prompt-template.md" "template pins implementer" 'subagent_type: "implementer"'
-check_in_file do          "modes/pr.md"                "impl+fix-cycle pins implementer" 'subagent_type: "implementer"'
-check_in_file quickfix    "SKILL.md"                   "agent-dispatched+fix-cycle pins implementer" 'subagent_type: "implementer"'
+# Scoped per-file (check_in_file_near) so adding the directive to an
+# unrelated file inside the skill tree doesn't satisfy the assertion —
+# each dispatch site is verified independently. Issue #517: the
+# `_near` form requires the pin literal to appear within 10 lines of
+# the `Agent` keyword (i.e., near a real dispatch directive); a
+# whole-file `grep -E` would let a demoted dispatch site (general-purpose)
+# pass as long as ANY footnote/comment elsewhere mentioned the pin.
+check_in_file_near run-plan    "SKILL.md"                   "impl-dispatch pins implementer" 'subagent_type: "implementer"' 'Agent' 0
+check_in_file_near run-plan    "modes/pr.md"                "fix-cycle pins implementer"     'subagent_type: "implementer"' 'Agent' 0
+check_in_file_near fix-issues  "SKILL.md"                   "fix-agent pins implementer"     'subagent_type: "implementer"' 'Agent' 0
+check_in_file_near fix-issues  "modes/pr.md"                "fix-cycle pins implementer"     'subagent_type: "implementer"' 'Agent' 0
+check_in_file_near land-pr     "references/fix-cycle-agent-prompt-template.md" "template pins implementer" 'subagent_type: "implementer"' 'Agent' 0
+check_in_file_near do          "modes/pr.md"                "impl+fix-cycle pins implementer" 'subagent_type: "implementer"' 'Agent' 0
+check_in_file_near quickfix    "SKILL.md"                   "agent-dispatched+fix-cycle pins implementer" 'subagent_type: "implementer"' 'Agent' 0
 
 # Agent definition file exists with the expected frontmatter shape.
 if [ -f "$REPO_ROOT/.claude/agents/implementer.md" ]; then

--- a/tests/test_zskills_monitor_server.sh
+++ b/tests/test_zskills_monitor_server.sh
@@ -339,9 +339,13 @@ if start_server "$MR5" "$PORT_D"; then
   fi
 
   # #473: activity[] filter must match the canonical `pipeline` key
-  # (not the old `pipeline_id`). Seed a tracking marker under a pipeline
-  # subdir whose name contains the plan slug, then verify activity[]
-  # picks it up.
+  # (not the old `pipeline_id`). Seed TWO tracking pipelines:
+  #   (a) run-sample-plan-001 — matches the plan slug; MUST appear in activity[].
+  #   (b) run-other-002       — unrelated; MUST NOT appear in activity[].
+  # Issue #517 negative-case: without (b) the test passes even if the
+  # slug filter is removed entirely (activity[] just returns all
+  # pipelines). The EXCLUSION assertion is what makes this load-bearing
+  # for the #473 fix.
   mkdir -p "$MR5/.zskills/tracking/run-sample-plan-001"
   cat >"$MR5/.zskills/tracking/run-sample-plan-001/fulfilled.test" <<'MARKER'
 date: 2026-05-20T10:00:00-04:00
@@ -349,13 +353,28 @@ skill: test
 status: ok
 output: /dev/null
 MARKER
+  mkdir -p "$MR5/.zskills/tracking/run-other-002"
+  cat >"$MR5/.zskills/tracking/run-other-002/fulfilled.test" <<'MARKER'
+date: 2026-05-20T11:00:00-04:00
+skill: test
+status: ok
+output: /dev/null
+MARKER
   PLAN_BODY=$(curl -sf -m 3 "http://127.0.0.1:$PORT_D/api/plan/sample-plan")
-  # activity[] must be non-empty AND contain the seeded pipeline name.
+  # Positive: activity[] non-empty AND contains the matching pipeline.
   if printf '%s' "$PLAN_BODY" | grep -q '"activity":[[:space:]]*\[[[:space:]]*{' \
      && printf '%s' "$PLAN_BODY" | grep -q '"pipeline":[[:space:]]*"run-sample-plan-001"'; then
     pass "/api/plan activity[] filters on canonical 'pipeline' key (#473)"
   else
     fail "/api/plan activity[] empty or missing seeded marker (#473); body: $PLAN_BODY"
+  fi
+  # Negative (issue #517): the unrelated pipeline MUST NOT appear in
+  # activity[]. If the slug filter regresses (returns all pipelines),
+  # this assertion fails.
+  if printf '%s' "$PLAN_BODY" | grep -q '"pipeline":[[:space:]]*"run-other-002"'; then
+    fail "/api/plan activity[] leaked unrelated pipeline 'run-other-002' (slug filter regressed; #517); body: $PLAN_BODY"
+  else
+    pass "/api/plan activity[] excludes unrelated pipeline 'run-other-002' (#517 negative case)"
   fi
 
   # 404 for unknown slug


### PR DESCRIPTION
## Summary
- Tightens three test assertions that pass for the wrong reason — each is the primary regression defense for a recent fix:
  - `tests/test-briefing-parity.sh:65-77` — drops the tautological `(-n||-z output)` clause; asserts per-subcommand expected substrings (`BRIEFING —`, `Report written to:`, `VERIFICATION`, `CURRENTLY IN FLIGHT`, JSON keys for `worktrees`/`commits`/`checkboxes`).
  - `tests/test_zskills_monitor_server.sh:341-359` — seeds a second pipeline `run-other-002` and asserts `/api/plan/sample-plan` activity[] EXCLUDES it (negative case for the #473 wrong-key fix).
  - `tests/test-skill-conformance.sh:535-541` — replaces whole-file `grep -E` with `check_in_file_near` (window=0, same-line) so a comment containing the literal can no longer satisfy the impl-dispatch pin check.

Closes #517.

## Test plan
- [x] `bash tests/run-all.sh` — 4510/4510 passed, 0 failed.
- [x] Each modified test passes in isolation.
- [x] Mutation #1: `def summary(): return 0` → missing `BRIEFING —` → fail. Verified by reading assertions.
- [x] Mutation #2: remove slug filter at server.py:840 → `run-other-002` appears → negative assertion fires.
- [x] Mutation #3: demoted dispatch + stray comment with literal but not same-line as `Agent` → awk exits 1 → check_in_file_near fails.
- [x] Scope: only the 3 test files (no source/skill/mirror edits).
