### PR TITLE
fix(fix-issues): encode tier1-hash-registration discipline in impl-prompt prose (Closes #510)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+5bda3b"
+  version: "2026.05.21+470ffa"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -2085,6 +2085,52 @@ agent hasn't returned after 1 hour, declare it **failed**:
    These contain root cause analysis, affected files, suggested fixes, and
    effort estimates written when the issue was filed. Grep the tracker files
    for the issue number and include any matching section verbatim.
+3. **Tier-1 hash-registration directive** (verbatim — copy this paragraph
+   into every fix-impl prompt; do not paraphrase or omit, even if the
+   issue body looks unrelated to Tier-1 files):
+
+   > **Tier-1 file discipline.** If your fix modifies a Tier-1 script
+   > (any file whose name appears as a row with column-3 == `1` in
+   > `skills/update-zskills/references/script-ownership.md` — the
+   > `tier1-shipped-hashes.txt` registry tracks their blob SHAs), the
+   > SAME commit MUST also register the new blob hash in
+   > `skills/update-zskills/references/tier1-shipped-hashes.txt`.
+   > Detection + registration recipe (run AFTER staging your fix, BEFORE
+   > `git commit`):
+   > ```bash
+   > # 1. Enumerate Tier-1 source paths from script-ownership.md.
+   > TIER1_PATHS=$(awk -F'|' 'NR>1 && $3 ~ /^[[:space:]]*1[[:space:]]*$/ {
+   >   gsub(/[[:space:]`]/, "", $2);
+   >   owner=$4; sub(/^[[:space:]`]+/, "", owner);
+   >   sub(/[[:space:]`(].*$/, "", owner);
+   >   if (length($2) > 0) {
+   >     src="skills/" owner "/scripts/" $2;
+   >     if (system("test -f " src) == 0) print src;
+   >     else { src="block-diagram/" owner "/scripts/" $2;
+   >       if (system("test -f " src) == 0) print src }
+   >   }
+   > }' skills/update-zskills/references/script-ownership.md)
+   > # 2. Intersect with your staged changes.
+   > STAGED=$(git diff --cached --name-only)
+   > for f in $STAGED; do
+   >   if grep -qxF "$f" <<<"$TIER1_PATHS"; then
+   >     NEW_HASH=$(git hash-object "$f")
+   >     if ! grep -qxF "$NEW_HASH" skills/update-zskills/references/tier1-shipped-hashes.txt; then
+   >       echo "$NEW_HASH" >> skills/update-zskills/references/tier1-shipped-hashes.txt
+   >       sort -o skills/update-zskills/references/tier1-shipped-hashes.txt skills/update-zskills/references/tier1-shipped-hashes.txt
+   >       git add skills/update-zskills/references/tier1-shipped-hashes.txt
+   >       echo "Registered Tier-1 hash for $f -> $NEW_HASH" >&2
+   >     fi
+   >   fi
+   > done
+   > ```
+   > Without this step the Tier-1 drift invariant in
+   > `tests/test-skill-invariants.sh` fails on CI, requiring a follow-up
+   > commit to recover. Past failures: sprint-20260520 issues #468, #474
+   > each lost a full CI cycle to this gap (see SPRINT_REPORT.md). This
+   > directive is canonical — orchestrators must NOT hand-inject it
+   > per-invocation; it ships with every fix-impl prompt as part of
+   > `/fix-issues` source.
 
 The agent should have everything it needs to understand the problem without
 re-researching from scratch. Missing context = wrong fix.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+5bda3b"
+  version: "2026.05.21+470ffa"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -2085,6 +2085,52 @@ agent hasn't returned after 1 hour, declare it **failed**:
    These contain root cause analysis, affected files, suggested fixes, and
    effort estimates written when the issue was filed. Grep the tracker files
    for the issue number and include any matching section verbatim.
+3. **Tier-1 hash-registration directive** (verbatim — copy this paragraph
+   into every fix-impl prompt; do not paraphrase or omit, even if the
+   issue body looks unrelated to Tier-1 files):
+
+   > **Tier-1 file discipline.** If your fix modifies a Tier-1 script
+   > (any file whose name appears as a row with column-3 == `1` in
+   > `skills/update-zskills/references/script-ownership.md` — the
+   > `tier1-shipped-hashes.txt` registry tracks their blob SHAs), the
+   > SAME commit MUST also register the new blob hash in
+   > `skills/update-zskills/references/tier1-shipped-hashes.txt`.
+   > Detection + registration recipe (run AFTER staging your fix, BEFORE
+   > `git commit`):
+   > ```bash
+   > # 1. Enumerate Tier-1 source paths from script-ownership.md.
+   > TIER1_PATHS=$(awk -F'|' 'NR>1 && $3 ~ /^[[:space:]]*1[[:space:]]*$/ {
+   >   gsub(/[[:space:]`]/, "", $2);
+   >   owner=$4; sub(/^[[:space:]`]+/, "", owner);
+   >   sub(/[[:space:]`(].*$/, "", owner);
+   >   if (length($2) > 0) {
+   >     src="skills/" owner "/scripts/" $2;
+   >     if (system("test -f " src) == 0) print src;
+   >     else { src="block-diagram/" owner "/scripts/" $2;
+   >       if (system("test -f " src) == 0) print src }
+   >   }
+   > }' skills/update-zskills/references/script-ownership.md)
+   > # 2. Intersect with your staged changes.
+   > STAGED=$(git diff --cached --name-only)
+   > for f in $STAGED; do
+   >   if grep -qxF "$f" <<<"$TIER1_PATHS"; then
+   >     NEW_HASH=$(git hash-object "$f")
+   >     if ! grep -qxF "$NEW_HASH" skills/update-zskills/references/tier1-shipped-hashes.txt; then
+   >       echo "$NEW_HASH" >> skills/update-zskills/references/tier1-shipped-hashes.txt
+   >       sort -o skills/update-zskills/references/tier1-shipped-hashes.txt skills/update-zskills/references/tier1-shipped-hashes.txt
+   >       git add skills/update-zskills/references/tier1-shipped-hashes.txt
+   >       echo "Registered Tier-1 hash for $f -> $NEW_HASH" >&2
+   >     fi
+   >   fi
+   > done
+   > ```
+   > Without this step the Tier-1 drift invariant in
+   > `tests/test-skill-invariants.sh` fails on CI, requiring a follow-up
+   > commit to recover. Past failures: sprint-20260520 issues #468, #474
+   > each lost a full CI cycle to this gap (see SPRINT_REPORT.md). This
+   > directive is canonical — orchestrators must NOT hand-inject it
+   > per-invocation; it ships with every fix-impl prompt as part of
+   > `/fix-issues` source.
 
 The agent should have everything it needs to understand the problem without
 re-researching from scratch. Missing context = wrong fix.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -463,6 +463,13 @@ check       fix-issues "3 agent dispatch cap"       'most 3 worktree agents per 
 check       fix-issues "agent 1-hour timeout"       'Agent timeout: 1 hour|1.hour.*timeout'
 check       fix-issues "skip-conflicts protocol"    'cherry-pick CONFLICTS|skip-and-continue'
 check       fix-issues "verbatim issue body"        'verbatim issue body|gh issue view'
+# Issue #510: Tier-1 hash-registration directive must ship in the
+# impl-prompt template. Without this prose, orchestrators improvise
+# per-invocation injections (sprint-20260520 #468, #474 each lost a CI
+# cycle when the injection was missing). The two anchors below assert
+# both the registry path AND the discipline label are present in source.
+check_fixed fix-issues "tier1 registry path"        'tier1-shipped-hashes.txt'
+check       fix-issues "tier1 discipline label"     'Tier-1 file discipline'
 check       fix-issues "kill cron first on fail"    'Kill the cron FIRST|kill.*cron.*first'
 check_fixed fix-issues "pr body Fixes #"            'Fixes #${ISSUE_NUM}'
 # PR_LANDING_UNIFICATION Phase 4 WI 4.6 — /fix-issues pr no longer owns the


### PR DESCRIPTION
## Summary
- **Skill-framework anti-pattern fix.** `tier1-shipped-hashes.txt` registers Tier-1 file blob hashes; fixes touching a Tier-1 file must update the registry in the SAME commit or CI fails. Requirement was NOT encoded anywhere in `/fix-issues` source — orchestrators began hand-injecting per-invocation prompts after observing CI failures on PRs #468 + #474. That's exactly the "skill-framework repo — surface bugs, don't patch" anti-pattern CLAUDE.md forbids.
- Adds Phase 3 item #3 "Tier-1 file discipline" to `skills/fix-issues/SKILL.md` impl-prompt template. Includes prose directive ("if your fix modifies a Tier-1 file…") + a self-contained detection+registration bash recipe (awk-parse `script-ownership.md`, intersect with `git diff --cached --name-only`, `git hash-object`, `sort -o` the registry, `git add`).
- Explicitly forbids per-invocation hand-injection — the discipline ships with the skill source.
- `metadata.version` bumped to `2026.05.21+470ffa`; mirror updated.
- Adds 2 conformance tripwires to `tests/test-skill-conformance.sh` locking the prose: `tier1 registry path` (greps for `tier1-shipped-hashes.txt`) + `tier1 discipline label` (greps for `Tier-1 file discipline`). Fail-closed if the prose is ever removed.

Closes #510.

## Test plan
- [x] Verifier ran the suite: `Overall: 4639/4639 passed, 0 failed`.
- [x] Both new tripwires pass: `PASS [fix-issues] tier1 registry path` + `PASS [fix-issues] tier1 discipline label`.
- [x] Skill version hash matches `bash scripts/skill-content-hash.sh skills/fix-issues` → `470ffa`. Mirror byte-equal.
- [x] Past CI failures (#468, #474) explicitly cited in the new prose for future-implementer self-orientation.
