### PR TITLE
fix(qe-audit): embed TIGHT-BAR + filter taxonomy in SKILL.md

### DIFF
--- a/.claude/skills/qe-audit/SKILL.md
+++ b/.claude/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.20+51a254"
+  version: "2026.05.22+3b81a7"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -159,6 +159,10 @@ If `$ARGUMENTS` contains `every <schedule>`:
 6. **If `now` is present:** proceed to the audit/bash.
    **If `now` is NOT present:** **Exit.** The cron fires later.
 
+**Cadence-stretch rule:** if 3 consecutive passes yield 0 findings on Tier 1+2 surfaces, suggest stretching cadence (2h, daily).
+
+**Recovery rule:** if any orchestrator-side post-triage closes >40% of agent-surfaced findings, the calibration drifted at the agent level — tighten the prompt for next pass (apply TIGHT-BAR more aggressively).
+
 If `every` is NOT present, skip this phase and proceed to the audit/bash
 (bare invocation always runs immediately).
 
@@ -186,6 +190,32 @@ Run when `bash` is NOT present in arguments.
    - Assess: Are tests good (testing real behavior, not no-ops)? Are there
      coverage gaps? Are there bugs?
    - Rate severity: Critical / High / Medium / Low / Very Low
+
+### TIGHT-BAR triage and filter rules
+
+**Each agent self-triages with 3 questions BEFORE surfacing a finding:**
+
+1. Verified falsifying trace? (concrete input → traced wrong output)
+2. Real user/agent plausibly hits this within ~1 month? (NOT "technically possible," NOT "constructible adversarially")
+3. Fix-cost + fix-risk genuinely worth the impact?
+
+If a candidate fails any of the 3, the agent stands down. Yield 0-1 issues is a CONVERGENCE SIGNAL, not failure.
+
+**Filter — do NOT file:**
+- Documentation/code mismatches with no observable user impact
+- Defense-in-depth gaps with no observed exploit
+- "Could trigger via contrived input"
+- "Test could be stronger" without a current masked defect
+- Latent bugs requiring infrastructure failure or rare race conditions
+- Defense-on-defense (closure-incomplete on test-matrix gap unless runtime exposed)
+
+**Filter — DO file:**
+- Real-impact bug observable in current sessions / sprint reports / memory anchors
+- Trivial-fix + low-risk consistency gaps (mirror-existing-pattern fixes are ALWAYS net-positive)
+- Skill prose contradicts security hooks / discipline rules
+- Closure-incomplete on a recent fix WHEN the runtime is still exposed
+
+**Family-pattern consolidation:** when 3+ findings across passes share the same defect class, file a single consolidating meta-issue (scope + structural fix) instead of additional individual issues. Update the meta-issue's BODY (via `gh issue edit --body-file`) when new siblings are surfaced — comments are a discoverability backstop, not the contract.
 
 5. **Verify each finding against ground truth before durable-state action.**
    For every "FILE ISSUE" or "MOVE TO RESOLVED" finding from a dispatched

--- a/skills/qe-audit/SKILL.md
+++ b/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.20+51a254"
+  version: "2026.05.22+3b81a7"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -159,6 +159,10 @@ If `$ARGUMENTS` contains `every <schedule>`:
 6. **If `now` is present:** proceed to the audit/bash.
    **If `now` is NOT present:** **Exit.** The cron fires later.
 
+**Cadence-stretch rule:** if 3 consecutive passes yield 0 findings on Tier 1+2 surfaces, suggest stretching cadence (2h, daily).
+
+**Recovery rule:** if any orchestrator-side post-triage closes >40% of agent-surfaced findings, the calibration drifted at the agent level — tighten the prompt for next pass (apply TIGHT-BAR more aggressively).
+
 If `every` is NOT present, skip this phase and proceed to the audit/bash
 (bare invocation always runs immediately).
 
@@ -186,6 +190,32 @@ Run when `bash` is NOT present in arguments.
    - Assess: Are tests good (testing real behavior, not no-ops)? Are there
      coverage gaps? Are there bugs?
    - Rate severity: Critical / High / Medium / Low / Very Low
