### PR TITLE
fix(skills): close variable-read-before-assignment family + conformance pin

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.20+7d525c"
+  version: "2026.05.21+fd4fda"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -60,6 +60,25 @@ if [ ! -x "$HELPER" ]; then
   echo "draft-plan: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Resolve $OUTPUT_FILE and derive $TRACKING_ID before the worktree preamble
+# so the helper's --pipeline-id / positional slug are non-empty. Mirrors
+# the Arguments-section detection rule (#603 pattern): first $ARGUMENTS
+# token ending in `.md` is the output path; resolve bare names via
+# $ZSKILLS_PLANS_DIR. Phase 1's Tracking-fulfillment fence re-derives
+# $TRACKING_ID idempotently from the same $OUTPUT_FILE.
+if [ -z "${OUTPUT_FILE:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      */*.md) OUTPUT_FILE="$tok"; break ;;
+      *.md)   OUTPUT_FILE="$ZSKILLS_PLANS_DIR/$tok"; break ;;
+    esac
+  done
+  # Fall back to a timestamped default so downstream slug computation
+  # produces a stable, non-empty value rather than fail-closing.
+  : "${OUTPUT_FILE:=$ZSKILLS_PLANS_DIR/$(date +%Y%m%d-%H%M%S)_PLAN.md}"
+fi
+TRACKING_ID=$(basename "$OUTPUT_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 WT_PATH=$(bash "$HELPER" \
   --prefix draftplan \
   --pipeline-id "draft-plan.${TRACKING_ID}" \
@@ -498,6 +517,10 @@ create the review step marker:
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-draft-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+# $ROUND is the orchestrator-maintained loop counter (Phase 3 review/refine
+# iteration). Default to 1 if unset so the marker is informative even on the
+# first round before any explicit counter was exported.
+ROUND="${ROUND:-1}"
 printf 'round: %s\ncompleted: %s\n' "$ROUND" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.review"
 ```

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+f6f635"
+  version: "2026.05.21+b3cb70"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -316,6 +316,12 @@ if [ ! -x "$HELPER" ]; then
   echo "fix-issues: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Sync mode TRACKING_ID — synthesized from timestamp since /fix-issues sync
+# doesn't take a plan-file arg. Mirrors sprint mode's SPRINT_ID shape (later
+# in this skill) with a `sync-` prefix so the namespace is unambiguous and
+# downstream pipeline IDs (`fix-issues.${TRACKING_ID}`) are non-empty.
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+TRACKING_ID="${TRACKING_ID:-sync-$(TZ="${TIMEZONE:-UTC}" date +%Y%m%d-%H%M%S)}"
 WT_PATH=$(bash "$HELPER" \
   --prefix fix-issues \
   --pipeline-id "fix-issues.${TRACKING_ID}" \

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+25b138"
+  version: "2026.05.21+7d824a"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -268,6 +268,19 @@ If `$ARGUMENTS` contains `status` (case-insensitive):
    "Read authority" section, duplicated here because `status` exits
    before Phase 1 preflight:
    ```bash
+   # Status-mode PLAN_FILE resolution — mirrors #603's $ARGUMENTS-token
+   # recipe (first `.md` token in $ARGUMENTS is the plan-file path).
+   # Status-mode exits before Phase 1 preflight, so PLAN_FILE must be
+   # resolved here rather than inheriting from Phase 1's later resolver.
+   if [ -z "${PLAN_FILE:-}" ]; then
+     for tok in $ARGUMENTS; do
+       case "$tok" in *.md) PLAN_FILE="$tok"; break ;; esac
+     done
+   fi
+   if [ -z "${PLAN_FILE:-}" ]; then
+     echo "ERROR: /run-plan status requires a plan-file path in \$ARGUMENTS" >&2
+     exit 2
+   fi
    PLAN_SLUG=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
    # Pre-worktree bootstrap: anchor on $CLAUDE_PROJECT_DIR (orchestrator's
    # project root, set by the harness) — WORKTREE_PATH is not yet in scope.

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.20+7d525c"
+  version: "2026.05.21+fd4fda"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -60,6 +60,25 @@ if [ ! -x "$HELPER" ]; then
   echo "draft-plan: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Resolve $OUTPUT_FILE and derive $TRACKING_ID before the worktree preamble
