### PR TITLE
fix(drafting-skills): add auto flag + /land-pr dispatch

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.21+fd4fda"
+  version: "2026.05.22+1e68ee"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -109,13 +109,18 @@ fi
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] <description...>
+/draft-plan [output FILE] [rounds N] [auto] <description...>
 ```
 
 - **output FILE** (optional) — where to write the plan. Default:
   `$ZSKILLS_PLANS_DIR/<slug-from-description>.md`
 - **rounds N** (optional) — max review/refine cycles. Default: 3. The
   process exits early if a round converges (no substantive new issues).
+- **auto** (optional positional token) — after the worktree auto-commit
+  succeeds in Phase 6, dispatch `/land-pr` to push the branch, open a PR,
+  monitor CI, and auto-merge. Without `auto`, the plan is committed in the
+  worktree but no PR is opened — caller must land manually. Mirrors the
+  `auto` token in `/run-plan`, `/do`, `/fix-issues`, `/quickfix`.
 - **description** (required) — everything after the recognized keywords.
   Can be brief ("add dark mode") or detailed ("implement thermal domain
   with conduction, convection, radiation, and multi-domain coupling to
@@ -131,8 +136,17 @@ fi
   `.claude/skills/update-zskills/scripts/zskills-paths.sh` from the
   orchestrator's bash fence; falls back to `plans/` when config silent).
 - `rounds` followed by a number — max review cycles
+- `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
+  for Phase 6's `/land-pr` dispatch
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
+
+```bash
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
 
 Examples:
 - `/draft-plan Add dark mode to the editor`
@@ -685,12 +699,69 @@ After each round of review + refinement:
    fi
    ```
 
-4. **Plan index — do not touch.** The plan index is regenerated from
+4. **Auto-land via `/land-pr` (when `auto` was passed).** Issue #581: in
+   projects with `execution.landing: pr` + `main_protected: true`, the
+   plan file is committed in the worktree (above) but never reaches main
+   without a `/land-pr` dispatch. When the user passed the `auto`
+   positional token, dispatch `/land-pr` so the branch pushes, a PR
+   opens, CI runs, and auto-merge lands the plan on main — making
+   `/draft-plan plans/X.md auto && /run-plan plans/X.md auto` work end
+   to end. Without `auto`, the worktree commit stands and the caller
+   lands manually.
+
+   ```bash
+   if [ "${AUTO_FLAG:-0}" = "1" ] && [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+     . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+     BRANCH_NAME=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+     SLUG="$TRACKING_ID"
+     PR_TITLE="docs(plans): draft $(basename "$OUTPUT_FILE" .md) via /draft-plan"
+     BODY_FILE="/tmp/pr-body-draft-plan-${SLUG}-$$.md"
+     RESULT_FILE="/tmp/land-pr-result-draft-plan-${SLUG}-$$.txt"
+     cat > "$BODY_FILE" <<BODY
+## Summary
+
+\`/draft-plan\` produced a plan file at \`$OUTPUT_FILE\` via $ROUND round(s)
+of adversarial review (reviewer + devil's-advocate + refiner).
+
+See the plan's \`## Plan Quality\` section for round history and remaining
+concerns.
+
+## Test plan
+
+- [x] Plan file committed on the draftplan branch (worktree-isolated)
+- [ ] No functional tests — this PR ships a plan document only; CI will
+      run skill-conformance / hook / fixture suites
+BODY
+     LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-plan --worktree-path=$TOPLEVEL --tracking-id=draft-plan.$SLUG --auto"
+
+     # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+     # Allow-list parse the /land-pr result (canonical caller-loop pattern —
+     # never `source`). See skills/land-pr/references/caller-loop-pattern.md.
+     if [ -f "$RESULT_FILE" ]; then
+       declare -A LP
+       while IFS='=' read -r KEY VALUE; do
+         case "$KEY" in
+           STATUS|PR_URL|PR_NUMBER|CI_STATUS|PR_STATE|REASON)
+             LP["$KEY"]="$VALUE" ;;
+           "") ;;
+           *) ;;  # unknown keys ignored (forward-compat)
+         esac
+       done < "$RESULT_FILE"
+       echo "/land-pr: STATUS=${LP[STATUS]:-?} CI_STATUS=${LP[CI_STATUS]:-?} PR=${LP[PR_URL]:-none}" >&2
+       rm -f "$RESULT_FILE"
+     else
+       echo "WARN: /draft-plan: /land-pr produced no result file at $RESULT_FILE" >&2
+     fi
+   fi
+   ```
+
+5. **Plan index — do not touch.** The plan index is regenerated from
    source-of-truth by `/plans rebuild` and auto-refreshed by `/plans`
    Mode: Show when the source has changed. No manual update needed
    here.
 
-5. **Present the result:**
+6. **Present the result:**
    > Plan drafted in N rounds (converged / max rounds reached).
    > [Remaining concerns if any]
    >

--- a/.claude/skills/draft-tests/SKILL.md
+++ b/.claude/skills/draft-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-tests
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
 description: >-
   Draft test specifications into an existing plan through iterative
   adversarial review. Appends a `### Tests` subsection per pending phase
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.05.22+73cefd"
+  version: "2026.05.22+f25079"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
@@ -124,7 +124,7 @@ fi
 ## Arguments
 
 ```
-/draft-tests <plan-file> [rounds N] [guidance...]
+/draft-tests <plan-file> [rounds N] [auto] [guidance...]
 ```
 
 - **plan-file** (required) — path to the plan `.md` file. If the token
@@ -136,10 +136,16 @@ fi
   `/draft-plan`; `/refine-plan`'s default is 2 because it operates on an
   already-refined plan, while `/draft-tests` is typically blank-slate
   spec drafting).
