### PR TITLE
fix(do): replace Phase 4 step 2 stash-based prose with /commit land dispatch (Closes #537)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.20+921677"
+  version: "2026.05.21+da7c08"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -818,20 +818,35 @@ Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invoca
    git push
    ```
 
-2. **If in worktree (Path B):** cherry-pick to main first, then push:
-   - Protect uncommitted work on main (`git stash -u` if needed)
-   - Cherry-pick worktree commits to main sequentially
-   - If any cherry-pick conflicts: **abort and clean up:**
-     ```bash
-     git cherry-pick --abort
-     ```
-     Restore stash if one was created (`git stash pop`). If `/do` has an
-     active cron, kill it (`CronList` + `CronDelete` any whose prompt
-     starts with `Run /do`). Report the conflict to the user. Do NOT
-     force-push or resolve automatically.
-   - Restore stash if one was created
-   - Push main
-   - Report what was pushed (commit hashes, branch)
+2. **If in worktree (Path B):** dispatch `/commit land` to cherry-pick worktree commits onto main, then push.
+
+   Dispatch via the Skill tool:
+
+   ```
+   Skill: { skill: "commit", args: "land" }
+   ```
+
+   `/commit land` (encoded in [`skills/commit/modes/land.md`](../commit/modes/land.md))
+   handles the full landing flow:
+   - Try-without-stash: does NOT run `git stash -u` (the
+     `hooks/block-unsafe-generic.sh` gate denies bare/push/save/-u stash
+     writes; `git cherry-pick` itself refuses on overlap, which preserves
+     evidence of conflicting work in other sessions).
+   - Cherry-picks worktree commits onto main sequentially. On any
+     refusal or conflict: STOPs and reports — does NOT `--abort`, stash,
+     or force-resolve.
+   - Runs the full test suite after the cherry-picks land.
+   - Writes the `.landed` marker on the worktree (`status: full`, source
+     `commit-land`, with the list of cherry-picked hashes).
+
+   On a clean return from `/commit land`:
+   - Push main (`git push`).
+   - Report what was pushed (commit hashes, branch).
+
+   On a STOP report from `/commit land` (conflict, test failure, or
+   refused cherry-pick): surface to the user verbatim. If `/do` has an
+   active cron, kill it (`CronList` + `CronDelete` any whose prompt
+   starts with `Run /do`). Do NOT force-push or resolve automatically.
 
 3. **If verification failed:** do NOT push. Report the verification
    findings and stop.

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.20+921677"
+  version: "2026.05.21+da7c08"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -818,20 +818,35 @@ Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invoca
    git push
    ```
 
-2. **If in worktree (Path B):** cherry-pick to main first, then push:
-   - Protect uncommitted work on main (`git stash -u` if needed)
-   - Cherry-pick worktree commits to main sequentially
-   - If any cherry-pick conflicts: **abort and clean up:**
-     ```bash
-     git cherry-pick --abort
-     ```
-     Restore stash if one was created (`git stash pop`). If `/do` has an
-     active cron, kill it (`CronList` + `CronDelete` any whose prompt
-     starts with `Run /do`). Report the conflict to the user. Do NOT
-     force-push or resolve automatically.
-   - Restore stash if one was created
-   - Push main
-   - Report what was pushed (commit hashes, branch)
+2. **If in worktree (Path B):** dispatch `/commit land` to cherry-pick worktree commits onto main, then push.
+
+   Dispatch via the Skill tool:
+
+   ```
+   Skill: { skill: "commit", args: "land" }
+   ```
+
+   `/commit land` (encoded in [`skills/commit/modes/land.md`](../commit/modes/land.md))
+   handles the full landing flow:
+   - Try-without-stash: does NOT run `git stash -u` (the
+     `hooks/block-unsafe-generic.sh` gate denies bare/push/save/-u stash
+     writes; `git cherry-pick` itself refuses on overlap, which preserves
+     evidence of conflicting work in other sessions).
+   - Cherry-picks worktree commits onto main sequentially. On any
+     refusal or conflict: STOPs and reports — does NOT `--abort`, stash,
+     or force-resolve.
+   - Runs the full test suite after the cherry-picks land.
+   - Writes the `.landed` marker on the worktree (`status: full`, source
+     `commit-land`, with the list of cherry-picked hashes).
+
+   On a clean return from `/commit land`:
+   - Push main (`git push`).
+   - Report what was pushed (commit hashes, branch).
+
+   On a STOP report from `/commit land` (conflict, test failure, or
+   refused cherry-pick): surface to the user verbatim. If `/do` has an
+   active cron, kill it (`CronList` + `CronDelete` any whose prompt
+   starts with `Run /do`). Do NOT force-push or resolve automatically.
 
 3. **If verification failed:** do NOT push. Report the verification
    findings and stop.


### PR DESCRIPTION
## Summary
- `/do` SKILL.md Phase 4 step 2 (Path B worktree cherry-pick landing) prose previously instructed `git stash -u` + `git stash pop`. `hooks/block-unsafe-generic.sh:387-388` denies every stash write subcommand, so agents following the documented prose hit hook-deny and stall.
- Replaces the stash-based prose with a dispatch to `/commit land` via the Skill tool (Option 1 in #537). `/commit land` already encodes the correct try-without-stash + cherry-pick + post-test gate + `.landed` marker pattern. Single source of truth — future fixes propagate.
- Source `skills/do/SKILL.md` edited; mirror `.claude/skills/do/SKILL.md` updated; `metadata.version` bumped to `2026.05.21+da7c08` per the skill-versioning discipline.

Closes #537.

## Test plan
- [x] `grep -n 'stash -u\|stash push\|stash save' skills/do/SKILL.md` returns only the negation/documentation line ("does NOT run `git stash -u`") — no remaining stash-write instruction.
- [x] `hooks/block-unsafe-generic.sh:380-390` deny-list unchanged (the fix is the SKILL prose, NOT weakening the hook).
- [x] `diff -q skills/do/SKILL.md .claude/skills/do/SKILL.md` silent (mirrors byte-equal).
- [x] Skill version hash matches `bash scripts/skill-content-hash.sh skills/do`.
- [x] `bash tests/test-skill-conformance.sh` passes 489/489.
- [x] Full suite: 4544/4545 (1 unrelated test-isolation flake at `test-create-worktree.sh` case 16, tracked in #540).
- [ ] Residual gap (non-blocker): no explicit conformance test forbidding `git stash -u` literal in `/do` SKILL.md Phase 4 step 2. Re-introduction wouldn't be caught by CI — file as a future test-gap follow-up.
