### PR TITLE
fix(hooks): resolve HEAD → current branch in push gate to close main-protection bypass (Closes #515)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -638,6 +638,16 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # fire (#470). Strip after the '+' strip so `+refs/heads/main` also
   # normalizes to "main".
   PUSH_TARGET="${PUSH_TARGET#refs/heads/}"
+  # If PUSH_TARGET is "HEAD", resolve to current local branch — Git pushes
+  # `origin HEAD` as the current-branch's remote-tracking ref (server-side
+  # resolution), defeating literal main/master string compare. Without this,
+  # `git push origin HEAD` from a `main` checkout silently bypassed the
+  # main-protection regime (#515). Apply AFTER colon-RHS / + / refs/heads/
+  # normalizations so all `HEAD`-bearing spellings (`+HEAD`, `refs/heads/HEAD`)
+  # also resolve.
+  if [ "$PUSH_TARGET" = "HEAD" ]; then
+    PUSH_TARGET=$(git branch --show-current 2>/dev/null)
+  fi
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -1035,6 +1035,31 @@ if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
       *) PUSH_ARGS="$PUSH_ARGS $word" ;;
     esac
   done
+  # Resolve a bare `HEAD` refspec to the current local branch before
+  # running rule (a)/(b)/(c). Git resolves `origin HEAD` server-side to the
+  # current branch — from a `main` checkout this targets remote `main` and
+  # defeats the main-protection regime (#515). Same family as #470 (the ref
+  # spelling enumerations) but `HEAD` is special because resolution happens
+  # SERVER-SIDE, not in the local parser. Substitute standalone `HEAD` /
+  # `+HEAD` / `refs/heads/HEAD` tokens (and their refspec-RHS forms like
+  # `feat:HEAD`) with the resolved branch so rule (a) and rule (b) match
+  # against the actual target.
+  _ZSK_CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+  if [ -n "$_ZSK_CURRENT_BRANCH" ]; then
+    _ZSK_NEW_ARGS=""
+    for word in $PUSH_ARGS; do
+      case "$word" in
+        HEAD|+HEAD|refs/heads/HEAD|+refs/heads/HEAD)
+          word="$_ZSK_CURRENT_BRANCH" ;;
+        *:HEAD|*:+HEAD|*:refs/heads/HEAD|*:+refs/heads/HEAD)
+          word="${word%:*}:$_ZSK_CURRENT_BRANCH" ;;
+      esac
+      _ZSK_NEW_ARGS="$_ZSK_NEW_ARGS $word"
+    done
+    PUSH_ARGS="$_ZSK_NEW_ARGS"
+    unset _ZSK_NEW_ARGS
+  fi
+  unset _ZSK_CURRENT_BRANCH
   # (a) Explicit origin main/master (optionally prefixed with + for
   # force-push or : for delete-refspec, and optionally fully-qualified as
   # refs/heads/main). Trailing class includes `'` and `"` so

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -638,6 +638,16 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # fire (#470). Strip after the '+' strip so `+refs/heads/main` also
   # normalizes to "main".
   PUSH_TARGET="${PUSH_TARGET#refs/heads/}"
+  # If PUSH_TARGET is "HEAD", resolve to current local branch — Git pushes
+  # `origin HEAD` as the current-branch's remote-tracking ref (server-side
+  # resolution), defeating literal main/master string compare. Without this,
+  # `git push origin HEAD` from a `main` checkout silently bypassed the
+  # main-protection regime (#515). Apply AFTER colon-RHS / + / refs/heads/
+  # normalizations so all `HEAD`-bearing spellings (`+HEAD`, `refs/heads/HEAD`)
+  # also resolve.
+  if [ "$PUSH_TARGET" = "HEAD" ]; then
+    PUSH_TARGET=$(git branch --show-current 2>/dev/null)
+  fi
 
   if [ "$BLOCK_MAIN_PUSH" = "1" ] && { [ "$PUSH_TARGET" = "main" ] || [ "$PUSH_TARGET" = "master" ]; }; then
     block_with_reason "BLOCKED: Agents must not push to main/master. Push feature branches instead, or the user can run: ! git push"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -1035,6 +1035,31 @@ if is_git_subcommand_in_wrappers "$COMMAND" push && is_main_protected; then
       *) PUSH_ARGS="$PUSH_ARGS $word" ;;
     esac
   done
