### PR TITLE
fix(run-plan,research-and-go,verify-changes): Phase 4/verify dispatch uses merge-base diff, not symmetric (Closes #557)

### DIFF
--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.16+087b59"
+  version: "2026.05.21+ab9adf"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -322,7 +322,7 @@ marker. It schedules:
 2. A re-entry cron firing `Run /run-plan $META_PLAN_PATH finish auto`
 
 The verify cron runs at top level (full Agent tool), performs cross-branch
-verification (`git diff main...HEAD`), and on success writes
+verification (`git diff $(git merge-base origin/main HEAD)..HEAD`), and on success writes
 `fulfilled.verify-changes.final.$META_PLAN_SLUG`. The re-entry cron then
 completes Phase 5b (mark plan complete) cleanly. The user sees the verify
 report as the final turn before the pipeline is truly complete.

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+3eba8d"
+  version: "2026.05.21+44771f"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -1589,8 +1589,12 @@ Include this VERBATIM in the verifier dispatch prompt:
      `basename` of the SAME path literal, so the baseline and the results land
      in the same `/tmp/zskills-tests/<name>/` bucket.
 
-   - The **worktree branch name** (so it can diff against main:
-     `git diff main...<branch>`)
+   - The **worktree branch name** (so it can diff against main using the
+     merge-base form: `git diff $(git merge-base origin/main HEAD)..HEAD`,
+     or commit-only: `git show HEAD`. Do NOT use `main...<branch>` or
+     bare `origin/main..HEAD --stat` — those are symmetric and produce
+     false-positive scope-creep on sibling-sprint cadence. See
+     `.claude/agents/verifier.md`.)
    - The **verbatim phase text** from the plan (same text the implementer got)
    - Instruction to run `/verify-changes worktree` — the verification agent
      runs this, NOT you. Do NOT run verification yourself — you are the

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.05.20+b479a1"
+  version: "2026.05.21+aaf42e"
 ---
 
 # /verify-changes [scope] — Verify, Test & Fix Changes
@@ -253,7 +253,7 @@ When `$SCOPE = "branch"` this writes to
 1. **Determine the diff scope** based on the argument:
    - Default: `git diff` + `git diff --cached` + `git status -s`
    - `worktree`: `git diff $(git merge-base HEAD main)..HEAD` + `git diff` + `git diff --cached`
-   - `branch`: `git log main..HEAD --oneline` + `git diff main...HEAD`
+   - `branch`: `git log $(git merge-base origin/main HEAD)..HEAD --oneline` + `git diff $(git merge-base origin/main HEAD)..HEAD`
    - `last`: `git diff HEAD~1..HEAD`
    - `last N`: `git diff HEAD~N..HEAD`
 

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.16+087b59"
+  version: "2026.05.21+ab9adf"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -322,7 +322,7 @@ marker. It schedules:
 2. A re-entry cron firing `Run /run-plan $META_PLAN_PATH finish auto`
 
 The verify cron runs at top level (full Agent tool), performs cross-branch
-verification (`git diff main...HEAD`), and on success writes
+verification (`git diff $(git merge-base origin/main HEAD)..HEAD`), and on success writes
 `fulfilled.verify-changes.final.$META_PLAN_SLUG`. The re-entry cron then
 completes Phase 5b (mark plan complete) cleanly. The user sees the verify
 report as the final turn before the pipeline is truly complete.

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+3eba8d"
+  version: "2026.05.21+44771f"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -1589,8 +1589,12 @@ Include this VERBATIM in the verifier dispatch prompt:
      `basename` of the SAME path literal, so the baseline and the results land
      in the same `/tmp/zskills-tests/<name>/` bucket.
 
-   - The **worktree branch name** (so it can diff against main:
-     `git diff main...<branch>`)
+   - The **worktree branch name** (so it can diff against main using the
+     merge-base form: `git diff $(git merge-base origin/main HEAD)..HEAD`,
+     or commit-only: `git show HEAD`. Do NOT use `main...<branch>` or
+     bare `origin/main..HEAD --stat` — those are symmetric and produce
+     false-positive scope-creep on sibling-sprint cadence. See
+     `.claude/agents/verifier.md`.)
    - The **verbatim phase text** from the plan (same text the implementer got)
    - Instruction to run `/verify-changes worktree` — the verification agent
      runs this, NOT you. Do NOT run verification yourself — you are the

--- a/skills/verify-changes/SKILL.md
+++ b/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.05.20+b479a1"
+  version: "2026.05.21+aaf42e"
 ---
 
 # /verify-changes [scope] — Verify, Test & Fix Changes
@@ -253,7 +253,7 @@ When `$SCOPE = "branch"` this writes to
 1. **Determine the diff scope** based on the argument:
    - Default: `git diff` + `git diff --cached` + `git status -s`
    - `worktree`: `git diff $(git merge-base HEAD main)..HEAD` + `git diff` + `git diff --cached`
-   - `branch`: `git log main..HEAD --oneline` + `git diff main...HEAD`
+   - `branch`: `git log $(git merge-base origin/main HEAD)..HEAD --oneline` + `git diff $(git merge-base origin/main HEAD)..HEAD`
    - `last`: `git diff HEAD~1..HEAD`
    - `last N`: `git diff HEAD~N..HEAD`
 

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -632,6 +632,24 @@ else
   fail "[.claude/agents/verifier.md] scope-creep: merge-base form" "merge-base diff form missing"
 fi
 
+# Symmetric-diff anti-pattern absence in skills/ (Issue #557).
+# The three-dot symmetric `main...<branch>` form has the same false-positive
+# failure mode as the two-dot bare `origin/main..HEAD --stat` (issue #448):
+# when origin/main advances past the branch merge-base mid-verification,
+# files added on origin appear as "deletions" in HEAD's diff and the
+# verifier REJECTs with a destructive recovery path. PR #453 fixed the
+# agent file; this tripwire prevents any skill SKILL.md from re-introducing
+# the orchestrator-side instruction that previously overrode the agent-file
+# defense at `skills/run-plan/SKILL.md:1592-1593`. Scope: skills/**/*.md
+# ONLY (not docs/ or issues/, where the literal appears in this issue's
+# own blurb and sprint-report prose).
+symmetric_hits=$(grep -rlE 'git (diff|log) (origin/)?main\.\.\.' "$REPO_ROOT/skills" --include='*.md' 2>/dev/null || true)
+if [ -z "$symmetric_hits" ]; then
+  pass "[skills/**/*.md] no symmetric-diff anti-pattern (git diff main...)"
+else
+  fail "[skills/**/*.md] no symmetric-diff anti-pattern (git diff main...)" "actionable symmetric-diff command appears in: $symmetric_hits"
+fi
+
 # Verifier test-output tally check (Issue #511).
 # Scanning visible inline PASS lines is insufficient — the verifier must
 # assert the canonical summary line (`Overall: N/M passed, F failed` from


### PR DESCRIPTION
## Summary
- **Closure-incomplete on PR #453** (fixed #448 in `.claude/agents/verifier.md`). The orchestrator-supplied dispatch prompt at `skills/run-plan/SKILL.md:1592-1593` still instructed the verifier to use `git diff main...<branch>` — three-dot symmetric + bare `main`. The orchestrator's instruction overrode the agent file's defense. Same documented two-failure incident (PR #447 landing window 2026-05-19/20).
- Replaced `git diff main...<branch>` at `skills/run-plan/SKILL.md:1592-1597` with the merge-base form `git diff $(git merge-base origin/main HEAD)..HEAD` (mirroring `.claude/agents/verifier.md`).
- **Bonus closure**: the new conformance tripwire flagged the same anti-pattern in `skills/research-and-go/SKILL.md:325` and `skills/verify-changes/SKILL.md:256`. Fixed both rather than narrowing the tripwire — surface bugs, don't patch.
- 3 source SKILL.md edits + 3 byte-equal mirrors + `metadata.version` bumps on all 3:
  - run-plan, research-and-go, verify-changes — all bumped to fresh content hashes.
- Conformance tripwire added: `git (diff|log) (origin/)?main\.\.\.` scoped to `skills/**/*.md` — fail-closed on any future regression. Tripwire correctly does NOT match the merge-base form, NOT match docs/, NOT match prohibition-quote backticks in prose.

Closes #557.

## Test plan
- [x] Full suite: 4642/4642 passed, 0 failed.
- [x] Tripwire grep returns zero hits across `skills/` after the 3-file rewrite.
- [x] All 3 affected skill version hashes match `bash scripts/skill-content-hash.sh skills/<name>`.
- [x] Mirror byte-equal for all 3 skills.
- [x] Tier-1 check: SKILL.md files are not Tier-1 (per `script-ownership.md` Tier-1 list is `scripts/` only) — no registry update needed.
