### PR TITLE
fix(update-zskills): add block-run-plan-unclaimed.sh to install list (#655)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.22+3cf4af"
+  version: "2026.05.26+0d4d7e"
 ---
 
 # Update Z Skills Infrastructure
@@ -1139,6 +1139,15 @@ Copy missing hooks from `$PORTABLE/hooks/` to `.claude/hooks/`.
   matches `fix-issue-NNN` or `fix/issue-NNN` and lacks a matching
   `.zskills/claims/issue-NNN/` claim directory
   (plans/fix-issues-claims.md Phase 2, W2.2c).
+- For `block-run-plan-unclaimed.sh`: copy as-is from `$PORTABLE/hooks/`
+  to `.claude/hooks/`. Wired into `settings.json` as PreToolUse on the
+  `Bash` matcher (see canonical-triples table below). Backstops the
+  `/run-plan` inline plan-claim-acquire prose — denies any Bash
+  invocation of `create-worktree.sh` / `ensure-worktree.sh` whose
+  resolved branch matches one of the three `/run-plan` shapes
+  (`cp-<slug>`, `cp-<slug>-phase-<N>`, or `${BRANCH_PREFIX}<slug>` for
+  PR mode) and lacks a matching `.zskills/plan-claims/<slug>/` claim
+  directory (plans/plans-claim-chip-parity.md Phase 2; PR #544).
 - For `scripts/test-all.sh`: copy as-is from
   `$PORTABLE/scripts/`. Reads `testing.unit_cmd` from
   `.claude/zskills-config.json` at runtime — no
@@ -1246,13 +1255,14 @@ not in this table is foreign and preserved untouched):
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-stale-skill-version.sh"`      |
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bypassed-land-pr.sh"`         |
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-fix-issue-unclaimed.sh"`      |
+| PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-run-plan-unclaimed.sh"`       |
 | PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`                   |
 | PreToolUse   | CronCreate | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bad-cron.sh"`              |
 | PreToolUse   | Edit\|Write | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-edits.sh"` |
 | PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 | PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 
-All 10 rows carry `"type": "command"` and `"timeout": 5`. The
+All 11 rows carry `"type": "command"` and `"timeout": 5`. The
 `warn-config-drift.sh` hook lands in Phase 3 of
 `plans/DRIFT_ARCH_FIX.md`; the two PostToolUse rows become live once
 that hook is installed.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.22+3cf4af"
+  version: "2026.05.26+0d4d7e"
 ---
 
 # Update Z Skills Infrastructure
@@ -1139,6 +1139,15 @@ Copy missing hooks from `$PORTABLE/hooks/` to `.claude/hooks/`.
   matches `fix-issue-NNN` or `fix/issue-NNN` and lacks a matching
   `.zskills/claims/issue-NNN/` claim directory
   (plans/fix-issues-claims.md Phase 2, W2.2c).
+- For `block-run-plan-unclaimed.sh`: copy as-is from `$PORTABLE/hooks/`
+  to `.claude/hooks/`. Wired into `settings.json` as PreToolUse on the
+  `Bash` matcher (see canonical-triples table below). Backstops the
+  `/run-plan` inline plan-claim-acquire prose — denies any Bash
+  invocation of `create-worktree.sh` / `ensure-worktree.sh` whose
+  resolved branch matches one of the three `/run-plan` shapes
+  (`cp-<slug>`, `cp-<slug>-phase-<N>`, or `${BRANCH_PREFIX}<slug>` for
+  PR mode) and lacks a matching `.zskills/plan-claims/<slug>/` claim
+  directory (plans/plans-claim-chip-parity.md Phase 2; PR #544).
 - For `scripts/test-all.sh`: copy as-is from
   `$PORTABLE/scripts/`. Reads `testing.unit_cmd` from
   `.claude/zskills-config.json` at runtime — no
@@ -1246,13 +1255,14 @@ not in this table is foreign and preserved untouched):
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-stale-skill-version.sh"`      |
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bypassed-land-pr.sh"`         |
 | PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-fix-issue-unclaimed.sh"`      |
+| PreToolUse   | Bash    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-run-plan-unclaimed.sh"`       |
 | PreToolUse   | Agent   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh"`                   |
 | PreToolUse   | CronCreate | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-bad-cron.sh"`              |
 | PreToolUse   | Edit\|Write | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-edits.sh"` |
 | PostToolUse  | Edit    | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 | PostToolUse  | Write   | `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/warn-config-drift.sh"`              |
 
-All 10 rows carry `"type": "command"` and `"timeout": 5`. The
+All 11 rows carry `"type": "command"` and `"timeout": 5`. The
 `warn-config-drift.sh` hook lands in Phase 3 of
 `plans/DRIFT_ARCH_FIX.md`; the two PostToolUse rows become live once
 that hook is installed.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1576,6 +1576,22 @@ fi
 check_fixed update-zskills "WI2.2: runtime-read note" \
   'Runtime-read fields (read by hooks and helper scripts at every invocation, NOT install-filled)'
 
+# Issue #655 — every hooks/block-*.sh must be referenced in /update-zskills's
+# install list (Step C copy-list prose AND/OR the canonical-triples table).
+# Closes the install-list-omission family (instance 1: #505 missed
+# block-bad-cron.sh + block-main-edits.sh; instance 2: #655 missed
+# block-run-plan-unclaimed.sh). Any new hook landing in hooks/block-*.sh
+# without a corresponding /update-zskills install-list reference fails CI.
+for hook_path in "$REPO_ROOT"/hooks/block-*.sh; do
+  hook_basename=$(basename "$hook_path")
+  if grep -qF -- "$hook_basename" "$REPO_ROOT/skills/update-zskills/SKILL.md"; then
+    pass "[update-zskills] #655: install-list references $hook_basename"
+  else
+    fail "[update-zskills] #655: hook $hook_basename not in /update-zskills install list" \
+      "missing from skills/update-zskills/SKILL.md (Step C copy list and/or canonical-triples table)"
+  fi
+done
+
 echo ""
 echo "=== Multi-agent adversarial-loop skills — Agent-tool-required preflight (issue #143) ==="
 # These five skills internally dispatch reviewer + devil's-advocate + refiner


### PR DESCRIPTION
## Summary
- Adds `hooks/block-run-plan-unclaimed.sh` to `/update-zskills`'s install scope (Step C copy list + canonical-triples table), closing the second instance of the install-list-omission family (#505 was instance 1).
- Mirror-syncs both `skills/update-zskills/SKILL.md` and `.claude/skills/update-zskills/SKILL.md`; bumps `metadata.version` to `2026.05.26+0d4d7e`.
- **Closes the family at CI time** with a conformance pin in `tests/test-skill-conformance.sh` iterating every `hooks/block-*.sh` and asserting each basename is referenced in `/update-zskills` SKILL.md. Falsifies-if-removed verified in-worktree.

## Test plan
- [x] `bash tests/run-all.sh` — 5920/5920 passed, 0 failed (implementer + independent verifier subagent both confirmed).
- [x] `grep -n 'block-run-plan-unclaimed' skills/update-zskills/SKILL.md` — 2 hits (Step C line 1142, canonical-triples row line 1258); mirror identical.
- [x] Conformance pin falsifies-if-removed: temporarily renamed `block-run-plan-unclaimed` → `block-XYZ-removed`; pin reported the expected failure; restored.
- [x] Row-count footer bumped 10 → 11.
- [x] Tier-1 hash registration: not-applicable (no `skills/<owner>/scripts/*` paths in staged diff).

Closes #655.
