### PR TITLE
fix(land-pr-callers): cover 3 missing STATUS values + conformance pin

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   only).
 argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.21+83be3b"
+  version: "2026.05.21+a44753"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow

--- a/.claude/skills/commit/modes/pr.md
+++ b/.claude/skills/commit/modes/pr.md
@@ -193,7 +193,28 @@ while :; do
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       LAND_OUTCOME=$STATUS
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget. pr-ready surface, but the
+      # discriminator is preserved in $LAND_OUTCOME for the explicit-
+      # finalize block + tracking marker (failure-class — `*)` arm below
+      # in the finalize maps to FINAL=failed).
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via the CI-status
+      # check below (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.21+163578"
+  version: "2026.05.21+d3f84c"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -304,7 +304,26 @@ while :; do
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       LAND_OUTCOME=$STATUS
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+      # surface but the discriminator is preserved in $LAND_OUTCOME.
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via CI-status
+      # (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+b3cb70"
+  version: "2026.05.21+7dac3a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/pr.md
+++ b/.claude/skills/fix-issues/modes/pr.md
@@ -193,7 +193,26 @@ BODY
         echo "ERROR: /land-pr STATUS=$STATUS for issue #$ISSUE_NUM REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
         LAND_OUTCOME=$STATUS
         break ;;
+      behind-thrash)
+        # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+        # surface but discriminator preserved in $LAND_OUTCOME.
+        echo "/land-pr STATUS=behind-thrash for issue #$ISSUE_NUM — auto-rebase budget exhausted, manual rebase needed" >&2
+        LAND_OUTCOME=$STATUS
+        break ;;
+      auto-rebase-conflict|auto-rebase-blocked)
+        # Step 6b auto-rebase merge-conflicted, or mergeStateStatus
+        # settled at BLOCKED for non-CI reasons. Issue #624 — must NOT
+        # be silently coerced to pr-ready by the CI-status check below.
+        echo "/land-pr STATUS=$STATUS for issue #$ISSUE_NUM REASON=${LP[REASON]:-} — manual intervention needed" >&2
+        LAND_OUTCOME=$STATUS
+        break ;;
       created|monitored|merged) ;;  # fall through to CI-status check
+      *)
+        # Unknown STATUS — fail loud rather than coerce via CI-status
+        # (issue #624 — closes the silent fall-through gap).
+        echo "WARN: unrecognized /land-pr STATUS=$STATUS for issue #$ISSUE_NUM — settling at unknown-status" >&2
+        LAND_OUTCOME="unknown-status-$STATUS"
+        break ;;
     esac
 
     case "$CI_STATUS" in

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.21+d6ead1"
+  version: "2026.05.21+d0346f"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/.claude/skills/land-pr/references/caller-loop-pattern.md
+++ b/.claude/skills/land-pr/references/caller-loop-pattern.md
@@ -124,7 +124,29 @@ while :; do
     push-failed|create-failed|monitor-failed|merge-failed|rebase-failed)
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       break ;;
+    behind-thrash)
+      # Step 6b iterated to the auto-rebase budget without converging
+      # (/land-pr SKILL.md status-table row 2b — pr-ready surface but the
+      # discriminator is preserved for the caller's report/tracking).
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase hit a merge conflict, or mergeStateStatus
+      # settled at BLOCKED for non-CI reasons. /land-pr SKILL.md
+      # status-table rows 1b/2c — failure-class outcomes that must NOT
+      # be silently coerced into pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — /land-pr emitted a value the caller's vocabulary
+      # does not enumerate. Surface loudly so future drift fails LOUD
+      # rather than coercing through the CI-status check below.
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.21+9b99f1"
+  version: "2026.05.21+7ce006"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -1164,7 +1164,26 @@ while :; do
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       LAND_OUTCOME=$STATUS
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+      # surface but discriminator preserved in $LAND_OUTCOME.
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via CI-status
+      # (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+7d824a"
+  version: "2026.05.21+4fff20"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -487,7 +487,24 @@ while :; do
     push-failed|create-failed|monitor-failed|merge-failed|rebase-failed)
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+      # surface; surface to the user via stderr so cron-fired runs leave
+      # an inspectable trace.
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via CI-status
+      # (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   only).
 argument-hint: "[pr] [scope] [push|land] [auto]"
 metadata:
-  version: "2026.05.21+83be3b"
+  version: "2026.05.21+a44753"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow

