### PR TITLE
docs(claude): update skill counts to 25 core + 4 add-ons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@
 
 Skill distribution repo and presentation site for Z Skills.
 
-- `skills/` — source skill definitions (18 core)
-- `block-diagram/` — add-on skills (3)
+- `skills/` — source skill definitions (25 core)
+- `block-diagram/` — add-on skills (4)
 - `.claude/skills/` — installed skill copies (what Claude Code reads)
 - `hooks/` — source hook scripts
 - `scripts/` — consumer-customizable stubs (stop-dev.sh, test-all.sh) and release-only repo tooling (build-prod.sh, mirror-skill.sh); skill machinery moved to `.claude/skills/<owner>/scripts/` (port.sh, clear-tracking.sh, statusline.sh in `update-zskills`; plan-drift-correct.sh in `run-plan`; full mapping in `skills/update-zskills/references/script-ownership.md`)

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -499,6 +499,21 @@ for _landed_status in full landed partial pr-ready pr-ci-failing pr-failed \
     "grep -qF '\"$_landed_status\"' .claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js"
 done
 
+# Issue #649: CLAUDE.md Architecture section's skill counts must match
+# `ls -d skills/*/` and `ls -d block-diagram/*/` (minus screenshots).
+# Stale counts ship outdated framing to every consumer reading CLAUDE.md.
+# These are two intentionally single-domain checks — one probes skills/,
+# the sibling check probes block-diagram/ — so the framework-wide
+# meta-lint's "must also reference block-diagram/" rule doesn't apply.
+# The opt-out below must sit IMMEDIATELY before the first `check` line
+# (no intervening non-marker lines) because the meta-lint resets the
+# skip flag on any non-marker line.
+# block-diagram-exempt: CLAUDE.md count check; sibling assertion below covers block-diagram/
+check "CLAUDE.md skills/ count matches ls -d skills/*/" \
+  "test \"\$(grep -oE '\\([0-9]+ core\\)' CLAUDE.md | head -1 | grep -oE '[0-9]+')\" = \"\$(ls -d skills/*/ | wc -l)\""
+check "CLAUDE.md block-diagram/ count matches ls -d block-diagram/*/ (minus screenshots)" \
+  "test \"\$(grep -oE 'add-on skills \\([0-9]+\\)' CLAUDE.md | head -1 | grep -oE '[0-9]+')\" = \"\$(ls -d block-diagram/*/ | grep -v screenshots | wc -l)\""
+
 # Emit format expected by tests/run-all.sh
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes #649

## Changes
- docs(claude): update skill counts to 25 core + 4 add-ons (#649)

`CLAUDE.md` lines 9-10 claimed `skills/` had 18 core + `block-diagram/` had 3 add-ons. Ground truth (per `ls -d skills/*/ | wc -l` and `ls -d block-diagram/*/ | grep -v screenshots | wc -l`): 25 core + 4 add-ons. The +1 add-on came from PR #584's git mv of /review-feedback. Conformance pin added to catch future drift.

## Test plan
- [x] Full suite passes (CI re-verifies on rebased branch)
- [x] Conformance pin: 2 checks asserting CLAUDE.md counts match `ls -d` output (block-diagram-exempt marker noted)
- [x] CLAUDE_TEMPLATE.md unaffected (counts only live in CLAUDE.md; no rerender needed)
- [ ] CI re-runs the suite on rebased branch
