### PR TITLE
fix(dashboard): plumb completed: frontmatter + honor null-column hide intent

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.22+4d8882"
+  version: "2026.05.22+5892a8"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -613,6 +613,7 @@ def parse_plan(path: Any) -> Optional[Dict[str, Any]]:
         "title": title,
         "status": fm.get("status", "").strip() or "active",
         "created": fm.get("created", "").strip(),
+        "completed": fm.get("completed", "").strip(),
         "issue": fm.get("issue") or None,
         "blurb": blurb,
         "phase_count": max(len(phases), len(tracker)),

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -443,10 +443,14 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
     }
   }
   // Add inferred entries for plans not present in state.
+  // Plans with no column (queue.column === null) are intentionally hidden
+  // by _infer_default_column — historical completes, out-of-window, or
+  // unbackfilled. Do NOT default these to "drafted" (Bug B from PR #650):
+  // that override inflates Drafted with plans the inference said to hide.
   for (const p of plans) {
     if (seenSlugs.has(p.slug)) continue;
-    const col = (p.queue && p.queue.column) || "drafted";
-    if (PLAN_COLUMNS.indexOf(col) < 0) continue;
+    const col = p.queue && p.queue.column;
+    if (!col || PLAN_COLUMNS.indexOf(col) < 0) continue;
     seenSlugs.add(p.slug);
     out.plans[col].push({ slug: p.slug });
   }