--- a/skills/commit/modes/pr.md
+++ b/skills/commit/modes/pr.md
@@ -193,7 +193,28 @@ while :; do
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       LAND_OUTCOME=$STATUS
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget. pr-ready surface, but the
+      # discriminator is preserved in $LAND_OUTCOME for the explicit-
+      # finalize block + tracking marker (failure-class — `*)` arm below
+      # in the finalize maps to FINAL=failed).
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via the CI-status
+      # check below (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.21+163578"
+  version: "2026.05.21+d3f84c"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -304,7 +304,26 @@ while :; do
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       LAND_OUTCOME=$STATUS
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+      # surface but the discriminator is preserved in $LAND_OUTCOME.
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via CI-status
+      # (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.21+b3cb70"
+  version: "2026.05.21+7dac3a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/pr.md
+++ b/skills/fix-issues/modes/pr.md
@@ -193,7 +193,26 @@ BODY
         echo "ERROR: /land-pr STATUS=$STATUS for issue #$ISSUE_NUM REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
         LAND_OUTCOME=$STATUS
         break ;;
+      behind-thrash)
+        # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+        # surface but discriminator preserved in $LAND_OUTCOME.
+        echo "/land-pr STATUS=behind-thrash for issue #$ISSUE_NUM — auto-rebase budget exhausted, manual rebase needed" >&2
+        LAND_OUTCOME=$STATUS
+        break ;;
+      auto-rebase-conflict|auto-rebase-blocked)
+        # Step 6b auto-rebase merge-conflicted, or mergeStateStatus
+        # settled at BLOCKED for non-CI reasons. Issue #624 — must NOT
+        # be silently coerced to pr-ready by the CI-status check below.
+        echo "/land-pr STATUS=$STATUS for issue #$ISSUE_NUM REASON=${LP[REASON]:-} — manual intervention needed" >&2
+        LAND_OUTCOME=$STATUS
+        break ;;
       created|monitored|merged) ;;  # fall through to CI-status check
+      *)
+        # Unknown STATUS — fail loud rather than coerce via CI-status
+        # (issue #624 — closes the silent fall-through gap).
+        echo "WARN: unrecognized /land-pr STATUS=$STATUS for issue #$ISSUE_NUM — settling at unknown-status" >&2
+        LAND_OUTCOME="unknown-status-$STATUS"
+        break ;;
     esac
 
     case "$CI_STATUS" in

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.21+d6ead1"
+  version: "2026.05.21+d0346f"
 ---
 
 # /land-pr — land a feature branch as a PR

--- a/skills/land-pr/references/caller-loop-pattern.md
+++ b/skills/land-pr/references/caller-loop-pattern.md
@@ -124,7 +124,29 @@ while :; do
     push-failed|create-failed|monitor-failed|merge-failed|rebase-failed)
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       break ;;
+    behind-thrash)
+      # Step 6b iterated to the auto-rebase budget without converging
+      # (/land-pr SKILL.md status-table row 2b — pr-ready surface but the
+      # discriminator is preserved for the caller's report/tracking).
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase hit a merge conflict, or mergeStateStatus
+      # settled at BLOCKED for non-CI reasons. /land-pr SKILL.md
+      # status-table rows 1b/2c — failure-class outcomes that must NOT
+      # be silently coerced into pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — /land-pr emitted a value the caller's vocabulary
+      # does not enumerate. Surface loudly so future drift fails LOUD
+      # rather than coercing through the CI-status check below.
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.21+9b99f1"
+  version: "2026.05.21+7ce006"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -1164,7 +1164,26 @@ while :; do
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       LAND_OUTCOME=$STATUS
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+      # surface but discriminator preserved in $LAND_OUTCOME.
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      LAND_OUTCOME=$STATUS
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via CI-status
+      # (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      LAND_OUTCOME="unknown-status-$STATUS"
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.21+7d824a"
+  version: "2026.05.21+4fff20"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -487,7 +487,24 @@ while :; do
     push-failed|create-failed|monitor-failed|merge-failed|rebase-failed)
       echo "ERROR: /land-pr STATUS=$STATUS REASON=${LP[REASON]:-} (see ${LP[CALL_ERROR_FILE]:-no-error-file})" >&2
       break ;;
+    behind-thrash)
+      # Step 6b exhausted auto-rebase budget (issue #624). pr-ready
+      # surface; surface to the user via stderr so cron-fired runs leave
+      # an inspectable trace.
+      echo "/land-pr STATUS=behind-thrash — auto-rebase budget exhausted, manual rebase needed" >&2
+      break ;;
+    auto-rebase-conflict|auto-rebase-blocked)
+      # Step 6b auto-rebase merge-conflicted, or mergeStateStatus settled
+      # at BLOCKED for non-CI reasons. Issue #624 — must NOT be silently
+      # coerced to pr-ready by the CI-status check below.
+      echo "/land-pr STATUS=$STATUS REASON=${LP[REASON]:-} — manual intervention needed" >&2
+      break ;;
     created|monitored|merged) ;;  # fall through to CI-status check
