### PR TITLE
fix(dashboard): polish collapse toggle, preview strip, move-all buttons (closes #700)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+59d6f8"
+  version: "2026.05.27+c33ddd"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -849,16 +849,21 @@ code, pre, .mono {
 /* Per-column collapse toggle (chevron at the trailing edge of column-head).
    When no .move-all-group is present (Completed in the below-band, the
    right-edge of Triage/Ready when neither side renders a move-all), the
-   toggle itself takes the margin-left:auto to stay right-aligned. */
+   toggle itself takes the margin-left:auto to stay right-aligned. Issue
+   #700 — enlarged from 0.9em/0 0.2em to 1.1em/2px 6px for a bigger hit
+   target + visual weight; subtle background on hover so the toggle reads
+   as interactive. */
 .column-collapse-toggle {
   background: none;
-  border: 0;
+  border: 1px solid transparent;
   cursor: pointer;
-  font-size: 0.9em;
-  padding: 0 0.2em;
+  font-size: 1.1em;
+  padding: 2px 6px;
   color: var(--text-dim);
   margin-left: 0.4em;
   line-height: 1;
+  border-radius: 4px;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 .column-head > .column-collapse-toggle:last-child {
   margin-left: auto;
@@ -869,12 +874,16 @@ code, pre, .mono {
 .column-collapse-toggle:hover,
 .column-collapse-toggle:focus-visible {
   color: var(--text);
+  background: rgba(88, 166, 255, 0.1);
+  border-color: var(--border);
   outline: none;
 }
 
 /* Collapsed: hide the dropzone list; keep the header visible with count +
    toggle. The column itself stays in the flex/grid flow so its width is
-   preserved — a collapsed column reads as a thin header strip. */
+   preserved — a collapsed column reads as a thin header strip. Issue #700
+   adds a `.collapsed-summary` preview strip showing "Label (N)" plus the
+   first 1-2 card titles so the user gets context without expanding. */
 .column.collapsed > .dropzone {
   display: none;
 }
@@ -883,6 +892,32 @@ code, pre, .mono {
 }
 .column.collapsed > .column-head {
   opacity: 0.85;
+}
+
+/* Collapsed-column preview strip (Issue #700). Rendered by JS when a
+   column is collapsed; hidden when expanded (applyCollapseStateToColumn
+   removes it). Shows a compact "Label (N) — title1, title2" line so
+   collapsed columns convey content at a glance. */
+.collapsed-summary {
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  border-top: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.collapsed-summary:hover {
+  color: var(--text);
+}
+.collapsed-summary .collapsed-summary-count {
+  font-weight: 600;
+  color: var(--text);
+}
+.collapsed-summary .collapsed-summary-titles {
+  margin-left: 0.4em;
+  font-style: italic;
 }
 
 .dropzone {
@@ -1081,26 +1116,28 @@ code, pre, .mono {
   cursor: not-allowed;
 }
 
-/* Column-header chevron buttons (move-all). Visually similar to .move-btn
-   but slightly larger/bolder so they read as a column-level action rather
-   than a per-card control. Sits in the column-head flex row. */
+/* Column-header chevron buttons (move-all). Issue #700 — restyled to match
+   the pill-pattern (section-nav-pill) for visual consistency: rounded
+   border-radius, slightly more padding, and smooth transitions. Sits in the
+   column-head flex row. */
 .move-all-group {
   display: inline-flex;
-  gap: 2px;
+  gap: 3px;
   margin-left: auto;
 }
 
 .move-all-btn {
-  background: var(--surface);
+  background: var(--surface2);
   color: var(--text-dim);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0 6px;
-  font-size: 1rem;
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 0.95rem;
   line-height: 1.2;
   font-weight: 700;
   cursor: pointer;
   font-family: inherit;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
 }
 
 .move-all-btn:hover,

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -148,6 +148,64 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
     toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + lbl);
     toggle.textContent = collapsed ? "▸" : "▾";
   }
+  // Issue #700 — collapsed-column preview strip. When collapsed, inject a
+  // compact summary showing "Label (N)" plus the first 1-2 card titles so
+  // the user sees content without expanding. When expanded, remove it.
+  const existingSummary = colDiv.querySelector(".collapsed-summary");
+  if (!collapsed) {
+    if (existingSummary) existingSummary.parentNode.removeChild(existingSummary);
+    return;
+  }
+  // Build the summary from the dropzone's cards (hidden by CSS but still
+  // in the DOM). This avoids a second data lookup.
+  const dz = colDiv.querySelector(".dropzone");
+  const cards = dz ? dz.querySelectorAll("li.card") : [];
+  const count = cards.length;
+  const labels = (kind === "plan") ? PLAN_COLUMN_LABELS : ISSUE_COLUMN_LABELS;
+  const colLabel = labels[col] || col;
+  const summary = el("div", {
+    cls: "collapsed-summary",
+    attrs: {
+      "data-action": "column-collapse-toggle",
+      "data-kind": kind,
+      "data-column": col,
+      role: "button",
+      "aria-label": "Expand " + colLabel + " (" + count + " items)",
+    },
+  });
+  const countSpan = el("span", {
+    cls: "collapsed-summary-count",
+    text: colLabel + " (" + count + ")",
+  });
+  summary.appendChild(countSpan);
+  // Append first 1-2 card titles as a teaser.
+  const titles = [];
+  for (let i = 0; i < Math.min(2, cards.length); i++) {
+    const card = cards[i];
+    const titleEl = card.querySelector(".card-title, .card-title-link");
+    if (titleEl) {
+      let t = titleEl.textContent || "";
+      if (t.length > 40) t = t.slice(0, 37) + "...";
+      titles.push(t);
+    }
+  }
+  if (titles.length > 0) {
+    const sep = (count > titles.length) ? " +" + (count - titles.length) + " more" : "";
+    summary.appendChild(el("span", {
+      cls: "collapsed-summary-titles",
+      text: "— " + titles.join(", ") + sep,
+    }));
+  }
+  // Remove stale summary if present, then append the new one after
+  // the column-head. This keeps the summary inside .column.collapsed
+  // but outside .dropzone.
+  if (existingSummary) existingSummary.parentNode.removeChild(existingSummary);
+  const head = colDiv.querySelector(".column-head");
+  if (head && head.nextSibling) {
+    colDiv.insertBefore(summary, head.nextSibling);
+  } else {
+    colDiv.appendChild(summary);
+  }
 }
 
 // Append the per-column collapse toggle to a column-head. Caller passes

--- a/docs/issues/ISSUES_PLAN.md
+++ b/docs/issues/ISSUES_PLAN.md
@@ -1311,11 +1311,7 @@ Plus a structural conformance pin in `tests/test-skill-conformance.sh` (or new t
 **Complexity:** S. **Action now:** /do pr — fix default-substitution on line 84 in source + mirror, add unbound-variable test, bump skill version
 
 ### #700 — Dashboard: polish collapse/expand toggle, collapsed-column preview, and column-move chevrons
-
-**Labels:** (none)
-
-**Problem.** Three related UX polish items on the dashboard below-band columns: (1) collapse/expand toggle too small, (2) collapsed columns show nothing, (3) column-move chevrons look rough. All CSS/JS frontend work needing visual verification.
-
-**Fix outline.** Replace chevron character with larger icon, add compact summary strip for collapsed columns, style chevrons with consistent padding/hover. Touches app.js and app.css across 3 sub-items.
-
-**Complexity:** M. **Action now:** /do pr — multi-item UI polish with visual-verification requirement; too broad for in-batch fix-agent.
+**Labels:** none | **Verdict:** actionable — CSS+JS cosmetic polish, scope well-defined
+**Problem.** Three below-band UX polish items: (1) collapse toggle (`▸`/`▾`) is too small at `font-size: 0.9em` + `padding: 0 0.2em` — reads as a dot, not a button; (2) collapsed columns hide the dropzone (`display: none`) but show nothing in its place — looks broken rather than intentionally collapsed; (3) move-all chevrons (`«`/`»`) have minimal styling (`padding: 0 6px`, `border-radius: 4px`) inconsistent with the section-nav pills and other action buttons that use `border-radius: 999px`, hover transitions, etc.
+**Fix outline.** All changes in two source files: `skills/zskills-dashboard/scripts/zskills_monitor/static/app.css` and `app.js` (mirror copies to `.claude/skills/` after). (1) Increase `.column-collapse-toggle` to `font-size: 1.1em`, `padding: 2px 6px`, add `border-radius: 4px` and a subtle background on hover. (2) In `applyCollapseStateToColumn` (JS ~L137), when collapsed, inject a compact summary strip into `colDiv` showing "Label (N)" with first 1-2 card titles truncated; in CSS add a `.collapsed-summary` rule for the strip. (3) Style `.move-all-btn` with `border-radius: 6px`, `padding: 2px 8px`, and a `transition: border-color 0.12s, color 0.12s, background 0.12s` matching `.section-nav-pill`.
+**Complexity:** S. **Action now:** /do pr — polish collapse toggle size, collapsed-column preview strip, and move-all chevron styling in dashboard CSS+JS

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+59d6f8"
+  version: "2026.05.27+c33ddd"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -849,16 +849,21 @@ code, pre, .mono {
 /* Per-column collapse toggle (chevron at the trailing edge of column-head).
    When no .move-all-group is present (Completed in the below-band, the
    right-edge of Triage/Ready when neither side renders a move-all), the
-   toggle itself takes the margin-left:auto to stay right-aligned. */
+   toggle itself takes the margin-left:auto to stay right-aligned. Issue
+   #700 — enlarged from 0.9em/0 0.2em to 1.1em/2px 6px for a bigger hit
+   target + visual weight; subtle background on hover so the toggle reads
+   as interactive. */
 .column-collapse-toggle {
   background: none;
-  border: 0;
+  border: 1px solid transparent;
   cursor: pointer;
-  font-size: 0.9em;
-  padding: 0 0.2em;
+  font-size: 1.1em;
+  padding: 2px 6px;
   color: var(--text-dim);
   margin-left: 0.4em;
   line-height: 1;
+  border-radius: 4px;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 .column-head > .column-collapse-toggle:last-child {
   margin-left: auto;
@@ -869,12 +874,16 @@ code, pre, .mono {
 .column-collapse-toggle:hover,
 .column-collapse-toggle:focus-visible {
   color: var(--text);
+  background: rgba(88, 166, 255, 0.1);
+  border-color: var(--border);
   outline: none;
 }
 
 /* Collapsed: hide the dropzone list; keep the header visible with count +
    toggle. The column itself stays in the flex/grid flow so its width is
-   preserved — a collapsed column reads as a thin header strip. */
+   preserved — a collapsed column reads as a thin header strip. Issue #700
+   adds a `.collapsed-summary` preview strip showing "Label (N)" plus the
+   first 1-2 card titles so the user gets context without expanding. */
 .column.collapsed > .dropzone {
   display: none;
 }
@@ -883,6 +892,32 @@ code, pre, .mono {
 }
 .column.collapsed > .column-head {
   opacity: 0.85;
+}
+
+/* Collapsed-column preview strip (Issue #700). Rendered by JS when a
+   column is collapsed; hidden when expanded (applyCollapseStateToColumn
+   removes it). Shows a compact "Label (N) — title1, title2" line so
+   collapsed columns convey content at a glance. */
+.collapsed-summary {
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  border-top: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+.collapsed-summary:hover {
+  color: var(--text);
+}
+.collapsed-summary .collapsed-summary-count {
+  font-weight: 600;
+  color: var(--text);
+}
+.collapsed-summary .collapsed-summary-titles {
+  margin-left: 0.4em;
+  font-style: italic;
 }
 
 .dropzone {
@@ -1081,26 +1116,28 @@ code, pre, .mono {
   cursor: not-allowed;
 }
 
-/* Column-header chevron buttons (move-all). Visually similar to .move-btn
-   but slightly larger/bolder so they read as a column-level action rather
-   than a per-card control. Sits in the column-head flex row. */
+/* Column-header chevron buttons (move-all). Issue #700 — restyled to match
+   the pill-pattern (section-nav-pill) for visual consistency: rounded
+   border-radius, slightly more padding, and smooth transitions. Sits in the
+   column-head flex row. */
 .move-all-group {
   display: inline-flex;
-  gap: 2px;
+  gap: 3px;
   margin-left: auto;
 }
 
 .move-all-btn {
-  background: var(--surface);
+  background: var(--surface2);
   color: var(--text-dim);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0 6px;
-  font-size: 1rem;
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 0.95rem;
   line-height: 1.2;
   font-weight: 700;
   cursor: pointer;
   font-family: inherit;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
 }
 
 .move-all-btn:hover,

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -148,6 +148,64 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
     toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + lbl);
     toggle.textContent = collapsed ? "▸" : "▾";
   }
+  // Issue #700 — collapsed-column preview strip. When collapsed, inject a
+  // compact summary showing "Label (N)" plus the first 1-2 card titles so
+  // the user sees content without expanding. When expanded, remove it.
+  const existingSummary = colDiv.querySelector(".collapsed-summary");
+  if (!collapsed) {
+    if (existingSummary) existingSummary.parentNode.removeChild(existingSummary);
+    return;
+  }
+  // Build the summary from the dropzone's cards (hidden by CSS but still
+  // in the DOM). This avoids a second data lookup.
+  const dz = colDiv.querySelector(".dropzone");
+  const cards = dz ? dz.querySelectorAll("li.card") : [];
+  const count = cards.length;
+  const labels = (kind === "plan") ? PLAN_COLUMN_LABELS : ISSUE_COLUMN_LABELS;
+  const colLabel = labels[col] || col;
+  const summary = el("div", {
+    cls: "collapsed-summary",
+    attrs: {
+      "data-action": "column-collapse-toggle",
+      "data-kind": kind,
+      "data-column": col,
+      role: "button",
+      "aria-label": "Expand " + colLabel + " (" + count + " items)",
+    },
+  });
+  const countSpan = el("span", {
+    cls: "collapsed-summary-count",
+    text: colLabel + " (" + count + ")",
+  });
+  summary.appendChild(countSpan);
+  // Append first 1-2 card titles as a teaser.
+  const titles = [];
+  for (let i = 0; i < Math.min(2, cards.length); i++) {
+    const card = cards[i];
+    const titleEl = card.querySelector(".card-title, .card-title-link");
+    if (titleEl) {
+      let t = titleEl.textContent || "";
+      if (t.length > 40) t = t.slice(0, 37) + "...";
+      titles.push(t);
+    }
+  }
+  if (titles.length > 0) {
+    const sep = (count > titles.length) ? " +" + (count - titles.length) + " more" : "";
+    summary.appendChild(el("span", {
+      cls: "collapsed-summary-titles",
+      text: "— " + titles.join(", ") + sep,
+    }));
+  }
+  // Remove stale summary if present, then append the new one after
+  // the column-head. This keeps the summary inside .column.collapsed
+  // but outside .dropzone.
+  if (existingSummary) existingSummary.parentNode.removeChild(existingSummary);
+  const head = colDiv.querySelector(".column-head");
+  if (head && head.nextSibling) {
+    colDiv.insertBefore(summary, head.nextSibling);
+  } else {
+    colDiv.appendChild(summary);
+  }
 }
 
 // Append the per-column collapse toggle to a column-head. Caller passes

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -1833,6 +1833,134 @@ else
   fail "#676: collect.py missing dashboard_completed_days in snapshot"
 fi
 
+###############################################################################
+# Issue #700 — Dashboard UI polish: collapse toggle, collapsed preview,
+# move-all button styling
+###############################################################################
+
+echo ""
+echo "=== Issue #700: collapse toggle, collapsed preview strip, move-all styling ==="
+
+# 700-1: Collapse toggle font-size increased to 1.1em (from 0.9em).
+if grep -qE '\.column-collapse-toggle\b' "$APP_CSS" \
+   && awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /font-size:[[:space:]]*1\.1em/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: collapse toggle font-size is 1.1em"
+else
+  fail "#700: collapse toggle font-size is NOT 1.1em"
+fi
+
+# 700-2: Collapse toggle padding increased to 2px 6px (from 0 0.2em).
+if awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /padding:[[:space:]]*2px 6px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: collapse toggle padding is 2px 6px"
+else
+  fail "#700: collapse toggle padding is NOT 2px 6px"
+fi
+
+# 700-3: Collapse toggle has border-radius: 4px.
+if awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /border-radius:[[:space:]]*4px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: collapse toggle border-radius is 4px"
+else
+  fail "#700: collapse toggle border-radius missing"
+fi
+
+# 700-4: Collapse toggle hover has background color.
+if awk '/\.column-collapse-toggle:hover/{flag=1} flag && /background:/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: collapse toggle hover has background"
+else
+  fail "#700: collapse toggle hover missing background"
+fi
+
+# 700-5: Collapse toggle has transition property.
+if awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /transition:/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: collapse toggle has CSS transition"
+else
+  fail "#700: collapse toggle missing CSS transition"
+fi
+
+# 700-6: Collapsed-summary CSS rule defined.
+if grep -qE '\.collapsed-summary\b' "$APP_CSS"; then
+  pass "#700: .collapsed-summary CSS rule defined"
+else
+  fail "#700: .collapsed-summary CSS rule missing"
+fi
+
+# 700-7: Collapsed-summary-count CSS sub-rule defined.
+if grep -qE '\.collapsed-summary-count' "$APP_CSS"; then
+  pass "#700: .collapsed-summary-count CSS rule defined"
+else
+  fail "#700: .collapsed-summary-count CSS rule missing"
+fi
+
+# 700-8: Collapsed-summary-titles CSS sub-rule defined.
+if grep -qE '\.collapsed-summary-titles' "$APP_CSS"; then
+  pass "#700: .collapsed-summary-titles CSS rule defined"
+else
+  fail "#700: .collapsed-summary-titles CSS rule missing"
+fi
+
+# 700-9: applyCollapseStateToColumn builds a collapsed-summary element when
+# the column is collapsed. Verify by grepping for the class in the JS body.
+COLLAPSE_BODY=$(awk '
+  /^function applyCollapseStateToColumn\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$COLLAPSE_BODY" | grep -qE 'collapsed-summary'; then
+  pass "#700: applyCollapseStateToColumn renders collapsed-summary element"
+else
+  fail "#700: applyCollapseStateToColumn does not render collapsed-summary"
+fi
+
+# 700-10: The collapsed-summary uses card titles from the hidden dropzone.
+if echo "$COLLAPSE_BODY" | grep -qE 'card-title.*card-title-link|\.card-title-link'; then
+  pass "#700: collapsed-summary extracts card titles from dropzone"
+else
+  fail "#700: collapsed-summary does not extract card titles"
+fi
+
+# 700-11: The collapsed-summary is removed when expanded.
+if echo "$COLLAPSE_BODY" | grep -qE 'removeChild.*existingSummary|existingSummary.*removeChild'; then
+  pass "#700: collapsed-summary removed on expand"
+else
+  fail "#700: collapsed-summary not removed on expand"
+fi
+
+# 700-12: Collapsed-summary carries data-action="column-collapse-toggle" so
+# clicking it expands the column (reuses the existing delegated handler).
+if echo "$COLLAPSE_BODY" | grep -qE '"data-action".*"column-collapse-toggle"'; then
+  pass "#700: collapsed-summary is clickable (data-action=column-collapse-toggle)"
+else
+  fail "#700: collapsed-summary missing data-action for click-to-expand"
+fi
+
+# 700-13: Move-all button border-radius increased to 6px (from 4px).
+if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /border-radius:[[:space:]]*6px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: move-all-btn border-radius is 6px"
+else
+  fail "#700: move-all-btn border-radius is NOT 6px"
+fi
+
+# 700-14: Move-all button padding increased to 2px 8px (from 0 6px).
+if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /padding:[[:space:]]*2px 8px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: move-all-btn padding is 2px 8px"
+else
+  fail "#700: move-all-btn padding is NOT 2px 8px"
+fi
+
+# 700-15: Move-all button has transition matching section-nav-pill pattern.
+if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /transition:.*border-color.*color.*background/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: move-all-btn has pill-style transition"
+else
+  fail "#700: move-all-btn missing pill-style transition"
+fi
+
+# 700-16: Move-all button background uses surface2 (consistent with pill pattern).
+if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /background:.*--surface2/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: move-all-btn background is var(--surface2)"
+else
+  fail "#700: move-all-btn background is NOT var(--surface2)"
+fi
+
 # Stop server cleanly via SIGTERM and verify port is released.
 kill -TERM "$SERVER_PID" 2>/dev/null || true
 for _ in 1 2 3 4 5 6 7 8 9 10; do


### PR DESCRIPTION
## Summary

Dashboard UI polish — three cosmetic improvements:

- **Collapse toggle:** enlarged from 0.9em to 1.1em, added padding/border-radius/hover transitions so it reads as interactive
- **Collapsed preview strip:** collapsed columns now show "Label (N)" + first 1-2 card titles instead of an empty header; clicking the strip expands the column
- **Move-all buttons:** restyled to pill pattern (border-radius, surface2 background, transitions) matching other dashboard buttons

Closes #700.

## Test plan

- [x] Full suite: 5957/5957 passed, 0 failed
- [x] 16 new static-grep assertions (700-1 through 700-16) for CSS properties + JS behavioral contracts
- [x] Mirrors byte-identical (SKILL.md, app.css, app.js)
- [x] metadata.version bumped
- [ ] Visual verification recommended (no dev server in worktree — UI changes are structural-grep tested only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
