### PR TITLE
fix(zskills-dashboard): hide per-card unresearched skip-chip — diagnostic value is aggregate, not per-card

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+014ba9"
+  version: "2026.05.21+a33d6c"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -872,11 +872,17 @@ function buildIssueCard(issue, num, col) {
   }
   card.appendChild(head);
   // Skip-reason chip (issue #445) — only renders for Ready-column issues
-  // whose tracker blurb resolves to a skip-class (needs-decision,
-  // plan-scale, bug-unclear-cause, unresearched). Tooltip carries the
-  // verbatim Action-now / Verdict source line. Non-interactive — card
-  // remains drag-and-droppable.
-  if (issue && issue.skip_reason && issue.skip_reason.code) {
+  // whose tracker blurb resolves to a *genuine* skip-class (needs-decision,
+  // plan-scale, bug-unclear-cause). `unresearched` is excluded: it signals
+  // "tracker has no blurb yet for this issue" rather than a true skip —
+  // /fix-issues N dashboard auto-syncs (Phase 1a) and researches these on
+  // next invocation, so the per-card chip carries no actionable signal
+  // for a human reader. The underlying `skip_reason` data stays in
+  // /api/state so a future aggregate signal (e.g. column-header
+  // "N untracked" badge) can consume it. Tooltip carries the verbatim
+  // Action-now / Verdict source line. Non-interactive — card remains
+  // drag-and-droppable.
+  if (issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
     const sr = issue.skip_reason;
     const code = String(sr.code || "");
     const label = String(sr.label || code || "");

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+014ba9"
+  version: "2026.05.21+a33d6c"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -872,11 +872,17 @@ function buildIssueCard(issue, num, col) {
   }
   card.appendChild(head);
   // Skip-reason chip (issue #445) — only renders for Ready-column issues
-  // whose tracker blurb resolves to a skip-class (needs-decision,
-  // plan-scale, bug-unclear-cause, unresearched). Tooltip carries the
-  // verbatim Action-now / Verdict source line. Non-interactive — card
-  // remains drag-and-droppable.
-  if (issue && issue.skip_reason && issue.skip_reason.code) {
+  // whose tracker blurb resolves to a *genuine* skip-class (needs-decision,
+  // plan-scale, bug-unclear-cause). `unresearched` is excluded: it signals
+  // "tracker has no blurb yet for this issue" rather than a true skip —
+  // /fix-issues N dashboard auto-syncs (Phase 1a) and researches these on
+  // next invocation, so the per-card chip carries no actionable signal
+  // for a human reader. The underlying `skip_reason` data stays in
+  // /api/state so a future aggregate signal (e.g. column-header
+  // "N untracked" badge) can consume it. Tooltip carries the verbatim
+  // Action-now / Verdict source line. Non-interactive — card remains
+  // drag-and-droppable.
+  if (issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
     const sr = issue.skip_reason;
     const code = String(sr.code || "");
     const label = String(sr.label || code || "");


### PR DESCRIPTION
## Summary

Stops rendering the per-card `skip: unresearched — not yet researched` chip in the dashboard's Issues view. The underlying `skip_reason` data in `/api/state` is unchanged; only the frontend render condition is tightened.

## Why

Surfaced during the visual-verification session for #609. The "skip:" framing is structurally wrong for the `unresearched` code:

| Code | True skip? | What `/fix-issues` actually does |
|---|---|---|
| `needs-decision` | YES | Won't touch — author decision needed |
| `plan-scale` | YES | Won't touch — needs `/draft-plan` first |
| `bug-unclear-cause` | YES | Won't touch — needs `/investigate` first |
| `unresearched` | **NO** | Researches as Phase 1a sync, then dispatches normally |

The other three skip codes name actions a human needs to take. `unresearched` names a state the next `/fix-issues` invocation will silently self-heal. The chip therefore carries no actionable signal for a human reader — and the "skip:" prefix actively misleads ("this issue is being skipped" when it isn't).

The signal **does** have aggregate value (knowing how many Ready issues are pending sync), but at the column-summary level, not per-card. A column-header "N untracked" badge would carry the same signal at 1/N the visual cost. Per the discussion thread, we'd rather drop the per-card chip now and revisit a column-header indicator only if the signal proves missed in practice.

## Change

One-line condition tightening in `buildIssueCard`:

```diff
- if (issue && issue.skip_reason && issue.skip_reason.code) {
+ if (issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
```

Plus an updated block comment explaining the exclusion rationale.

**What stays:**

- `collect.py:_build_skip_reason_index` keeps emitting `unresearched` entries for tracker-missing / section-absent / `Verdict: NOT YET RESEARCHED` cases.
- `/api/state` keeps returning `skip_reason: {code: "unresearched", ...}` on those issues.
- All existing backend tests (`test-issues-skip-reason-parse.sh`) keep passing — they test the data model, not the chip rendering.
- The `.skip-chip--unresearched` CSS rule stays in place (zero-cost dead code, easy to revive if a future PR re-enables the chip in some form).

**What changes user-visibly:** issues whose only `skip_reason` is `unresearched` will show no skip-chip on their cards. Cards still show all other chip families (claim, label, mode) and any genuine skip-chip.

## Files

- `skills/zskills-dashboard/scripts/zskills_monitor/static/app.js` — one-line condition change in `buildIssueCard` + updated block comment.
- `skills/zskills-dashboard/SKILL.md` — `metadata.version` → `2026.05.21+a33d6c`.
- `.claude/skills/zskills-dashboard/` mirror byte-equal.

## Test plan

- [x] Full suite: `bash tests/run-all.sh` — gating on `Overall: N/M passed, 0 failed`. Backend `unresearched` data is unchanged, so backend tests are uninvolved.
- [x] `tests/test-issues-skip-reason-parse.sh` green (data model unchanged).
- [x] Mirror parity: `diff -rq skills/zskills-dashboard .claude/skills/zskills-dashboard` empty.
- [ ] **Visual verification (post-merge by reviewer):** open dashboard with at least one issue whose only `skip_reason` is `unresearched` (e.g. any newly-filed issue before next `/fix-issues sync`). Hard-refresh — that card should now show no chip in the previously-occupied row. Cards with other skip codes (`needs-decision`/`plan-scale`/`bug-unclear-cause`) and claim chips remain visible.

## Not in scope

- Column-header "N untracked" aggregate badge — defer; surface only if we miss the per-card signal in practice.
- Cache-bust `<link href="/app.css">` with skill version — separate follow-up PR; closes the hard-refresh trap we hit verifying #609.
- Move-all column buttons + shake-on-claim — separate follow-up PR; original feature ask from the same session, behavioral change with race-window considerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
