### PR TITLE
fix(review-feedback): relocate from skills/ to block-diagram/ tree

### DIFF
--- a/.claude/skills/review-feedback/SKILL.md
+++ b/.claude/skills/review-feedback/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   user says "review feedback", "triage feedback", or "file feedback
   issues".
 metadata:
-  version: "2026.05.21+b962c3"
+  version: "2026.05.22+b962c3"
 ---
 
 # /review-feedback — Review and triage user feedback

--- a/block-diagram/review-feedback/SKILL.md
+++ b/block-diagram/review-feedback/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   user says "review feedback", "triage feedback", or "file feedback
   issues".
 metadata:
-  version: "2026.05.21+b962c3"
+  version: "2026.05.22+b962c3"
 ---
 
 # /review-feedback — Review and triage user feedback

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -463,7 +463,7 @@ fi
 # of reporter's self-rated severity propagates miscategorization through
 # every downstream /fix-issues sprint.
 check "review-feedback re-rate severity rule (source)" \
-  'grep -q "Independently re-rate severity" skills/review-feedback/SKILL.md'
+  'grep -q "Independently re-rate severity" block-diagram/review-feedback/SKILL.md'
 check "review-feedback re-rate severity rule (mirror)" \
   'grep -q "Independently re-rate severity" .claude/skills/review-feedback/SKILL.md'
 

--- a/tests/test-skill-version-delta.sh
+++ b/tests/test-skill-version-delta.sh
@@ -154,14 +154,16 @@ if [ "$REAL_RC" -ne 0 ]; then
 else
   REAL_LINES=$(wc -l < "$FIXT/real.tsv")
   if [ "$REAL_LINES" -ge 29 ]; then
-    pass "real-repo smoke: $REAL_LINES rows (≥ 26 core + 3 addon = 29)"
+    pass "real-repo smoke: $REAL_LINES rows (≥ 25 core + 4 addon = 29)"
   else
     fail "real-repo smoke row count" "expected ≥29 got $REAL_LINES"
   fi
   CORE_COUNT=$(awk -F'\t' '$2 == "core"' "$FIXT/real.tsv" | wc -l)
   ADDON_COUNT=$(awk -F'\t' '$2 == "addon"' "$FIXT/real.tsv" | wc -l)
-  if [ "$CORE_COUNT" -ge 26 ] && [ "$ADDON_COUNT" -ge 3 ]; then
-    pass "real-repo smoke: core=$CORE_COUNT (≥26) addon=$ADDON_COUNT (≥3)"
+  # Issue #584: review-feedback moved from skills/ (core) to
+  # block-diagram/ (addon) — kind split now 25 core + 4 addon.
+  if [ "$CORE_COUNT" -ge 25 ] && [ "$ADDON_COUNT" -ge 4 ]; then
+    pass "real-repo smoke: core=$CORE_COUNT (≥25) addon=$ADDON_COUNT (≥4)"
   else
     fail "real-repo smoke: kind split" "core=$CORE_COUNT addon=$ADDON_COUNT"
   fi


### PR DESCRIPTION
Fixes #584

## Changes
- fix(review-feedback): relocate from skills/ to block-diagram/ tree (#584)

`skills/review-feedback/` is structurally a block-diagram-editor-specific skill (references "Feedback Panel > History > Export JSON", `src/io/FeedbackStore.js`, body-template Blocks/Solver/ode45 domain vocab) but lived under `skills/` (the project-agnostic framework tree). Moved to `block-diagram/review-feedback/` to match the existing add-on tree organization (add-block, add-example, model-design).

`git mv` preserved history. The `.claude/skills/review-feedback/` mirror stays in place — `scripts/mirror-skill.sh` lines 38-45 codify that block-diagram add-ons mirror flat to `.claude/skills/<name>/` (no `block-diagram` parent in the consumer-install layout — matches add-block + add-example pattern).

Two conformance fixtures updated:
- `tests/test-skill-invariants.sh` — issue #583 source-path pin updated to new location.
- `tests/test-skill-version-delta.sh` — `real-repo smoke kind split` baseline adjusted (`core≥25 + addon≥4`).

## Test plan
- [x] Full suite passed (`bash tests/run-all.sh` — 5475/5475)
- [x] git mv detected the rename (99% similarity)
- [x] `metadata.version` bumped
- [ ] CI re-runs the suite on rebased branch
