### PR TITLE
fix(dashboard): column-head separator + below-band visibility + drop-where-dropped

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.22+42ffc1"
+  version: "2026.05.22+90e90d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -809,14 +809,21 @@ code, pre, .mono {
 
 .column-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.4em;
   padding: 2px 4px;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-dim);
 }
+
+/* Push the move-all chevron group to the trailing edge of the column-head
+   while keeping the label/count pair tight (gap: 0.4em) at the leading
+   edge. Replaces the previous `justify-content: space-between` which
+   spread three children evenly and produced "Drafted66" — count touching
+   label — when the column was narrow. */
+.column-head .move-all-group { margin-left: auto; }
 
 .dropzone {
   list-style: none;

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1242,20 +1242,15 @@ function renderBelowPanelBand(opts) {
     ? (queues && queues.plans) || {}
     : (queues && queues.issues) || {};
 
-  // Count membership per BELOW_BAND column to decide band-level collapse.
-  // BACKLOG always renders as a drop-target even when empty (D5: drag-in
-  // affordance); the collapse rule fires only when BOTH columns are empty.
-  let totalCount = 0;
-  for (const c of BELOW_BAND_COLUMNS) {
-    const arr = queueDict[c] || [];
-    totalCount += arr.length;
-  }
-
+  // Below-panel band ALWAYS renders (post-#650 reversal). Backlog stays a
+  // visible drop-target even when empty (D5 affordance + "Drag here to
+  // defer" placeholder); Completed renders even when empty so the user
+  // sees a stable two-column band rather than the band appearing /
+  // disappearing as state changes.
   const band = el("div", {
     cls: "below-panel-band",
     attrs: { "data-kind": kind, role: "group", "aria-label": "Backlog and Completed" },
   });
-  if (totalCount === 0) band.setAttribute("hidden", "");
 
   for (const c of BELOW_BAND_COLUMNS) {
     const colDiv = el("div", { cls: "column" });
@@ -1918,8 +1913,8 @@ function onDragStart(ev) {
   const kind = card.getAttribute("data-kind");
   const slug = card.getAttribute("data-slug");
   const num = card.getAttribute("data-number");
-  // Phase 4 / W4.4 — capture the source column so onDrop can apply the
-  // D5 leftmost-active rewrite rule when dragging out of Backlog.
+  // Capture the source column for postQueue (used elsewhere to strip
+  // `completed` defensively, and for column-aware drag affordances).
   const sourceColumn = card.getAttribute("data-column");
   dragState = { kind, slug, num, sourceColumn };
   if (ev.dataTransfer) {
@@ -2031,17 +2026,7 @@ async function onDrop(ev) {
     dragState = null;
     return;
   }
-  // Phase 4 / W4.4 / D5 — When the drag SOURCE is Backlog, rewrite the
-  // destination to the leftmost active column ("triage" for issues,
-  // "drafted" for plans) regardless of which active column the user
-  // actually dropped onto. This is symmetric with how Backlog is
-  // conceptually "off the active flow" — promoting out of Backlog just
-  // means "make it active again," so we avoid forcing the user to
-  // remember the column order.
-  if (dragState.sourceColumn === "backlog" && targetCol !== "backlog") {
-    targetCol = (dragState.kind === "plan") ? "drafted" : "triage";
-    targetIdx = 0;
-  }
+  // Backlog→active: land where dropped (overrides plan D5; see PR description).
   if (dragState.kind === "plan" && dragState.slug) {
     await movePlan(dragState.slug, { col: targetCol, idx: targetIdx });
   } else if (dragState.kind === "issue" && dragState.num) {

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.22+42ffc1"
+  version: "2026.05.22+90e90d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -809,14 +809,21 @@ code, pre, .mono {
 
 .column-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.4em;
   padding: 2px 4px;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-dim);
 }
+
+/* Push the move-all chevron group to the trailing edge of the column-head
+   while keeping the label/count pair tight (gap: 0.4em) at the leading
+   edge. Replaces the previous `justify-content: space-between` which
+   spread three children evenly and produced "Drafted66" — count touching
+   label — when the column was narrow. */
+.column-head .move-all-group { margin-left: auto; }
 
 .dropzone {
   list-style: none;

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1242,20 +1242,15 @@ function renderBelowPanelBand(opts) {
     ? (queues && queues.plans) || {}
     : (queues && queues.issues) || {};
 
-  // Count membership per BELOW_BAND column to decide band-level collapse.
-  // BACKLOG always renders as a drop-target even when empty (D5: drag-in
-  // affordance); the collapse rule fires only when BOTH columns are empty.
-  let totalCount = 0;
-  for (const c of BELOW_BAND_COLUMNS) {
-    const arr = queueDict[c] || [];
-    totalCount += arr.length;
-  }
-
+  // Below-panel band ALWAYS renders (post-#650 reversal). Backlog stays a
+  // visible drop-target even when empty (D5 affordance + "Drag here to
+  // defer" placeholder); Completed renders even when empty so the user
+  // sees a stable two-column band rather than the band appearing /
+  // disappearing as state changes.
   const band = el("div", {
     cls: "below-panel-band",
     attrs: { "data-kind": kind, role: "group", "aria-label": "Backlog and Completed" },
   });
-  if (totalCount === 0) band.setAttribute("hidden", "");
 
   for (const c of BELOW_BAND_COLUMNS) {
     const colDiv = el("div", { cls: "column" });
@@ -1918,8 +1913,8 @@ function onDragStart(ev) {
   const kind = card.getAttribute("data-kind");
   const slug = card.getAttribute("data-slug");
   const num = card.getAttribute("data-number");
-  // Phase 4 / W4.4 — capture the source column so onDrop can apply the
-  // D5 leftmost-active rewrite rule when dragging out of Backlog.
+  // Capture the source column for postQueue (used elsewhere to strip
+  // `completed` defensively, and for column-aware drag affordances).
   const sourceColumn = card.getAttribute("data-column");
   dragState = { kind, slug, num, sourceColumn };
   if (ev.dataTransfer) {
@@ -2031,17 +2026,7 @@ async function onDrop(ev) {
     dragState = null;
     return;
   }
-  // Phase 4 / W4.4 / D5 — When the drag SOURCE is Backlog, rewrite the
-  // destination to the leftmost active column ("triage" for issues,
-  // "drafted" for plans) regardless of which active column the user
-  // actually dropped onto. This is symmetric with how Backlog is
-  // conceptually "off the active flow" — promoting out of Backlog just
-  // means "make it active again," so we avoid forcing the user to
-  // remember the column order.
-  if (dragState.sourceColumn === "backlog" && targetCol !== "backlog") {
-    targetCol = (dragState.kind === "plan") ? "drafted" : "triage";
-    targetIdx = 0;
-  }
+  // Backlog→active: land where dropped (overrides plan D5; see PR description).
   if (dragState.kind === "plan" && dragState.slug) {
     await movePlan(dragState.slug, { col: targetCol, idx: targetIdx });
   } else if (dragState.kind === "issue" && dragState.num) {

--- a/tests/test-dashboard-backlog-bidir.sh
+++ b/tests/test-dashboard-backlog-bidir.sh
@@ -61,8 +61,9 @@ if [ ! -f "$APP_JS" ]; then
   print_summary_and_exit
 fi
 
-# Static-grep contract: onDrop must reject completed drops and rewrite
-# from-backlog drops to leftmost active.
+# W4.9 (post-#650 reversal; was rewrite-to-leftmost) — Static-grep
+# contract: onDrop must still reject completed drops, but the D5
+# leftmost-active rewrite branch is REMOVED. Drops land where dropped.
 ONDROP_BODY=$(awk '/^async function onDrop\(/{f=1} f{print} f && /^}$/{exit}' "$APP_JS")
 if printf '%s' "$ONDROP_BODY" | grep -qE 'targetCol === "completed"'; then
   pass "onDrop guards on targetCol === 'completed'"
@@ -74,15 +75,18 @@ if printf '%s' "$ONDROP_BODY" | grep -q 'console.warn'; then
 else
   fail "onDrop completed reject missing console.warn"
 fi
+# Inverted: the sourceColumn==='backlog' rewrite branch must NOT exist.
 if printf '%s' "$ONDROP_BODY" | grep -qE 'sourceColumn === "backlog"'; then
-  pass "onDrop applies D5 backlog leftmost-active rewrite"
+  fail "onDrop still has D5 backlog leftmost-active rewrite (should be removed in post-#650 reversal)"
 else
-  fail "onDrop missing D5 backlog rewrite branch"
+  pass "onDrop no longer rewrites backlog drops — drops land where dropped (post-#650 reversal)"
 fi
-if printf '%s' "$ONDROP_BODY" | grep -qE 'D5'; then
-  pass "onDrop has explicit D5 code comment (W4.4)"
+# A one-line comment about the design reversal should be present so
+# future readers know D5 was inverted intentionally.
+if printf '%s' "$ONDROP_BODY" | grep -qE 'overrides plan D5|post-#650|land where dropped'; then
+  pass "onDrop has a comment noting the D5 design reversal"
 else
-  fail "onDrop missing explicit D5 citation"
+  fail "onDrop missing the D5-reversal comment — future readers won't know the inversion is intentional"
 fi
 
 # onDragStart must capture sourceColumn so onDrop knows to rewrite.
@@ -257,9 +261,10 @@ async function run() {
   expect(globalThis.__getDragState(), null, "T4.9.a dragState cleared after drop");
 
   // ------------------------------------------------------------------
-  // T4.9.b(i) — Drag issue from Backlog → Ready. D5 rewrite:
-  // target column is REWRITTEN to "triage" (leftmost active for issues),
-  // not "ready" (the dropzone the user actually targeted).
+  // T4.9.b(i) (post-#650 reversal; was rewrite-to-leftmost) — Drag issue
+  // from Backlog → Ready. Drops land where dropped: target stays "ready",
+  // not "triage". Idx is whatever computeInsertIndex returned (0 here
+  // because the test dropzone is empty).
   // ------------------------------------------------------------------
   globalThis.__resetCalls();
   const card2 = makeCard({ kind: "issue", num: 99, col: "backlog" });
@@ -268,14 +273,12 @@ async function run() {
   await onDrop(makeDropEvent(dz2));
   const calls2 = globalThis.__getMoveCalls();
   expect(calls2.issue.length, 1, "T4.9.b(i) moveIssue called once on Backlog→Ready");
-  expect(calls2.issue[0][1].col, "triage",
-    "T4.9.b(i) D5 rewrite: Backlog→Ready becomes triage (leftmost active for issues)");
-  expect(calls2.issue[0][1].idx, 0,
-    "T4.9.b(i) D5 rewrite places card at idx=0 of leftmost active");
+  expect(calls2.issue[0][1].col, "ready",
+    "T4.9.b(i) Backlog→Ready lands in Ready (drops land where dropped; D5 rewrite removed)");
 
   // ------------------------------------------------------------------
-  // T4.9.b(ii) — Drag plan from Backlog → Ready. D5 rewrite:
-  // target column is REWRITTEN to "drafted" (leftmost active for plans).
+  // T4.9.b(ii) (post-#650 reversal) — Drag plan from Backlog → Ready.
+  // Target stays "ready", not "drafted".
   // ------------------------------------------------------------------
   globalThis.__resetCalls();
   const card3 = makeCard({ kind: "plan", slug: "p1", col: "backlog" });
@@ -284,25 +287,26 @@ async function run() {
   await onDrop(makeDropEvent(dz3));
   const calls3 = globalThis.__getMoveCalls();
   expect(calls3.plan.length, 1, "T4.9.b(ii) movePlan called once on Backlog→Ready (plan)");
-  expect(calls3.plan[0][1].col, "drafted",
-    "T4.9.b(ii) D5 rewrite: Backlog→Ready becomes drafted (leftmost active for plans)");
+  expect(calls3.plan[0][1].col, "ready",
+    "T4.9.b(ii) Backlog→Ready (plan) lands in Ready (drops land where dropped; D5 rewrite removed)");
 
   // ------------------------------------------------------------------
-  // T4.9.b(iii) — Drag plan from Backlog → Drafted. Already leftmost;
-  // post body has drafted (no rewrite visible but result is identical).
+  // T4.9.b(iii) (post-#650 reversal) — Drag plan from Backlog → Reviewed.
+  // Target stays "reviewed", proving the user's chosen column is honored
+  // even when it's NOT the leftmost active column.
   // ------------------------------------------------------------------
   globalThis.__resetCalls();
   const card3b = makeCard({ kind: "plan", slug: "p2", col: "backlog" });
   onDragStart(makeDragEvent(card3b));
-  const dz3b = makeDropzone("plan", "drafted");
+  const dz3b = makeDropzone("plan", "reviewed");
   await onDrop(makeDropEvent(dz3b));
   const calls3b = globalThis.__getMoveCalls();
-  expect(calls3b.plan[0][1].col, "drafted",
-    "T4.9.b(iii) Backlog→Drafted (already leftmost) lands on drafted");
+  expect(calls3b.plan[0][1].col, "reviewed",
+    "T4.9.b(iii) Backlog→Reviewed (non-leftmost target) lands in Reviewed — honors user's chosen column");
 
   // ------------------------------------------------------------------
-  // T4.9.b(iv) — Drag from Ready (NOT backlog) → Backlog. Source is
-  // active, target is backlog — D5 rewrite must NOT fire.
+  // T4.9.b(iv) — Drag from Ready (NOT backlog) → Backlog. Always landed
+  // in backlog (defer). Unchanged by the reversal.
   // ------------------------------------------------------------------
   globalThis.__resetCalls();
   const card4 = makeCard({ kind: "issue", num: 50, col: "ready" });
@@ -311,7 +315,7 @@ async function run() {
   await onDrop(makeDropEvent(dz4));
   const calls4 = globalThis.__getMoveCalls();
   expect(calls4.issue[0][1].col, "backlog",
-    "T4.9.b(iv) Ready→Backlog (active source) does NOT trigger D5 rewrite");
+    "T4.9.b(iv) Ready→Backlog (active source) lands in backlog as defer");
 
   // ------------------------------------------------------------------
   // T4.9.c — Drop onto data-column="completed" is rejected + warns.

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -894,17 +894,28 @@ else
   fail "W3.5 / D3: .below-panel-band composed with .columns-2 (D3 violation)"
 fi
 
-# W3.7 — Count-derived collapse. Band sets `hidden` only when BOTH
-# sub-columns are empty; Backlog renders a placeholder when empty.
+# W3.7 (post-#650 reversal) — Below-panel band ALWAYS visible. The prior
+# count-derived collapse (`if (totalCount === 0) band.setAttribute("hidden", "")`)
+# was removed because the collapsing band created a moving-target UX:
+# Backlog should always present as a stable drop affordance, and Completed
+# should always show its header (even at 0) so the user has a stable
+# spatial anchor. Backlog still renders a placeholder when empty.
 BAND_BODY=$(awk '
   /^function renderBelowPanelBand\(/ { flag=1 }
   flag { print }
   flag && /^}$/ { exit }
 ' "$APP_JS")
-if echo "$BAND_BODY" | grep -qE 'if \(totalCount === 0\) band\.setAttribute\("hidden", ""\)'; then
-  pass "W3.7: band sets hidden when totalCount (Backlog + Completed) is 0"
+# Negative assertion: the collapse predicate must NOT exist anymore.
+if echo "$BAND_BODY" | grep -qE 'setAttribute\("hidden"'; then
+  fail "W3.7: band must NOT call setAttribute('hidden',...) — collapse logic removed in post-#650 reversal"
 else
-  fail "W3.7: collapse logic missing or wrong predicate"
+  pass "W3.7: band has no setAttribute('hidden',...) call — always-visible reversal landed"
+fi
+# Negative assertion: the dead totalCount accumulator must also be gone.
+if echo "$BAND_BODY" | grep -qE 'totalCount \+= arr\.length'; then
+  fail "W3.7: dead totalCount accumulator still present — should be removed"
+else
+  pass "W3.7: dead totalCount accumulator removed alongside collapse predicate"
 fi
 if echo "$BAND_BODY" | grep -qE 'if \(c === "backlog" && arr\.length === 0\)'; then
   pass "W3.7: Backlog renders placeholder drop-target when empty"
@@ -996,29 +1007,32 @@ else
   fail "renders_backlog_band_below_plans_panel — buildPlanCard not invoked in band"
 fi
 
-# W3.11 — below_panel_band_visible_when_backlog_empty_but_no_completed
-# Backlog is always a visible drop-target; band stays visible whenever
-# Backlog has items (totalCount > 0). Test the predicate: collapse fires
-# ONLY when totalCount === 0 (both empty), NOT when one is empty.
-if echo "$BAND_BODY" | grep -qE 'totalCount \+= arr\.length'; then
-  pass "below_panel_band_visible_when_backlog_empty_but_no_completed — totalCount sums BOTH sub-columns"
+# W3.11 (post-#650 reversal; was below_panel_band_visible_when_backlog_empty_but_no_completed)
+# Reframed: the band is ALWAYS visible, no matter which sub-column is
+# empty. The Backlog dropzone must be present (it's the user's defer
+# affordance) and Completed must render its header even at zero.
+if echo "$BAND_BODY" | grep -qE 'data-column": c'; then
+  pass "below_panel_band_always_visible — Backlog dropzone <ul> wired (data-column=c, accepts drops)"
 else
-  fail "below_panel_band_visible_when_backlog_empty_but_no_completed — totalCount accumulator missing"
+  fail "below_panel_band_always_visible — Backlog dropzone <ul> missing data-column wiring"
 fi
-# Predicate must be `=== 0`, not `<= 0` or `!== ...` — exact-zero gate.
-if echo "$BAND_BODY" | grep -qE 'if \(totalCount === 0\) band\.setAttribute\("hidden"'; then
-  pass "below_panel_band_visible_when_backlog_empty_but_no_completed — collapse predicate is exact-zero (both-empty)"
+# Completed column-head must be appended unconditionally; the loop over
+# BELOW_BAND_COLUMNS already does this, but pin the absence of any
+# completed-specific skip-when-empty guard.
+if echo "$BAND_BODY" | grep -qE 'completed.*continue|completed.*return'; then
+  fail "below_panel_band_always_visible — Completed has an early-skip when empty (should always render)"
 else
-  fail "below_panel_band_visible_when_backlog_empty_but_no_completed — collapse predicate wrong"
+  pass "below_panel_band_always_visible — Completed renders unconditionally (no skip-when-empty)"
 fi
 
-# W3.12 — below_panel_band_collapse_when_both_empty
-# Already exercised by W3.7 predicate test above; pin under the named
-# acceptance label for explicit phase coverage.
-if echo "$BAND_BODY" | grep -qE 'if \(totalCount === 0\) band\.setAttribute\("hidden"'; then
-  pass "below_panel_band_collapse_when_both_empty — hidden attribute set on zero-count band"
+# W3.12 (post-#650 reversal; was below_panel_band_collapse_when_both_empty)
+# Old behavior: band sets `hidden=""` when totalCount===0. New behavior:
+# band always renders so the spatial layout is stable. Assert the
+# inversion: no `hidden` attribute is ever set on the band element.
+if echo "$BAND_BODY" | grep -qE 'band\.setAttribute\("hidden"'; then
+  fail "below_panel_band_always_visible_with_backlog_droptarget — band must NOT set hidden attribute"
 else
-  fail "below_panel_band_collapse_when_both_empty — hidden attr never set"
+  pass "below_panel_band_always_visible_with_backlog_droptarget — band does not call setAttribute('hidden') (always visible)"
 fi
 
 # W3.12b — truncation_banner_renders_with_actual_limit_value
@@ -1115,16 +1129,19 @@ else
   fail "W4.12b onDrop missing completed-target reject (AC4.6)"
 fi
 
-# W4.12c — D5 leftmost-active rewrite on backlog-source drag.
+# W4.12c (post-#650 reversal) — D5 leftmost-active rewrite REMOVED.
+# Drops from Backlog now land where dropped (the user's chosen active
+# column is honored). Assert the inversion: no sourceColumn==='backlog'
+# branch survives, and a comment notes the reversal.
 if echo "$ONDROP_BODY" | grep -qE 'sourceColumn === "backlog"'; then
-  pass "W4.12c onDrop applies D5 backlog leftmost-rewrite (AC4.5)"
+  fail "W4.12c onDrop still rewrites backlog drops — D5 rewrite should be removed (post-#650 reversal, AC4.5 inverted)"
 else
-  fail "W4.12c onDrop missing D5 backlog rewrite branch"
+  pass "W4.12c onDrop no longer rewrites backlog→active drops (lands where dropped; post-#650 reversal)"
 fi
-if echo "$ONDROP_BODY" | grep -qE 'D5'; then
-  pass "W4.12c onDrop carries explicit D5 code-comment citation (W4.4)"
+if echo "$ONDROP_BODY" | grep -qE 'overrides plan D5|post-#650|land where dropped'; then
+  pass "W4.12c onDrop has a comment noting the D5 design reversal"
 else
-  fail "W4.12c onDrop missing explicit D5 citation comment"
+  fail "W4.12c onDrop missing D5-reversal comment — future readers won't know the inversion is intentional"
 fi
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Three follow-up fixes to issues that shipped in PR #650 (`completed-backlog-sections`). All three touch the same column-head / below-band rendering code in `app.js` and `app.css`.

## What changed

1. **Visible separator between title and count** — `.column-head` was a flexbox with `justify-content: space-between`, which only spaces *out* a 2-child row; with three children (label, count, move-all chevron group) the count and label collapsed adjacent ("Drafted66"). Switched to `align-items: baseline; gap: 0.4em` plus `margin-left: auto` on the move-all group so the chevron stays at the trailing edge. Applies to both active-row column headers AND below-band headers via a single `.column-head` rule.

2. **Below-panel band always renders** — removed the `if (totalCount === 0) band.setAttribute("hidden", "")` line from `renderBelowPanelBand` (and the now-dead `totalCount` accumulator above it). The original plan's W3.7 spec was self-contradictory ("Backlog ALWAYS renders as a visible drop-target even when empty" + "the Completed sub-column collapses... ONLY when BOTH sub-columns are empty"); the Phase 3 implementer chose the wrong interpretation and W3.12 locked it in. With both fresh-repo states (no in-window completed plans, nothing in backlog), the Plans tab's below-band silently disappeared, leaving no drop-target. Now the band always renders with the existing "Drag here to defer" placeholder when Backlog is empty.

3. **Drop where dropped — reverses plan D5** — removed the `sourceColumn === "backlog"` block in `onDrop` that rewrote `targetCol` to the leftmost active column (`triage` for issues, `drafted` for plans) regardless of which active column received the drop. **This is a deliberate UX design reversal of plan Locked Decision D5 from PR #650**, not a regression. The user's explicit drop target is the meaningful state change; forcing every Backlog-→active drag through the leftmost column ignored user intent and produced "I dropped on Ready and it landed in Drafted, now I have to drag it again" pain. The `«` move-all chevron on the Backlog column-head continues to use adjacent-step semantics (it points at Ready) which is fine for "move all unclaimed back to active flow" semantics — only the drag path changes.

## D5 reversal rationale (for future readers)

Plan `plans/completed-backlog-sections.md` D5 codified rewrite-to-leftmost with the rationale "promoting just means 'make it active again,' and rewrite-to-leftmost avoids forcing the user to remember column order." Hands-on use revealed the rationale was weak:
- The user already chose a column by dropping on it; "they didn't really mean Ready" is the design overruling the user's literal action.
- Columns are visible right there — the user isn't recalling order from memory.
- The user now has to drag twice (Drafted → Ready) to get the card where they originally aimed.
- It's asymmetric with every other inter-column drag, which lands where dropped.

The plan file itself is NOT edited (`status: complete` — historical record preserved). This PR's commit message and the body above are the canonical source for the reversal.

## Tests

Two tests currently encoded the broken behavior. Both are FLIPPED, not deleted. Each flipped assertion is more specific than the original (e.g., T4.9.b(iii) now targets `reviewed` — a non-leftmost column that only the new behavior could hit — where the original asserted `drafted`, which coincidentally matched the old rewrite output).

- `tests/test_zskills_monitor_dashboard_ui.sh` — W3.7 / W3.11 / W3.12 / W4.12c inverted with negative-grep on the removed code and positive-grep on the new D5-reversal comment.
- `tests/test-dashboard-backlog-bidir.sh` — W4.9 JSDOM cases T4.9.b(i)/(ii)/(iii) now assert drop-target column is honored.

Full suite: `Overall: 5898/5898 passed, 0 failed`.

## Manual verification

Playwright screenshots at `.playwright/output/phase-do-*.png`:
- `phase-do-0-prefix-baseline.png` — baseline showing `DRAFTED66` adjacency (the bug).
- `phase-do-1-header-separation.png` — Fix 1 active: `DRAFTED 66` with visible gap, chevrons at trailing edge.
- `phase-do-2b-below-band-scrolled.png` — Fix 2 active: `BACKLOG 0` and `COMPLETED 0` both rendered even with both empty.

Fix 3 (drag) was NOT visually verified in playwright because the running dashboard is anchored to `MAIN_ROOT` via `git rev-parse --git-common-dir` and serves main's pre-fix JS regardless of which worktree starts the server. The JSDOM bidir-drag harness in `test-dashboard-backlog-bidir.sh` exercises the worktree's `onDrop` directly with synthetic events; T4.9.b(i)/(ii)/(iii) cover the lands-where-dropped behavior across both kinds and across leftmost / non-leftmost target columns. Worth a follow-up to support worktree-rooted dashboard launches so future agents can do live drag verification end-to-end.

## Notes for reviewers

- This corrective PR is a sibling to PR #650 in scope: tightly-scoped UX polish + spec reversal that hands-on use surfaced. No new tests; only flips.
- The Phase 3 implementer's defensive `postQueue` strip of `completed` (added in #650 as defense-in-depth) is left in place — it remains a useful safety net.
