### PR TITLE
fix(hooks): requires.* enforcement only fires when committing on main (Closes #547)

### DIFF
--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -808,7 +808,17 @@ if is_git_subcommand_in_wrappers "$COMMAND" commit; then
 
       # Delegation check: requires.* must have matching fulfilled.*
       # Subdir-only reader (Phase 6: dual-read fallback removed; all writers migrated).
-      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ]; then
+      #
+      # Fire ONLY when committing on main (issue #547). The gate's purpose is
+      # to protect the actual landing event — commits hitting `main`. Commits
+      # on feature branches (`feat/*`, `fix/*`, `cp-*`, worktree branches) are
+      # legitimate intermediate work that will be PR-merged or cherry-picked
+      # later, and must not be blocked by a `requires.land-pr.<id>` marker
+      # whose fulfillment can only happen AFTER those very commits land.
+      # PR #211's protection is preserved: a `finish-auto` exit before
+      # /land-pr leaves `requires.land-pr` unfulfilled, and any subsequent
+      # commit-to-main in that pipeline is still blocked.
+      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ] && is_on_main; then
         for req in "$PIPELINE_SUBDIR"/requires.*; do
           [ -e "$req" ] || continue
           enforce_requires_marker "$req" "committing"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -808,7 +808,17 @@ if is_git_subcommand_in_wrappers "$COMMAND" commit; then
 
       # Delegation check: requires.* must have matching fulfilled.*
       # Subdir-only reader (Phase 6: dual-read fallback removed; all writers migrated).
-      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ]; then
+      #
+      # Fire ONLY when committing on main (issue #547). The gate's purpose is
+      # to protect the actual landing event — commits hitting `main`. Commits
+      # on feature branches (`feat/*`, `fix/*`, `cp-*`, worktree branches) are
+      # legitimate intermediate work that will be PR-merged or cherry-picked
+      # later, and must not be blocked by a `requires.land-pr.<id>` marker
+      # whose fulfillment can only happen AFTER those very commits land.
+      # PR #211's protection is preserved: a `finish-auto` exit before
+      # /land-pr leaves `requires.land-pr` unfulfilled, and any subsequent
+      # commit-to-main in that pipeline is still blocked.
+      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ] && is_on_main; then
         for req in "$PIPELINE_SUBDIR"/requires.*; do
           [ -e "$req" ] || continue
           enforce_requires_marker "$req" "committing"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -912,6 +912,46 @@ touch "$TEST_TMPDIR/$DEFAULT_SUBDIR/requires.land-pr.test-plan"
 expect_project_deny "git cherry-pick abc123"
 teardown_project_test
 
