### PR TITLE
fix(skills): assign missing variables in standalone-invocation fences across 4 drafting skills (Closes #579, Closes #596, Closes #592, Closes #582)

### DIFF
--- a/.claude/skills/draft-tests/SKILL.md
+++ b/.claude/skills/draft-tests/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.05.20+0e54e6"
+  version: "2026.05.21+6fc43c"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
@@ -74,6 +74,26 @@ if [ ! -x "$HELPER" ]; then
   echo "draft-tests: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Resolve $PLAN_FILE and derive $TRACKING_ID before the worktree preamble
+# so the helper's --pipeline-id / positional slug are non-empty. Mirrors
+# the Arguments-section detection rule: first $ARGUMENTS token ending in
+# `.md` or containing `/` is the plan file; resolve bare names via
+# $ZSKILLS_PLANS_DIR. Phase 1's Tracking-fulfillment fence re-derives
+# $TRACKING_ID idempotently from the same $PLAN_FILE.
+if [ -z "${PLAN_FILE:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      */*) PLAN_FILE="$tok"; break ;;
+      *.md) PLAN_FILE="$ZSKILLS_PLANS_DIR/$tok"; break ;;
+    esac
+  done
+fi
+if [ -z "${PLAN_FILE:-}" ]; then
+  echo "draft-tests: PLAN_FILE not resolved from \$ARGUMENTS (need a *.md token)" >&2
+  exit 2
+fi
+TRACKING_ID=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 WT_PATH=$(bash "$HELPER" \
   --prefix drafttests \
   --pipeline-id "draft-tests.${TRACKING_ID}" \

--- a/.claude/skills/refine-plan/SKILL.md
+++ b/.claude/skills/refine-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.05.20+2f426f"
+  version: "2026.05.21+289f05"
 ---
 
 # /refine-plan \<plan-file> [rounds N] [guidance...] — Adversarial Plan Refiner
@@ -71,6 +71,25 @@ if [ ! -x "$HELPER" ]; then
   echo "refine-plan: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Resolve $PLAN_FILE and derive $TRACKING_ID before the worktree preamble
+# so the helper's --pipeline-id / positional slug are non-empty. Mirrors
+# the Arguments-section detection rule: first $ARGUMENTS token ending in
+# `.md` is the plan file; resolve bare names via $ZSKILLS_PLANS_DIR.
+# Phase 1's Tracking-fulfillment fence re-uses $TRACKING_ID idempotently.
+if [ -z "${PLAN_FILE:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      */*) PLAN_FILE="$tok"; break ;;
+      *.md) PLAN_FILE="$ZSKILLS_PLANS_DIR/$tok"; break ;;
+    esac
+  done
+fi
+if [ -z "${PLAN_FILE:-}" ]; then
+  echo "refine-plan: PLAN_FILE not resolved from \$ARGUMENTS (need a *.md token)" >&2
+  exit 2
+fi
+TRACKING_ID=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 WT_PATH=$(bash "$HELPER" \
   --prefix refineplan \
   --pipeline-id "refine-plan.${TRACKING_ID}" \

--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.21+ab9adf"
+  version: "2026.05.21+28baac"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -267,6 +267,11 @@ Phase 3a in `/run-plan` and `/fix-issues`, extended to recognize sentence
 punctuation `.!?` since this is prose-like goal text):
 
 ```bash
+# Resolve $GOAL from the original description. /research-and-go's input
+# is the broad goal text — orchestrators typically pass it as $ARGUMENTS
+# or as $DESCRIPTION. Prefer existing $GOAL, then $DESCRIPTION, then
+# $ARGUMENTS, so the regex below operates on a populated value.
+GOAL="${GOAL:-${DESCRIPTION:-$ARGUMENTS}}"
 LANDING_ARG=""
 if [[ "$GOAL" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
   LANDING_ARG="pr"

--- a/.claude/skills/research-and-plan/SKILL.md
+++ b/.claude/skills/research-and-plan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Researches the domain, identifies sub-problems and dependencies,
   produces a meta-plan whose phases each delegate to /run-plan.
 metadata:
-  version: "2026.05.15+3617bb"
+  version: "2026.05.21+c35245"
 ---
 
 # /research-and-plan [output FILE] \<description...> — Meta-Plan Decomposer
@@ -358,6 +358,23 @@ meta-plan filename gives a stable, per-run scope):
 # $META_PLAN_PATH is the output path where the meta-plan is (or will be)
 # written — same value used as the `output FILE` argument / default
 # (`$ZSKILLS_PLANS_DIR/<SLUG>_META.md`). Derive a stable slug from it.
+# Resolve $META_PLAN_PATH from $ARGUMENTS if not already set by the
+# parent skill (`/research-and-go` exports it; standalone invocations
+# parse it from the `output FILE` positional argument or fall back to
+# the canonical default).
+if [ -z "${META_PLAN_PATH:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  # First `.md` token in $ARGUMENTS is the output path. If absent, fall
+  # back to a timestamped default so the slug computation below produces
+  # a stable, non-empty value rather than fail-closing the sanitiser.
+  META_PLAN_PATH=""
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      *.md) META_PLAN_PATH="$tok"; break ;;
+    esac
+  done
+  : "${META_PLAN_PATH:=$ZSKILLS_PLANS_DIR/$(date +%Y%m%d-%H%M%S)_META.md}"
+fi
 META_PLAN_SLUG=$(basename "$META_PLAN_PATH" .md | tr '[:upper:]_' '[:lower:]-')
 PIPELINE_ID="research-and-plan.$META_PLAN_SLUG"
 PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")

--- a/skills/draft-tests/SKILL.md
+++ b/skills/draft-tests/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.05.20+0e54e6"
+  version: "2026.05.21+6fc43c"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
@@ -74,6 +74,26 @@ if [ ! -x "$HELPER" ]; then
   echo "draft-tests: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Resolve $PLAN_FILE and derive $TRACKING_ID before the worktree preamble
+# so the helper's --pipeline-id / positional slug are non-empty. Mirrors
+# the Arguments-section detection rule: first $ARGUMENTS token ending in
+# `.md` or containing `/` is the plan file; resolve bare names via
+# $ZSKILLS_PLANS_DIR. Phase 1's Tracking-fulfillment fence re-derives
+# $TRACKING_ID idempotently from the same $PLAN_FILE.
+if [ -z "${PLAN_FILE:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      */*) PLAN_FILE="$tok"; break ;;
+      *.md) PLAN_FILE="$ZSKILLS_PLANS_DIR/$tok"; break ;;
+    esac
+  done
+fi
+if [ -z "${PLAN_FILE:-}" ]; then
+  echo "draft-tests: PLAN_FILE not resolved from \$ARGUMENTS (need a *.md token)" >&2
+  exit 2
+fi
+TRACKING_ID=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 WT_PATH=$(bash "$HELPER" \
   --prefix drafttests \
   --pipeline-id "draft-tests.${TRACKING_ID}" \

--- a/skills/refine-plan/SKILL.md
+++ b/skills/refine-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.05.20+2f426f"
+  version: "2026.05.21+289f05"
 ---
 
 # /refine-plan \<plan-file> [rounds N] [guidance...] — Adversarial Plan Refiner
@@ -71,6 +71,25 @@ if [ ! -x "$HELPER" ]; then
   echo "refine-plan: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Resolve $PLAN_FILE and derive $TRACKING_ID before the worktree preamble
+# so the helper's --pipeline-id / positional slug are non-empty. Mirrors
+# the Arguments-section detection rule: first $ARGUMENTS token ending in
+# `.md` is the plan file; resolve bare names via $ZSKILLS_PLANS_DIR.
+# Phase 1's Tracking-fulfillment fence re-uses $TRACKING_ID idempotently.
+if [ -z "${PLAN_FILE:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      */*) PLAN_FILE="$tok"; break ;;
+      *.md) PLAN_FILE="$ZSKILLS_PLANS_DIR/$tok"; break ;;
+    esac
+  done
+fi
+if [ -z "${PLAN_FILE:-}" ]; then
+  echo "refine-plan: PLAN_FILE not resolved from \$ARGUMENTS (need a *.md token)" >&2
+  exit 2
+fi
+TRACKING_ID=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 WT_PATH=$(bash "$HELPER" \
   --prefix refineplan \
   --pipeline-id "refine-plan.${TRACKING_ID}" \

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.21+ab9adf"
+  version: "2026.05.21+28baac"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -267,6 +267,11 @@ Phase 3a in `/run-plan` and `/fix-issues`, extended to recognize sentence
 punctuation `.!?` since this is prose-like goal text):
 
 ```bash
+# Resolve $GOAL from the original description. /research-and-go's input
+# is the broad goal text — orchestrators typically pass it as $ARGUMENTS
+# or as $DESCRIPTION. Prefer existing $GOAL, then $DESCRIPTION, then
+# $ARGUMENTS, so the regex below operates on a populated value.
+GOAL="${GOAL:-${DESCRIPTION:-$ARGUMENTS}}"
 LANDING_ARG=""
 if [[ "$GOAL" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?]) ]]; then
   LANDING_ARG="pr"

