### PR TITLE
feat(zskills-dashboard): cache-bust app.css / app.js via mtime ?v=

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+a33d6c"
+  version: "2026.05.21+9e1390"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -723,9 +723,10 @@ class MonitorHandler(BaseHTTPRequestHandler):
 
     def _serve_static_index(self) -> None:
         ctx = self._ctx()
-        index = ctx["static_dir"] / "index.html"
+        static_dir = ctx["static_dir"]
+        index = static_dir / "index.html"
         if index.is_file():
-            self._send_static(200, index, "text/html; charset=utf-8")
+            self._serve_index_with_cache_bust(index, static_dir)
             return
         # Phase 6 hasn't shipped UI yet — return a friendly placeholder
         # rather than 404 so /api/health and curl smoke land cleanly.
@@ -747,6 +748,31 @@ class MonitorHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": f"{name} not present (Phase 6)"})
             return
         self._send_static(200, path, content_type)
+
+    def _serve_index_with_cache_bust(
+        self, index: pathlib.Path, static_dir: pathlib.Path
+    ) -> None:
+        # Substitute ?v=<mtime_ns> into the <link href> and <script src>
+        # references so a browser cache picks up CSS/JS edits on the next
+        # normal page reload (no hard-refresh required). mtime_ns auto-
+        # updates on any file edit — independent of skill-versioning.
+        try:
+            html = index.read_bytes()
+        except OSError as exc:
+            self._send_json(500, {"error": f"index.html unreadable: {exc}"})
+            return
+        for asset, ref in (("app.css", b'href="/app.css"'), ("app.js", b'src="/app.js"')):
+            try:
+                mtime_ns = (static_dir / asset).stat().st_mtime_ns
+            except OSError:
+                continue  # asset missing → leave reference untouched
+            replacement = ref[:-1] + f'?v={mtime_ns}"'.encode("ascii")
+            html = html.replace(ref, replacement, 1)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(html)))
+        self.end_headers()
+        self.wfile.write(html)
 
     def _handle_health(self) -> None:
         ctx = self._ctx()

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+a33d6c"
+  version: "2026.05.21+9e1390"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -723,9 +723,10 @@ class MonitorHandler(BaseHTTPRequestHandler):
 
     def _serve_static_index(self) -> None:
         ctx = self._ctx()
-        index = ctx["static_dir"] / "index.html"
+        static_dir = ctx["static_dir"]
+        index = static_dir / "index.html"
         if index.is_file():
-            self._send_static(200, index, "text/html; charset=utf-8")
+            self._serve_index_with_cache_bust(index, static_dir)
             return
         # Phase 6 hasn't shipped UI yet — return a friendly placeholder
         # rather than 404 so /api/health and curl smoke land cleanly.
@@ -747,6 +748,31 @@ class MonitorHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": f"{name} not present (Phase 6)"})
             return
         self._send_static(200, path, content_type)
+
+    def _serve_index_with_cache_bust(
+        self, index: pathlib.Path, static_dir: pathlib.Path
+    ) -> None:
+        # Substitute ?v=<mtime_ns> into the <link href> and <script src>
+        # references so a browser cache picks up CSS/JS edits on the next
+        # normal page reload (no hard-refresh required). mtime_ns auto-
+        # updates on any file edit — independent of skill-versioning.
+        try:
+            html = index.read_bytes()
+        except OSError as exc:
+            self._send_json(500, {"error": f"index.html unreadable: {exc}"})
+            return
+        for asset, ref in (("app.css", b'href="/app.css"'), ("app.js", b'src="/app.js"')):
+            try:
+                mtime_ns = (static_dir / asset).stat().st_mtime_ns
+            except OSError:
+                continue  # asset missing → leave reference untouched
+            replacement = ref[:-1] + f'?v={mtime_ns}"'.encode("ascii")
+            html = html.replace(ref, replacement, 1)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(html)))
+        self.end_headers()
+        self.wfile.write(html)
 
     def _handle_health(self) -> None:
         ctx = self._ctx()

