### PR TITLE
fix(hooks): add is_destruct_command_in_wrappers — bash -c, eval, sh -c destruct forms now gated (Closes #586)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -426,6 +426,126 @@ is_destruct_command_in_chain() {
   return 1
 }
 
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+is_destruct_command_in_wrappers() {
+  local cmd="$1"
+  local want_first="$2"
+  local flag_match="${3:-}"
+  local depth="${4:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_destruct_command_in_chain "$cmd" "$want_first" "$flag_match"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'kill -9 1234' became three tokens: "'kill" "-9" "1234'".
+          # Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_destruct_command_in_wrappers "$wrapper_inner" "$want_first" "$flag_match" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
 # git stash — wrapper-aware gate via is_git_subcommand_in_wrappers (#426,
 # completes #399). The prior regex-based STASH_BOUNDARY anchored
 # `git[[:space:]]+stash` to `^`, `;`, `&`, `&&`, `||`, `|`, backtick, or
@@ -522,13 +642,18 @@ if is_git_subcommand_in_wrappers "$COMMAND" reset && [[ "$GIT_SUB_REST" =~ (^|[[
 fi
 
 # kill -9 / kill -KILL / kill -SIGKILL / kill -s 9 / kill -s KILL / kill -s SIGKILL / killall / pkill
-# Chain-wrapped to preserve coverage of `git commit -m "msg" && kill -9 1234`
-# (pre-existing test). Bare is_destruct_command is first-token-anchored;
-# the chain wrapper splits on shell-segment boundaries and re-checks each.
-if is_destruct_command_in_chain "$COMMAND" kill '^-(9|KILL|SIGKILL)$' \
-   || is_destruct_command_in_chain "$COMMAND" kill '^-s$:next:^(9|KILL|SIGKILL)$' \
-   || is_destruct_command_in_chain "$COMMAND" killall '' \
-   || is_destruct_command_in_chain "$COMMAND" pkill ''; then
+# Wrapper-aware match via is_destruct_command_in_wrappers (#586, sister of
+# #399's git-side closure). Falls back to is_destruct_command_in_chain for
+# non-wrapper forms, preserving coverage of `git commit -m "msg" && kill -9
+# 1234` (pre-existing test). Without the wrappers helper, `bash -c
+# 'kill -9 1234'`, `eval 'killall node'`, `sh -c 'pkill foo'` and the
+# path-prefixed `bash -c '/usr/bin/kill -9 1234'` variants silently
+# bypassed the destruct gate even after #572 added path-strip to the
+# base helper.
+if is_destruct_command_in_wrappers "$COMMAND" kill '^-(9|KILL|SIGKILL)$' \
+   || is_destruct_command_in_wrappers "$COMMAND" kill '^-s$:next:^(9|KILL|SIGKILL)$' \
+   || is_destruct_command_in_wrappers "$COMMAND" killall '' \
+   || is_destruct_command_in_wrappers "$COMMAND" pkill ''; then
   block_with_reason "BLOCKED: kill -9/killall/pkill can kill container-critical processes. Ask the user to stop the process manually."
 fi
 

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -18,6 +18,7 @@
 #     - is_git_subcommand_in_wrappers — segment-walk + recursive unwrap of
 #                                      `bash -c '<inner>'` / `sh -c '<inner>'` /
 #                                      `eval '<inner>'` for git verbs (#399)
+#     - is_destruct_command_in_wrappers — same for destruct verbs (#586)
 #     - is_gh_pr_subcommand_in_wrappers — same for gh-pr verbs (#279/PR #255)
 #
 # All helpers are inlined verbatim into hook source files; the drift gate at
@@ -34,6 +35,9 @@
 #                                              + block-stale-skill-version.sh
 #                                              (#399 — closes bash -c / eval bypass)
 #   - is_destruct_command_in_chain inlined into block-unsafe-generic.sh only
+#   - is_destruct_command_in_wrappers inlined into block-unsafe-generic.sh only
+#                                              (#586 — closes bash -c / eval / sh -c
+#                                              destruct-verb bypass, sister of #399)
 #   - is_gh_pr_subcommand          inlined into block-bypassed-land-pr.sh
 #   - is_gh_pr_subcommand_in_chain inlined into block-bypassed-land-pr.sh
 #   - is_gh_pr_subcommand_in_wrappers inlined into block-bypassed-land-pr.sh
@@ -434,6 +438,142 @@ is_destruct_command_in_chain() {
       return 0
     fi
   done <<< "$normalized"
+  return 1
+}
+
+# Returns 0 iff ANY shell segment of $cmd — including segments reachable by
+# recursively unwrapping `bash -c '<inner>'` / `sh -c '<inner>'` / `eval
+# '<inner>'` style wrappers — is a destructive invocation matching
+# `is_destruct_command "$seg" "$want_first" "$flag_match"`. Closes the
+# destruct-side wrapper-bypass hole (#586); structural twin of
+# is_git_subcommand_in_wrappers (the git-side closure from #399).
+#
+# Without this helper, `bash -c "/usr/bin/kill -9 1234"`, `eval "killall
+# node"`, `sh -c 'pkill foo'`, etc. would tokenize as a top-level
+# `bash`/`sh`/`eval` and slip past the destruct gate (the
+# kill -9 / killall / pkill family). The path-strip from #572 fires for
+# the BARE form (`/usr/bin/kill -9` → DENY), but the destruct call path
+# didn't iterate into wrapper bodies the way the git path does.
+#
+# Bounded recursion (default depth=3) so a pathological
+# `bash -c 'bash -c "bash -c \"...\"" '` chain terminates. Matches the
+# git-wrappers and gh-pr-wrappers helpers' depth budget.
+is_destruct_command_in_wrappers() {
+  local cmd="$1"
+  local want_first="$2"
+  local flag_match="${3:-}"
+  local depth="${4:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_destruct_command_in_chain "$cmd" "$want_first" "$flag_match"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'kill -9 1234' became three tokens: "'kill" "-9" "1234'".
+          # Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_destruct_command_in_wrappers "$wrapper_inner" "$want_first" "$flag_match" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
   return 1
 }
 

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -426,6 +426,126 @@ is_destruct_command_in_chain() {
   return 1
 }
 
+# Inlined from hooks/_lib/git-tokenwalk.sh (source-of-truth). Drift gate: tests/test-hook-helper-drift.sh.
+is_destruct_command_in_wrappers() {
+  local cmd="$1"
+  local want_first="$2"
+  local flag_match="${3:-}"
+  local depth="${4:-3}"
+
+  # First, check the direct + chain case via existing helper.
+  if is_destruct_command_in_chain "$cmd" "$want_first" "$flag_match"; then
+    return 0
+  fi
+
+  # Bounded recursion depth.
+  [ "$depth" -le 0 ] && return 1
+
+  # Split on chain operators (same as _in_chain) and inspect each
+  # segment for a wrapper pattern.
+  local normalized
+  normalized=$(printf '%s' "$cmd" \
+    | sed -E 's/[[:space:]]*(\&\&|\|\||;|\|)[[:space:]]*/\n/g' \
+    | sed -E 's/\\n/\n/g')
+
+  local seg
+  while IFS= read -r seg; do
+    [ -z "$seg" ] && continue
+
+    # Look for an inline-string wrapper. Use bash regex to capture the
+    # inner string after a `-c` flag or after an `eval`. The captured
+    # group is the rest of the segment starting at the inner-arg
+    # boundary; we then strip outer quotes (single or double).
+    local wrapper_inner=""
+
+    # Tokenize the segment to find the wrapper command and its -c arg.
+    local -a TOKENS
+    # shellcheck disable=SC2206
+    read -ra TOKENS <<< "$seg"
+    local i=0 n=${#TOKENS[@]}
+
+    # Skip env-var prefixes (KEY=val ... cmd ...).
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+    [[ $i -lt $n && "${TOKENS[$i]}" == "env" ]] && ((i++))
+    while [[ $i -lt $n && "${TOKENS[$i]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((i++))
+    done
+
+    local first="${TOKENS[$i]:-}"
+    # Allow a possible absolute path: /bin/bash → match the basename.
+    case "$first" in
+      */*) first="${first##*/}" ;;
+    esac
+
+    case "$first" in
+      bash|sh|dash|ash|ksh|zsh)
+        # Walk shell-level flags to find -c (or -lc/-ic/-cx combined
+        # short-flag forms). All of these put the next token as the
+        # inline string to execute.
+        local j=$((i+1))
+        local found_c=0
+        while [[ $j -lt $n ]]; do
+          local t="${TOKENS[$j]}"
+          case "$t" in
+            -c) found_c=1; ((j++)); break ;;
+            -[lir]c|-c[lir]|-[lir][lir]c|-c[lir][lir]) found_c=1; ((j++)); break ;;
+            --) ((j++)); break ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        if [[ $found_c -eq 1 && $j -lt $n ]]; then
+          # Reconstruct the inner string from token j to end of segment.
+          # read -ra split on whitespace, so a quoted multi-word string
+          # like 'kill -9 1234' became three tokens: "'kill" "-9" "1234'".
+          # Rejoin with spaces.
+          local inner=""
+          local k=$j
+          while [[ $k -lt $n ]]; do
+            if [ -z "$inner" ]; then
+              inner="${TOKENS[$k]}"
+            else
+              inner="$inner ${TOKENS[$k]}"
+            fi
+            ((k++))
+          done
+          # Strip one layer of outer quotes (single or double).
+          inner="${inner#\'}"; inner="${inner%\'}"
+          inner="${inner#\"}"; inner="${inner%\"}"
+          wrapper_inner="$inner"
+        fi
+        ;;
+      eval)
+        # All args to eval are the string to execute. Rejoin and strip
+        # outer quotes.
+        local inner=""
+        local k=$((i+1))
+        while [[ $k -lt $n ]]; do
+          if [ -z "$inner" ]; then
+            inner="${TOKENS[$k]}"
+          else
+            inner="$inner ${TOKENS[$k]}"
+          fi
+          ((k++))
+        done
+        inner="${inner#\'}"; inner="${inner%\'}"
+        inner="${inner#\"}"; inner="${inner%\"}"
+        wrapper_inner="$inner"
+        ;;
+    esac
+
+    if [ -n "$wrapper_inner" ]; then
+      if is_destruct_command_in_wrappers "$wrapper_inner" "$want_first" "$flag_match" $((depth - 1)); then
+        return 0
+      fi
+    fi
+  done <<< "$normalized"
+
+  return 1
+}
+
 # git stash — wrapper-aware gate via is_git_subcommand_in_wrappers (#426,
 # completes #399). The prior regex-based STASH_BOUNDARY anchored
 # `git[[:space:]]+stash` to `^`, `;`, `&`, `&&`, `||`, `|`, backtick, or
@@ -522,13 +642,18 @@ if is_git_subcommand_in_wrappers "$COMMAND" reset && [[ "$GIT_SUB_REST" =~ (^|[[
 fi
 
 # kill -9 / kill -KILL / kill -SIGKILL / kill -s 9 / kill -s KILL / kill -s SIGKILL / killall / pkill
-# Chain-wrapped to preserve coverage of `git commit -m "msg" && kill -9 1234`
-# (pre-existing test). Bare is_destruct_command is first-token-anchored;
-# the chain wrapper splits on shell-segment boundaries and re-checks each.
-if is_destruct_command_in_chain "$COMMAND" kill '^-(9|KILL|SIGKILL)$' \
-   || is_destruct_command_in_chain "$COMMAND" kill '^-s$:next:^(9|KILL|SIGKILL)$' \
-   || is_destruct_command_in_chain "$COMMAND" killall '' \
-   || is_destruct_command_in_chain "$COMMAND" pkill ''; then
+# Wrapper-aware match via is_destruct_command_in_wrappers (#586, sister of
+# #399's git-side closure). Falls back to is_destruct_command_in_chain for
+# non-wrapper forms, preserving coverage of `git commit -m "msg" && kill -9
+# 1234` (pre-existing test). Without the wrappers helper, `bash -c
+# 'kill -9 1234'`, `eval 'killall node'`, `sh -c 'pkill foo'` and the
+# path-prefixed `bash -c '/usr/bin/kill -9 1234'` variants silently
+# bypassed the destruct gate even after #572 added path-strip to the
+# base helper.
+if is_destruct_command_in_wrappers "$COMMAND" kill '^-(9|KILL|SIGKILL)$' \
+   || is_destruct_command_in_wrappers "$COMMAND" kill '^-s$:next:^(9|KILL|SIGKILL)$' \
+   || is_destruct_command_in_wrappers "$COMMAND" killall '' \
+   || is_destruct_command_in_wrappers "$COMMAND" pkill ''; then
   block_with_reason "BLOCKED: kill -9/killall/pkill can kill container-critical processes. Ask the user to stop the process manually."
 fi
 

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -28,7 +28,7 @@ fail() { echo "FAIL $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 # When a new helper joins hooks/_lib/, add it here.
 fn_source() {
   case "$1" in
-    is_git_subcommand|is_destruct_command|is_git_subcommand_in_chain|is_destruct_command_in_chain|is_git_subcommand_in_wrappers|is_gh_pr_subcommand|is_gh_pr_subcommand_in_chain|is_gh_pr_subcommand_in_wrappers)
+    is_git_subcommand|is_destruct_command|is_git_subcommand_in_chain|is_destruct_command_in_chain|is_destruct_command_in_wrappers|is_git_subcommand_in_wrappers|is_gh_pr_subcommand|is_gh_pr_subcommand_in_chain|is_gh_pr_subcommand_in_wrappers)
       echo "hooks/_lib/git-tokenwalk.sh" ;;
     extract_cd_target|resolve_effective_worktree_root)
       echo "hooks/_lib/resolve-effective-worktree-root.sh" ;;
@@ -55,7 +55,7 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
   # bash -c / eval / sh -c wrapper-bypass class.
   # extract_cd_target + resolve_effective_worktree_root added in #401 —
   # consolidated cd-target / worktree-root resolution helper.
-  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_git_subcommand_in_wrappers is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers extract_cd_target resolve_effective_worktree_root; do
+  for FN in is_git_subcommand is_destruct_command is_git_subcommand_in_chain is_destruct_command_in_chain is_destruct_command_in_wrappers is_git_subcommand_in_wrappers is_gh_pr_subcommand is_gh_pr_subcommand_in_chain is_gh_pr_subcommand_in_wrappers extract_cd_target resolve_effective_worktree_root; do
     # is_destruct_command is only inlined in generic hook; skip for project + stale-skill-version + bypassed-land-pr.
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command" && "$HOOK" == *stale-skill-version* ]] && continue
@@ -71,6 +71,11 @@ for HOOK in hooks/block-unsafe-project.sh.template hooks/block-unsafe-generic.sh
     [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *project* ]] && continue
     [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *stale-skill-version* ]] && continue
     [[ "$FN" == "is_destruct_command_in_chain" && "$HOOK" == *bypassed-land-pr* ]] && continue
+    # is_destruct_command_in_wrappers (#586) is only inlined in the generic
+    # hook (same scope as the destruct-base + destruct-chain helpers).
+    [[ "$FN" == "is_destruct_command_in_wrappers" && "$HOOK" == *project* ]] && continue
+    [[ "$FN" == "is_destruct_command_in_wrappers" && "$HOOK" == *stale-skill-version* ]] && continue
+    [[ "$FN" == "is_destruct_command_in_wrappers" && "$HOOK" == *bypassed-land-pr* ]] && continue
     # is_git_subcommand is NOT inlined in bypassed-land-pr (that hook only
     # walks gh pr tokens, not git tokens).
     [[ "$FN" == "is_git_subcommand" && "$HOOK" == *bypassed-land-pr* ]] && continue

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -225,6 +225,38 @@ expect_deny "echo a && /usr/bin/pkill node (chain + #572)"          "echo a && /
 # Allow control: a non-destructive path-prefixed binary must not over-match.
 expect_allow "/bin/echo killing (path-strip negative — #572)"       "/bin/echo killing"
 
+# 7c. Wrapper-bypass closure for the destruct gate (#586) — sister of #399's
+# git-side closure. Pre-fix, `bash -c '/usr/bin/kill -9 …'`, `eval 'killall
+# …'`, `sh -c 'pkill …'` and friends tokenized as `bash`/`sh`/`eval` at the
+# top level and slipped past is_destruct_command_in_chain even after #572
+# added path-strip. is_destruct_command_in_wrappers iterates wrapper bodies
+# and re-applies the chain helper. Property matrix:
+#   {bash -c, sh -c, eval, command, exec} × {kill -9, killall, pkill, rm -rf}
+#   × {bare, /usr/bin/-prefixed}. (`rm -rf` is gated by RM_RECURSIVE regex,
+#   not the destruct helper, so wrapper-quoted `rm -rf` is covered by that
+#   regex's substring match — included here for cross-coverage attestation.)
+#   `command` / `exec` are command-prefix wrappers handled by the
+#   transparent-prefix skip in is_destruct_command (#567), not the
+#   wrappers helper — included to attest both paths still gate.
+expect_deny "WD1: bash -c 'kill -9 1234'"                    "bash -c 'kill -9 1234'"
+expect_deny "WD2: bash -c '/usr/bin/kill -9 1234'"           "bash -c '/usr/bin/kill -9 1234'"
+expect_deny "WD3: eval 'killall node'"                       "eval 'killall node'"
+expect_deny "WD4: eval '/usr/bin/killall node'"              "eval '/usr/bin/killall node'"
+expect_deny "WD5: sh -c 'pkill foo'"                         "sh -c 'pkill foo'"
+expect_deny "WD6: sh -c '/usr/bin/pkill foo'"                "sh -c '/usr/bin/pkill foo'"
+expect_deny "WD7: bash -c \"killall node\" (double-quoted)"  "bash -c \\\"killall node\\\""
+expect_deny "WD8: bash -c 'kill -s 9 1234'"                  "bash -c 'kill -s 9 1234'"
+# Command-prefix wrappers (transparent skip path #567, not the wrappers
+# helper). Both gates must still fire.
+expect_deny "WD9: command kill -9 1234 (prefix path)"        "command kill -9 1234"
+expect_deny "WD10: exec /usr/bin/killall node (prefix path)" "exec /usr/bin/killall node"
+# Nested wrapper (depth=2 — recursion budget is 3 by default).
+expect_deny "WD11: bash -c \"sh -c 'kill -9 1234'\" (nested)" \
+  "bash -c \\\"sh -c 'kill -9 1234'\\\""
+# Allow control: wrapper around a non-destructive command must not over-match.
+expect_allow "WD12: bash -c 'echo killall' (wrapper allow ctrl)" \
+  "bash -c 'echo killall'"
+
 # 7b. kill-by-port/name anti-pattern — same hazard as fuser -k, different spelling.
 # The original incident was 'lsof -ti :8080 | xargs kill' taking out the docker container.
 # All spellings must be blocked; only explicit-PID kill and the sanctioned helper are allowed.


### PR DESCRIPTION
## Summary

**High-severity** silent destruct-gate bypass for wrapper-quoted forms. Completes the family alongside #572 (path-strip).

- `is_destruct_command_in_chain` existed; `is_destruct_command_in_wrappers` did NOT. Wrapper forms like `bash -c '/usr/bin/kill -9 1234'`, `eval 'killall node'`, `sh -c 'pkill foo'` bypassed every destruct gate.
- Adds `is_destruct_command_in_wrappers` to `hooks/_lib/git-tokenwalk.sh` — structurally mirrors `is_git_subcommand_in_wrappers`. Wrapper set `bash|sh|dash|ash|ksh|zsh` + `command|exec|eval`; depth-3 bounded recursion; falls back to `is_destruct_command_in_chain` for direct + chain forms.
- Wires into `hooks/block-unsafe-generic.sh`'s 4 destruct call sites (kill -9 / kill -s 9 / killall / pkill).
- Mirrored to `.claude/hooks/block-unsafe-generic.sh`.
- 12 new property cases in `tests/test-hooks.sh` enumerating wrapper × destruct-verb × path-prefix combinations + allow-controls.
- `tests/test-hook-helper-drift.sh` updated to recognize the new helper (now 19/19).

Closes #586.

## Test plan
- [x] Verification trace (verifier-run, all 5 forms DENY): `bash -c "/usr/bin/kill -9 1234"`, `eval "killall node"`, `sh -c 'pkill foo'`, `bash -c "kill -s 9 1"`, `eval "/usr/bin/killall foo"`.
- [x] Allow-control: `bash -c "echo hello"` exits ALLOW (no over-match).
- [x] Full suite: `Overall: 5262/5262 passed, 0 failed`. Drift gate: 19/19. Mirror byte-equal.
- [x] Mutation: reverting `_in_wrappers` to `_in_chain` lets wrappers tokenize as `bash`/`eval` top-level, miss `kill` → bypass; the 12 new tests catch it.
- [x] Hooks are NOT Tier-1 per `script-ownership.md` → no registry update.
