### PR TITLE
fix(tests): eliminate phantom fixture-extension diagnostic noise + fix run_suite tally miscount (Closes #587 Part A)

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -22,10 +22,25 @@ run_suite() {
 
   echo "$output"
 
-  # Extract counts from the "Results: X passed, Y failed" line
-  local passed failed
-  passed=$(echo "$output" | grep -oP '\d+(?= passed)' | tail -1)
-  failed=$(echo "$output" | grep -oP '\d+(?= failed)' | tail -1)
+  # Extract counts from the canonical "Results: <N> passed, <N> failed"
+  # line. Anchor to that exact line shape so any inner-test diagnostics
+  # (e.g., test-hooks.sh's fixture-extension synthetic-fixture run that
+  # nests a `tests/test-skill-conformance.sh` invocation — see #587) can't
+  # leak a count into the outer parser. Strip ANSI color codes first
+  # (some suites colorize Results in red/green). If no canonical line is
+  # found in the output, fall through with 0/0 — the suite's own exit
+  # code still flips OVERALL_EXIT below, so an unparseable suite is not
+  # silently dropped.
+  local passed failed results_line stripped
+  stripped=$(echo "$output" | sed -E $'s/\x1b\\[[0-9;]*m//g')
+  results_line=$(echo "$stripped" | grep -E '^Results: [0-9]+ passed,( [0-9]+ failed|.* [0-9]+ failed)' | tail -1)
+  if [[ -n "$results_line" ]]; then
+    passed=$(echo "$results_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+')
+    failed=$(echo "$results_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+')
+  else
+    passed=0
+    failed=0
+  fi
 
   TOTAL_PASS=$((TOTAL_PASS + ${passed:-0}))
   TOTAL_FAIL=$((TOTAL_FAIL + ${failed:-0}))

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -4552,7 +4552,19 @@ if grep -q '__TEST_LITERAL__' "$EXT_DENY_OUT"; then
   pass "fixture-extension: deny-list test picks up appended literal — DRIFT line emitted"
 else
   fail "fixture-extension: deny-list test missed appended literal" "no __TEST_LITERAL__ in output (rc=$EXT_DENY_RC)"
-  head -50 "$EXT_DENY_OUT" >&2
+  # Surface ONLY the deny-list / forbidden-literals section of the
+  # conformance output — that's where __TEST_LITERAL__ should appear.
+  # Avoid dumping unrelated [run-plan]/[verify-changes] FAILs that fire
+  # because the synthetic fixture lacks real skills (expected) — those
+  # FAILs are noise (#587 root cause), and any inner "N passed, N failed"
+  # tally line leaked here would be miscounted by run_suite's parser.
+  echo "  -- relevant conformance output (deny-list / forbidden section) --" >&2
+  if ! grep -E 'deny-list|forbidden|__TEST_LITERAL__' "$EXT_DENY_OUT" \
+       | grep -v -E '^[[:space:]]*Results:[[:space:]]+[0-9]+ passed' \
+       | head -30 >&2; then
+    echo "  -- (no deny-list/forbidden lines in output; conformance may have crashed before reaching that section) --" >&2
+  fi
+  echo "  -- end relevant output --" >&2
 fi
 rm -f "$EXT_DENY_OUT"
 rm -rf /tmp/zskills-fixture-extension-test


### PR DESCRIPTION
## Summary

The user-visible "3 failures non-deterministic under `bash tests/run-all.sh`" mystery (#587) had **two coupled root causes**, both fixed here (Part A):

### Cause 1 — diagnostic noise (`tests/test-hooks.sh:4555`)

The "Fixture-extension coverage" section invokes `bash tests/test-skill-conformance.sh` against a synthetic fixture dir (`/tmp/zskills-fixture-extension-test/`) containing ONLY `skills/synthetic/SKILL.md`. The inner conformance test expectedly fails its `[run-plan]`, `[verify-changes]`, etc. assertions because those skills don't exist in the synthetic dir.

When the OUTER assertion (`grep -q '__TEST_LITERAL__' "$EXT_DENY_OUT"`) failed, `head -50 "$EXT_DENY_OUT" >&2` dumped 50 lines of expectedly-failing conformance output as diagnostic — producing ~17 phantom `[run-plan] FAIL` lines that LOOKED like real failures.

**Fix**: replace `head -50` with targeted `grep -E 'deny-list|forbidden|__TEST_LITERAL__'` filtered through `grep -v '^[[:space:]]*Results:'` (also strips inner Results lines), bookended by `-- relevant conformance output --` markers, with a fallback when grep is empty.

### Cause 2 — `run_suite()` tally miscount (`tests/run-all.sh:27-28`)

`tests/run-all.sh` was greppling `\d+(?= passed)` and `\d+(?= failed)` with `tail -1`. When test-hooks.sh emitted its own canonical `Results: N passed, N failed` AND ALSO captured the inner conformance's `Results: ...` line (via the `head -50` dump or otherwise), `tail -1` picked the inner-test counts — miscounting expected-inner-failures as real outer failures, producing the persistent `3 failed` Overall tally.

**Fix**: ANSI-strip output, then anchor `^Results: [0-9]+ passed,( [0-9]+ failed|.* [0-9]+ failed)` (start-of-line + canonical shape), then `tail -1` to pick the outermost suite's Results line. With Cause 1's diagnostic also stripping inner Results lines, the outer is now unambiguously picked.

### Part B — filed as #594

Why the OUTER `fixture-extension: deny-list test missed appended literal` assertion intermittently fails (the actual underlying flake). Out of scope for this PR — investigated separately.

Closes #587 Part A. Filed [#594](https://github.com/zeveck/zskills-dev/issues/594) for Part B.

## Test plan
- [x] Full suite: `Overall: 5145/5145 passed, 0 failed` (verifier-run, post-rebase).
- [x] Diagnostic on the fail path now prints ONLY deny-list / forbidden-literals / __TEST_LITERAL__ context, no `[run-plan]` noise.
- [x] `run_suite()` parser anchors on `^Results:` start-of-line; nested Results lines (when an inner test invokes another) no longer confuse the outer tally.
- [x] Mutation walkthrough: inner `Results: 103 passed, 0 failed (of 103)` followed by outer `Results: 14 passed, 0 failed (14 total)` → both match anchored regex; `tail -1` picks outer. Confirmed by verifier.
