### PR TITLE
fix(docs): reframe /quickfix vs /do as peers not tiers (closes #682)

### DIFF
--- a/.claude/rules/zskills/managed.md
+++ b/.claude/rules/zskills/managed.md
@@ -296,14 +296,14 @@ moves SECOND (atomic per-file), manifest LAST (the lock claim).
 
 ## Which skill for which input
 
-Decision table for picking a skill when a user describes a generic action. Match on the LEFT, dispatch the RIGHT. When multiple rows could fit, prefer the shorter/lighter one — the heavier skills (`/draft-plan`, `/research-and-*`) cost more rounds and should only be used when the lighter ones cannot.
+Decision table for picking a skill when a user describes a generic action. Match on the LEFT, dispatch the RIGHT. When multiple rows could fit, prefer the lower-overhead one — the multi-round skills (`/draft-plan`, `/research-and-*`) cost more rounds and should only be used when the single-round ones cannot.
 
 | You have | Run |
 |---|---|
-| Clear small bug or doc tweak, ready to ship as one PR | `/quickfix` |
+| One-commit PR — edit in-place on main, no worktree (only valid when `main_protected: false`) | `/quickfix` |
 | Several small bugs / issues in a backlog | `/fix-issues N` |
 | Bug, but root cause is unclear | `/investigate` |
-| Ad-hoc task (docs, refactor, content) larger than `/quickfix` | `/do` |
+| One-commit PR — needs worktree isolation (required when `main_protected: true`) | `/do` |
 | Plan file already drafted, ready to execute | `/run-plan <path>` |
 | Plan-scale design surface — needs adversarial review before execution | `/draft-plan` |
 | Broad goal that decomposes into multiple sub-plans | `/research-and-plan` |
@@ -316,7 +316,7 @@ Decision table for picking a skill when a user describes a generic action. Match
 
 **Common confusions:**
 
-- `/quickfix` vs `/do`: `/quickfix` is the FLOOR of "with review" — no worktree, picks up an in-flight edit in main, one-commit PR. `/do` runs in a worktree and is for ad-hoc tasks too big for one commit but too small to draft a plan for. If the user is mid-edit in main, `/quickfix`. If they're describing the task fresh and it's >1 commit, `/do`.
+- `/quickfix` vs `/do`: **They are PEERS, not TIERS.** Same lifecycle (triage → review → commit → PR → land); same `/land-pr` dispatch; same one-commit-PR shape. The structural difference is where the work tree lives — `/quickfix` does `git checkout -b` on main; `/do` uses a worktree. Pick by **project policy, not task size**: in `main_protected: true` projects, use `/do` (always); in non-main-protected projects, either works (pick by preference). Per-task size is NOT a useful axis between them.
 - `/draft-plan` vs `/run-plan`: `/draft-plan` produces a plan file; `/run-plan` executes one. They are sequential, not alternatives. If the user has a plan file path, `/run-plan`. If they have a goal but no plan, `/draft-plan` first.
 - `/research-and-plan` vs `/research-and-go`: same drafting machinery; `-and-plan` stops after the meta-plan is ready for review, `-and-go` continues into execution. Use `-and-plan` when the user wants a checkpoint before commit-volume work begins; `-and-go` when they've said "walk away."
 - `/draft-plan` vs `/quickfix` / `/do`: `/draft-plan` is reserved for skills/workflows with non-trivial design surface (integration points, multiple commands, hook interactions). Thin prompt-wrapper changes and prose edits don't need adversarial review — go straight to `/quickfix` or `/do`.

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -296,14 +296,14 @@ moves SECOND (atomic per-file), manifest LAST (the lock claim).
 
 ## Which skill for which input
 
-Decision table for picking a skill when a user describes a generic action. Match on the LEFT, dispatch the RIGHT. When multiple rows could fit, prefer the shorter/lighter one — the heavier skills (`/draft-plan`, `/research-and-*`) cost more rounds and should only be used when the lighter ones cannot.
+Decision table for picking a skill when a user describes a generic action. Match on the LEFT, dispatch the RIGHT. When multiple rows could fit, prefer the lower-overhead one — the multi-round skills (`/draft-plan`, `/research-and-*`) cost more rounds and should only be used when the single-round ones cannot.
 
 | You have | Run |
 |---|---|
-| Clear small bug or doc tweak, ready to ship as one PR | `/quickfix` |
+| One-commit PR — edit in-place on main, no worktree (only valid when `main_protected: false`) | `/quickfix` |
 | Several small bugs / issues in a backlog | `/fix-issues N` |
 | Bug, but root cause is unclear | `/investigate` |
-| Ad-hoc task (docs, refactor, content) larger than `/quickfix` | `/do` |
+| One-commit PR — needs worktree isolation (required when `main_protected: true`) | `/do` |
 | Plan file already drafted, ready to execute | `/run-plan <path>` |
 | Plan-scale design surface — needs adversarial review before execution | `/draft-plan` |
 | Broad goal that decomposes into multiple sub-plans | `/research-and-plan` |
@@ -316,7 +316,7 @@ Decision table for picking a skill when a user describes a generic action. Match
 
 **Common confusions:**
 
-- `/quickfix` vs `/do`: `/quickfix` is the FLOOR of "with review" — no worktree, picks up an in-flight edit in main, one-commit PR. `/do` runs in a worktree and is for ad-hoc tasks too big for one commit but too small to draft a plan for. If the user is mid-edit in main, `/quickfix`. If they're describing the task fresh and it's >1 commit, `/do`.
+- `/quickfix` vs `/do`: **They are PEERS, not TIERS.** Same lifecycle (triage → review → commit → PR → land); same `/land-pr` dispatch; same one-commit-PR shape. The structural difference is where the work tree lives — `/quickfix` does `git checkout -b` on main; `/do` uses a worktree. Pick by **project policy, not task size**: in `main_protected: true` projects, use `/do` (always); in non-main-protected projects, either works (pick by preference). Per-task size is NOT a useful axis between them.
 - `/draft-plan` vs `/run-plan`: `/draft-plan` produces a plan file; `/run-plan` executes one. They are sequential, not alternatives. If the user has a plan file path, `/run-plan`. If they have a goal but no plan, `/draft-plan` first.
 - `/research-and-plan` vs `/research-and-go`: same drafting machinery; `-and-plan` stops after the meta-plan is ready for review, `-and-go` continues into execution. Use `-and-plan` when the user wants a checkpoint before commit-volume work begins; `-and-go` when they've said "walk away."
 - `/draft-plan` vs `/quickfix` / `/do`: `/draft-plan` is reserved for skills/workflows with non-trivial design surface (integration points, multiple commands, hook interactions). Thin prompt-wrapper changes and prose edits don't need adversarial review — go straight to `/quickfix` or `/do`.

--- a/docs/issues/ISSUES_PLAN.md
+++ b/docs/issues/ISSUES_PLAN.md
@@ -1255,3 +1255,13 @@ Both fixes extend `tests/test-skill-conformance.sh` with grep-counting tripwires
 Plus a structural conformance pin in `tests/test-skill-conformance.sh` (or new test): assert every `hooks/block-*.sh` is referenced in `/update-zskills` SKILL.md install list — terminates the family at CI time, preventing instance #3.
 
 **Complexity:** S. **Action now:** /fix-issues — 2-surface SKILL.md edit + ~10-line conformance test; body is verification-anchored and all line refs verified against current main.
+
+### #682 — Decision-table prose trains agents to see /quickfix vs /do as size hierarchy — reframe as worktree-vs-main (the real distinction)
+
+**Labels:** (none) | **Verdict:** NEEDS FIX
+
+**Problem.** The "Which skill for which input" decision table in `CLAUDE_TEMPLATE.md` (and the rendered `.claude/rules/zskills/managed.md`) describes `/do` as "Ad-hoc task ... larger than `/quickfix`," and the "Common confusions" subsection reinforces a size-based framing ("/quickfix is the FLOOR ..."). The real structural distinction between the two skills is worktree-vs-main, not size — and in this repo (`main_protected: true`), `/quickfix`'s in-place-on-main checkout is structurally inappropriate. Agents repeatedly propose `/quickfix` here as "the lighter option," which the user catches every time at proposal time.
+
+**Fix outline.** In `CLAUDE_TEMPLATE.md`, reframe the two table rows (lines 303 and 306) to key on worktree-vs-main (and project policy) rather than task size, and rewrite the "Common confusions" `/quickfix` vs `/do` bullet (line 319) to state explicitly that they are PEERS, not TIERS — same lifecycle, same /land-pr dispatch, same one-commit-PR shape; pick by `main_protected` policy, not size. Run `/update-zskills --rerender` to refresh `.claude/rules/zskills/managed.md` (the duplicated copies at managed.md lines 303/306/319 follow automatically). Add 2-3 conformance pins to `tests/test-skill-conformance.sh` (positive: "PEERS, not TIERS"; positive: "pick by ... project policy ... not task size"; negative: no "larger than `/quickfix`" phrasing) using the existing `check_in_file` / inverted helpers around line 94/161.
+
+**Complexity:** S. **Action now:** /quickfix — reframe CLAUDE_TEMPLATE.md decision-table rows + Common-confusions bullet to peers-not-tiers, rerender managed.md, add 3 conformance pins (peers-not-tiers, pick-by-policy, negative-pin on old phrasing).

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2451,6 +2451,28 @@ for prose_file in "$REPO_ROOT/CLAUDE_TEMPLATE.md" "$REPO_ROOT/.claude/rules/zski
   else
     fail "[propagation-prose] $rel" "missing literal: 'Never \`CronDelete\` on the strength of a confused fire'"
   fi
+  # Issue #682 — /quickfix vs /do decision-table reframe: peers-not-tiers.
+  # The decision table previously framed /quickfix as the lighter / smaller
+  # task option ("FLOOR of with-review", "larger than /quickfix"), training
+  # agents to pattern-match on size. The real distinction is worktree-vs-
+  # main, gated by main_protected. Pin the new peer wording on both prose
+  # surfaces and negative-pin the old size-hierarchy phrases so they cannot
+  # silently regress.
+  if grep -qF 'They are PEERS, not TIERS' "$prose_file"; then
+    pass "[propagation-prose] $rel contains 'PEERS, not TIERS' decision-table reframe (#682)"
+  else
+    fail "[propagation-prose] $rel" "missing literal: 'They are PEERS, not TIERS' (#682)"
+  fi
+  if grep -qF 'Pick by **project policy, not task size**' "$prose_file"; then
+    pass "[propagation-prose] $rel contains 'pick by project policy, not task size' literal (#682)"
+  else
+    fail "[propagation-prose] $rel" "missing literal: 'Pick by **project policy, not task size**' (#682)"
+  fi
+  if grep -qF 'larger than `/quickfix`' "$prose_file"; then
+    fail "[propagation-prose] $rel" "obsolete size-hierarchy phrase 'larger than \`/quickfix\`' must be removed (#682)"
+  else
+    pass "[propagation-prose] $rel does not contain obsolete 'larger than /quickfix' phrase (#682)"
+  fi
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Reframes `/quickfix` vs `/do` in the decision table and Common confusions as **peers, not tiers** — the structural difference is worktree-vs-main (gated by `main_protected`), not task size.

- Decision table: `/quickfix` = "one-commit PR, edit in-place on main (only valid when `main_protected: false`)" vs `/do` = "one-commit PR, needs worktree isolation (required when `main_protected: true`)"
- Common confusions: replaced "FLOOR of with review" with "PEERS, not TIERS — pick by project policy, not task size"
- 3 conformance pins (positive for peers/policy framing, negative for obsolete "larger than /quickfix")

Closes #682.

## Test plan

- [x] `test-managed-md-up-to-date.sh` — managed.md matches CLAUDE_TEMPLATE.md render
- [x] `test-skill-conformance.sh` — 3 new pins pass (PEERS not TIERS, project policy, no "larger than /quickfix")
- [x] Full suite: 5912/5912 passed, 0 failed
- [x] No skill SKILL.md files touched — no metadata.version bump needed
- [x] Verifier verdict: A+

🤖 Generated with [Claude Code](https://claude.com/claude-code)