+# Issue #547: requires.* enforcement on commit fires ONLY when on main.
+# Commits on feature branches (where PR-mode /run-plan implementer/verifier
+# subagents actually commit) must NOT be gated by `requires.land-pr.<id>` —
+# that marker's fulfillment can only happen AFTER those commits land via
+# /land-pr. Past failure: PR #544 verifier commit blocked on feature branch.
+
+# Positive case: commit on feature branch with UNFULFILLED requires.land-pr
+# is allowed. (Asserts the gate now only fires on main — the marker is
+# present and there is no fulfilled.land-pr companion. If we tightened the
+# check by mistake — e.g., always denying — this test would catch it.)
+setup_project_test
+mkdir -p "$TEST_TMPDIR/$DEFAULT_SUBDIR"
+touch "$TEST_TMPDIR/$DEFAULT_SUBDIR/requires.land-pr.test-plan"
+# Confirm the marker is unfulfilled: no fulfilled.land-pr.* in the subdir.
+if compgen -G "$TEST_TMPDIR/$DEFAULT_SUBDIR/fulfilled.land-pr.*" >/dev/null; then
+  fail "issue-547 positive setup: fulfilled.land-pr.* should not exist"
+fi
+# Switch to a feature branch so is_on_main returns false.
+(cd "$TEST_TMPDIR" && git checkout -q -b fix/issue-547-test 2>/dev/null)
+(cd "$TEST_TMPDIR" && echo "var x=1;" > app.js && git add app.js)
+expect_project_allow "issue-547: commit on feature branch with unfulfilled requires.land-pr" "git commit -m test"
+teardown_project_test
+
+# Negative case: same pipeline, same unfulfilled marker — but on main —
+# is STILL denied. (Preserves PR #211's protection: a finish-auto exit
+# before /land-pr leaves the marker unfulfilled, and any commit-to-main
+# in that pipeline is blocked.)
+setup_project_test
+mkdir -p "$TEST_TMPDIR/$DEFAULT_SUBDIR"
+touch "$TEST_TMPDIR/$DEFAULT_SUBDIR/requires.land-pr.test-plan"
+# setup_project_test leaves us on the init default branch (master) which
+# is_on_main accepts. Explicit assertion for clarity:
+_branch=$(cd "$TEST_TMPDIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ "$_branch" != "main" && "$_branch" != "master" ]]; then
+  fail "issue-547 negative setup: expected main/master, got $_branch"
+fi
+(cd "$TEST_TMPDIR" && echo "var x=1;" > app.js && git add app.js)
+expect_project_deny "issue-547: commit on main with unfulfilled requires.land-pr (still blocked)" "git commit -m test"
+teardown_project_test
+
 echo ""
 echo "=== Project hook: step enforcement ==="
 

--- a/tests/test-tracking-integration.sh
+++ b/tests/test-tracking-integration.sh
@@ -243,13 +243,19 @@ echo "=== Test 3: Worktree enforcement ==="
 
 setup_repo
 
-# Create a branch for the worktree
-(cd "$TEST_TMPDIR" && git checkout -q -b worktree-branch && git checkout -q master 2>/dev/null || git checkout -q main 2>/dev/null)
+# Per issue #547: requires.* enforcement fires only when committing on
+# main/master. To preserve the original mechanism-coverage intent of this
+# block (the hook reads tracking markers from MAIN repo's tracking dir
+# via git-common-dir from inside a worktree), we put the worktree ON the
+# MAIN branch — switching the main repo away to a feature branch first
+# so the main branch is free for the worktree.
+MAIN_BRANCH=$(cd "$TEST_TMPDIR" && git rev-parse --abbrev-ref HEAD)
+(cd "$TEST_TMPDIR" && git checkout -q -b feat-main-host-3 2>/dev/null)
 
-# Create a worktree
+# Create a worktree on the main branch (where is_on_main → true).
 WORKTREE_DIR=$(mktemp -d)
 rmdir "$WORKTREE_DIR"  # git worktree add needs non-existing dir
-(cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" worktree-branch 2>/dev/null)
+(cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" "$MAIN_BRANCH" 2>/dev/null)
 
 if [ ! -d "$WORKTREE_DIR" ]; then
   fail "Test 3: could not create worktree, skipping"
@@ -274,13 +280,15 @@ else
   # Stage a code file in the worktree
   (cd "$WORKTREE_DIR" && echo "var x = 1;" > thermal.js && git add thermal.js)
 
-  # Attempt commit in the worktree -- should be BLOCKED
-  # The hook reads .zskills-tracked from WORKTREE (REPO_ROOT), but tracking
-  # markers from MAIN repo (TRACKING_ROOT).
+  # Attempt commit in the worktree (on the main branch).
+  # is_on_main → true → requires.* enforcement fires.
+  # This exercises the original purpose of Test 3: the hook reads tracking
+  # markers from MAIN repo's tracking dir via git-common-dir even when
+  # invoked from the worktree.
   if try_commit_worktree "$WORKTREE_DIR" "$TEST_TMPDIR" "$WORKTREE_DIR/.claude/hooks/block-unsafe-project.sh"; then
-    fail "Test 3a: worktree commit should be blocked by unfulfilled requires marker"
+    fail "Test 3a: worktree commit on main should be blocked by unfulfilled requires marker"
   else
-    pass "Test 3a: worktree commit blocked by main repo's unfulfilled requires marker"
+    pass "Test 3a: main-branch worktree commit blocked by main repo's unfulfilled requires marker"
   fi
 
   # Create fulfilled marker in the SAME subdir in the main repo
@@ -317,11 +325,15 @@ echo "=== Test 3-cd-chain: Worktree enforcement via cd-chained command (#391) ==
 
 setup_repo
 
-# Create a branch + worktree.
-(cd "$TEST_TMPDIR" && git checkout -q -b worktree-branch-cdchain && git checkout -q master 2>/dev/null || git checkout -q main 2>/dev/null)
+# Per issue #547: requires.* enforcement fires only when committing on
+# main/master. Put the worktree ON the main branch so the deny-expectation
+# below exercises the cd-chain LOCAL_ROOT extraction (the original #391
+# regression coverage) without colliding with the new is_on_main gate.
+MAIN_BRANCH=$(cd "$TEST_TMPDIR" && git rev-parse --abbrev-ref HEAD)
+(cd "$TEST_TMPDIR" && git checkout -q -b feat-main-host-cdchain 2>/dev/null)
 WORKTREE_DIR=$(mktemp -d)
 rmdir "$WORKTREE_DIR"
-(cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" worktree-branch-cdchain 2>/dev/null)
+(cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" "$MAIN_BRANCH" 2>/dev/null)
 
 if [ ! -d "$WORKTREE_DIR" ]; then
   fail "Test 3-cd-chain: could not create worktree, skipping"
@@ -404,10 +416,15 @@ echo "=== Test 3-wrapper-cd: Worktree enforcement via wrapper-cd envelope (#427)
 for wrapper_case in bash-c sh-c eval; do
   setup_repo
 
-  (cd "$TEST_TMPDIR" && git checkout -q -b "wrapper-branch-$wrapper_case" && git checkout -q master 2>/dev/null || git checkout -q main 2>/dev/null)
+  # Per issue #547: requires.* enforcement fires only when committing on
+  # main/master. Put the worktree ON the main branch so the deny-expectation
+  # below exercises the wrapper-cd LOCAL_ROOT extraction (the original #427
+  # regression coverage) without colliding with the new is_on_main gate.
+  MAIN_BRANCH=$(cd "$TEST_TMPDIR" && git rev-parse --abbrev-ref HEAD)
+  (cd "$TEST_TMPDIR" && git checkout -q -b "feat-main-host-$wrapper_case" 2>/dev/null)
   WORKTREE_DIR=$(mktemp -d)
   rmdir "$WORKTREE_DIR"
-  (cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" "wrapper-branch-$wrapper_case" 2>/dev/null)
+  (cd "$TEST_TMPDIR" && git worktree add -q "$WORKTREE_DIR" "$MAIN_BRANCH" 2>/dev/null)
 
   if [ ! -d "$WORKTREE_DIR" ]; then
     fail "Test 3-wrapper-cd-$wrapper_case: could not create worktree, skipping"


### PR DESCRIPTION
## Summary
- `block-unsafe-project.sh:805-810` enforced ALL `requires.*` markers on every `git commit` in a pipeline, but `requires.land-pr` (written by `/run-plan` PR mode at SKILL.md:926-931 since PR #211) is fulfilled AFTER the feature-branch commits the gate was blocking. Verifier subagent's per-phase commit hit the deny. Workaround in PR #544 (delete marker → commit → rewrite) was patch-not-fix.
- Gate now fires only when committing ON MAIN (reuses existing `is_on_main()` helper). Feature-branch commits in pipelines with unfulfilled `requires.*` markers proceed normally. Push-to-main (the actual landing event) remains gated, preserving PR #211's protection against finish-auto Phase-6-skip holes.
- Mirrored source `hooks/block-unsafe-project.sh.template` → `.claude/hooks/block-unsafe-project.sh`.
- Added positive (feat branch + unfulfilled `requires.land-pr.*` + commit → ALLOW) + negative (main → DENY) cases to `tests/test-hooks.sh`. Reworked `tests/test-tracking-integration.sh` Test 3 family so the worktree runs on main — preserves #391 cd-chain + #427 wrapper-cd mechanism coverage under the new gate.

Closes #547.

## Test plan
- [x] Full suite: 4628/4628 passed.
- [x] `test-hooks.sh` 1736/1736; `test-hook-helper-drift.sh` 18/18; `test-hooks-mirror-parity.sh` 21/21; `test-tracking-integration.sh` 30/30.
- [x] Mutation: remove `is_on_main` guard → positive case (feat-branch ALLOW) fails. Invert to `! is_on_main` → negative case (main DENY) fails. Both regressions caught.
- [x] Test 3 rework defensibility verified by fresh verifier: the prior test had the worktree off a non-main branch, so the requires gate fired regardless. Rework puts the worktree ON main to actually exercise the new gate (not a weakening — a re-target).
