### PR TITLE
fix(zskills-dashboard): restore ZSKILLS_DASHBOARD_ROOT SKILL.md wiring (#704)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+e5c1df"
+  version: "2026.05.27+5bf878"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -45,14 +45,43 @@ or empty is a usage error:
 
 Exit 2.
 
+## Worktree override — `ZSKILLS_DASHBOARD_ROOT`
+
+By default the dashboard anchors to the main checkout so all sessions
+share one canonical view.  When an agent in a worktree needs to verify
+**its own** frontend changes visually, set the `ZSKILLS_DASHBOARD_ROOT`
+environment variable to the worktree path before invoking
+`/zskills-dashboard start`:
+
+```
+ZSKILLS_DASHBOARD_ROOT=/tmp/zskills-do-foo /zskills-dashboard start
+```
+
+This overrides `MAIN_ROOT` in the SKILL.md setup block and passes
+`--main-root` to the Python server so that both the collector
+(`collect.py:_resolve_main_root`) and the static-file serving use the
+worktree's filesystem instead of main's.
+
+When the variable is unset or empty, behavior is unchanged — the
+dashboard serves from the main checkout as before.
+
+The Python server also accepts `--main-root DIR` directly on the CLI
+(used by tests); the env var is the agent-facing surface.
+
 ## Step 0 — Common setup (every mode)
 
-Anchor `MAIN_ROOT` to the main checkout regardless of which worktree
-the skill was invoked from. The PID file, log file, and tracking
-markers all live under `$MAIN_ROOT/.zskills/`.
+Anchor `MAIN_ROOT` to the main checkout by default.  If
+`ZSKILLS_DASHBOARD_ROOT` is set to an existing directory, use that
+instead — this is the worktree-override path documented above.
+The PID file, log file, and tracking markers all live under
+`$MAIN_ROOT/.zskills/`.
 
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ] && [ -d "$ZSKILLS_DASHBOARD_ROOT" ]; then
+  MAIN_ROOT=$(cd "$ZSKILLS_DASHBOARD_ROOT" && pwd)
+else
+  MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+fi
 PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
 LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
 PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
@@ -262,9 +291,16 @@ if [ "$SUB" = "start" ]; then
   # without an install. nohup + disown survives parent-shell exit.
   # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to
   # PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (per DA-5).
+  # When ZSKILLS_DASHBOARD_ROOT is set, pass --main-root so the server's
+  # collector reads state from the override path (worktree verification).
+  MAIN_ROOT_FLAG=""
+  if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ]; then
+    MAIN_ROOT_FLAG="--main-root $MAIN_ROOT"
+  fi
   ( cd "$MAIN_ROOT" && \
     PYTHONPATH="$PKG_PARENT:${PYTHONPATH:-}" \
-    nohup python3 -m zskills_monitor.server \
+    ZSKILLS_DASHBOARD_ROOT="${ZSKILLS_DASHBOARD_ROOT:-}" \
+    nohup python3 -m zskills_monitor.server $MAIN_ROOT_FLAG \
       > "$LOG_FILE" 2>&1 < /dev/null & disown )
 
   # Health-check loop — up to ~10s for bind + first response. Python

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+e5c1df"
+  version: "2026.05.27+5bf878"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -45,14 +45,43 @@ or empty is a usage error:
 
 Exit 2.
 
+## Worktree override — `ZSKILLS_DASHBOARD_ROOT`
+
+By default the dashboard anchors to the main checkout so all sessions
+share one canonical view.  When an agent in a worktree needs to verify
+**its own** frontend changes visually, set the `ZSKILLS_DASHBOARD_ROOT`
+environment variable to the worktree path before invoking
+`/zskills-dashboard start`:
+
+```
+ZSKILLS_DASHBOARD_ROOT=/tmp/zskills-do-foo /zskills-dashboard start
+```
+
+This overrides `MAIN_ROOT` in the SKILL.md setup block and passes
+`--main-root` to the Python server so that both the collector
+(`collect.py:_resolve_main_root`) and the static-file serving use the
+worktree's filesystem instead of main's.
+
+When the variable is unset or empty, behavior is unchanged — the
+dashboard serves from the main checkout as before.
+
+The Python server also accepts `--main-root DIR` directly on the CLI
+(used by tests); the env var is the agent-facing surface.
+
 ## Step 0 — Common setup (every mode)
 
-Anchor `MAIN_ROOT` to the main checkout regardless of which worktree
-the skill was invoked from. The PID file, log file, and tracking
-markers all live under `$MAIN_ROOT/.zskills/`.
+Anchor `MAIN_ROOT` to the main checkout by default.  If
+`ZSKILLS_DASHBOARD_ROOT` is set to an existing directory, use that
+instead — this is the worktree-override path documented above.
+The PID file, log file, and tracking markers all live under
+`$MAIN_ROOT/.zskills/`.
 
 ```bash
-MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ] && [ -d "$ZSKILLS_DASHBOARD_ROOT" ]; then
+  MAIN_ROOT=$(cd "$ZSKILLS_DASHBOARD_ROOT" && pwd)
+else
+  MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+fi
 PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
 LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
 PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
@@ -262,9 +291,16 @@ if [ "$SUB" = "start" ]; then
   # without an install. nohup + disown survives parent-shell exit.
   # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to
   # PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (per DA-5).
+  # When ZSKILLS_DASHBOARD_ROOT is set, pass --main-root so the server's
+  # collector reads state from the override path (worktree verification).
+  MAIN_ROOT_FLAG=""
+  if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ]; then
+    MAIN_ROOT_FLAG="--main-root $MAIN_ROOT"
+  fi
   ( cd "$MAIN_ROOT" && \
     PYTHONPATH="$PKG_PARENT:${PYTHONPATH:-}" \
-    nohup python3 -m zskills_monitor.server \
+    ZSKILLS_DASHBOARD_ROOT="${ZSKILLS_DASHBOARD_ROOT:-}" \
+    nohup python3 -m zskills_monitor.server $MAIN_ROOT_FLAG \
       > "$LOG_FILE" 2>&1 < /dev/null & disown )
 
   # Health-check loop — up to ~10s for bind + first response. Python


### PR DESCRIPTION
## Summary
- Restore all `ZSKILLS_DASHBOARD_ROOT` SKILL.md wiring accidentally reverted by 7ee3132 (#702)
- Restores: Worktree override section, Step 0 env check, --main-root passthrough, nohup env propagation
- 9 references restored, matching known-good 4c493ad

## Test plan
- [x] 9 ZSKILLS_DASHBOARD_ROOT refs match known-good commit 4c493ad
- [x] Mirror consistency verified
- [x] Full test suite: 5957/5957 passed, 0 failed

Fixes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
