### PR TITLE
fix(commit): migrate test invocations to canonical $TEST_OUT capture idiom (Closes #536)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   only).
 argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.20+8d882c"
+  version: "2026.05.21+6c6976"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow
@@ -270,10 +270,23 @@ For every file classified as "related":
      just parrot it — write a proper commit message)
 
 2. **Run tests if code was staged** — if any staged files are code (`.js`,
-   `.css`, `.html`, `.rs`), run `$FULL_TEST_CMD` (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if you don't already have it in your environment) before committing. All
-   suites must pass. If tests fail after two fix attempts on the same error,
+   `.css`, `.html`, `.rs`), run the full test suite before committing using
+   the canonical capture idiom:
+
+   ```bash
+   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+   if [ -z "$FULL_TEST_CMD" ]; then
+     echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+     exit 1
+   fi
+   TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
+   mkdir -p "$TEST_OUT"
+   $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
+   ```
+
+   Read `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` to check
+   results. All suites must pass. If tests fail, read the captured output
+   file to diagnose. If tests fail after two fix attempts on the same error,
    STOP and report to the user (CLAUDE.md: "NEVER thrash on a failing fix").
    Skip this step for content-only commits (`.md`, `.jpg`, `.png`, logs).
 

--- a/.claude/skills/commit/modes/land.md
+++ b/.claude/skills/commit/modes/land.md
@@ -43,11 +43,15 @@ This is for landing worktree work onto main via cherry-pick.
      echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
      exit 1
    fi
-   $FULL_TEST_CMD
+   TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
+   mkdir -p "$TEST_OUT"
+   $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
    ```
-   If tests fail, report to the user. Do NOT attempt to fix — the
-   cherry-picked code was already tested in the worktree. A failure here
-   means a main-specific conflict that needs human judgment.
+   Read `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` to check
+   results. If tests fail, read the captured output file and report to the
+   user. Do NOT attempt to fix — the cherry-picked code was already tested
+   in the worktree. A failure here means a main-specific conflict that
+   needs human judgment.
 
 6. **Write `.landed` marker** on the worktree (so `/fix-report` knows
    it's safe to remove):

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   only).
 argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.20+8d882c"
+  version: "2026.05.21+6c6976"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow
@@ -270,10 +270,23 @@ For every file classified as "related":
      just parrot it — write a proper commit message)
 
 2. **Run tests if code was staged** — if any staged files are code (`.js`,
-   `.css`, `.html`, `.rs`), run `$FULL_TEST_CMD` (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if you don't already have it in your environment) before committing. All
-   suites must pass. If tests fail after two fix attempts on the same error,
+   `.css`, `.html`, `.rs`), run the full test suite before committing using
+   the canonical capture idiom:
+
+   ```bash
+   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+   if [ -z "$FULL_TEST_CMD" ]; then
+     echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+     exit 1
+   fi
+   TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
+   mkdir -p "$TEST_OUT"
+   $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
+   ```
+
+   Read `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` to check
+   results. All suites must pass. If tests fail, read the captured output
+   file to diagnose. If tests fail after two fix attempts on the same error,
    STOP and report to the user (CLAUDE.md: "NEVER thrash on a failing fix").
    Skip this step for content-only commits (`.md`, `.jpg`, `.png`, logs).
 

--- a/skills/commit/modes/land.md
+++ b/skills/commit/modes/land.md
@@ -43,11 +43,15 @@ This is for landing worktree work onto main via cherry-pick.
      echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
      exit 1
    fi
-   $FULL_TEST_CMD
+   TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
+   mkdir -p "$TEST_OUT"
+   $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
    ```
-   If tests fail, report to the user. Do NOT attempt to fix — the
-   cherry-picked code was already tested in the worktree. A failure here
-   means a main-specific conflict that needs human judgment.
+   Read `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` to check
+   results. If tests fail, read the captured output file and report to the
+   user. Do NOT attempt to fix — the cherry-picked code was already tested
+   in the worktree. A failure here means a main-specific conflict that
+   needs human judgment.
 
 6. **Write `.landed` marker** on the worktree (so `/fix-report` knows
    it's safe to remove):


### PR DESCRIPTION
## Summary
- `/commit` Phase 5 step 2 (`skills/commit/SKILL.md:272-278`) and `/commit modes/land.md` Phase 7 step 5 (lines 40-50) previously invoked `$FULL_TEST_CMD` raw. Output dumped to terminal, scrolled past, lost on long suites. CLAUDE.md `## Tests` and the `forbidden-literals.txt` deny-list mandate the canonical `TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"; mkdir -p "$TEST_OUT"; $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1` capture pattern (already in 4 peer skills).
- Both sites migrated to the canonical idiom with a "if tests fail, read the captured output" fallback line.
- Canonical-config-prelude sourcing kept in-fence at both sites per CLAUDE.md `## Skill-file hardcode discipline`.
- Source + mirror updated; `/commit` SKILL.md `metadata.version` bumped to `2026.05.21+6c6976`.

Closes #536.

## Test plan
- [x] `grep -nE '\$FULL_TEST_CMD' skills/commit/SKILL.md skills/commit/modes/land.md | grep -v TEST_OUT` returns only env-checks (`if [ -z "$FULL_TEST_CMD" ]`) — no remaining raw invocations.
- [x] `TEST_OUT=` appears exactly at the two expected sites.
- [x] `diff -rq skills/commit/ .claude/skills/commit/` silent (mirrors byte-equal).
- [x] `metadata.version` hash matches `bash scripts/skill-content-hash.sh skills/commit`.
- [x] `bash tests/test-skill-conformance.sh` passes 489/489; deny-list doesn't catch `/commit`.
- [x] Full suite: 4545/4545 passed, 0 failed.
