### PR TITLE
chore(dashboard): backfill completed: frontmatter + favicon + read-only Completed cursor

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.22+90e90d"
+  version: "2026.05.22+4d8882"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -711,6 +711,15 @@ class MonitorHandler(BaseHTTPRequestHandler):
         if decoded_path == "/app.css":
             self._serve_static_file("app.css", "text/css")
             return
+        if decoded_path == "/favicon.svg":
+            self._serve_static_file("favicon.svg", "image/svg+xml")
+            return
+        if decoded_path == "/favicon.ico":
+            # Many browsers request /favicon.ico by default. We serve the
+            # SVG with the SVG MIME type — modern browsers (Firefox,
+            # Chrome, Safari) accept this. No separate .ico asset needed.
+            self._serve_static_file("favicon.svg", "image/svg+xml")
+            return
         if decoded_path == "/api/health":
             self._handle_health()
             return

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -886,6 +886,22 @@ code, pre, .mono {
   border-radius: 4px;
 }
 
+/* Phase 4 / W4.2 — Completed is read-only. The onDrop handler rejects
+   drops onto Completed (defense-in-depth), but the user shouldn't see
+   any "this is a drop target" affordance — neither at rest nor while
+   dragging over. The CSS layer makes the rejection visible BEFORE the
+   user releases: cursor reads as not-allowed; no hover highlight. */
+.dropzone[data-column="completed"] {
+  cursor: not-allowed;
+}
+
+.dropzone[data-column="completed"].drop-target {
+  /* Override the blue tint .dropzone.drop-target paints on every
+     dropzone during dragenter. Completed should never read as a
+     viable target. */
+  background: transparent;
+}
+
 .dropzone .card {
   cursor: grab;
 }

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/favicon.svg
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4fc3f7"/>
+      <stop offset="50%" stop-color="#2196f3"/>
+      <stop offset="100%" stop-color="#7c4dff"/>
+    </linearGradient>
+  </defs>
+  <text x="16" y="26" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif" font-size="28" font-weight="700" fill="url(#g)">Z</text>
+</svg>

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Z Skills Dashboard</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="/app.css" />
 </head>
 <body>

--- a/docs/plans/ADAPTIVE_CRON_BACKOFF.md
+++ b/docs/plans/ADAPTIVE_CRON_BACKOFF.md
@@ -3,6 +3,7 @@ issue: 110
 title: Adaptive Backoff for /run-plan finish auto Chunking Cron
 created: 2026-04-29
 status: complete
+completed: "2026-04-30T22:06:34Z"
 ---
 
 # Plan: Adaptive Backoff for /run-plan finish auto Chunking Cron

--- a/docs/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
+++ b/docs/plans/BLOCK_DIAGRAM_TRACKING_CATCHUP.md
@@ -2,6 +2,7 @@
 title: Block-Diagram Tracking-Naming Catch-up
 created: 2026-04-26
 status: complete
+completed: "2026-04-29T00:42:30Z"
 ---
 
 # Plan: Block-Diagram Tracking-Naming Catch-up

--- a/docs/plans/CANARY10_PR_MODE.md
+++ b/docs/plans/CANARY10_PR_MODE.md
@@ -2,6 +2,7 @@
 title: Canary 10 — PR Mode End-to-End
 created: 2026-04-16
 status: complete
+completed: "2026-04-20T18:10:25Z"
 ---
 
 # Plan: Canary 10 — PR Mode End-to-End

--- a/docs/plans/CANARY5_AUTONOMOUS.md
+++ b/docs/plans/CANARY5_AUTONOMOUS.md
@@ -2,6 +2,7 @@
 title: Canary 5 — Autonomous End-to-End
 created: 2026-04-14
 status: complete
+completed: "2026-04-14T04:42:18Z"
 ---
 
 # Plan: Canary 5 — Autonomous End-to-End

--- a/docs/plans/CANARY7_CHUNKED_FINISH.md
+++ b/docs/plans/CANARY7_CHUNKED_FINISH.md
@@ -2,6 +2,7 @@
 title: Canary 7 — Chunked Finish Auto End-to-End
 created: 2026-04-16
 status: complete
+completed: "2026-05-13T02:35:51Z"
 ---
 
 # Plan: Canary 7 — Chunked Finish Auto End-to-End

--- a/docs/plans/CANARY_FAILURE_INJECTION.md
+++ b/docs/plans/CANARY_FAILURE_INJECTION.md
@@ -2,6 +2,7 @@
 title: Canary Failure Injection
 created: 2026-04-16
 status: complete
+completed: "2026-04-17T03:59:11Z"
 ---
 
 # Plan: Canary Failure Injection

--- a/docs/plans/CHUNKED_CRON_CANARY.md
+++ b/docs/plans/CHUNKED_CRON_CANARY.md
@@ -2,6 +2,7 @@
 title: Chunked Finish-Auto Cron Canary
 created: 2026-04-18
 status: complete
+completed: "2026-04-18T23:09:36Z"
 ---
 
 # Plan: Chunked Finish-Auto Cron Canary

--- a/docs/plans/CI_FIX_CYCLE_CANARY.md
+++ b/docs/plans/CI_FIX_CYCLE_CANARY.md
@@ -2,6 +2,7 @@
 title: CI Fix Cycle Canary
 created: 2026-04-18
 status: complete
+completed: "2026-04-18T14:54:36Z"
 ---
 
 # Plan: CI Fix Cycle Canary

--- a/docs/plans/CREATE_WORKTREE_SKILL.md
+++ b/docs/plans/CREATE_WORKTREE_SKILL.md
@@ -2,6 +2,7 @@
 title: /create-worktree Skill — Unify Worktree Creation Across Skills
 created: 2026-04-18
 status: complete
+completed: "2026-04-21T06:40:34Z"
 ---
 
 # Plan: /create-worktree Skill — Unify Worktree Creation Across Skills

--- a/docs/plans/DASHBOARD_TABS_AND_RENAME.md
+++ b/docs/plans/DASHBOARD_TABS_AND_RENAME.md
@@ -3,6 +3,7 @@ issue: 229
 title: Dashboard Tabs and Rename (Z Skills Monitor → Z Skills Dashboard)
 created: 2026-05-12
 status: complete
+completed: "2026-05-13T19:53:53Z"
 ---
 
 # Plan: Dashboard Tabs and Rename

--- a/docs/plans/DEFAULT_PORT_CONFIG.md
+++ b/docs/plans/DEFAULT_PORT_CONFIG.md
@@ -2,6 +2,7 @@
 title: Default Port Config — Schema-Driven, Runtime-Read
 created: 2026-04-25
 status: complete
+completed: "2026-04-29T15:11:46Z"
 ---
 
 # Plan: Default Port Config — Schema-Driven, Runtime-Read

--- a/docs/plans/DRAFT_TESTS_SKILL_PLAN.md
+++ b/docs/plans/DRAFT_TESTS_SKILL_PLAN.md
@@ -2,6 +2,7 @@
 title: /draft-tests Skill
 created: 2026-04-24
 status: complete
+completed: "2026-04-30T14:38:34Z"
 ---
 
 # Plan: /draft-tests Skill

--- a/docs/plans/EPHEMERAL_TO_TMP.md
+++ b/docs/plans/EPHEMERAL_TO_TMP.md
@@ -2,6 +2,7 @@
 title: Route ephemeral test outputs to /tmp
 created: 2026-04-16
 status: complete
+completed: "2026-04-16T23:37:27Z"
 ---
 
 # Plan: Route ephemeral test outputs to /tmp

--- a/docs/plans/EXECUTION_MODES.md
+++ b/docs/plans/EXECUTION_MODES.md
@@ -2,6 +2,7 @@
 title: Execution Modes
 created: 2026-04-13
 status: complete
+completed: "2026-04-15T04:05:31Z"
 ---
 
 # Plan: Execution Modes

--- a/docs/plans/FIX_ISSUES_SYNC_HARDENING.md
+++ b/docs/plans/FIX_ISSUES_SYNC_HARDENING.md
@@ -3,6 +3,7 @@ issue: 231
 title: /fix-issues sync — bootstrap empty issues_dir (#231)
 created: 2026-05-12
 status: complete
+completed: "2026-05-15T06:27:19Z"
 ---
 
 # Plan: /fix-issues sync — bootstrap empty issues_dir (#231)

--- a/docs/plans/FIX_PR_STATE_RATE_LIMIT.md
+++ b/docs/plans/FIX_PR_STATE_RATE_LIMIT.md
@@ -3,6 +3,7 @@ issue: 26
 title: Fix gh pr view Rate-Limit Silent Default to OPEN (zombie feature branches)
 created: 2026-04-17
 status: complete
+completed: "2026-04-17T16:40:53Z"
 ---
 
 # Plan: Fix gh pr view Rate-Limit Silent Default to OPEN

--- a/docs/plans/FIX_WORKTREE_POISONED_BRANCH.md
+++ b/docs/plans/FIX_WORKTREE_POISONED_BRANCH.md
@@ -2,6 +2,7 @@
 title: Fix Worktree-Add Silent Attach to Poisoned Stale Branches
 created: 2026-04-17
 status: complete
+completed: "2026-04-17T17:27:18Z"
 ---
 
 # Plan: Fix Worktree-Add Silent Attach to Poisoned Stale Branches

--- a/docs/plans/IMPROVE_STALENESS_DETECTION.md
+++ b/docs/plans/IMPROVE_STALENESS_DETECTION.md
@@ -2,6 +2,7 @@
 title: Improve /run-plan Staleness Detection (Arithmetic Drift)
 created: 2026-04-19
 status: complete
+completed: "2026-04-28T06:27:00Z"
 ---
 
 # Plan: Improve /run-plan Staleness Detection (Arithmetic Drift)

--- a/docs/plans/LAND_PR_BYPASS_HARDENING.md
+++ b/docs/plans/LAND_PR_BYPASS_HARDENING.md
@@ -2,6 +2,7 @@
 title: Close /land-pr Bypass Hole — Caller Tracker Parity + PreToolUse Hook
 created: 2026-05-12
 status: complete
+completed: "2026-05-13T11:26:49Z"
 ---
 
 # Plan: Close /land-pr Bypass Hole — Caller Tracker Parity + PreToolUse Hook

--- a/docs/plans/PARALLEL_CANARYA.md
+++ b/docs/plans/PARALLEL_CANARYA.md
@@ -2,6 +2,7 @@
 title: Parallel Pipeline Canary A
 created: 2026-04-18
 status: complete
+completed: "2026-04-18T13:21:16Z"
 ---
 
 # Plan: Parallel Pipeline Canary A

--- a/docs/plans/PARALLEL_CANARYB.md
+++ b/docs/plans/PARALLEL_CANARYB.md
@@ -2,6 +2,7 @@
 title: Parallel Pipeline Canary B
 created: 2026-04-18
 status: complete
+completed: "2026-04-18T13:27:03Z"
 ---
 
 # Plan: Parallel Pipeline Canary B

--- a/docs/plans/PREAMBLE_WORKTREE_GATE.md
+++ b/docs/plans/PREAMBLE_WORKTREE_GATE.md
@@ -3,6 +3,7 @@ issue: 226
 title: Shared preamble worktree gate for file-writing skills
 created: 2026-05-12
 status: complete
+completed: "2026-05-13T19:21:59Z"
 ---
 
 # Plan: Shared preamble worktree gate for file-writing skills

--- a/docs/plans/PR_LANDING_UNIFICATION.md
+++ b/docs/plans/PR_LANDING_UNIFICATION.md
@@ -2,6 +2,7 @@
 title: PR Landing Unification — extract /land-pr from 5 duplicating skills
 created: 2026-04-27
 status: complete
+completed: "2026-05-01T21:40:43Z"
 ---
 
 # Plan: PR Landing Unification

--- a/docs/plans/QUICKFIX_DO_TRIAGE_PLAN.md
+++ b/docs/plans/QUICKFIX_DO_TRIAGE_PLAN.md
@@ -2,6 +2,7 @@
 title: /quickfix and /do — Triage Gate, Inline Plan, and Fresh-Agent Plan Review
 created: 2026-04-25
 status: complete
+completed: "2026-05-01T10:23:41Z"
 ---
 
 # Plan: /quickfix and /do — Triage Gate, Inline Plan, and Fresh-Agent Plan Review

--- a/docs/plans/QUICKFIX_GRAMMAR_REDESIGN.md
+++ b/docs/plans/QUICKFIX_GRAMMAR_REDESIGN.md
@@ -3,6 +3,7 @@ issue: 310
 title: /quickfix argument-grammar inconsistency + cross-skill auto semantics drift
 created: 2026-05-16
 status: complete
+completed: "2026-05-17T14:14:40Z"
 ---
 
 > **⚠ SUPERSEDED.** This plan was executed via /run-plan (landed PR #342), then largely reverted in PR #349 because the `auto`/`unattended` split was over-engineering per `feedback_no_premature_backcompat.md`. Subsequent cleanup in PRs #352 + #354 finalized the simpler design. Retained as historical record. Anyone grepping `unattended` lands here — that's expected; the token does not exist anywhere else in the codebase.

--- a/docs/plans/REFINE_PLAN_SKILL.md
+++ b/docs/plans/REFINE_PLAN_SKILL.md
@@ -2,6 +2,7 @@
 title: /refine-plan Skill
 created: 2026-04-13
 status: complete
+completed: "2026-04-13T17:46:30Z"
 ---
 
 # Plan: /refine-plan Skill

--- a/docs/plans/REPORTS_DIR_MIGRATION.md
+++ b/docs/plans/REPORTS_DIR_MIGRATION.md
@@ -3,6 +3,7 @@ issue: 217
 title: Reports Dir Migration — Drive .zskills/ to Zero Force-Tracked
 created: 2026-05-18
 status: complete
+completed: "2026-05-18T18:23:27Z"
 ---
 
 # Plan: Reports Dir Migration — Drive .zskills/ to Zero Force-Tracked

--- a/docs/plans/RUN_PLAN_FINISH_AUTO_REUSE_SEMANTICS.md
+++ b/docs/plans/RUN_PLAN_FINISH_AUTO_REUSE_SEMANTICS.md
@@ -3,6 +3,7 @@ issue: 191
 title: /run-plan finish — cherry-pick mode reuses plan-scoped worktree
 created: 2026-05-11
 status: complete
+completed: "2026-05-12T01:55:27Z"
 ---
 
 # Plan: /run-plan finish — cherry-pick mode reuses plan-scoped worktree

--- a/docs/plans/TRACKING_SYSTEM.md
+++ b/docs/plans/TRACKING_SYSTEM.md
@@ -2,6 +2,7 @@
 title: Skill Tracking System — Mechanical Enforcement of Skill Invocations and Step Completion
 created: 2026-04-05
 status: complete
+completed: "2026-04-05T21:23:54Z"
 ---
 
 # Plan: Skill Tracking System — Mechanical Enforcement of Skill Invocations and Step Completion

--- a/docs/plans/UNIFY_TRACKING_NAMES.md
+++ b/docs/plans/UNIFY_TRACKING_NAMES.md
@@ -2,6 +2,7 @@
 title: Unify Tracking-Marker File-Naming Convention
 created: 2026-04-17
 status: complete
+completed: "2026-04-18T02:40:16Z"
 ---
 
 # Plan: Unify Tracking-Marker File-Naming Convention

--- a/docs/plans/ZSKILLS_MONITOR_PLAN.md
+++ b/docs/plans/ZSKILLS_MONITOR_PLAN.md
@@ -2,6 +2,7 @@
 title: Zskills Monitor Dashboard
 created: 2026-04-18
 status: complete
+completed: "2026-04-29T07:17:03Z"
 ---
 
 # Plan: Zskills Monitor Dashboard

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.22+90e90d"
+  version: "2026.05.22+4d8882"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -711,6 +711,15 @@ class MonitorHandler(BaseHTTPRequestHandler):
         if decoded_path == "/app.css":
             self._serve_static_file("app.css", "text/css")
             return
+        if decoded_path == "/favicon.svg":
+            self._serve_static_file("favicon.svg", "image/svg+xml")
+            return
+        if decoded_path == "/favicon.ico":
+            # Many browsers request /favicon.ico by default. We serve the
+            # SVG with the SVG MIME type — modern browsers (Firefox,
+            # Chrome, Safari) accept this. No separate .ico asset needed.
+            self._serve_static_file("favicon.svg", "image/svg+xml")
+            return
         if decoded_path == "/api/health":
             self._handle_health()
             return

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -886,6 +886,22 @@ code, pre, .mono {
   border-radius: 4px;
 }
 
+/* Phase 4 / W4.2 — Completed is read-only. The onDrop handler rejects
+   drops onto Completed (defense-in-depth), but the user shouldn't see
+   any "this is a drop target" affordance — neither at rest nor while
+   dragging over. The CSS layer makes the rejection visible BEFORE the
+   user releases: cursor reads as not-allowed; no hover highlight. */
+.dropzone[data-column="completed"] {
+  cursor: not-allowed;
+}
+
+.dropzone[data-column="completed"].drop-target {
+  /* Override the blue tint .dropzone.drop-target paints on every
+     dropzone during dragenter. Completed should never read as a
+     viable target. */
+  background: transparent;
+}
+
 .dropzone .card {
   cursor: grab;
 }

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/favicon.svg
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4fc3f7"/>
+      <stop offset="50%" stop-color="#2196f3"/>
+      <stop offset="100%" stop-color="#7c4dff"/>
+    </linearGradient>
+  </defs>
+  <text x="16" y="26" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif" font-size="28" font-weight="700" fill="url(#g)">Z</text>
+</svg>

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Z Skills Dashboard</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="/app.css" />
 </head>
 <body>

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -1145,6 +1145,62 @@ else
 fi
 
 ###############################################################################
+# Block 3b — Favicon + Completed-dropzone read-only cursor (post-#654 cleanup)
+###############################################################################
+
+echo ""
+echo "=== Post-#654 cleanup: favicon + completed-dropzone cursor ==="
+
+# index.html must link the SVG favicon. Browsers without the link tag
+# fall back to /favicon.ico; the server routes BOTH paths to favicon.svg
+# (see below) but having the explicit <link> is what gives well-behaved
+# UAs the right MIME type without a redirect.
+if grep -qE '<link[[:space:]]+rel="icon"[[:space:]]+type="image/svg\+xml"[[:space:]]+href="/favicon.svg"' "$INDEX_HTML"; then
+  pass "index_html_links_favicon_svg — <link rel=\"icon\" type=\"image/svg+xml\" href=\"/favicon.svg\">"
+else
+  fail "index_html_links_favicon_svg — head missing the favicon <link>"
+fi
+
+# server.py must route BOTH /favicon.svg AND /favicon.ico to the SVG
+# asset (Firefox/Chrome accept image/svg+xml for either path; serving
+# from a single asset avoids a separate .ico build step).
+if grep -qE 'decoded_path == "/favicon\.svg"' "$SERVER_PY" \
+   && grep -qE '_serve_static_file\("favicon\.svg",[[:space:]]*"image/svg\+xml"\)' "$SERVER_PY"; then
+  pass "server_routes_favicon_svg — server.py routes /favicon.svg and /favicon.ico"
+else
+  fail "server_routes_favicon_svg — server.py missing /favicon.svg or /favicon.ico route to favicon.svg"
+fi
+# Sibling: /favicon.ico exists as its own decoded_path arm.
+if grep -qE 'decoded_path == "/favicon\.ico"' "$SERVER_PY"; then
+  pass "server_routes_favicon_ico — server.py routes /favicon.ico"
+else
+  fail "server_routes_favicon_ico — server.py missing /favicon.ico arm (browsers default to this path)"
+fi
+
+# Favicon asset must be present in static/.
+if [ -f "$STATIC_DIR/favicon.svg" ] && [ -s "$STATIC_DIR/favicon.svg" ]; then
+  pass "favicon_svg_asset_present — static/favicon.svg exists and is non-empty"
+else
+  fail "favicon_svg_asset_present — static/favicon.svg missing or empty"
+fi
+
+# CSS must read-only-mark the Completed dropzone via cursor: not-allowed.
+# Verify the rule is keyed on [data-column="completed"] AND that the
+# declaration block contains `cursor: not-allowed`. Implementation:
+# extract the rule block for the selector and assert the declaration is
+# inside it (a bare `cursor: not-allowed` elsewhere wouldn't count).
+COMPLETED_BLOCK=$(awk '
+  /\.dropzone\[data-column="completed"\][[:space:]]*\{/ {p=1}
+  p {print}
+  p && /\}/ {p=0; print "----"}
+' "$APP_CSS")
+if echo "$COMPLETED_BLOCK" | grep -qE 'cursor:[[:space:]]*not-allowed'; then
+  pass "dropzone_completed_cursor_not_allowed — .dropzone[data-column=\"completed\"] has cursor: not-allowed"
+else
+  fail "dropzone_completed_cursor_not_allowed — .dropzone[data-column=\"completed\"] missing cursor: not-allowed"
+fi
+
+###############################################################################
 # Block 4 — Phase 7: live write-back smoke (server already running)
 ###############################################################################
 


### PR DESCRIPTION
## Summary

Three follow-up fixes to the dashboard after PR #650 / PR #654 landed:

1. **Run the plan-completed backfill** (the one-time cleanup that PR #650 landed but never executed). 31 plans with `status: complete` but no `completed:` frontmatter now have their `completed:` field populated from git pickaxe history. Result: those plans actually appear in the Completed band — previously they sat invisible because column placement requires `completed:` not `status:` alone.

2. **Read-only cursor on Completed dropzone**: `cursor: not-allowed` + transparent `.drop-target` highlight so users get an immediate visual signal that dragging into Completed isn't supported. The existing JS reject + `console.warn` stays as defense-in-depth.

3. **Favicon**: add `static/favicon.svg` (485-byte blue→purple gradient Z, lifted from zimulink.synapticnoise.com), wire `<link rel="icon">` in `index.html`, add server routes for `/favicon.svg` and `/favicon.ico` (both serve the SVG). Resolves the 404 every browser was hitting.

## Tests

5 new assertions in `tests/test_zskills_monitor_dashboard_ui.sh`:
- `index_html_links_favicon_svg`
- `server_routes_favicon_svg`
- `server_routes_favicon_ico`
- `favicon_svg_asset_present`
- `dropzone_completed_cursor_not_allowed`

Full suite: `Overall: 5910/5910 passed, 0 failed`.

## Manual verification

Visual confirmation via Python `http.server` dry-render against the worktree's static dir (worked around the dashboard server's MAIN_ROOT-anchoring that PR #654 surfaced):
- Favicon renders as expected blue→purple gradient Z.
- `getComputedStyle().cursor` on `.dropzone[data-column="completed"]` returns `"not-allowed"`; on Backlog returns `"auto"`. CSS rule fires selectively.

End-to-end visual confirmation against the production server route is post-merge — once main has the favicon route handler and the running dashboard picks it up, the favicon will appear in the browser tab on the next reload.

## Notes for reviewers

- The backfill modifies 31 plan files under `docs/plans/`. Each diff is a single `+completed: "<ISO-UTC-Z>"` line in frontmatter, no other content touched. Spot-checked 3 plans manually; the pickaxe-recovered dates match the actual git commit that introduced `status: complete`.
- **Operator note (worth a follow-up issue, NOT in scope for this PR)**: `skills/zskills-dashboard/scripts/backfill-plan-completed.sh` has a `CLAUDE_PROJECT_DIR` fallback at lines 84-89 that's unreachable under `set -u`. Worked around inline by exporting `CLAUDE_PROJECT_DIR` before invocation. Future runs of the script on a freshly-cloned consumer repo will hit this; should be fixed via `${CLAUDE_PROJECT_DIR:-}` or a `: "${CLAUDE_PROJECT_DIR:=$(pwd)}"` pre-shim.
- The MAIN_ROOT-anchoring limitation surfaced in PR #654 remains open — worktree-based playwright visual verification of dashboard changes requires the dry-render workaround used here. Separate follow-up.
