### PR TITLE
feat(dashboard): add copy-to-clipboard button on card action bars

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+c33ddd"
+  version: "2026.05.27+e5c1df"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1211,6 +1211,13 @@ code, pre, .mono {
   outline: none;
 }
 
+/* Copy-to-clipboard button — sits at the trailing edge of .card-controls.
+   Inherits .move-btn base styling; margin-left: auto pushes it right so
+   it visually separates from the move/remove cluster. */
+.copy-btn {
+  margin-left: auto;
+}
+
 .toast-region {
   position: fixed;
   top: 16px;

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -995,25 +995,30 @@ function buildPlanCard(plan, slug, col, defaultMode) {
 
   // Card controls: ↑ ↓ ← → and remove. Omitted for completed plans
   // (Phase 4 / D5 — Completed is read-only; no per-card action buttons).
-  if (!isCompleted) {
+  // The copy button is always present (copying is safe regardless of
+  // claim or completed state).
+  {
     const controls = el("div", {
       cls: "card-controls",
-      attrs: { role: "group", "aria-label": "Move this plan" },
+      attrs: { role: "group", "aria-label": isCompleted ? "Plan actions" : "Move this plan" },
     });
-    controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
-    controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
-    controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
-    controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
-    controls.appendChild(el("button", {
-      cls: "remove-btn",
-      attrs: {
-        type: "button",
-        "data-action": "plan-discard",
-        "data-slug": slug,
-        "aria-label": "Discard plan (move to Discarded)",
-      },
-      text: "✕",
-    }));
+    if (!isCompleted) {
+      controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
+      controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
+      controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
+      controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
+      controls.appendChild(el("button", {
+        cls: "remove-btn",
+        attrs: {
+          type: "button",
+          "data-action": "plan-discard",
+          "data-slug": slug,
+          "aria-label": "Discard plan (move to Discarded)",
+        },
+        text: "✕",
+      }));
+    }
+    controls.appendChild(makeCopyBtn((plan && plan.title) || slug));
     card.appendChild(controls);
   }
 
@@ -1044,6 +1049,30 @@ function makeIssueMoveBtn(action, num, label, ariaLabel) {
     },
     text: label,
   });
+}
+
+// Copy-to-clipboard button. Uses a direct event listener (not the
+// delegated data-action dispatch) so it bypasses the claim guard — copying
+// title text is always safe. Shows a brief checkmark on success.
+function makeCopyBtn(titleText) {
+  var btn = el("button", {
+    cls: "move-btn copy-btn",
+    attrs: {
+      type: "button",
+      "data-action": "copy-title",
+      "aria-label": "Copy title to clipboard",
+    },
+    text: "📋",
+  });
+  btn.addEventListener("click", function(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard.writeText(titleText).then(function() {
+      btn.textContent = "✓";
+      setTimeout(function() { btn.textContent = "📋"; }, 1500);
+    });
+  });
+  return btn;
 }
 
 // Column-header chevron button: triggers "move all non-claimed cards in
@@ -1380,26 +1409,32 @@ function buildIssueCard(issue, num, col) {
     }
     card.appendChild(labels);
   }
-  // Phase 4 / D5 — Completed cards skip per-card action controls.
-  if (!isCompleted) {
+  // Phase 4 / D5 — Completed cards skip per-card move/remove controls.
+  // The copy button is always present (copying is safe regardless of
+  // claim or completed state).
+  {
     const controls = el("div", {
       cls: "card-controls",
-      attrs: { role: "group", "aria-label": "Move this issue" },
+      attrs: { role: "group", "aria-label": isCompleted ? "Issue actions" : "Move this issue" },
     });
-    controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
-    controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
-    controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
-    controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
-    controls.appendChild(el("button", {
-      cls: "remove-btn",
-      attrs: {
-        type: "button",
-        "data-action": "issue-remove",
-        "data-number": String(num),
-        "aria-label": "Remove issue from queue",
-      },
-      text: "✕",
-    }));
+    if (!isCompleted) {
+      controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
+      controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
+      controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
+      controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
+      controls.appendChild(el("button", {
+        cls: "remove-btn",
+        attrs: {
+          type: "button",
+          "data-action": "issue-remove",
+          "data-number": String(num),
+          "aria-label": "Remove issue from queue",
+        },
+        text: "✕",
+      }));
+    }
+    const issueTitle = issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num);
+    controls.appendChild(makeCopyBtn(issueTitle));
     card.appendChild(controls);
   }
   return card;

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+c33ddd"
+  version: "2026.05.27+e5c1df"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1211,6 +1211,13 @@ code, pre, .mono {
   outline: none;
 }
 