--- a/tests/test_zskills_monitor_server.sh
+++ b/tests/test_zskills_monitor_server.sh
@@ -983,4 +983,45 @@ else
   fail "couldn't start server for parallel-write test"
 fi
 
+###############################################################################
+# Phase 12 — index.html cache-bust: ?v=<mtime_ns> substituted on /
+###############################################################################
+echo ""
+echo "=== Phase 12: index.html cache-bust (?v= on app.css / app.js refs) ==="
+
+MR9="$TMP_ROOT/mr9"
+mkdir -p "$MR9/.claude" "$MR9/plans"
+PORT_H=$(( BASE_PORT + 7 ))
+cat >"$MR9/.claude/zskills-config.json" <<EOF
+{ "dev_server": { "default_port": $PORT_H } }
+EOF
+if start_server "$MR9" "$PORT_H"; then
+  INDEX_BODY=$(curl -sf -m 3 "http://127.0.0.1:$PORT_H/")
+  if printf '%s' "$INDEX_BODY" | grep -qE 'href="/app\.css\?v=[0-9]+"'; then
+    pass "served / contains href=\"/app.css?v=<digits>\""
+  else
+    fail "served / missing cache-bust on app.css: $(printf '%s' "$INDEX_BODY" | grep -oE 'href="/app\.css[^"]*"' | head -1)"
+  fi
+  if printf '%s' "$INDEX_BODY" | grep -qE 'src="/app\.js\?v=[0-9]+"'; then
+    pass "served / contains src=\"/app.js?v=<digits>\""
+  else
+    fail "served / missing cache-bust on app.js: $(printf '%s' "$INDEX_BODY" | grep -oE 'src="/app\.js[^"]*"' | head -1)"
+  fi
+  # Two requests should return the same ?v= value when the asset is
+  # unchanged (mtime stable). Tolerate the FS quirk where mtime_ns may
+  # tick by one if the assets were just written by mirror-skill.sh, by
+  # extracting the value and comparing.
+  V1=$(printf '%s' "$INDEX_BODY" | grep -oE '/app\.css\?v=[0-9]+' | head -1)
+  INDEX_BODY2=$(curl -sf -m 3 "http://127.0.0.1:$PORT_H/")
+  V2=$(printf '%s' "$INDEX_BODY2" | grep -oE '/app\.css\?v=[0-9]+' | head -1)
+  if [ -n "$V1" ] && [ "$V1" = "$V2" ]; then
+    pass "cache-bust value stable across two consecutive requests"
+  else
+    fail "cache-bust value not stable: V1=$V1 V2=$V2"
+  fi
+  stop_server "$MR9/.zskills/dashboard-server.pid" "$PORT_H" >/dev/null
+else
+  fail "couldn't start server for cache-bust test"
+fi
+
 print_summary_and_exit


### PR DESCRIPTION
## Summary

- Server-side cache-bust for `app.css` / `app.js`: on every `GET /`, substitute `?v=<mtime_ns>` into the `<link href>` and `<script src>` attributes.
- mtime auto-updates on every edit, so a normal page reload picks up new CSS/JS without a hard-refresh.
- mtime is independent of skill-versioning — local edits bust the cache even before the version bump runs.
- Added Phase 12 to `test_zskills_monitor_server.sh`: GET `/` contains `?v=<digits>` on both asset references, value is stable across two consecutive requests.

## Test plan

- [x] `bash tests/run-all.sh` → `Overall: 5316/5316 passed, 0 failed`
- [x] New server test (Phase 12) asserts `?v=<digits>` substitution + stability
- [ ] After merge: restart the running dashboard server (`bash scripts/stop-dev.sh && bash scripts/start-dev.sh`), load `http://127.0.0.1:8080/`, view-source confirms `href="/app.css?v=<digits>"` and `src="/app.js?v=<digits>"`
- [ ] After merge: edit `app.css` (e.g., bump a color), reload page (NOT hard-refresh), new value should apply
