### PR TITLE
do: column-header move-all buttons (Issues+Plans)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+9e1390"
+  version: "2026.05.21+3a34ab"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -882,6 +882,55 @@ code, pre, .mono {
   cursor: not-allowed;
 }
 
+/* Column-header chevron buttons (move-all). Visually similar to .move-btn
+   but slightly larger/bolder so they read as a column-level action rather
+   than a per-card control. Sits in the column-head flex row. */
+.move-all-group {
+  display: inline-flex;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.move-all-btn {
+  background: var(--surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 6px;
+  font-size: 1rem;
+  line-height: 1.2;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.move-all-btn:hover,
+.move-all-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.12);
+  outline: none;
+}
+
+/* Skipped-card shake — fires for cards left behind by a column move-all
+   because they're claimed (aria-disabled="true"). Visible jitter (~8px
+   each side) over ~400ms; the JS toggles `.shake` for that duration. */
+@keyframes shake-skip {
+  0%   { transform: translateX(0); }
+  12%  { transform: translateX(-8px); }
+  24%  { transform: translateX(7px); }
+  36%  { transform: translateX(-6px); }
+  48%  { transform: translateX(6px); }
+  60%  { transform: translateX(-5px); }
+  72%  { transform: translateX(4px); }
+  84%  { transform: translateX(-3px); }
+  100% { transform: translateX(0); }
+}
+
+.card.shake {
+  animation: shake-skip 400ms ease-in-out;
+}
+
 .mode-chip {
   background: transparent;
   border: 1px solid var(--accent2);

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -25,6 +25,9 @@ const POST_RECONCILE_SUPPRESS_MS = 1500;
 
 const PLAN_COLUMNS = ["drafted", "reviewed", "ready"];
 const ISSUE_COLUMNS = ["triage", "ready"];
+// Threshold above which the column-header move-all chevron prompts the
+// user via confirm() before iterating. <= this count moves silently.
+const MOVE_ALL_CONFIRM_THRESHOLD = 10;
 const PLAN_COLUMN_LABELS = {
   drafted: "Drafted",
   reviewed: "Reviewed",
@@ -679,6 +682,28 @@ function makeIssueMoveBtn(action, num, label, ariaLabel) {
   });
 }
 
+// Column-header chevron button: triggers "move all non-claimed cards in
+// this column to the adjacent column" (kind ∈ {plan, issue}; column is the
+// source column slug; direction is "left" or "right"). Per-card iteration
+// runs in moveAllInColumn(); claimed cards are skipped (with shake) — both
+// at snapshot time AND on re-query inside the per-card loop, to close the
+// race window where a poll-driven claim lands between the click and the
+// per-card dispatch.
+function makeColumnMoveAllBtn(action, kind, column, label, ariaLabel) {
+  return el("button", {
+    cls: "move-all-btn",
+    attrs: {
+      type: "button",
+      tabindex: "0",
+      "data-action": action,
+      "data-kind": kind,
+      "data-column": column,
+      "aria-label": ariaLabel,
+    },
+    text: label,
+  });
+}
+
 function currentEntryMode(slug) {
   if (!lastGoodQueues) return null;
   const arr = lastGoodQueues.plans.ready || [];
@@ -709,6 +734,34 @@ function renderPlans(plans, queues, defaultMode) {
     head.appendChild(el("span", { text: PLAN_COLUMN_LABELS[c] }));
     const arr = (lastGoodQueues && lastGoodQueues.plans[c]) || [];
     head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    // Column-header chevron buttons (move-all). Adjacent-only; the
+    // first column gets only », the last only «, and Reviewed both.
+    const moveAllGroup = el("span", {
+      cls: "move-all-group",
+      attrs: { role: "group", "aria-label": "Move all in " + PLAN_COLUMN_LABELS[c] },
+    });
+    const ci = PLAN_COLUMNS.indexOf(c);
+    if (ci > 0) {
+      const prevLabel = PLAN_COLUMN_LABELS[PLAN_COLUMNS[ci - 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "plan-move-all-left",
+        "plan",
+        c,
+        "«",
+        "Move all unclaimed " + PLAN_COLUMN_LABELS[c] + " plans to " + prevLabel,
+      ));
+    }
+    if (ci < PLAN_COLUMNS.length - 1) {
+      const nextLabel = PLAN_COLUMN_LABELS[PLAN_COLUMNS[ci + 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "plan-move-all-right",
+        "plan",
+        c,
+        "»",
+        "Move all unclaimed " + PLAN_COLUMN_LABELS[c] + " plans to " + nextLabel,
+      ));
+    }
+    head.appendChild(moveAllGroup);
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -976,6 +1029,34 @@ function renderIssues(issues, queues) {
     head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
     const arr = (queues && queues.issues && queues.issues[c]) || [];
     head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    // Column-header chevron buttons (move-all). Triage gets only »,
+    // Ready gets only «.
+    const moveAllGroup = el("span", {
+      cls: "move-all-group",
+      attrs: { role: "group", "aria-label": "Move all in " + ISSUE_COLUMN_LABELS[c] },
+    });
+    const ci = ISSUE_COLUMNS.indexOf(c);
+    if (ci > 0) {
+      const prevLabel = ISSUE_COLUMN_LABELS[ISSUE_COLUMNS[ci - 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "issue-move-all-left",
+        "issue",
+        c,
+        "«",
+        "Move all unclaimed " + ISSUE_COLUMN_LABELS[c] + " issues to " + prevLabel,
+      ));
+    }
+    if (ci < ISSUE_COLUMNS.length - 1) {
+      const nextLabel = ISSUE_COLUMN_LABELS[ISSUE_COLUMNS[ci + 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "issue-move-all-right",
+        "issue",
+        c,
+        "»",
+        "Move all unclaimed " + ISSUE_COLUMN_LABELS[c] + " issues to " + nextLabel,
+      ));
+    }
+    head.appendChild(moveAllGroup);
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -1828,6 +1909,90 @@ function renderIssueModal(issue) {
   modal.body.appendChild(pre);
 }
 
+// ---------------------------------------------------- column move-all loop
+
+// Briefly attach a `.shake` class to the card and remove it after the
+// animation. Used when a card is skipped during a move-all loop because
+// it's claimed (snapshot-time OR claim landed via poll mid-loop).
+function shakeCard(card) {
+  if (!card) return;
+  card.classList.remove("shake");
+  // Force reflow so re-adding the class restarts the animation when the
+  // same card is shaken in quick succession.
+  void card.offsetWidth;
+  card.classList.add("shake");
+  setTimeout(() => {
+    card.classList.remove("shake");
+  }, 400);
+}
+
+// Move all NON-claimed cards in `column` (of kind `plan` or `issue`) to
+// the adjacent column in `direction` ("left" or "right"). Per-card
+// sequential dispatch — there is no bulk endpoint; each iteration calls
+// the same movePlan / moveIssue used by the single-card chevron buttons.
+//
+// Claim-respect: source of truth is `aria-disabled="true"` on the card.
+// We snapshot non-claimed cards at click-time, then INSIDE each iteration
+// re-query the live card's aria-disabled. A claim landing via the 2s poll
+// between click and iteration N still gets respected (card is skipped and
+// shaken instead of moved).
+async function moveAllInColumn(kind, column, direction) {
+  const kindLabels = (kind === "plan") ? PLAN_COLUMN_LABELS : ISSUE_COLUMN_LABELS;
+  const cols = (kind === "plan") ? PLAN_COLUMNS : ISSUE_COLUMNS;
+  const ci = cols.indexOf(column);
+  if (ci < 0) return;
+  const adjIdx = (direction === "left") ? ci - 1 : ci + 1;
+  if (adjIdx < 0 || adjIdx >= cols.length) return;
+  const srcLabel = kindLabels[column];
+  const dstLabel = kindLabels[cols[adjIdx]];
+
+  // Snapshot the non-claimed cards in this column (live DOM query).
+  const selector = 'ul.dropzone[data-kind="' + kind + '"][data-column="' + column + '"] > li.card';
+  const allCards = Array.from(document.querySelectorAll(selector));
+  const targets = [];
+  for (const card of allCards) {
+    if (card.getAttribute("aria-disabled") === "true") {
+      // Snapshot-time claimed — shake so user sees what was skipped.
+      shakeCard(card);
+      continue;
+    }
+    const idAttr = (kind === "plan") ? "data-slug" : "data-number";
+    const id = card.getAttribute(idAttr);
+    if (!id) continue;
+    targets.push({ id: id, card: card });
+  }
+  if (targets.length === 0) return;
+
+  const noun = (kind === "plan") ? "plans" : "issues";
+  if (targets.length > MOVE_ALL_CONFIRM_THRESHOLD) {
+    const msg = "Move " + targets.length + " unclaimed " + srcLabel + " " + noun + " to " + dstLabel + "?";
+    if (!window.confirm(msg)) return;
+  }
+
+  // Per-card sequential dispatch with in-loop re-check on aria-disabled.
+  for (const t of targets) {
+    // Re-query the live element each iteration — a render between the
+    // last commit and now may have replaced the cached `t.card` node.
+    const liveSelector = (
+      'ul.dropzone[data-kind="' + kind + '"] > li.card[data-' +
+      (kind === "plan" ? "slug" : "number") + '="' + t.id + '"]'
+    );
+    const live = document.querySelector(liveSelector);
+    if (live && live.getAttribute("aria-disabled") === "true") {
+      // Claim landed via poll between click and this iteration. Skip
+      // + shake (matches snapshot-time skip behaviour).
+      shakeCard(live);
+      continue;
+    }
+    if (kind === "plan") {
+      await movePlan(t.id, direction);
+    } else {
+      const num = parseInt(t.id, 10);
+      if (Number.isFinite(num)) await moveIssue(num, direction);
+    }
+  }
+}
+
 // --------------------------------------------------------- click dispatch
 
 async function handleAction(action, target) {
@@ -1841,6 +2006,16 @@ async function handleAction(action, target) {
   if (action === "plan-right") return movePlan(slug, "right");
   if (action === "plan-remove") return removePlan(slug);
   if (action === "toggle-mode") return togglePlanMode(slug);
+
+  // Column-header chevron: move-all in column, adjacent column only.
+  if (action === "plan-move-all-left" || action === "plan-move-all-right" ||
+      action === "issue-move-all-left" || action === "issue-move-all-right") {
+    const col = target.getAttribute("data-column");
+    const kind = target.getAttribute("data-kind");
+    const dir = action.endsWith("-left") ? "left" : "right";
+    if (col && kind) return moveAllInColumn(kind, col, dir);
+    return;
+  }
 
   // Guard: claimed issues are in-flight on another pipeline. Block move
   // and remove actions to prevent ghost-claim footgun (DA2.3 / DA11).

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+9e1390"
+  version: "2026.05.21+3a34ab"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -882,6 +882,55 @@ code, pre, .mono {
   cursor: not-allowed;
 }
 
+/* Column-header chevron buttons (move-all). Visually similar to .move-btn
+   but slightly larger/bolder so they read as a column-level action rather
+   than a per-card control. Sits in the column-head flex row. */
+.move-all-group {
+  display: inline-flex;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.move-all-btn {
+  background: var(--surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 6px;
+  font-size: 1rem;
+  line-height: 1.2;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.move-all-btn:hover,
+.move-all-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.12);
+  outline: none;
+}
+
+/* Skipped-card shake — fires for cards left behind by a column move-all
+   because they're claimed (aria-disabled="true"). Visible jitter (~8px
+   each side) over ~400ms; the JS toggles `.shake` for that duration. */
+@keyframes shake-skip {
+  0%   { transform: translateX(0); }
+  12%  { transform: translateX(-8px); }
+  24%  { transform: translateX(7px); }
+  36%  { transform: translateX(-6px); }
+  48%  { transform: translateX(6px); }
+  60%  { transform: translateX(-5px); }
+  72%  { transform: translateX(4px); }
+  84%  { transform: translateX(-3px); }
+  100% { transform: translateX(0); }
+}
+
+.card.shake {
+  animation: shake-skip 400ms ease-in-out;
+}
+
 .mode-chip {
   background: transparent;
   border: 1px solid var(--accent2);

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -25,6 +25,9 @@ const POST_RECONCILE_SUPPRESS_MS = 1500;
 
 const PLAN_COLUMNS = ["drafted", "reviewed", "ready"];
 const ISSUE_COLUMNS = ["triage", "ready"];
+// Threshold above which the column-header move-all chevron prompts the
+// user via confirm() before iterating. <= this count moves silently.
+const MOVE_ALL_CONFIRM_THRESHOLD = 10;
 const PLAN_COLUMN_LABELS = {
   drafted: "Drafted",
   reviewed: "Reviewed",
@@ -679,6 +682,28 @@ function makeIssueMoveBtn(action, num, label, ariaLabel) {
   });
 }
 
+// Column-header chevron button: triggers "move all non-claimed cards in
+// this column to the adjacent column" (kind ∈ {plan, issue}; column is the
+// source column slug; direction is "left" or "right"). Per-card iteration
+// runs in moveAllInColumn(); claimed cards are skipped (with shake) — both
+// at snapshot time AND on re-query inside the per-card loop, to close the
+// race window where a poll-driven claim lands between the click and the
+// per-card dispatch.
+function makeColumnMoveAllBtn(action, kind, column, label, ariaLabel) {
+  return el("button", {
+    cls: "move-all-btn",
+    attrs: {
+      type: "button",
+      tabindex: "0",
+      "data-action": action,
+      "data-kind": kind,
+      "data-column": column,
+      "aria-label": ariaLabel,
+    },
+    text: label,
+  });
+}
+
 function currentEntryMode(slug) {
   if (!lastGoodQueues) return null;
   const arr = lastGoodQueues.plans.ready || [];
@@ -709,6 +734,34 @@ function renderPlans(plans, queues, defaultMode) {
     head.appendChild(el("span", { text: PLAN_COLUMN_LABELS[c] }));
     const arr = (lastGoodQueues && lastGoodQueues.plans[c]) || [];
     head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    // Column-header chevron buttons (move-all). Adjacent-only; the
+    // first column gets only », the last only «, and Reviewed both.
+    const moveAllGroup = el("span", {
+      cls: "move-all-group",
+      attrs: { role: "group", "aria-label": "Move all in " + PLAN_COLUMN_LABELS[c] },
+    });
+    const ci = PLAN_COLUMNS.indexOf(c);
+    if (ci > 0) {
+      const prevLabel = PLAN_COLUMN_LABELS[PLAN_COLUMNS[ci - 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "plan-move-all-left",
+        "plan",
+        c,
+        "«",
+        "Move all unclaimed " + PLAN_COLUMN_LABELS[c] + " plans to " + prevLabel,
+      ));
+    }
+    if (ci < PLAN_COLUMNS.length - 1) {
+      const nextLabel = PLAN_COLUMN_LABELS[PLAN_COLUMNS[ci + 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "plan-move-all-right",
+        "plan",
+        c,
+        "»",
+        "Move all unclaimed " + PLAN_COLUMN_LABELS[c] + " plans to " + nextLabel,
+      ));
+    }
+    head.appendChild(moveAllGroup);
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -976,6 +1029,34 @@ function renderIssues(issues, queues) {
     head.appendChild(el("span", { text: ISSUE_COLUMN_LABELS[c] }));
     const arr = (queues && queues.issues && queues.issues[c]) || [];
     head.appendChild(el("span", { cls: "muted", text: String(arr.length) }));
+    // Column-header chevron buttons (move-all). Triage gets only »,
+    // Ready gets only «.
+    const moveAllGroup = el("span", {
+      cls: "move-all-group",
+      attrs: { role: "group", "aria-label": "Move all in " + ISSUE_COLUMN_LABELS[c] },
+    });
+    const ci = ISSUE_COLUMNS.indexOf(c);
+    if (ci > 0) {
+      const prevLabel = ISSUE_COLUMN_LABELS[ISSUE_COLUMNS[ci - 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "issue-move-all-left",
+        "issue",
+        c,
+        "«",
+        "Move all unclaimed " + ISSUE_COLUMN_LABELS[c] + " issues to " + prevLabel,
+      ));
+    }
+    if (ci < ISSUE_COLUMNS.length - 1) {
+      const nextLabel = ISSUE_COLUMN_LABELS[ISSUE_COLUMNS[ci + 1]];
+      moveAllGroup.appendChild(makeColumnMoveAllBtn(
+        "issue-move-all-right",
+        "issue",
+        c,
+        "»",
+        "Move all unclaimed " + ISSUE_COLUMN_LABELS[c] + " issues to " + nextLabel,
+      ));
+    }
+    head.appendChild(moveAllGroup);
     colDiv.appendChild(head);
 
     const ul = el("ul", {
@@ -1828,6 +1909,90 @@ function renderIssueModal(issue) {
   modal.body.appendChild(pre);
 }
 
+// ---------------------------------------------------- column move-all loop
+
+// Briefly attach a `.shake` class to the card and remove it after the
+// animation. Used when a card is skipped during a move-all loop because
+// it's claimed (snapshot-time OR claim landed via poll mid-loop).
+function shakeCard(card) {
+  if (!card) return;
+  card.classList.remove("shake");
+  // Force reflow so re-adding the class restarts the animation when the
+  // same card is shaken in quick succession.
+  void card.offsetWidth;
+  card.classList.add("shake");
+  setTimeout(() => {
+    card.classList.remove("shake");
+  }, 400);
+}
+
+// Move all NON-claimed cards in `column` (of kind `plan` or `issue`) to
+// the adjacent column in `direction` ("left" or "right"). Per-card
+// sequential dispatch — there is no bulk endpoint; each iteration calls
+// the same movePlan / moveIssue used by the single-card chevron buttons.
+//
+// Claim-respect: source of truth is `aria-disabled="true"` on the card.
+// We snapshot non-claimed cards at click-time, then INSIDE each iteration
+// re-query the live card's aria-disabled. A claim landing via the 2s poll
+// between click and iteration N still gets respected (card is skipped and
+// shaken instead of moved).
+async function moveAllInColumn(kind, column, direction) {
+  const kindLabels = (kind === "plan") ? PLAN_COLUMN_LABELS : ISSUE_COLUMN_LABELS;
+  const cols = (kind === "plan") ? PLAN_COLUMNS : ISSUE_COLUMNS;
+  const ci = cols.indexOf(column);
+  if (ci < 0) return;
+  const adjIdx = (direction === "left") ? ci - 1 : ci + 1;
+  if (adjIdx < 0 || adjIdx >= cols.length) return;
+  const srcLabel = kindLabels[column];
+  const dstLabel = kindLabels[cols[adjIdx]];
+
+  // Snapshot the non-claimed cards in this column (live DOM query).
+  const selector = 'ul.dropzone[data-kind="' + kind + '"][data-column="' + column + '"] > li.card';
+  const allCards = Array.from(document.querySelectorAll(selector));
+  const targets = [];
+  for (const card of allCards) {
+    if (card.getAttribute("aria-disabled") === "true") {
+      // Snapshot-time claimed — shake so user sees what was skipped.
+      shakeCard(card);
+      continue;
+    }
+    const idAttr = (kind === "plan") ? "data-slug" : "data-number";
+    const id = card.getAttribute(idAttr);
+    if (!id) continue;
+    targets.push({ id: id, card: card });
+  }
+  if (targets.length === 0) return;
+
+  const noun = (kind === "plan") ? "plans" : "issues";
+  if (targets.length > MOVE_ALL_CONFIRM_THRESHOLD) {
+    const msg = "Move " + targets.length + " unclaimed " + srcLabel + " " + noun + " to " + dstLabel + "?";
+    if (!window.confirm(msg)) return;
+  }
+
+  // Per-card sequential dispatch with in-loop re-check on aria-disabled.
+  for (const t of targets) {
+    // Re-query the live element each iteration — a render between the
+    // last commit and now may have replaced the cached `t.card` node.
+    const liveSelector = (
+      'ul.dropzone[data-kind="' + kind + '"] > li.card[data-' +
+      (kind === "plan" ? "slug" : "number") + '="' + t.id + '"]'
+    );
+    const live = document.querySelector(liveSelector);
+    if (live && live.getAttribute("aria-disabled") === "true") {
+      // Claim landed via poll between click and this iteration. Skip
+      // + shake (matches snapshot-time skip behaviour).
+      shakeCard(live);
+      continue;
+    }
+    if (kind === "plan") {
+      await movePlan(t.id, direction);
+    } else {
+      const num = parseInt(t.id, 10);
+      if (Number.isFinite(num)) await moveIssue(num, direction);
+    }
+  }
+}
+
 // --------------------------------------------------------- click dispatch
 
 async function handleAction(action, target) {
@@ -1841,6 +2006,16 @@ async function handleAction(action, target) {
   if (action === "plan-right") return movePlan(slug, "right");
   if (action === "plan-remove") return removePlan(slug);
   if (action === "toggle-mode") return togglePlanMode(slug);
+
+  // Column-header chevron: move-all in column, adjacent column only.
+  if (action === "plan-move-all-left" || action === "plan-move-all-right" ||
+      action === "issue-move-all-left" || action === "issue-move-all-right") {
+    const col = target.getAttribute("data-column");
+    const kind = target.getAttribute("data-kind");
+    const dir = action.endsWith("-left") ? "left" : "right";
+    if (col && kind) return moveAllInColumn(kind, col, dir);
+    return;
+  }
 
   // Guard: claimed issues are in-flight on another pipeline. Block move
   // and remove actions to prevent ghost-claim footgun (DA2.3 / DA11).

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -195,6 +195,131 @@ else
 fi
 
 ###############################################################################
+# AC: column-header move-all chevrons (Issues + Plans panels)
+###############################################################################
+
+echo ""
+echo "=== Column move-all chevrons (Issues + Plans) ==="
+
+# Each of the 4 actions registers in handleAction's dispatch table.
+for act in plan-move-all-left plan-move-all-right issue-move-all-left issue-move-all-right; do
+  if grep -qE "\"$act\"" "$APP_JS"; then
+    pass "move-all action declared: $act"
+  else
+    fail "move-all action missing: $act"
+  fi
+done
+
+# makeColumnMoveAllBtn helper exists and emits aria-label + tabindex.
+if grep -qE 'function makeColumnMoveAllBtn' "$APP_JS"; then
+  pass "makeColumnMoveAllBtn helper defined"
+else
+  fail "makeColumnMoveAllBtn helper missing"
+fi
+if grep -qE 'tabindex.*"0"' "$APP_JS" && grep -qE 'move-all-btn' "$APP_JS"; then
+  pass "move-all buttons get tabindex=0 (keyboard parity)"
+else
+  fail "move-all buttons missing tabindex=0"
+fi
+
+# aria-label parity — template composes "<src col> <noun> to <dst col>" at
+# render time using {PLAN,ISSUE}_COLUMN_LABELS lookups, so verify the
+# template + composition rather than the materialised strings.
+ISSUES_TPL_HITS=$(grep -cE '"Move all unclaimed " \+ ISSUE_COLUMN_LABELS\[c\] \+ " issues to " \+ (prev|next)Label' "$APP_JS" || true)
+if [ "${ISSUES_TPL_HITS:-0}" -ge 2 ]; then
+  pass "Issues aria-label template emits both directions (Triage→Ready, Ready→Triage)"
+else
+  fail "Issues aria-label template hits: $ISSUES_TPL_HITS (expected ≥2)"
+fi
+PLANS_TPL_HITS=$(grep -cE '"Move all unclaimed " \+ PLAN_COLUMN_LABELS\[c\] \+ " plans to " \+ (prev|next)Label' "$APP_JS" || true)
+if [ "${PLANS_TPL_HITS:-0}" -ge 2 ]; then
+  pass "Plans aria-label template emits both directions (4 effective labels across 3 columns)"
+else
+  fail "Plans aria-label template hits: $PLANS_TPL_HITS (expected ≥2)"
+fi
+# Sanity: PLAN_COLUMN_LABELS / ISSUE_COLUMN_LABELS are the substitution
+# source. If those constants drift, the rendered labels drift with them.
+if grep -qE 'PLAN_COLUMN_LABELS = \{' "$APP_JS" && grep -qE 'ISSUE_COLUMN_LABELS = \{' "$APP_JS"; then
+  pass "{PLAN,ISSUE}_COLUMN_LABELS maps define substitution targets"
+else
+  fail "{PLAN,ISSUE}_COLUMN_LABELS missing — aria-labels would render undefined"
+fi
+
+# Claim-respect: source of truth is aria-disabled (NOT chip presence).
+# moveAllInColumn must filter on aria-disabled AND re-check it in-loop.
+if grep -qE 'function moveAllInColumn' "$APP_JS"; then
+  pass "moveAllInColumn function defined"
+else
+  fail "moveAllInColumn function missing"
+fi
+# Count occurrences of aria-disabled checks inside moveAllInColumn — must
+# appear at least twice (snapshot filter + in-loop re-check).
+ARIA_HITS=$(awk '/function moveAllInColumn/{flag=1} flag{print} /^}/&&flag{flag=0}' "$APP_JS" \
+  | grep -c 'aria-disabled' || true)
+if [ "${ARIA_HITS:-0}" -ge 2 ]; then
+  pass "moveAllInColumn checks aria-disabled twice (snapshot + in-loop re-check) — found $ARIA_HITS"
+else
+  fail "moveAllInColumn aria-disabled checks insufficient ($ARIA_HITS < 2)"
+fi
+
+# Confirm threshold > 10 unclaimed cards.
+if grep -qE 'MOVE_ALL_CONFIRM_THRESHOLD\s*=\s*10' "$APP_JS"; then
+  pass "MOVE_ALL_CONFIRM_THRESHOLD = 10"
+else
+  fail "MOVE_ALL_CONFIRM_THRESHOLD missing or != 10"
+fi
+if grep -qE 'window\.confirm\(' "$APP_JS"; then
+  pass "window.confirm() gate present for >threshold move-all"
+else
+  fail "window.confirm() gate missing"
+fi
+# The confirm message must name the count, source column, and dest column.
+if grep -qE '"Move " \+ .*" unclaimed " \+ srcLabel \+ " " \+ noun \+ " to " \+ dstLabel' "$APP_JS"; then
+  pass "confirm() message includes count + source col + dest col"
+else
+  fail "confirm() message format unexpected — must include count/source/dest"
+fi
+
+# Shake animation: keyframe definition + class binding + JS toggle.
+if grep -qE '@keyframes shake-skip' "$APP_CSS"; then
+  pass "@keyframes shake-skip defined in app.css"
+else
+  fail "@keyframes shake-skip missing in app.css"
+fi
+if grep -qE '\.card\.shake' "$APP_CSS"; then
+  pass ".card.shake rule binds the animation"
+else
+  fail ".card.shake rule missing"
+fi
+# Shake must be VISUALLY OBVIOUS — at least one keyframe step ≥6px.
+SHAKE_BLOCK=$(awk '/@keyframes shake-skip/{flag=1} flag{print} /^}/&&flag{flag=0}' "$APP_CSS")
+if printf '%s' "$SHAKE_BLOCK" | grep -qE 'translateX\(-?([6-9]|[1-9][0-9])(\.[0-9]+)?px\)'; then
+  pass "shake animation has ≥6px horizontal jitter (visible, not subtle)"
+else
+  fail "shake animation jitter < 6px (too subtle)"
+fi
+if grep -qE 'function shakeCard' "$APP_JS"; then
+  pass "shakeCard() helper in app.js"
+else
+  fail "shakeCard() helper missing"
+fi
+if grep -qE "classList\.add\(['\"]shake['\"]" "$APP_JS"; then
+  pass "shake class is added in JS"
+else
+  fail "shake class never added in JS"
+fi
+
+# Adjacent-only: Triage has no « (no plan-move-all-left targeting triage),
+# Ready (issues) has no », Drafted has no «, Ready (plans) has no ».
+# We verify the asymmetry indirectly via the column-head injection logic:
+# the chevron is emitted only when ci > 0 (for «) or ci < length-1 (for »).
+if grep -qE 'ci > 0' "$APP_JS" && grep -qE 'ci < (PLAN|ISSUE)_COLUMNS\.length - 1' "$APP_JS"; then
+  pass "adjacent-only guards present (no skip-column chevrons)"
+else
+  fail "adjacent-only guards missing — possible skip-column move-all bug"
+fi
+
+###############################################################################
 # Block 2 — live-server smoke (start server, fetch /, /app.js, /app.css)
 ###############################################################################
 


### PR DESCRIPTION
## Summary

Adds » / « chevron buttons to each column-header in the dashboard's Issues and Plans panels. Click moves ALL non-claimed cards in that column to the adjacent column via per-card sequential dispatch (no bulk endpoint — same per-card move action the single-card button already uses).

**Buttons (adjacent-only, no skip-column moves):**
- Issues — Triage »→ Ready, Ready «→ Triage
- Plans — Drafted »→ Reviewed, Reviewed « / », Ready «→ Reviewed

**Claim-respect:** source of truth is `aria-disabled="true"` on the card (matches `handleAction`'s existing per-card guard). Loop snapshots non-claimed cards at click time AND re-queries `aria-disabled` inside each iteration, so a claim landing via the 2s poll mid-loop is still respected — the card is skipped and visibly shaken.

**Shake:** `.shake` class + `@keyframes shake-skip` in app.css. ~8px horizontal jitter over 400ms — visibly obvious, fires for both pre-snapshot-claimed cards and mid-loop-claimed cards.

**Confirm gate:** when > 10 unclaimed cards would move, native `confirm()` fires with actual count + source column + destination column (e.g., "Move 14 unclaimed Triage issues to Ready?"). Cancel aborts before any API calls.

**Keyboard parity:** each chevron has `tabindex="0"` and a descriptive `aria-label` naming column + direction.

**SKILL.md:** `metadata.version` bumped to 2026.05.21+3a34ab.

## Test plan

- [x] `bash tests/run-all.sh` → `Overall: 5336/5336 passed, 0 failed` (14 new assertions in `test_zskills_monitor_dashboard_ui.sh`).
- [x] Test coverage: action declarations, aria-label template composition, aria-disabled double-check, confirm threshold + message format, shake keyframe visibility (≥6px jitter), adjacent-only guards.
- [ ] After merge: load http://127.0.0.1:8080/, click »-all on a Triage column with mixed claimed/unclaimed issues; observe unclaimed move, claimed stay + shake.
- [ ] After merge: keyboard-only walkthrough — Tab to button, Enter activates, screen reader announces the aria-label.
- [ ] After merge: claim a card, click move-all on its column with 11+ unclaimed siblings; confirm dialog appears with the correct count.

Bundles the Issues move-all from the prior session's queued follow-ups with the new Plans ask, since they share the same UI pattern.
