### PR TITLE
do: A+F + write-back — close #606 tax (PR 2 of 2)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.26+a2eeb6"
+  version: "2026.05.26+4913e0"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -1560,6 +1560,35 @@ if ! declare -p RESEARCHED_SET >/dev/null 2>&1; then
   done
   unset __r
 fi
+
+# PR-2 / A+F: drop SKIP_TAGGED candidates from CANDIDATE_ISSUES. The
+# filter-script SKIP_TAGGED line lists `<num>:<skip-code>` for rows
+# whose `Action now:` value resolves to a canonical dashboard skip-code
+# (plan-scale / bug-unclear-cause / needs-decision). These were
+# classified as non-actionable in prior fires; skip re-research and
+# re-triage now (#606 tax fix).
+read -r -a SKIP_TAGGED_ARR <<<"${SKIP_TAGGED:-}"
+declare -A SKIP_TAGGED_SET=()
+for tok in "${SKIP_TAGGED_ARR[@]+"${SKIP_TAGGED_ARR[@]}"}"; do
+  case "$tok" in
+    *:*) SKIP_TAGGED_SET["${tok%%:*}"]="${tok#*:}" ;;
+  esac
+done
+unset tok
+if [ "${#SKIP_TAGGED_SET[@]}" -gt 0 ]; then
+  declare -a _FILTERED=()
+  for N in "${CANDIDATE_ISSUES[@]}"; do
+    if [ -z "${SKIP_TAGGED_SET[$N]:-}" ]; then
+      _FILTERED+=("$N")
+    else
+      echo "fix-issues Phase 2: dropping skip-tagged #$N (${SKIP_TAGGED_SET[$N]}) — already classified" >&2
+    fi
+  done
+  # `+` suffix guards `set -u` when _FILTERED is empty (all candidates dropped).
+  CANDIDATE_ISSUES=("${_FILTERED[@]+"${_FILTERED[@]}"}")
+  unset _FILTERED N
+fi
+
 echo "Candidates after Phase 2 source-filter: ${CANDIDATE_ISSUES[*]:-(none)}"
 echo "  researched (will dispatch directly): ${RESEARCHED_ARR[*]:-(none)}"
 echo "  un-researched (Phase 3 will research-on-demand): ${MISSING_ARR[*]:-(none)}"
@@ -1716,6 +1745,31 @@ if ! declare -p RESEARCHED_SET >/dev/null 2>&1; then
   done
   unset __r
 fi
+
+# PR-2 / A+F: drop SKIP_TAGGED candidates from CANDIDATE_ISSUES. Mirrors
+# the dashboard branch's block — see expanded prose there. Functions
+# don't span skill fences so the block is duplicated literally.
+read -r -a SKIP_TAGGED_ARR <<<"${SKIP_TAGGED:-}"
+declare -A SKIP_TAGGED_SET=()
+for tok in "${SKIP_TAGGED_ARR[@]+"${SKIP_TAGGED_ARR[@]}"}"; do
+  case "$tok" in
+    *:*) SKIP_TAGGED_SET["${tok%%:*}"]="${tok#*:}" ;;
+  esac
+done
+unset tok
+if [ "${#SKIP_TAGGED_SET[@]}" -gt 0 ]; then
+  declare -a _FILTERED=()
+  for N in "${CANDIDATE_ISSUES[@]}"; do
+    if [ -z "${SKIP_TAGGED_SET[$N]:-}" ]; then
+      _FILTERED+=("$N")
+    else
+      echo "fix-issues Phase 2: dropping skip-tagged #$N (${SKIP_TAGGED_SET[$N]}) — already classified" >&2
+    fi
+  done
+  CANDIDATE_ISSUES=("${_FILTERED[@]+"${_FILTERED[@]}"}")
+  unset _FILTERED N
+fi
+
 echo "Candidates after Phase 2 source-filter: ${CANDIDATE_ISSUES[*]:-(none)}"
 echo "  researched (will dispatch directly): ${RESEARCHED_ARR[*]:-(none)}"
 echo "  un-researched (Phase 3 will research-on-demand): ${MISSING_ARR[*]:-(none)}"
@@ -2437,19 +2491,45 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   case "$CLASS" in
     actionable-in-batch|actionable-do-pr) ;;
     plan-scale|bug-unclear-cause|needs-decision|too-vague|author-decision)
-      # PR-2 / A+F write-back HOOK: PR 2 will rewrite the `**Action now:**` line
-      # in the scratchpad here to `Action now: <canonical-skip-value> — <rationale>`
-      # before promotion. PR 1 promotes the scratchpad as-is (research agent's
-      # original Action-now line) — the row still lands so future Phase 2 filters
-      # see it; the tag refinement is PR 2's scope.
+      # PR-2 / A+F write-back: rewrite the scratchpad's `**Action now:**`
+      # line to the canonical skip-value BEFORE promotion + commit, so the
+      # next fire's filter-script SKIP_TAGGED output picks up this
+      # classification and Phase 2 A drops the candidate without re-research
+      # (#606 tax fix). `too-vague` is intentionally left untouched (no
+      # canonical dashboard skip-code; vague rows need user clarification,
+      # not auto-tagging — re-classified next fire by design).
       SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
       if [ -f "$SCRATCH" ]; then
+        NEW_ACTION_NOW=""
+        case "$CLASS" in
+          plan-scale)
+            NEW_ACTION_NOW="**Action now:** /draft-plan — plan-scale design surface; needs adversarial plan review before any fix."
+            ;;
+          bug-unclear-cause)
+            NEW_ACTION_NOW="**Action now:** /investigate — root cause unclear; needs structured investigation before patching."
+            ;;
+          needs-decision|author-decision)
+            NEW_ACTION_NOW="**Action now:** none — author decision needed on direction; not auto-fixable."
+            ;;
+          too-vague)
+            : ;;  # leave scratchpad untouched
+        esac
+        if [ -n "$NEW_ACTION_NOW" ]; then
+          # Replace the entire `**Action now:** ...` line content. Line-anchored
+          # sed regex (period `.` is fine here because `sed` is line-mode by
+          # default; we use `[^\n]*` semantics via the explicit charclass to be
+          # clear about intent). Replacing the whole line drops any trailing
+          # research-agent rationale that would otherwise be semantically
+          # attached to the new canonical directive.
+          sed -i "s|\*\*Action now:\*\*[^\n]*|$NEW_ACTION_NOW|" "$SCRATCH" \
+            || echo "WARN: fix-issues write-back: sed rewrite failed for $SCRATCH (proceeding with original scratchpad content)" >&2
+        fi
         {
           echo ""
           cat "$SCRATCH"
         } >> "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
         git add "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
-        git commit -m "fix-issues: research blurb + skip-class triage for #${ISSUE_NUM}"
+        git commit -m "fix-issues: research blurb + skip-class triage (${CLASS}) for #${ISSUE_NUM}"
         rm -f "$SCRATCH"
       fi
       SKIP_RECORD+=("$CLASS:$ISSUE_NUM")