-- **guidance...** (optional) — any tokens not matched as plan file or
-  `rounds N` are joined with spaces into **guidance text** — prepended
-  to BOTH the reviewer and devil's-advocate prompts in Phase 4 as a
-  "User-driven scope/focus directive" section, mirroring
+- **auto** (optional positional token) — after the worktree auto-commit
+  in Phase 6 succeeds, dispatch `/land-pr` to push the branch, open a
+  PR, monitor CI, and auto-merge. Without `auto`, the spec-augmented
+  plan is committed in the worktree but no PR is opened. Mirrors `auto`
+  in `/run-plan`, `/do`, `/fix-issues`, `/quickfix`, `/draft-plan`,
+  `/refine-plan`.
+- **guidance...** (optional) — any tokens not matched as plan file,
+  `rounds N`, or `auto` are joined with spaces into **guidance text** —
+  prepended to BOTH the reviewer and devil's-advocate prompts in Phase 4
+  as a "User-driven scope/focus directive" section, mirroring
   `/refine-plan`'s positional-tail semantics. Empty guidance preserves
   byte-identical reviewer/DA prompt output (regression-safe). Guidance
   is **priming context** that shapes WHAT the agents pressure-test —
@@ -153,10 +159,20 @@ fi
 - `rounds` followed by a numeric argument sets max cycles. (`rounds`
   not followed by a number is treated as guidance text, not the
   keyword.)
-- Any tokens not matched as the plan file or `rounds N` keyword are
-  joined with spaces into guidance text.
+- `auto` (whitespace-anchored, case-insensitive) sets `AUTO_FLAG=1` for
+  the Phase 6 `/land-pr` dispatch. The token is consumed by the flag
+  parse and does NOT enter guidance text.
+- Any tokens not matched as the plan file, `rounds N` keyword, or the
+  `auto` token are joined with spaces into guidance text.
 - If no plan file is detected, **error:**
-  `Usage: /draft-tests <plan-file> [rounds N] [guidance...]`
+  `Usage: /draft-tests <plan-file> [rounds N] [auto] [guidance...]`
+
+```bash
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
 
 Examples:
 - `/draft-tests plans/FEATURE.md`
@@ -1846,6 +1862,64 @@ if [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
     git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" -m "$COMMIT_MSG_SUBJECT"
   else
     git -C "$TOPLEVEL" commit -m "$COMMIT_MSG_SUBJECT"
+  fi
+fi
+```
+
+### Auto-land via /land-pr (when `auto` was passed)
+
+Issue #581: in projects with `execution.landing: pr` +
+`main_protected: true`, the plan with appended test specs is committed
+in the worktree (above) but never reaches main without a `/land-pr`
+dispatch. When the user passed the `auto` positional token, dispatch
+`/land-pr` so the branch pushes, a PR opens, CI runs, and auto-merge
+lands the test-spec-augmented plan on main. Without `auto`, the
+worktree commit stands and the caller lands manually.
+
+```bash
+if [ "${AUTO_FLAG:-0}" = "1" ] && [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  BRANCH_NAME=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+  SLUG="$TRACKING_ID"
+  PR_TITLE="docs(tests): draft test specs for $(basename "$PLAN_FILE" .md) via /draft-tests"
+  BODY_FILE="/tmp/pr-body-draft-tests-${SLUG}-$$.md"
+  RESULT_FILE="/tmp/land-pr-result-draft-tests-${SLUG}-$$.txt"
+  cat > "$BODY_FILE" <<BODY
+## Summary
+
+\`/draft-tests\` appended \`### Tests\` subsections to Pending phases of
+\`$PLAN_FILE\` via adversarial review (senior-QE reviewer +
+devil's-advocate + refiner). Completed phases were NOT modified
+(checksum-gated).
+
+## Test plan
+
+- [x] Test-spec-augmented plan committed on the draft-tests branch
+      (worktree-isolated)
+- [x] Completed-phase byte-identity verified via Phase-1 checksums
+- [ ] No functional tests — this PR ships test SPECS in a plan document;
+      CI will run skill-conformance / hook / fixture suites
+BODY
+  LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-tests --worktree-path=$TOPLEVEL --tracking-id=draft-tests.$SLUG --auto"
+
+  # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+  # Allow-list parse the /land-pr result (canonical caller-loop pattern —
+  # never `source`). See skills/land-pr/references/caller-loop-pattern.md.
+  if [ -f "$RESULT_FILE" ]; then
+    declare -A LP
+    while IFS='=' read -r KEY VALUE; do
+      case "$KEY" in
+        STATUS|PR_URL|PR_NUMBER|CI_STATUS|PR_STATE|REASON)
+          LP["$KEY"]="$VALUE" ;;
+        "") ;;
+        *) ;;  # unknown keys ignored (forward-compat)
+      esac
+    done < "$RESULT_FILE"
+    echo "/land-pr: STATUS=${LP[STATUS]:-?} CI_STATUS=${LP[CI_STATUS]:-?} PR=${LP[PR_URL]:-none}" >&2
+    rm -f "$RESULT_FILE"
+  else
+    echo "WARN: /draft-tests: /land-pr produced no result file at $RESULT_FILE" >&2
   fi
 fi
 ```

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -1,22 +1,26 @@
 ---
 name: land-pr
 user-invocable: false
-description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
+description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.21+d0346f"
+  version: "2026.05.22+1186c0"
 ---
 
 # /land-pr — land a feature branch as a PR
 
 `/land-pr` owns the rebase → push → create-or-detect → monitor → merge
 sequence for a feature branch that is already in a presentable state.
