### PR TITLE
sprint-report: sprint-20260521-232542-sprint

### DIFF
--- a/docs/issues/ISSUES_PLAN.md
+++ b/docs/issues/ISSUES_PLAN.md
@@ -1078,6 +1078,18 @@ Both fixes extend `tests/test-skill-conformance.sh` with grep-counting tripwires
 
 ---
 
+### #602 — /fix-report Step 6 case statement masks failure-class statuses (failed, direct-push-failed, direct-verify-failed) as generic 'PARTIAL' — contradicts the skill's own prose
+
+**Labels:** (none) | **Verdict:** NOT FIXED
+
+**Problem.** `skills/fix-report/SKILL.md` Step 6 (lines 352-371) classifies worktrees by `.landed` `status:` value with 5 explicit case arms (`full|landed`, `pr-ready`, `pr-ci-failing`, `pr-failed`, `conflict`); the `*)` wildcard collapses everything else — including failure-class statuses `failed`, `direct-push-failed`, `direct-verify-failed`, `pr-state-unknown`, and `partial` — to generic "PARTIAL — has unlanded or unresolved work." Same SKILL.md prose (lines 272-276) explicitly says these failure-class markers must be "surface[d] in the report as failed sprints" — case statement contradicts the prose; case statement wins at runtime. Reader-side of the same vocabulary expansion #518 / #530 handled writer-side; `tests/test-landed-schema.sh:158-175` checks `status:` substring but cannot detect case-arm drift.
+
+**Fix outline.** Extend the case statement with 3 new arms: `failed|direct-push-failed|direct-verify-failed)` → FAILED label (failure-class, see reason field); `pr-state-unknown)` → NEEDS ATTENTION (PR state unverified); `partial)` → explicit PARTIAL label (vs. silent collapse). Replace generic `*)` arm with `UNKNOWN: unrecognized status` so future status drift fails loudly. Tighten `tests/test-landed-schema.sh` to assert each documented status (`full`, `landed`, `pr-ready`, `pr-ci-failing`, `pr-failed`, `conflict`, `failed`, `direct-push-failed`, `direct-verify-failed`, `pr-state-unknown`, `partial`) appears as a case-arm pattern in `/fix-report` SKILL.md — mirror-of-existing-pattern from #586 / #587 closure-tightening tests. Bump `/fix-report` `metadata.version` per skill-versioning discipline; mirror to `.claude/skills/`.
+
+**Complexity:** S (one case-statement extension + one test extension + version bump + mirror). **Action now:** /do pr — add 3 failure-class case arms (FAILED + pr-state-unknown + partial) to `skills/fix-report/SKILL.md:352-371`; replace `*)` arm with loud-fail UNKNOWN; extend `tests/test-landed-schema.sh` with per-status case-arm grep loop; bump version + mirror.
+
+---
+
 ### #601 — /fix-issues PR-mode body uses `${CHANGE_SUMMARY}` (modes/pr.md:110) but variable is never assigned — every PR ships with empty "## Changes" section
 
 **Labels:** (none) | **Verdict:** NOT FIXED — confirmed defect, 5th sibling in variable-read-never-assigned family

--- a/docs/issues/ISSUES_PLAN.md
+++ b/docs/issues/ISSUES_PLAN.md
@@ -1076,3 +1076,15 @@ Both fixes extend `tests/test-skill-conformance.sh` with grep-counting tripwires
 
 **Complexity:** S (test additions in existing file; no source edits). **Action now:** /do pr — add `sweep_stale_claims` test cases + `claim_ttl_seconds` config-resolver test cases to `tests/test-fix-issues-claim-script.sh`.
 