@@ -2606,6 +2686,7 @@ race-loss arm).
 
 <!-- allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /ISSUES_PLAN.md tail -->
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 PROJECT_NAME=$(basename "$PROJECT_ROOT")
@@ -2649,14 +2730,33 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   case "$CLASS" in
     actionable-in-batch|actionable-do-pr) ;;
     plan-scale|bug-unclear-cause|needs-decision|too-vague|author-decision)
-      # PR-mode carve-out: in PR mode with main_protected, skip-class promotion
-      # requires a tracker-only sync PR (mirrors the existing "dashboard-empty
-      # sync PR" pattern at SKILL.md ~1303). This is deferred to PR 2 — its
-      # write-back design naturally covers PR-mode promotion. PR 1 holds the
-      # scratchpad in place; PR 2 will collect held scratchpads and ship them
-      # via the sync-PR pattern.
-      # PR-2 hook: collect this scratchpad at end of Phase 3 and ship as
-      # tracker-only PR with the canonical skip-tag rewrite.
+      # PR-2 / A+F write-back: rewrite the scratchpad's `**Action now:**`
+      # line NOW so when the end-of-Phase-3 sync-PR ships these rows they
+      # carry the canonical skip-tag. main_protected blocks direct commit
+      # here — the scratchpad is held in `.zskills/research-staging/` for
+      # the end-of-loop batch sync-PR that mirrors the dashboard-empty
+      # pattern at SKILL.md ~1303-1378.
+      SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
+      if [ -f "$SCRATCH" ]; then
+        NEW_ACTION_NOW=""
+        case "$CLASS" in
+          plan-scale)
+            NEW_ACTION_NOW="**Action now:** /draft-plan — plan-scale design surface; needs adversarial plan review before any fix."
+            ;;
+          bug-unclear-cause)
+            NEW_ACTION_NOW="**Action now:** /investigate — root cause unclear; needs structured investigation before patching."
+            ;;
+          needs-decision|author-decision)
+            NEW_ACTION_NOW="**Action now:** none — author decision needed on direction; not auto-fixable."
+            ;;
+          too-vague)
+            : ;;  # leave scratchpad untouched
+        esac
+        if [ -n "$NEW_ACTION_NOW" ]; then
+          sed -i "s|\*\*Action now:\*\*[^\n]*|$NEW_ACTION_NOW|" "$SCRATCH" \
+            || echo "WARN: fix-issues PR-mode write-back: sed rewrite failed for $SCRATCH" >&2
+        fi
+      fi
       SKIP_RECORD+=("$CLASS:$ISSUE_NUM")
       continue
       ;;
@@ -2737,10 +2837,86 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   # Phase 6 via `/land-pr` (per-issue).
   DISPATCHED=$((DISPATCHED + 1))
 done
-# PR-mode leftover scratchpads (ranked-but-not-iterated + skip-class
-# held earlier) remain in `.zskills/research-staging/$PIPELINE_ID/` for
-# PR 2 to collect and ship via the sync-PR pattern. PR 1 does NOT
-# promote these — they are held by design.
+
+# PR-2 / A+F: end-of-PR-mode-Phase-3 sprint-tracker rollup. Collect any
+# remaining scratchpads in `.zskills/research-staging/$PIPELINE_ID/`
+# (skip-class write-back from triage above, plus any
+# ranked-but-not-iterated leftovers — PR mode held both intentionally so
+# the canonical skip-tag rewrite ships in ISSUES_PLAN.md). If non-empty,
+# ship as a tracker-only sync PR via the dashboard-empty pattern at
+# SKILL.md ~1283-1378. The sync-PR ALWAYS auto-merges regardless of the
+# user's `auto` arg — tracker-only content has no code-review surface;
+# review gates apply to code PRs only (same rationale as the
+# dashboard-empty sync at lines 1338-1341).
+declare -a TRACKER_SCRATCHPADS=()
+for N in "${CANDIDATE_ISSUES[@]+"${CANDIDATE_ISSUES[@]}"}"; do
+  S=".zskills/research-staging/$PIPELINE_ID/issue-${N}.md"
+  [ -f "$S" ] && TRACKER_SCRATCHPADS+=("$S")
+done
+unset N S
+
+if [ "${#TRACKER_SCRATCHPADS[@]}" -gt 0 ]; then
+  echo "fix-issues PR-mode: shipping ${#TRACKER_SCRATCHPADS[@]} skip-tag / leftover row(s) as sprint-tracker PR" >&2
+  TRACKER_WT=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/create-worktree.sh" \
+    --prefix tracker \
+    --branch-name "fix-issues-tracker/$SPRINT_ID" \
+    --purpose "fix-issues sprint-tracker skip-tag rollup" \
+    --pipeline-id "$PIPELINE_ID" \
+    "$SPRINT_ID")
+  TRACKER_RC=$?
+  if [ "$TRACKER_RC" -ne 0 ]; then
+    echo "fix-issues PR-mode: tracker worktree creation failed (rc=$TRACKER_RC); scratchpads retained for next fire" >&2
+  else
+    (
+      cd "$TRACKER_WT" || exit 1
+      for S in "${TRACKER_SCRATCHPADS[@]}"; do
+        {
+          echo ""
+          cat "$MAIN_ROOT/$S"
+        } >> "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
+      done
+      git add "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
+      if [ -n "${COMMIT_CO_AUTHOR:-}" ]; then
+        git commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" \
+          -m "docs(sync): /fix-issues skip-tag rollup sprint $SPRINT_ID"
+      else
+        git commit -m "docs(sync): /fix-issues skip-tag rollup sprint $SPRINT_ID"
+      fi
+    )
+    # Dispatch /land-pr --auto for the tracker PR. Mirrors the
+    # dashboard-empty pattern's LAND_ARGS shape (always --auto because
+    # this is sync-only content with no code-review surface).
+    TRACKER_LAND_ID="fix-issues.tracker-rollup.${SPRINT_ID}"
+    TRACKER_RESULT=$(mktemp)
+    TRACKER_BODY=$(mktemp)
+    {
+      printf '## Summary\n`/fix-issues` PR-mode sprint %s: %d skip-tag / leftover row(s) shipped as tracker-only sync.\n\n' \
+        "$SPRINT_ID" "${#TRACKER_SCRATCHPADS[@]}"
+      printf '## Test plan\n- [x] Tracker-only diff; no per-issue work in this PR.\n'
+    } > "$TRACKER_BODY"
+    mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+    printf 'skill: land-pr\nrequired-by: fix-issues-pr-mode-tracker-rollup\ndate: %s\n' \
+      "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
+      > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${TRACKER_LAND_ID}"
+    TRACKER_LAND_ARGS="--branch=fix-issues-tracker/$SPRINT_ID --title=\"sync: /fix-issues skip-tag rollup sprint $SPRINT_ID\" --body-file=$TRACKER_BODY --result-file=$TRACKER_RESULT --landed-source=fix-issues-pr-mode-tracker-rollup --worktree-path=$TRACKER_WT --tracking-id=$TRACKER_LAND_ID --auto"
+    echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+    # Skill: { skill: "land-pr", args: "$TRACKER_LAND_ARGS" }
+    # (Allow-list parser handles result file; mirrors dashboard-empty pattern.)
+    # On success, remove the scratchpads. On failure, retain for next fire.
+    if [ -f "$TRACKER_RESULT" ]; then
+      while IFS='=' read -r K V; do
+        if [ "$K" = "STATUS" ] && [ "$V" = "merged" ]; then
+          for S in "${TRACKER_SCRATCHPADS[@]}"; do rm -f "$S"; done
+          printf 'skill: land-pr\nid: %s\npr: -\nbranch: fix-issues-tracker/%s\ndate: %s\n' \
+            "$TRACKER_LAND_ID" "$SPRINT_ID" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
+            > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.land-pr.$TRACKER_LAND_ID"
+        fi
+      done < "$TRACKER_RESULT"
+    fi
+    rm -f "$TRACKER_RESULT" "$TRACKER_BODY"
+  fi
+fi
+unset TRACKER_SCRATCHPADS TRACKER_WT TRACKER_RC S
 ```
 
 **Dispatching fix agents in PR mode:** Dispatch agents WITHOUT

--- a/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -9,11 +9,22 @@
 # This script source-filters candidates rather than gating the sprint.
 # Candidates that have an "**Action now:**" line within their
 # `### #<N> ` section in any tracker file under $ZSKILLS_ISSUES_DIR are