+# so the helper's --pipeline-id / positional slug are non-empty. Mirrors
+# the Arguments-section detection rule (#603 pattern): first $ARGUMENTS
+# token ending in `.md` is the output path; resolve bare names via
+# $ZSKILLS_PLANS_DIR. Phase 1's Tracking-fulfillment fence re-derives
+# $TRACKING_ID idempotently from the same $OUTPUT_FILE.
+if [ -z "${OUTPUT_FILE:-}" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  for tok in $ARGUMENTS; do
+    case "$tok" in
+      */*.md) OUTPUT_FILE="$tok"; break ;;
+      *.md)   OUTPUT_FILE="$ZSKILLS_PLANS_DIR/$tok"; break ;;
+    esac
+  done
+  # Fall back to a timestamped default so downstream slug computation
+  # produces a stable, non-empty value rather than fail-closing.
+  : "${OUTPUT_FILE:=$ZSKILLS_PLANS_DIR/$(date +%Y%m%d-%H%M%S)_PLAN.md}"
+fi
+TRACKING_ID=$(basename "$OUTPUT_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
 WT_PATH=$(bash "$HELPER" \
   --prefix draftplan \
   --pipeline-id "draft-plan.${TRACKING_ID}" \
@@ -498,6 +517,10 @@ create the review step marker:
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-draft-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+# $ROUND is the orchestrator-maintained loop counter (Phase 3 review/refine
+# iteration). Default to 1 if unset so the marker is informative even on the
+# first round before any explicit counter was exported.
+ROUND="${ROUND:-1}"
 printf 'round: %s\ncompleted: %s\n' "$ROUND" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.review"
 ```

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+f6f635"
+  version: "2026.05.21+b3cb70"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -316,6 +316,12 @@ if [ ! -x "$HELPER" ]; then
   echo "fix-issues: ensure-worktree.sh missing at $HELPER — run /update-zskills to repair" >&2
   exit 11
 fi
+# Sync mode TRACKING_ID — synthesized from timestamp since /fix-issues sync
+# doesn't take a plan-file arg. Mirrors sprint mode's SPRINT_ID shape (later
+# in this skill) with a `sync-` prefix so the namespace is unambiguous and
+# downstream pipeline IDs (`fix-issues.${TRACKING_ID}`) are non-empty.
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+TRACKING_ID="${TRACKING_ID:-sync-$(TZ="${TIMEZONE:-UTC}" date +%Y%m%d-%H%M%S)}"
 WT_PATH=$(bash "$HELPER" \
   --prefix fix-issues \
   --pipeline-id "fix-issues.${TRACKING_ID}" \

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+25b138"
+  version: "2026.05.21+7d824a"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -268,6 +268,19 @@ If `$ARGUMENTS` contains `status` (case-insensitive):
    "Read authority" section, duplicated here because `status` exits
    before Phase 1 preflight:
    ```bash
+   # Status-mode PLAN_FILE resolution — mirrors #603's $ARGUMENTS-token
+   # recipe (first `.md` token in $ARGUMENTS is the plan-file path).
+   # Status-mode exits before Phase 1 preflight, so PLAN_FILE must be
+   # resolved here rather than inheriting from Phase 1's later resolver.
+   if [ -z "${PLAN_FILE:-}" ]; then
+     for tok in $ARGUMENTS; do
+       case "$tok" in *.md) PLAN_FILE="$tok"; break ;; esac
+     done
+   fi
+   if [ -z "${PLAN_FILE:-}" ]; then
+     echo "ERROR: /run-plan status requires a plan-file path in \$ARGUMENTS" >&2
+     exit 2
+   fi
    PLAN_SLUG=$(basename "$PLAN_FILE" .md | tr '[:upper:]' '[:lower:]' | tr '_' '-')
    # Pre-worktree bootstrap: anchor on $CLAUDE_PROJECT_DIR (orchestrator's
    # project root, set by the harness) — WORKTREE_PATH is not yet in scope.

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -54,6 +54,130 @@ check "fix-issues pr.md assigns CHANGE_SUMMARY before heredoc read" \
 check "fix-issues pr.md mirror assigns CHANGE_SUMMARY before heredoc read" \
   'grep -qE "^[[:space:]]*CHANGE_SUMMARY=" .claude/skills/fix-issues/modes/pr.md'
 
+# Issue #606: variable-read-before-assignment family — close remaining
+# 4 siblings (post-#603 closure-verification sweep). Each entry below
+# names a (file, var) where the file's fenced bash blocks read $VAR but
+# previously had zero assignment sites — causing failed-closed
+# standalone invocations. Each pair is regression-pinned: an assignment
+# (bare `VAR=`, case-branch `) VAR=`, `${VAR:=...}`, `${VAR:-...}`,
+# `read VAR`, or `for VAR in`) must exist in the same file.
+#
+# Sibling of #601 above, but covers 4 vars across 3 source skills.
+# Source + mirror both checked so drift catches early.
+#
+# Helper: emit 0 iff $1 file has an assignment-like construct for $2 var.
+has_assign() {
+  local f="$1" v="$2"
+  grep -qE "(^|[^A-Za-z0-9_])${v}=" "$f" && return 0
+  grep -qE "(^|[[:space:]])read[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*${v}([[:space:]]|$)" "$f" && return 0
+  grep -qE "(^|[[:space:]])for[[:space:]]+${v}[[:space:]]+in[[:space:]]" "$f" && return 0
+  grep -qE "\\\$\{${v}:=" "$f" && return 0
+  grep -qE "\\\$\{${v}:-" "$f" && return 0
+  return 1
+}
+
+# (file, var) pairs covering #606's 4 siblings.
+ISSUE_606_PAIRS=(
+  "skills/draft-plan/SKILL.md|TRACKING_ID"
+  "skills/draft-plan/SKILL.md|OUTPUT_FILE"
+  "skills/draft-plan/SKILL.md|ROUND"
+  "skills/fix-issues/SKILL.md|TRACKING_ID"
+  "skills/run-plan/SKILL.md|PLAN_FILE"
+)
+for pair in "${ISSUE_606_PAIRS[@]}"; do
+  f="${pair%%|*}"; v="${pair##*|}"
+  if has_assign "$f" "$v"; then
+    check "issue #606: $f assigns \$$v before any read" 'true'
+  else
+    check "issue #606: $f assigns \$$v before any read" 'false'
+  fi
+  # Mirror under .claude/ must match (drift catch).
+  mf=".claude/$f"
+  if [ -f "$mf" ]; then
+    if has_assign "$mf" "$v"; then
+      check "issue #606: mirror $mf assigns \$$v before any read" 'true'
+    else
+      check "issue #606: mirror $mf assigns \$$v before any read" 'false'
+    fi
+  fi
+done
+
+# Structural family scan — broad sweep across skills/**/*.md and
+# block-diagram/**/*.md for the family-pattern variables (TRACKING_ID,
+# PLAN_FILE, OUTPUT_FILE, META_PLAN_PATH, GOAL, CHANGE_SUMMARY, SPRINT_ID,
+# ROUND). Each occurrence inside a ```bash...``` fence MUST be backed by
+# an assignment in the same file. This catches the next person editing
+# a skill body who copies the failed-closed read pattern without copying
+# the resolver.
+#
+# Allow-list: files where the family-pattern variable is known to be
+# inherited from a parent skill via ZSKILLS_PIPELINE_ID and is read in
+# a mode/reference file that DOCUMENTS but does not own the resolver.
+# Each entry SHOULD be replaced over time by an in-file resolver — the
+# allow-list is the "known acceptable tail" of the closure, NOT a
+# license to add more. Format: file<TAB>VAR. Add with a comment naming
+# the upstream owner.
+ISSUE_606_ALLOWLIST=(
+  # /refine-plan's $ROUND is the per-round orchestrator counter mirrored
+  # from /draft-plan; both files use the same shape. Same allow as
+  # /draft-plan's ROUND (which the targeted pair above now resolves via
+  # ${ROUND:-1} default). Filed: separate issue (post-#606 follow-up).
+  "skills/refine-plan/SKILL.md	ROUND"
+  # /research-and-plan's $GOAL is set by /research-and-go upstream; the
+  # in-file resolver was added by #603 for /research-and-go's own GOAL
+  # read but /research-and-plan reads it from env. Filed: separate
+  # issue (post-#606 follow-up).
+  "skills/research-and-plan/SKILL.md	GOAL"
+  # PR-mode reference files inherit $PLAN_FILE and $TRACKING_ID from the
+  # main SKILL.md's worktree preamble; these files are not entrypoints
+  # so they don't need their own resolver. Filed: separate issue
+  # (post-#606 follow-up) if the family-pattern test fails on them.
+  "skills/run-plan/references/failure-protocol.md	PLAN_FILE"
+  "skills/run-plan/modes/pr.md	PLAN_FILE"
+  "skills/run-plan/modes/pr.md	TRACKING_ID"
+  "skills/commit/modes/pr.md	TRACKING_ID"
+  "skills/fix-issues/modes/pr.md	SPRINT_ID"
+)
+FAMILY_VARS_RE='^(TRACKING_ID|PLAN_FILE|OUTPUT_FILE|META_PLAN_PATH|GOAL|CHANGE_SUMMARY|SPRINT_ID|ROUND)$'
+FAMILY_FAIL=""
+while IFS= read -r f; do
+  # Inline awk: emit one var-name per bash-fence read of $VAR / ${VAR}.
+  fence_vars=$(awk '
+    /^```bash/ { in_b=1; next }
+    /^```[^`]*$/ { in_b=0; next }
+    !in_b { next }
+    {
+      s=$0
+      while (match(s, /\$\{[A-Za-z_][A-Za-z0-9_]*|\$[A-Za-z_][A-Za-z0-9_]*/)) {
+        tok=substr(s, RSTART, RLENGTH)
+        s=substr(s, RSTART+RLENGTH)
+        sub(/^\$\{?/, "", tok)
+        print tok
+      }
+    }
+  ' "$f" | sort -u)
+  while IFS= read -r v; do
+    [ -z "$v" ] && continue
+    printf '%s\n' "$v" | grep -qE "$FAMILY_VARS_RE" || continue
+    has_assign "$f" "$v" && continue
+    # Check allow-list.
+    allowed=0
+    for entry in "${ISSUE_606_ALLOWLIST[@]}"; do
+      if [ "$entry" = "$(printf '%s\t%s' "$f" "$v")" ]; then
+        allowed=1; break
+      fi
+    done
+    [ "$allowed" -eq 1 ] && continue
+    FAMILY_FAIL+="$(printf '%s\t%s\n' "$f" "$v")"$'\n'
+  done <<< "$fence_vars"
+done < <(find skills block-diagram -name '*.md' -type f 2>/dev/null)
+if [ -z "$FAMILY_FAIL" ]; then
+  check 'issue #606: family-pattern vars (TRACKING_ID/PLAN_FILE/OUTPUT_FILE/META_PLAN_PATH/GOAL/CHANGE_SUMMARY/SPRINT_ID/ROUND) all have same-file assignments' 'true'
+else
+  printf '%s\n' "$FAMILY_FAIL" >&2
+  check 'issue #606: family-pattern vars (TRACKING_ID/PLAN_FILE/OUTPUT_FILE/META_PLAN_PATH/GOAL/CHANGE_SUMMARY/SPRINT_ID/ROUND) all have same-file assignments' 'false'
+fi
+
 # Phase C: tool-list-aware dispatch (4 skills)
 for f in skills/run-plan/SKILL.md skills/fix-issues/SKILL.md \
          skills/verify-changes/SKILL.md \


### PR DESCRIPTION
Fixes #606

## Changes
- fix(skills): close variable-read-before-assignment family + add conformance pin (#606)

Closes the 4 remaining siblings of PR #603's family:
- `skills/draft-plan/SKILL.md`: resolve `$OUTPUT_FILE` from `$ARGUMENTS` (first `.md` token, #603 pattern), derive `$TRACKING_ID` from basename slug; default `$ROUND` to 1 at the review-tracking fence
- `skills/fix-issues/SKILL.md` (sync mode): synthesize `TRACKING_ID="sync-$(TZ=… date +%Y%m%d-%H%M%S)"` above the worktree gate (mirrors sprint-mode's SPRINT_ID shape)
- `skills/run-plan/SKILL.md` (status mode): resolve `$PLAN_FILE` from `$ARGUMENTS` inside the status-mode fence (status exits before Phase 1's resolver)
- `tests/test-skill-invariants.sh`: new structural conformance pin — targeted (file, var) pairs for the 5 cited fixes + family scan across `skills/**/*.md` + `block-diagram/**/*.md` for the 8 family pattern names

## Test plan
- [x] Full suite passed (`bash tests/run-all.sh` — 5369/5369)
- [x] Negative test on conformance pin: reverting `ROUND` resolver fires `FAIL: issue #606: skills/draft-plan/SKILL.md assigns $ROUND before any read` (verifier-confirmed)
- [x] All 3 mirrors byte-equal (`diff` empty)
- [x] 3 `metadata.version` bumped (draft-plan, fix-issues, run-plan)
- [x] Allow-list documents 7 follow-up read-before-assign in mode/reference files (separate work item — legitimate parent-inheritance, verified)
- [ ] CI re-runs the suite on the rebased branch
