### PR TITLE
do: auto-prune closed issues + orphan plan slugs

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.26+2d459c"
+  version: "2026.05.26+765e1b"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1601,12 +1601,23 @@ def _annotate_plans_queue(
     state_plans: Dict[str, List[Dict[str, Any]]] = state.get("plans", {})
     # state-file column iteration — picks up new columns from PLAN_COLUMNS / ISSUE_COLUMNS dynamically; conformance: tests/test-skill-conformance.sh
     # Build slug → (column, index, mode) lookup.
+    # Auto-prune orphan slugs (#671): derive the set of known slugs from
+    # the `plans` list parameter (parsed plan files). State-file entries
+    # whose slug has no corresponding parsed plan are orphans — silently
+    # drop them from `pos` so they never render and don't accumulate
+    # forever in the snapshot.
+    known_slugs: set = {
+        p["slug"] for p in plans
+        if isinstance(p.get("slug"), str) and p["slug"]
+    }
     pos: Dict[str, Tuple[str, int, Optional[str]]] = {}
     for col, entries in state_plans.items():
         for i, e in enumerate(entries):
             slug = e.get("slug", "")
+            if not slug or slug not in known_slugs:
+                continue  # orphan — plan file does not exist
             mode = e.get("mode") if col == "ready" else None
-            if slug and slug not in pos:
+            if slug not in pos:
                 pos[slug] = (col, i, mode)
 
     # Plan-claim index — parallel to the issue-side `claim_index`. Gated
@@ -1658,13 +1669,29 @@ def _annotate_issues_queue(
     actionable issues get no `skip_reason` field.
     """
     state_issues: Dict[str, List[Any]] = state.get("issues", {})
+    # Auto-prune closed issues (#670): derive the set of closed issue
+    # numbers from the `issues` list parameter, then skip them when
+    # building the explicit-position `pos` lookup. Closed issues are
+    # then routed via `_infer_issue_default_column` to `completed`
+    # (in-window) or `triage` (out-of-window, where the caller's
+    # open-fetch + closed-window-fetch contract typically also drops
+    # them from the list entirely).
+    closed_set: set = set()
+    for issue in issues:
+        num = issue.get("number")
+        if isinstance(num, int) and issue.get("closed_at"):
+            closed_set.add(num)
+
     pos: Dict[int, Tuple[str, int]] = {}
     for col, entries in state_issues.items():
         for i, num in enumerate(entries):
             try:
-                pos[int(num)] = (col, i)
+                n = int(num)
             except Exception:
                 continue
+            if n in closed_set:
+                continue  # closed — route via inference to completed/triage
+            pos[n] = (col, i)
 
     # Build skip-reason index once per snapshot (avoids re-parsing the
     # tracker per Ready issue). Only populated when main_root is given.

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.26+2d459c"
+  version: "2026.05.26+765e1b"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1601,12 +1601,23 @@ def _annotate_plans_queue(
     state_plans: Dict[str, List[Dict[str, Any]]] = state.get("plans", {})
     # state-file column iteration — picks up new columns from PLAN_COLUMNS / ISSUE_COLUMNS dynamically; conformance: tests/test-skill-conformance.sh
     # Build slug → (column, index, mode) lookup.
+    # Auto-prune orphan slugs (#671): derive the set of known slugs from
+    # the `plans` list parameter (parsed plan files). State-file entries
+    # whose slug has no corresponding parsed plan are orphans — silently
+    # drop them from `pos` so they never render and don't accumulate
+    # forever in the snapshot.
+    known_slugs: set = {
+        p["slug"] for p in plans
+        if isinstance(p.get("slug"), str) and p["slug"]
+    }
     pos: Dict[str, Tuple[str, int, Optional[str]]] = {}
     for col, entries in state_plans.items():
         for i, e in enumerate(entries):
             slug = e.get("slug", "")
+            if not slug or slug not in known_slugs:
+                continue  # orphan — plan file does not exist
             mode = e.get("mode") if col == "ready" else None
-            if slug and slug not in pos:
+            if slug not in pos:
                 pos[slug] = (col, i, mode)
 
     # Plan-claim index — parallel to the issue-side `claim_index`. Gated
@@ -1658,13 +1669,29 @@ def _annotate_issues_queue(
     actionable issues get no `skip_reason` field.
     """
     state_issues: Dict[str, List[Any]] = state.get("issues", {})
+    # Auto-prune closed issues (#670): derive the set of closed issue
+    # numbers from the `issues` list parameter, then skip them when
+    # building the explicit-position `pos` lookup. Closed issues are
+    # then routed via `_infer_issue_default_column` to `completed`
+    # (in-window) or `triage` (out-of-window, where the caller's
+    # open-fetch + closed-window-fetch contract typically also drops
+    # them from the list entirely).
+    closed_set: set = set()
+    for issue in issues:
+        num = issue.get("number")
+        if isinstance(num, int) and issue.get("closed_at"):
+            closed_set.add(num)
+
     pos: Dict[int, Tuple[str, int]] = {}
     for col, entries in state_issues.items():
         for i, num in enumerate(entries):
             try:
-                pos[int(num)] = (col, i)
+                n = int(num)
             except Exception:
                 continue
+            if n in closed_set:
+                continue  # closed — route via inference to completed/triage
+            pos[n] = (col, i)
 
     # Build skip-reason index once per snapshot (avoids re-parsing the
     # tracker per Ready issue). Only populated when main_root is given.

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -1510,6 +1510,124 @@ else
   fail "W1.20: got '$W120'"
 fi
 
+# W1.21 — annotate_issues_queue_drops_closed_from_explicit_positions:
+# state-file has issue #N in `triage` with `closed_at` set within window.
+# The explicit-position bypass must NOT keep it in `triage`; instead
+# `_infer_issue_default_column` routes it to `completed` (in-window).
+# Closes #670 — auto-prune closed issues from explicit-active columns.
+W121=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+from datetime import datetime, timezone, timedelta
+
+now = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+state = {
+    "issues": {"triage": [42], "backlog": []},
+    "plans": {"backlog": []},
+}
+# Issue #42 is in state.issues.triage AND closed in-window.
+# The auto-prune must filter it out of `pos`, letting inference win.
+issues = [
+    {"number": 42, "closed_at": (now - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")},
+]
+c._annotate_issues_queue(issues, state, None, now_utc=now, window_days=14)
+print("col=" + issues[0]["queue"]["column"])
+' 2>&1)
+if printf '%s\n' "$W121" | grep -q "^col=completed$"; then
+  pass "W1.21: annotate_issues_queue_drops_closed_from_explicit_positions (#670)"
+else
+  fail "W1.21: got '$W121'"
+fi
+
+# W1.22 — annotate_issues_queue_hides_closed_out_of_window_with_explicit_position:
+# state-file has issue #N in `triage` with `closed_at` OUTSIDE the 14-day
+# window. Auto-prune still drops it from `pos`; inference fallback routes
+# to `triage` (the `_infer_issue_default_column` default). The "hide"
+# part is enforced upstream by the caller's open+closed-window fetch
+# contract — at this boundary we only assert the explicit-position bypass
+# fires (state-file says triage, but inference owns the column).
+# Closes #670.
+W122=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+from datetime import datetime, timezone, timedelta
+
+now = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+state = {
+    "issues": {"triage": [99], "backlog": []},
+    "plans": {"backlog": []},
+}
+# Closed 30 days ago — outside the 14-day window.
+issues = [
+    {"number": 99, "closed_at": (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")},
+]
+c._annotate_issues_queue(issues, state, None, now_utc=now, window_days=14)
+print("col=" + issues[0]["queue"]["column"])
+print("index=" + str(issues[0]["queue"]["index"]))
+' 2>&1)
+if printf '%s\n' "$W122" | grep -q "^col=triage$" \
+    && printf '%s\n' "$W122" | grep -q "^index=-1$"; then
+  pass "W1.22: annotate_issues_queue_hides_closed_out_of_window_with_explicit_position (#670)"
+else
+  fail "W1.22: got '$W122'"
+fi
+
+# W1.23 — annotate_plans_queue_drops_orphan_state_file_entries:
+# state-file has slug `nonexistent-plan` in `drafted`, but the `plans`
+# list passed in does NOT contain a dict with that slug. The orphan must
+# be auto-pruned from `pos` so it never affects rendering, and unrelated
+# plans (e.g. `real-plan` in `backlog`) must NOT pick up the orphan's
+# index-0 position from the state file's `drafted` array.
+#
+# Without the auto-prune, `pos` would have
+# `{"nonexistent-plan": ("drafted", 0, None)}`. `real-plan` would not be
+# in `pos` and would fall through to inference. The auto-prune ensures
+# the orphan never enters `pos`, AND a same-column-different-slug
+# scenario does not get its index shifted by the orphan's presence.
+#
+# Concrete assertion: real-plan-in-backlog must end up with
+# `column=backlog, index=0` (the explicit state-file position), and the
+# orphan slug must never appear anywhere in the output.
+# Closes #671 — auto-prune orphan plan slugs.
+W123=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+from datetime import datetime, timezone
+
+now = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+state = {
+    "plans": {
+        "drafted": [{"slug": "nonexistent-plan"}],
+        "backlog": [{"slug": "real-plan"}],
+    },
+    "issues": {"backlog": []},
+}
+# `real-plan` is the only parsed plan; `nonexistent-plan` is an orphan.
+plans = [
+    {"slug": "real-plan", "status": "active", "phases_done": 0},
+]
+c._annotate_plans_queue(plans, state, now_utc=now, window_days=14)
+# real-plan picks up backlog from its OWN state-file position, NOT
+# from the orphan-slug entry in drafted.
+print("real_col=" + plans[0]["queue"]["column"])
+print("real_index=" + str(plans[0]["queue"]["index"]))
+# Confirm no plan in the result list has slug == nonexistent-plan.
+orphan_present = any(p.get("slug") == "nonexistent-plan" for p in plans)
+print("orphan_present=" + str(orphan_present))
+print("plan_count=" + str(len(plans)))
+' 2>&1)
+if printf '%s\n' "$W123" | grep -q "^real_col=backlog$" \
+    && printf '%s\n' "$W123" | grep -q "^real_index=0$" \
+    && printf '%s\n' "$W123" | grep -q "^orphan_present=False$" \
+    && printf '%s\n' "$W123" | grep -q "^plan_count=1$"; then
+  pass "W1.23: annotate_plans_queue_drops_orphan_state_file_entries (#671)"
+else
+  fail "W1.23: got '$W123'"
+fi
+
 # ---------------------------------------------------------------------------
 # Phase 1: backfill-plan-completed.sh tests (W1.13–W1.18)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two parallel auto-prune fixes for stale entries in the dashboard's `_annotate_*_queue` explicit-position `pos` lookup. Issue-side analog to PR #662 on the plans side.

- **#670** — `_annotate_issues_queue` now derives `closed_set` from issues with `closed_at` set and skips those numbers when building `pos`. Closed-in-window issues then route via `_infer_issue_default_column` to `completed`; closed-out-of-window fall through to `triage` (and are typically dropped from the live `issues` list by the caller's open-fetch + closed-window-fetch contract). Fixes the case where `/fix-issues` cron repeatedly no-op'd on #655 sitting in `state.issues.ready`.
- **#671** — `_annotate_plans_queue` now derives `known_slugs` from the `plans` list parameter and skips orphan state-file entries. Prevents unbounded growth of `state.plans.drafted` as plans are renamed or deleted.

## Test plan

- [x] Three new W-numbered tests (W1.21/W1.22/W1.23) in `tests/test_zskills_monitor_collect.sh`, pattern after W1.11/W1.19/W1.20:
  - `annotate_issues_queue_drops_closed_from_explicit_positions` — closed-in-window with explicit `triage` position → `completed`
  - `annotate_issues_queue_hides_closed_out_of_window_with_explicit_position` — closed-out-of-window → `triage` (inference fallback)
  - `annotate_plans_queue_drops_orphan_state_file_entries` — orphan slug in `drafted` filtered; sibling real plan at `state.plans.backlog[0]` preserved with `column=backlog, index=0`
- [x] Full `bash tests/run-all.sh` clean: 5932/5932 passed (baseline ~5919 + 3 new + ~10 from intervening main).
- [x] Local `.zskills/monitor-state.json` cleaned (closed #655/#649/#648/#191 dropped from active columns; 10 orphan slugs dropped from `plans.drafted`). Backup at `.bak`. Local-only file; not part of the commit.
- [ ] Post-merge: restart production dashboard (`/zskills-dashboard restart`) to pick up the new code.

Closes #670
Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