-# RESEARCHED; the rest are MISSING. Output is two `key="val val val"`
-# lines on stdout (RHS quoted so multi-token values survive `eval`):
+# RESEARCHED; the rest are MISSING. Additionally, candidates whose
+# Action-now value resolves to a canonical dashboard skip-code
+# (`plan-scale`, `bug-unclear-cause`, `needs-decision`) are also emitted
+# in a third SKIP_TAGGED line so Phase 2 A can drop them from
+# CANDIDATE_ISSUES before triage (PR 2 / #606 tax fix).
+#
+# Output is three `key="val val val"` lines on stdout (RHS quoted so
+# multi-token values survive `eval`):
 #
 #   RESEARCHED="11 12 13"
 #   MISSING="14 15"
+#   SKIP_TAGGED="11:plan-scale 13:bug-unclear-cause"
+#
+# SKIP_TAGGED tokens have the shape `<issue-num>:<skip-code>`; the line
+# is always emitted (empty when no skip-class rows are found) so legacy
+# consumers that only read RESEARCHED/MISSING keep working.
 #
 # Signal choice: `**Action now:**` (the Phase-2-consumed tier field), NOT
 # `**Verdict:**`. Reasons:
@@ -23,12 +34,17 @@
 #   - Row-writer creates stubs with `**Verdict:** NOT YET RESEARCHED`; a
 #     Verdict-presence check would no-op the gate.
 #
+# Skip-code derivation mirrors `_parse_action_now` priority order in
+# `skills/zskills-dashboard/scripts/zskills_monitor/collect.py` (none →
+# /draft-plan|/run-plan → /investigate). POSIX-portable boundary class
+# `[^[:alnum:]_-]` is used in place of awk `\b` (non-portable).
+#
 # Usage:
 #   ZSKILLS_ISSUES_DIR=/path/to/issues bash filter-unresearched-candidates.sh 380 390 392 ...
 #   eval "$(ZSKILLS_ISSUES_DIR=... bash filter-unresearched-candidates.sh "${CANDIDATE_ISSUES[@]}")"
 #
 # Exit:
-#   0 — always (an empty candidate list also exits 0 with both arrays empty).
+#   0 — always (an empty candidate list also exits 0 with all arrays empty).
 #   1 — usage error (ZSKILLS_ISSUES_DIR unset, etc.).
 
 set -u
@@ -40,6 +56,7 @@ fi
 
 RESEARCHED=()
 MISSING=()
+SKIP_TAGGED=()
 
 for N in "$@"; do
   # Skip non-numeric tokens defensively.
@@ -56,20 +73,51 @@ for N in "$@"; do
   # `### ` heading (any). A naive `grep -A 50` would bleed into the
   # following section and yield false positives when a later researched
   # row sits within 50 lines.
+  #
+  # Awk also extracts the Action-now value (substring after the bold
+  # marker) and prints `SKIP=<code>` if it resolves to one of the three
+  # canonical dashboard skip-codes via POSIX-portable boundary matching.
   found=0
+  skip_code=""
   for f in "$ZSKILLS_ISSUES_DIR"/*.md; do
     [ -f "$f" ] || continue
-    if awk -v n="$N" '
+    out=$(awk -v n="$N" '
       $0 ~ "^### #" n " " { in_sec=1; next }
       in_sec && /^### / { exit }
-      in_sec && index($0, "**Action now:**") > 0 { print "HIT"; exit }
-    ' "$f" 2>/dev/null | grep -q '^HIT$'; then
+      in_sec && index($0, "**Action now:**") > 0 {
+        print "HIT"
+        if (match($0, /\*\*Action now:\*\*[[:space:]]*/)) {
+          val = substr($0, RSTART + RLENGTH)
+          # Lowercase for case-insensitive prefix matching.
+          val_lc = tolower(val)
+          # Priority: none → /draft-plan|/run-plan → /investigate.
+          # POSIX-portable boundary: NOT [:alnum:]_- or end-of-string.
+          if (val_lc ~ /^none([^[:alnum:]_-]|$)/) {
+            print "SKIP=needs-decision"
+          } else if (val_lc ~ /^\/draft-plan([^[:alnum:]_-]|$)/ || val_lc ~ /^\/run-plan([^[:alnum:]_-]|$)/) {
+            print "SKIP=plan-scale"
+          } else if (val_lc ~ /^\/investigate([^[:alnum:]_-]|$)/) {
+            print "SKIP=bug-unclear-cause"
+          }
+        }
+        exit
+      }
+    ' "$f" 2>/dev/null)
+    if printf '%s\n' "$out" | grep -q '^HIT$'; then
       found=1
+      # Extract skip code if any (first-match-wins across files).
+      sk=$(printf '%s\n' "$out" | grep '^SKIP=' | head -1 | sed 's/^SKIP=//')
+      if [ -n "$sk" ]; then
+        skip_code="$sk"
+      fi
       break
     fi
   done
   if [ "$found" -eq 1 ]; then
     RESEARCHED+=("$N")
+    if [ -n "$skip_code" ]; then
+      SKIP_TAGGED+=("$N:$skip_code")
+    fi
   else
     MISSING+=("$N")
   fi
@@ -77,3 +125,4 @@ done
 
 printf 'RESEARCHED="%s"\n' "${RESEARCHED[*]}"
 printf 'MISSING="%s"\n' "${MISSING[*]}"