@@ -498,7 +502,11 @@ function fingerprintPlans(plans, queues, defaultMode) {
     rows: plans.map(p => [
       p.slug, p.title, p.status, p.landing_mode,
       p.phase_count, p.phases_done, p.blurb,
-      pos[p.slug] || [(p.queue && p.queue.column) || "drafted", -1, null],
+      pos[p.slug] || [
+        (p.queue && p.queue.column) || null,
+        -1,
+        null,
+      ],
       // Claim state — symmetric to fingerprintIssues' claim tuple.
       // We track `last_heartbeat_at` (NOT `started_at`) so the chip
       // re-renders when the pipeline emits a phase heartbeat —

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.22+4d8882"
+  version: "2026.05.22+5892a8"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -613,6 +613,7 @@ def parse_plan(path: Any) -> Optional[Dict[str, Any]]:
         "title": title,
         "status": fm.get("status", "").strip() or "active",
         "created": fm.get("created", "").strip(),
+        "completed": fm.get("completed", "").strip(),
         "issue": fm.get("issue") or None,
         "blurb": blurb,
         "phase_count": max(len(phases), len(tracker)),

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -443,10 +443,14 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
     }
   }
   // Add inferred entries for plans not present in state.
+  // Plans with no column (queue.column === null) are intentionally hidden
+  // by _infer_default_column — historical completes, out-of-window, or
+  // unbackfilled. Do NOT default these to "drafted" (Bug B from PR #650):
+  // that override inflates Drafted with plans the inference said to hide.
   for (const p of plans) {
     if (seenSlugs.has(p.slug)) continue;
-    const col = (p.queue && p.queue.column) || "drafted";
-    if (PLAN_COLUMNS.indexOf(col) < 0) continue;
+    const col = p.queue && p.queue.column;
+    if (!col || PLAN_COLUMNS.indexOf(col) < 0) continue;
     seenSlugs.add(p.slug);
     out.plans[col].push({ slug: p.slug });
   }
@@ -498,7 +502,11 @@ function fingerprintPlans(plans, queues, defaultMode) {
     rows: plans.map(p => [
       p.slug, p.title, p.status, p.landing_mode,
       p.phase_count, p.phases_done, p.blurb,
-      pos[p.slug] || [(p.queue && p.queue.column) || "drafted", -1, null],
+      pos[p.slug] || [
+        (p.queue && p.queue.column) || null,
+        -1,
+        null,
+      ],
       // Claim state — symmetric to fingerprintIssues' claim tuple.
       // We track `last_heartbeat_at` (NOT `started_at`) so the chip
       // re-renders when the pipeline emits a phase heartbeat —

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -1290,6 +1290,75 @@ else
   fail "W1.9: got '$W19'"
 fi
 
+# W1.9a — parse_plan_extracts_completed_field: write a plan markdown with
+# `completed:` frontmatter, call parse_plan, assert the returned dict has
+# the `completed` key populated. Closes Bug A of PR #650 fields-plumbing:
+# parse_plan previously stripped the field so `_infer_default_column`
+# never saw it, and every status=complete plan was hidden regardless of
+# `completed:` value. End-to-end (W1.9b) compounds this with the
+# inference call to prove the full pipeline now works.
+W19A=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import pathlib, sys, tempfile
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+tmp = pathlib.Path(tempfile.mkdtemp())
+fp = tmp / "test-plan.md"
+fp.write_text("""---
+title: "Test Plan"
+status: complete
+created: "2026-05-01T00:00:00Z"
+completed: "2026-05-15T12:30:00Z"
+---
+
+# Test Plan
+""")
+plan = c.parse_plan(fp)
+print("has_completed=" + str("completed" in plan))
+print("completed=" + repr(plan.get("completed")))
+print("status=" + repr(plan.get("status")))
+' 2>&1)
+if printf '%s\n' "$W19A" | grep -q "^has_completed=True$" \
+    && printf '%s\n' "$W19A" | grep -q "^completed='2026-05-15T12:30:00Z'$" \
+    && printf '%s\n' "$W19A" | grep -q "^status='complete'$"; then
+  pass "W1.9a: parse_plan_extracts_completed_field"
+else
+  fail "W1.9a: got '$W19A'"
+fi
+
+# W1.9b — infer_default_column_through_parse_plan: end-to-end. Calls
+# parse_plan() on the SAME fixture (not a hand-stubbed dict) and passes
+# the result into _infer_default_column. The W1.9 stub-dict test passed
+# even while Bug A made the parse_plan pipeline strip `completed`; this
+# end-to-end variant is the regression bar.
+W19B=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import pathlib, sys, tempfile
+from datetime import datetime, timezone
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+
+tmp = pathlib.Path(tempfile.mkdtemp())
+fp = tmp / "test-plan.md"
+fp.write_text("""---
+title: "Test Plan"
+status: complete
+created: "2026-05-01T00:00:00Z"
+completed: "2026-05-15T12:30:00Z"
+---
+
+# Test Plan
+""")
+plan = c.parse_plan(fp)
+now = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+col = c._infer_default_column(plan, now_utc=now, window_days=14)
+print("col=" + repr(col))
+' 2>&1)
+if printf '%s\n' "$W19B" | grep -q "^col='completed'$"; then
+  pass "W1.9b: infer_default_column_through_parse_plan (end-to-end)"
+else
+  fail "W1.9b: got '$W19B'"
+fi
+
 # W1.10 — read_state_file_v11_migration: v1.1 fixture parses cleanly,
 # `backlog` defaults to [] for both plans and issues.
 W110=$(PYTHONPATH="$PKG_PARENT" python3 -c '

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -806,6 +806,61 @@ if echo "$FPI_BODY" | grep -qE 'for \(const c of ISSUE_COLUMNS\)'; then
 else
   fail "W3.3: fingerprintIssues does not loop ISSUE_COLUMNS — drag-into-backlog will not re-render"
 fi
+
+# W3.3b — deepCloneQueues_skips_null_column_plans: Bug B from PR #650
+# fields-plumbing. The inferred-entry loop previously coerced
+# `(p.queue && p.queue.column) || "drafted"` — so any plan whose Python-
+# side _infer_default_column returned None (historical complete, outside
+# window, unbackfilled) got silently re-routed into Drafted, inflating
+# that column. Fix asserts: (1) the literal `|| "drafted"` fallback is
+# gone from the plan-inference branch, and (2) the new guard
+# `if (!col || PLAN_COLUMNS.indexOf(col) < 0) continue;` is present.
+# Issue `|| "triage"` fallbacks at the issue-inference branch + the
+# fingerprintIssues line are intentionally untouched — _infer_issue_default_column
+# always returns "completed" or "triage", never None.
+DEEPCLONE_BODY_FRESH=$(awk '
+  /^function deepCloneQueues\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+# Negative assertion: the plan-inference branch must NOT carry `|| "drafted"`.
+# Use a precise pattern — `p.queue.column` followed by `|| "drafted"` — so the
+# issue branch's `it.queue.column || "triage"` is unaffected. The plan-branch
+# selector is the only one referencing p.queue (vs it.queue).
+if echo "$DEEPCLONE_BODY_FRESH" | grep -qE 'p\.queue && p\.queue\.column\) \|\| "drafted"'; then
+  fail "W3.3b: deepCloneQueues still has p.queue.column || \"drafted\" — Bug B alive"
+else
+  pass "W3.3b: deepCloneQueues no longer coerces null plan column to drafted (Bug B fix)"
+fi
+# Positive assertion: the new guard MUST be present in the plan-inference branch.
+if echo "$DEEPCLONE_BODY_FRESH" | grep -qE 'const col = p\.queue && p\.queue\.column' \
+   && echo "$DEEPCLONE_BODY_FRESH" | grep -qE 'if \(!col \|\| PLAN_COLUMNS\.indexOf\(col\) < 0\) continue'; then
+  pass "W3.3b: deepCloneQueues guards null plan column with skip (Bug B fix)"
+else
+  fail "W3.3b: deepCloneQueues plan-inference guard missing — null-column plans will re-leak"
+fi
+# fingerprintPlans must also drop the `|| "drafted"` coercion so the
+# fingerprint stays truthful about hidden plans (drag-into-or-out-of
+# "hidden" still re-renders, but no fake "drafted" tuple).
+FPP_BODY_FRESH=$(awk '
+  /^function fingerprintPlans\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$FPP_BODY_FRESH" | grep -qE '\|\| "drafted"'; then
+  fail "W3.3b: fingerprintPlans still has || \"drafted\" — fingerprint lies about hidden plans"
+else
+  pass "W3.3b: fingerprintPlans drops || \"drafted\" coercion (Bug B fix)"
+fi
+# Issue-side fallbacks must remain untouched — _infer_issue_default_column
+# returns "triage" as its non-completed default, so the defensive `|| "triage"`
+# is correct and not part of Bug B. Pin this so a future cleanup doesn't
+# accidentally strip both.
+if grep -qE 'it\.queue && it\.queue\.column\) \|\| "triage"' "$APP_JS"; then
+  pass "W3.3b: issue || \"triage\" fallback preserved (correct for issues; not Bug B)"
+else
+  fail "W3.3b: issue || \"triage\" fallback was stripped — issues will now leak as null-column"
+fi
 # W3.3 — truncation flag participates in fingerprintIssues so the banner
 # rerenders on flag toggle.
 if echo "$FPI_BODY" | grep -qE 'closed_issues_truncated'; then


### PR DESCRIPTION
## Summary

Fixes two compounding bugs in PR #650's implementation that surfaced in production use after PR #658 ran the backfill: status:complete plans never appeared in the Completed column, and the Drafted column inflated with plans that should have been hidden.

## Bugs

**Bug A — `parse_plan()` strips the `completed:` frontmatter field.** In `collect.py:586-634`, the parser reads frontmatter into `fm` and returns a dict with `status`, `created`, `issue`, etc. — but never `fm.get("completed")`. Then `_infer_default_column` checks `plan.get("completed")`, sees `None`, returns `None` (hidden). The PR #650 backfill wrote correct ISO timestamps to 31 plan files; nothing read them back. **W1.9 missed this because it stubbed the plan dict directly instead of going through `parse_plan`.**

**Bug B — Frontend `|| "drafted"` overrides null-column hide intent.** `app.js:448` `deepCloneQueues` had `const col = (p.queue && p.queue.column) || "drafted"`. When `_infer_default_column` returned `None` (Python) → JSON `null`, the JS fallback converted it to `"drafted"` and routed the plan into Drafted instead of hiding it. Same pattern at line 501 in `fingerprintPlans`. Issue-side `|| "triage"` at lines 477 + 548 is correctly left in place — `_infer_issue_default_column` never returns null, so the defensive default is harmless there.

**Compounded effect on a fresh consumer:** every status:complete plan whose `completed:` was None (after Bug A stripped it) fell through inference to null, then Bug B routed it into Drafted. Result: 0 plans in Completed, ~3x more plans in Drafted than the explicit state file actually contained.

## Verification (end-to-end this time)

Path-2 verification via worktree-rooted standalone server on :9123. `/api/state` returned:
- **45 status:complete/landed plans** now have populated `completed` field (0 missing — Bug A fixed).
- **10 in-window plans** route to Completed (`queue.column="completed"`).
- **35 outside-window plans** correctly route to `column=null` and are hidden (Bug B no longer leaks them into Drafted).
- **Drafted = 10** (just the explicit unresolved-slug entries in the state file).
- Specific spot-check: `canary7-chunked-finish` has `status='complete'`, `completed='2026-05-13T02:35:51Z'`, `queue.column='completed'`.

Production dashboard at :8080 was left running on main's code throughout verification.

## Tests

+3 new (5910 → 5913, full suite green):

- **W1.9a** `parse_plan_extracts_completed_field` — fixture markdown with `completed:` frontmatter, calls `parse_plan`, asserts dict contains the exact ISO value.
- **W1.9b** `infer_default_column_through_parse_plan` — true end-to-end: `parse_plan()` → `_infer_default_column()`, asserts in-window completes route to Completed. **This is the test that would have caught Bug A** — W1.9 stubbed the dict and bypassed `parse_plan` entirely.
- **W3.3b** `deepCloneQueues_skips_null_column_plans` — 4 sub-assertions: no `p.queue.column) || "drafted"`, new guard present, `fingerprintPlans` drops `|| "drafted"`, issue-side `|| "triage"` preserved (preserved-behavior pin).

## Process notes

The original PR #650 verification gap (no end-to-end playwright on a worktree-rooted dashboard) is what hid both of these bugs through landing AND through the PR #658 backfill. The current PR's verification used a worktree-rooted standalone python server on a different port — sidesteps the dashboard's MAIN_ROOT-anchoring limitation surfaced in PR #654 (still open as a follow-up).