+---
+
+### #601 — /fix-issues PR-mode body uses `${CHANGE_SUMMARY}` (modes/pr.md:110) but variable is never assigned — every PR ships with empty "## Changes" section
+
+**Labels:** (none) | **Verdict:** NOT FIXED — confirmed defect, 5th sibling in variable-read-never-assigned family
+
+**Problem.** `skills/fix-issues/modes/pr.md` composes a per-PR body via an unquoted heredoc (lines 102-115) that expands `${CHANGE_SUMMARY}`, but no assignment exists anywhere in the executable path (`grep -rnE '^[[:space:]]*CHANGE_SUMMARY=' skills/fix-issues/` returns empty). Result: every /fix-issues PR-mode PR — the dominant PR producer in this repo via the hourly cron — ships with a blank `## Changes` section, stripping context from human reviewers and from downstream consumers (sprint reports, /fix-report, briefings) that scan PR bodies. Fifth confirmed sibling of the variable-read-before-assignment family alongside #579 (META_PLAN_PATH), #582 ($GOAL), #592 (TRACKING_ID + PLAN_FILE in /draft-tests), and #596 (TRACKING_ID + PLAN_FILE in /refine-plan).
+
+**Fix outline.** Assign `CHANGE_SUMMARY` immediately before the heredoc at line 102 by deriving it from `git log origin/main..HEAD --format='- %s'` inside `$WORKTREE_PATH`, with a fallback string when no commits exist yet (e.g. `_(no commits yet — body will be updated on first push)_`). ~5-line addition to `skills/fix-issues/modes/pr.md`. Add a conformance test pin asserting every `${VAR}` referenced inside heredoc fences in `modes/pr.md` has a same-file assignment (mirrors the #592/#596 pattern; ideally a framework-level invariant closing the whole 5-sibling family at once). Bump `metadata.version` per skill-versioning rule.
+
+**Complexity:** S (single-file ~5-line bash assignment + conformance test pin + metadata version bump). **Action now:** /do pr — add `CHANGE_SUMMARY=$(git log origin/main..HEAD --format='- %s')` assignment before the heredoc in `skills/fix-issues/modes/pr.md`, add conformance assertion against unset-heredoc-vars in `modes/pr.md`, and bump the skill's `metadata.version`.
+

--- a/docs/reports/SPRINT_REPORT.md
+++ b/docs/reports/SPRINT_REPORT.md
@@ -1777,3 +1777,28 @@ Deleted branch wt-nopre-cw-smoke-9468-c20 (was 3ed8e8f).
 - Sprint started: 2026-05-21T16:37:16-04:00
 - Cron `8cc665fb` (`*/30 * * * *`) — active.
 
+
+## Sprint — 2026-05-21 20:16 EDT [UNFINALIZED]
+
+**Mode:** auto (dashboard-sourced) | **Focus:** default | **Sprint ID:** sprint-20260521-232542-sprint
+
+### Fixed
+| # | Title | Worktree | Commit | Tests | Agent Verify | User Verify |
+|---|-------|----------|--------|-------|--------------|-------------|
+| #601 | /fix-issues PR-mode body uses `${CHANGE_SUMMARY}` but variable never assigned | /tmp/zskills-fix-issue-601 | 7831e7f | 5315/5315 + 2 new pins (test-skill-invariants.sh) | PASS (verifier APPROVED FOR LANDING) | N/A (skill prose only) |
+| #602 | /fix-report Step 6 case statement masks failure-class statuses as 'PARTIAL' | /tmp/zskills-fix-issue-602 | 3dc74e9 | 5314/5314 + 1 new test (test-landed-schema.sh) | PASS (verifier APPROVED FOR LANDING) | N/A (skill prose only) |
+
+### Skipped — Too Vague
+(none)
+
+### Skipped — Too Complex (need /run-plan)
+(none)
+
+### Skipped — Cherry-Pick Conflict
+(none)
+
+### Not Fixed
+(none)
+
+### Notes
+Dashboard Ready queue head at sprint start: `[601, 602]`. Source: `.zskills/monitor-state.json`. Both issues belong to the variable-read-before-assignment family (#601) and the reader-side vocabulary-drift family (#602). Both received /fix-issues source-filter backfill (research-blurb commit on sprint worktree: a30a525, d547124) and proceeded via in-batch fix-agent + fresh verifier — independent sizing returned **S, /do pr-tier** for both, but the work was small enough that post-execution verifier dispatch was sufficient (no plan-review needed before fix).


### PR DESCRIPTION
## Summary
`/fix-issues` sprint `sprint-20260521-232542-sprint` — 2 PRs landed.

- #601 → PR #614 (merged)
- #602 → PR #615 (merged)

This sprint commit lands the per-issue research blurbs (added to `docs/issues/ISSUES_PLAN.md` by Phase 2 source-filter backfill for both candidates that arrived without `**Action now:**` tracker rows) and the SPRINT_REPORT.md section recording the sprint.

## Test plan
- [x] Per-issue PRs (#614, #615) each ran their own CI; both passed and merged.
- [x] Sprint-level changes are docs-only (tracker rows + sprint report).
- [ ] CI re-runs the suite on the rebased sprint branch.
