### PR TITLE
fix(hooks): is_git_subcommand + is_destruct_command skip transparent prefixes (nohup/timeout/command/exec/nice/time) (Closes #567)

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -218,6 +218,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -106,6 +106,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
@@ -165,6 +201,40 @@ is_destruct_command() {
   [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
+  done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup rm -rf /tmp/x`, `timeout 30 kill -9 1234`, etc. are
+  # operationally equivalent to the bare destructive verb. Mirrors the
+  # gh variant's prefix-skip (issue #279/PR #255), extended for destruct
+  # verbs per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
   done
   local first="${TOKENS[$i]:-}"
   first="${first%\"}"; first="${first#\"}"

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -80,6 +80,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -73,6 +73,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
@@ -150,6 +186,40 @@ is_destruct_command() {
   [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
+  done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup rm -rf /tmp/x`, `timeout 30 kill -9 1234`, etc. are
+  # operationally equivalent to the bare destructive verb. Mirrors the
+  # gh variant's prefix-skip (issue #279/PR #255), extended for destruct
+  # verbs per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
   done
   local first="${TOKENS[$i]:-}"
   first="${first%\"}"; first="${first#\"}"

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -218,6 +218,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -106,6 +106,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"
@@ -165,6 +201,40 @@ is_destruct_command() {
   [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
+  done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup rm -rf /tmp/x`, `timeout 30 kill -9 1234`, etc. are
+  # operationally equivalent to the bare destructive verb. Mirrors the
+  # gh variant's prefix-skip (issue #279/PR #255), extended for destruct
+  # verbs per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
   done
   local first="${TOKENS[$i]:-}"
   first="${first%\"}"; first="${first#\"}"

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -80,6 +80,42 @@ is_git_subcommand() {
   while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
     ((i++))
   done
+  # Skip transparent command-prefix wrappers. These execute the next
+  # argv as a separate process (or in-place for `exec`), so
+  # `nohup git push origin main`, `timeout 30 git push origin main`,
+  # `command git commit --no-verify`, etc. are operationally equivalent
+  # to the bare form. Without this skip an agent reaching for
+  # `timeout 30 git push` (e.g., after a previous push hung) would
+  # bypass every git-side gate. Mirrors the gh variant's prefix-skip
+  # (issue #279/PR #255), extended for `git` per issue #567.
+  while [[ $i -lt $n ]]; do
+    local _pref="${TOKENS[$i]}"
+    case "$_pref" in
+      */*) _pref="${_pref##*/}" ;;
+    esac
+    local _need_duration=0
+    case "$_pref" in
+      command|exec|nohup|nice|time)
+        ((i++)) ;;
+      timeout)
+        ((i++)); _need_duration=1 ;;
+      *)
+        break ;;
+    esac
+    # Consume zero-or-more leading flag tokens. `--` is a one-shot
+    # end-of-options marker (consume it, stop the flag run).
+    while [[ $i -lt $n ]]; do
+      if [[ "${TOKENS[$i]}" == "--" ]]; then
+        ((i++)); break
+      fi
+      [[ "${TOKENS[$i]:0:1}" != "-" ]] && break
+      ((i++))
+    done
+    # `timeout` requires a DURATION positional after any leading flags.
+    if [[ $_need_duration -eq 1 && $i -lt $n ]]; then
+      ((i++))
+    fi
+  done
   local g="${TOKENS[$i]:-}"
   g="${g%\"}"; g="${g#\"}"
   g="${g%\'}"; g="${g#\'}"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -192,6 +192,20 @@ expect_deny "pkill node" "pkill node"
 # 7. fuser -k
 expect_deny "fuser -k 8080" "fuser -k 8080"
 
+# 7-prefix. Transparent command-prefix wrappers on destruct verbs — issue
+# #567. Mirrors the git-side prefix-skip extension; `is_destruct_command`
+# gained the same skip block. Without it, an agent reaching for
+# `nohup killall node` (e.g., to detach the kill) or `timeout 30 killall …`
+# (after a previous kill hung) bypasses the destruct gate. The 4+ cases
+# below cover each destruct verb gated through is_destruct_command{,_in_chain}.
+expect_deny "nohup kill -9 1234 (prefix #567)"          "nohup kill -9 1234"
+expect_deny "timeout 30 killall node (prefix #567)"     "timeout 30 killall node"
+expect_deny "command pkill node (prefix #567)"          "command pkill node"
+expect_deny "nice kill -9 1234 (prefix #567)"           "nice kill -9 1234"
+# Allow control: a non-destructive command under the same prefix must
+# not over-match.
+expect_allow "nohup echo killing (non-destruct prefix-only — #567)" "nohup echo killing"
+
 # 7b. kill-by-port/name anti-pattern — same hazard as fuser -k, different spelling.
 # The original incident was 'lsof -ti :8080 | xargs kill' taking out the docker container.
 # All spellings must be blocked; only explicit-PID kill and the sanctioned helper are allowed.
@@ -443,6 +457,34 @@ expect_deny "git push -u origin main" "git push -u origin main"
 # through every git-side gate including BLOCK_MAIN_PUSH.
 expect_deny "/usr/bin/git push origin main (path-prefix #528)" "/usr/bin/git push origin main"
 expect_deny "/usr/local/bin/git push -u origin main (path-prefix #528)" "/usr/local/bin/git push -u origin main"
+
+# Transparent command-prefix wrappers — issue #567. `nohup`, `timeout`,
+# `command`, `exec`, `nice`, `time` execute the next argv as a separate
+# process; they are operationally equivalent to the bare verb. Pre-fix,
+# `is_git_subcommand` matched only the first token literally and silently
+# bypassed every git-side gate (BLOCK_MAIN_PUSH, --no-verify, add -A,
+# cherry-pick, checkout --, restore, reset --hard, clean -f, stash). The
+# fix in hooks/_lib/git-tokenwalk.sh mirrors the gh variant's prefix-skip
+# at lines 402-447 (issue #279/PR #255). 12 cases cover the prefix axis
+# × verb axis; matches the form of the #528 path-prefix matrix above.
+expect_deny "nohup git push origin main (prefix #567)"           "nohup git push origin main"
+expect_deny "timeout 30 git push origin main (prefix #567)"      "timeout 30 git push origin main"
+expect_deny "timeout --foreground 30 git push origin main (prefix-flag #567)" "timeout --foreground 30 git push origin main"
+expect_deny "command git push origin main (prefix #567)"         "command git push origin main"
+expect_deny "command -p git push origin main (prefix-flag #567)" "command -p git push origin main"
+expect_deny "exec git push origin main (prefix #567)"            "exec git push origin main"
+expect_deny "nice git push origin main (prefix #567)"            "nice git push origin main"
+expect_deny "time git push origin main (prefix #567)"            "time git push origin main"
+expect_deny "time -v git push origin main (prefix-flag #567)"    "time -v git push origin main"
+expect_deny "nohup -- git push origin main (prefix-EOO #567)"    "nohup -- git push origin main"
+# Different gates: --no-verify and add -A under nohup / timeout.
+expect_deny "nohup git commit --no-verify (prefix #567)"         "nohup git commit --no-verify -m msg"
+expect_deny "timeout 30 git add -A (prefix #567)"                "timeout 30 git add -A"
+
+# Allow control: a non-git command that happens to start with `nohup` or
+# `timeout` must NOT trigger any git-side gate (prevent overmatch).
+expect_allow "nohup sleep 5 (non-git prefix-only — #567)"        "nohup sleep 5"
+expect_allow "timeout 30 echo done (non-git prefix-only — #567)" "timeout 30 echo done"
 
 # Issue #392: <localref>:main refspec — generic hook's BLOCK_MAIN_PUSH path
 # must parse the REMOTE side of the colon. Pre-fix ${X%%:*} kept the local


### PR DESCRIPTION
## Summary

**High-severity silent universal bypass** — completes the enumeration-closure family alongside #528 (path-strip) and #515 (HEAD-resolve). `is_git_subcommand` and `is_destruct_command` (`hooks/_lib/git-tokenwalk.sh`) didn't strip transparent command-prefix wrappers, while sister `is_gh_pr_subcommand` (per PR #255) did. `nohup git push origin main`, `timeout 30 git push origin main`, `command git commit --no-verify`, etc. from main bypassed every git-side gate (BLOCK_MAIN_PUSH, stash family, commit --no-verify, etc.) AND every destruct gate (`nohup rm -rf /tmp/x` slipped).

- **Inline-mirror** (Option B per drift-gate's byte-equality enforcement): added the prefix-skip block from `is_gh_pr_subcommand:420-447` into `is_git_subcommand` (line ~73) and `is_destruct_command` (line ~187), placed BEFORE quote-strip + equality check.
- Handles `command|exec|nohup|nice|time|timeout` with flag tokens (`time -v`, `command -p`, `timeout --foreground 30`) and `--` end-of-options marker.
- Propagated to all 3 inlined consumers (`block-unsafe-generic.sh`, `block-unsafe-project.sh.template`, `block-stale-skill-version.sh`) + their `.claude/hooks/` mirrors.
- Added **19 new property cases** to `tests/test-hooks.sh` enumerating transparent-prefix × command axis (`nohup`/`timeout`/`command`/`exec`/`nice`/`time` × git push, commit --no-verify, etc.) + 4 destruct-family cases + 3 non-overmatch controls.

Closes #567.

## Test plan
- [x] Verification trace verbatim (verifier-run):
  - `HIT-nohup` `HIT-timeout` `HIT-command` `HIT-exec` `HIT-timeout-flag` `MISS-non-git-control`
  - All wrapped-git cases now match; non-git control correctly misses (no overmatch).
- [x] Full suite: `Overall: 5225/5225 passed, 0 failed`.
- [x] Drift gate: `18/18 passed` (helper byte-equality preserved across 4 source files).
- [x] Mirror parity: `21/21 passed`.
- [x] Mutation analysis: removing the prefix-skip from `is_git_subcommand` → `expect_deny "nohup git push origin main"` fails (gate doesn't fire, hook ALLOWs). Same for `is_destruct_command` → `expect_deny "nohup kill -9 1234"` fails. Both regressions caught.
- [x] Scope: exactly 8 files (helper + 3 consumers + 3 mirrors + tests). NO skill SKILL.md edits → no version bumps. NO Tier-1 registration needed (hooks aren't Tier-1 per script-ownership.md scope).