-Five callers (`/run-plan`, `/commit pr`, `/do pr`, `/fix-issues pr`,
-`/quickfix`) dispatch into this skill via the Skill tool. `/land-pr` is
-a helper, not a user-facing command: the API requires `--body-file` and
-`--result-file`, both of which only make sense when a caller has set
-them up. Users wanting to ship an existing branch should use `/commit pr`,
-which dispatches `/land-pr` internally with the right arguments.
+Eight callers dispatch into this skill via the Skill tool: the five
+implementation callers (`/run-plan`, `/commit pr`, `/do pr`,
+`/fix-issues pr`, `/quickfix`) and the three drafting callers
+(`/draft-plan`, `/refine-plan`, `/draft-tests` — added per issue #581 so
+their worktree-committed plan/spec files reach main under
+`landing: pr` + `main_protected: true`). `/land-pr` is a helper, not a
+user-facing command: the API requires `--body-file` and `--result-file`,
+both of which only make sense when a caller has set them up. Users
+wanting to ship an existing branch should use `/commit pr`, which
+dispatches `/land-pr` internally with the right arguments.
 
 The skill is a **prose-driven procedure**: when invoked, you (Claude) read
 this SKILL.md and execute the procedure step-by-step, calling the four

--- a/.claude/skills/refine-plan/SKILL.md
+++ b/.claude/skills/refine-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
 description: >-
   Refine an in-progress plan by reviewing remaining phases against
   completed work. Dispatches reviewer + devil's-advocate agents to surface
@@ -9,7 +9,7 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.05.21+289f05"
+  version: "2026.05.22+cdf69d"
 ---
 
 # /refine-plan \<plan-file> [rounds N] [guidance...] — Adversarial Plan Refiner
@@ -120,7 +120,7 @@ fi
 ## Arguments
 
 ```
-/refine-plan <plan-file> [rounds N] [guidance...]
+/refine-plan <plan-file> [rounds N] [auto] [guidance...]
 ```
 
 - **plan-file** (required) — path to the plan `.md` file to refine.
@@ -128,13 +128,26 @@ fi
   process exits early if a round converges (no substantive new issues).
   Default is 2 (not 3 like `/draft-plan`) because this is a refinement
   pass on an existing plan, not blank-slate creation.
+- **auto** (optional positional token) — after the worktree auto-commit
+  in Phase 5 succeeds, dispatch `/land-pr` to push the branch, open a
+  PR, monitor CI, and auto-merge. Without `auto`, the refined plan is
+  committed in the worktree but no PR is opened. Mirrors `auto` in
+  `/run-plan`, `/do`, `/fix-issues`, `/quickfix`, `/draft-plan`.
 
 **Detection:** scan `$ARGUMENTS` from the start:
 - The **first token** ending in `.md` is the plan file. If the token contains `/`, use as-is; otherwise resolve via `$ZSKILLS_PLANS_DIR/<token>` (sourcing `.claude/skills/update-zskills/scripts/zskills-paths.sh` from the orchestrator's bash fence; falls back to `plans/` when config silent).
 - `rounds` followed by a numeric argument sets max cycles. (`rounds` not followed by a number is treated as guidance text, not the keyword.)
-- Any tokens not matched as the plan file or `rounds N` keyword are joined with spaces into **guidance text** — prepended to the reviewer + devil's advocate agent prompts in Phase 2 as a "User-driven scope/focus directive" section.
+- `auto` (whitespace-anchored, case-insensitive) sets `AUTO_FLAG=1` for the Phase 5 `/land-pr` dispatch. The token is consumed by the flag parse and does NOT enter guidance text.
+- Any tokens not matched as the plan file or `rounds N` keyword OR the `auto` token are joined with spaces into **guidance text** — prepended to the reviewer + devil's advocate agent prompts in Phase 2 as a "User-driven scope/focus directive" section.
 - Empty guidance preserves today's reviewer/DA prompt output (no behavior change for invocations without trailing guidance tokens).
-- If no plan file is detected, **error:** "No plan file specified. Usage: `/refine-plan <plan-file> [rounds N] [guidance...]`"
+- If no plan file is detected, **error:** "No plan file specified. Usage: `/refine-plan <plan-file> [rounds N] [auto] [guidance...]`"
+
+```bash
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
 
 Examples:
 - `/refine-plan plans/EXECUTION_MODES.md`
@@ -633,6 +646,63 @@ if [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
     git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" -m "$COMMIT_MSG_SUBJECT"
   else
     git -C "$TOPLEVEL" commit -m "$COMMIT_MSG_SUBJECT"
+  fi
+fi
+```
+
+### Auto-land via /land-pr (when `auto` was passed)
+
+Issue #581: in projects with `execution.landing: pr` +
+`main_protected: true`, the refined plan file is committed in the
+worktree (above) but never reaches main without a `/land-pr` dispatch.
+When the user passed the `auto` positional token, dispatch `/land-pr` so
+the branch pushes, a PR opens, CI runs, and auto-merge lands the refined
+plan on main. Without `auto`, the worktree commit stands and the caller
+lands manually.
+
+```bash
+if [ "${AUTO_FLAG:-0}" = "1" ] && [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  BRANCH_NAME=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+  SLUG="$TRACKING_ID"
+  PR_TITLE="docs(plans): refine $(basename "$PLAN_FILE" .md) via /refine-plan"
+  BODY_FILE="/tmp/pr-body-refine-plan-${SLUG}-$$.md"
+  RESULT_FILE="/tmp/land-pr-result-refine-plan-${SLUG}-$$.txt"
+  cat > "$BODY_FILE" <<BODY
+## Summary
+
+\`/refine-plan\` updated \`$PLAN_FILE\` via $ROUND round(s) of adversarial
+review (reviewer + devil's-advocate + refiner). Completed phases were
+NOT modified (checksum-gated). Pending phases were refined; \`## Drift
+Log\` and \`## Plan Review\` sections appended.
+
+## Test plan
+
+- [x] Refined plan committed on the refine-plan branch (worktree-isolated)
+- [x] Completed-phase byte-identity verified via Phase-1 checksums
+- [ ] No functional tests — this PR ships a plan document only; CI will
+      run skill-conformance / hook / fixture suites
+BODY
+  LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=refine-plan --worktree-path=$TOPLEVEL --tracking-id=refine-plan.$SLUG --auto"
+
+  # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+  # Allow-list parse the /land-pr result (canonical caller-loop pattern —
+  # never `source`). See skills/land-pr/references/caller-loop-pattern.md.
+  if [ -f "$RESULT_FILE" ]; then
+    declare -A LP
+    while IFS='=' read -r KEY VALUE; do
+      case "$KEY" in
+        STATUS|PR_URL|PR_NUMBER|CI_STATUS|PR_STATE|REASON)
+          LP["$KEY"]="$VALUE" ;;
+        "") ;;
+        *) ;;  # unknown keys ignored (forward-compat)
+      esac
+    done < "$RESULT_FILE"
+    echo "/land-pr: STATUS=${LP[STATUS]:-?} CI_STATUS=${LP[CI_STATUS]:-?} PR=${LP[PR_URL]:-none}" >&2
+    rm -f "$RESULT_FILE"
+  else
+    echo "WARN: /refine-plan: /land-pr produced no result file at $RESULT_FILE" >&2
   fi
 fi
 ```

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.21+fd4fda"
+  version: "2026.05.22+1e68ee"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -109,13 +109,18 @@ fi
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] <description...>
+/draft-plan [output FILE] [rounds N] [auto] <description...>
 ```
 
 - **output FILE** (optional) — where to write the plan. Default:
   `$ZSKILLS_PLANS_DIR/<slug-from-description>.md`
 - **rounds N** (optional) — max review/refine cycles. Default: 3. The
   process exits early if a round converges (no substantive new issues).
+- **auto** (optional positional token) — after the worktree auto-commit
+  succeeds in Phase 6, dispatch `/land-pr` to push the branch, open a PR,
+  monitor CI, and auto-merge. Without `auto`, the plan is committed in the
+  worktree but no PR is opened — caller must land manually. Mirrors the
+  `auto` token in `/run-plan`, `/do`, `/fix-issues`, `/quickfix`.
 - **description** (required) — everything after the recognized keywords.
   Can be brief ("add dark mode") or detailed ("implement thermal domain
   with conduction, convection, radiation, and multi-domain coupling to
@@ -131,8 +136,17 @@ fi
   `.claude/skills/update-zskills/scripts/zskills-paths.sh` from the
   orchestrator's bash fence; falls back to `plans/` when config silent).
 - `rounds` followed by a number — max review cycles
+- `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
+  for Phase 6's `/land-pr` dispatch
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
+
+```bash
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
 
 Examples:
 - `/draft-plan Add dark mode to the editor`
@@ -685,12 +699,69 @@ After each round of review + refinement:
    fi
    ```
 
