### PR TITLE
do: opt-in race-isolation test (RUN_RACE_TESTS=1)

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -105,7 +105,14 @@ run_suite "test-fix-issues-sprint-land-pr.sh" "tests/test-fix-issues-sprint-land
 run_suite "test-fix-issues-phase2-source-filter.sh" "tests/test-fix-issues-phase2-source-filter.sh"
 run_suite "test-do.sh" "tests/test-do.sh"
 run_suite "test-commit.sh" "tests/test-commit.sh"
-run_suite "test-fixture-race-isolation.sh" "tests/test-fixture-race-isolation.sh"
+# Opt-in race-isolation test for the #594 fix pattern. Adds ~2-3 min
+# to run-all.sh (20+5 conformance invocations), and the value is
+# documentation-of-bug-class rather than direct regression coverage —
+# the actual fix-regression guard lives in tests/test-skill-conformance.sh
+# (PID-scope structural pin). Opt in with RUN_RACE_TESTS=1.
+if [ -n "${RUN_RACE_TESTS:-}" ]; then
+  run_suite "test-fixture-race-isolation.sh" "tests/test-fixture-race-isolation.sh"
+fi
 run_suite "test-frontmatter-helpers.sh" "tests/test-frontmatter-helpers.sh"
 run_suite "test-update-zskills-migration.sh" "tests/test-update-zskills-migration.sh"
 run_suite "test-update-zskills-agent-install" "tests/test-update-zskills-agent-install.sh"

--- a/tests/test-fixture-race-isolation.sh
+++ b/tests/test-fixture-race-isolation.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Opt-in race-isolation test (set RUN_RACE_TESTS=1 in tests/run-all.sh).
+# Demonstrates the #594 parallel-process race class: a background `rm -rf`
+# racer against a shared `/tmp/` fixture path defeats the deny-list
+# assertion (Phase 1), while a $$-scoped fixture path is immune (Phase 2).
+# Not a direct regression guard for the test-hooks.sh fix — that lives in
+# tests/test-skill-conformance.sh as a `grep -qF` structural pin.
+#
 # Regression test for issue #594: parallel-process race on hardcoded
 # /tmp/ synthetic-fixture paths in tests/test-hooks.sh.
 #


### PR DESCRIPTION
## Summary

Gate `tests/test-fixture-race-isolation.sh` behind `RUN_RACE_TESTS=1`. Mirrors the existing `RUN_E2E` opt-in pattern at `tests/run-all.sh`. Saves ~2-3 min of CI time on every default `bash tests/run-all.sh` invocation.

## Why

The race test (20+5 conformance invocations under a background `rm -rf` racer) demonstrates the #594 parallel-process race **class** — it doesn't directly guard the test-hooks.sh fix. The actual regression guard is the `grep -qF` structural pin in `tests/test-skill-conformance.sh`, which asserts the literal `$$`-suffixed source tokens are present. That pin is what would catch a future silent revert; this test exists for documentation-by-test.

Two CI runs per default `bash tests/run-all.sh` were paying ~2-3 min for documentation. Opt-in keeps the test available for posterity and ad-hoc debugging via `RUN_RACE_TESTS=1`.

## Changes

- `tests/run-all.sh` — wrap the existing `run_suite test-fixture-race-isolation.sh` line in `if [ -n "${RUN_RACE_TESTS:-}" ]; then ... fi`. Same placement as before. Comment block explains the rationale.
- `tests/test-fixture-race-isolation.sh` — prepend a 7-line opt-in header comment block (after the shebang). No changes to the test body, iteration counts, or assertions.

## Test plan

- [x] `bash tests/run-all.sh` — exit 0, 5903/5903 passed, 0 hits for "Tests: test-fixture-race-isolation.sh" header line.
- [x] `RUN_RACE_TESTS=1 bash tests/run-all.sh` — exit 0, 5905/5905 passed (+2 for the race test's 2 assertions), 1 hit for the race-test header line.
- [x] `git show HEAD --stat` shows exactly 2 files (`tests/run-all.sh`, `tests/test-fixture-race-isolation.sh`); no scope creep.

Follow-up to #635 (the #594 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
