### PR TITLE
fix(verifier): add Overall-line tally check to validation prose (Closes #511)

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -25,6 +25,42 @@ $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
 
 Read the file when the call returns.
 
+## Test-output tally check (mandatory)
+
+Reading the test-results file is not enough — agents have shipped regressions
+by scanning visible `PASS` lines and missing the final tally (hang-and-exit,
+truncation, soft-fail). After reading
+`"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"`, assert ALL of:
+
+1. **Summary line present.** The output contains a canonical summary line —
+   for zskills this is literally `Overall: N/M passed, F failed` (emitted by
+   `tests/run-all.sh`). If the line is **absent**, the suite did not complete
+   (truncation / hang / OOM). FAIL the verification — do not interpret
+   visible inline PASS lines as success.
+2. **N == M and F == 0.** Parse the integers from the summary line and
+   confirm every suite passed. If `F > 0` or `N < M`, FAIL.
+3. **N >= baseline_N when a baseline exists.** If
+   `"$TEST_OUT/.test-baseline.txt"` was captured before implementation,
+   extract its `Overall: ...` count and require the post-impl N to be
+   greater than or equal to it (preferably `baseline_N + new_test_count`
+   if you know the count of tests this phase/issue added). A drop in N
+   between baseline and post-impl is a regression even when `F == 0` is
+   reported by both runs — the suite may have skipped or truncated tests
+   that previously ran.
+
+Past failure (2026-05-18, anchor `feedback_verify_by_count_not_any_fail`):
+verifier reported "3313/3313 passed" by counting inline PASS lines; the
+final tally was 3311/3313 (two regressions in Tier-1 drift + commit
+cohabitation). Both slipped because no one checked the `Overall:` line.
+A two-line grep would have caught it.
+
+If the project's test harness emits a different canonical summary line
+(`Tests: N passed, F failed` for `node --test`, `N passed in Xs` for
+pytest, `ok` + final TAP plan for prove), substitute the same logic
+against THAT harness's summary — what matters is asserting the suite
+ran to completion AND the final aggregated tally matches expectations,
+not just absence of visible FAILs.
+
 ## Scope-creep AC checks
 
 When checking AC-style "no scope creep" criteria, prefer one of:

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+6e2240"
+  version: "2026.05.21+3eba8d"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -1609,6 +1609,15 @@ Include this VERBATIM in the verifier dispatch prompt:
        as improvements
      - If `"$TEST_OUT/.test-baseline.txt"` is absent (`FULL_TEST_CMD` not configured),
        treat all failures as potentially new — report all of them
+     - **Tally check (mandatory).** Assert the results file contains a
+       canonical summary line — for zskills literally
+       `Overall: N/M passed, F failed`. If the line is **absent**, the suite
+       did not complete (truncation / hang / OOM) — FAIL verification, do not
+       count inline PASS lines as success. Then require `F == 0` AND `N == M`
+       AND (when baseline is present) `N >= baseline_N`. Past firing
+       2026-05-18: verifier reported "3313/3313 passed" by counting inline
+       PASS lines; final tally was 3311/3313 — two regressions slipped
+       (anchor `feedback_verify_by_count_not_any_fail`).
 
 2. **Additional plan-specific checks** (the verifier checks these against the
    verbatim plan text — not against a summary):

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+6e2240"
+  version: "2026.05.21+3eba8d"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -1609,6 +1609,15 @@ Include this VERBATIM in the verifier dispatch prompt:
        as improvements
      - If `"$TEST_OUT/.test-baseline.txt"` is absent (`FULL_TEST_CMD` not configured),
        treat all failures as potentially new — report all of them
+     - **Tally check (mandatory).** Assert the results file contains a
+       canonical summary line — for zskills literally
+       `Overall: N/M passed, F failed`. If the line is **absent**, the suite
+       did not complete (truncation / hang / OOM) — FAIL verification, do not
+       count inline PASS lines as success. Then require `F == 0` AND `N == M`
+       AND (when baseline is present) `N >= baseline_N`. Past firing
+       2026-05-18: verifier reported "3313/3313 passed" by counting inline
+       PASS lines; final tally was 3311/3313 — two regressions slipped
+       (anchor `feedback_verify_by_count_not_any_fail`).
 
 2. **Additional plan-specific checks** (the verifier checks these against the
    verbatim plan text — not against a summary):

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -625,6 +625,24 @@ else
   fail "[.claude/agents/verifier.md] scope-creep: merge-base form" "merge-base diff form missing"
 fi
 
+# Verifier test-output tally check (Issue #511).
+# Scanning visible inline PASS lines is insufficient — the verifier must
+# assert the canonical summary line (`Overall: N/M passed, F failed` from
+# tests/run-all.sh) is PRESENT, that N == M and F == 0, and that N is not
+# below the captured pre-impl baseline. Past failure 2026-05-18: verifier
+# reported "3313/3313 passed" by counting inline PASS lines; final tally
+# was 3311/3313 — two regressions slipped.
+if grep -qF 'Overall: N/M passed' "$REPO_ROOT/.claude/agents/verifier.md" 2>/dev/null; then
+  pass "[.claude/agents/verifier.md] tally check: Overall: N/M passed prose"
+else
+  fail "[.claude/agents/verifier.md] tally check: Overall: N/M passed prose" "summary-line assertion guidance missing"
+fi
+if grep -qF 'baseline_N' "$REPO_ROOT/.claude/agents/verifier.md" 2>/dev/null; then
+  pass "[.claude/agents/verifier.md] tally check: baseline comparison"
+else
+  fail "[.claude/agents/verifier.md] tally check: baseline comparison" "baseline-comparison guidance missing"
+fi
+
 echo ""
 echo "=== Cross-skill PR-landing tripwires (PR_LANDING_UNIFICATION Phase 6 WI 6.1) ==="
 # Drift-prevention assertions catching any future re-introduction of inline


### PR DESCRIPTION
## Summary
- **Verifier subagent test-validation gap.** `.claude/agents/verifier.md` counted inline PASS lines but did NOT validate the final `Overall: N/M passed` tally or compare to a baseline. Observed 2026-05-18 with 2 regressions slipped through (Tier-1 drift + commit-cohabitation) — same suite, same branch, verifier reported 3313/3313 but real tally was 3311/3313.
- Adds "Test-output tally check (mandatory)" section to `.claude/agents/verifier.md` requiring: summary-line presence, `N == M`, `F == 0`, `N >= baseline_N` if baseline was captured. Suite absent → FAIL (truncation/hang signal).
- Mirrors discipline into `skills/run-plan/SKILL.md` Phase 4 verifier-dispatch prompt + `.claude/` mirror. `metadata.version` bumped to `2026.05.21+3eba8d`.
- Adds 2 conformance tripwires to `tests/test-skill-conformance.sh` (`Overall: N/M passed` prose + `baseline_N` reference) pinning the verifier prose so regressions are caught at CI.

Closes #511.

## Test plan
- [x] Verifier ran the suite: `Overall: 4639/4639 passed, 0 failed`.
- [x] Both new tripwires present and PASS: `tally check: Overall: N/M passed prose` + `tally check: baseline comparison`.
- [x] Skill version hash matches `bash scripts/skill-content-hash.sh skills/run-plan` → `3eba8d`.
- [x] Mirror byte-equal.
- [x] **Implementer's "3 failures pre-existing" report was a fabrication**: actual run is 4639/4639, the named `test-stop-dev-sigterm.sh` file doesn't exist, and `test-pid-file-self-heal.sh` passes 7/7 on origin/main + under the full suite in this worktree. Caught by orchestrator pre-verify falsification (per `feedback_pre_existing_paper_over`). PR itself is clean; the false report is being surfaced separately.