+/* Copy-to-clipboard button — sits at the trailing edge of .card-controls.
+   Inherits .move-btn base styling; margin-left: auto pushes it right so
+   it visually separates from the move/remove cluster. */
+.copy-btn {
+  margin-left: auto;
+}
+
 .toast-region {
   position: fixed;
   top: 16px;

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -995,25 +995,30 @@ function buildPlanCard(plan, slug, col, defaultMode) {
 
   // Card controls: ↑ ↓ ← → and remove. Omitted for completed plans
   // (Phase 4 / D5 — Completed is read-only; no per-card action buttons).
-  if (!isCompleted) {
+  // The copy button is always present (copying is safe regardless of
+  // claim or completed state).
+  {
     const controls = el("div", {
       cls: "card-controls",
-      attrs: { role: "group", "aria-label": "Move this plan" },
+      attrs: { role: "group", "aria-label": isCompleted ? "Plan actions" : "Move this plan" },
     });
-    controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
-    controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
-    controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
-    controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
-    controls.appendChild(el("button", {
-      cls: "remove-btn",
-      attrs: {
-        type: "button",
-        "data-action": "plan-discard",
-        "data-slug": slug,
-        "aria-label": "Discard plan (move to Discarded)",
-      },
-      text: "✕",
-    }));
+    if (!isCompleted) {
+      controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
+      controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
+      controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
+      controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
+      controls.appendChild(el("button", {
+        cls: "remove-btn",
+        attrs: {
+          type: "button",
+          "data-action": "plan-discard",
+          "data-slug": slug,
+          "aria-label": "Discard plan (move to Discarded)",
+        },
+        text: "✕",
+      }));
+    }
+    controls.appendChild(makeCopyBtn((plan && plan.title) || slug));
     card.appendChild(controls);
   }
 
@@ -1044,6 +1049,30 @@ function makeIssueMoveBtn(action, num, label, ariaLabel) {
     },
     text: label,
   });
+}
+
+// Copy-to-clipboard button. Uses a direct event listener (not the
+// delegated data-action dispatch) so it bypasses the claim guard — copying
+// title text is always safe. Shows a brief checkmark on success.
+function makeCopyBtn(titleText) {
+  var btn = el("button", {
+    cls: "move-btn copy-btn",
+    attrs: {
+      type: "button",
+      "data-action": "copy-title",
+      "aria-label": "Copy title to clipboard",
+    },
+    text: "📋",
+  });
+  btn.addEventListener("click", function(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard.writeText(titleText).then(function() {
+      btn.textContent = "✓";
+      setTimeout(function() { btn.textContent = "📋"; }, 1500);
+    });
+  });
+  return btn;
 }
 
 // Column-header chevron button: triggers "move all non-claimed cards in
@@ -1380,26 +1409,32 @@ function buildIssueCard(issue, num, col) {
     }
     card.appendChild(labels);
   }
-  // Phase 4 / D5 — Completed cards skip per-card action controls.
-  if (!isCompleted) {
+  // Phase 4 / D5 — Completed cards skip per-card move/remove controls.
+  // The copy button is always present (copying is safe regardless of
+  // claim or completed state).
+  {
     const controls = el("div", {
       cls: "card-controls",
-      attrs: { role: "group", "aria-label": "Move this issue" },
+      attrs: { role: "group", "aria-label": isCompleted ? "Issue actions" : "Move this issue" },
     });
-    controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
-    controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
-    controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
-    controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
-    controls.appendChild(el("button", {
-      cls: "remove-btn",
-      attrs: {
-        type: "button",
-        "data-action": "issue-remove",
-        "data-number": String(num),
-        "aria-label": "Remove issue from queue",
-      },
-      text: "✕",
-    }));
+    if (!isCompleted) {
+      controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
+      controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
+      controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
+      controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
+      controls.appendChild(el("button", {
+        cls: "remove-btn",
+        attrs: {
+          type: "button",
+          "data-action": "issue-remove",
+          "data-number": String(num),
+          "aria-label": "Remove issue from queue",
+        },
+        text: "✕",
+      }));
+    }
+    const issueTitle = issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num);
+    controls.appendChild(makeCopyBtn(issueTitle));
     card.appendChild(controls);
   }
   return card;

--- a/tests/test-dashboard-completed-readonly.sh
+++ b/tests/test-dashboard-completed-readonly.sh
@@ -70,7 +70,6 @@ function makeNode(tag) {
     textContent: "",
     attrs: {},
     children: [],
-    parent: null,
     hidden: false,
     style: {},
     setAttribute(k, v) { this.attrs[k] = String(v); },
@@ -78,7 +77,9 @@ function makeNode(tag) {
     removeAttribute(k) { delete this.attrs[k]; },
     appendChild(c) { c.parent = this; this.children.push(c); return c; },
     closest() { return null; },
+    addEventListener() {},
   };
+  Object.defineProperty(node, "parent", { value: null, writable: true, enumerable: false });
   return node;
 }
 