+printf 'SKIP_TAGGED="%s"\n' "${SKIP_TAGGED[*]}"

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.26+a2eeb6"
+  version: "2026.05.26+4913e0"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -1560,6 +1560,35 @@ if ! declare -p RESEARCHED_SET >/dev/null 2>&1; then
   done
   unset __r
 fi
+
+# PR-2 / A+F: drop SKIP_TAGGED candidates from CANDIDATE_ISSUES. The
+# filter-script SKIP_TAGGED line lists `<num>:<skip-code>` for rows
+# whose `Action now:` value resolves to a canonical dashboard skip-code
+# (plan-scale / bug-unclear-cause / needs-decision). These were
+# classified as non-actionable in prior fires; skip re-research and
+# re-triage now (#606 tax fix).
+read -r -a SKIP_TAGGED_ARR <<<"${SKIP_TAGGED:-}"
+declare -A SKIP_TAGGED_SET=()
+for tok in "${SKIP_TAGGED_ARR[@]+"${SKIP_TAGGED_ARR[@]}"}"; do
+  case "$tok" in
+    *:*) SKIP_TAGGED_SET["${tok%%:*}"]="${tok#*:}" ;;
+  esac
+done
+unset tok
+if [ "${#SKIP_TAGGED_SET[@]}" -gt 0 ]; then
+  declare -a _FILTERED=()
+  for N in "${CANDIDATE_ISSUES[@]}"; do
+    if [ -z "${SKIP_TAGGED_SET[$N]:-}" ]; then
+      _FILTERED+=("$N")
+    else
+      echo "fix-issues Phase 2: dropping skip-tagged #$N (${SKIP_TAGGED_SET[$N]}) — already classified" >&2
+    fi
+  done
+  # `+` suffix guards `set -u` when _FILTERED is empty (all candidates dropped).
+  CANDIDATE_ISSUES=("${_FILTERED[@]+"${_FILTERED[@]}"}")
+  unset _FILTERED N
+fi
+
 echo "Candidates after Phase 2 source-filter: ${CANDIDATE_ISSUES[*]:-(none)}"
 echo "  researched (will dispatch directly): ${RESEARCHED_ARR[*]:-(none)}"
 echo "  un-researched (Phase 3 will research-on-demand): ${MISSING_ARR[*]:-(none)}"
@@ -1716,6 +1745,31 @@ if ! declare -p RESEARCHED_SET >/dev/null 2>&1; then
   done
   unset __r
 fi
+
+# PR-2 / A+F: drop SKIP_TAGGED candidates from CANDIDATE_ISSUES. Mirrors
+# the dashboard branch's block — see expanded prose there. Functions
+# don't span skill fences so the block is duplicated literally.
+read -r -a SKIP_TAGGED_ARR <<<"${SKIP_TAGGED:-}"
+declare -A SKIP_TAGGED_SET=()
+for tok in "${SKIP_TAGGED_ARR[@]+"${SKIP_TAGGED_ARR[@]}"}"; do
+  case "$tok" in
+    *:*) SKIP_TAGGED_SET["${tok%%:*}"]="${tok#*:}" ;;
+  esac
+done
+unset tok
+if [ "${#SKIP_TAGGED_SET[@]}" -gt 0 ]; then
+  declare -a _FILTERED=()
+  for N in "${CANDIDATE_ISSUES[@]}"; do
+    if [ -z "${SKIP_TAGGED_SET[$N]:-}" ]; then
+      _FILTERED+=("$N")
+    else
+      echo "fix-issues Phase 2: dropping skip-tagged #$N (${SKIP_TAGGED_SET[$N]}) — already classified" >&2
+    fi
+  done
+  CANDIDATE_ISSUES=("${_FILTERED[@]+"${_FILTERED[@]}"}")
+  unset _FILTERED N
+fi
+
 echo "Candidates after Phase 2 source-filter: ${CANDIDATE_ISSUES[*]:-(none)}"
 echo "  researched (will dispatch directly): ${RESEARCHED_ARR[*]:-(none)}"
 echo "  un-researched (Phase 3 will research-on-demand): ${MISSING_ARR[*]:-(none)}"
@@ -2437,19 +2491,45 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   case "$CLASS" in
     actionable-in-batch|actionable-do-pr) ;;
     plan-scale|bug-unclear-cause|needs-decision|too-vague|author-decision)
-      # PR-2 / A+F write-back HOOK: PR 2 will rewrite the `**Action now:**` line
-      # in the scratchpad here to `Action now: <canonical-skip-value> — <rationale>`
-      # before promotion. PR 1 promotes the scratchpad as-is (research agent's
-      # original Action-now line) — the row still lands so future Phase 2 filters
-      # see it; the tag refinement is PR 2's scope.
+      # PR-2 / A+F write-back: rewrite the scratchpad's `**Action now:**`
+      # line to the canonical skip-value BEFORE promotion + commit, so the
+      # next fire's filter-script SKIP_TAGGED output picks up this
+      # classification and Phase 2 A drops the candidate without re-research
+      # (#606 tax fix). `too-vague` is intentionally left untouched (no
+      # canonical dashboard skip-code; vague rows need user clarification,
+      # not auto-tagging — re-classified next fire by design).
       SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
       if [ -f "$SCRATCH" ]; then
+        NEW_ACTION_NOW=""
+        case "$CLASS" in
+          plan-scale)
+            NEW_ACTION_NOW="**Action now:** /draft-plan — plan-scale design surface; needs adversarial plan review before any fix."
+            ;;
+          bug-unclear-cause)
+            NEW_ACTION_NOW="**Action now:** /investigate — root cause unclear; needs structured investigation before patching."
+            ;;
+          needs-decision|author-decision)
+            NEW_ACTION_NOW="**Action now:** none — author decision needed on direction; not auto-fixable."
+            ;;
+          too-vague)
+            : ;;  # leave scratchpad untouched
+        esac
+        if [ -n "$NEW_ACTION_NOW" ]; then
+          # Replace the entire `**Action now:** ...` line content. Line-anchored
+          # sed regex (period `.` is fine here because `sed` is line-mode by
+          # default; we use `[^\n]*` semantics via the explicit charclass to be
+          # clear about intent). Replacing the whole line drops any trailing
+          # research-agent rationale that would otherwise be semantically
+          # attached to the new canonical directive.
+          sed -i "s|\*\*Action now:\*\*[^\n]*|$NEW_ACTION_NOW|" "$SCRATCH" \
+            || echo "WARN: fix-issues write-back: sed rewrite failed for $SCRATCH (proceeding with original scratchpad content)" >&2
+        fi
         {
           echo ""
           cat "$SCRATCH"
         } >> "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
         git add "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
-        git commit -m "fix-issues: research blurb + skip-class triage for #${ISSUE_NUM}"
+        git commit -m "fix-issues: research blurb + skip-class triage (${CLASS}) for #${ISSUE_NUM}"
         rm -f "$SCRATCH"
       fi
       SKIP_RECORD+=("$CLASS:$ISSUE_NUM")
