### PR TITLE
fix(fix-issues): selection-aware filter for Phase 2 candidate picker (#641)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.26+4913e0"
+  version: "2026.05.26+9b72f3"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -2404,6 +2404,61 @@ the fix agent. The default branch name is `fix-issue-NNN` (derived from
 `${WORKTREE_ROOT:-/tmp}/<project-name>-fix-issue-NNN`. PR mode overrides
 the branch name to `fix/issue-NNN` via `--branch-name` — see that
 subsection below.
+
+#### Selection filter (#641) — drop in-flight issue claims
+
+Pipe the just-finalized `CANDIDATE_ISSUES` through
+`filter-in-flight-issue-claims.sh` to drop issue numbers whose
+`.zskills/claims/issue-<N>/claim.json` indicates an in-flight pipeline.
+This is the unified downstream point — both Phase 2 paths (dashboard-mode
+at ~line 1460, rubric-mode at the ranked-table block) have populated and
+finalized `CANDIDATE_ISSUES` by here, and Phase 3's `for ISSUE_NUM in
+"${CANDIDATE_ISSUES[@]}"` loop below is the first dispatch read. Mirrors
+`/work-on-plans` Step 4's D4 filter (PR #645), adapted for integer issue
+numbers instead of kebab-case plan slugs. See
+`plans/plans-claim-chip-parity.md` for the parity rationale.
+
+**Honest scope (DA2.7 mirror).** This filter closes the **steady-state**
+race only — the claim is already on disk when both `/fix-issues`
+invocations run filter. It does NOT close the **fresh-start** race
+(both pipelines observe an empty claims-dir before either acquires);
+that residual window is bounded by `claim-issue.sh`'s acquire-EEXIST
+atomic mkdir → exit 10 contract, which Phase 3's per-iteration acquire
+already handles via the `race-lost` skip-record arm. Same architecture
+as `/work-on-plans` + `/run-plan`.
+
+The pre-filter sweep is R2.6 symmetric — reap any stale claim metadata
+right before the filter reads it, so a long-dead pipeline whose claim
+TTL has expired doesn't shadow a candidate that is actually free. The
+earlier preflight sweep at "### Preflight: sweep stale claims" runs near
+the top of Phase 2 BEFORE the picker runs; this second sweep is cheap
+(idempotent) and closes the window where a stale claim crossed the TTL
+boundary between preflight and selection.
+
+```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" sweep || true
+```
+
+```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+FILTER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh"
+if [ -x "$FILTER" ] && [ "${#CANDIDATE_ISSUES[@]}" -gt 0 ]; then
+  FILTERED=$(printf '%s\n' "${CANDIDATE_ISSUES[@]}" | bash "$FILTER")
+  if [ -n "$FILTERED" ]; then
+    mapfile -t CANDIDATE_ISSUES <<< "$FILTERED"
+  else
+    CANDIDATE_ISSUES=()
+  fi
+fi
+```
+
+(Defensive `[ -x ]` check so older installations without the script
+don't break. Empty filter output rebuilds `CANDIDATE_ISSUES` as an empty
+array rather than a one-element array with an empty string. The
+`${#CANDIDATE_ISSUES[@]} -gt 0` guard is symmetric with the existing
+SKIP_TAGGED fence guards above — both arms are no-ops when the array
+is already empty.)
 
 **Per-issue dispatch loop (B-proper).** The dispatch is an explicit
 fenced `for` loop over `CANDIDATE_ISSUES` (the full uncapped Ready∩Open

--- a/.claude/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh
+++ b/.claude/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# filter-in-flight-issue-claims.sh — Selection-aware filter for /fix-issues.
+#
+# Sibling of skills/work-on-plans/scripts/filter-in-flight-plan-claims.sh
+# (PR #645 D4), adapted for integer issue numbers instead of kebab-case
+# plan slugs. Closes #641 — the steady-state parallel-selection race the
+# user originally reported in PR #645's plan but that was deferred there.
+#
+# Why selection-time (not acquire-time): the atomic-mkdir acquire inside
+# Phase 3 fires AFTER /fix-issues has already burned the cost of building
+# dispatch state for that issue number. Catching the in-flight pipeline at
+# SELECTION time keeps a freshly-fired /fix-issues from spinning up
+# redundant impl dispatches against an issue another pipeline is already
+# working. The atomic acquire remains the final defense for the fresh-
+# start race (both invocations observe an empty claims-dir before either
+# acquires); that residual race is bounded by claim-issue.sh's
+# acquire-EEXIST mkdir → exit 10 contract. Same DA2.7 framing as the
+# /work-on-plans + /run-plan pair.
+#
+# Interface:
+#   stdin   — bare integers, one per line; empty / blank lines tolerated.
+#             (Differs from filter-in-flight-plan-claims.sh, which takes
+#             TSV — /fix-issues Phase 2 uses a bash array of integers,
+#             not TSV-row strings.)
+#   stdout  — bare integers (filtered).
+#   stderr  — "Skipped N issue(s) currently in-flight: <num1> <num2> ..."
+#             (single line) if any were filtered. Permission-error claims
+#             root → single diagnostic line, proceed with empty set.
+#   exit    — 0 always (filter NEVER fails dispatch — graceful degradation).
+#
+# MAIN_ROOT resolution: `git rev-parse --git-common-dir` parent, mirroring
+# claim-issue.sh's MAIN_ROOT resolution (DA4.1 / DA7 invariant). NEVER
+# falls back to $PWD silently — outside a git tree, treats in-flight set
+# as empty (filter is a no-op rather than a hard failure).
+#
+# Reading claims: best-effort. Malformed JSON, missing claim.json, non-
+# issue-* dirs, non-integer claim names are skipped silently.
+#
+# No jq — Python stdlib json per CLAUDE.md "Python is required".
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Python interpreter resolution (CLAUDE.md "Python is required").
+# ---------------------------------------------------------------------------
+_FILTER_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$_FILTER_PYTHON" ]; then
+  echo "fix-issues filter-in-flight-issue-claims.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
+  # Filter never fails dispatch — fall through with passthrough.
+  cat
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve MAIN_ROOT — sibling of claim-issue.sh's resolution.
+# Outside a git tree we cannot find the claims root, so the in-flight set
+# is empty and we pass through (graceful degradation).
+# ---------------------------------------------------------------------------
+_resolve_main_root() {
+  local common_dir
+  if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+    return 1
+  fi
+  if ! MAIN_ROOT=$(cd "$common_dir/.." && pwd); then
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Build the in-flight issue-number set from .zskills/claims/issue-*/claim.json.
+# Emits one integer per line on stdout.
+#
+# Permission errors on the claims root itself → single stderr diagnostic
+# and treat as empty. Missing claims root (the common case before any
+# claim has been acquired) → silent empty.
+# ---------------------------------------------------------------------------
+_build_in_flight_set() {
+  local claims_root="$1"
+
+  if [ ! -d "$claims_root" ]; then
+    return 0
+  fi
+
+  # Permission probe — if we cannot list the dir, surface ONE diagnostic
+  # and return empty. `ls` is the read-permission probe; we do not
+  # care about the listing itself.
+  if ! ls "$claims_root" >/dev/null 2>&1; then
+    echo "fix-issues filter: cannot read $claims_root (permission denied?); proceeding with empty in-flight set" >&2
+    return 0
+  fi
+
+  "$_FILTER_PYTHON" - "$claims_root" <<'PY'
+import json, os, re, sys
+
+claims_root = sys.argv[1]
+num_re = re.compile(r"^[0-9]+$")
+
+try:
+    entries = sorted(os.listdir(claims_root))
+except OSError:
+    sys.exit(0)
+
+for name in entries:
+    if not name.startswith("issue-"):
+        continue
+    num = name[len("issue-"):]
+    if not num or not num_re.match(num):
+        continue
+    claim_dir = os.path.join(claims_root, name)
+    if not os.path.isdir(claim_dir):
+        continue
+    claim_file = os.path.join(claim_dir, "claim.json")
+    if not os.path.isfile(claim_file):
+        # Missing claim.json — mid-acquire window or orphan dir; skip.
+        # Conservative: do NOT treat as in-flight here, because we
+        # cannot confirm a live pipeline (sweep reaps truly stale).
+        continue
+    try:
+        with open(claim_file) as fh:
+            body = json.load(fh)
+    except Exception:
+        # Malformed JSON — skip silently (symmetric to the plan-side
+        # filter and to the dashboard collector).
+        continue
+    # Issue number from claim.json (preferred) falls back to dir-derived.
+    body_num = body.get("issue") or body.get("number") or num
+    if isinstance(body_num, int):
+        body_num = str(body_num)
+    if not isinstance(body_num, str) or not num_re.match(body_num):
+        body_num = num
+    print(body_num)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+main() {
+  local MAIN_ROOT=""
+  if ! _resolve_main_root; then
+    # Outside a git tree — passthrough.
+    cat
+    return 0
+  fi
+
+  local claims_root="${MAIN_ROOT}/.zskills/claims"
+
+  # Build in-flight integer set (one per line on stdout of the helper).
+  local in_flight
+  in_flight=$(_build_in_flight_set "$claims_root")
+
+  # Read all input rows first so we can iterate and also report.
+  # `|| [ -n "$row" ]` clause catches the final line when stdin has no
+  # trailing newline.
+  local -a INPUT_ROWS=()
+  local row
+  while IFS= read -r row || [ -n "$row" ]; do
+    INPUT_ROWS+=("$row")
+  done
+
+  if [ -z "$in_flight" ]; then
+    # Fast path — no claims; emit input verbatim (preserving non-empty rows).
+    if [ "${#INPUT_ROWS[@]}" -gt 0 ]; then
+      local r
+      for r in "${INPUT_ROWS[@]}"; do
+        [ -z "$r" ] && continue
+        printf '%s\n' "$r"
+      done
+    fi
+    return 0
+  fi
+
+  # Build associative set for O(1) lookup.
+  declare -A IN_FLIGHT_SET=()
+  while IFS= read -r s; do
+    [ -z "$s" ] && continue
+    IN_FLIGHT_SET["$s"]=1
+  done <<<"$in_flight"
+
+  local -a FILTERED=()
+  local -a SKIPPED=()
+  local r
+  for r in "${INPUT_ROWS[@]}"; do
+    # Skip wholly empty input lines.
+    if [ -z "$r" ]; then
+      continue
+    fi
+    # Match on the literal line (input is bare integers — no TSV split).
+    # Non-integer lines pass through unchanged (most defensive — mirrors
+    # plan-side malformed-slug treatment).
+    if [ -n "${IN_FLIGHT_SET[$r]:-}" ]; then
+      SKIPPED+=("$r")
+    else
+      FILTERED+=("$r")
+    fi
+  done
+
+  if [ "${#SKIPPED[@]}" -gt 0 ]; then
+    printf 'Skipped %d issue(s) currently in-flight: %s\n' \
+      "${#SKIPPED[@]}" "${SKIPPED[*]}" >&2
+  fi
+
+  if [ "${#FILTERED[@]}" -gt 0 ]; then
+    printf '%s\n' "${FILTERED[@]}"
+  fi
+  return 0
+}
+
+main "$@"

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.26+4913e0"
+  version: "2026.05.26+9b72f3"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -2404,6 +2404,61 @@ the fix agent. The default branch name is `fix-issue-NNN` (derived from
 `${WORKTREE_ROOT:-/tmp}/<project-name>-fix-issue-NNN`. PR mode overrides
 the branch name to `fix/issue-NNN` via `--branch-name` — see that
 subsection below.
+
+#### Selection filter (#641) — drop in-flight issue claims
+
+Pipe the just-finalized `CANDIDATE_ISSUES` through
+`filter-in-flight-issue-claims.sh` to drop issue numbers whose
+`.zskills/claims/issue-<N>/claim.json` indicates an in-flight pipeline.
+This is the unified downstream point — both Phase 2 paths (dashboard-mode
+at ~line 1460, rubric-mode at the ranked-table block) have populated and
+finalized `CANDIDATE_ISSUES` by here, and Phase 3's `for ISSUE_NUM in
+"${CANDIDATE_ISSUES[@]}"` loop below is the first dispatch read. Mirrors
+`/work-on-plans` Step 4's D4 filter (PR #645), adapted for integer issue
+numbers instead of kebab-case plan slugs. See
+`plans/plans-claim-chip-parity.md` for the parity rationale.
+
+**Honest scope (DA2.7 mirror).** This filter closes the **steady-state**
+race only — the claim is already on disk when both `/fix-issues`
+invocations run filter. It does NOT close the **fresh-start** race
+(both pipelines observe an empty claims-dir before either acquires);
+that residual window is bounded by `claim-issue.sh`'s acquire-EEXIST
+atomic mkdir → exit 10 contract, which Phase 3's per-iteration acquire
+already handles via the `race-lost` skip-record arm. Same architecture
+as `/work-on-plans` + `/run-plan`.
+
+The pre-filter sweep is R2.6 symmetric — reap any stale claim metadata
+right before the filter reads it, so a long-dead pipeline whose claim
+TTL has expired doesn't shadow a candidate that is actually free. The
+earlier preflight sweep at "### Preflight: sweep stale claims" runs near
+the top of Phase 2 BEFORE the picker runs; this second sweep is cheap
+(idempotent) and closes the window where a stale claim crossed the TTL
+boundary between preflight and selection.
+
+```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" sweep || true
+```
+
+```bash
+. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+FILTER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh"
+if [ -x "$FILTER" ] && [ "${#CANDIDATE_ISSUES[@]}" -gt 0 ]; then
+  FILTERED=$(printf '%s\n' "${CANDIDATE_ISSUES[@]}" | bash "$FILTER")
+  if [ -n "$FILTERED" ]; then
+    mapfile -t CANDIDATE_ISSUES <<< "$FILTERED"
+  else
+    CANDIDATE_ISSUES=()
+  fi
+fi
+```
+
+(Defensive `[ -x ]` check so older installations without the script
+don't break. Empty filter output rebuilds `CANDIDATE_ISSUES` as an empty
+array rather than a one-element array with an empty string. The
+`${#CANDIDATE_ISSUES[@]} -gt 0` guard is symmetric with the existing
+SKIP_TAGGED fence guards above — both arms are no-ops when the array
+is already empty.)
 
 **Per-issue dispatch loop (B-proper).** The dispatch is an explicit
 fenced `for` loop over `CANDIDATE_ISSUES` (the full uncapped Ready∩Open

--- a/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh
+++ b/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# filter-in-flight-issue-claims.sh — Selection-aware filter for /fix-issues.
+#
+# Sibling of skills/work-on-plans/scripts/filter-in-flight-plan-claims.sh
+# (PR #645 D4), adapted for integer issue numbers instead of kebab-case
+# plan slugs. Closes #641 — the steady-state parallel-selection race the
+# user originally reported in PR #645's plan but that was deferred there.
+#
+# Why selection-time (not acquire-time): the atomic-mkdir acquire inside
+# Phase 3 fires AFTER /fix-issues has already burned the cost of building
+# dispatch state for that issue number. Catching the in-flight pipeline at
+# SELECTION time keeps a freshly-fired /fix-issues from spinning up
+# redundant impl dispatches against an issue another pipeline is already
+# working. The atomic acquire remains the final defense for the fresh-
+# start race (both invocations observe an empty claims-dir before either
+# acquires); that residual race is bounded by claim-issue.sh's
+# acquire-EEXIST mkdir → exit 10 contract. Same DA2.7 framing as the
+# /work-on-plans + /run-plan pair.
+#
+# Interface:
+#   stdin   — bare integers, one per line; empty / blank lines tolerated.
+#             (Differs from filter-in-flight-plan-claims.sh, which takes
+#             TSV — /fix-issues Phase 2 uses a bash array of integers,
+#             not TSV-row strings.)
+#   stdout  — bare integers (filtered).
+#   stderr  — "Skipped N issue(s) currently in-flight: <num1> <num2> ..."
+#             (single line) if any were filtered. Permission-error claims
+#             root → single diagnostic line, proceed with empty set.
+#   exit    — 0 always (filter NEVER fails dispatch — graceful degradation).
+#
+# MAIN_ROOT resolution: `git rev-parse --git-common-dir` parent, mirroring
+# claim-issue.sh's MAIN_ROOT resolution (DA4.1 / DA7 invariant). NEVER
+# falls back to $PWD silently — outside a git tree, treats in-flight set
+# as empty (filter is a no-op rather than a hard failure).
+#
+# Reading claims: best-effort. Malformed JSON, missing claim.json, non-
+# issue-* dirs, non-integer claim names are skipped silently.
+#
+# No jq — Python stdlib json per CLAUDE.md "Python is required".
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Python interpreter resolution (CLAUDE.md "Python is required").
+# ---------------------------------------------------------------------------
+_FILTER_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$_FILTER_PYTHON" ]; then
+  echo "fix-issues filter-in-flight-issue-claims.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
+  # Filter never fails dispatch — fall through with passthrough.
+  cat
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve MAIN_ROOT — sibling of claim-issue.sh's resolution.
+# Outside a git tree we cannot find the claims root, so the in-flight set
+# is empty and we pass through (graceful degradation).
+# ---------------------------------------------------------------------------
+_resolve_main_root() {
+  local common_dir
+  if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+    return 1
+  fi
+  if ! MAIN_ROOT=$(cd "$common_dir/.." && pwd); then
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Build the in-flight issue-number set from .zskills/claims/issue-*/claim.json.
+# Emits one integer per line on stdout.
+#
+# Permission errors on the claims root itself → single stderr diagnostic
+# and treat as empty. Missing claims root (the common case before any
+# claim has been acquired) → silent empty.
+# ---------------------------------------------------------------------------
+_build_in_flight_set() {
+  local claims_root="$1"
+
+  if [ ! -d "$claims_root" ]; then
+    return 0
+  fi
+
+  # Permission probe — if we cannot list the dir, surface ONE diagnostic
+  # and return empty. `ls` is the read-permission probe; we do not
+  # care about the listing itself.
+  if ! ls "$claims_root" >/dev/null 2>&1; then
+    echo "fix-issues filter: cannot read $claims_root (permission denied?); proceeding with empty in-flight set" >&2
+    return 0
+  fi
+
+  "$_FILTER_PYTHON" - "$claims_root" <<'PY'
+import json, os, re, sys
+
+claims_root = sys.argv[1]
+num_re = re.compile(r"^[0-9]+$")
+
+try:
+    entries = sorted(os.listdir(claims_root))
+except OSError:
+    sys.exit(0)
+
+for name in entries:
+    if not name.startswith("issue-"):
+        continue
+    num = name[len("issue-"):]
+    if not num or not num_re.match(num):
+        continue
+    claim_dir = os.path.join(claims_root, name)
+    if not os.path.isdir(claim_dir):
+        continue
+    claim_file = os.path.join(claim_dir, "claim.json")
+    if not os.path.isfile(claim_file):
+        # Missing claim.json — mid-acquire window or orphan dir; skip.
+        # Conservative: do NOT treat as in-flight here, because we
+        # cannot confirm a live pipeline (sweep reaps truly stale).
+        continue
+    try:
+        with open(claim_file) as fh:
+            body = json.load(fh)
+    except Exception:
+        # Malformed JSON — skip silently (symmetric to the plan-side
+        # filter and to the dashboard collector).
+        continue
+    # Issue number from claim.json (preferred) falls back to dir-derived.
+    body_num = body.get("issue") or body.get("number") or num
+    if isinstance(body_num, int):
+        body_num = str(body_num)
+    if not isinstance(body_num, str) or not num_re.match(body_num):
+        body_num = num
+    print(body_num)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+main() {
+  local MAIN_ROOT=""
+  if ! _resolve_main_root; then
+    # Outside a git tree — passthrough.
+    cat
+    return 0
+  fi
+
+  local claims_root="${MAIN_ROOT}/.zskills/claims"
+
+  # Build in-flight integer set (one per line on stdout of the helper).
+  local in_flight
+  in_flight=$(_build_in_flight_set "$claims_root")
+
+  # Read all input rows first so we can iterate and also report.
+  # `|| [ -n "$row" ]` clause catches the final line when stdin has no
+  # trailing newline.
+  local -a INPUT_ROWS=()
+  local row
+  while IFS= read -r row || [ -n "$row" ]; do
+    INPUT_ROWS+=("$row")
+  done
+
+  if [ -z "$in_flight" ]; then
+    # Fast path — no claims; emit input verbatim (preserving non-empty rows).
+    if [ "${#INPUT_ROWS[@]}" -gt 0 ]; then
+      local r
+      for r in "${INPUT_ROWS[@]}"; do
+        [ -z "$r" ] && continue
+        printf '%s\n' "$r"
+      done
+    fi
+    return 0
+  fi
+
+  # Build associative set for O(1) lookup.
+  declare -A IN_FLIGHT_SET=()
+  while IFS= read -r s; do
+    [ -z "$s" ] && continue
+    IN_FLIGHT_SET["$s"]=1
+  done <<<"$in_flight"
+
+  local -a FILTERED=()
+  local -a SKIPPED=()
+  local r
+  for r in "${INPUT_ROWS[@]}"; do
+    # Skip wholly empty input lines.
+    if [ -z "$r" ]; then
+      continue
+    fi
+    # Match on the literal line (input is bare integers — no TSV split).
+    # Non-integer lines pass through unchanged (most defensive — mirrors
+    # plan-side malformed-slug treatment).
+    if [ -n "${IN_FLIGHT_SET[$r]:-}" ]; then
+      SKIPPED+=("$r")
+    else
+      FILTERED+=("$r")
+    fi
+  done
+
+  if [ "${#SKIPPED[@]}" -gt 0 ]; then
+    printf 'Skipped %d issue(s) currently in-flight: %s\n' \
+      "${#SKIPPED[@]}" "${SKIPPED[*]}" >&2
+  fi
+
+  if [ "${#FILTERED[@]}" -gt 0 ]; then
+    printf '%s\n' "${FILTERED[@]}"
+  fi
+  return 0
+}
+
+main "$@"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -181,6 +181,7 @@ run_suite "test-plan-claim-release-already-complete.sh" "tests/test-plan-claim-r
 run_suite "test-plan-claim-selection-filter.sh" "tests/test-plan-claim-selection-filter.sh"
 run_suite "test-work-on-plans-parallel-selection.sh" "tests/test-work-on-plans-parallel-selection.sh"
 run_suite "test-plan-claim-filter-edge-cases.sh" "tests/test-plan-claim-filter-edge-cases.sh"
+run_suite "test-fix-issues-selection-filter.sh" "tests/test-fix-issues-selection-filter.sh"
 run_suite "test-plan-claim-collector.sh" "tests/test-plan-claim-collector.sh"
 run_suite "test-plan-claim-render-dom.sh" "tests/test-plan-claim-render-dom.sh"
 run_suite "test-plan-claim-handleaction-guard.sh" "tests/test-plan-claim-handleaction-guard.sh"

--- a/tests/test-fix-issues-selection-filter.sh
+++ b/tests/test-fix-issues-selection-filter.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# test-fix-issues-selection-filter.sh — selection-aware filter for /fix-issues
+# Phase 2 candidate picker (closes #641).
+#
+# Mirror of tests/test-plan-claim-selection-filter.sh +
+# test-plan-claim-filter-edge-cases.sh, adapted for bare-integer input.
+#
+# Synthesise `.zskills/claims/issue-42/claim.json` via `claim-issue.sh
+# acquire 42 --pipeline-id ... --sprint-id ...` (exercises the real schema —
+# DA2.12 equivalent for issues), feed CANDIDATE_ISSUES=[42, 43] through
+# filter-in-flight-issue-claims.sh, assert:
+#   (a) `42` is filtered out of stdout
+#   (b) `43` is preserved in stdout
+#   (c) stderr contains "Skipped 1 issue(s) currently in-flight: 42"
+#   (d) filter exits 0
+#
+# Plus edge cases mirroring the plan-side coverage:
+#   - Empty claims root           → passthrough
+#   - Missing claims root         → passthrough
+#   - Missing claim.json          → claim dir skipped silently
+#   - Malformed claim.json        → claim dir skipped silently
+#   - Empty stdin                 → empty stdout
+#   - Non-issue-* dir             → ignored (e.g., plan-foo)
+#
+# Honest scope (DA2.7 mirror): this filter closes the STEADY-STATE race
+# only (claim already on disk when both /fix-issues invocations run
+# filter). It does NOT close the FRESH-START race (both pipelines observe
+# empty claims-dir before either acquires); that residual window is
+# bounded by claim-issue.sh's acquire-EEXIST atomic mkdir → exit 10
+# contract. Same architecture as /work-on-plans + /run-plan.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FILTER="$REPO_ROOT/skills/fix-issues/scripts/filter-in-flight-issue-claims.sh"
+CLAIM_SH="$REPO_ROOT/skills/fix-issues/scripts/claim-issue.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRATCH="/tmp/test-fix-issues-selection-filter-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then return; fi
+  if [ -d "$SCRATCH" ]; then
+    find "$SCRATCH" -type d -exec chmod u+rwx {} \; 2>/dev/null || true
+    rm -rf "$SCRATCH"
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH"
+
+echo "=== /fix-issues selection filter (#641) ==="
+
+# Sanity: filter script + claim-issue.sh exist and are executable.
+if [ ! -x "$FILTER" ]; then
+  fail "filter script executable" "$FILTER not found or not executable"
+  echo "Results: $PASS_COUNT passed, $((FAIL_COUNT + 1)) failed"
+  exit 1
+fi
+if [ ! -f "$CLAIM_SH" ]; then
+  fail "claim-issue.sh present" "$CLAIM_SH not found"
+  echo "Results: $PASS_COUNT passed, $((FAIL_COUNT + 1)) failed"
+  exit 1
+fi
+pass "filter + claim-issue.sh present (claim-issue.sh invoked via bash; not chmod +x by design)"
+
+# Helpers ---------------------------------------------------------------------
+make_fixture() {
+  local f="$1"
+  mkdir -p "$f"
+  (
+    cd "$f"
+    git init -q
+    git config user.email "t@t"
+    git config user.name "t"
+    git commit --allow-empty -q -m "init"
+  ) >/dev/null 2>&1
+}
+
+run_filter_in() {
+  local fixture="$1"
+  local input="$2"
+  STDOUT="$SCRATCH/stdout.$$"
+  STDERR="$SCRATCH/stderr.$$"
+  (
+    cd "$fixture"
+    printf '%s' "$input" | bash "$FILTER"
+  ) >"$STDOUT" 2>"$STDERR"
+  RC=$?
+}
+
+# === Happy path ===
+# Build a real git fixture so MAIN_ROOT resolves predictably.
+FIXTURE="$SCRATCH/happy"
+make_fixture "$FIXTURE"
+
+# Acquire a real claim for issue 42.
+(
+  cd "$FIXTURE"
+  bash "$CLAIM_SH" acquire 42 \
+    --pipeline-id "fix-issues.test" \
+    --sprint-id   "sprint.test"
+) >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail "acquire claim for 42" "exit $rc"
+  echo "Results: $PASS_COUNT passed, $((FAIL_COUNT + 1)) failed"
+  exit 1
+fi
+pass "acquired claim issue-42 via claim-issue.sh acquire"
+
+if [ ! -f "$FIXTURE/.zskills/claims/issue-42/claim.json" ]; then
+  fail "claim.json on disk" "missing $FIXTURE/.zskills/claims/issue-42/claim.json"
+else
+  pass "claim.json present on disk"
+fi
+
+# Feed bare integers (one per line) — input shape is integers, NOT TSV.
+INPUT=$'42\n43'
+STDOUT_FILE="$SCRATCH/stdout.txt"
+STDERR_FILE="$SCRATCH/stderr.txt"
+(
+  cd "$FIXTURE"
+  printf '%s' "$INPUT" | bash "$FILTER"
+) >"$STDOUT_FILE" 2>"$STDERR_FILE"
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  pass "filter exits 0"
+else
+  fail "filter exits 0" "got rc=$rc"
+fi
+
+# Assertion (a): 42 is filtered out.
+if ! grep -qE '^42$' "$STDOUT_FILE"; then
+  pass "42 is filtered out of stdout"
+else
+  fail "42 is filtered out" "found 42 in stdout: $(cat "$STDOUT_FILE")"
+fi
+
+# Assertion (b): 43 is preserved.
+if grep -qE '^43$' "$STDOUT_FILE"; then
+  pass "43 is preserved in stdout"
+else
+  fail "43 preserved" "stdout: $(cat "$STDOUT_FILE")"
+fi
+
+# Assertion (c): stderr Skipped-N line.
+if grep -qE 'Skipped 1 issue\(s\) currently in-flight: 42' "$STDERR_FILE"; then
+  pass "stderr contains 'Skipped 1 issue(s) currently in-flight: 42'"
+else
+  fail "stderr Skipped-N line" "stderr: $(cat "$STDERR_FILE")"
+fi
+
+# === Edge cases ==============================================================
+
+# --- 1. Missing claims root → passthrough ----------------------------------
+test_missing_claims_root() {
+  local f="$SCRATCH/case_missing_root"
+  make_fixture "$f"
+  # No .zskills/claims dir at all.
+  run_filter_in "$f" $'7\n8'
+  if [ "$RC" -eq 0 ] \
+     && grep -qE '^7$' "$STDOUT" \
+     && grep -qE '^8$' "$STDOUT" \
+     && [ ! -s "$STDERR" ]; then
+    pass "missing claims root → passthrough"
+  else
+    fail "missing claims root" "rc=$RC stdout=$(cat "$STDOUT") stderr=$(cat "$STDERR")"
+  fi
+}
+
+# --- 2. Empty claims root → passthrough ------------------------------------
+test_empty_claims_root() {
+  local f="$SCRATCH/case_empty_root"
+  make_fixture "$f"
+  mkdir -p "$f/.zskills/claims"
+  run_filter_in "$f" $'7\n8'
+  if [ "$RC" -eq 0 ] \
+     && grep -qE '^7$' "$STDOUT" \
+     && grep -qE '^8$' "$STDOUT" \
+     && [ ! -s "$STDERR" ]; then
+    pass "empty claims root → passthrough"
+  else
+    fail "empty claims root" "rc=$RC stdout=$(cat "$STDOUT") stderr=$(cat "$STDERR")"
+  fi
+}
+
+# --- 3. claim dir without claim.json → ignored (not in-flight) -------------
+test_missing_claim_json() {
+  local f="$SCRATCH/case_missing_json"
+  make_fixture "$f"
+  mkdir -p "$f/.zskills/claims/issue-100"
+  # No claim.json inside.
+  run_filter_in "$f" $'100\n101'
+  if [ "$RC" -eq 0 ] \
+     && grep -qE '^100$' "$STDOUT" \
+     && grep -qE '^101$' "$STDOUT"; then
+    pass "missing claim.json → claim dir skipped; both preserved"
+  else
+    fail "missing claim.json" "rc=$RC stdout=$(cat "$STDOUT") stderr=$(cat "$STDERR")"
+  fi
+}
+
+# --- 4. Malformed claim.json → ignored -------------------------------------
+test_malformed_claim_json() {
+  local f="$SCRATCH/case_malformed_json"
+  make_fixture "$f"
+  mkdir -p "$f/.zskills/claims/issue-200"
+  echo "this is not json {" > "$f/.zskills/claims/issue-200/claim.json"
+  run_filter_in "$f" $'200\n201'
+  if [ "$RC" -eq 0 ] \
+     && grep -qE '^200$' "$STDOUT" \
+     && grep -qE '^201$' "$STDOUT"; then
+    pass "malformed claim.json → claim skipped; both preserved"
+  else
+    fail "malformed claim.json" "rc=$RC stdout=$(cat "$STDOUT") stderr=$(cat "$STDERR")"
+  fi
+}
+
+# --- 5. Non-issue-* directory in claims root → ignored ---------------------
+test_non_issue_dir() {
+  local f="$SCRATCH/case_non_issue"
+  make_fixture "$f"
+  mkdir -p "$f/.zskills/claims/plan-foo"
+  echo '{"pipeline_id":"x","slug":"foo"}' > "$f/.zskills/claims/plan-foo/claim.json"
+  run_filter_in "$f" $'300\n301'
+  if [ "$RC" -eq 0 ] \
+     && grep -qE '^300$' "$STDOUT" \
+     && grep -qE '^301$' "$STDOUT"; then
+    pass "non-issue-* dir (plan-foo) → ignored; both preserved"
+  else
+    fail "non-issue-* dir ignored" "rc=$RC stdout=$(cat "$STDOUT")"
+  fi
+}
+
+# --- 6. Empty stdin → empty stdout (no crash) ------------------------------
+test_empty_stdin() {
+  local f="$SCRATCH/case_empty_stdin"
+  make_fixture "$f"
+  STDOUT="$SCRATCH/stdout.empty"
+  STDERR="$SCRATCH/stderr.empty"
+  ( cd "$f" && : | bash "$FILTER" ) >"$STDOUT" 2>"$STDERR"
+  RC=$?
+  if [ "$RC" -eq 0 ] && [ ! -s "$STDOUT" ]; then
+    pass "empty stdin → empty stdout, exit 0"
+  else
+    fail "empty stdin" "rc=$RC stdout=$(cat "$STDOUT") stderr=$(cat "$STDERR")"
+  fi
+}
+
+# --- 7. Unreadable claims root → diagnostic + passthrough ------------------
+test_unreadable_claims_root() {
+  # Skip if running as root (chmod 000 doesn't block root).
+  if [ "$(id -u)" -eq 0 ]; then
+    pass "unreadable claims root (SKIPPED: running as root, perm check no-ops)"
+    return
+  fi
+  local f="$SCRATCH/case_unreadable"
+  make_fixture "$f"
+  mkdir -p "$f/.zskills/claims"
+  chmod 000 "$f/.zskills/claims"
+  run_filter_in "$f" $'400\n401'
+  # Restore perms immediately so cleanup works.
+  chmod u+rwx "$f/.zskills/claims" 2>/dev/null || true
+  if [ "$RC" -eq 0 ] \
+     && grep -qE '^400$' "$STDOUT" \
+     && grep -qE '^401$' "$STDOUT" \
+     && grep -qF 'cannot read' "$STDERR"; then
+    pass "unreadable claims root → diagnostic line + passthrough"
+  else
+    fail "unreadable claims root" "rc=$RC stdout=$(cat "$STDOUT") stderr=$(cat "$STDERR")"
+  fi
+}
+
+test_missing_claims_root
+test_empty_claims_root
+test_missing_claim_json
+test_malformed_claim_json
+test_non_issue_dir
+test_empty_stdin
+test_unreadable_claims_root
+
+echo ""
+echo "---"
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

Ports the structural selection-aware filter that landed in PR #645 (`D4` — `/work-on-plans` Step 4) to `/fix-issues` Phase 2 candidate picker. **Closes #641.**

The PR #645 work transferred the lesson only halfway: the user's original real-world failure was two parallel `/fix-issues` agents both picking the same issue, but #645 fixed `/work-on-plans` instead. This PR closes that gap by applying the symmetric filter to the picker that actually has the bug.

## What's added

- **`skills/fix-issues/scripts/filter-in-flight-issue-claims.sh`** (210 lines)
  Sibling-clone of `filter-in-flight-plan-claims.sh`, adapted for **bare-integer `CANDIDATE_ISSUES`** input (NOT TSV — the issue-side picker uses a bash array of integers).
  - Input: bare integers on stdin; output: filtered bare integers
  - Stderr: `Skipped N issue(s) currently in-flight: <num1> <num2> ...`
  - Reads `.zskills/claims/issue-*/claim.json` via Python json (no jq)
  - MAIN_ROOT-anchored via `git rev-parse --git-common-dir` parent (DA7 immune to worktree CWD)
  - Exit 0 always (filter never fails dispatch)
- **`skills/fix-issues/SKILL.md`** Phase 2 picker: pre-filter sweep (`claim-issue.sh sweep`, already exists) + selection filter fences at the unified downstream point where `CANDIDATE_ISSUES` is finalized AND before the Phase 3 per-issue dispatch loop reads it. New H4 "Selection filter (#641)" with prose explaining the DA2.7 honest scope.
- **`tests/test-fix-issues-selection-filter.sh`** (290 lines, 14 assertions)
  Mirrors `test-plan-claim-selection-filter.sh` shape, plus edge cases (malformed JSON, missing claim.json, non-issue-* dirs, empty input, unreadable claims root).
- `skills/fix-issues/SKILL.md` `metadata.version` → `2026.05.26+9b72f3`
- `.claude/` mirrors byte-identical to sources

## Honest scope (DA2.7 mirror)

The filter closes the **steady-state** race only — a claim already on disk when both `/fix-issues` invocations run filter. It does **NOT** eliminate the **fresh-start** race where both invocations observe an empty claims-dir before either acquires; that residual window is bounded by `claim-issue.sh`'s acquire-EEXIST atomic mkdir (the loser exits with rc=10 and declines). Same two-layer architecture as `/work-on-plans` + `/run-plan`.

The test file's name + comments document this scope explicitly — no test asserts structural fresh-start elimination.

## Insertion-site note (deviation from spec)

The spec said "two paths converge after line 1462." On reading the actual SKILL.md the two paths (dashboard-mode at ~line 1460-1595 and rubric-mode at ~line 1670-1776) are parallel duplicated source-filter blocks — they don't literally converge there. The implementer picked the **true unified downstream point** — just before the Phase 3 dispatch `for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"` loop — which is where the spec's semantic constraint ("ONCE", "after both paths populated", "before dispatch loop") unambiguously points. Initial placement broke a conformance assertion (`test-fix-issues-claim-conformance.sh` test 16 requires CLAIM_HELPER and `exit 0` within ±15 lines); moved up one paragraph to preserve the existing proximity. Documented as in-scope adjustment.

## Out of scope (filed separately)

- **#687** — Dashboard closure-reason chip on Completed-column issue cards (distinguishing `completed` vs `not_planned`). Different file tree (`zskills-dashboard/`); different scope; reviewer recommended split, user authorized.

## Test plan

- [x] `bash tests/run-all.sh` → `Overall: 5892/5892 passed, 0 failed`
- [x] New `tests/test-fix-issues-selection-filter.sh` → 14/14 assertions
- [x] `tests/test-fix-issues-claim-conformance.sh` → unchanged, still passing
- [x] Spot checks (acquire/release/sweep paths untouched; hook still registered; mirrors byte-identical)
- [ ] Two-shell parallel `/fix-issues` manual e2e — deferred for post-merge user verification (same shape as #645 W5.2)

## Follow-up after merge

- Two-shell e2e (Phase 5 W5.2 deferred items from #645 + #684 + this PR — all share the same manual-verification need)
- #687 closure-reason chip — small dashboard-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
