### PR TITLE
fix(review-feedback): add 'independently re-rate severity' rule

### DIFF
--- a/.claude/skills/review-feedback/SKILL.md
+++ b/.claude/skills/review-feedback/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   user says "review feedback", "triage feedback", or "file feedback
   issues".
 metadata:
-  version: "2026.05.15+903532"
+  version: "2026.05.21+b962c3"
 ---
 
 # /review-feedback — Review and triage user feedback
@@ -33,6 +33,7 @@ will specify the path). This file is exported from the app via
 
 2. **For each pending entry**, evaluate:
    - Is it a real, actionable bug or feature request?
+   - **Independently re-rate severity.** The reporter's self-rated severity is a hint, not authoritative. Re-evaluate against impact (data loss > crash > broken feature > polish > nit) and frequency before filling the table.
    - Is it a duplicate of an existing GitHub issue? Check with:
      ```bash
      gh issue list --search "keyword" --state open
@@ -40,8 +41,8 @@ will specify the path). This file is exported from the app via
    - What label(s) should it get? (`bug`, `enhancement`, `ui`, `question`)
 
 3. **Present a summary table** to the user showing your recommendations:
-   | # | Title | Type | Severity | Recommendation | Reason |
-   |---|-------|------|----------|----------------|--------|
+   | # | Title | Type | Re-rated Severity | Recommendation | Reason |
+   |---|-------|------|-------------------|----------------|--------|
    | 1 | ... | bug | high | File | Clear repro |
    | 2 | ... | feature | low | Dismiss | Too vague |
 

--- a/skills/review-feedback/SKILL.md
+++ b/skills/review-feedback/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   user says "review feedback", "triage feedback", or "file feedback
   issues".
 metadata:
-  version: "2026.05.15+903532"
+  version: "2026.05.21+b962c3"
 ---
 
 # /review-feedback — Review and triage user feedback
@@ -33,6 +33,7 @@ will specify the path). This file is exported from the app via
 
 2. **For each pending entry**, evaluate:
    - Is it a real, actionable bug or feature request?
+   - **Independently re-rate severity.** The reporter's self-rated severity is a hint, not authoritative. Re-evaluate against impact (data loss > crash > broken feature > polish > nit) and frequency before filling the table.
    - Is it a duplicate of an existing GitHub issue? Check with:
      ```bash
      gh issue list --search "keyword" --state open
@@ -40,8 +41,8 @@ will specify the path). This file is exported from the app via
    - What label(s) should it get? (`bug`, `enhancement`, `ui`, `question`)
 
 3. **Present a summary table** to the user showing your recommendations:
-   | # | Title | Type | Severity | Recommendation | Reason |
-   |---|-------|------|----------|----------------|--------|
+   | # | Title | Type | Re-rated Severity | Recommendation | Reason |
+   |---|-------|------|-------------------|----------------|--------|
    | 1 | ... | bug | high | File | Clear repro |
    | 2 | ... | feature | low | Dismiss | Too vague |
 

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -449,6 +449,15 @@ else
   check 'meta: framework-wide checks cover block-diagram/' 'false'
 fi
 
+# Issue #583: /review-feedback Step 2 must independently re-rate severity
+# (sibling triage-discipline rule to QE_ISSUES.md #404/#444). Pass-through
+# of reporter's self-rated severity propagates miscategorization through
+# every downstream /fix-issues sprint.
+check "review-feedback re-rate severity rule (source)" \
+  'grep -q "Independently re-rate severity" skills/review-feedback/SKILL.md'
+check "review-feedback re-rate severity rule (mirror)" \
+  'grep -q "Independently re-rate severity" .claude/skills/review-feedback/SKILL.md'
+
 # Emit format expected by tests/run-all.sh
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes #583

## Changes
- fix(review-feedback): add 'independently re-rate severity' rule + conformance pin (#583)

`skills/review-feedback/SKILL.md` Step 2 now requires independent severity re-rating instead of passing through the reporter's self-rated value. Step 3's summary-table column renamed from "Severity" to "Re-rated Severity" to make the discipline visible.

## Test plan
- [x] Full suite passed (`bash tests/run-all.sh` — 5360/5360)
- [x] Step 2 prose addition: "Independently re-rate severity. The reporter's self-rated severity is a hint, not authoritative. Re-evaluate against impact (data loss > crash > broken feature > polish > nit) and frequency before filling the table."
- [x] Step 3 column header: `| # | Title | Type | Re-rated Severity | Recommendation | Reason |`
- [x] Conformance pin: 2 grep checks (source + mirror) asserting the literal "Independently re-rate severity" is present
- [x] Mirror byte-equal; `metadata.version` bumped
- [ ] CI re-runs the suite on the rebased branch
