### PR TITLE
fix(fix-report): enumerate all 9 PR-mode statuses in Step 1 (#659)

### DIFF
--- a/.claude/skills/fix-report/SKILL.md
+++ b/.claude/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.21+434b2f"
+  version: "2026.05.26+c2429c"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -178,6 +178,10 @@ PR-landed fixes (sprint YYYY-MM-DD HH:MM):
 - `pr-ci-failing` — PR open but CI failed after max fix attempts
 - `pr-failed` — push succeeded but PR creation failed; show branch name
 - `conflict` — rebase conflict; worktree left clean for the user to resume
+- `pr-state-unknown` — `/land-pr` returned but PR state could not be verified; show PR URL (if any) and direct the user to inspect on GitHub
+- `failed` — generic terminal failure from `/land-pr` (failure-class marker per `failure-protocol.md`); surface the worktree path and `reason` field
+- `direct-push-failed` — direct-landing-mode push to main failed; commit landed on the worktree branch only; surface the worktree path and `reason` field
+- `direct-verify-failed` — direct-landing-mode verification failed before push; nothing landed on main; surface the worktree path and `reason` field
 
 Include PR URLs in the final `$ZSKILLS_AUDIT_DIR/FIX_REPORT.md` domain sections so the user
 can click through to review each fix.

--- a/skills/fix-report/SKILL.md
+++ b/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.21+434b2f"
+  version: "2026.05.26+c2429c"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -178,6 +178,10 @@ PR-landed fixes (sprint YYYY-MM-DD HH:MM):
 - `pr-ci-failing` — PR open but CI failed after max fix attempts
 - `pr-failed` — push succeeded but PR creation failed; show branch name
 - `conflict` — rebase conflict; worktree left clean for the user to resume
+- `pr-state-unknown` — `/land-pr` returned but PR state could not be verified; show PR URL (if any) and direct the user to inspect on GitHub
+- `failed` — generic terminal failure from `/land-pr` (failure-class marker per `failure-protocol.md`); surface the worktree path and `reason` field
+- `direct-push-failed` — direct-landing-mode push to main failed; commit landed on the worktree branch only; surface the worktree path and `reason` field
+- `direct-verify-failed` — direct-landing-mode verification failed before push; nothing landed on main; surface the worktree path and `reason` field
 
 Include PR URLs in the final `$ZSKILLS_AUDIT_DIR/FIX_REPORT.md` domain sections so the user
 can click through to review each fix.


### PR DESCRIPTION
## Summary
- Add the 4 missing PR-mode `.landed` status entries (`pr-state-unknown`, `failed`, `direct-push-failed`, `direct-verify-failed`) to `/fix-report` Step 1's user-facing enumeration, matching the Step 6 case statement that already covers all 9

## Test plan
- [x] Step 1 now enumerates exactly 9 PR-mode statuses matching the L160 declaration
- [x] Step 6 case statement semantics consistent with new Step 1 descriptions
- [x] Mirror consistency: `diff` between source and installed copy is empty
- [x] Full test suite: 5898/5898 passed, 0 failed

Fixes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