--- a/skills/research-and-plan/SKILL.md
+++ b/skills/research-and-plan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Researches the domain, identifies sub-problems and dependencies,
   produces a meta-plan whose phases each delegate to /run-plan.
 metadata:
-  version: "2026.05.15+3617bb"
+  version: "2026.05.21+c35245"
 ---
 
 # /research-and-plan [output FILE] \<description...> — Meta-Plan Decomposer
@@ -358,6 +358,23 @@ meta-plan filename gives a stable, per-run scope):
 # $META_PLAN_PATH is the output path where the meta-plan is (or will be)
 # written — same value used as the `output FILE` argument / default
 # (`$ZSKILLS_PLANS_DIR/<SLUG>_META.md`). Derive a stable slug from it.
+# Resolve $META_PLAN_PATH from $ARGUMENTS if not already set by the
+# parent skill (`/research-and-go` exports it; standalone invocations
+# parse it from the `output FILE` positional argument or fall back to
+# the canonical default).
+if [ -z "${META_PLAN_PATH:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  # First `.md` token in $ARGUMENTS is the output path. If absent, fall
+  # back to a timestamped default so the slug computation below produces
+  # a stable, non-empty value rather than fail-closing the sanitiser.
+  META_PLAN_PATH=""
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      *.md) META_PLAN_PATH="$tok"; break ;;
+    esac
+  done
+  : "${META_PLAN_PATH:=$ZSKILLS_PLANS_DIR/$(date +%Y%m%d-%H%M%S)_META.md}"
+fi
 META_PLAN_SLUG=$(basename "$META_PLAN_PATH" .md | tr '[:upper:]_' '[:lower:]-')
 PIPELINE_ID="research-and-plan.$META_PLAN_SLUG"
 PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")


