### PR TITLE
fix(fix-issues): assign CHANGE_SUMMARY before PR-mode heredoc

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+6ae52a"
+  version: "2026.05.21+f6f635"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/pr.md
+++ b/.claude/skills/fix-issues/modes/pr.md
@@ -102,6 +102,12 @@ MARK
   # PR body: explicit, with Fixes #N linking. Composed once before the
   # caller loop; /land-pr writes the body only on initial PR creation,
   # so a per-issue static body is the right choice here.
+  #
+  # Per-issue change summary: bullet list of commit subjects added to the
+  # feature branch beyond origin/main. Tolerant of empty (no commits yet)
+  # and of detached HEAD (worktree at branch tip).
+  CHANGE_SUMMARY=$(cd "$WORKTREE_PATH" && git log origin/main..HEAD --format='- %s' 2>/dev/null)
+  CHANGE_SUMMARY="${CHANGE_SUMMARY:-_(no commits yet — body will be updated on first push)_}"
   BODY_FILE="/tmp/pr-body-fix-issues-$BRANCH_SLUG.md"
   cat > "$BODY_FILE" <<BODY
 Fixes #${ISSUE_NUM}

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+6ae52a"
+  version: "2026.05.21+f6f635"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/pr.md
+++ b/skills/fix-issues/modes/pr.md
@@ -102,6 +102,12 @@ MARK
   # PR body: explicit, with Fixes #N linking. Composed once before the
   # caller loop; /land-pr writes the body only on initial PR creation,
   # so a per-issue static body is the right choice here.
+  #
+  # Per-issue change summary: bullet list of commit subjects added to the
+  # feature branch beyond origin/main. Tolerant of empty (no commits yet)
+  # and of detached HEAD (worktree at branch tip).
+  CHANGE_SUMMARY=$(cd "$WORKTREE_PATH" && git log origin/main..HEAD --format='- %s' 2>/dev/null)
+  CHANGE_SUMMARY="${CHANGE_SUMMARY:-_(no commits yet — body will be updated on first push)_}"
   BODY_FILE="/tmp/pr-body-fix-issues-$BRANCH_SLUG.md"
   cat > "$BODY_FILE" <<BODY
 Fixes #${ISSUE_NUM}

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -44,6 +44,16 @@ check "research-and-go pre-decides meta-plan path" \
 check "research-and-go drops every 4h" \
   '! grep -q "every 4h now" skills/research-and-go/SKILL.md'
 
+# Issue #601: /fix-issues PR-mode pr.md heredoc reads ${CHANGE_SUMMARY};
+# the variable must be assigned in the same file before the heredoc.
+# Sibling of #579 (META_PLAN_PATH), #582 ($GOAL), #592/#596
+# (TRACKING_ID + PLAN_FILE). Read-before-assignment shipped empty
+# "## Changes" sections in every PR-mode PR body.
+check "fix-issues pr.md assigns CHANGE_SUMMARY before heredoc read" \
+  'grep -qE "^[[:space:]]*CHANGE_SUMMARY=" skills/fix-issues/modes/pr.md'
+check "fix-issues pr.md mirror assigns CHANGE_SUMMARY before heredoc read" \
+  'grep -qE "^[[:space:]]*CHANGE_SUMMARY=" .claude/skills/fix-issues/modes/pr.md'
+
 # Phase C: tool-list-aware dispatch (4 skills)
 for f in skills/run-plan/SKILL.md skills/fix-issues/SKILL.md \
          skills/verify-changes/SKILL.md \


### PR DESCRIPTION
Fixes #601

## Changes
- fix(fix-issues): assign CHANGE_SUMMARY before PR-mode heredoc (#601)

## Test plan
- [x] Full test suite passed locally (`bash tests/run-all.sh` — confirmed by fresh verifier subagent)
- [x] New test pin added to lock the invariant going forward
- [x] Skill source + `.claude/` mirror diff = empty (byte-equality preserved)
- [x] `metadata.version` bumped on the changed skill
- [ ] CI re-runs the suite on the rebased branch