-4. **Plan index — do not touch.** The plan index is regenerated from
+4. **Auto-land via `/land-pr` (when `auto` was passed).** Issue #581: in
+   projects with `execution.landing: pr` + `main_protected: true`, the
+   plan file is committed in the worktree (above) but never reaches main
+   without a `/land-pr` dispatch. When the user passed the `auto`
+   positional token, dispatch `/land-pr` so the branch pushes, a PR
+   opens, CI runs, and auto-merge lands the plan on main — making
+   `/draft-plan plans/X.md auto && /run-plan plans/X.md auto` work end
+   to end. Without `auto`, the worktree commit stands and the caller
+   lands manually.
+
+   ```bash
+   if [ "${AUTO_FLAG:-0}" = "1" ] && [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+     . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+     BRANCH_NAME=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+     SLUG="$TRACKING_ID"
+     PR_TITLE="docs(plans): draft $(basename "$OUTPUT_FILE" .md) via /draft-plan"
+     BODY_FILE="/tmp/pr-body-draft-plan-${SLUG}-$$.md"
+     RESULT_FILE="/tmp/land-pr-result-draft-plan-${SLUG}-$$.txt"
+     cat > "$BODY_FILE" <<BODY
+## Summary
+
+\`/draft-plan\` produced a plan file at \`$OUTPUT_FILE\` via $ROUND round(s)
+of adversarial review (reviewer + devil's-advocate + refiner).
+
+See the plan's \`## Plan Quality\` section for round history and remaining
+concerns.
+
+## Test plan
+
+- [x] Plan file committed on the draftplan branch (worktree-isolated)
+- [ ] No functional tests — this PR ships a plan document only; CI will
+      run skill-conformance / hook / fixture suites
+BODY
+     LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-plan --worktree-path=$TOPLEVEL --tracking-id=draft-plan.$SLUG --auto"
+
+     # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+     # Allow-list parse the /land-pr result (canonical caller-loop pattern —
+     # never `source`). See skills/land-pr/references/caller-loop-pattern.md.
+     if [ -f "$RESULT_FILE" ]; then
+       declare -A LP
+       while IFS='=' read -r KEY VALUE; do
+         case "$KEY" in
+           STATUS|PR_URL|PR_NUMBER|CI_STATUS|PR_STATE|REASON)
+             LP["$KEY"]="$VALUE" ;;
+           "") ;;
+           *) ;;  # unknown keys ignored (forward-compat)
+         esac
+       done < "$RESULT_FILE"
+       echo "/land-pr: STATUS=${LP[STATUS]:-?} CI_STATUS=${LP[CI_STATUS]:-?} PR=${LP[PR_URL]:-none}" >&2
+       rm -f "$RESULT_FILE"
+     else
+       echo "WARN: /draft-plan: /land-pr produced no result file at $RESULT_FILE" >&2
+     fi
+   fi
+   ```
+
+5. **Plan index — do not touch.** The plan index is regenerated from
    source-of-truth by `/plans rebuild` and auto-refreshed by `/plans`
    Mode: Show when the source has changed. No manual update needed
    here.
 