### PR DESCRIPTION
## Summary
Bundled fix for 4 sister bugs — skill bash fences READ variables without first ASSIGNING them. Each skill works fine when DISPATCHED by a parent but FAILS on direct standalone invocation.

- **#579** — `/research-and-plan` standalone Tracking fence: assign `META_PLAN_PATH` from `$ARGUMENTS` (parse `*.md` token; fallback to dated path under `$ZSKILLS_PLANS_DIR`).
- **#582** — `/research-and-go` Step 2 landing-mode detection: `GOAL="${GOAL:-${DESCRIPTION:-$ARGUMENTS}}"` before regex.
- **#592** — `/draft-tests` worktree preamble: assign `PLAN_FILE` from `$ARGUMENTS` + derive `TRACKING_ID` inline at the top (was at line 160 after first read).
- **#596** — `/refine-plan` worktree preamble: same pattern as #592.

Versions bumped: research-and-plan `+c35245`, research-and-go `+28baac`, draft-tests `+6fc43c`, refine-plan `+289f05`. All 4 mirrors byte-equal.

Closes #579, Closes #596, Closes #592, Closes #582.

## Test plan
- [x] Full suite (implementer): 5158/5158 passed, 0 failed.
- [x] Skill version hashes match for all 4 skills.
- [x] Scope: 4 source SKILL.md + 4 mirrors = 8 files.
- [x] Tier-1: SKILL.md files not Tier-1.
