### PR TITLE
fix(hooks): is_destruct_command path-strips so /usr/bin/kill, nohup /usr/bin/killall are gated (Closes #572)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -239,6 +239,14 @@ is_destruct_command() {
   local first="${TOKENS[$i]:-}"
   first="${first%\"}"; first="${first#\"}"
   first="${first%\'}"; first="${first#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/kill -9 1234`,
+  # `/usr/bin/killall node`, `./pkill foo` are recognized as their
+  # destructive bases. Mirrors is_git_subcommand's path-strip (issue
+  # #528). Without this, path-prefixed destructive forms silently
+  # bypassed every destruct-side hook gate (issue #572).
+  case "$first" in
+    */*) first="${first##*/}" ;;
+  esac
   [[ "$first" != "$want_first" ]] && return 1
   [[ -z "$flag_match" ]] && return 0
   ((i++))

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -224,6 +224,14 @@ is_destruct_command() {
   local first="${TOKENS[$i]:-}"
   first="${first%\"}"; first="${first#\"}"
   first="${first%\'}"; first="${first#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/kill -9 1234`,
+  # `/usr/bin/killall node`, `./pkill foo` are recognized as their
+  # destructive bases. Mirrors is_git_subcommand's path-strip (issue
+  # #528). Without this, path-prefixed destructive forms silently
+  # bypassed every destruct-side hook gate (issue #572).
+  case "$first" in
+    */*) first="${first##*/}" ;;
+  esac
   [[ "$first" != "$want_first" ]] && return 1
   [[ -z "$flag_match" ]] && return 0
   ((i++))

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -239,6 +239,14 @@ is_destruct_command() {
   local first="${TOKENS[$i]:-}"
   first="${first%\"}"; first="${first#\"}"
   first="${first%\'}"; first="${first#\'}"
+  # Strip absolute/relative path prefix so `/usr/bin/kill -9 1234`,
+  # `/usr/bin/killall node`, `./pkill foo` are recognized as their
+  # destructive bases. Mirrors is_git_subcommand's path-strip (issue
+  # #528). Without this, path-prefixed destructive forms silently
+  # bypassed every destruct-side hook gate (issue #572).
+  case "$first" in
+    */*) first="${first##*/}" ;;
+  esac
   [[ "$first" != "$want_first" ]] && return 1
   [[ -z "$flag_match" ]] && return 0
   ((i++))

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -206,6 +206,25 @@ expect_deny "nice kill -9 1234 (prefix #567)"           "nice kill -9 1234"
 # not over-match.
 expect_allow "nohup echo killing (non-destruct prefix-only — #567)" "nohup echo killing"
 
+# 7-pathstrip. Path-prefixed destruct verbs — issue #572. Sister of #528
+# (which added the path-strip to is_git_subcommand). is_destruct_command
+# gained the same `case "$first" in */*) first="${first##*/}" ;; esac`
+# block after the prefix-skip loop. Without it, an agent reaching for
+# `command -v kill` (which prints /usr/bin/kill) followed by execution of
+# the absolute path silently bypasses the destruct gate that CLAUDE.md
+# treats as load-bearing. Matrix: each destruct verb × bare-path,
+# prefix+path (combines #567 SKIP + path-strip), and wrapper-recursion.
+expect_deny "/usr/bin/kill -9 1234 (path-strip #572)"               "/usr/bin/kill -9 1234"
+expect_deny "/usr/bin/killall node (path-strip #572)"               "/usr/bin/killall node"
+expect_deny "/usr/bin/pkill node (path-strip #572)"                 "/usr/bin/pkill node"
+expect_deny "/usr/local/bin/pkill foo (path-strip #572)"            "/usr/local/bin/pkill foo"
+expect_deny "nohup /usr/bin/kill -9 1234 (#567 + #572)"             "nohup /usr/bin/kill -9 1234"
+expect_deny "timeout 30 /usr/bin/killall node (#567 + #572)"        "timeout 30 /usr/bin/killall node"
+expect_deny "cd /tmp && /usr/bin/killall node (chain + #572)"       "cd /tmp && /usr/bin/killall node"
+expect_deny "echo a && /usr/bin/pkill node (chain + #572)"          "echo a && /usr/bin/pkill node"
+# Allow control: a non-destructive path-prefixed binary must not over-match.
+expect_allow "/bin/echo killing (path-strip negative — #572)"       "/bin/echo killing"
+
 # 7b. kill-by-port/name anti-pattern — same hazard as fuser -k, different spelling.
 # The original incident was 'lsof -ti :8080 | xargs kill' taking out the docker container.
 # All spellings must be blocked; only explicit-PID kill and the sanctioned helper are allowed.


### PR DESCRIPTION
## Summary

**High-severity silent destruct-gate bypass** — completes the gh-sister-symmetry family alongside #528 (git path-strip, PR #550), #515 (HEAD-resolve, PR #553), #567 (transparent-prefix, PR #570). `is_destruct_command` got the transparent-prefix skip from #567 but NEVER received the path-strip from #528. `/usr/bin/kill -9`, `nohup /usr/bin/killall`, `/usr/local/bin/pkill` all bypassed the destruct gate.

- Adds `case "$first" in */*) first="${first##*/}" ;; esac` to `is_destruct_command` source — mirrors the existing pattern in `is_git_subcommand`.
- Propagated to the 1 inlined consumer (only `hooks/block-unsafe-generic.sh`; the other 2 consumers don't inline `is_destruct_command` — verified independently by the verifier).
- Mirrored to `.claude/hooks/`. Drift gate (`tests/test-hook-helper-drift.sh`) verified byte-equality.
- 8 new property cases + 1 allow-control added to `tests/test-hooks.sh` covering path-prefixed destruct forms.

Closes #572.

## Test plan
- [x] Verification trace verbatim (verifier-run): `/usr/bin/kill -9`, `nohup /usr/bin/killall`, `/usr/local/bin/pkill` all produce `permissionDecision":"deny"` envelopes (were bypass pre-fix).
- [x] Full suite: `Overall: 5234/5234 passed, 0 failed`. Drift: 18/18.
- [x] Scope: 4 files (helper source + 1 inlined consumer + 1 mirror + tests). NO skill SKILL.md edits → no version bumps.
- [x] Tier-1 discipline: hooks are not Tier-1 per `script-ownership.md` → no registry update.
- **Follow-up filed**: #586 — destruct gate has no `_in_wrappers` variant; `bash -c '/usr/bin/kill -9'` still bypasses. Out of scope for this PR.