+  # Resolve a bare `HEAD` refspec to the current local branch before
+  # running rule (a)/(b)/(c). Git resolves `origin HEAD` server-side to the
+  # current branch — from a `main` checkout this targets remote `main` and
+  # defeats the main-protection regime (#515). Same family as #470 (the ref
+  # spelling enumerations) but `HEAD` is special because resolution happens
+  # SERVER-SIDE, not in the local parser. Substitute standalone `HEAD` /
+  # `+HEAD` / `refs/heads/HEAD` tokens (and their refspec-RHS forms like
+  # `feat:HEAD`) with the resolved branch so rule (a) and rule (b) match
+  # against the actual target.
+  _ZSK_CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+  if [ -n "$_ZSK_CURRENT_BRANCH" ]; then
+    _ZSK_NEW_ARGS=""
+    for word in $PUSH_ARGS; do
+      case "$word" in
+        HEAD|+HEAD|refs/heads/HEAD|+refs/heads/HEAD)
+          word="$_ZSK_CURRENT_BRANCH" ;;
+        *:HEAD|*:+HEAD|*:refs/heads/HEAD|*:+refs/heads/HEAD)
+          word="${word%:*}:$_ZSK_CURRENT_BRANCH" ;;
+      esac
+      _ZSK_NEW_ARGS="$_ZSK_NEW_ARGS $word"
+    done
+    PUSH_ARGS="$_ZSK_NEW_ARGS"
+    unset _ZSK_NEW_ARGS
+  fi
+  unset _ZSK_CURRENT_BRANCH
   # (a) Explicit origin main/master (optionally prefixed with + for
   # force-push or : for delete-refspec, and optionally fully-qualified as
   # refs/heads/main). Trailing class includes `'` and `"` so

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -465,6 +465,24 @@ toggle_test "BLOCK_MAIN_PUSH=0 allows git push on master" 0 "master" "allow"
 toggle_test "BLOCK_MAIN_PUSH=0 allows 'git push origin main' (explicit refspec)" 0 "feat/test" "allow" "git push origin main"
 toggle_test "BLOCK_MAIN_PUSH=0 allows 'git push -u origin main' (upstream + refspec)" 0 "feat/test" "allow" "git push -u origin main"
 
+# Issue #515: `git push origin HEAD` from a `main` checkout resolves
+# server-side to remote `main` — defeats the main-protection regime via a
+# one-keystroke substitution. Same family as #470 (the ref-spelling
+# enumerations) but `HEAD` is special because resolution happens
+# SERVER-SIDE, not in the local parser. Pre-fix, PUSH_TARGET="HEAD"
+# survived all normalizations (colon-RHS, +, refs/heads/) and the equality
+# check against "main"/"master" missed. Post-fix, an explicit
+# `if [ "$PUSH_TARGET" = "HEAD" ]` block resolves to the current local
+# branch before the equality check.
+toggle_test "BLOCK_MAIN_PUSH=1 denies 'git push origin HEAD' from main (#515)" 1 "main" "deny" "git push origin HEAD"
+toggle_test "BLOCK_MAIN_PUSH=1 allows 'git push origin HEAD' from feat branch (#515)" 1 "feat/test" "allow" "git push origin HEAD"
+toggle_test "BLOCK_MAIN_PUSH=1 denies 'git push origin HEAD' from master (#515)" 1 "master" "deny" "git push origin HEAD"
+# Combines with #528's path-strip fix: `/usr/bin/git push origin HEAD`
+# from main must also deny — the wrapper-recursion's path-strip recognizes
+# the absolute-path git invocation, and the new HEAD resolution then maps
+# PUSH_TARGET to "main".
+toggle_test "BLOCK_MAIN_PUSH=1 denies '/usr/bin/git push origin HEAD' from main (#515 + #528)" 1 "main" "deny" "/usr/bin/git push origin HEAD"
+
 echo ""
 echo "=== Non-Bash tool_name ==="
 


### PR DESCRIPTION
## Summary
- **High-severity universal main-protection bypass.** `git push origin HEAD` from `main` was ALLOWED because the parser normalizes `HEAD` through colon-strip / `+`-strip / `refs/heads/`-strip but never resolves `HEAD` → current local branch. Server-side, Git resolves `origin HEAD` to current-branch's remote-tracking ref → from local `main` → remote `main` — defeating `main_protected: true`. Same enumeration-closure family as #470/#392/#457/#399/#426/#427/#528.
- `hooks/block-unsafe-generic.sh`: added `if [ "$PUSH_TARGET" = "HEAD" ]; then PUSH_TARGET=$(git branch --show-current 2>/dev/null); fi` after existing normalizations + before equality check. Detached-HEAD yields empty → safe fall-through.
- `hooks/block-unsafe-project.sh.template`: token-by-token rewrite over `PUSH_ARGS` handles `HEAD`, `+HEAD`, `refs/heads/HEAD`, `+refs/heads/HEAD`, AND refspec-RHS forms (`*:HEAD`, `*:+HEAD`, etc.) so rule (a) `origin[[:space:]]+...(main|master)` fires post-resolution.
- Mirrored to `.claude/hooks/`. Added 4 `toggle_test` cases at `tests/test-hooks.sh:467+`:
  - `git push origin HEAD` from main → DENY
  - `git push origin HEAD` from `feat/test` → ALLOW
  - `git push origin HEAD` from `master` → DENY
  - `/usr/bin/git push origin HEAD` from main → DENY (composes with #528's path-strip fix; locks the combined defense)

Closes #515.

## Test plan
- [x] Verification trace: pre-fix `git push origin HEAD` from main → ALLOWED (per body's reproduction). Post-fix → DENY confirmed by implementer's `/tmp/zsk-trace-515` and verifier's isolated test-hooks.sh run.
- [x] Full suite: 4630/4630 passed.
- [x] `test-hooks.sh` 1738/1738; `test-hook-helper-drift.sh` 18/18; `test-hooks-mirror-parity.sh` 21/21.
- [x] All 4 new cases mutation-verified by verifier (each catches a distinct regression class: HEAD-resolver removal, over-eager block, master-only handling, path-strip composition).