@@ -2606,6 +2686,7 @@ race-loss arm).
 
 <!-- allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /ISSUES_PLAN.md tail -->
 ```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 PROJECT_NAME=$(basename "$PROJECT_ROOT")
@@ -2649,14 +2730,33 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   case "$CLASS" in
     actionable-in-batch|actionable-do-pr) ;;
     plan-scale|bug-unclear-cause|needs-decision|too-vague|author-decision)
-      # PR-mode carve-out: in PR mode with main_protected, skip-class promotion
-      # requires a tracker-only sync PR (mirrors the existing "dashboard-empty
-      # sync PR" pattern at SKILL.md ~1303). This is deferred to PR 2 — its
-      # write-back design naturally covers PR-mode promotion. PR 1 holds the
-      # scratchpad in place; PR 2 will collect held scratchpads and ship them
-      # via the sync-PR pattern.
-      # PR-2 hook: collect this scratchpad at end of Phase 3 and ship as
-      # tracker-only PR with the canonical skip-tag rewrite.
+      # PR-2 / A+F write-back: rewrite the scratchpad's `**Action now:**`
+      # line NOW so when the end-of-Phase-3 sync-PR ships these rows they
+      # carry the canonical skip-tag. main_protected blocks direct commit
+      # here — the scratchpad is held in `.zskills/research-staging/` for
+      # the end-of-loop batch sync-PR that mirrors the dashboard-empty
+      # pattern at SKILL.md ~1303-1378.
+      SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
+      if [ -f "$SCRATCH" ]; then
+        NEW_ACTION_NOW=""
+        case "$CLASS" in
+          plan-scale)
+            NEW_ACTION_NOW="**Action now:** /draft-plan — plan-scale design surface; needs adversarial plan review before any fix."
+            ;;
+          bug-unclear-cause)
+            NEW_ACTION_NOW="**Action now:** /investigate — root cause unclear; needs structured investigation before patching."
+            ;;
+          needs-decision|author-decision)
+            NEW_ACTION_NOW="**Action now:** none — author decision needed on direction; not auto-fixable."
+            ;;
+          too-vague)
+            : ;;  # leave scratchpad untouched
+        esac
+        if [ -n "$NEW_ACTION_NOW" ]; then
+          sed -i "s|\*\*Action now:\*\*[^\n]*|$NEW_ACTION_NOW|" "$SCRATCH" \
+            || echo "WARN: fix-issues PR-mode write-back: sed rewrite failed for $SCRATCH" >&2
+        fi
+      fi
       SKIP_RECORD+=("$CLASS:$ISSUE_NUM")
       continue
       ;;
@@ -2737,10 +2837,86 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   # Phase 6 via `/land-pr` (per-issue).
   DISPATCHED=$((DISPATCHED + 1))
 done
-# PR-mode leftover scratchpads (ranked-but-not-iterated + skip-class
-# held earlier) remain in `.zskills/research-staging/$PIPELINE_ID/` for
-# PR 2 to collect and ship via the sync-PR pattern. PR 1 does NOT
-# promote these — they are held by design.
+
+# PR-2 / A+F: end-of-PR-mode-Phase-3 sprint-tracker rollup. Collect any
+# remaining scratchpads in `.zskills/research-staging/$PIPELINE_ID/`
+# (skip-class write-back from triage above, plus any
+# ranked-but-not-iterated leftovers — PR mode held both intentionally so
+# the canonical skip-tag rewrite ships in ISSUES_PLAN.md). If non-empty,
+# ship as a tracker-only sync PR via the dashboard-empty pattern at
+# SKILL.md ~1283-1378. The sync-PR ALWAYS auto-merges regardless of the
+# user's `auto` arg — tracker-only content has no code-review surface;
+# review gates apply to code PRs only (same rationale as the
+# dashboard-empty sync at lines 1338-1341).
+declare -a TRACKER_SCRATCHPADS=()
+for N in "${CANDIDATE_ISSUES[@]+"${CANDIDATE_ISSUES[@]}"}"; do
+  S=".zskills/research-staging/$PIPELINE_ID/issue-${N}.md"
+  [ -f "$S" ] && TRACKER_SCRATCHPADS+=("$S")
+done
+unset N S
+
+if [ "${#TRACKER_SCRATCHPADS[@]}" -gt 0 ]; then
+  echo "fix-issues PR-mode: shipping ${#TRACKER_SCRATCHPADS[@]} skip-tag / leftover row(s) as sprint-tracker PR" >&2
+  TRACKER_WT=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/create-worktree.sh" \
+    --prefix tracker \
+    --branch-name "fix-issues-tracker/$SPRINT_ID" \
+    --purpose "fix-issues sprint-tracker skip-tag rollup" \
+    --pipeline-id "$PIPELINE_ID" \
+    "$SPRINT_ID")
+  TRACKER_RC=$?
+  if [ "$TRACKER_RC" -ne 0 ]; then
+    echo "fix-issues PR-mode: tracker worktree creation failed (rc=$TRACKER_RC); scratchpads retained for next fire" >&2
+  else
+    (
+      cd "$TRACKER_WT" || exit 1
+      for S in "${TRACKER_SCRATCHPADS[@]}"; do
+        {
+          echo ""
+          cat "$MAIN_ROOT/$S"
+        } >> "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
+      done
+      git add "$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
+      if [ -n "${COMMIT_CO_AUTHOR:-}" ]; then
+        git commit --trailer "Co-Authored-By: $COMMIT_CO_AUTHOR" \
+          -m "docs(sync): /fix-issues skip-tag rollup sprint $SPRINT_ID"
+      else
+        git commit -m "docs(sync): /fix-issues skip-tag rollup sprint $SPRINT_ID"
+      fi
+    )
+    # Dispatch /land-pr --auto for the tracker PR. Mirrors the
+    # dashboard-empty pattern's LAND_ARGS shape (always --auto because
+    # this is sync-only content with no code-review surface).
+    TRACKER_LAND_ID="fix-issues.tracker-rollup.${SPRINT_ID}"
+    TRACKER_RESULT=$(mktemp)
+    TRACKER_BODY=$(mktemp)
+    {
+      printf '## Summary\n`/fix-issues` PR-mode sprint %s: %d skip-tag / leftover row(s) shipped as tracker-only sync.\n\n' \
+        "$SPRINT_ID" "${#TRACKER_SCRATCHPADS[@]}"
+      printf '## Test plan\n- [x] Tracker-only diff; no per-issue work in this PR.\n'
+    } > "$TRACKER_BODY"
+    mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
+    printf 'skill: land-pr\nrequired-by: fix-issues-pr-mode-tracker-rollup\ndate: %s\n' \
+      "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
+      > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${TRACKER_LAND_ID}"
+    TRACKER_LAND_ARGS="--branch=fix-issues-tracker/$SPRINT_ID --title=\"sync: /fix-issues skip-tag rollup sprint $SPRINT_ID\" --body-file=$TRACKER_BODY --result-file=$TRACKER_RESULT --landed-source=fix-issues-pr-mode-tracker-rollup --worktree-path=$TRACKER_WT --tracking-id=$TRACKER_LAND_ID --auto"
+    echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+    # Skill: { skill: "land-pr", args: "$TRACKER_LAND_ARGS" }
+    # (Allow-list parser handles result file; mirrors dashboard-empty pattern.)
+    # On success, remove the scratchpads. On failure, retain for next fire.
+    if [ -f "$TRACKER_RESULT" ]; then
+      while IFS='=' read -r K V; do
+        if [ "$K" = "STATUS" ] && [ "$V" = "merged" ]; then
+          for S in "${TRACKER_SCRATCHPADS[@]}"; do rm -f "$S"; done
+          printf 'skill: land-pr\nid: %s\npr: -\nbranch: fix-issues-tracker/%s\ndate: %s\n' \
+            "$TRACKER_LAND_ID" "$SPRINT_ID" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
+            > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.land-pr.$TRACKER_LAND_ID"
+        fi
+      done < "$TRACKER_RESULT"
+    fi
+    rm -f "$TRACKER_RESULT" "$TRACKER_BODY"
+  fi
+fi
+unset TRACKER_SCRATCHPADS TRACKER_WT TRACKER_RC S
 ```
 
 **Dispatching fix agents in PR mode:** Dispatch agents WITHOUT

