### PR TITLE
fix(fix-report): surface failure-class statuses distinctly

### DIFF
--- a/.claude/skills/fix-report/SKILL.md
+++ b/.claude/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.20+246baf"
+  version: "2026.05.21+434b2f"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -365,8 +365,17 @@ for wt in $(git worktree list | awk '{print $1}' | tail -n +2); do
       conflict)
         echo "NEEDS ATTENTION: $wt — rebase conflict, needs manual resolution ⚠"
         ;;
+      failed|direct-push-failed|direct-verify-failed)
+        echo "FAILED: $wt — status: $STATUS (failure-class, see reason field) ✗"
+        ;;
+      pr-state-unknown)
+        echo "NEEDS ATTENTION: $wt — PR state unverified (see PR ${PR_URL:-unknown}) ⚠"
+        ;;
+      partial)
+        echo "PARTIAL: $wt — partial landing, see worktree for unlanded commits ⚠"
+        ;;
       *)
-        echo "PARTIAL: $wt — status: $STATUS (has unlanded or unresolved work) ⚠"
+        echo "UNKNOWN: $wt — unrecognized status: $STATUS"
         ;;
     esac
   else

--- a/skills/fix-report/SKILL.md
+++ b/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.20+246baf"
+  version: "2026.05.21+434b2f"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -365,8 +365,17 @@ for wt in $(git worktree list | awk '{print $1}' | tail -n +2); do
       conflict)
         echo "NEEDS ATTENTION: $wt — rebase conflict, needs manual resolution ⚠"
         ;;
+      failed|direct-push-failed|direct-verify-failed)
+        echo "FAILED: $wt — status: $STATUS (failure-class, see reason field) ✗"
+        ;;
+      pr-state-unknown)
+        echo "NEEDS ATTENTION: $wt — PR state unverified (see PR ${PR_URL:-unknown}) ⚠"
+        ;;
+      partial)
+        echo "PARTIAL: $wt — partial landing, see worktree for unlanded commits ⚠"
+        ;;
       *)
-        echo "PARTIAL: $wt — status: $STATUS (has unlanded or unresolved work) ⚠"
+        echo "UNKNOWN: $wt — unrecognized status: $STATUS"
         ;;
     esac
   else

--- a/tests/test-landed-schema.sh
+++ b/tests/test-landed-schema.sh
@@ -174,6 +174,37 @@ test_fix_report_canonical_parser() {
   fi
 }
 
+# /fix-report Step 6 case statement must have a distinct arm for every
+# status the writers produce — otherwise failure-class statuses
+# (failed, direct-push-failed, direct-verify-failed, pr-state-unknown,
+# partial) silently collapse into the wildcard arm, contradicting the
+# skill's own prose at Step 4 that says they must be surfaced as failed
+# sprints. See #602.
+test_fix_report_case_arm_per_status() {
+  local target="$REPO_ROOT/skills/fix-report/SKILL.md"
+  if [ ! -f "$target" ]; then
+    pass "/fix-report case-arm coverage: skill not present (skipped)"
+    return
+  fi
+  local status missing=""
+  for status in full landed pr-ready pr-ci-failing pr-failed conflict \
+                failed direct-push-failed direct-verify-failed \
+                pr-state-unknown partial; do
+    # Match the status at the start of a case-arm pattern OR as one of
+    # the alternatives in a piped pattern (e.g., `full|landed)` or
+    # `failed|direct-push-failed|direct-verify-failed)`).
+    if ! grep -qE "(^[[:space:]]*|\|)${status}(\)|\|)" "$target"; then
+      missing="$missing $status"
+    fi
+  done
+  if [ -z "$missing" ]; then
+    pass "/fix-report Step 6 case statement has arm for every status"
+  else
+    fail "/fix-report Step 6 case statement has arm for every status" \
+      "missing arms for:$missing"
+  fi
+}
+
 echo "=== .landed canonical schema parser tests ==="
 test_landphase_grep_canonical_landed
 test_landphase_grep_canonical_pr_ready
@@ -181,6 +212,7 @@ test_landphase_grep_rejects_conflict
 test_landphase_source_pattern
 test_landphase_e2e_canonical
 test_fix_report_canonical_parser
+test_fix_report_case_arm_per_status
 
 echo ""
 echo "---"


### PR DESCRIPTION
Fixes #602

## Changes
- fix(fix-report): surface failure-class statuses distinctly in Step 6 case statement (#602)

## Test plan
- [x] Full test suite passed locally (`bash tests/run-all.sh` — confirmed by fresh verifier subagent)
- [x] New test pin added to lock the invariant going forward
- [x] Skill source + `.claude/` mirror diff = empty (byte-equality preserved)
- [x] `metadata.version` bumped on the changed skill
- [ ] CI re-runs the suite on the rebased branch
