### PR TITLE
fix(land-pr,callers): recognize REBASE_STDERR_FILE in result allow-list + cleanup sidecar (Closes #535)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   only).
 argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.21+6c6976"
+  version: "2026.05.21+83be3b"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow

--- a/.claude/skills/commit/modes/pr.md
+++ b/.claude/skills/commit/modes/pr.md
@@ -163,7 +163,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -177,7 +177,7 @@ while :; do
 
   # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array —
   # the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.21+da7c08"
+  version: "2026.05.21+163578"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -274,7 +274,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -288,7 +288,7 @@ while :; do
 
   # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array —
   # the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+2e3023"
+  version: "2026.05.21+5bda3b"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/pr.md
+++ b/.claude/skills/fix-issues/modes/pr.md
@@ -155,7 +155,7 @@ BODY
       case "$KEY" in
         STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
         MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-        CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+        CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
           LP["$KEY"]="$VALUE" ;;
         "") ;;  # blank line — ignore
         *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -169,7 +169,7 @@ BODY
 
     # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array
     # — the fix-cycle agent below reads it.
-    _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+    _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
     rm -f "$RESULT_FILE"
 
     case "$STATUS" in

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.20+e3cf3d"
+  version: "2026.05.21+699f2c"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/.claude/skills/land-pr/references/caller-loop-pattern.md
+++ b/.claude/skills/land-pr/references/caller-loop-pattern.md
@@ -86,7 +86,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -108,7 +108,7 @@ while :; do
   # prefix. Build the array from cleanup-targets only.
   # Per DA2-11: use an array (not space-joined string) to avoid
   # field-splitting bugs if a sidecar path ever contains spaces.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.18+be6644"
+  version: "2026.05.21+9b99f1"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -1124,7 +1124,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -1138,7 +1138,7 @@ while :; do
 
   # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array —
   # the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   # WI 1.16 — append the PR URL to the fulfillment marker as soon as

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.20+3f7678"
+  version: "2026.05.21+6e2240"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -399,7 +399,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -413,7 +413,7 @@ while :; do
 
   # Sidecar cleanup paths (per DA1-12, DA2-11). CI_LOG_FILE is intentionally
   # NOT in the array — the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   only).
 argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.21+6c6976"
+  version: "2026.05.21+83be3b"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow

--- a/skills/commit/modes/pr.md
+++ b/skills/commit/modes/pr.md
@@ -163,7 +163,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -177,7 +177,7 @@ while :; do
 
   # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array —
   # the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.21+da7c08"
+  version: "2026.05.21+163578"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -274,7 +274,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -288,7 +288,7 @@ while :; do
 
   # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array —
   # the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+2e3023"
+  version: "2026.05.21+5bda3b"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/pr.md
+++ b/skills/fix-issues/modes/pr.md
@@ -155,7 +155,7 @@ BODY
       case "$KEY" in
         STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
         MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-        CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+        CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
           LP["$KEY"]="$VALUE" ;;
         "") ;;  # blank line — ignore
         *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -169,7 +169,7 @@ BODY
 
     # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array
     # — the fix-cycle agent below reads it.
-    _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+    _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
     rm -f "$RESULT_FILE"
 
     case "$STATUS" in

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.20+e3cf3d"
+  version: "2026.05.21+699f2c"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/skills/land-pr/references/caller-loop-pattern.md
+++ b/skills/land-pr/references/caller-loop-pattern.md
@@ -86,7 +86,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -108,7 +108,7 @@ while :; do
   # prefix. Build the array from cleanup-targets only.
   # Per DA2-11: use an array (not space-joined string) to avoid
   # field-splitting bugs if a sidecar path ever contains spaces.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.18+be6644"
+  version: "2026.05.21+9b99f1"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -1124,7 +1124,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -1138,7 +1138,7 @@ while :; do
 
   # Sidecar cleanup paths. CI_LOG_FILE intentionally NOT in the array —
   # the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   # WI 1.16 — append the PR URL to the fulfillment marker as soon as

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.20+3f7678"
+  version: "2026.05.21+6e2240"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -399,7 +399,7 @@ while :; do
     case "$KEY" in
       STATUS|PR_URL|PR_NUMBER|PR_EXISTING|CI_STATUS|CI_LOG_FILE|\
       MERGE_REQUESTED|MERGE_REASON|PR_STATE|REASON|\
-      CONFLICT_FILES_LIST|CALL_ERROR_FILE)
+      CONFLICT_FILES_LIST|CALL_ERROR_FILE|REBASE_STDERR_FILE)
         LP["$KEY"]="$VALUE" ;;
       "") ;;  # blank line — ignore
       *) printf 'WARN: /land-pr result has unknown key %q — ignoring\n' "$KEY" >&2 ;;
@@ -413,7 +413,7 @@ while :; do
 
   # Sidecar cleanup paths (per DA1-12, DA2-11). CI_LOG_FILE is intentionally
   # NOT in the array — the fix-cycle agent below reads it.
-  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}")
+  _CLEANUP_PATHS=("${LP[CALL_ERROR_FILE]:-}" "${LP[CONFLICT_FILES_LIST]:-}" "${LP[REBASE_STDERR_FILE]:-}")
   rm -f "$RESULT_FILE"
 
   case "$STATUS" in


### PR DESCRIPTION
## Summary
- `skills/land-pr/SKILL.md` declares + writes `REBASE_STDERR_FILE` on every Step-6b failure, but the canonical allow-list parser and all 5 caller copies omitted it. Each Step-6b failure produced a `WARN: unknown key REBASE_STDERR_FILE — ignoring` log + a `/tmp/land-pr-auto-rebase-stderr-*-*.log` sidecar leak.
- Adds `REBASE_STDERR_FILE` to the `case "$KEY" in ...)` arm in all 6 sites (canonical pattern + 5 caller copies).
- Adds the sidecar path to `_CLEANUP_PATHS` in all 6 sites so the file is unlinked on caller exit.
- 6 skill SKILL.md `metadata.version` bumps:
  - land-pr `2026.05.21+699f2c`, run-plan `+6e2240`, fix-issues `+5bda3b` (recomputed post-rebase after PR #544), do `+163578`, commit `+83be3b`, quickfix `+9b99f1`.
- 6 byte-equal mirrors under `.claude/skills/`.

Closes #535.

## Test plan
- [x] `grep -rn REBASE_STDERR_FILE skills/{land-pr,run-plan,fix-issues,do,commit,quickfix}/` shows hits at all 6 expected sites + cleanup additions.
- [x] All 6 skill version hashes match `bash scripts/skill-content-hash.sh skills/<name>`.
- [x] `diff -rq skills/ .claude/skills/` silent on edited skills.
- [x] Full suite: `Overall: 4618/4618 passed, 0 failed`.
- [x] `test-skill-conformance.sh`: 489/489. `test-skills-mirror-parity.sh`: 59/59.
