### PR TITLE
test(claim): cover sweep_stale_claims helper + claim_ttl_seconds resolver (Closes #574)

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -157,6 +157,7 @@ run_suite "test-fix-issues-claim-race-e2e.sh" "tests/test-fix-issues-claim-race-
 run_suite "test-fix-issues-claim-race-baseline.sh" "tests/test-fix-issues-claim-race-baseline.sh"
 run_suite "test-fix-issues-claim-conformance.sh" "tests/test-fix-issues-claim-conformance.sh"
 run_suite "test-fix-issues-claim-regression-single.sh" "tests/test-fix-issues-claim-regression-single.sh"
+run_suite "test-claim-ttl-config-resolver.sh" "tests/test-claim-ttl-config-resolver.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test-claim-ttl-config-resolver.sh
+++ b/tests/test-claim-ttl-config-resolver.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# tests/test-claim-ttl-config-resolver.sh — unit tests for the
+# zskills-resolve-config.sh parse of execution.claim_ttl_seconds (issue
+# #574, PR #544 Phase 1 adjacent surface).
+#
+# Covers four resolver edge cases that the existing
+# tests/test-fix-issues-claim-script.sh suite bypasses by `export
+# ZSKILLS_CLAIM_TTL_SECONDS=...` directly:
+#   - field absent     -> default 7200
+#   - field = 1800     -> 1800 (valid)
+#   - field = 30       -> 7200 (sub-60 floor rejected, fallback to default)
+#   - field = "30"     -> 7200 (string, [ -ge 60 ] guard rejects)
+#
+# Strategy: each case writes a minimal .claude/zskills-config.json under a
+# tmp $CLAUDE_PROJECT_DIR, then sources zskills-resolve-config.sh in a
+# subshell (so the export/var bleed doesn't leak across cases). Subshell
+# isolation also lets us `unset CLAUDE_PROJECT_DIR` per-case despite the
+# parent test-harness having set it.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVER_SH="$REPO_ROOT/skills/update-zskills/scripts/zskills-resolve-config.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRATCH_ROOT="/tmp/test-claim-ttl-config-resolver-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then
+    echo "TEST_KEEP_SCRATCH set — leaving $SCRATCH_ROOT for inspection" >&2
+    return
+  fi
+  if [ -d "$SCRATCH_ROOT" ]; then
+    find "$SCRATCH_ROOT" -mindepth 1 -delete 2>/dev/null || true
+    rmdir "$SCRATCH_ROOT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH_ROOT"
+
+if [ ! -f "$RESOLVER_SH" ]; then
+  echo "FATAL: zskills-resolve-config.sh missing at $RESOLVER_SH" >&2
+  exit 1
+fi
+
+echo "=== zskills-resolve-config.sh claim_ttl_seconds tests ==="
+
+# Helper: writes a config json with the given execution body, then sources
+# the resolver in a subshell from inside a fresh git repo (resolver's
+# git-common-dir fallback requires being inside one). Echoes the resolved
+# ZSKILLS_CLAIM_TTL_SECONDS to stdout.
+#
+# Args:
+#   $1 — case label (used as subdir name under SCRATCH_ROOT)
+#   $2 — JSON body for .claude/zskills-config.json (full content)
+resolve_in_case() {
+  local label="$1"
+  local config_body="$2"
+  local case_root="$SCRATCH_ROOT/$label"
+  mkdir -p "$case_root/.claude"
+  printf '%s' "$config_body" > "$case_root/.claude/zskills-config.json"
+  # Init a git repo so the resolver's git-common-dir fallback path works
+  # if CLAUDE_PROJECT_DIR somehow isn't honored. We set it explicitly.
+  (cd "$case_root" && git init -q && git config user.email "t@t" && git config user.name "t" && git commit --allow-empty -q -m "init") || return 1
+  # Subshell: clear and reset CLAUDE_PROJECT_DIR; clear inherited TTL var so
+  # the resolver's own defaulting + parse is what's under test (not the
+  # parent harness's export).
+  (
+    unset ZSKILLS_CLAIM_TTL_SECONDS
+    export CLAUDE_PROJECT_DIR="$case_root"
+    cd "$case_root" || exit 1
+    # shellcheck source=/dev/null
+    . "$RESOLVER_SH" >/dev/null 2>&1
+    echo "$ZSKILLS_CLAIM_TTL_SECONDS"
+  )
+}
+
+# ───────────────────────────────────────────────────────────────────────
+# Test D: field present (= 1800) -> 1800.
+# ───────────────────────────────────────────────────────────────────────
+got=$(resolve_in_case "d_present_1800" '{"execution":{"claim_ttl_seconds":1800}}')
+if [ "$got" = "1800" ]; then
+  pass "execution.claim_ttl_seconds=1800 -> ZSKILLS_CLAIM_TTL_SECONDS=1800"
+else
+  fail "claim_ttl_seconds=1800 resolved" "expected 1800, got '$got'"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test E: field absent (config has no execution.claim_ttl_seconds, but the
+# enclosing execution object exists) -> default 7200.
+# ───────────────────────────────────────────────────────────────────────
+got=$(resolve_in_case "e_absent" '{"execution":{"max_concurrent_worktrees":3}}')
+if [ "$got" = "7200" ]; then
+  pass "execution.claim_ttl_seconds absent -> ZSKILLS_CLAIM_TTL_SECONDS=7200 (default)"
+else
+  fail "claim_ttl_seconds absent resolved to default" "expected 7200, got '$got'"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test F: field below sub-60 floor (= 30) -> 7200 (default kept).
+# Schema documents `min 60`; the resolver enforces the floor via
+# `[ "$_ZSK_TTL" -ge 60 ]`. Sub-60 values must not be honored.
+# ───────────────────────────────────────────────────────────────────────
+got=$(resolve_in_case "f_below_floor" '{"execution":{"claim_ttl_seconds":30}}')
+if [ "$got" = "7200" ]; then
+  pass "execution.claim_ttl_seconds=30 (below floor) -> ZSKILLS_CLAIM_TTL_SECONDS=7200 (rejected)"
+else
+  fail "claim_ttl_seconds sub-60 floor enforced" "expected 7200, got '$got'"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test G: malformed value (string "not-a-number" where int is expected)
+# -> 7200 (Python-parse path returns the string, the bash `-ge 60` guard
+# rejects non-numeric and the initializer default of 7200 is kept).
+# ───────────────────────────────────────────────────────────────────────
+got=$(resolve_in_case "g_malformed" '{"execution":{"claim_ttl_seconds":"not-a-number"}}')
+if [ "$got" = "7200" ]; then
+  pass "execution.claim_ttl_seconds=\"not-a-number\" -> ZSKILLS_CLAIM_TTL_SECONDS=7200 (parse-fallback)"
+else
+  fail "claim_ttl_seconds string fallback" "expected 7200, got '$got'"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (%d total)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (%d total)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-fix-issues-claim-script.sh
+++ b/tests/test-fix-issues-claim-script.sh
@@ -634,6 +634,128 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# Test 14: sweep_stale_claims helper — wrapper invocation removes stale,
+# leaves fresh. Exercises the SKILL.md-fence-facing surface (issue #574).
+# ───────────────────────────────────────────────────────────────────────
+HELPERS_SH="$REPO_ROOT/skills/fix-issues/scripts/claim-fence-helpers.sh"
+if [ ! -f "$HELPERS_SH" ]; then
+  fail "sweep_stale_claims wrapper" "claim-fence-helpers.sh missing at $HELPERS_SH"
+else
+t14_root="$SCRATCH_ROOT/t14"
+make_repo "$t14_root"
+(
+  cd "$t14_root" || exit 1
+  export ZSKILLS_CLAIM_TTL_SECONDS=7200
+  # Stale claim (issue-300): NOW-3h, will be swept.
+  bash "$CLAIM_SH" acquire 300 --pipeline-id pipe-stale --sprint-id sprint-stale >/dev/null
+  python3 -c "
+import json, datetime
+p = '$t14_root/.zskills/claims/issue-300/claim.json'
+with open(p) as f: b = json.load(f)
+b['started_at'] = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=3)).isoformat(timespec='seconds')
+with open(p, 'w') as f: json.dump(b, f, sort_keys=True)
+"
+  # Fresh claim (issue-301): NOW, should remain.
+  bash "$CLAIM_SH" acquire 301 --pipeline-id pipe-fresh --sprint-id sprint-fresh >/dev/null
+
+  # Source helper and invoke wrapper. Capture stderr.
+  # shellcheck source=/dev/null
+  . "$HELPERS_SH" || { echo "FAIL_REASON failed to source claim-fence-helpers.sh"; exit 1; }
+  if ! declare -F sweep_stale_claims >/dev/null; then
+    echo "FAIL_REASON sweep_stale_claims function not defined after sourcing"
+    exit 1
+  fi
+  wrapper_stderr=$(sweep_stale_claims 2>&1 >/dev/null)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL_REASON sweep_stale_claims returned $rc, expected 0; stderr: $wrapper_stderr"
+    exit 1
+  fi
+  if [ -d "$t14_root/.zskills/claims/issue-300" ]; then
+    echo "FAIL_REASON stale claim issue-300 not swept by wrapper"
+    exit 1
+  fi
+  if [ ! -d "$t14_root/.zskills/claims/issue-301" ]; then
+    echo "FAIL_REASON fresh claim issue-301 wrongly swept by wrapper"
+    exit 1
+  fi
+  if ! echo "$wrapper_stderr" | grep -q "swept stale claim issue-300"; then
+    echo "FAIL_REASON wrapper stderr missing swept line; got: $wrapper_stderr"
+    exit 1
+  fi
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  pass "sweep_stale_claims wrapper: sourced, function defined, removes stale claim, leaves fresh, forwards stderr"
+else
+  fail "sweep_stale_claims wrapper happy path" "see FAIL_REASON above"
+fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 15: sweep_stale_claims helper — empty claims dir (no claims at
+# all) is a no-op, exits 0. Mirrors the SKILL.md-fence preflight call
+# pattern (`sweep_stale_claims || true`).
+# ───────────────────────────────────────────────────────────────────────
+if [ -f "$HELPERS_SH" ]; then
+t15_root="$SCRATCH_ROOT/t15"
+make_repo "$t15_root"
+(
+  cd "$t15_root" || exit 1
+  # No claims acquired — claims dir doesn't exist yet.
+  # shellcheck source=/dev/null
+  . "$HELPERS_SH" || { echo "FAIL_REASON failed to source claim-fence-helpers.sh"; exit 1; }
+  out=$(sweep_stale_claims 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL_REASON sweep_stale_claims on empty dir returned $rc, expected 0; out: $out"
+    exit 1
+  fi
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  pass "sweep_stale_claims wrapper: empty/missing claims dir is no-op, exits 0"
+else
+  fail "sweep_stale_claims wrapper empty dir" "see FAIL_REASON above"
+fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 16: sweep_stale_claims helper — claim-issue.sh path-resolution
+# failure surfaces non-zero exit + error stderr. Simulated by sourcing
+# the helper, then overriding the internal _CLAIM_ISSUE_SH pointer to a
+# non-existent path before calling the wrapper. Verifies the
+# `[ ! -x ] && [ ! -f ]` guard in claim-fence-helpers.sh actually fires.
+# ───────────────────────────────────────────────────────────────────────
+if [ -f "$HELPERS_SH" ]; then
+t16_root="$SCRATCH_ROOT/t16"
+make_repo "$t16_root"
+(
+  cd "$t16_root" || exit 1
+  # shellcheck source=/dev/null
+  . "$HELPERS_SH" || { echo "FAIL_REASON failed to source claim-fence-helpers.sh"; exit 1; }
+  # Override the internal pointer to a missing path.
+  _CLAIM_ISSUE_SH="/tmp/test-fix-issues-claim-script-nonexistent-$$/claim-issue.sh"
+  out=$(sweep_stale_claims 2>&1)
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL_REASON sweep_stale_claims with missing claim-issue.sh returned 0, expected non-zero; out: $out"
+    exit 1
+  fi
+  if ! echo "$out" | grep -q "cannot locate claim-issue.sh"; then
+    echo "FAIL_REASON missing 'cannot locate claim-issue.sh' stderr; got: $out"
+    exit 1
+  fi
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  pass "sweep_stale_claims wrapper: missing claim-issue.sh path -> non-zero + 'cannot locate' stderr"
+else
+  fail "sweep_stale_claims wrapper missing-target guard" "see FAIL_REASON above"
+fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
Test coverage for two adjacent surfaces of the claim primitive (PR #544 Phase 1):
- **`sweep_stale_claims` helper** (in `claim-fence-helpers.sh`) — 3 new cases: happy path (stale removed, fresh kept), empty/missing dir no-op, missing `claim-issue.sh` guard.
- **`claim_ttl_seconds` resolver** (in `zskills-resolve-config.sh`) — 4 new cases: 1800 → 1800, absent → default 7200, below-floor 30 → 7200, non-number → 7200 (Python-parse fallback).

New test file `tests/test-claim-ttl-config-resolver.sh` registered in `run-all.sh`.

Closes #574.

## Test plan
- [x] Full suite: 5165/5165 passed, 0 failed.
- [x] 7 new test cases (T14-T16 in existing file + D/E/F/G in new file).
- [x] Mutation reasoning: removing the helper / removing the resolver / removing the `-ge 60` floor / removing Python try/except all cause specific test cases to FAIL.
- [x] Scope: 3 files (existing test extended + new test + run-all.sh registration).
