### PR TITLE
fix(work-on-plans): schedule_under_1h minute-form numeric guard (Closes #546)

### DIFF
--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   queue (add/rank/remove/default) and recurring schedules. Mirrors
   /fix-issues for bugs.
 metadata:
-  version: "2026.05.15+2d47a4"
+  version: "2026.05.21+bd5465"
 ---
 
 # /work-on-plans — Batch Plan Executor
@@ -1071,8 +1071,11 @@ below that detects sub-hour intervals (`m`-suffixed numbers,
 schedule_under_1h() {
   # Returns 0 (true) iff $1 looks like a sub-hour interval.
   local s="$1"
-  # forms: "30m", "5m", "every 30m"
-  [[ "$s" =~ (^|[[:space:]])([0-9]+)m([[:space:]]|$) ]] && return 0
+  # forms: "30m", "5m", "every 30m" (N<60 only — "60m"/"120m" are ≥1h)
+  [[ "$s" =~ (^|[[:space:]])([0-9]+)m([[:space:]]|$) ]] && {
+    local n="${BASH_REMATCH[2]}"
+    [ "$n" -lt 60 ] && return 0
+  }
   # forms: "*/30 * * * *", "*/5 * * * *"
   [[ "$s" =~ ^\*/([0-9]+)[[:space:]] ]] && {
     local n="${BASH_REMATCH[1]}"

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   queue (add/rank/remove/default) and recurring schedules. Mirrors
   /fix-issues for bugs.
 metadata:
-  version: "2026.05.15+2d47a4"
+  version: "2026.05.21+bd5465"
 ---
 
 # /work-on-plans — Batch Plan Executor
@@ -1071,8 +1071,11 @@ below that detects sub-hour intervals (`m`-suffixed numbers,
 schedule_under_1h() {
   # Returns 0 (true) iff $1 looks like a sub-hour interval.
   local s="$1"
-  # forms: "30m", "5m", "every 30m"
-  [[ "$s" =~ (^|[[:space:]])([0-9]+)m([[:space:]]|$) ]] && return 0
+  # forms: "30m", "5m", "every 30m" (N<60 only — "60m"/"120m" are ≥1h)
+  [[ "$s" =~ (^|[[:space:]])([0-9]+)m([[:space:]]|$) ]] && {
+    local n="${BASH_REMATCH[2]}"
+    [ "$n" -lt 60 ] && return 0
+  }
   # forms: "*/30 * * * *", "*/5 * * * *"
   [[ "$s" =~ ^\*/([0-9]+)[[:space:]] ]] && {
     local n="${BASH_REMATCH[1]}"

--- a/tests/test-work-on-plans.sh
+++ b/tests/test-work-on-plans.sh
@@ -156,7 +156,10 @@ PY
 # Sub-hour detector mirroring SKILL.md schedule_under_1h() exactly.
 schedule_under_1h() {
   local s="$1"
-  [[ "$s" =~ (^|[[:space:]])([0-9]+)m([[:space:]]|$) ]] && return 0
+  [[ "$s" =~ (^|[[:space:]])([0-9]+)m([[:space:]]|$) ]] && {
+    local n="${BASH_REMATCH[2]}"
+    [ "$n" -lt 60 ] && return 0
+  }
   [[ "$s" =~ ^\*/([0-9]+)[[:space:]] ]] && {
     local n="${BASH_REMATCH[1]}"
     [ "$n" -lt 60 ] && return 0
@@ -367,6 +370,35 @@ if schedule_under_1h "*/2 * * * *"; then
   pass "AC-4 schedule_under_1h detects cron '*/2'"
 else
   fail "AC-4 schedule_under_1h '*/2' should be sub-hour"
+fi
+
+# --- #546 regression: minute-form must compare N<60 ----------------------
+# Pre-fix bug: any <N>m was classified sub-hour without comparing N to 60.
+if schedule_under_1h "60m"; then
+  fail "#546 schedule_under_1h '60m' must NOT be sub-hour (=1h boundary)"
+else
+  pass "#546 schedule_under_1h '60m' is NOT sub-hour"
+fi
+if schedule_under_1h "120m"; then
+  fail "#546 schedule_under_1h '120m' must NOT be sub-hour (=2h)"
+else
+  pass "#546 schedule_under_1h '120m' is NOT sub-hour"
+fi
+if schedule_under_1h "every 60m"; then
+  fail "#546 schedule_under_1h 'every 60m' must NOT be sub-hour"
+else
+  pass "#546 schedule_under_1h 'every 60m' is NOT sub-hour"
+fi
+if schedule_under_1h "1440m"; then
+  fail "#546 schedule_under_1h '1440m' must NOT be sub-hour (24h)"
+else
+  pass "#546 schedule_under_1h '1440m' is NOT sub-hour"
+fi
+# Confirm sub-60 minute forms still detected after the N<60 guard.
+if schedule_under_1h "59m"; then
+  pass "#546 schedule_under_1h '59m' is still sub-hour"
+else
+  fail "#546 schedule_under_1h '59m' should be sub-hour"
 fi
 
 # --- Test 13: SKILL.md cites the AC-4 ≥1h diagnostic --------------------


### PR DESCRIPTION
## Summary
- `skills/work-on-plans/SKILL.md:1068-1082` `schedule_under_1h` minute-form branch matched `<N>m` and returned 0 (true = sub-hour) without comparing N to 60. So `60m`, `120m`, `1440m`, `every 60m` all misclassified as sub-hour and incorrectly rejected with "must be ≥1h."
- One-line fix: numeric guard mirroring the cron-form pattern at the very next line. `metadata.version` bumped to `2026.05.21+bd5465`; mirror byte-equal.
- 5 regression cases added to `tests/test-work-on-plans.sh`: `60m`/`120m`/`every 60m`/`1440m` (all NOT-sub-hour) + `59m` (boundary control still REJECT).

Closes #546.

## Test plan
- [x] Full suite: 4631/4631 passed.
- [x] `test-work-on-plans.sh` 33/33; `test-skill-conformance.sh` 489/489; `test-skills-mirror-parity.sh` 59/59.
- [x] Mutation: reverting the `[ "$n" -lt 60 ]` guard makes the minute-form unconditionally return 0; first failing assertion is `60m` → not-sub-hour expected but got sub-hour.
- [x] Mirror byte-equal; skill version hash matches `bd5465`.
