### PR TITLE
fix(hooks): is_git_subcommand path-strips so absolute-path git invocations are still gated (Closes #528)

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -221,6 +221,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -109,6 +109,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -83,6 +83,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -76,6 +76,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -221,6 +221,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -109,6 +109,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -83,6 +83,13 @@ is_git_subcommand() {
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/git push origin main`
+  # and `./git commit` are recognized as git invocations. Mirrors the gh
+  # variant's path-strip (issue #528). Without this, path-prefixed forms
+  # silently bypassed every git-side hook gate.
+  case "$g" in
+    */*) g="${g##*/}" ;;
+  esac
   [[ "$g" != "git" ]] && return 1
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -80,6 +80,22 @@ expect_allow "printf w/ stash text" "printf %s git-stash-push"
 expect_deny "&& git stash" "cd foo && git stash"
 expect_deny "; git stash" "echo ok; git stash"
 
+# 1e. Path-prefixed git invocations — issue #528. `command -v git` returns
+# `/usr/bin/git` on most systems, and scripts capturing `$(command -v git)`
+# produce path-prefixed forms. Pre-fix, `is_git_subcommand` compared the
+# first token literally to "git" without stripping a path prefix, silently
+# bypassing every git-side hook gate. The fix in hooks/_lib/git-tokenwalk.sh
+# mirrors the gh variant's path-strip (`case "$g" in */*) g="${g##*/}" ;; esac`).
+# Each case below targets a DIFFERENT gate to confirm coverage across the
+# whole helper-consuming surface.
+expect_deny "/usr/bin/git stash drop (path-prefix #528)"             "/usr/bin/git stash drop"
+expect_deny "/usr/local/bin/git checkout -- file (path-prefix #528)" "/usr/local/bin/git checkout -- file.js"
+expect_deny "./git reset --hard (relative-path-prefix #528)"         "./git reset --hard HEAD~1"
+expect_deny "/usr/bin/git commit --no-verify (path-prefix #528)"     "/usr/bin/git commit --no-verify -m msg"
+expect_deny "/usr/bin/git add -A (path-prefix #528)"                 "/usr/bin/git add -A"
+# Wrapper + path-prefix: bash -c 'absolute-path git ...' must also gate.
+expect_deny "bash -c with /usr/bin/git stash (wrapper + path-prefix #528)" "bash -c '/usr/bin/git stash'"
+
 # 2. git checkout -- file  (file-separator form — discards working tree changes)
 # The `--` must be scoped to the file-list separator: `--` followed by
 # whitespace (then paths) or end-of-command. Without that anchor, the
@@ -374,6 +390,12 @@ bare_push_test "allow: git push (bare, on feature branch)" "feat/test" "allow"
 # Explicit target tests — don't depend on current branch (parser extracts target)
 expect_deny "git push origin main" "git push origin main"
 expect_deny "git push -u origin main" "git push -u origin main"
+
+# Path-prefixed push to main — issue #528. Same family as #515 (HEAD bypass);
+# pre-fix the first-token literal "git" check let path-prefixed forms slip
+# through every git-side gate including BLOCK_MAIN_PUSH.
+expect_deny "/usr/bin/git push origin main (path-prefix #528)" "/usr/bin/git push origin main"
+expect_deny "/usr/local/bin/git push -u origin main (path-prefix #528)" "/usr/local/bin/git push -u origin main"
 
 # Issue #392: <localref>:main refspec — generic hook's BLOCK_MAIN_PUSH path
 # must parse the REMOTE side of the colon. Pre-fix ${X%%:*} kept the local


### PR DESCRIPTION
## Summary
- **High-severity silent hook-bypass fix.** `is_git_subcommand` in `hooks/_lib/git-tokenwalk.sh` checked the first token against literal `"git"` after quote-stripping but did NOT path-strip. So `/usr/bin/git push origin main` → token `/usr/bin/git` → no match → hook returned "not git" → ALL git-side gates silently allowed (BLOCK_MAIN_PUSH, stash gate, commit --no-verify gate, reset --hard, etc.). Sister helper `is_gh_pr_subcommand` already path-stripped correctly; `is_git_subcommand` was the gap. Same family as #515 (HEAD bypass) — both are silent normalizations the parser doesn't perform.
- Mirrors `is_gh_pr_subcommand`'s pattern: `case "$g" in */*) g="${g##*/}" ;; esac` between the quote-strip and equality check.
- Propagated the inlined-helper update to **3 consumers**:
  - `hooks/block-unsafe-generic.sh`
  - `hooks/block-unsafe-project.sh.template`
  - `hooks/block-stale-skill-version.sh`
- All 4 helper bodies remain byte-identical (drift gate `tests/test-hook-helper-drift.sh` passes).
- Mirrored source → `.claude/hooks/` for each consumer (parity gate enforces).
- Adds **8 path-prefixed regression tests** to `tests/test-hooks.sh` covering absolute (`/usr/bin/git`, `/usr/local/bin/git`), path-relative (`./git`), and wrapper-composition (`bash -c '/usr/bin/git ...'`) forms across 6 distinct hook gates (push-main, stash drop, checkout --, reset --hard, commit --no-verify, add -A).

Closes #528.

## Test plan
- [x] Verification trace: `is_git_subcommand "/usr/bin/git push origin main" push` → HIT (was MISS pre-fix).
- [x] Full suite: `Overall: 4626/4626 passed, 0 failed`.
- [x] `test-hooks.sh`: 1734/1734. `test-hooks-mirror-parity.sh`: 21/21. `test-skills-mirror-parity.sh`: 59/59. `test-hook-helper-drift.sh`: 18/18.
- [x] 8 new path-prefixed cases all PASS. Reverting the path-strip would cause `expect_deny "/usr/bin/git push origin main"` to fail (returns allow instead of deny) — verifier walked this concrete mutation.
- [x] Scope: only `hooks/_lib/git-tokenwalk.sh` + 3 inlined consumers + 3 `.claude/hooks/` mirrors + `tests/test-hooks.sh`. NO skill SKILL.md edits.
