### PR TITLE
fix(zskills-dashboard): map all 11 .landed statuses in landedPillClass

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+3a34ab"
+  version: "2026.05.22+e174c4"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -364,9 +364,12 @@ code, pre, .mono {
 .pill-mode-direct  { color: var(--green); border-color: var(--green); }
 .pill-mode-unknown { color: var(--orange); border-color: var(--orange); background: rgba(210, 153, 34, 0.08); }
 
-.pill-landed-full     { color: var(--green); border-color: var(--green); }
-.pill-landed-partial  { color: var(--orange); border-color: var(--orange); }
-.pill-landed-not      { color: var(--text-dim); border-color: var(--border); }
+.pill-landed-full                { color: var(--green); border-color: var(--green); }
+.pill-landed-partial             { color: var(--orange); border-color: var(--orange); }
+.pill-landed-pr-ready            { color: var(--accent); border-color: var(--accent); }
+.pill-landed-pr-needs-attention  { color: var(--orange); border-color: var(--orange); }
+.pill-landed-failed              { color: var(--red); border-color: var(--red); }
+.pill-landed-not                 { color: var(--text-dim); border-color: var(--border); }
 
 .label-chip {
   display: inline-block;

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1082,9 +1082,23 @@ function renderIssues(issues, queues) {
 // ------------------------------------------------------------- worktrees
 
 function landedPillClass(status) {
+  // Canonical `.landed` status vocabulary (tests/test-landed-status-vocabulary.sh):
+  //   full, landed                                            -> green  (landed-full)
+  //   partial                                                 -> orange (landed-partial)
+  //   pr-ready                                                -> blue   (landed-pr-ready)
+  //   pr-ci-failing, pr-failed, conflict, pr-state-unknown    -> orange (landed-pr-needs-attention)
+  //   failed, direct-push-failed, direct-verify-failed        -> red    (landed-failed)
+  // Issue #618 (mirror of #602 prose-side / #621 briefing.py).
   const s = (status || "").toLowerCase();
-  if (s === "full") return "pill-landed-full";
+  if (s === "full" || s === "landed") return "pill-landed-full";
   if (s === "partial") return "pill-landed-partial";
+  if (s === "pr-ready") return "pill-landed-pr-ready";
+  if (s === "pr-ci-failing" || s === "pr-failed" || s === "conflict" || s === "pr-state-unknown") {
+    return "pill-landed-pr-needs-attention";
+  }
+  if (s === "failed" || s === "direct-push-failed" || s === "direct-verify-failed") {
+    return "pill-landed-failed";
+  }
   return "pill-landed-not";
 }
 

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.21+3a34ab"
+  version: "2026.05.22+e174c4"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -364,9 +364,12 @@ code, pre, .mono {
 .pill-mode-direct  { color: var(--green); border-color: var(--green); }
 .pill-mode-unknown { color: var(--orange); border-color: var(--orange); background: rgba(210, 153, 34, 0.08); }
 
-.pill-landed-full     { color: var(--green); border-color: var(--green); }
-.pill-landed-partial  { color: var(--orange); border-color: var(--orange); }
-.pill-landed-not      { color: var(--text-dim); border-color: var(--border); }
+.pill-landed-full                { color: var(--green); border-color: var(--green); }
+.pill-landed-partial             { color: var(--orange); border-color: var(--orange); }
+.pill-landed-pr-ready            { color: var(--accent); border-color: var(--accent); }
+.pill-landed-pr-needs-attention  { color: var(--orange); border-color: var(--orange); }
+.pill-landed-failed              { color: var(--red); border-color: var(--red); }
+.pill-landed-not                 { color: var(--text-dim); border-color: var(--border); }
 
 .label-chip {
   display: inline-block;

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1082,9 +1082,23 @@ function renderIssues(issues, queues) {
 // ------------------------------------------------------------- worktrees
 
 function landedPillClass(status) {
+  // Canonical `.landed` status vocabulary (tests/test-landed-status-vocabulary.sh):
+  //   full, landed                                            -> green  (landed-full)
+  //   partial                                                 -> orange (landed-partial)
+  //   pr-ready                                                -> blue   (landed-pr-ready)
+  //   pr-ci-failing, pr-failed, conflict, pr-state-unknown    -> orange (landed-pr-needs-attention)
+  //   failed, direct-push-failed, direct-verify-failed        -> red    (landed-failed)
+  // Issue #618 (mirror of #602 prose-side / #621 briefing.py).
   const s = (status || "").toLowerCase();
-  if (s === "full") return "pill-landed-full";
+  if (s === "full" || s === "landed") return "pill-landed-full";
   if (s === "partial") return "pill-landed-partial";
+  if (s === "pr-ready") return "pill-landed-pr-ready";
+  if (s === "pr-ci-failing" || s === "pr-failed" || s === "conflict" || s === "pr-state-unknown") {
+    return "pill-landed-pr-needs-attention";
+  }
+  if (s === "failed" || s === "direct-push-failed" || s === "direct-verify-failed") {
+    return "pill-landed-failed";
+  }
   return "pill-landed-not";
 }
 

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -484,6 +484,21 @@ for _briefing_status in landed-full landed-pr-ready landed-pr-needs-attention \
     "grep -qF \"'$_briefing_status'\" .claude/skills/briefing/scripts/briefing.py"
 done
 
+# Issue #618: zskills-dashboard app.js landedPillClass() must enumerate every
+# canonical .landed status value. PR #532's analog on briefing.py (#621) and
+# fix-report/SKILL.md (#602) closed the prose/Python reader-side; this closes
+# the JS reader-side. Canonical 11-value vocabulary is locked by
+# tests/test-landed-status-vocabulary.sh; this pin asserts each value appears
+# as a quoted literal in landedPillClass.
+for _landed_status in full landed partial pr-ready pr-ci-failing pr-failed \
+                      conflict pr-state-unknown failed direct-push-failed \
+                      direct-verify-failed; do
+  check "app.js landedPillClass references canonical status '$_landed_status' (source)" \
+    "grep -qF '\"$_landed_status\"' skills/zskills-dashboard/scripts/zskills_monitor/static/app.js"
+  check "app.js landedPillClass references canonical status '$_landed_status' (mirror)" \
+    "grep -qF '\"$_landed_status\"' .claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js"
+done
+
 # Emit format expected by tests/run-all.sh
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes #618

## Changes
- fix(zskills-dashboard): map all 11 canonical .landed statuses in landedPillClass (#618)

Extends `landedPillClass(status)` from 2 of 9 mapped statuses (full + partial, with everything else falling through to grey "not-landed") to all 11 canonical statuses:
- `full|landed` → green (`pill-landed-full`)
- `partial` → orange (`pill-landed-partial`)
- `pr-ready` → blue (`pill-landed-pr-ready` — new)
- `pr-ci-failing|pr-failed|conflict|pr-state-unknown` → orange (`pill-landed-pr-needs-attention` — new)
- `failed|direct-push-failed|direct-verify-failed` → red (`pill-landed-failed` — new)
- `*` → grey (`pill-landed-not`)

Mirror of #602 (closed BASH surface) and #621 (just closed PY renderers). Same vocab-drift family.

## Test plan
- [x] Full suite: 5496/5497 pass; 1 fail is the pre-existing `test-create-worktree.sh` case 10 isolation flake (passes standalone, 26/26).
- [x] New conformance pin: 22 checks (11 statuses × source + mirror) in `tests/test-skill-invariants.sh`.
- [x] 2 mirror diffs byte-equal (app.js, app.css, SKILL.md).
- [x] `metadata.version` bumped (`2026.05.21+3a34ab` → `2026.05.22+e174c4`).
- [ ] CI re-runs the suite on rebased branch.
