### PR TITLE
style(zskills-dashboard): tune chip palette for visibility — severity-binned skip + green in-flight

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+ea8b34"
+  version: "2026.05.21+014ba9"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -380,20 +380,22 @@ code, pre, .mono {
 }
 
 /* Skip-reason chip (issue #445) — surfaces tracker-derived skip class
-   for Ready-column issues. Visually distinct from label-chip:
-   stronger left-border accent + colored text, pill-shape with a
-   bottom margin so it sits on its own visual row above labels. */
+   for Ready-column issues. Severity-binned palette: magenta for reasons
+   that need a human (needs-decision, bug-unclear-cause), blue for
+   "queued for /draft-plan" (plan-scale), gray-with-fill for "parked"
+   (unresearched). Tinted background + heavier border + bolder text
+   gives chips real visual weight against the dark dashboard surface. */
 .skip-chip {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 3px 10px;
   margin: 4px 4px 4px 0;
-  font-size: 0.72rem;
-  font-weight: 500;
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-left-width: 3px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(247, 120, 186, 0.14);
+  border: 1px solid var(--pink);
+  border-left-width: 4px;
   border-radius: 4px;
-  color: var(--text);
+  color: var(--pink);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -401,25 +403,36 @@ code, pre, .mono {
   vertical-align: middle;
 }
 
-.skip-chip--needs-decision    { border-left-color: var(--orange);  color: var(--orange);  }
-.skip-chip--plan-scale        { border-left-color: var(--accent);  color: var(--accent);  }
-.skip-chip--bug-unclear-cause { border-left-color: var(--accent2); color: var(--accent2); }
-.skip-chip--unresearched      { border-left-color: var(--text-dim); color: var(--text-dim); }
+/* needs-decision and bug-unclear-cause inherit the default magenta —
+   both are "needs human now" reasons. No override needed. */
+
+.skip-chip--plan-scale {
+  background: rgba(88, 166, 255, 0.14);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.skip-chip--unresearched {
+  background: rgba(139, 148, 158, 0.18);
+  border-color: var(--text-dim);
+  color: var(--text);
+}
 
 /* Claim chip (fix-issues claim — plans/fix-issues-claims.md Phase 3).
-   Soft-amber background with a darker amber text, visually distinct
-   from skip-chip's bordered-pill aesthetic — solid-fill so a "this is
-   actively being worked on" signal reads at a glance. Non-interactive. */
+   Green to read as "active healthy work happening"; matches skip-chip's
+   bordered-pill + tinted-background aesthetic so the palette feels
+   coherent rather than introducing a third visual language. */
 .claim-chip--in-flight {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 3px 10px;
   margin: 4px 4px 4px 0;
-  font-size: 0.72rem;
-  font-weight: 500;
-  background: #fff3d6;
-  color: #7a5a00;
-  border: 1px solid #e6c478;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(63, 185, 80, 0.14);
+  border: 1px solid var(--green);
+  border-left-width: 4px;
   border-radius: 4px;
+  color: var(--green);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+ea8b34"
+  version: "2026.05.21+014ba9"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -380,20 +380,22 @@ code, pre, .mono {
 }
 
 /* Skip-reason chip (issue #445) — surfaces tracker-derived skip class
-   for Ready-column issues. Visually distinct from label-chip:
-   stronger left-border accent + colored text, pill-shape with a
-   bottom margin so it sits on its own visual row above labels. */
+   for Ready-column issues. Severity-binned palette: magenta for reasons
+   that need a human (needs-decision, bug-unclear-cause), blue for
+   "queued for /draft-plan" (plan-scale), gray-with-fill for "parked"
+   (unresearched). Tinted background + heavier border + bolder text
+   gives chips real visual weight against the dark dashboard surface. */
 .skip-chip {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 3px 10px;
   margin: 4px 4px 4px 0;
-  font-size: 0.72rem;
-  font-weight: 500;
-  background: var(--surface2);
-  border: 1px solid var(--border);
-  border-left-width: 3px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(247, 120, 186, 0.14);
+  border: 1px solid var(--pink);
+  border-left-width: 4px;
   border-radius: 4px;
-  color: var(--text);
+  color: var(--pink);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -401,25 +403,36 @@ code, pre, .mono {
   vertical-align: middle;
 }
 
-.skip-chip--needs-decision    { border-left-color: var(--orange);  color: var(--orange);  }
-.skip-chip--plan-scale        { border-left-color: var(--accent);  color: var(--accent);  }
-.skip-chip--bug-unclear-cause { border-left-color: var(--accent2); color: var(--accent2); }
-.skip-chip--unresearched      { border-left-color: var(--text-dim); color: var(--text-dim); }
+/* needs-decision and bug-unclear-cause inherit the default magenta —
+   both are "needs human now" reasons. No override needed. */
+
+.skip-chip--plan-scale {
+  background: rgba(88, 166, 255, 0.14);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.skip-chip--unresearched {
+  background: rgba(139, 148, 158, 0.18);
+  border-color: var(--text-dim);
+  color: var(--text);
+}
 
 /* Claim chip (fix-issues claim — plans/fix-issues-claims.md Phase 3).
-   Soft-amber background with a darker amber text, visually distinct
-   from skip-chip's bordered-pill aesthetic — solid-fill so a "this is
-   actively being worked on" signal reads at a glance. Non-interactive. */
+   Green to read as "active healthy work happening"; matches skip-chip's
+   bordered-pill + tinted-background aesthetic so the palette feels
+   coherent rather than introducing a third visual language. */
 .claim-chip--in-flight {
   display: inline-block;
-  padding: 2px 8px;
+  padding: 3px 10px;
   margin: 4px 4px 4px 0;
-  font-size: 0.72rem;
-  font-weight: 500;
-  background: #fff3d6;
-  color: #7a5a00;
-  border: 1px solid #e6c478;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(63, 185, 80, 0.14);
+  border: 1px solid var(--green);
+  border-left-width: 4px;
   border-radius: 4px;
+  color: var(--green);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Tune the dashboard chip palette for visibility. Shipped per the **Proposal C** design from the partial visual-verification session for #600.

**Skip-chip** (`.skip-chip` + 4 variant classes) — severity-binned instead of one-color-per-reason:

| Variant | Old color | New color | Rationale |
|---|---|---|---|
| `--needs-decision` | orange text on dark, no bg | magenta (`--pink`) + tinted bg | "needs human now" |
| `--bug-unclear-cause` | purple text on dark, no bg | magenta (`--pink`) + tinted bg | "needs human now" |
| `--plan-scale` | blue text on dark, no bg | blue (`--accent`) + tinted bg | "queued for /draft-plan" |
| `--unresearched` | gray-on-gray (barely visible) | gray-tint bg + `--text` (white) text | "parked" |

**Claim-chip** (`.claim-chip--in-flight`) — green-themed bordered-pill instead of solid cream/brown fill:

- Old: `#fff3d6` (cream) bg, `#7a5a00` (brown) text, `#e6c478` (amber) border — solid-fill, only chip in the UI with this aesthetic.
- New: `rgba(63,185,80,0.14)` (`--green` tinted) bg, `--green` text, `--green` border — reads as "active healthy work happening" and matches skip-chip's bordered-pill aesthetic so the palette feels coherent.

**Common to both chip families:**

- Font weight bumped `500 → 600`, font size `0.72rem → 0.78rem`, padding `2px 8px → 3px 10px`, border-left width `3px → 4px`. All chips now have real visual weight.
- All overflow/ellipsis/vertical-align rules preserved (no layout regression risk).
- Existing `.card[aria-disabled="true"]` cursor/opacity rule untouched.

## Decision history

Three palette options were prototyped in `/tmp/chip-palette-preview.html` and rendered via playwright-cli to `.playwright/output/chip-palette-proposals.png`. An independent reviewer picked C with the rationale: "C collapses to the actually-actionable axis ('needs human now' / 'queued for /draft-plan' / 'parked'), which is how a triager actually scans the column." Proposal A's 4-shade magenta was rejected because the hue shifts (`#ffabd2` vs `#e070a8` vs `#c0588f`) are barely distinguishable in the screenshot; Proposal B was honest about that but threw away the per-reason signal entirely.

## Files changed

- `skills/zskills-dashboard/scripts/zskills_monitor/static/app.css` (lines 382–428) + mirror — palette swap, no other rules touched.
- `skills/zskills-dashboard/SKILL.md` — `metadata.version` bumped to `2026.05.21+014ba9` (hash reflects the CSS edit).
- `.claude/skills/zskills-dashboard/` mirror is byte-equal to source.

No JS, no Python, no test fixtures touched. CSS-only diff.

## Test plan

- [x] Full suite: `bash tests/run-all.sh` — gating on `Overall: N/M passed, 0 failed`. CSS-only change so no behavior regression expected; this gates that no test fixture happens to grep on the old hex values.
- [x] `bash tests/test-skill-conformance.sh` — mirror byte-equality + skill-content-hash invariants.
- [ ] **Visual verification (post-merge by reviewer):** `/zskills-dashboard restart` to load the new CSS into the running process — note that static files are re-read on each HTTP request so a hard browser refresh alone is enough; the restart is only needed for Python module changes (none here). Then check:
  - Skip chips on Ready-column issues read clearly against the dark surface — particularly `--unresearched` which was gray-on-gray before.
  - Claim chip on a fix-issues claim reads as green-tinted, matching the skip-chip aesthetic rather than a different visual language.
  - No color collision with link-shaped elements adjacent to a `--plan-scale` skip chip (both use `--accent` blue).

## Not in scope

- Move-all column button (Triage ↔ Ready bulk move with shake-on-claim) — designed in the same session but split per reviewer's recommendation; behavioral change with race-window concerns and keyboard-accessibility requirements that warrant its own PR + test plan.
- Other dashboard polish ideas from the same session — held for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