--- a/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -9,11 +9,22 @@
 # This script source-filters candidates rather than gating the sprint.
 # Candidates that have an "**Action now:**" line within their
 # `### #<N> ` section in any tracker file under $ZSKILLS_ISSUES_DIR are
-# RESEARCHED; the rest are MISSING. Output is two `key="val val val"`
-# lines on stdout (RHS quoted so multi-token values survive `eval`):
+# RESEARCHED; the rest are MISSING. Additionally, candidates whose
+# Action-now value resolves to a canonical dashboard skip-code
+# (`plan-scale`, `bug-unclear-cause`, `needs-decision`) are also emitted
+# in a third SKIP_TAGGED line so Phase 2 A can drop them from
+# CANDIDATE_ISSUES before triage (PR 2 / #606 tax fix).
+#
+# Output is three `key="val val val"` lines on stdout (RHS quoted so
+# multi-token values survive `eval`):
 #
 #   RESEARCHED="11 12 13"
 #   MISSING="14 15"
+#   SKIP_TAGGED="11:plan-scale 13:bug-unclear-cause"
+#
+# SKIP_TAGGED tokens have the shape `<issue-num>:<skip-code>`; the line
+# is always emitted (empty when no skip-class rows are found) so legacy
+# consumers that only read RESEARCHED/MISSING keep working.
 #
 # Signal choice: `**Action now:**` (the Phase-2-consumed tier field), NOT
 # `**Verdict:**`. Reasons:
@@ -23,12 +34,17 @@
 #   - Row-writer creates stubs with `**Verdict:** NOT YET RESEARCHED`; a
 #     Verdict-presence check would no-op the gate.
 #
+# Skip-code derivation mirrors `_parse_action_now` priority order in
+# `skills/zskills-dashboard/scripts/zskills_monitor/collect.py` (none →
+# /draft-plan|/run-plan → /investigate). POSIX-portable boundary class
+# `[^[:alnum:]_-]` is used in place of awk `\b` (non-portable).
+#
 # Usage:
 #   ZSKILLS_ISSUES_DIR=/path/to/issues bash filter-unresearched-candidates.sh 380 390 392 ...
 #   eval "$(ZSKILLS_ISSUES_DIR=... bash filter-unresearched-candidates.sh "${CANDIDATE_ISSUES[@]}")"
 #
 # Exit:
-#   0 — always (an empty candidate list also exits 0 with both arrays empty).
+#   0 — always (an empty candidate list also exits 0 with all arrays empty).
 #   1 — usage error (ZSKILLS_ISSUES_DIR unset, etc.).
 
 set -u
@@ -40,6 +56,7 @@ fi
 
 RESEARCHED=()
 MISSING=()
+SKIP_TAGGED=()
 
 for N in "$@"; do
   # Skip non-numeric tokens defensively.
@@ -56,20 +73,51 @@ for N in "$@"; do
   # `### ` heading (any). A naive `grep -A 50` would bleed into the
   # following section and yield false positives when a later researched
   # row sits within 50 lines.
+  #
+  # Awk also extracts the Action-now value (substring after the bold
+  # marker) and prints `SKIP=<code>` if it resolves to one of the three
+  # canonical dashboard skip-codes via POSIX-portable boundary matching.
   found=0
+  skip_code=""
   for f in "$ZSKILLS_ISSUES_DIR"/*.md; do
     [ -f "$f" ] || continue
-    if awk -v n="$N" '
+    out=$(awk -v n="$N" '
       $0 ~ "^### #" n " " { in_sec=1; next }
       in_sec && /^### / { exit }
-      in_sec && index($0, "**Action now:**") > 0 { print "HIT"; exit }
-    ' "$f" 2>/dev/null | grep -q '^HIT$'; then
+      in_sec && index($0, "**Action now:**") > 0 {
+        print "HIT"
+        if (match($0, /\*\*Action now:\*\*[[:space:]]*/)) {
+          val = substr($0, RSTART + RLENGTH)
+          # Lowercase for case-insensitive prefix matching.
+          val_lc = tolower(val)
+          # Priority: none → /draft-plan|/run-plan → /investigate.
+          # POSIX-portable boundary: NOT [:alnum:]_- or end-of-string.
+          if (val_lc ~ /^none([^[:alnum:]_-]|$)/) {
+            print "SKIP=needs-decision"
+          } else if (val_lc ~ /^\/draft-plan([^[:alnum:]_-]|$)/ || val_lc ~ /^\/run-plan([^[:alnum:]_-]|$)/) {
+            print "SKIP=plan-scale"
+          } else if (val_lc ~ /^\/investigate([^[:alnum:]_-]|$)/) {
+            print "SKIP=bug-unclear-cause"
+          }
+        }
+        exit
+      }
+    ' "$f" 2>/dev/null)
+    if printf '%s\n' "$out" | grep -q '^HIT$'; then
       found=1
+      # Extract skip code if any (first-match-wins across files).
+      sk=$(printf '%s\n' "$out" | grep '^SKIP=' | head -1 | sed 's/^SKIP=//')
+      if [ -n "$sk" ]; then
+        skip_code="$sk"
+      fi
       break
     fi
   done
   if [ "$found" -eq 1 ]; then
     RESEARCHED+=("$N")
+    if [ -n "$skip_code" ]; then
+      SKIP_TAGGED+=("$N:$skip_code")
+    fi
   else
     MISSING+=("$N")
   fi
