### PR TITLE
fix(skills): propagate auto in parent→child drafting dispatches

### DIFF
--- a/.claude/skills/research-and-plan/SKILL.md
+++ b/.claude/skills/research-and-plan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Researches the domain, identifies sub-problems and dependencies,
   produces a meta-plan whose phases each delegate to /run-plan.
 metadata:
-  version: "2026.05.21+b00e01"
+  version: "2026.05.22+a7dd8e"
 ---
 
 # /research-and-plan [output FILE] \<description...> — Meta-Plan Decomposer
@@ -155,11 +155,27 @@ For each sub-problem:
    user specify).
 2. If research from Step 1 was written to a file, pass that path to the
    `/draft-plan` agent so it has the decomposition context.
-3. Dispatch: `/draft-plan output <path> <sub-problem description>`
+3. Dispatch: `/draft-plan output <path> <sub-problem description>$AUTO_ARG`
+   - **`$AUTO_ARG` propagation.** If `/research-and-plan` itself was
+     invoked with `auto` (i.e. you are running under `/research-and-go`
+     or the user passed `auto` to /research-and-plan), thread that token
+     into every `/draft-plan` dispatch so the child skill's `AUTO_FLAG`
+     detection fires. Resolve once near the argument-detection block:
+     ```bash
+     AUTO_ARG=""
+     if [[ "$ARGUMENTS" =~ (^|[[:space:]])auto($|[[:space:]]) ]]; then
+       AUTO_ARG=" auto"
+     fi
+     ```
+     Then append `$AUTO_ARG` to every `/draft-plan` dispatch string.
+     Without this, `/draft-plan`'s `AUTO_FLAG` stays 0, the child commits
+     in its worktree and never dispatches `/land-pr`, and the sub-plan
+     is stranded on a `draft-plan/<slug>` branch instead of landing on
+     main. (Closure for #648; child-side fix was #581 / PR #642.)
    - **If `LANDING_ARG` is non-empty**, append `. Landing mode: <LANDING_ARG>`
      to the description so `/draft-plan` can embed the matching hint in
      the generated plan. Example:
-     `/draft-plan output $ZSKILLS_PLANS_DIR/X.md rounds 2 <description>. Landing mode: pr`
+     `/draft-plan output $ZSKILLS_PLANS_DIR/X.md rounds 2 <description>. Landing mode: pr$AUTO_ARG`
    - If `LANDING_ARG` is empty, omit the suffix entirely — do NOT pass
      an empty `Landing mode:` token.
 4. After each `/draft-plan` invocation returns, report progress, then

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.22+eaaa77"
+  version: "2026.05.22+0f12a4"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -143,6 +143,15 @@ fi
 # `/run-plan plan.md finish auto every 4h`.
 if [ "$FINISH_MODE" = "finish-auto" ]; then
   AUTO_FLAG=1
+fi
+
+# AUTO_ARG: the suffix string to thread into every child-skill dispatch
+# that recognizes positional `auto` (e.g. /refine-plan, /draft-plan,
+# /draft-tests per #581 / PR #642). Empty when AUTO_FLAG=0 so children
+# stay in non-auto behavior. Closure-incomplete #648 sites used this.
+AUTO_ARG=""
+if [ "$AUTO_FLAG" = "1" ]; then
+  AUTO_ARG=" auto"
 fi
 ```
 
@@ -901,8 +910,10 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    design, not actual code," the plan may be stale:
    - Without `auto`: tell the user "this plan was drafted before its
      dependency was implemented. Want me to refresh it with `/refine-plan`?"
-   - With `auto`: dispatch `/refine-plan` on the plan file to update it.
-     After the refresh, re-read the plan and continue.
+   - With `auto`: dispatch `/refine-plan <plan-file>$AUTO_ARG` on the plan
+     file to update it (the trailing `$AUTO_ARG` propagates auto so
+     /refine-plan's own AUTO_FLAG fires and it dispatches /land-pr per
+     #648). After the refresh, re-read the plan and continue.
    - Skip this check if the plan file was modified more recently than
      the dependency's completion (it may already be up to date).
 
@@ -947,10 +958,11 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
      this check for this phase)?"
    - **With `auto`:** if
      any bullet has drift >20%, dispatch
-     `/refine-plan <plan-file>` (plan-level issue, not per-band);
-     after refresh, re-read and continue. If all drifts are
-     ≤20%, log findings to the phase report and proceed — Phase
-     3.5 will auto-correct post-hoc within the ≤20% band.
+     `/refine-plan <plan-file>$AUTO_ARG` (plan-level issue, not per-band;
+     the trailing `$AUTO_ARG` propagates auto so /refine-plan dispatches
+     /land-pr per #648); after refresh, re-read and continue. If all
+     drifts are ≤20%, log findings to the phase report and proceed —
+     Phase 3.5 will auto-correct post-hoc within the ≤20% band.
 
 7. **Save the VERBATIM phase text** — copy the entire section from the plan
    file exactly as written. Every sentence, every bullet, every formula, every
@@ -1143,7 +1155,7 @@ skill manages its own worktree, verification, and landing.
 Use cases:
 - `### Execution: delegate /add-block DiscreteFilter` — block expansion
 - `### Execution: delegate /run-plan plans/SUB_PLAN.md finish auto` — meta-plans
-- `### Execution: delegate /draft-plan plans/FOO.md <description>` — plan generation
+- `### Execution: delegate /draft-plan plans/FOO.md <description> auto` — plan generation (omit `auto` if /run-plan was invoked without auto; thread `$AUTO_ARG` per #648)
 
 ### Plan-text drift signals
 

--- a/skills/research-and-plan/SKILL.md
+++ b/skills/research-and-plan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Researches the domain, identifies sub-problems and dependencies,
   produces a meta-plan whose phases each delegate to /run-plan.
 metadata:
-  version: "2026.05.21+b00e01"
+  version: "2026.05.22+a7dd8e"
 ---
 
 # /research-and-plan [output FILE] \<description...> — Meta-Plan Decomposer
@@ -155,11 +155,27 @@ For each sub-problem:
    user specify).
 2. If research from Step 1 was written to a file, pass that path to the
    `/draft-plan` agent so it has the decomposition context.
-3. Dispatch: `/draft-plan output <path> <sub-problem description>`
+3. Dispatch: `/draft-plan output <path> <sub-problem description>$AUTO_ARG`
+   - **`$AUTO_ARG` propagation.** If `/research-and-plan` itself was
+     invoked with `auto` (i.e. you are running under `/research-and-go`
+     or the user passed `auto` to /research-and-plan), thread that token
+     into every `/draft-plan` dispatch so the child skill's `AUTO_FLAG`
+     detection fires. Resolve once near the argument-detection block:
+     ```bash
+     AUTO_ARG=""
+     if [[ "$ARGUMENTS" =~ (^|[[:space:]])auto($|[[:space:]]) ]]; then
+       AUTO_ARG=" auto"
+     fi
+     ```
+     Then append `$AUTO_ARG` to every `/draft-plan` dispatch string.
+     Without this, `/draft-plan`'s `AUTO_FLAG` stays 0, the child commits
+     in its worktree and never dispatches `/land-pr`, and the sub-plan
+     is stranded on a `draft-plan/<slug>` branch instead of landing on
+     main. (Closure for #648; child-side fix was #581 / PR #642.)
    - **If `LANDING_ARG` is non-empty**, append `. Landing mode: <LANDING_ARG>`
      to the description so `/draft-plan` can embed the matching hint in
      the generated plan. Example:
-     `/draft-plan output $ZSKILLS_PLANS_DIR/X.md rounds 2 <description>. Landing mode: pr`
+     `/draft-plan output $ZSKILLS_PLANS_DIR/X.md rounds 2 <description>. Landing mode: pr$AUTO_ARG`
    - If `LANDING_ARG` is empty, omit the suffix entirely — do NOT pass
      an empty `Landing mode:` token.
 4. After each `/draft-plan` invocation returns, report progress, then

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.22+eaaa77"
+  version: "2026.05.22+0f12a4"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -143,6 +143,15 @@ fi
 # `/run-plan plan.md finish auto every 4h`.
 if [ "$FINISH_MODE" = "finish-auto" ]; then
   AUTO_FLAG=1
+fi
+
+# AUTO_ARG: the suffix string to thread into every child-skill dispatch
+# that recognizes positional `auto` (e.g. /refine-plan, /draft-plan,
+# /draft-tests per #581 / PR #642). Empty when AUTO_FLAG=0 so children
+# stay in non-auto behavior. Closure-incomplete #648 sites used this.
+AUTO_ARG=""
+if [ "$AUTO_FLAG" = "1" ]; then
+  AUTO_ARG=" auto"
 fi
 ```
 
@@ -901,8 +910,10 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    design, not actual code," the plan may be stale:
    - Without `auto`: tell the user "this plan was drafted before its
      dependency was implemented. Want me to refresh it with `/refine-plan`?"
-   - With `auto`: dispatch `/refine-plan` on the plan file to update it.
-     After the refresh, re-read the plan and continue.
+   - With `auto`: dispatch `/refine-plan <plan-file>$AUTO_ARG` on the plan
+     file to update it (the trailing `$AUTO_ARG` propagates auto so
+     /refine-plan's own AUTO_FLAG fires and it dispatches /land-pr per
+     #648). After the refresh, re-read the plan and continue.
    - Skip this check if the plan file was modified more recently than
      the dependency's completion (it may already be up to date).
 
@@ -947,10 +958,11 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
      this check for this phase)?"
    - **With `auto`:** if
      any bullet has drift >20%, dispatch
-     `/refine-plan <plan-file>` (plan-level issue, not per-band);
-     after refresh, re-read and continue. If all drifts are
-     ≤20%, log findings to the phase report and proceed — Phase
-     3.5 will auto-correct post-hoc within the ≤20% band.
+     `/refine-plan <plan-file>$AUTO_ARG` (plan-level issue, not per-band;
+     the trailing `$AUTO_ARG` propagates auto so /refine-plan dispatches
+     /land-pr per #648); after refresh, re-read and continue. If all
+     drifts are ≤20%, log findings to the phase report and proceed —
+     Phase 3.5 will auto-correct post-hoc within the ≤20% band.
 
 7. **Save the VERBATIM phase text** — copy the entire section from the plan
    file exactly as written. Every sentence, every bullet, every formula, every
@@ -1143,7 +1155,7 @@ skill manages its own worktree, verification, and landing.
 Use cases:
 - `### Execution: delegate /add-block DiscreteFilter` — block expansion
 - `### Execution: delegate /run-plan plans/SUB_PLAN.md finish auto` — meta-plans
-- `### Execution: delegate /draft-plan plans/FOO.md <description>` — plan generation
+- `### Execution: delegate /draft-plan plans/FOO.md <description> auto` — plan generation (omit `auto` if /run-plan was invoked without auto; thread `$AUTO_ARG` per #648)
 
 ### Plan-text drift signals
 

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -593,6 +593,39 @@ for skill in draft-plan refine-plan draft-tests; do
 done
 
 echo ""
+echo "=== parent→child auto propagation — closure for #581 / PR #642 (#648) ==="
+# Issue #648: #581's child-side fix made /draft-plan, /refine-plan,
+# /draft-tests recognize positional `auto` and dispatch /land-pr.
+# But three parent dispatch sites didn't propagate `auto` to the
+# children, so under /research-and-go (or /run-plan auto pr with a stale
+# plan), the child skill commits in its worktree and never lands on
+# main. Each parent skill MUST:
+#   (a) resolve $AUTO_ARG from its own auto-detect block, and
+#   (b) thread $AUTO_ARG (or literal `auto`) into every dispatch string
+#       targeting a /draft-* or /refine-* child.
+for parent in research-and-plan run-plan; do
+  check_fixed "$parent" "AUTO_ARG resolver present"      'AUTO_ARG'
+done
+# /research-and-plan dispatches /draft-plan; site MUST carry $AUTO_ARG.
+check       research-and-plan "/draft-plan dispatch threads \$AUTO_ARG" \
+  '/draft-plan .*\$AUTO_ARG'
+# /run-plan dispatches /refine-plan; sites MUST carry $AUTO_ARG.
+check       run-plan "/refine-plan dispatch threads \$AUTO_ARG" \
+  '/refine-plan <plan-file>\$AUTO_ARG'
+# Both dispatch arms (textual staleness L912ish, arithmetic drift L961ish)
+# share the `/refine-plan <plan-file>$AUTO_ARG` literal. Assert exactly 2.
+# (The non-dispatch recommendation prose at "Recommend running
+# `/refine-plan <plan-file>` after close-out" uses no `$` after, so the
+# fixed-string `<plan-file>$AUTO_ARG` distinguishes dispatches reliably.)
+SITE_COUNT=$(grep -cF '/refine-plan <plan-file>$AUTO_ARG' "$REPO_ROOT/skills/run-plan/SKILL.md")
+if [ "$SITE_COUNT" -ge 2 ]; then
+  pass "[run-plan] both /refine-plan dispatch arms thread \$AUTO_ARG (count=$SITE_COUNT)"
+else
+  fail "[run-plan] both /refine-plan dispatch arms thread \$AUTO_ARG" \
+    "expected ≥2 occurrences, found $SITE_COUNT"
+fi
+
+echo ""
 echo "=== implementer subagent — impl-dispatch site pins (Verifier-cannot-run symmetry) ==="
 # Each impl-class dispatch (orchestrator asks a sub-agent to write code,
 # run tests, and/or commit) MUST declare `subagent_type: "implementer"`.


### PR DESCRIPTION
Fixes #648

## Changes
- fix(skills): propagate auto in parent→child drafting dispatches (#648)

Closure-incomplete on #581 (PR #642). 3 parent dispatch sites now propagate `auto` to their drafting children:
- `skills/research-and-plan/SKILL.md:158` → `/draft-plan ... $AUTO_ARG`
- `skills/run-plan/SKILL.md` L905 (textual staleness) → `/refine-plan <plan-file>$AUTO_ARG`
- `skills/run-plan/SKILL.md` L951 (arithmetic drift) → `/refine-plan <plan-file>$AUTO_ARG`
- `skills/run-plan/SKILL.md:1146` delegate-mode example — fixed for symmetry

Plus an `AUTO_ARG=""; [ AUTO_FLAG=1 ] && AUTO_ARG=" auto"` resolver in each parent so the propagation is mechanical, not template-literal. 5-check conformance pin in `tests/test-skill-conformance.sh`.

## Test plan
- [x] 5 new conformance pins all pass (`test-skill-conformance.sh: 648/648`)
- [x] Mirror byte-equal (2 diffs)
- [x] 2 `metadata.version` bumps (research-and-plan, run-plan)
- [x] Local env-state 7 failures in `test_zskills_monitor_server.sh` are NOT caused by this change (touched files don't intersect the dashboard surface; PR #650 CI on main passed those tests)
- [ ] CI re-runs the suite on rebased branch
