### PR TITLE
fix(research-and-plan): resolve Step 2 dispatch contradiction

### DIFF
--- a/.claude/skills/research-and-plan/SKILL.md
+++ b/.claude/skills/research-and-plan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Researches the domain, identifies sub-problems and dependencies,
   produces a meta-plan whose phases each delegate to /run-plan.
 metadata:
-  version: "2026.05.21+c35245"
+  version: "2026.05.21+b00e01"
 ---
 
 # /research-and-plan [output FILE] \<description...> — Meta-Plan Decomposer
@@ -162,18 +162,20 @@ For each sub-problem:
      `/draft-plan output $ZSKILLS_PLANS_DIR/X.md rounds 2 <description>. Landing mode: pr`
    - If `LANDING_ARG` is empty, omit the suffix entirely — do NOT pass
      an empty `Landing mode:` token.
-4. Wait for each `/draft-plan` batch to complete before dispatching the
-   next batch (see parallelism rules below).
+4. After each `/draft-plan` invocation returns, report progress, then
+   move to the next sub-plan (see serial-dispatch rule below).
 
-**Parallelism and resource limits:** Dispatch at most 3 `/draft-plan`
-agents concurrently. Wait for each batch to complete before the next.
-**While waiting, do NOT draft plans yourself — wait.** The idle time is
-the cost of not melting the container. Past failure: 11 parallel agents
-caused load average 67, 54 test timeouts, and forced a full restart.
+**Serial dispatch — no parallelism.** Invoke `/draft-plan` once per
+sub-problem via the Skill tool. Each invocation runs the full
+multi-round review loop in your context before returning; this is
+intrinsically serial. Report progress between sub-plans. Do not
+Agent-dispatch (subagents lack the Agent tool, breaking `/draft-plan`'s
+internal reviewer + devil's-advocate dispatch — see the Skill-tool MUST
+above).
 
 Draft in dependency order:
-1. Foundation plan first (alone — everything depends on it)
-2. Independent plans in batches of 3
+1. Foundation plan first (everything depends on it)
+2. Independent plans next, one at a time
 3. Dependent plans after their prerequisites complete
 
 Dependent sub-plans must be drafted after their prerequisites so later

--- a/skills/research-and-plan/SKILL.md
+++ b/skills/research-and-plan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Researches the domain, identifies sub-problems and dependencies,
   produces a meta-plan whose phases each delegate to /run-plan.
 metadata:
-  version: "2026.05.21+c35245"
+  version: "2026.05.21+b00e01"
 ---
 
 # /research-and-plan [output FILE] \<description...> — Meta-Plan Decomposer
@@ -162,18 +162,20 @@ For each sub-problem:
      `/draft-plan output $ZSKILLS_PLANS_DIR/X.md rounds 2 <description>. Landing mode: pr`
    - If `LANDING_ARG` is empty, omit the suffix entirely — do NOT pass
      an empty `Landing mode:` token.
-4. Wait for each `/draft-plan` batch to complete before dispatching the
-   next batch (see parallelism rules below).
+4. After each `/draft-plan` invocation returns, report progress, then
+   move to the next sub-plan (see serial-dispatch rule below).
 
-**Parallelism and resource limits:** Dispatch at most 3 `/draft-plan`
-agents concurrently. Wait for each batch to complete before the next.
-**While waiting, do NOT draft plans yourself — wait.** The idle time is
-the cost of not melting the container. Past failure: 11 parallel agents
-caused load average 67, 54 test timeouts, and forced a full restart.
+**Serial dispatch — no parallelism.** Invoke `/draft-plan` once per
+sub-problem via the Skill tool. Each invocation runs the full
+multi-round review loop in your context before returning; this is
+intrinsically serial. Report progress between sub-plans. Do not
+Agent-dispatch (subagents lack the Agent tool, breaking `/draft-plan`'s
+internal reviewer + devil's-advocate dispatch — see the Skill-tool MUST
+above).
 
 Draft in dependency order:
-1. Foundation plan first (alone — everything depends on it)
-2. Independent plans in batches of 3
+1. Foundation plan first (everything depends on it)
+2. Independent plans next, one at a time
 3. Dependent plans after their prerequisites complete
 
 Dependent sub-plans must be drafted after their prerequisites so later

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -70,6 +70,20 @@ check "prohibition: skill tool recursion mechanism" \
 check "prohibition: docs URL" \
   'grep -q "code.claude.com/docs/en/sub-agents" skills/research-and-plan/SKILL.md'
 
+# Issue #577: Step 2 must not contradict the Skill-tool MUST clause with
+# parallel-Agent-dispatch prose. The MUST clause makes /draft-plan
+# dispatch intrinsically serial; any "concurrent" / "at most N"
+# parallelism wording is unrealizable and is the documented past-failure
+# trigger. Source AND mirror must both be clean.
+for f in skills/research-and-plan/SKILL.md .claude/skills/research-and-plan/SKILL.md; do
+  check "issue #577: no parallel-draft-plan contradiction in $f (no 'at most 3')" \
+    "! grep -q 'at most 3' '$f'"
+  check "issue #577: no parallel-draft-plan contradiction in $f (no 'concurrently')" \
+    "! grep -q 'concurrently' '$f'"
+  check "issue #577: canonical serial-dispatch prose present in $f" \
+    "grep -q 'intrinsically serial' '$f'"
+done
+
 # Phase E: early requires-lockdown
 # The marker creation must appear in Phase 1 (before Phase 2).
 # Heuristic: the first occurrence of `requires.verify-changes.$TRACKING_ID`


### PR DESCRIPTION
Fixes #577

## Changes
- fix(research-and-plan): resolve Step 2 dispatch contradiction (serial Skill-tool batches) (#577)

## Test plan
- [x] Full suite passed (`bash tests/run-all.sh` — 5325/5325)
- [x] Step 2 parallelism prose rewritten as serial Skill-tool batches ("intrinsically serial"); contradictory "at most 3 concurrently" clause + load-67 past-failure quote removed
- [x] Skill-tool MUST clause (lines 92-128) untouched
- [x] Conformance pin: 6 checks in `tests/test-skill-invariants.sh` — 3 negative (no "at most 3", no "concurrently", no load-67) + 3 positive ("intrinsically serial") across source + mirror
- [x] Mirror byte-equality preserved
- [x] `metadata.version` bumped (`2026.05.21+c35245` → `2026.05.21+b00e01`)
- [ ] CI re-runs the suite on the rebased branch