-5. **Present the result:**
+6. **Present the result:**
    > Plan drafted in N rounds (converged / max rounds reached).
    > [Remaining concerns if any]
    >

--- a/skills/draft-tests/SKILL.md
+++ b/skills/draft-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-tests
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
 description: >-
   Draft test specifications into an existing plan through iterative
   adversarial review. Appends a `### Tests` subsection per pending phase
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.05.22+73cefd"
+  version: "2026.05.22+f25079"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
@@ -124,7 +124,7 @@ fi
 ## Arguments
 
 ```
-/draft-tests <plan-file> [rounds N] [guidance...]
+/draft-tests <plan-file> [rounds N] [auto] [guidance...]
 ```
 
 - **plan-file** (required) — path to the plan `.md` file. If the token
@@ -136,10 +136,16 @@ fi
   `/draft-plan`; `/refine-plan`'s default is 2 because it operates on an
   already-refined plan, while `/draft-tests` is typically blank-slate
   spec drafting).
-- **guidance...** (optional) — any tokens not matched as plan file or
-  `rounds N` are joined with spaces into **guidance text** — prepended
-  to BOTH the reviewer and devil's-advocate prompts in Phase 4 as a
-  "User-driven scope/focus directive" section, mirroring
+- **auto** (optional positional token) — after the worktree auto-commit
+  in Phase 6 succeeds, dispatch `/land-pr` to push the branch, open a
+  PR, monitor CI, and auto-merge. Without `auto`, the spec-augmented
+  plan is committed in the worktree but no PR is opened. Mirrors `auto`
+  in `/run-plan`, `/do`, `/fix-issues`, `/quickfix`, `/draft-plan`,
+  `/refine-plan`.
+- **guidance...** (optional) — any tokens not matched as plan file,
+  `rounds N`, or `auto` are joined with spaces into **guidance text** —
+  prepended to BOTH the reviewer and devil's-advocate prompts in Phase 4
+  as a "User-driven scope/focus directive" section, mirroring
   `/refine-plan`'s positional-tail semantics. Empty guidance preserves
   byte-identical reviewer/DA prompt output (regression-safe). Guidance
   is **priming context** that shapes WHAT the agents pressure-test —
@@ -153,10 +159,20 @@ fi
 - `rounds` followed by a numeric argument sets max cycles. (`rounds`
   not followed by a number is treated as guidance text, not the
   keyword.)
-- Any tokens not matched as the plan file or `rounds N` keyword are
-  joined with spaces into guidance text.
+- `auto` (whitespace-anchored, case-insensitive) sets `AUTO_FLAG=1` for
+  the Phase 6 `/land-pr` dispatch. The token is consumed by the flag
+  parse and does NOT enter guidance text.
+- Any tokens not matched as the plan file, `rounds N` keyword, or the
+  `auto` token are joined with spaces into guidance text.
 - If no plan file is detected, **error:**
-  `Usage: /draft-tests <plan-file> [rounds N] [guidance...]`
+  `Usage: /draft-tests <plan-file> [rounds N] [auto] [guidance...]`
+
+```bash
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
 
 Examples:
 - `/draft-tests plans/FEATURE.md`
@@ -1846,6 +1862,64 @@ if [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
     git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" -m "$COMMIT_MSG_SUBJECT"
   else
     git -C "$TOPLEVEL" commit -m "$COMMIT_MSG_SUBJECT"
+  fi
+fi
+```
+
+### Auto-land via /land-pr (when `auto` was passed)
+
+Issue #581: in projects with `execution.landing: pr` +
+`main_protected: true`, the plan with appended test specs is committed
+in the worktree (above) but never reaches main without a `/land-pr`
+dispatch. When the user passed the `auto` positional token, dispatch
+`/land-pr` so the branch pushes, a PR opens, CI runs, and auto-merge
+lands the test-spec-augmented plan on main. Without `auto`, the
+worktree commit stands and the caller lands manually.
+
+```bash
+if [ "${AUTO_FLAG:-0}" = "1" ] && [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  BRANCH_NAME=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+  SLUG="$TRACKING_ID"
+  PR_TITLE="docs(tests): draft test specs for $(basename "$PLAN_FILE" .md) via /draft-tests"
+  BODY_FILE="/tmp/pr-body-draft-tests-${SLUG}-$$.md"
+  RESULT_FILE="/tmp/land-pr-result-draft-tests-${SLUG}-$$.txt"
+  cat > "$BODY_FILE" <<BODY
+## Summary
+
+\`/draft-tests\` appended \`### Tests\` subsections to Pending phases of
+\`$PLAN_FILE\` via adversarial review (senior-QE reviewer +
+devil's-advocate + refiner). Completed phases were NOT modified
+(checksum-gated).
+
+## Test plan
+
+- [x] Test-spec-augmented plan committed on the draft-tests branch
+      (worktree-isolated)
+- [x] Completed-phase byte-identity verified via Phase-1 checksums
+- [ ] No functional tests — this PR ships test SPECS in a plan document;
+      CI will run skill-conformance / hook / fixture suites
+BODY
+  LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-tests --worktree-path=$TOPLEVEL --tracking-id=draft-tests.$SLUG --auto"
+
+  # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+  # Allow-list parse the /land-pr result (canonical caller-loop pattern —
+  # never `source`). See skills/land-pr/references/caller-loop-pattern.md.
+  if [ -f "$RESULT_FILE" ]; then
+    declare -A LP
+    while IFS='=' read -r KEY VALUE; do
+      case "$KEY" in
+        STATUS|PR_URL|PR_NUMBER|CI_STATUS|PR_STATE|REASON)
+          LP["$KEY"]="$VALUE" ;;
+        "") ;;
+        *) ;;  # unknown keys ignored (forward-compat)
+      esac
+    done < "$RESULT_FILE"
+    echo "/land-pr: STATUS=${LP[STATUS]:-?} CI_STATUS=${LP[CI_STATUS]:-?} PR=${LP[PR_URL]:-none}" >&2
+    rm -f "$RESULT_FILE"
+  else
+    echo "WARN: /draft-tests: /land-pr produced no result file at $RESULT_FILE" >&2
   fi
 fi
 ```

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -1,22 +1,26 @@
 ---
 name: land-pr
 user-invocable: false
