### PR TITLE
fix(skills): close 2 remaining variable-read-before-assignment siblings

### DIFF
--- a/.claude/skills/draft-tests/SKILL.md
+++ b/.claude/skills/draft-tests/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.05.21+6fc43c"
+  version: "2026.05.22+73cefd"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
@@ -1119,6 +1119,14 @@ invocation mode).
 Invocation:
 
 ```bash
+# Issue #629: this fence is a per-iteration recipe meant to run inside
+# the orchestrator's round loop where $ROUND_N is the counter and
+# $PREV_INPUT is the previous round's refiner input. Default-resolve
+# both so a standalone read of this fence (or first-round invocation
+# before $PREV_INPUT exists) doesn't fail-closed. Mirrors
+# /draft-plan's `ROUND="${ROUND:-1}"` pattern at SKILL.md L523.
+ROUND_N="${ROUND_N:-1}"
+PREV_INPUT="${PREV_INPUT:-}"
 PRECHECK="$CLAUDE_PROJECT_DIR/.claude/skills/draft-tests/scripts/coverage-floor-precheck.sh"
 bash "$PRECHECK" \
   "$PLAN_FILE" "$PARSED_STATE" "$PREV_INPUT" \

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.21+7ce006"
+  version: "2026.05.22+ec24bd"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -1112,7 +1112,12 @@ while :; do
     # explicit-finalize block). $MARKER survives from WI 1.8 in the
     # persistent shell.
     [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-    rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
+    # Issue #629: standalone /quickfix doesn't set ZSKILLS_PIPELINE_ID;
+    # only callers like /fix-issues do. Guard the rm so the cleanup
+    # silently no-ops on standalone (no parent pipeline marker to remove)
+    # and runs correctly when called by a parent pipeline. Mirrors the
+    # `[ -n "${ZSKILLS_PIPELINE_ID:-}" ]` guard at line 1310 below.
+    [ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
     exit 5
   fi
 

--- a/skills/draft-tests/SKILL.md
+++ b/skills/draft-tests/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.05.21+6fc43c"
+  version: "2026.05.22+73cefd"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
@@ -1119,6 +1119,14 @@ invocation mode).
 Invocation:
 
 ```bash
+# Issue #629: this fence is a per-iteration recipe meant to run inside
+# the orchestrator's round loop where $ROUND_N is the counter and
+# $PREV_INPUT is the previous round's refiner input. Default-resolve
+# both so a standalone read of this fence (or first-round invocation
+# before $PREV_INPUT exists) doesn't fail-closed. Mirrors
+# /draft-plan's `ROUND="${ROUND:-1}"` pattern at SKILL.md L523.
+ROUND_N="${ROUND_N:-1}"
+PREV_INPUT="${PREV_INPUT:-}"
 PRECHECK="$CLAUDE_PROJECT_DIR/.claude/skills/draft-tests/scripts/coverage-floor-precheck.sh"
 bash "$PRECHECK" \
   "$PLAN_FILE" "$PARSED_STATE" "$PREV_INPUT" \

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.21+7ce006"
+  version: "2026.05.22+ec24bd"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -1112,7 +1112,12 @@ while :; do
     # explicit-finalize block). $MARKER survives from WI 1.8 in the
     # persistent shell.
     [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-    rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
+    # Issue #629: standalone /quickfix doesn't set ZSKILLS_PIPELINE_ID;
+    # only callers like /fix-issues do. Guard the rm so the cleanup
+    # silently no-ops on standalone (no parent pipeline marker to remove)
+    # and runs correctly when called by a parent pipeline. Mirrors the
+    # `[ -n "${ZSKILLS_PIPELINE_ID:-}" ]` guard at line 1310 below.
+    [ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
     exit 5
   fi
 

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -76,13 +76,22 @@ has_assign() {
   return 1
 }
 
-# (file, var) pairs covering #606's 4 siblings.
+# (file, var) pairs covering #606's 4 siblings, plus #629's 2 additional
+# siblings (/quickfix $ZSKILLS_PIPELINE_ID, /draft-tests $ROUND_N and
+# $PREV_INPUT) that were added via comments on #606 but missed by PR #626.
+# Issue #629 chose targeted pairs over extending FAMILY_VARS_RE so that
+# legitimate env-inherited reads of these var names in OTHER skills
+# (e.g., a skill called by /fix-issues that reads ZSKILLS_PIPELINE_ID
+# from the env) aren't surfaced as defects.
 ISSUE_606_PAIRS=(
   "skills/draft-plan/SKILL.md|TRACKING_ID"
   "skills/draft-plan/SKILL.md|OUTPUT_FILE"
   "skills/draft-plan/SKILL.md|ROUND"
   "skills/fix-issues/SKILL.md|TRACKING_ID"
   "skills/run-plan/SKILL.md|PLAN_FILE"
+  "skills/quickfix/SKILL.md|ZSKILLS_PIPELINE_ID"
+  "skills/draft-tests/SKILL.md|ROUND_N"
+  "skills/draft-tests/SKILL.md|PREV_INPUT"
 )
 for pair in "${ISSUE_606_PAIRS[@]}"; do
   f="${pair%%|*}"; v="${pair##*|}"


### PR DESCRIPTION
Fixes #629

## Changes
- fix(skills): close 2 remaining variable-read-before-assignment siblings (#629)

PR #626 (#606 closure) addressed 4 listed siblings but missed 2 added via comments:

- `/quickfix` L1115 — `$ZSKILLS_PIPELINE_ID` read in cleanup path; standalone invocation hit empty-substitution. Fix: guarded rm `[ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f ...` (mirror of the existing guard at L1310 in the same file).
- `/draft-tests` L1124 — `$ROUND_N` and `$PREV_INPUT` read in PRECHECK fence. Fix: `${ROUND_N:-1}` and `${PREV_INPUT:-}` defaults at fence top (mirror of `/draft-plan`'s `ROUND="${ROUND:-1}"` pattern at L523).

Conformance pin: targeted `ISSUE_606_PAIRS` extension with 3 (file, var) pairs × source + mirror (option (b) over `FAMILY_VARS_RE` extension — avoids surfacing legitimate env-inherited reads in other skills).

## Test plan
- [x] Full suite passed (`bash tests/run-all.sh` — 5455/5455)
- [x] 2 `metadata.version` bumped (quickfix, draft-tests)
- [x] 2 mirror diffs byte-equal
- [ ] CI re-runs the suite on the rebased branch
