### PR TITLE
fix(session-report): use nested $PIPELINE_ID/fulfilled.run-plan path per canonical tracking scheme (Closes #580)

### DIFF
--- a/.claude/skills/session-report/SKILL.md
+++ b/.claude/skills/session-report/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   worktrees), not conversation memory — items may have been completed in
   another session.
 metadata:
-  version: "2026.05.15+593f05"
+  version: "2026.05.21+a6f97e"
 ---
 
 # /session-report — Session Intent vs. Actual State
@@ -60,7 +60,7 @@ that resolves the item:
 |---|---|
 | File written/edited (skill, script, hook, plan, doc) | `git status -s <path>`; if path has a mirror (e.g. `skills/X/` ↔ `.claude/skills/X/`), `diff -q` both. Untracked = uncommitted; modified = uncommitted edit. |
 | Plan drafted | `git status -s "$ZSKILLS_PLANS_DIR/<name>.md"` + `Read` the file (count `[ ]` vs `[x]`, note Phase status lines). |
-| Plan executed (some/all phases) | `Read` the plan's Phase status; `git log --oneline main` for matching commits; if `/run-plan` was used, check `.zskills/tracking/fulfilled.run-plan.<slug>` and `requires.*`. |
+| Plan executed (some/all phases) | `Read` the plan's Phase status; `git log --oneline main` for matching commits; if `/run-plan` was used, check `.zskills/tracking/$PIPELINE_ID/fulfilled.run-plan.<id>` and `requires.*` (per `docs/tracking/TRACKING_NAMING.md` — markers are nested under per-pipeline subdirs). Find existing markers with `find .zskills/tracking -name 'fulfilled.run-plan.*'` (absence = no run-plan completion marker). |
 | PR opened | `gh pr view <N> --json state,mergeable,reviewDecision,statusCheckRollup` + `gh pr checks <N>`. |
 | PR merged | `gh pr view <N> --json state,mergeCommit` — confirm `MERGED` and the merge commit is on main. |
 | Bug fixed | `git log --oneline -10 -- <file>` for the fix commit; if a regression test was promised, grep for it. |

--- a/skills/session-report/SKILL.md
+++ b/skills/session-report/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   worktrees), not conversation memory — items may have been completed in
   another session.
 metadata:
-  version: "2026.05.15+593f05"
+  version: "2026.05.21+a6f97e"
 ---
 
 # /session-report — Session Intent vs. Actual State
@@ -60,7 +60,7 @@ that resolves the item:
 |---|---|
 | File written/edited (skill, script, hook, plan, doc) | `git status -s <path>`; if path has a mirror (e.g. `skills/X/` ↔ `.claude/skills/X/`), `diff -q` both. Untracked = uncommitted; modified = uncommitted edit. |
 | Plan drafted | `git status -s "$ZSKILLS_PLANS_DIR/<name>.md"` + `Read` the file (count `[ ]` vs `[x]`, note Phase status lines). |
-| Plan executed (some/all phases) | `Read` the plan's Phase status; `git log --oneline main` for matching commits; if `/run-plan` was used, check `.zskills/tracking/fulfilled.run-plan.<slug>` and `requires.*`. |
+| Plan executed (some/all phases) | `Read` the plan's Phase status; `git log --oneline main` for matching commits; if `/run-plan` was used, check `.zskills/tracking/$PIPELINE_ID/fulfilled.run-plan.<id>` and `requires.*` (per `docs/tracking/TRACKING_NAMING.md` — markers are nested under per-pipeline subdirs). Find existing markers with `find .zskills/tracking -name 'fulfilled.run-plan.*'` (absence = no run-plan completion marker). |
 | PR opened | `gh pr view <N> --json state,mergeable,reviewDecision,statusCheckRollup` + `gh pr checks <N>`. |
 | PR merged | `gh pr view <N> --json state,mergeCommit` — confirm `MERGED` and the merge commit is on main. |
 | Bug fixed | `git log --oneline -10 -- <file>` for the fix commit; if a regression test was promised, grep for it. |


### PR DESCRIPTION
## Summary
- `skills/session-report/SKILL.md:63` directed the agent to verify "Plan executed" claims via flat `.zskills/tracking/fulfilled.run-plan.<slug>` — but the canonical scheme per `docs/tracking/TRACKING_NAMING.md:44` is **nested** `.zskills/tracking/$PIPELINE_ID/{fulfilled,requires,step}.*`. `/run-plan` writes nested (verified at `skills/run-plan/SKILL.md:904` + `:2437`). The ground-truth-auditor skill had stale ground-truth paths — agent following the table literally would `ls .zskills/tracking/fulfilled.run-plan.*`, find zero matches, conclude "no run-plan evidence" — ironic failure mode where the auditor misses ground truth because its own command is wrong.
- Replaced flat path with the nested canonical form, added citation to `docs/tracking/TRACKING_NAMING.md`, and provided a `find .zskills/tracking -name 'fulfilled.run-plan.*'` enumeration recipe for when `$PIPELINE_ID` isn't known.
- `metadata.version` bumped to `2026.05.21+a6f97e`; mirror byte-equal.
- Grep confirmed no OTHER stale tracking paths in session-report SKILL.md (single hit at line 63).

Closes #580.

## Test plan
- [x] Verifier independent run: `Overall: 5225/5225 passed, 0 failed` (clean — no flake fired this run).
- [x] Implementer's earlier 3-failure run + a 2nd orchestrator re-run BOTH showed `5222/5225, 3 failed` but with DIFFERENT specific FAILs each time. Investigated:
  - `test-skill-conformance.sh` in isolation: 498/498 passes both in worktree AND on origin/main.
  - The patterns the `[run-plan]` failures claim "not found" DO exist in `skills/run-plan/SKILL.md` (verified 1 hit each); file hash byte-identical to origin/main.
  - Conclusion: **non-deterministic test-isolation flake** in the full-suite run, same family as #540. Filed as **#587** for follow-up; orthogonal to this PR's diff.
- [x] Skill version hash matches; mirror byte-equal.
- [x] Future-hardening flag: no conformance assertion currently pins the nested-path discipline in session-report. A follow-up tripwire could lock it.