@@ -77,3 +125,4 @@ done
 
 printf 'RESEARCHED="%s"\n' "${RESEARCHED[*]}"
 printf 'MISSING="%s"\n' "${MISSING[*]}"
+printf 'SKIP_TAGGED="%s"\n' "${SKIP_TAGGED[*]}"

--- a/tests/test-fix-issues-phase2-source-filter.sh
+++ b/tests/test-fix-issues-phase2-source-filter.sh
@@ -366,6 +366,161 @@ test_skill_research_agent_no_commit() {
   fi
 }
 
+# --- PR-2 / A+F: filter emits SKIP_TAGGED line -------------------------
+# Mixed fixture with /draft-plan, /do pr rows. SKIP_TAGGED must contain
+# the /draft-plan issue tagged `:plan-scale` and must NOT contain the
+# /do pr issue.
+build_skip_tagged_fixture() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/ISSUES.md" <<'EOF'
+### #700 — plan-scale issue
+
+**Labels:** bug | **Verdict:** NOT FIXED.
+
+**Complexity:** L. **Action now:** /draft-plan — needs design review.
+
+### #701 — actionable
+
+**Labels:** bug | **Verdict:** NOT FIXED.
+
+**Complexity:** S. **Action now:** /do pr — bounded.
+
+### #702 — investigate
+
+**Labels:** bug | **Verdict:** UNCLEAR.
+
+**Complexity:** M. **Action now:** /investigate — root cause unclear.
+
+### #703 — needs decision
+
+**Labels:** bug | **Verdict:** NOT FIXED.
+
+**Complexity:** S. **Action now:** none — author decision needed.
+
+### #704 — false-positive boundary (must NOT match `none`)
+
+**Complexity:** S. **Action now:** none-of-the-above — placeholder.
+
+### #705 — /run-plan should map to plan-scale
+
+**Complexity:** S. **Action now:** /run-plan — execute existing plan.
+EOF
+}
+
+test_filter_emits_skip_tagged() {
+  local dir="$TMP_ROOT/skip-tagged"
+  build_skip_tagged_fixture "$dir"
+  local out skip_tagged
+  out=$(run_filter "$dir" 700 701)
+  skip_tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  if [ "$skip_tagged" = "700:plan-scale" ]; then
+    pass "SKIP_TAGGED emitted for /draft-plan row; /do pr row excluded"
+  else
+    fail "SKIP_TAGGED emission" "expected '700:plan-scale', got [$skip_tagged]"
+  fi
+}
+
+test_filter_skip_tagged_codes() {
+  local dir="$TMP_ROOT/codes"
+  build_skip_tagged_fixture "$dir"
+  local out skip_tagged
+  out=$(run_filter "$dir" 700 701 702 703 704 705)
+  skip_tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  # Expected: 700:plan-scale (draft-plan), 702:bug-unclear-cause (investigate),
+  # 703:needs-decision (none), 705:plan-scale (run-plan).
+  # 701 (/do pr) and 704 (none-of-the-above boundary) must NOT appear.
+  local expected="700:plan-scale 702:bug-unclear-cause 703:needs-decision 705:plan-scale"
+  if [ "$skip_tagged" = "$expected" ]; then
+    pass "SKIP_TAGGED per-code coverage: /draft-plan→plan-scale, /investigate→bug-unclear-cause, none→needs-decision, /run-plan→plan-scale; boundaries excluded"
+  else
+    fail "SKIP_TAGGED per-code coverage" "expected '$expected', got [$skip_tagged]"
+  fi
+}
+
+test_filter_skip_tagged_empty_when_no_skip_rows() {
+  local dir="$TMP_ROOT/no-skip"
+  mkdir -p "$dir"
+  cat > "$dir/ISSUES.md" <<'EOF'
+### #800 — actionable only
+
+**Complexity:** S. **Action now:** /do pr — bounded.
+EOF
+  local out skip_tagged
+  out=$(run_filter "$dir" 800)
+  # The SKIP_TAGGED line MUST still be emitted (backward-compat) but empty.
+  if ! echo "$out" | grep -q '^SKIP_TAGGED='; then
+    fail "SKIP_TAGGED always emitted" "no SKIP_TAGGED line found in output: $out"
+    return
+  fi
+  skip_tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  if [ -z "$skip_tagged" ]; then
+    pass "SKIP_TAGGED line present but empty when no skip-class rows"
+  else
+    fail "SKIP_TAGGED empty when no skip rows" "got [$skip_tagged]"
+  fi
+}
+
+# --- PR-2 / A+F: SKILL.md Phase 2 drop logic in both branches ----------
+test_skill_phase2_drops_skip_tagged() {
+  # Expect the SKIP_TAGGED_SET array population AND the _FILTERED
+  # reduction loop AND the `dropping skip-tagged` log line to appear
+  # in BOTH dashboard branch and default-rubric branch (2 hits each).
+  local set_count filtered_count drop_log_count
+  set_count=$(grep -c 'declare -A SKIP_TAGGED_SET' "$SKILL")
+  filtered_count=$(grep -c 'declare -a _FILTERED=()' "$SKILL")
+  drop_log_count=$(grep -c 'dropping skip-tagged' "$SKILL")
+  if [ "$set_count" -eq 2 ] && [ "$filtered_count" -eq 2 ] && [ "$drop_log_count" -eq 2 ]; then
+    pass "SKILL.md Phase 2 drop block present in BOTH branches (SKIP_TAGGED_SET=2, _FILTERED=2, drop-log=2)"
+  else
+    fail "SKILL.md Phase 2 drop block coverage" \
+         "expected 2 each — got SKIP_TAGGED_SET=$set_count _FILTERED=$filtered_count drop-log=$drop_log_count"
+  fi
+}
+
+# --- PR-2 / A+F: write-back rewrites scratchpad in BOTH mode arms ------
+test_skill_writeback_rewrites_scratchpad() {
+  # Each mode (cherry-pick/direct + PR-mode) must contain a case branch
+  # mapping plan-scale / bug-unclear-cause / needs-decision /
+  # author-decision to canonical NEW_ACTION_NOW values. Expect >=8
+  # NEW_ACTION_NOW= assignments total (4 cases × 2 modes).
+  local nan_count
+  nan_count=$(grep -c '^[[:space:]]*NEW_ACTION_NOW=' "$SKILL")
+  if [ "$nan_count" -lt 8 ]; then
+    fail "SKILL.md NEW_ACTION_NOW count" "expected >=8 (4 cases × 2 modes), got $nan_count"
+    return
+  fi
+  # Load-bearing: the actual `sed -i` rewrite MUST appear EXACTLY 2 times
+  # (once per mode). Without this assertion the impl could declare the
+  # mapping vars but skip the sed call.
+  local sed_count
+  sed_count=$(grep -c 'sed -i.*Action now' "$SKILL")
+  if [ "$sed_count" -eq 2 ]; then
+    pass "SKILL.md write-back: NEW_ACTION_NOW assigned $nan_count times (>=8) AND sed -i rewrite present exactly 2 times (cherry-pick + PR-mode)"
+  else
+    fail "SKILL.md write-back sed -i count" "expected exactly 2 sed-i Action-now rewrites, got $sed_count"
+  fi
+}
+
+# --- PR-2 / A+F: PR-mode end-of-loop tracker rollup --------------------
+test_skill_pr_mode_tracker_rollup() {
+  # Assertions:
+  #   - branch name `fix-issues-tracker/$SPRINT_ID` referenced.
+  #   - create-worktree.sh invoked with --prefix tracker.
+  #   - Skill: { skill: "land-pr" comment line for the tracker dispatch.
+  #   - --landed-source=fix-issues-pr-mode-tracker-rollup tag used.
+  local missing=""
+  grep -qF 'fix-issues-tracker/$SPRINT_ID' "$SKILL" || missing="$missing fix-issues-tracker/\$SPRINT_ID"
+  grep -qF -- '--prefix tracker' "$SKILL" || missing="$missing --prefix-tracker"
+  grep -qF 'Skill: { skill: "land-pr"' "$SKILL" || missing="$missing land-pr-skill-comment"
+  grep -qF -- '--landed-source=fix-issues-pr-mode-tracker-rollup' "$SKILL" || missing="$missing landed-source-tag"
+  if [ -z "$missing" ]; then
+    pass "SKILL.md PR-mode tracker rollup: branch + create-worktree --prefix tracker + land-pr skill comment + landed-source tag"
+  else
+    fail "SKILL.md PR-mode tracker rollup" "missing:$missing"
+  fi
+}
+
 # --- 7. Interactive-mode prose emits /fix-issues sync diagnostic --------
 test_skill_interactive_abort_prose() {
   # The interactive branch must (a) emit a diagnostic pointing at
@@ -421,6 +576,12 @@ test_skill_scratchpad_path_prose
 test_skill_research_agent_no_commit
 test_skill_interactive_abort_prose
 test_skill_interactive_exit_1
+test_filter_emits_skip_tagged
+test_filter_skip_tagged_codes
+test_filter_skip_tagged_empty_when_no_skip_rows
+test_skill_phase2_drops_skip_tagged
+test_skill_writeback_rewrites_scratchpad
+test_skill_pr_mode_tracker_rollup
 
 echo ""
 echo "---"


### PR DESCRIPTION
## Summary

A+F + write-back for `/fix-issues` — PR 2 of a 2-PR follow-up to PR #632 (B-proper). Closes the "#606 tax" so plan-scale issues stop re-researching every cron fire.

Builds on PR 1 (#669: stage-and-decide row commits). Three coordinated edits:

- **F** — `filter-unresearched-candidates.sh` adds a new `SKIP_TAGGED` output line mapping `<issue>:<skip-code>` for rows whose `**Action now:**` value matches a canonical skip directive (`/draft-plan`/`/run-plan` → `plan-scale`, `/investigate` → `bug-unclear-cause`, `none` → `needs-decision`). Awk uses POSIX boundary class `[^[:alnum:]_-]` (no `\b` — awk-portable).
- **A** — Phase 2 dashboard branch + default-rubric branch both drop `SKIP_TAGGED` candidates from `CANDIDATE_ISSUES` before triage. Empty-safe array expansion via `"${_FILTERED[@]+"${_FILTERED[@]}"}"`.
- **Write-back** — Phase 3 triage-skip arms (cherry-pick/direct AND PR mode) rewrite the scratchpad's `**Action now:**` line to the canonical skip-value via `sed -i "s|\*\*Action now:\*\*[^\n]*|<canonical>|"` (full-line replacement so multi-period values don't produce semantic garbage). The four mapped classes are `plan-scale`, `bug-unclear-cause`, `needs-decision`, `author-decision`; `too-vague` is intentionally untouched (vague descriptions need user clarification, not auto-tagging).
- **PR-mode terminus** — PR mode held the rewritten scratchpads; an end-of-Phase-3 post-loop block ships them via a tracker-only sync PR using the existing `ship_sync_only_or_cleanup` pattern (`fix-issues-tracker/$SPRINT_ID` branch, always `--auto`-merges since tracker-only content has no code-review surface).

## Why this isn't split further

F's `SKIP_TAGGED` output is dead code without A. A has nothing to drop without F. Write-back without F+A leaves the rewritten tags invisible to the next fire's filter. PR-mode post-loop rollup is the write-back's PR-mode terminus — splitting would leave scratchpads piling up under `.zskills/research-staging/` with no consumer. The three are one feature.

## Out of scope (mention in PR body, do not implement)

- Verdict-level signal handling in the filter script (`Verdict: UNCLEAR` → `bug-unclear-cause`). Out of scope; dashboard handles parse-time, and rows with researched Action-now lines don't typically have ambiguous Verdicts.
- The `too-vague` triage class write-back (left untagged on purpose).
- Sentinel-anchor for ISSUES_PLAN.md append (Option H — deferred).
- Rubber-stamp risk in triage verdicts (separate discipline concern).

## Test plan

- [x] Full suite: `bash tests/run-all.sh` → 5935/5935 passed, 0 failed (135 suites, 0 skipped)
- [x] `test-fix-issues-phase2-source-filter.sh` → 24/24 passed (incl. 6 new shape-locks: SKIP_TAGGED per-code, Phase 2 drop, write-back canonical-tag mapping ×2 modes with `sed -i.*Action now` count==2 assertion, PR-mode tracker rollup)
- [x] `test-skill-conformance.sh` → 655/655 passed
- [x] PR-1 shape-locks (`test_skill_scratchpad_path_prose`, `test_skill_research_agent_no_commit`) preserved and pass
- [x] Filter smoke test verified: POSIX boundary class correctly excludes `/investigate-foo` and `none-of-the-above`; correctly maps `/draft-plan`, `/run-plan`, `/investigate`, `none` to canonical skip codes
- [x] Mirrors byte-identical (both SKILL.md mirror and filter-script mirror)
- [x] `metadata.version` bumped (`2026.05.26+4913e0`)
- [x] Scope: only `skills/fix-issues/SKILL.md`, `.claude/skills/fix-issues/SKILL.md`, `skills/fix-issues/scripts/filter-unresearched-candidates.sh`, `.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh`, `tests/test-fix-issues-phase2-source-filter.sh` changed (claim-acquire-inline test file NOT touched, as required)
- [x] Worked-example trace verified end-to-end against actual code (Fire #1: 2 PRs land — #701 fix + #700 tracker rollup; Fire #2: #700 dropped from CANDIDATE_ISSUES via SKIP_TAGGED, no re-research waste)
- [x] Adversarially-reviewed `/do pr` prompt (round 1 surfaced 4 must-fix gaps — `set -u` array expansion, awk `\b` portability, sed semantic-garbage on multi-period values, sed shape-lock weakness; all addressed before dispatch)
- [x] Fresh verifier verdict: A+

🤖 Generated with [Claude Code](https://claude.com/claude-code)
