### PR TITLE
do: add topline summary slides for reports/

### DIFF
--- a/reports/slide-cost-methodology.html
+++ b/reports/slide-cost-methodology.html
@@ -39,7 +39,7 @@
 <div class="frame">
   <div class="eyebrow">Cost Methodology</div>
   <h1>How the cost figure was computed</h1>
-  <p class="deck">From <strong>raw session transcripts</strong> to a defensible cost estimate. The methodology dedup&shy;licates against <code>message.id</code> because Claude Code splits each API response into multiple JSONL records (one per content block).</p>
+  <p class="deck">From <strong>raw session transcripts</strong> to a defensible cost estimate. See the <a href="COSTS.html#method">full methodology section</a> of the cost report for the dedup logic, API-response semantics, and verification details.</p>
 
   <div class="flow">
     <div class="step"><span class="num">1</span><h3>Collect</h3><p>Scan 1,617 JSONL files across 8 project working directories (<code>~/.claude/projects/-workspaces-zskills/</code> + 7 worktree-spawned dirs). Extract every assistant <code>usage</code> record.</p></div>

--- a/reports/slide-cost-methodology.html
+++ b/reports/slide-cost-methodology.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Cost Methodology — Z Skills</title>
+<style>
+  :root {
+    --bg: #0d1117; --surface: #161b22; --surface2: #1c2129; --border: #30363d;
+    --text: #e6edf3; --text-dim: #8b949e;
+    --accent: #58a6ff; --accent2: #bc8cff;
+    --green: #3fb950; --orange: #d29922; --pink: #f778ba;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; padding: 56px 64px; }
+  .frame { max-width: 1240px; margin: 0 auto; }
+  .eyebrow { color: var(--text-dim); font-size: 0.9em; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
+  h1 { font-size: 2.4em; font-weight: 700; line-height: 1.15; margin-bottom: 12px; background: linear-gradient(135deg, var(--accent), var(--accent2)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+  .deck { color: var(--text-dim); font-size: 1.1em; max-width: 900px; margin-bottom: 32px; }
+  .deck strong { color: var(--text); }
+  code { background: var(--surface2); padding: 1px 6px; border-radius: 4px; font-size: 0.95em; }
+  .flow { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; margin-bottom: 32px; }
+  .step { background: var(--surface); border: 1px solid var(--border); padding: 22px 18px; position: relative; }
+  .step:first-child { border-radius: 8px 0 0 8px; }
+  .step:last-child { border-radius: 0 8px 8px 0; }
+  .step + .step { border-left: none; }
+  .step + .step::before { content: ''; position: absolute; left: -10px; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 9px solid transparent; border-bottom: 9px solid transparent; border-left: 10px solid var(--accent); z-index: 1; }
+  .step .num { display: inline-block; background: var(--accent); color: var(--bg); font-weight: 700; font-size: 0.85em; padding: 1px 9px; border-radius: 999px; margin-bottom: 10px; }
+  .step h3 { font-size: 1.05em; color: var(--text); margin-bottom: 8px; }
+  .step p { color: var(--text-dim); font-size: 0.9em; margin: 0; }
+  .verif { background: var(--surface); border: 1px solid var(--border); border-left: 4px solid var(--green); border-radius: 8px; padding: 20px 22px; margin-bottom: 16px; }
+  .verif h3 { color: var(--text); font-size: 1em; margin-bottom: 10px; letter-spacing: 0.03em; }
+  .verif ul { color: var(--text-dim); font-size: 0.92em; list-style: none; padding-left: 0; }
+  .verif li { padding: 3px 0; padding-left: 22px; position: relative; }
+  .verif li::before { content: '✓'; position: absolute; left: 0; color: var(--green); font-weight: 700; }
+  .footnote { color: var(--text-dim); font-size: 0.85em; margin-top: 12px; padding-top: 16px; border-top: 1px solid var(--border); }
+</style>
+</head>
+<body>
+<div class="frame">
+  <div class="eyebrow">Cost Methodology</div>
+  <h1>How the cost figure was computed</h1>
+  <p class="deck">From <strong>raw session transcripts</strong> to a defensible cost estimate. The methodology dedup&shy;licates against <code>message.id</code> because Claude Code splits each API response into multiple JSONL records (one per content block).</p>
+
+  <div class="flow">
+    <div class="step"><span class="num">1</span><h3>Collect</h3><p>Scan 1,617 JSONL files across 8 project working directories (<code>~/.claude/projects/-workspaces-zskills/</code> + 7 worktree-spawned dirs). Extract every assistant <code>usage</code> record.</p></div>
+    <div class="step"><span class="num">2</span><h3>Dedup</h3><p>Group records by <code>message.id</code> — one ID = one API response. For <code>output_tokens</code> (cumulative across streaming records) take the max; other fields are constant per response.</p></div>
+    <div class="step"><span class="num">3</span><h3>Price</h3><p>Apply Anthropic's published per-MTok rates: Opus 4.7 at $5/$25/$6.25/$10/$0.50; Haiku 4.5 at $1/$5/$1.25/$2/$0.10. No Fast mode, no batch, default global residency.</p></div>
+    <div class="step"><span class="num">4</span><h3>Project</h3><p>For the 23-day Opus 4.6 era (pre-logging), scale the logged daily rate by commits/day workload ratio (0.633). Range bounded for tokenizer-density uncertainty.</p></div>
+  </div>
+
+  <div class="verif">
+    <h3>Verification</h3>
+    <ul>
+      <li><strong>API semantics</strong> — Anthropic streaming docs confirm <code>usage</code> is per-response, with cumulative <code>output_tokens</code> across <code>message_delta</code> events.</li>
+      <li><strong>Field consistency</strong> — 100% of multi-record <code>message.id</code>s show identical <code>input_tokens</code> / <code>cache_*</code> values (verified across 35k+ multi-record IDs).</li>
+      <li><strong>Cross-file uniqueness</strong> — no <code>message.id</code> appears in more than one JSONL.</li>
+      <li><strong>Manual trace</strong> — 20 random message.ids inspected by hand; matches dedup logic.</li>
+      <li><strong>End-to-end session walk</strong> — a short session counted by eye (5 API responses) matches dedup-by-id (5).</li>
+      <li><strong>Three arithmetic methods</strong> — aggregate, per-record, per-day — reproduce the grand total to the cent.</li>
+    </ul>
+  </div>
+
+  <div class="footnote">
+    Limits: pre-2026-04-18 era has no JSONL transcripts — its cost is a workload-ratio projection, not a measurement. No external billing oracle (Claude Max subscription has no per-token invoice).
+  </div>
+</div>
+</body>
+</html>

--- a/reports/slide-cost-topline.html
+++ b/reports/slide-cost-topline.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Cost Topline — Z Skills</title>
+<style>
+  :root {
+    --bg: #0d1117; --surface: #161b22; --surface2: #1c2129; --border: #30363d;
+    --text: #e6edf3; --text-dim: #8b949e;
+    --accent: #58a6ff; --accent2: #bc8cff;
+    --green: #3fb950; --orange: #d29922; --pink: #f778ba;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; padding: 56px 64px; }
+  .frame { max-width: 1240px; margin: 0 auto; }
+  .eyebrow { color: var(--text-dim); font-size: 0.9em; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
+  h1 { font-size: 2.4em; font-weight: 700; line-height: 1.15; margin-bottom: 12px; background: linear-gradient(135deg, var(--accent), var(--accent2)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+  .deck { color: var(--text-dim); font-size: 1.1em; max-width: 900px; margin-bottom: 32px; }
+  .deck strong { color: var(--text); }
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; margin-bottom: 24px; }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 8px; padding: 22px 20px; }
+  .stat.orange { border-left-color: var(--orange); }
+  .stat.green { border-left-color: var(--green); }
+  .stat.purple { border-left-color: var(--accent2); }
+  .stat.pink { border-left-color: var(--pink); }
+  .stat .val { font-size: 2.2em; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; line-height: 1.1; }
+  .stat .label { font-size: 0.8em; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 6px; }
+  .stat .sub { color: var(--text-dim); font-size: 0.85em; margin-top: 8px; line-height: 1.4; }
+  .footnote { color: var(--text-dim); font-size: 0.85em; margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--border); }
+  .footnote code { background: var(--surface2); padding: 1px 6px; border-radius: 4px; font-size: 0.95em; }
+</style>
+</head>
+<body>
+<div class="frame">
+  <div class="eyebrow">Cost Topline</div>
+  <h1>What Z Skills cost — at Claude API list prices</h1>
+  <p class="deck"><strong>Actual out-of-pocket:</strong> $200/mo Claude Max x20 subscription. The numbers below are the API-list-price equivalent of the same work, computed from 1,617 JSONL session transcripts.</p>
+
+  <div class="stats">
+    <div class="stat orange">
+      <div class="val">$8,916</div>
+      <div class="label">Logged spend</div>
+      <div class="sub">Opus 4.7 + Haiku 4.5 across 34 days (2026-04-18 → 2026-05-22), 55,520 distinct API responses.</div>
+    </div>
+    <div class="stat pink">
+      <div class="val">~$12.7k</div>
+      <div class="label">Projected total</div>
+      <div class="sub">Logged plus an estimate for the 23-day Opus 4.6 era that pre-dates JSONL logging. Range ~$11.7k–$13.5k.</div>
+    </div>
+    <div class="stat green">
+      <div class="val">715 / 410</div>
+      <div class="label">Commits / merged PRs</div>
+      <div class="sub">What was actually built on <code>main</code>. ~5 commits and ~3 merged PRs per day on average.</div>
+    </div>
+    <div class="stat purple">
+      <div class="val">9.7 B</div>
+      <div class="label">Tokens processed</div>
+      <div class="sub">~9.74 B input-side + 41 M output across 55,520 API responses. Heavy prompt caching kept the bill at $8,916 rather than ~$50k.</div>
+    </div>
+  </div>
+
+  <div class="footnote">
+    Per-API-response billing (dedup by <code>message.id</code>). Rates from <code>platform.claude.com/docs/en/about-claude/pricing</code>, fetched 2026-05-21. Opus 4.5/4.6/4.7 share the same rate card.
+  </div>
+</div>
+</body>
+</html>

--- a/reports/slide-cost-topline.html
+++ b/reports/slide-cost-topline.html
@@ -34,7 +34,7 @@
 <div class="frame">
   <div class="eyebrow">Cost Topline</div>
   <h1>What Z Skills cost — at Claude API list prices</h1>
-  <p class="deck"><strong>Actual out-of-pocket:</strong> $200/mo Claude Max x20 subscription. The numbers below are the API-list-price equivalent of the same work, computed from 1,617 JSONL session transcripts.</p>
+  <p class="deck"><strong>Actual out-of-pocket:</strong> $200/mo Claude Max x20 subscription + ~$500 in extra usage. The numbers below are the API-list-price equivalent of the same work, computed from 1,617 JSONL session transcripts.</p>
 
   <div class="stats">
     <div class="stat orange">

--- a/reports/slide-permissions-topline.html
+++ b/reports/slide-permissions-topline.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Permissions Topline — Z Skills</title>
+<style>
+  :root {
+    --bg: #0d1117; --surface: #161b22; --surface2: #1c2129; --border: #30363d;
+    --text: #e6edf3; --text-dim: #8b949e;
+    --accent: #58a6ff; --accent2: #bc8cff;
+    --green: #3fb950; --orange: #d29922; --pink: #f778ba;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; padding: 56px 64px; }
+  .frame { max-width: 1240px; margin: 0 auto; }
+  .eyebrow { color: var(--text-dim); font-size: 0.9em; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 8px; }
+  h1 { font-size: 2.4em; font-weight: 700; line-height: 1.15; margin-bottom: 12px; background: linear-gradient(135deg, var(--accent), var(--accent2)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+  .deck { color: var(--text-dim); font-size: 1.1em; max-width: 900px; margin-bottom: 32px; }
+  .deck strong { color: var(--text); }
+  code { background: var(--surface2); padding: 1px 6px; border-radius: 4px; font-size: 0.95em; }
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; margin-bottom: 24px; }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 8px; padding: 22px 20px; }
+  .stat.orange { border-left-color: var(--orange); }
+  .stat.green { border-left-color: var(--green); }
+  .stat.purple { border-left-color: var(--accent2); }
+  .stat.pink { border-left-color: var(--pink); }
+  .stat .val { font-size: 2.2em; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; line-height: 1.1; }
+  .stat .label { font-size: 0.8em; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 6px; }
+  .stat .sub { color: var(--text-dim); font-size: 0.85em; margin-top: 8px; line-height: 1.4; }
+  .driver { background: var(--surface); border: 1px solid var(--border); border-left: 4px solid var(--orange); border-radius: 8px; padding: 18px 22px; margin-bottom: 16px; display: flex; align-items: baseline; gap: 18px; }
+  .driver .big { font-size: 1.8em; font-weight: 700; color: var(--orange); font-variant-numeric: tabular-nums; }
+  .driver .text { color: var(--text-dim); font-size: 0.95em; }
+  .driver .text strong { color: var(--text); }
+  .footnote { color: var(--text-dim); font-size: 0.85em; margin-top: 12px; padding-top: 16px; border-top: 1px solid var(--border); }
+</style>
+</head>
+<body>
+<div class="frame">
+  <div class="eyebrow">Permissions Topline</div>
+  <h1>Approvals that would have fired</h1>
+  <p class="deck">Z Skills development ran with <code>--dangerously-skip-permissions</code>. Under a representative enterprise-leaning config (<code>EXAMPLE_settings.json</code>) the same workload would have generated <strong>~2,695 permission prompts</strong> across the 34-day logged window. The headline scales heavily with what's in <code>ask</code>.</p>
+
+  <div class="stats">
+    <div class="stat orange">
+      <div class="val">~2,695</div>
+      <div class="label">Total estimated prompts</div>
+      <div class="sub">~79/day average over 34 days. Mix of front-loaded one-time and sustained recurring.</div>
+    </div>
+    <div class="stat">
+      <div class="val">1,228</div>
+      <div class="label">Every-time (recurring)</div>
+      <div class="sub">From <code>ask</code> rules. Prompt on every invocation; no "always-allow" escape.</div>
+    </div>
+    <div class="stat purple">
+      <div class="val">1,020</div>
+      <div class="label">Session-scoped resets</div>
+      <div class="sub">Edit (511) + Write (509). "Always-allow" expires at session end; each new session re-prompts.</div>
+    </div>
+    <div class="stat green">
+      <div class="val">440</div>
+      <div class="label">First-time Bash prefixes</div>
+      <div class="sub">Each prompts once then permanent. Front-loaded in the first ~1-2 weeks.</div>
+    </div>
+  </div>
+
+  <div class="driver">
+    <div class="big">948</div>
+    <div class="text"><strong>Single biggest driver: <code>gh *</code> in the <code>ask</code> list.</strong> 35% of all prompts. Every PR / issue / CI interaction. Moving <code>gh *</code> to <code>allow</code> would cut the total to ~1.75k.</div>
+  </div>
+
+  <div class="footnote">
+    Plus 92 hard-denied calls (89× <code>rm -rf /...</code>, 2× <code>dd</code>, 1× <code>sudo</code>) — caught by <code>deny</code> rules with no escape. Anthropic permission model: <a href="https://code.claude.com/docs/en/permissions">code.claude.com/docs/en/permissions</a>.
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Task: Add three pre-built standalone summary slide HTML files to `reports/` — companion artifacts to the deep-dive reports landed in PR #612.

## Files

- `reports/slide-cost-topline.html` — 4-card cost headline + framing line about $200/mo Max x20 actual cost
- `reports/slide-cost-methodology.html` — 4-step Collect → Dedup → Price → Project flow + verification checklist
- `reports/slide-permissions-topline.html` — 4-card permissions topline (~2,695 total, 1,228 recurring, 1,020 session-scoped, 440 first-time prefixes) + `gh *` driver callout

Standalone single-page slides — no nav, no cross-linking, designed for screenshotting. Dark theme matches the rest of the report set.

## Test plan

- [x] Files load standalone (no broken stylesheet refs — all CSS inline)
- [x] No cross-page links (intentional — no nav, no footer links)
- [ ] Visual check at the live URL after merge

Worktree: `/tmp/zskills-do-topline-slides`