-description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
+description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.21+d0346f"
+  version: "2026.05.22+1186c0"
 ---
 
 # /land-pr — land a feature branch as a PR
 
 `/land-pr` owns the rebase → push → create-or-detect → monitor → merge
 sequence for a feature branch that is already in a presentable state.
-Five callers (`/run-plan`, `/commit pr`, `/do pr`, `/fix-issues pr`,
-`/quickfix`) dispatch into this skill via the Skill tool. `/land-pr` is
-a helper, not a user-facing command: the API requires `--body-file` and
-`--result-file`, both of which only make sense when a caller has set
-them up. Users wanting to ship an existing branch should use `/commit pr`,
-which dispatches `/land-pr` internally with the right arguments.
+Eight callers dispatch into this skill via the Skill tool: the five
+implementation callers (`/run-plan`, `/commit pr`, `/do pr`,
+`/fix-issues pr`, `/quickfix`) and the three drafting callers
+(`/draft-plan`, `/refine-plan`, `/draft-tests` — added per issue #581 so
+their worktree-committed plan/spec files reach main under
+`landing: pr` + `main_protected: true`). `/land-pr` is a helper, not a
+user-facing command: the API requires `--body-file` and `--result-file`,
+both of which only make sense when a caller has set them up. Users
+wanting to ship an existing branch should use `/commit pr`, which
+dispatches `/land-pr` internally with the right arguments.
 
 The skill is a **prose-driven procedure**: when invoked, you (Claude) read
 this SKILL.md and execute the procedure step-by-step, calling the four

--- a/skills/refine-plan/SKILL.md
+++ b/skills/refine-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
 description: >-
   Refine an in-progress plan by reviewing remaining phases against
   completed work. Dispatches reviewer + devil's-advocate agents to surface
@@ -9,7 +9,7 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.05.21+289f05"
+  version: "2026.05.22+cdf69d"
 ---
 
 # /refine-plan \<plan-file> [rounds N] [guidance...] — Adversarial Plan Refiner
@@ -120,7 +120,7 @@ fi
 ## Arguments
 
 ```
-/refine-plan <plan-file> [rounds N] [guidance...]
+/refine-plan <plan-file> [rounds N] [auto] [guidance...]
 ```
 
 - **plan-file** (required) — path to the plan `.md` file to refine.
@@ -128,13 +128,26 @@ fi
   process exits early if a round converges (no substantive new issues).
   Default is 2 (not 3 like `/draft-plan`) because this is a refinement
   pass on an existing plan, not blank-slate creation.