+    *)
+      # Unknown STATUS — fail loud rather than coerce via CI-status
+      # (issue #624 — closes the silent fall-through gap).
+      echo "WARN: unrecognized /land-pr STATUS=$STATUS — settling at unknown-status" >&2
+      break ;;
   esac
 
   case "$CI_STATUS" in

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1334,6 +1334,46 @@ check_fixed land-pr 'never source: parser rationale'  'allow-list parser, not `s
 check_not land-pr "no source-based result parsing in caller pattern" \
   'source[[:space:]]+.*RESULT_FILE|^\.[[:space:]]+.*RESULT_FILE'
 
+# --- Caller STATUS case-arm coverage (Issue #624) ---
+# /land-pr documents 12 STATUS values in its return envelope
+# (skills/land-pr/SKILL.md:158). The 5 caller skills + the canonical
+# reference pattern must enumerate every documented value as an explicit
+# case-arm — silent fall-through (e.g. `auto-rebase-blocked` reaching the
+# CI-status check below and being coerced to `pr-ready`) is a real-life
+# hazard (see issue body's "auto-rebase-blocked path is hit in real life"
+# section). Pin shape mirrors #602's case-arm-per-status closure but on
+# /land-pr's STATUS vocabulary instead of `.landed`. The `*)` default arm
+# is also required so unknown future STATUS values fail LOUD.
+_LP_STATUS_VALUES="created monitored merged push-failed rebase-conflict create-failed monitor-failed merge-failed rebase-failed behind-thrash auto-rebase-conflict auto-rebase-blocked"
+# Per-caller assertion: each STATUS appears at line-leading (after
+# whitespace) OR after `|` followed by `)` or `|`. This anchors on the
+# case-arm syntax so a mere mention in a comment does NOT satisfy.
+# Each entry is "skill_name relpath".
+for _LP_PAIR in \
+    "commit modes/pr.md" \
+    "do modes/pr.md" \
+    "fix-issues modes/pr.md" \
+    "quickfix SKILL.md" \
+    "run-plan modes/pr.md" \
+    "land-pr references/caller-loop-pattern.md"; do
+  _LP_SKILL="${_LP_PAIR%% *}"
+  _LP_REL="${_LP_PAIR#* }"
+  for _LP_STATUS in $_LP_STATUS_VALUES; do
+    # Match the STATUS as a case-arm token: preceded by line-start
+    # whitespace OR `|`, followed by `)` or `|`. The `[[:space:]]*\|` form
+    # also covers the alternation form `STATUS_A|STATUS_B)`.
+    check_in_file "$_LP_SKILL" "$_LP_REL" \
+      "STATUS case-arm: $_LP_STATUS (Issue #624)" \
+      "(^[[:space:]]+|\\|)${_LP_STATUS}(\\)|\\|)"
+  done
+  # The `*)` default arm is mandatory — surfaces unknown future STATUS
+  # values via `LAND_OUTCOME="unknown-status-..."` + stderr WARN (or
+  # bare stderr WARN in /run-plan which doesn't carry LAND_OUTCOME).
+  check_in_file "$_LP_SKILL" "$_LP_REL" \
+    "STATUS case-arm: default arm \`*)\` (Issue #624)" \
+    'unrecognized /land-pr STATUS'
+done
+
 # --- Step 7b post-merge fast-forward (Issue #254) ---
 # Guard the literal sentinel so a future refactor can't silently drop the
 # step that fast-forwards local main after a successful squash-merge.


### PR DESCRIPTION
Fixes #624

## Changes
- fix(land-pr-callers): cover 3 missing STATUS values + structural conformance pin (#624)

All 5 `/land-pr` callers (commit, do, fix-issues, quickfix, run-plan) plus the canonical reference (`references/caller-loop-pattern.md`) now name all 12 STATUS arms + an `*)` default that surfaces unknown values loudly. Closes the silent fall-through where `behind-thrash`, `auto-rebase-conflict`, `auto-rebase-blocked` were coerced to `pr-ready` (and for `/commit pr` then mis-marked as `fulfilled.commit.<id> status: complete`).

## Test plan
- [x] Full suite passed (`bash tests/run-all.sh` — 5449/5449)
- [x] New conformance pin: 78 assertions (12 STATUS × 6 files + 1 default-arm × 6) in `tests/test-skill-conformance.sh`
- [x] All 6 source/mirror diffs byte-equal
- [x] 6 `metadata.version` bumps (commit, do, fix-issues, quickfix, run-plan, land-pr)
- [ ] CI re-runs the suite on the rebased branch
