### PR TITLE
fix(fix-issues): closed-issue guard between claim and dispatch

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.27+fdef5c"
+  version: "2026.05.27+e16c55"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -2631,6 +2631,18 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
     exit "$ACQ_RC"
   fi
 
+  # 3b. Final GitHub-state guard (race-condition defense). The issue may
+  # have been auto-closed by a sibling PR merge between the Ready-queue
+  # read and this dispatch. Check live state; if CLOSED, release the
+  # claim and skip — don't waste a worktree + agent cycle.
+  LIVE_STATE=$(gh issue view "$ISSUE_NUM" --json state -q .state 2>/dev/null || echo "UNKNOWN")
+  if [ "$LIVE_STATE" = "CLOSED" ]; then
+    echo "fix-issues: issue #$ISSUE_NUM is CLOSED on GitHub (race — closed after Ready-queue read); releasing claim and skipping." >&2
+    bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" || true
+    SKIP_RECORD+=("closed-on-github:$ISSUE_NUM")
+    continue
+  fi
+
   # 4. Materialise worktree + dispatch impl agent.
   WORKTREE_PATH="/tmp/$(basename "$MAIN_ROOT")-fix-issue-${ISSUE_NUM}"
   if [ -d "$WORKTREE_PATH" ]; then
@@ -2850,6 +2862,18 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   if [ "$ACQ_RC" != 0 ]; then
     echo "fix-issues: claim acquire failed for issue $ISSUE_NUM (rc=$ACQ_RC); aborting sprint." >&2
     exit "$ACQ_RC"
+  fi
+
+  # 3b. Final GitHub-state guard (race-condition defense). The issue may
+  # have been auto-closed by a sibling PR merge between the Ready-queue
+  # read and this dispatch. Check live state; if CLOSED, release the
+  # claim and skip — don't waste a worktree + agent cycle.
+  LIVE_STATE=$(gh issue view "$ISSUE_NUM" --json state -q .state 2>/dev/null || echo "UNKNOWN")
+  if [ "$LIVE_STATE" = "CLOSED" ]; then
+    echo "fix-issues: issue #$ISSUE_NUM is CLOSED on GitHub (race — closed after Ready-queue read); releasing claim and skipping." >&2
+    bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" || true
+    SKIP_RECORD+=("closed-on-github:$ISSUE_NUM")
+    continue
   fi
 
   # 4. Materialise per-issue PR-mode worktree.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.27+fdef5c"
+  version: "2026.05.27+e16c55"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
@@ -2631,6 +2631,18 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
     exit "$ACQ_RC"
   fi
 
+  # 3b. Final GitHub-state guard (race-condition defense). The issue may
+  # have been auto-closed by a sibling PR merge between the Ready-queue
+  # read and this dispatch. Check live state; if CLOSED, release the
+  # claim and skip — don't waste a worktree + agent cycle.
+  LIVE_STATE=$(gh issue view "$ISSUE_NUM" --json state -q .state 2>/dev/null || echo "UNKNOWN")
+  if [ "$LIVE_STATE" = "CLOSED" ]; then
+    echo "fix-issues: issue #$ISSUE_NUM is CLOSED on GitHub (race — closed after Ready-queue read); releasing claim and skipping." >&2
+    bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" || true
+    SKIP_RECORD+=("closed-on-github:$ISSUE_NUM")
+    continue
+  fi
+
   # 4. Materialise worktree + dispatch impl agent.
   WORKTREE_PATH="/tmp/$(basename "$MAIN_ROOT")-fix-issue-${ISSUE_NUM}"
   if [ -d "$WORKTREE_PATH" ]; then
@@ -2850,6 +2862,18 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
   if [ "$ACQ_RC" != 0 ]; then
     echo "fix-issues: claim acquire failed for issue $ISSUE_NUM (rc=$ACQ_RC); aborting sprint." >&2
     exit "$ACQ_RC"
+  fi
+
+  # 3b. Final GitHub-state guard (race-condition defense). The issue may
+  # have been auto-closed by a sibling PR merge between the Ready-queue
+  # read and this dispatch. Check live state; if CLOSED, release the
+  # claim and skip — don't waste a worktree + agent cycle.
+  LIVE_STATE=$(gh issue view "$ISSUE_NUM" --json state -q .state 2>/dev/null || echo "UNKNOWN")
+  if [ "$LIVE_STATE" = "CLOSED" ]; then
+    echo "fix-issues: issue #$ISSUE_NUM is CLOSED on GitHub (race — closed after Ready-queue read); releasing claim and skipping." >&2
+    bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" || true
+    SKIP_RECORD+=("closed-on-github:$ISSUE_NUM")
+    continue
   fi
 
   # 4. Materialise per-issue PR-mode worktree.


### PR DESCRIPTION
## Summary

Adds a final `gh issue view $N --json state` guard between claim-acquire and impl-agent dispatch in `/fix-issues`. Closes the race condition where a PR auto-closes an issue but the Ready-queue state file and `gh issue list` cache still show it as open, causing `/fix-issues` to dispatch an impl agent for an already-closed issue.

Applied to both dispatch loops (cherry-pick/direct mode and PR mode). On CLOSED: releases the claim, records `closed-on-github:$ISSUE_NUM` in SKIP_RECORD, continues to next candidate. On `gh` failure: falls back to UNKNOWN (proceeds conservatively — no silent drops).

## Test plan

- [x] Full suite: 5940/5940 passed.
- [x] Prose-only change (skill SKILL.md); no new Python/JS code to test.
- [ ] Next `/fix-issues` cron fire on a closed issue verifies the skip path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