+- **auto** (optional positional token) — after the worktree auto-commit
+  in Phase 5 succeeds, dispatch `/land-pr` to push the branch, open a
+  PR, monitor CI, and auto-merge. Without `auto`, the refined plan is
+  committed in the worktree but no PR is opened. Mirrors `auto` in
+  `/run-plan`, `/do`, `/fix-issues`, `/quickfix`, `/draft-plan`.
 
 **Detection:** scan `$ARGUMENTS` from the start:
 - The **first token** ending in `.md` is the plan file. If the token contains `/`, use as-is; otherwise resolve via `$ZSKILLS_PLANS_DIR/<token>` (sourcing `.claude/skills/update-zskills/scripts/zskills-paths.sh` from the orchestrator's bash fence; falls back to `plans/` when config silent).
 - `rounds` followed by a numeric argument sets max cycles. (`rounds` not followed by a number is treated as guidance text, not the keyword.)
-- Any tokens not matched as the plan file or `rounds N` keyword are joined with spaces into **guidance text** — prepended to the reviewer + devil's advocate agent prompts in Phase 2 as a "User-driven scope/focus directive" section.
+- `auto` (whitespace-anchored, case-insensitive) sets `AUTO_FLAG=1` for the Phase 5 `/land-pr` dispatch. The token is consumed by the flag parse and does NOT enter guidance text.
+- Any tokens not matched as the plan file or `rounds N` keyword OR the `auto` token are joined with spaces into **guidance text** — prepended to the reviewer + devil's advocate agent prompts in Phase 2 as a "User-driven scope/focus directive" section.
 - Empty guidance preserves today's reviewer/DA prompt output (no behavior change for invocations without trailing guidance tokens).
-- If no plan file is detected, **error:** "No plan file specified. Usage: `/refine-plan <plan-file> [rounds N] [guidance...]`"
+- If no plan file is detected, **error:** "No plan file specified. Usage: `/refine-plan <plan-file> [rounds N] [auto] [guidance...]`"
+
+```bash
+AUTO_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
 
 Examples:
 - `/refine-plan plans/EXECUTION_MODES.md`
@@ -633,6 +646,63 @@ if [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
     git -C "$TOPLEVEL" commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" -m "$COMMIT_MSG_SUBJECT"
   else
     git -C "$TOPLEVEL" commit -m "$COMMIT_MSG_SUBJECT"
+  fi
+fi
+```
+
+### Auto-land via /land-pr (when `auto` was passed)
+
+Issue #581: in projects with `execution.landing: pr` +
+`main_protected: true`, the refined plan file is committed in the
+worktree (above) but never reaches main without a `/land-pr` dispatch.
+When the user passed the `auto` positional token, dispatch `/land-pr` so
+the branch pushes, a PR opens, CI runs, and auto-merge lands the refined
+plan on main. Without `auto`, the worktree commit stands and the caller
+lands manually.
+
+```bash
+if [ "${AUTO_FLAG:-0}" = "1" ] && [ "$TOPLEVEL" != "$MAIN_ROOT" ]; then
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  BRANCH_NAME=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
+  SLUG="$TRACKING_ID"
+  PR_TITLE="docs(plans): refine $(basename "$PLAN_FILE" .md) via /refine-plan"
+  BODY_FILE="/tmp/pr-body-refine-plan-${SLUG}-$$.md"
+  RESULT_FILE="/tmp/land-pr-result-refine-plan-${SLUG}-$$.txt"
+  cat > "$BODY_FILE" <<BODY
+## Summary
+
+\`/refine-plan\` updated \`$PLAN_FILE\` via $ROUND round(s) of adversarial
+review (reviewer + devil's-advocate + refiner). Completed phases were
+NOT modified (checksum-gated). Pending phases were refined; \`## Drift
+Log\` and \`## Plan Review\` sections appended.
+
+## Test plan
+
+- [x] Refined plan committed on the refine-plan branch (worktree-isolated)
+- [x] Completed-phase byte-identity verified via Phase-1 checksums
+- [ ] No functional tests — this PR ships a plan document only; CI will
+      run skill-conformance / hook / fixture suites
+BODY
+  LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=refine-plan --worktree-path=$TOPLEVEL --tracking-id=refine-plan.$SLUG --auto"
+
+  # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
+
+  # Allow-list parse the /land-pr result (canonical caller-loop pattern —
+  # never `source`). See skills/land-pr/references/caller-loop-pattern.md.
+  if [ -f "$RESULT_FILE" ]; then
+    declare -A LP
+    while IFS='=' read -r KEY VALUE; do
+      case "$KEY" in
+        STATUS|PR_URL|PR_NUMBER|CI_STATUS|PR_STATE|REASON)
+          LP["$KEY"]="$VALUE" ;;
+        "") ;;
+        *) ;;  # unknown keys ignored (forward-compat)
+      esac
+    done < "$RESULT_FILE"
+    echo "/land-pr: STATUS=${LP[STATUS]:-?} CI_STATUS=${LP[CI_STATUS]:-?} PR=${LP[PR_URL]:-none}" >&2
+    rm -f "$RESULT_FILE"
+  else
+    echo "WARN: /refine-plan: /land-pr produced no result file at $RESULT_FILE" >&2
   fi
 fi
 ```

--- a/tests/test-draft-tests.sh
+++ b/tests/test-draft-tests.sh
@@ -102,8 +102,8 @@ fi
 
 expect_skill_matches "AC-1.1: frontmatter name"               '^name:[[:space:]]+draft-tests'
 expect_skill_matches "AC-1.1: frontmatter disable-model-invocation" '^disable-model-invocation:[[:space:]]+false'
-expect_skill_matches "AC-1.1: frontmatter argument-hint with [guidance...]" \
-  '^argument-hint:[[:space:]]+"<plan-file>[[:space:]]+\[rounds N\][[:space:]]+\[guidance\.\.\.\]"'
+expect_skill_matches "AC-1.1: frontmatter argument-hint with [auto] [guidance...]" \
+  '^argument-hint:[[:space:]]+"<plan-file>[[:space:]]+\[rounds N\][[:space:]]+\[auto\][[:space:]]+\[guidance\.\.\.\]"'
 expect_skill_matches "AC-1.1: frontmatter description"        '^description:'
 
 # ----------------------------------------------------------------------
@@ -116,7 +116,7 @@ echo ""
 echo "=== AC-1.2 — Usage / error string ==="
 
 expect_skill_contains "AC-1.2: usage string verbatim" \
-  'Usage: /draft-tests <plan-file> [rounds N] [guidance...]'
+  'Usage: /draft-tests <plan-file> [rounds N] [auto] [guidance...]'
 
 # ----------------------------------------------------------------------
 # AC-1.2b — Reviewer + DA prompt prepend semantics for guidance.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -575,6 +575,24 @@ check_not   quickfix "no inline gh pr create"      'gh pr create'
 check_not   quickfix "no fire-and-forget literal"  'Fire-and-forget'
 
 echo ""
+echo "=== /draft-plan, /refine-plan, /draft-tests — auto flag + /land-pr dispatch (#581) ==="
+# Issue #581: the three drafting skills create worktrees but had no
+# auto-landing path. Under `execution.landing: pr` + `main_protected: true`,
+# /draft-plan → /run-plan silently failed because the plan file was
+# committed in the worktree, not on main. Each skill now recognizes the
+# positional `auto` token and dispatches /land-pr after the Phase-N
+# worktree auto-commit.
+for skill in draft-plan refine-plan draft-tests; do
+  check_fixed "$skill" "AUTO_FLAG init"          'AUTO_FLAG=0'
+  check       "$skill" "auto token detection"    '\[aA\]\[uU\]\[tT\]\[oO\]'
+  check_fixed "$skill" "dispatches /land-pr"     'land-pr'
+  check_fixed "$skill" "AUTO_FLAG gates dispatch" '${AUTO_FLAG:-0}" = "1"'
+  check_fixed "$skill" "Skill tool dispatch line" 'Skill: { skill: "land-pr"'
+  check_fixed "$skill" "--auto flag passed to land-pr" '--auto'
+  check       "$skill" "argument-hint contains auto" 'argument-hint:.*\[auto\]'
+done
+
+echo ""
 echo "=== implementer subagent — impl-dispatch site pins (Verifier-cannot-run symmetry) ==="
 # Each impl-class dispatch (orchestrator asks a sub-agent to write code,
 # run tests, and/or commit) MUST declare `subagent_type: "implementer"`.
@@ -760,19 +778,23 @@ cross_check_no_invocation "no inline gh pr merge (.claude/skills/)" \
   '^[[:space:]]*(if[[:space:]]+!?[[:space:]]*)?[A-Z_]*=?(\$\()?gh pr merge\b' \
   "$REPO_ROOT/.claude/skills"
 
-# --- WI 6.1 (d) — All 5 callers dispatch /land-pr ---
+# --- WI 6.1 (d) — All 8 callers dispatch /land-pr (5 impl + 3 drafting per #581) ---
 # Substring match suffices because `land-pr` only appears in dispatch
-# contexts inside the caller files (verified during Phase 2-5 migrations).
+# contexts inside the caller files (verified during Phase 2-5 migrations
+# and #581's drafting-skill adoption).
 # These checks duplicate the per-skill assertions above (run-plan,
-# commit, do, fix-issues, quickfix already each have their own
-# `dispatches /land-pr` check) but consolidate them as a single
-# cross-skill drift-prevention claim.
+# commit, do, fix-issues, quickfix, draft-plan, refine-plan, draft-tests
+# already each have their own `dispatches /land-pr` check) but consolidate
+# them as a single cross-skill drift-prevention claim.
 LAND_PR_CALLERS=(
   "skills/run-plan/modes/pr.md"
   "skills/commit/modes/pr.md"
   "skills/do/modes/pr.md"
   "skills/fix-issues/modes/pr.md"
   "skills/quickfix/SKILL.md"
+  "skills/draft-plan/SKILL.md"
+  "skills/refine-plan/SKILL.md"
+  "skills/draft-tests/SKILL.md"
 )
 ALL_CALLERS_OK=1
 for caller in "${LAND_PR_CALLERS[@]}"; do
@@ -785,7 +807,7 @@ for caller in "${LAND_PR_CALLERS[@]}"; do
   fi
 done
 if [ "$ALL_CALLERS_OK" -eq 1 ]; then
-  pass "[cross-skill] all 5 callers reference /land-pr (dispatch present)"
+  pass "[cross-skill] all 8 callers reference /land-pr (dispatch present)"
 fi
 
 # --- WI 6.1 (e) — Orchestrator-level dispatch verification ---
@@ -823,7 +845,7 @@ for caller in "${LAND_PR_CALLERS[@]}"; do
   fi
 done
 if [ "$ORCH_DISPATCH_FAIL" -eq 0 ]; then
-  pass "[cross-skill] /land-pr dispatched at orchestrator level in all 5 callers (no nested-Agent markers within ±15 lines)"
+  pass "[cross-skill] /land-pr dispatched at orchestrator level in all 8 callers (no nested-Agent markers within ±15 lines)"
 fi
 
 echo ""
@@ -1550,8 +1572,8 @@ echo "=== /draft-tests — behavior contracts (WI 6.3) ==="
 # count. WI 6.3 is the authoritative enumeration source.
 #
 # 1. Frontmatter shape (incl. `[guidance...]` positional tail in argument-hint)
-check       draft-tests "frontmatter argument-hint with [guidance...]" \
-  '^argument-hint:[[:space:]]+"<plan-file> \[rounds N\] \[guidance\.\.\.\]"'
+check       draft-tests "frontmatter argument-hint with [auto] [guidance...]" \
+  '^argument-hint:[[:space:]]+"<plan-file> \[rounds N\] \[auto\] \[guidance\.\.\.\]"'
 # 2. Tracking marker basename matches canonical scheme `fulfilled.draft-tests.<id>`
 check_fixed draft-tests "fulfilled marker basename" \
   'fulfilled.draft-tests.$TRACKING_ID'


### PR DESCRIPTION
Fixes #581

## Changes
- fix(drafting-skills): add `auto` flag + /land-pr dispatch (#581)

Each of `/draft-plan`, `/refine-plan`, `/draft-tests` now:
- Recognizes positional `auto` token (case-insensitive, whitespace-anchored) and sets `AUTO_FLAG=1`
- Dispatches `/land-pr --auto` at the auto-commit phase when `AUTO_FLAG=1` (gated also on `$TOPLEVEL != $MAIN_ROOT` — no-op when not in a worktree)
- Allow-list parses the /land-pr result file per `references/caller-loop-pattern.md`'s "never source" contract

Plus: `/land-pr` SKILL.md prose updated from "Five callers" to "Eight callers" (the 3 drafting skills now join /commit, /do, /fix-issues, /quickfix, /run-plan in the canonical caller list); LAND_PR_CALLERS conformance array extended from 5 to 8 with cross-skill claim updates.

## Test plan
- [x] Full suite: 5522/5522 passed
- [x] 4 metadata.version bumps (draft-plan, refine-plan, draft-tests, land-pr)
- [x] 21 new conformance checks in tests/test-skill-conformance.sh (7 assertions × 3 drafting skills)
- [x] Pre-existing argument-hint pins in test-draft-tests.sh + test-skill-conformance.sh:1575 updated for the new `[auto]` token
- [x] 4 mirror diffs byte-equal
- [ ] CI re-runs the suite on rebased branch