+
+### TIGHT-BAR triage and filter rules
+
+**Each agent self-triages with 3 questions BEFORE surfacing a finding:**
+
+1. Verified falsifying trace? (concrete input → traced wrong output)
+2. Real user/agent plausibly hits this within ~1 month? (NOT "technically possible," NOT "constructible adversarially")
+3. Fix-cost + fix-risk genuinely worth the impact?
+
+If a candidate fails any of the 3, the agent stands down. Yield 0-1 issues is a CONVERGENCE SIGNAL, not failure.
+
+**Filter — do NOT file:**
+- Documentation/code mismatches with no observable user impact
+- Defense-in-depth gaps with no observed exploit
+- "Could trigger via contrived input"
+- "Test could be stronger" without a current masked defect
+- Latent bugs requiring infrastructure failure or rare race conditions
+- Defense-on-defense (closure-incomplete on test-matrix gap unless runtime exposed)
+
+**Filter — DO file:**
+- Real-impact bug observable in current sessions / sprint reports / memory anchors
+- Trivial-fix + low-risk consistency gaps (mirror-existing-pattern fixes are ALWAYS net-positive)
+- Skill prose contradicts security hooks / discipline rules
+- Closure-incomplete on a recent fix WHEN the runtime is still exposed
+
+**Family-pattern consolidation:** when 3+ findings across passes share the same defect class, file a single consolidating meta-issue (scope + structural fix) instead of additional individual issues. Update the meta-issue's BODY (via `gh issue edit --body-file`) when new siblings are surfaced — comments are a discoverability backstop, not the contract.
 
 5. **Verify each finding against ground truth before durable-state action.**
    For every "FILE ISSUE" or "MOVE TO RESOLVED" finding from a dispatched

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2676,6 +2676,35 @@ check_fixed qe-audit "worked example: past failure #390"  'past failure #390'
 check_fixed qe-audit "bash-mode sweep echoes the rule"    'Ban caveats: the Commit Audit Step 6'
 
 echo ""
+echo "=== /qe-audit — TIGHT-BAR + filter taxonomy + cadence/recovery (issue #637) ==="
+# Issue #637: SKILL.md body had drifted from operational calibration —
+# TIGHT-BAR 3-question self-triage, do/DON'T filter taxonomy, family-pattern
+# consolidation, cadence-stretch rule, and orchestrator-recovery rule lived
+# only in the cron-fired prompt. Fresh-session loads (post-/clear) dispatched
+# /qe-audit with none of these → regression to passes 1-11 yield patterns.
+# These pins lock the calibration into the body so cron-prompt drift cannot
+# erase it again. 12 checks: 6 fingerprints × 2 files (source + mirror).
+for QE_FILE in "$REPO_ROOT/skills/qe-audit/SKILL.md" "$REPO_ROOT/.claude/skills/qe-audit/SKILL.md"; do
+  QE_REL="${QE_FILE#$REPO_ROOT/}"
+  for QE_FP_LABEL in \
+    "TIGHT-BAR triage section heading|TIGHT-BAR triage and filter rules" \
+    "falsifying-trace question|Verified falsifying trace" \
+    "do NOT file filter bucket|Filter — do NOT file" \
+    "family-pattern consolidation rule|Family-pattern consolidation" \
+    "cadence-stretch rule|Cadence-stretch rule" \
+    "recovery rule (orchestrator drift)|Recovery rule"
+  do
+    QE_LABEL="${QE_FP_LABEL%%|*}"
+    QE_PAT="${QE_FP_LABEL#*|}"
+    if grep -qF -- "$QE_PAT" "$QE_FILE" 2>/dev/null; then
+      pass "[$QE_REL] $QE_LABEL"
+    else
+      fail "[$QE_REL] $QE_LABEL" "missing fingerprint: $QE_PAT"
+    fi
+  done
+done
+
+echo ""
 echo "=== /update-zskills — Step 0.5 parent-scoped JSON extraction (issue #428) ==="
 # Issue #428: Step 0.5 "Read Config" in skills/update-zskills/SKILL.md
 # teaches a config-extraction recipe using bash regex on JSON. The


### PR DESCRIPTION
Fixes #637

## Changes
- fix(qe-audit): embed TIGHT-BAR + filter taxonomy + cadence/recovery rules in SKILL.md (#637)

`/qe-audit` SKILL.md had drifted — operational calibration (TIGHT-BAR 3-question / DO and DO-NOT file taxonomy / family-pattern consolidation / cadence-stretch / recovery rules) lived only in the cron-fired prompt, not in the skill body. A fresh-session load (post-`/clear`) would dispatch without the discipline. This PR moves the durable discipline INTO the SKILL.md so it survives `/clear`.

New section "### TIGHT-BAR triage and filter rules" inserted between Step 4 and Step 5 of Commit Audit. Cadence-stretch + recovery rules added to Phase 0.

## Test plan
- [x] Full suite: 5535/5535 passed
- [x] 12 new conformance checks in `tests/test-skill-conformance.sh` (6 fingerprints × source + mirror) — all pass
- [x] Mirror byte-equal
- [x] `metadata.version` bumped (`2026.05.20+51a254` → `2026.05.22+3b81a7`)
- [ ] CI re-runs the suite on rebased branch
