### PR TITLE
fix(run-plan): Phase 1 step 6a textual-staleness dispatches /refine-plan (Closes #578)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+44771f"
+  version: "2026.05.21+25b138"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -799,10 +799,9 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    and data structures referenced here are based on [another plan's]
    design, not actual code," the plan may be stale:
    - Without `auto`: tell the user "this plan was drafted before its
-     dependency was implemented. Want me to refresh it with `/draft-plan`?"
-   - With `auto`: dispatch `/draft-plan` on the plan file to update it.
-     `/draft-plan` handles existing files as modernizations. After the
-     refresh, re-read the plan and continue.
+     dependency was implemented. Want me to refresh it with `/refine-plan`?"
+   - With `auto`: dispatch `/refine-plan` on the plan file to update it.
+     After the refresh, re-read the plan and continue.
    - Skip this check if the plan file was modified more recently than
      the dependency's completion (it may already be up to date).
 

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+44771f"
+  version: "2026.05.21+25b138"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -799,10 +799,9 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    and data structures referenced here are based on [another plan's]
    design, not actual code," the plan may be stale:
    - Without `auto`: tell the user "this plan was drafted before its
-     dependency was implemented. Want me to refresh it with `/draft-plan`?"
-   - With `auto`: dispatch `/draft-plan` on the plan file to update it.
-     `/draft-plan` handles existing files as modernizations. After the
-     refresh, re-read the plan and continue.
+     dependency was implemented. Want me to refresh it with `/refine-plan`?"
+   - With `auto`: dispatch `/refine-plan` on the plan file to update it.
+     After the refresh, re-read the plan and continue.
    - Skip this check if the plan file was modified more recently than
      the dependency's completion (it may already be up to date).
 


### PR DESCRIPTION
## Summary
- `skills/run-plan/SKILL.md:800-805` Phase 1 step 6a textual-staleness path now dispatches `/refine-plan` instead of `/draft-plan` — matches the symmetric arithmetic-staleness path at line 846.
- `/refine-plan` is the correct skill for refreshing in-progress plans: preserves completed phases as immutable context, appends a drift log, defaults to 2 rounds. `/draft-plan` would treat the file as a new draft and lose in-progress completion state.
- Other `/draft-plan` references in the file PRESERVED (initial-draft contexts, delegate syntax).
- `metadata.version` bumped to `2026.05.21+25b138`; mirror byte-equal.

Closes #578.

## Test plan
- [x] Full suite: `Overall: 5249/5249 passed, 0 failed`.
- [x] `test-skill-conformance.sh` in isolation: 498/498 passes.
- [x] Skill version hash matches; mirror byte-equal.
- [x] Scope: 2 files (source + mirror).
