### PR TITLE
feat(dashboard): closure-reason chip on Completed issue cards (#687)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+a52b7c"
+  version: "2026.05.27+59d6f8"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1317,7 +1317,7 @@ def list_closed_issues_in_window(
                 "--limit",
                 str(int(limit)),
                 "--json",
-                "number,title,labels,createdAt,closedAt,body",
+                "number,title,labels,createdAt,closedAt,body,stateReason",
             ],
             capture_output=True,
             text=True,
@@ -1363,6 +1363,7 @@ def list_closed_issues_in_window(
                 "created_at": entry.get("createdAt", ""),
                 "closed_at": entry.get("closedAt", ""),
                 "body": entry.get("body", ""),
+                "state_reason": entry.get("stateReason", ""),
             })
         _CLOSED_ISSUE_CACHE[key] = {
             "ts": now,

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -443,6 +443,27 @@ code, pre, .mono {
   vertical-align: middle;
 }
 
+/* Closure-reason chip (#687) — muted pill for "not planned" / "closed"
+   on Completed-column issue cards. Matches claim-chip--in-flight's pill
+   aesthetic but uses neutral grey to read as informational, not active. */
+.closure-chip {
+  display: inline-block;
+  padding: 3px 10px;
+  margin: 4px 4px 4px 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(139, 148, 158, 0.18);
+  border: 1px solid var(--text-dim);
+  border-left-width: 4px;
+  border-radius: 4px;
+  color: var(--text-dim);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
 /* Visual signal that a card is drag-disabled (claim chip sets this). */
 .card[aria-disabled="true"] {
   cursor: not-allowed;

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1250,6 +1250,19 @@ function buildIssueCard(issue, num, col) {
     head.appendChild(el("span", { cls: "card-sub", text: relativeTime(issue.created_at) }));
   }
   card.appendChild(head);
+  // Closure-reason chip (issue #687) — only renders for Completed-column
+  // cards whose stateReason is NOT "COMPLETED". Distinguishes "not planned"
+  // closures from genuine completions. Reuses .claim-chip styling.
+  if (isCompleted && issue && issue.state_reason !== "COMPLETED") {
+    const reason = issue.state_reason === "NOT_PLANNED" ? "not planned" : "closed";
+    const row = el("div", { cls: "card-sub" });
+    row.appendChild(el("span", {
+      cls: "closure-chip",
+      attrs: { title: "stateReason: " + (issue.state_reason || "null") },
+      text: reason,
+    }));
+    card.appendChild(row);
+  }
   // Skip-reason chip (issue #445) — only renders for Ready-column issues
   // whose tracker blurb resolves to a *genuine* skip-class (needs-decision,
   // plan-scale, bug-unclear-cause). `unresearched` is excluded: it signals

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+a52b7c"
+  version: "2026.05.27+59d6f8"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1317,7 +1317,7 @@ def list_closed_issues_in_window(
                 "--limit",
                 str(int(limit)),
                 "--json",
-                "number,title,labels,createdAt,closedAt,body",
+                "number,title,labels,createdAt,closedAt,body,stateReason",
             ],
             capture_output=True,
             text=True,
@@ -1363,6 +1363,7 @@ def list_closed_issues_in_window(
                 "created_at": entry.get("createdAt", ""),
                 "closed_at": entry.get("closedAt", ""),
                 "body": entry.get("body", ""),
+                "state_reason": entry.get("stateReason", ""),
             })
         _CLOSED_ISSUE_CACHE[key] = {
             "ts": now,

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -443,6 +443,27 @@ code, pre, .mono {
   vertical-align: middle;
 }
 
+/* Closure-reason chip (#687) — muted pill for "not planned" / "closed"
+   on Completed-column issue cards. Matches claim-chip--in-flight's pill
+   aesthetic but uses neutral grey to read as informational, not active. */
+.closure-chip {
+  display: inline-block;
+  padding: 3px 10px;
+  margin: 4px 4px 4px 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(139, 148, 158, 0.18);
+  border: 1px solid var(--text-dim);
+  border-left-width: 4px;
+  border-radius: 4px;
+  color: var(--text-dim);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
 /* Visual signal that a card is drag-disabled (claim chip sets this). */
 .card[aria-disabled="true"] {
   cursor: not-allowed;

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1250,6 +1250,19 @@ function buildIssueCard(issue, num, col) {
     head.appendChild(el("span", { cls: "card-sub", text: relativeTime(issue.created_at) }));
   }
   card.appendChild(head);
+  // Closure-reason chip (issue #687) — only renders for Completed-column
+  // cards whose stateReason is NOT "COMPLETED". Distinguishes "not planned"
+  // closures from genuine completions. Reuses .claim-chip styling.
+  if (isCompleted && issue && issue.state_reason !== "COMPLETED") {
+    const reason = issue.state_reason === "NOT_PLANNED" ? "not planned" : "closed";
+    const row = el("div", { cls: "card-sub" });
+    row.appendChild(el("span", {
+      cls: "closure-chip",
+      attrs: { title: "stateReason: " + (issue.state_reason || "null") },
+      text: reason,
+    }));
+    card.appendChild(row);
+  }
   // Skip-reason chip (issue #445) — only renders for Ready-column issues
   // whose tracker blurb resolves to a *genuine* skip-class (needs-decision,
   // plan-scale, bug-unclear-cause). `unresearched` is excluded: it signals


### PR DESCRIPTION
## Summary
- Add closure-reason chip to the dashboard's Completed-column issue cards
- When `stateReason !== "COMPLETED"`, a chip shows "not planned" (for NOT_PLANNED) or "closed" (for null/other)
- Distinguishes agent-filed-then-closed issues from genuinely completed ones

## Test plan
- [x] `stateReason` added to gh fetch field list in collect.py
- [x] Chip renders only for completed column when state_reason is not COMPLETED
- [x] `.closure-chip` class (not `.claim-chip`) avoids breaking existing test invariants
- [x] Mirror consistency verified
- [x] Full test suite: 5941/5941 passed, 0 failed

Fixes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