@@ -102,6 +103,7 @@ const issueUrlBlock = extractBlock(src, /\nfunction issueUrl\(/, "\n}\n");
 const planUrlBlock = extractBlock(src, /\nfunction planUrl\(/, "\n}\n");
 const makeIssueBtnBlock = extractBlock(src, /\nfunction makeIssueMoveBtn\(/, "\n}\n");
 const makeMoveBtnBlock = extractBlock(src, /\nfunction makeMoveBtn\(/, "\n}\n");
+const makeCopyBtnBlock = extractBlock(src, /\nfunction makeCopyBtn\(/, "\n}\n");
 const statusPillBlock = extractBlock(src, /\nfunction statusPillClass\(/, "\n}\n");
 const modePillBlock = extractBlock(src, /\nfunction modePillClass\(/, "\n}\n");
 const currentEntryModeBlock = extractBlock(src, /\nfunction currentEntryMode\(/, "\n}\n");
@@ -112,6 +114,8 @@ const buildPlanBlock = extractBlock(src, /\nfunction buildPlanCard\(/, "\n  retu
 const harness = `
 let repoUrl = "https://example.invalid/repo";
 let lastGoodQueues = null;
+if (typeof navigator === "undefined") globalThis.navigator = {};
+if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
 
 ${elBlock}
 ${titleNodeBlock}
@@ -120,6 +124,7 @@ ${issueUrlBlock}
 ${planUrlBlock}
 ${makeIssueBtnBlock}
 ${makeMoveBtnBlock}
+${makeCopyBtnBlock}
 ${statusPillBlock}
 ${modePillBlock}
 ${currentEntryModeBlock}
@@ -187,10 +192,12 @@ function findByClass(root, cls) {
     "T4.8.a completed issue has no aria-disabled (no claim chip path)");
   expect(findByClass(card, "claim-chip"), null,
     "T4.8.a completed issue has no .claim-chip");
-  expect(findByClass(card, "card-controls"), null,
-    "T4.8.a completed issue has no .card-controls block");
+  expectTrue(findByClass(card, "card-controls"),
+    "T4.8.a completed issue has .card-controls (copy-only)");
   expect(findByClass(card, "remove-btn"), null,
     "T4.8.a completed issue has no .remove-btn (no per-card ✕)");
+  expectTrue(findByClass(card, "copy-btn"),
+    "T4.8.a completed issue has copy button");
   expect(card.getAttribute("data-column"), "completed",
     "T4.8.a completed issue retains data-column='completed'");
 }
@@ -211,8 +218,8 @@ function findByClass(root, cls) {
   const card = buildPlanCard(plan, "demo-plan", "completed", "phase");
   expect(card.getAttribute("draggable"), null,
     "T4.8.b completed plan has no draggable attribute");
-  expect(findByClass(card, "card-controls"), null,
-    "T4.8.b completed plan has no .card-controls block");
+  expectTrue(findByClass(card, "card-controls"),
+    "T4.8.b completed plan has .card-controls (copy-only)");
   expect(findByClass(card, "remove-btn"), null,
     "T4.8.b completed plan has no .remove-btn");
   // DA10 — completed plans render plain title text, no card-title-link.

--- a/tests/test-fix-issues-claim-render-dom.sh
+++ b/tests/test-fix-issues-claim-render-dom.sh
@@ -160,6 +160,7 @@ function makeNode(tag) {
       }
       return null;
     },
+    addEventListener() {},
   };
   return node;
 }
@@ -206,6 +207,7 @@ const titleNodeBlock = extractBlock(src, /\nfunction titleNode\(/, "\n}\n");
 const relativeTimeBlock = extractBlock(src, /\nfunction relativeTime\(/, "\n}\n");
 const issueUrlBlock = extractBlock(src, /\nfunction issueUrl\(/, "\n}\n");
 const makeBtnBlock = extractBlock(src, /\nfunction makeIssueMoveBtn\(/, "\n}\n");
+const makeCopyBtnBlock = extractBlock(src, /\nfunction makeCopyBtn\(/, "\n}\n");
 const buildCardBlock = extractBlock(src, /\nfunction buildIssueCard\(/, "\n  return card;\n}\n");
 const fingerprintBlock = extractBlock(src, /\nfunction fingerprintIssues\(/, "\n}\n");
 
@@ -228,6 +230,8 @@ const guardSrc = extractBlock(
 // Build the full harness source.
 const harness = `
 let repoUrl = "https://example.invalid/repo";
+if (typeof navigator === "undefined") globalThis.navigator = {};
+if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
 ${issueColumnsBlock}
 
 ${elBlock}
@@ -239,6 +243,8 @@ ${relativeTimeBlock}
 ${issueUrlBlock}
 
 ${makeBtnBlock}
+
+${makeCopyBtnBlock}
 
 ${buildCardBlock}
 

--- a/tests/test-plan-claim-handleaction-guard.sh
+++ b/tests/test-plan-claim-handleaction-guard.sh
@@ -91,6 +91,7 @@ function makeNode(tag) {
       }
       return null;
     },
+    addEventListener() {},
   };
   return node;
 }
@@ -137,6 +138,7 @@ const planUrlBlock   = extractBlock(src, /\nfunction planUrl\(/, "\n}\n");
 const statusPillCls  = extractBlock(src, /\nfunction statusPillClass\(/, "\n}\n");
 const modePillCls    = extractBlock(src, /\nfunction modePillClass\(/, "\n}\n");
 const makeMoveBtnBlk = extractBlock(src, /\nfunction makeMoveBtn\(/, "\n}\n");
+const makeCopyBtnBlk = extractBlock(src, /\nfunction makeCopyBtn\(/, "\n}\n");
 const buildPlanBlock = extractBlock(src, /\nfunction buildPlanCard\(/, "\n  return card;\n}\n");
 
 // Extract the plan-action guard block — the literal slice from the
@@ -149,6 +151,8 @@ const guardSrc = extractBlock(
 
 const harness = `
 let repoUrl = "https://example.invalid/repo";
+if (typeof navigator === "undefined") globalThis.navigator = {};
+if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
 function currentEntryMode(_slug) { return null; }
 
 ${elBlock}
@@ -164,6 +168,8 @@ ${statusPillCls}
 ${modePillCls}
 
 ${makeMoveBtnBlk}
+
+${makeCopyBtnBlk}
 
 ${buildPlanBlock}
 

--- a/tests/test-plan-claim-render-dom.sh
+++ b/tests/test-plan-claim-render-dom.sh
@@ -128,6 +128,7 @@ function makeNode(tag) {
     removeAttribute(k) { delete this.attrs[k]; },
     appendChild(c) { c.parent = this; this.children.push(c); return c; },
     closest(_sel) { return null; },  // unused in buildPlanCard render
+    addEventListener() {},
   };
   return node;
 }
@@ -153,12 +154,15 @@ const planUrlBlock    = extractBlock(src, /\nfunction planUrl\(/, "\n}\n");
 const statusPillCls   = extractBlock(src, /\nfunction statusPillClass\(/, "\n}\n");
 const modePillCls     = extractBlock(src, /\nfunction modePillClass\(/, "\n}\n");
 const makeMoveBtnBlk  = extractBlock(src, /\nfunction makeMoveBtn\(/, "\n}\n");
+const makeCopyBtnBlk  = extractBlock(src, /\nfunction makeCopyBtn\(/, "\n}\n");
 const buildPlanBlock  = extractBlock(src, /\nfunction buildPlanCard\(/, "\n  return card;\n}\n");
 
 // currentEntryMode is used inside buildPlanCard for the ready-column
 // mode chip — stub it.
 const harness = `
 let repoUrl = "https://example.invalid/repo";
+if (typeof navigator === "undefined") globalThis.navigator = {};
+if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
 function currentEntryMode(_slug) { return null; }
 
 ${elBlock}
@@ -174,6 +178,8 @@ ${statusPillCls}
 ${modePillCls}
 
 ${makeMoveBtnBlk}
+
+${makeCopyBtnBlk}
 
 ${buildPlanBlock}
 


### PR DESCRIPTION
## Summary

Adds a 📋 copy-to-clipboard button to plan and issue card action bars. Copies the card title text via `navigator.clipboard.writeText()` with ✓ feedback for 1.5s. Uses direct event listener (not delegated action dispatch) so the claim-guard doesn't block it — copying is always safe.

- Plan cards: copies `plan.title || slug`
- Issue cards: copies `#N title`
- Button pushed to trailing edge via `margin-left: auto`
- Completed/below-band cards also get the button (`.card-controls` always rendered)

Solves the UX gap where users can't select card text because mousedown initiates drag.

## Test plan

- [x] Full suite: 3447/0 passed.
- [x] Visual verification: worktree-rooted server on :9234, button visible on cards.
- [ ] Post-merge: restart dashboard, click 📋 on a card, paste to verify clipboard content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
