### PR TITLE
feat(dashboard): UI polish round 2 — SVG icons, label colors, button fixes

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+d10554"
+  version: "2026.05.27+104fdd"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+b2ea1c"
+  version: "2026.05.27+d10554"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1227,14 +1227,14 @@ def list_issues(
             if not isinstance(entry, dict):
                 continue
             labels_raw = entry.get("labels") or []
-            labels: List[str] = []
+            labels: list = []
             for lab in labels_raw:
                 if isinstance(lab, dict):
                     name = lab.get("name")
                     if name:
-                        labels.append(str(name))
+                        labels.append({"name": str(name), "color": lab.get("color", "")})
                 elif isinstance(lab, str):
-                    labels.append(lab)
+                    labels.append({"name": lab, "color": ""})
             issues.append({
                 "number": entry.get("number"),
                 "title": entry.get("title", ""),
@@ -1348,14 +1348,14 @@ def list_closed_issues_in_window(
             if not isinstance(entry, dict):
                 continue
             labels_raw = entry.get("labels") or []
-            labels: List[str] = []
+            labels: list = []
             for lab in labels_raw:
                 if isinstance(lab, dict):
                     name = lab.get("name")
                     if name:
-                        labels.append(str(name))
+                        labels.append({"name": str(name), "color": lab.get("color", "")})
                 elif isinstance(lab, str):
-                    labels.append(lab)
+                    labels.append({"name": lab, "color": ""})
             issues.append({
                 "number": entry.get("number"),
                 "title": entry.get("title", ""),
@@ -1717,14 +1717,15 @@ def _annotate_issues_queue(
             # allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto resolved issues_dir (parallels the fix-issues/SKILL.md exemption at line 1050); the literal tail is the canonical tracker filename
             _resolve_paths(main_root)["issues_dir"] / "ISSUES_PLAN.md"
         )
-        ready_nums: List[int] = []
-        for num in state_issues.get("ready", []) or []:
-            try:
-                ready_nums.append(int(num))
-            except Exception:
-                continue
-        if ready_nums:
-            skip_index = _build_skip_reason_index(issues_plan_path, ready_nums)
+        all_nums: List[int] = []
+        for col_entries in state_issues.values():
+            for num in (col_entries or []):
+                try:
+                    all_nums.append(int(num))
+                except Exception:
+                    continue
+        if all_nums:
+            skip_index = _build_skip_reason_index(issues_plan_path, all_nums)
         claim_index = _read_claims(main_root)
 
     if now_utc is None:
@@ -1758,7 +1759,7 @@ def _annotate_issues_queue(
         if isinstance(num, int) and num in pos:
             col, i = pos[num]
             issue["queue"] = {"column": col, "index": i}
-            if col == "ready" and num in skip_index:
+            if num in skip_index:
                 reason = skip_index[num]
                 if reason is not None:
                     issue["skip_reason"] = reason

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -714,6 +714,9 @@ class MonitorHandler(BaseHTTPRequestHandler):
         if decoded_path == "/favicon.svg":
             self._serve_static_file("favicon.svg", "image/svg+xml")
             return
+        if decoded_path == "/sampler.html":
+            self._serve_static_file("sampler.html", "text/html")
+            return
         if decoded_path == "/favicon.ico":
             # Many browsers request /favicon.ico by default. We serve the
             # SVG with the SVG MIME type — modern browsers (Firefox,

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -64,19 +64,7 @@ code, pre, .mono {
   font-weight: 600;
 }
 
-.under-construction {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 12px;
-  margin-right: auto;
-  padding: 4px 10px;
-  font-size: 0.8rem;
-  color: var(--accent2);
-  border: 1px solid var(--accent2);
-  border-radius: 999px;
-  white-space: nowrap;
-  cursor: help;
-}
+/* Under Construction marker removed — dashboard is production-ready. */
 
 .topbar-meta {
   font-size: 0.85rem;
@@ -345,6 +333,7 @@ code, pre, .mono {
 .pill {
   display: inline-block;
   padding: 1px 8px;
+  margin-left: 6px;
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
@@ -373,13 +362,16 @@ code, pre, .mono {
 
 .label-chip {
   display: inline-block;
-  padding: 1px 6px;
+  padding: 2px 8px;
   margin-right: 4px;
-  font-size: 0.7rem;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text-dim);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.3);
+  border-radius: 999px;
+  color: var(--accent);
 }
 
 /* Skip-reason chip (issue #445, #721) — surfaces tracker-derived skip class
@@ -457,14 +449,15 @@ code, pre, .mono {
    aesthetic but uses neutral grey to read as informational, not active. */
 .closure-chip {
   display: inline-block;
-  padding: 3px 10px;
+  padding: 1px 8px;
   margin: 4px 4px 4px 0;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  background: rgba(139, 148, 158, 0.18);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--surface);
   border: 1px solid var(--text-dim);
-  border-left-width: 4px;
-  border-radius: 4px;
+  border-radius: 999px;
   color: var(--text-dim);
   max-width: 100%;
   overflow: hidden;
@@ -506,9 +499,9 @@ code, pre, .mono {
 
 .activity-row .a-pipe { color: var(--accent2); }
 .activity-row .a-skill { color: var(--accent); }
-.activity-row .a-status-pass    { color: var(--green); }
-.activity-row .a-status-fail    { color: var(--red); }
-.activity-row .a-status-running { color: var(--orange); }
+.activity-row .a-status-pass    { color: var(--green); border-color: var(--green); }
+.activity-row .a-status-fail    { color: var(--red); border-color: var(--red); }
+.activity-row .a-status-running { color: var(--orange); border-color: var(--orange); }
 .activity-row .a-parent { color: var(--text-dim); font-style: italic; margin-left: 6px; }
 .activity-row .a-subject { color: var(--text); }
 .activity-row .a-time { color: var(--text-dim); }
@@ -765,7 +758,7 @@ code, pre, .mono {
 .clear-stale-btn,
 .add-mini-btn {
   background: var(--surface);
-  color: var(--text);
+  color: var(--text-dim);
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 3px 9px;
@@ -773,6 +766,7 @@ code, pre, .mono {
   cursor: pointer;
   font-family: inherit;
 }
+.copy-btn { margin-left: auto; }
 
 .run-btn:hover,
 .run-btn:focus-visible,
@@ -834,6 +828,7 @@ code, pre, .mono {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
   min-height: 60px;
 }
 
@@ -862,17 +857,37 @@ code, pre, .mono {
    #700 — enlarged from 0.9em/0 0.2em to 1.1em/2px 6px for a bigger hit
    target + visual weight; subtle background on hover so the toggle reads
    as interactive. */
-.column-collapse-toggle {
-  background: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-  font-size: 1.1em;
-  padding: 2px 6px;
+/* SVG icons inside buttons: vertical centering. */
+button svg { display: inline-block; vertical-align: middle; }
+
+/* Shared base for column-header action buttons (move-all + collapse toggle).
+   Ensures consistent height, padding, and border treatment. */
+.column-head-btn {
+  background: var(--surface2);
   color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 3px 7px;
+  cursor: pointer;
+  font-family: inherit;
+  min-width: 28px;
+  min-height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.column-head-btn:hover,
+.column-head-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.12);
+  outline: none;
+}
+
+.column-collapse-toggle {
   margin-left: 0.4em;
-  line-height: 1;
-  border-radius: 4px;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  width: 28px;
 }
 .column-head > .column-collapse-toggle:last-child {
   margin-left: auto;
@@ -880,13 +895,7 @@ code, pre, .mono {
 .column-head .move-all-group + .column-collapse-toggle {
   margin-left: 0.4em;
 }
-.column-collapse-toggle:hover,
-.column-collapse-toggle:focus-visible {
-  color: var(--text);
-  background: rgba(88, 166, 255, 0.1);
-  border-color: var(--border);
-  outline: none;
-}
+/* collapse-toggle hover/focus handled by .column-head-btn base */
 
 /* Collapsed: hide the dropzone list; keep the header visible with count +
    toggle. The column itself stays in the flex/grid flow so its width is
@@ -908,25 +917,30 @@ code, pre, .mono {
    removes it). Shows a compact "Label (N) — title1, title2" line so
    collapsed columns convey content at a glance. */
 .collapsed-summary {
-  padding: 4px 8px;
-  font-size: 0.78rem;
+  padding: 6px 10px;
+  margin-top: 2px;
+  font-size: 0.82rem;
   color: var(--text-dim);
   border-top: 1px solid var(--border);
+  background: rgba(88, 166, 255, 0.03);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
+  border-radius: 0 0 4px 4px;
 }
 .collapsed-summary:hover {
   color: var(--text);
+  background: rgba(88, 166, 255, 0.06);
 }
 .collapsed-summary .collapsed-summary-count {
   font-weight: 600;
   color: var(--text);
 }
 .collapsed-summary .collapsed-summary-titles {
-  margin-left: 0.4em;
+  margin-left: 0.5em;
   font-style: italic;
+  color: var(--text-dim);
 }
 
 .dropzone {
@@ -1105,12 +1119,18 @@ code, pre, .mono {
   background: var(--surface);
   color: var(--text-dim);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 6px;
-  font-size: 0.85rem;
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 0.78rem;
   cursor: pointer;
   font-family: inherit;
   line-height: 1;
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
 .move-btn:hover,
@@ -1135,27 +1155,7 @@ code, pre, .mono {
   margin-left: auto;
 }
 
-.move-all-btn {
-  background: var(--surface2);
-  color: var(--text-dim);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 2px 8px;
-  font-size: 0.95rem;
-  line-height: 1.2;
-  font-weight: 700;
-  cursor: pointer;
-  font-family: inherit;
-  transition: border-color 0.12s, color 0.12s, background 0.12s;
-}
-
-.move-all-btn:hover,
-.move-all-btn:focus-visible {
-  color: var(--text);
-  border-color: var(--accent);
-  background: rgba(88, 166, 255, 0.12);
-  outline: none;
-}
+/* move-all-btn inherits from .column-head-btn; no overrides needed. */
 
 /* Skipped-card shake — fires for cards left behind by a column move-all
    because they're claimed (aria-disabled="true"). Visible jitter (~8px

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -146,7 +146,7 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
     toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
     const lbl = labelText || toggle.dataset.column || "";
     toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + lbl);
-    toggle.textContent = collapsed ? "▸" : "▾";
+    toggle.innerHTML = collapsed ? SVG_ICONS.plus : SVG_ICONS.minus; // chrome-only
   }
   // Issue #700 — collapsed-column preview strip. When collapsed, inject a
   // compact summary showing "Label (N)" plus the first 1-2 card titles so
@@ -178,14 +178,14 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
     text: colLabel + " (" + count + ")",
   });
   summary.appendChild(countSpan);
-  // Append first 1-2 card titles as a teaser.
+  // Append first 3 card titles as a teaser.
   const titles = [];
-  for (let i = 0; i < Math.min(2, cards.length); i++) {
+  for (let i = 0; i < Math.min(3, cards.length); i++) {
     const card = cards[i];
     const titleEl = card.querySelector(".card-title, .card-title-link");
     if (titleEl) {
       let t = titleEl.textContent || "";
-      if (t.length > 40) t = t.slice(0, 37) + "...";
+      if (t.length > 35) t = t.slice(0, 32) + "...";
       titles.push(t);
     }
   }
@@ -214,7 +214,7 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
 // delegated click handler (handleAction) flips state and re-applies.
 function appendCollapseToggle(head, kind, col, labelText) {
   const toggle = el("button", {
-    cls: "column-collapse-toggle",
+    cls: "column-head-btn column-collapse-toggle",
     attrs: {
       type: "button",
       "data-action": "column-collapse-toggle",
@@ -224,7 +224,7 @@ function appendCollapseToggle(head, kind, col, labelText) {
       "aria-label": "Collapse " + labelText,
       title: "Collapse / expand",
     },
-    text: "▾",
+    html: SVG_ICONS.minus,
   });
   head.appendChild(toggle);
   return toggle;
@@ -244,7 +244,8 @@ function el(tag, opts) {
   const node = document.createElement(tag);
   if (!opts) return node;
   if (opts.cls) node.className = opts.cls;
-  if (opts.text != null) node.textContent = String(opts.text);
+  if (opts.html != null) node.innerHTML = opts.html; // chrome-only
+  else if (opts.text != null) node.textContent = String(opts.text);
   if (opts.attrs) {
     for (const k of Object.keys(opts.attrs)) {
       const v = opts.attrs[k];
@@ -253,6 +254,21 @@ function el(tag, opts) {
   }
   return node;
 }
+
+var SVG_ICONS = {
+  chevronLeft: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3L5 8l5 5"/></svg>',
+  chevronRight: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3l5 5-5 5"/></svg>',
+  chevronsLeft: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3L3 8l5 5"/><path d="M13 3L8 8l5 5"/></svg>',
+  chevronsRight: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3l5 5-5 5"/><path d="M8 3l5 5-5 5"/></svg>',
+  arrowUp: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 13V3"/><path d="M3 7l5-5 5 5"/></svg>',
+  arrowDown: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v10"/><path d="M3 9l5 5 5-5"/></svg>',
+  arrowLeft: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 8H3"/><path d="M7 3L2 8l5 5"/></svg>',
+  arrowRight: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h10"/><path d="M9 3l5 5-5 5"/></svg>',
+  x: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 4l8 8"/><path d="M12 4l-8 8"/></svg>',
+  copy: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M2 11V3a1.5 1.5 0 011.5-1.5H11"/></svg>',
+  minus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/></svg>',
+  plus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/><path d="M8 4v8"/></svg>',
+};
 
 // titleNode(text, href) — returns a span containing either plain text
 // (when href is empty) or an <a> with target=_blank. Anchors carry
@@ -799,7 +815,7 @@ function fingerprintIssues(issues, queues) {
     trunc: trunc,
     cw: _gcwI ? _gcwI("issue") : null,
     rows: issues.map(i => [
-      i.number, i.title, (i.labels || []).slice().sort(), i.created_at,
+      i.number, i.title, (i.labels || []).map(function(l) { return (l && l.name) || l; }).sort(), i.created_at,
       pos[i.number] || [(i.queue && i.queue.column) || "triage", -1],
       // Claim state — DA5: without this, the fingerprint is byte-identical
       // between "no claim" and "claim present" snapshots, so applySnapshot
@@ -1003,20 +1019,28 @@ function buildPlanCard(plan, slug, col, defaultMode) {
       attrs: { role: "group", "aria-label": isCompleted ? "Plan actions" : "Move this plan" },
     });
     if (!isCompleted) {
+      var writablePlanCols = ["drafted", "reviewed", "ready", "backlog", "discarded"];
+      var planColIdx = writablePlanCols.indexOf(col);
       controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
       controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
-      controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
-      controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
-      controls.appendChild(el("button", {
-        cls: "remove-btn",
-        attrs: {
-          type: "button",
-          "data-action": "plan-discard",
-          "data-slug": slug,
-          "aria-label": "Discard plan (move to Discarded)",
-        },
-        text: "✕",
-      }));
+      if (planColIdx > 0) {
+        controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
+      }
+      if (planColIdx >= 0 && planColIdx < writablePlanCols.length - 1) {
+        controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
+      }
+      if (col !== "discarded") {
+        controls.appendChild(el("button", {
+          cls: "remove-btn",
+          attrs: {
+            type: "button",
+            "data-action": "plan-discard",
+            "data-slug": slug,
+            "aria-label": "Discard plan (move to Discarded)",
+          },
+          html: SVG_ICONS.x,
+        }));
+      }
     }
     controls.appendChild(makeCopyBtn((plan && plan.title) || slug));
     card.appendChild(controls);
@@ -1025,7 +1049,10 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   return card;
 }
 
+var MOVE_ICON_MAP = {"↑": "arrowUp", "↓": "arrowDown", "←": "arrowLeft", "→": "arrowRight"};
+
 function makeMoveBtn(action, slug, label, ariaLabel) {
+  var icon = MOVE_ICON_MAP[label] ? SVG_ICONS[MOVE_ICON_MAP[label]] : label;
   return el("button", {
     cls: "move-btn",
     attrs: {
@@ -1034,11 +1061,12 @@ function makeMoveBtn(action, slug, label, ariaLabel) {
       "data-slug": slug,
       "aria-label": ariaLabel,
     },
-    text: label,
+    html: icon,
   });
 }
 
 function makeIssueMoveBtn(action, num, label, ariaLabel) {
+  var icon = MOVE_ICON_MAP[label] ? SVG_ICONS[MOVE_ICON_MAP[label]] : label;
   return el("button", {
     cls: "move-btn",
     attrs: {
@@ -1047,7 +1075,7 @@ function makeIssueMoveBtn(action, num, label, ariaLabel) {
       "data-number": String(num),
       "aria-label": ariaLabel,
     },
-    text: label,
+    html: icon,
   });
 }
 
@@ -1062,14 +1090,14 @@ function makeCopyBtn(titleText) {
       "data-action": "copy-title",
       "aria-label": "Copy title to clipboard",
     },
-    text: "📋",
+    html: SVG_ICONS.copy,
   });
   btn.addEventListener("click", function(e) {
     e.stopPropagation();
     e.preventDefault();
     navigator.clipboard.writeText(titleText).then(function() {
       btn.textContent = "✓";
-      setTimeout(function() { btn.textContent = "📋"; }, 1500);
+      setTimeout(function() { btn.innerHTML = SVG_ICONS.copy; }, 1500); // chrome-only
     });
   });
   return btn;
@@ -1083,8 +1111,9 @@ function makeCopyBtn(titleText) {
 // race window where a poll-driven claim lands between the click and the
 // per-card dispatch.
 function makeColumnMoveAllBtn(action, kind, column, label, ariaLabel) {
+  var icon = label === "«" ? SVG_ICONS.chevronsLeft : SVG_ICONS.chevronsRight;
   return el("button", {
-    cls: "move-all-btn",
+    cls: "column-head-btn move-all-btn",
     attrs: {
       type: "button",
       tabindex: "0",
@@ -1093,7 +1122,7 @@ function makeColumnMoveAllBtn(action, kind, column, label, ariaLabel) {
       "data-column": column,
       "aria-label": ariaLabel,
     },
-    text: label,
+    html: icon,
   });
 }
 
@@ -1250,9 +1279,8 @@ function renderBranches(branches, worktrees) {
   const backed = backedBranchSet(worktrees);
   const byBranch = worktreesByBranch(worktrees);
   for (const b of branches) {
-    const dim = backed.has(b.name);
     const card = el("article", {
-      cls: dim ? "card dim" : "card",
+      cls: "card",
       attrs: {
         tabindex: "0",
         role: "button",
@@ -1405,7 +1433,15 @@ function buildIssueCard(issue, num, col) {
   if (issue && (issue.labels || []).length) {
     const labels = el("div", { cls: "card-sub" });
     for (const lab of issue.labels) {
-      labels.appendChild(el("span", { cls: "label-chip", text: lab }));
+      const name = (lab && lab.name) || lab || "";
+      const color = (lab && lab.color) || "";
+      const chip = el("span", { cls: "label-chip", text: name });
+      if (color) {
+        chip.style.color = "#" + color;
+        chip.style.borderColor = "#" + color;
+        chip.style.background = "#" + color + "18";
+      }
+      labels.appendChild(chip);
     }
     card.appendChild(labels);
   }
@@ -1420,18 +1456,14 @@ function buildIssueCard(issue, num, col) {
     if (!isCompleted) {
       controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
       controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
-      controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
-      controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
-      controls.appendChild(el("button", {
-        cls: "remove-btn",
-        attrs: {
-          type: "button",
-          "data-action": "issue-remove",
-          "data-number": String(num),
-          "aria-label": "Remove issue from queue",
-        },
-        text: "✕",
-      }));
+      var writableIssueCols = ["triage", "ready", "backlog"];
+      var colIdx = writableIssueCols.indexOf(col);
+      if (colIdx > 0) {
+        controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
+      }
+      if (colIdx >= 0 && colIdx < writableIssueCols.length - 1) {
+        controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
+      }
     }
     const issueTitle = issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num);
     controls.appendChild(makeCopyBtn(issueTitle));
@@ -1545,9 +1577,8 @@ function renderIssues(issues, queues) {
 // it is expanded first. The strip uses `data-action="section-nav-pill"` so
 // the shared delegated click handler in handleAction dispatches it.
 //
-// Sections:
-//   Plans:  Active (drafted+reviewed+ready), Backlog, Discarded, Completed
-//   Issues: Active (triage+ready), Backlog, Completed
+// Sections: one pill per column (Drafted, Reviewed, Ready, ... for plans;
+// Triage, Ready, Backlog, Completed for issues). Discarded skipped for issues.
 function buildSectionNavStrip(kind, queues) {
   const strip = el("nav", {
     cls: "section-nav-strip",
@@ -1559,22 +1590,14 @@ function buildSectionNavStrip(kind, queues) {
   const activeCols = (kind === "plan") ? ACTIVE_PLAN_COLUMNS : ACTIVE_ISSUE_COLUMNS;
   const labels = (kind === "plan") ? PLAN_COLUMN_LABELS : ISSUE_COLUMN_LABELS;
 
-  // Active section — aggregate count across the active columns.
-  let activeCount = 0;
-  for (const c of activeCols) {
-    activeCount += (queueDict[c] || []).length;
-  }
-  // The first active column's head id is the scroll target for the active
-  // section pill (top of the column grid).
-  const activeTarget = (kind === "plan" ? "plans" : "issues") + "-col-" + activeCols[0];
-  strip.appendChild(buildNavPill("Active", activeCount, activeTarget, kind, null));
-
-  // Below-band sections — one pill per BELOW_BAND_COLUMNS entry,
-  // skipping discarded for the issues panel (mirrors renderBelowPanelBand).
-  for (const c of BELOW_BAND_COLUMNS) {
+  // One pill per column — active columns first, then below-band.
+  var allCols = (kind === "plan") ? PLAN_COLUMNS : ISSUE_COLUMNS;
+  var prefix = (kind === "plan") ? "plans" : "issues";
+  for (var ci = 0; ci < allCols.length; ci++) {
+    var c = allCols[ci];
     if (c === "discarded" && kind !== "plan") continue;
-    const count = (queueDict[c] || []).length;
-    const headId = (kind === "plan" ? "plans" : "issues") + "-col-" + c;
+    var count = (queueDict[c] || []).length;
+    var headId = prefix + "-col-" + c;
     strip.appendChild(buildNavPill(labels[c], count, headId, kind, c));
   }
   return strip;
@@ -1936,8 +1959,8 @@ function renderRunStatus(ws) {
     root.appendChild(el("code", { cls: "run-cmd-snippet", text: cmd }));
     const copyBtn = el("button", {
       cls: "copy-btn",
-      attrs: { type: "button", "data-action": "copy-cmd", "data-cmd": cmd },
-      text: "Copy",
+      attrs: { type: "button", "data-action": "copy-cmd", "data-cmd": cmd, "aria-label": "Copy command" },
+      html: SVG_ICONS.copy,
     });
     root.appendChild(copyBtn);
   }
@@ -2125,21 +2148,22 @@ async function movePlan(slug, dCol, dIdxAdjust) {
   } else if (dCol === "down") {
     targetIdx = Math.min(next.plans[loc.col].length, loc.idx + 1);
   } else if (dCol === "left") {
-    const ci = PLAN_COLUMNS.indexOf(loc.col);
+    var writablePlanCols = ["drafted", "reviewed", "ready", "backlog", "discarded"];
+    const ci = writablePlanCols.indexOf(loc.col);
     if (ci <= 0) {
-      // Restore — no-op.
       next.plans[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = PLAN_COLUMNS[ci - 1];
+    targetCol = writablePlanCols[ci - 1];
     targetIdx = next.plans[targetCol].length;
   } else if (dCol === "right") {
-    const ci = PLAN_COLUMNS.indexOf(loc.col);
-    if (ci >= PLAN_COLUMNS.length - 1) {
+    var writablePlanCols2 = ["drafted", "reviewed", "ready", "backlog", "discarded"];
+    const ci = writablePlanCols2.indexOf(loc.col);
+    if (ci < 0 || ci >= writablePlanCols2.length - 1) {
       next.plans[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = PLAN_COLUMNS[ci + 1];
+    targetCol = writablePlanCols2[ci + 1];
     targetIdx = next.plans[targetCol].length;
   } else if (typeof dCol === "object" && dCol && dCol.col) {
     targetCol = dCol.col;
@@ -2183,20 +2207,22 @@ async function moveIssue(num, dCol) {
   } else if (dCol === "down") {
     targetIdx = Math.min(next.issues[loc.col].length, loc.idx + 1);
   } else if (dCol === "left") {
-    const ci = ISSUE_COLUMNS.indexOf(loc.col);
+    var writableIssueCols = ["triage", "ready", "backlog"];
+    const ci = writableIssueCols.indexOf(loc.col);
     if (ci <= 0) {
       next.issues[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = ISSUE_COLUMNS[ci - 1];
+    targetCol = writableIssueCols[ci - 1];
     targetIdx = next.issues[targetCol].length;
   } else if (dCol === "right") {
-    const ci = ISSUE_COLUMNS.indexOf(loc.col);
-    if (ci >= ISSUE_COLUMNS.length - 1) {
+    var writableIssueCols2 = ["triage", "ready", "backlog"];
+    const ci = writableIssueCols2.indexOf(loc.col);
+    if (ci < 0 || ci >= writableIssueCols2.length - 1) {
       next.issues[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = ISSUE_COLUMNS[ci + 1];
+    targetCol = writableIssueCols2[ci + 1];
     targetIdx = next.issues[targetCol].length;
   } else if (typeof dCol === "object" && dCol && dCol.col) {
     targetCol = dCol.col;
@@ -2643,8 +2669,17 @@ function renderIssueModal(issue) {
   if ((issue.labels || []).length) {
     const labels = el("div");
     for (const lab of issue.labels) {
-      const name = (lab && lab.name) || lab;
-      if (name) labels.appendChild(el("span", { cls: "label-chip", text: name }));
+      const name = (lab && lab.name) || lab || "";
+      const color = (lab && lab.color) || "";
+      if (name) {
+        const chip = el("span", { cls: "label-chip", text: name });
+        if (color) {
+          chip.style.color = "#" + color;
+          chip.style.borderColor = "#" + color;
+          chip.style.background = "#" + color + "18";
+        }
+        labels.appendChild(chip);
+      }
     }
     modal.body.appendChild(labels);
   }
@@ -3009,6 +3044,18 @@ function boot() {
   setActiveTab(readTabFromHash(), { pushHash: false });  // NEW
   schedulePoll(0);
   scheduleWorkPoll(0);
+
+  // Persist activity-strip resize height across reloads.
+  var actStrip = document.getElementById("activity-strip");
+  if (actStrip) {
+    var savedH = localStorage.getItem("zskills:dashboard:activity-height");
+    if (savedH) actStrip.style.height = savedH;
+    if (typeof ResizeObserver !== "undefined") {
+      new ResizeObserver(function() {
+        localStorage.setItem("zskills:dashboard:activity-height", actStrip.style.height || (actStrip.offsetHeight + "px"));
+      }).observe(actStrip);
+    }
+  }
 }
 
 if (document.readyState === "loading") {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -10,7 +10,7 @@
 <body>
   <header class="topbar">
     <h1>Z Skills Dashboard</h1>
-    <span class="under-construction" title="Z Skills Dashboard is an early build — features are in flux">🚧 Under Construction</span>
+
     <div class="topbar-meta">
       <span id="updated-at" class="muted" aria-live="polite"></span>
     </div>

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>UI Sampler</title>
+  <link rel="stylesheet" href="/app.css"/>
+  <style>
+    body { padding: 24px; }
+    .sample-section { margin: 24px 0; padding: 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; }
+    .sample-section h2 { margin: 0 0 12px; font-size: 1rem; color: var(--accent); }
+    .sample-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin: 8px 0; }
+    .sample-label { color: var(--text-dim); font-size: 0.8rem; min-width: 120px; }
+  </style>
+</head>
+<body>
+  <h1 style="color:var(--accent)">UI Component Sampler</h1>
+
+  <div class="sample-section">
+    <h2>Pills — Status</h2>
+    <div class="sample-row">
+      <span class="pill pill-status-active">ACTIVE</span>
+      <span class="pill pill-status-done">DONE</span>
+      <span class="pill pill-status-blocked">BLOCKED</span>
+      <span class="pill pill-status-paused">PAUSED</span>
+      <span class="pill">UNKNOWN</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Plan mode</h2>
+    <div class="sample-row">
+      <span class="pill pill-mode-pr">PR</span>
+      <span class="pill pill-mode-direct">DIRECT</span>
+      <span class="pill pill-mode-unknown">UNKNOWN</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Landed (branches tab)</h2>
+    <div class="sample-row">
+      <span class="pill pill-landed-full">LANDED</span>
+      <span class="pill pill-landed-partial">PARTIAL</span>
+      <span class="pill pill-landed-pr-ready">PR-READY</span>
+      <span class="pill pill-landed-pr-needs-attention">NEEDS ATTENTION</span>
+      <span class="pill pill-landed-failed">FAILED</span>
+      <span class="pill pill-landed-not">NOT LANDED</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Activity status (recent activity)</h2>
+    <div class="sample-row activity-row">
+      <span class="pill a-status-pass">COMPLETE</span>
+      <span class="pill a-status-fail">FAILED</span>
+      <span class="pill a-status-running">RUNNING</span>
+      <span class="pill">UNKNOWN</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Closure reason</h2>
+    <div class="sample-row">
+      <span class="closure-chip">NOT PLANNED</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — GitHub labels (real colors)</h2>
+    <div class="sample-row">
+      <span class="label-chip" style="color:#d73a4a;border-color:#d73a4a;background:#d73a4a18">BUG</span>
+      <span class="label-chip" style="color:#a2eeef;border-color:#a2eeef;background:#a2eeef18">ENHANCEMENT</span>
+      <span class="label-chip" style="color:#0075ca;border-color:#0075ca;background:#0075ca18">DOCUMENTATION</span>
+      <span class="label-chip" style="color:#7057ff;border-color:#7057ff;background:#7057ff18">GOOD FIRST ISSUE</span>
+      <span class="label-chip" style="color:#008672;border-color:#008672;background:#00867218">HELP WANTED</span>
+      <span class="label-chip" style="color:#d876e3;border-color:#d876e3;background:#d876e318">QUESTION</span>
+      <span class="label-chip" style="color:#cfd3d7;border-color:#cfd3d7;background:#cfd3d718">DUPLICATE</span>
+      <span class="label-chip" style="color:#e4e669;border-color:#e4e669;background:#e4e66918">INVALID</span>
+      <span class="label-chip" style="color:#ffffff;border-color:#ffffff;background:#ffffff18">WONTFIX</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Plan card mode</h2>
+    <div class="sample-row">
+      <span class="mode-chip">PHASE</span>
+      <span class="mode-chip">FINISH</span>
+      <span class="mode-chip" data-source="inherit">PHASE (inherited)</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Chips — Skip reason (long-form annotations)</h2>
+    <div class="sample-row">
+      <span class="skip-chip">needs-decision — leave open as architectural memo</span>
+      <span class="skip-chip skip-chip--plan-scale">plan-scale — full skill interface redesign</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Chips — Claim (long-form annotations)</h2>
+    <div class="sample-row">
+      <span class="claim-chip claim-chip--in-flight">in-flight &middot; abc123 &middot; 5m ago</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Column-header buttons</h2>
+    <div class="sample-row" id="col-btns"></div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Card action buttons</h2>
+    <div class="sample-row" id="card-btns"></div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Nav pills (section strip)</h2>
+    <div class="sample-row">
+      <button class="section-nav-pill">Triage 5</button>
+      <button class="section-nav-pill">Ready 12</button>
+      <button class="section-nav-pill">Backlog 3</button>
+      <button class="section-nav-pill">Discarded 0</button>
+      <button class="section-nav-pill">Completed 7</button>
+    </div>
+  </div>
+
+  <script src="/app.js"></script>
+  <script>
+    var colRow = document.getElementById("col-btns");
+    ["chevronsLeft", "chevronsRight", "minus", "plus"].forEach(function(k) {
+      var b = document.createElement("button");
+      b.className = "column-head-btn " + (k === "minus" || k === "plus" ? "column-collapse-toggle" : "move-all-btn");
+      b.innerHTML = SVG_ICONS[k];
+      colRow.appendChild(b);
+    });
+
+    var cardRow = document.getElementById("card-btns");
+    ["arrowUp","arrowDown","arrowLeft","arrowRight"].forEach(function(k) {
+      var b = document.createElement("button");
+      b.className = "move-btn";
+      b.innerHTML = SVG_ICONS[k];
+      cardRow.appendChild(b);
+    });
+    var xBtn = document.createElement("button");
+    xBtn.className = "move-btn";
+    xBtn.innerHTML = SVG_ICONS.x;
+    cardRow.appendChild(xBtn);
+    var cpBtn = document.createElement("button");
+    cpBtn.className = "move-btn copy-btn";
+    cpBtn.innerHTML = SVG_ICONS.copy;
+    cardRow.appendChild(cpBtn);
+  </script>
+</body>
+</html>

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+d10554"
+  version: "2026.05.27+104fdd"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+b2ea1c"
+  version: "2026.05.27+d10554"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1227,14 +1227,14 @@ def list_issues(
             if not isinstance(entry, dict):
                 continue
             labels_raw = entry.get("labels") or []
-            labels: List[str] = []
+            labels: list = []
             for lab in labels_raw:
                 if isinstance(lab, dict):
                     name = lab.get("name")
                     if name:
-                        labels.append(str(name))
+                        labels.append({"name": str(name), "color": lab.get("color", "")})
                 elif isinstance(lab, str):
-                    labels.append(lab)
+                    labels.append({"name": lab, "color": ""})
             issues.append({
                 "number": entry.get("number"),
                 "title": entry.get("title", ""),
@@ -1348,14 +1348,14 @@ def list_closed_issues_in_window(
             if not isinstance(entry, dict):
                 continue
             labels_raw = entry.get("labels") or []
-            labels: List[str] = []
+            labels: list = []
             for lab in labels_raw:
                 if isinstance(lab, dict):
                     name = lab.get("name")
                     if name:
-                        labels.append(str(name))
+                        labels.append({"name": str(name), "color": lab.get("color", "")})
                 elif isinstance(lab, str):
-                    labels.append(lab)
+                    labels.append({"name": lab, "color": ""})
             issues.append({
                 "number": entry.get("number"),
                 "title": entry.get("title", ""),
@@ -1717,14 +1717,15 @@ def _annotate_issues_queue(
             # allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto resolved issues_dir (parallels the fix-issues/SKILL.md exemption at line 1050); the literal tail is the canonical tracker filename
             _resolve_paths(main_root)["issues_dir"] / "ISSUES_PLAN.md"
         )
-        ready_nums: List[int] = []
-        for num in state_issues.get("ready", []) or []:
-            try:
-                ready_nums.append(int(num))
-            except Exception:
-                continue
-        if ready_nums:
-            skip_index = _build_skip_reason_index(issues_plan_path, ready_nums)
+        all_nums: List[int] = []
+        for col_entries in state_issues.values():
+            for num in (col_entries or []):
+                try:
+                    all_nums.append(int(num))
+                except Exception:
+                    continue
+        if all_nums:
+            skip_index = _build_skip_reason_index(issues_plan_path, all_nums)
         claim_index = _read_claims(main_root)
 
     if now_utc is None:
@@ -1758,7 +1759,7 @@ def _annotate_issues_queue(
         if isinstance(num, int) and num in pos:
             col, i = pos[num]
             issue["queue"] = {"column": col, "index": i}
-            if col == "ready" and num in skip_index:
+            if num in skip_index:
                 reason = skip_index[num]
                 if reason is not None:
                     issue["skip_reason"] = reason

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -714,6 +714,9 @@ class MonitorHandler(BaseHTTPRequestHandler):
         if decoded_path == "/favicon.svg":
             self._serve_static_file("favicon.svg", "image/svg+xml")
             return
+        if decoded_path == "/sampler.html":
+            self._serve_static_file("sampler.html", "text/html")
+            return
         if decoded_path == "/favicon.ico":
             # Many browsers request /favicon.ico by default. We serve the
             # SVG with the SVG MIME type — modern browsers (Firefox,

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -64,19 +64,7 @@ code, pre, .mono {
   font-weight: 600;
 }
 
-.under-construction {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 12px;
-  margin-right: auto;
-  padding: 4px 10px;
-  font-size: 0.8rem;
-  color: var(--accent2);
-  border: 1px solid var(--accent2);
-  border-radius: 999px;
-  white-space: nowrap;
-  cursor: help;
-}
+/* Under Construction marker removed — dashboard is production-ready. */
 
 .topbar-meta {
   font-size: 0.85rem;
@@ -345,6 +333,7 @@ code, pre, .mono {
 .pill {
   display: inline-block;
   padding: 1px 8px;
+  margin-left: 6px;
   border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 600;
@@ -373,13 +362,16 @@ code, pre, .mono {
 
 .label-chip {
   display: inline-block;
-  padding: 1px 6px;
+  padding: 2px 8px;
   margin-right: 4px;
-  font-size: 0.7rem;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text-dim);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.3);
+  border-radius: 999px;
+  color: var(--accent);
 }
 
 /* Skip-reason chip (issue #445, #721) — surfaces tracker-derived skip class
@@ -457,14 +449,15 @@ code, pre, .mono {
    aesthetic but uses neutral grey to read as informational, not active. */
 .closure-chip {
   display: inline-block;
-  padding: 3px 10px;
+  padding: 1px 8px;
   margin: 4px 4px 4px 0;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  background: rgba(139, 148, 158, 0.18);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--surface);
   border: 1px solid var(--text-dim);
-  border-left-width: 4px;
-  border-radius: 4px;
+  border-radius: 999px;
   color: var(--text-dim);
   max-width: 100%;
   overflow: hidden;
@@ -506,9 +499,9 @@ code, pre, .mono {
 
 .activity-row .a-pipe { color: var(--accent2); }
 .activity-row .a-skill { color: var(--accent); }
-.activity-row .a-status-pass    { color: var(--green); }
-.activity-row .a-status-fail    { color: var(--red); }
-.activity-row .a-status-running { color: var(--orange); }
+.activity-row .a-status-pass    { color: var(--green); border-color: var(--green); }
+.activity-row .a-status-fail    { color: var(--red); border-color: var(--red); }
+.activity-row .a-status-running { color: var(--orange); border-color: var(--orange); }
 .activity-row .a-parent { color: var(--text-dim); font-style: italic; margin-left: 6px; }
 .activity-row .a-subject { color: var(--text); }
 .activity-row .a-time { color: var(--text-dim); }
@@ -765,7 +758,7 @@ code, pre, .mono {
 .clear-stale-btn,
 .add-mini-btn {
   background: var(--surface);
-  color: var(--text);
+  color: var(--text-dim);
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 3px 9px;
@@ -773,6 +766,7 @@ code, pre, .mono {
   cursor: pointer;
   font-family: inherit;
 }
+.copy-btn { margin-left: auto; }
 
 .run-btn:hover,
 .run-btn:focus-visible,
@@ -834,6 +828,7 @@ code, pre, .mono {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
   min-height: 60px;
 }
 
@@ -862,17 +857,37 @@ code, pre, .mono {
    #700 — enlarged from 0.9em/0 0.2em to 1.1em/2px 6px for a bigger hit
    target + visual weight; subtle background on hover so the toggle reads
    as interactive. */
-.column-collapse-toggle {
-  background: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-  font-size: 1.1em;
-  padding: 2px 6px;
+/* SVG icons inside buttons: vertical centering. */
+button svg { display: inline-block; vertical-align: middle; }
+
+/* Shared base for column-header action buttons (move-all + collapse toggle).
+   Ensures consistent height, padding, and border treatment. */
+.column-head-btn {
+  background: var(--surface2);
   color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 3px 7px;
+  cursor: pointer;
+  font-family: inherit;
+  min-width: 28px;
+  min-height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.column-head-btn:hover,
+.column-head-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.12);
+  outline: none;
+}
+
+.column-collapse-toggle {
   margin-left: 0.4em;
-  line-height: 1;
-  border-radius: 4px;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
+  width: 28px;
 }
 .column-head > .column-collapse-toggle:last-child {
   margin-left: auto;
@@ -880,13 +895,7 @@ code, pre, .mono {
 .column-head .move-all-group + .column-collapse-toggle {
   margin-left: 0.4em;
 }
-.column-collapse-toggle:hover,
-.column-collapse-toggle:focus-visible {
-  color: var(--text);
-  background: rgba(88, 166, 255, 0.1);
-  border-color: var(--border);
-  outline: none;
-}
+/* collapse-toggle hover/focus handled by .column-head-btn base */
 
 /* Collapsed: hide the dropzone list; keep the header visible with count +
    toggle. The column itself stays in the flex/grid flow so its width is
@@ -908,25 +917,30 @@ code, pre, .mono {
    removes it). Shows a compact "Label (N) — title1, title2" line so
    collapsed columns convey content at a glance. */
 .collapsed-summary {
-  padding: 4px 8px;
-  font-size: 0.78rem;
+  padding: 6px 10px;
+  margin-top: 2px;
+  font-size: 0.82rem;
   color: var(--text-dim);
   border-top: 1px solid var(--border);
+  background: rgba(88, 166, 255, 0.03);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
+  border-radius: 0 0 4px 4px;
 }
 .collapsed-summary:hover {
   color: var(--text);
+  background: rgba(88, 166, 255, 0.06);
 }
 .collapsed-summary .collapsed-summary-count {
   font-weight: 600;
   color: var(--text);
 }
 .collapsed-summary .collapsed-summary-titles {
-  margin-left: 0.4em;
+  margin-left: 0.5em;
   font-style: italic;
+  color: var(--text-dim);
 }
 
 .dropzone {
@@ -1105,12 +1119,18 @@ code, pre, .mono {
   background: var(--surface);
   color: var(--text-dim);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 6px;
-  font-size: 0.85rem;
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 0.78rem;
   cursor: pointer;
   font-family: inherit;
   line-height: 1;
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
 .move-btn:hover,
@@ -1135,27 +1155,7 @@ code, pre, .mono {
   margin-left: auto;
 }
 
-.move-all-btn {
-  background: var(--surface2);
-  color: var(--text-dim);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 2px 8px;
-  font-size: 0.95rem;
-  line-height: 1.2;
-  font-weight: 700;
-  cursor: pointer;
-  font-family: inherit;
-  transition: border-color 0.12s, color 0.12s, background 0.12s;
-}
-
-.move-all-btn:hover,
-.move-all-btn:focus-visible {
-  color: var(--text);
-  border-color: var(--accent);
-  background: rgba(88, 166, 255, 0.12);
-  outline: none;
-}
+/* move-all-btn inherits from .column-head-btn; no overrides needed. */
 
 /* Skipped-card shake — fires for cards left behind by a column move-all
    because they're claimed (aria-disabled="true"). Visible jitter (~8px

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -146,7 +146,7 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
     toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
     const lbl = labelText || toggle.dataset.column || "";
     toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + lbl);
-    toggle.textContent = collapsed ? "▸" : "▾";
+    toggle.innerHTML = collapsed ? SVG_ICONS.plus : SVG_ICONS.minus; // chrome-only
   }
   // Issue #700 — collapsed-column preview strip. When collapsed, inject a
   // compact summary showing "Label (N)" plus the first 1-2 card titles so
@@ -178,14 +178,14 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
     text: colLabel + " (" + count + ")",
   });
   summary.appendChild(countSpan);
-  // Append first 1-2 card titles as a teaser.
+  // Append first 3 card titles as a teaser.
   const titles = [];
-  for (let i = 0; i < Math.min(2, cards.length); i++) {
+  for (let i = 0; i < Math.min(3, cards.length); i++) {
     const card = cards[i];
     const titleEl = card.querySelector(".card-title, .card-title-link");
     if (titleEl) {
       let t = titleEl.textContent || "";
-      if (t.length > 40) t = t.slice(0, 37) + "...";
+      if (t.length > 35) t = t.slice(0, 32) + "...";
       titles.push(t);
     }
   }
@@ -214,7 +214,7 @@ function applyCollapseStateToColumn(colDiv, kind, col, labelText) {
 // delegated click handler (handleAction) flips state and re-applies.
 function appendCollapseToggle(head, kind, col, labelText) {
   const toggle = el("button", {
-    cls: "column-collapse-toggle",
+    cls: "column-head-btn column-collapse-toggle",
     attrs: {
       type: "button",
       "data-action": "column-collapse-toggle",
@@ -224,7 +224,7 @@ function appendCollapseToggle(head, kind, col, labelText) {
       "aria-label": "Collapse " + labelText,
       title: "Collapse / expand",
     },
-    text: "▾",
+    html: SVG_ICONS.minus,
   });
   head.appendChild(toggle);
   return toggle;
@@ -244,7 +244,8 @@ function el(tag, opts) {
   const node = document.createElement(tag);
   if (!opts) return node;
   if (opts.cls) node.className = opts.cls;
-  if (opts.text != null) node.textContent = String(opts.text);
+  if (opts.html != null) node.innerHTML = opts.html; // chrome-only
+  else if (opts.text != null) node.textContent = String(opts.text);
   if (opts.attrs) {
     for (const k of Object.keys(opts.attrs)) {
       const v = opts.attrs[k];
@@ -253,6 +254,21 @@ function el(tag, opts) {
   }
   return node;
 }
+
+var SVG_ICONS = {
+  chevronLeft: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3L5 8l5 5"/></svg>',
+  chevronRight: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3l5 5-5 5"/></svg>',
+  chevronsLeft: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3L3 8l5 5"/><path d="M13 3L8 8l5 5"/></svg>',
+  chevronsRight: '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3l5 5-5 5"/><path d="M8 3l5 5-5 5"/></svg>',
+  arrowUp: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 13V3"/><path d="M3 7l5-5 5 5"/></svg>',
+  arrowDown: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v10"/><path d="M3 9l5 5 5-5"/></svg>',
+  arrowLeft: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 8H3"/><path d="M7 3L2 8l5 5"/></svg>',
+  arrowRight: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h10"/><path d="M9 3l5 5-5 5"/></svg>',
+  x: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 4l8 8"/><path d="M12 4l-8 8"/></svg>',
+  copy: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M2 11V3a1.5 1.5 0 011.5-1.5H11"/></svg>',
+  minus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/></svg>',
+  plus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/><path d="M8 4v8"/></svg>',
+};
 
 // titleNode(text, href) — returns a span containing either plain text
 // (when href is empty) or an <a> with target=_blank. Anchors carry
@@ -799,7 +815,7 @@ function fingerprintIssues(issues, queues) {
     trunc: trunc,
     cw: _gcwI ? _gcwI("issue") : null,
     rows: issues.map(i => [
-      i.number, i.title, (i.labels || []).slice().sort(), i.created_at,
+      i.number, i.title, (i.labels || []).map(function(l) { return (l && l.name) || l; }).sort(), i.created_at,
       pos[i.number] || [(i.queue && i.queue.column) || "triage", -1],
       // Claim state — DA5: without this, the fingerprint is byte-identical
       // between "no claim" and "claim present" snapshots, so applySnapshot
@@ -1003,20 +1019,28 @@ function buildPlanCard(plan, slug, col, defaultMode) {
       attrs: { role: "group", "aria-label": isCompleted ? "Plan actions" : "Move this plan" },
     });
     if (!isCompleted) {
+      var writablePlanCols = ["drafted", "reviewed", "ready", "backlog", "discarded"];
+      var planColIdx = writablePlanCols.indexOf(col);
       controls.appendChild(makeMoveBtn("plan-up", slug, "↑", "Move up"));
       controls.appendChild(makeMoveBtn("plan-down", slug, "↓", "Move down"));
-      controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
-      controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
-      controls.appendChild(el("button", {
-        cls: "remove-btn",
-        attrs: {
-          type: "button",
-          "data-action": "plan-discard",
-          "data-slug": slug,
-          "aria-label": "Discard plan (move to Discarded)",
-        },
-        text: "✕",
-      }));
+      if (planColIdx > 0) {
+        controls.appendChild(makeMoveBtn("plan-left", slug, "←", "Move to previous column"));
+      }
+      if (planColIdx >= 0 && planColIdx < writablePlanCols.length - 1) {
+        controls.appendChild(makeMoveBtn("plan-right", slug, "→", "Move to next column"));
+      }
+      if (col !== "discarded") {
+        controls.appendChild(el("button", {
+          cls: "remove-btn",
+          attrs: {
+            type: "button",
+            "data-action": "plan-discard",
+            "data-slug": slug,
+            "aria-label": "Discard plan (move to Discarded)",
+          },
+          html: SVG_ICONS.x,
+        }));
+      }
     }
     controls.appendChild(makeCopyBtn((plan && plan.title) || slug));
     card.appendChild(controls);
@@ -1025,7 +1049,10 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   return card;
 }
 
+var MOVE_ICON_MAP = {"↑": "arrowUp", "↓": "arrowDown", "←": "arrowLeft", "→": "arrowRight"};
+
 function makeMoveBtn(action, slug, label, ariaLabel) {
+  var icon = MOVE_ICON_MAP[label] ? SVG_ICONS[MOVE_ICON_MAP[label]] : label;
   return el("button", {
     cls: "move-btn",
     attrs: {
@@ -1034,11 +1061,12 @@ function makeMoveBtn(action, slug, label, ariaLabel) {
       "data-slug": slug,
       "aria-label": ariaLabel,
     },
-    text: label,
+    html: icon,
   });
 }
 
 function makeIssueMoveBtn(action, num, label, ariaLabel) {
+  var icon = MOVE_ICON_MAP[label] ? SVG_ICONS[MOVE_ICON_MAP[label]] : label;
   return el("button", {
     cls: "move-btn",
     attrs: {
@@ -1047,7 +1075,7 @@ function makeIssueMoveBtn(action, num, label, ariaLabel) {
       "data-number": String(num),
       "aria-label": ariaLabel,
     },
-    text: label,
+    html: icon,
   });
 }
 
@@ -1062,14 +1090,14 @@ function makeCopyBtn(titleText) {
       "data-action": "copy-title",
       "aria-label": "Copy title to clipboard",
     },
-    text: "📋",
+    html: SVG_ICONS.copy,
   });
   btn.addEventListener("click", function(e) {
     e.stopPropagation();
     e.preventDefault();
     navigator.clipboard.writeText(titleText).then(function() {
       btn.textContent = "✓";
-      setTimeout(function() { btn.textContent = "📋"; }, 1500);
+      setTimeout(function() { btn.innerHTML = SVG_ICONS.copy; }, 1500); // chrome-only
     });
   });
   return btn;
@@ -1083,8 +1111,9 @@ function makeCopyBtn(titleText) {
 // race window where a poll-driven claim lands between the click and the
 // per-card dispatch.
 function makeColumnMoveAllBtn(action, kind, column, label, ariaLabel) {
+  var icon = label === "«" ? SVG_ICONS.chevronsLeft : SVG_ICONS.chevronsRight;
   return el("button", {
-    cls: "move-all-btn",
+    cls: "column-head-btn move-all-btn",
     attrs: {
       type: "button",
       tabindex: "0",
@@ -1093,7 +1122,7 @@ function makeColumnMoveAllBtn(action, kind, column, label, ariaLabel) {
       "data-column": column,
       "aria-label": ariaLabel,
     },
-    text: label,
+    html: icon,
   });
 }
 
@@ -1250,9 +1279,8 @@ function renderBranches(branches, worktrees) {
   const backed = backedBranchSet(worktrees);
   const byBranch = worktreesByBranch(worktrees);
   for (const b of branches) {
-    const dim = backed.has(b.name);
     const card = el("article", {
-      cls: dim ? "card dim" : "card",
+      cls: "card",
       attrs: {
         tabindex: "0",
         role: "button",
@@ -1405,7 +1433,15 @@ function buildIssueCard(issue, num, col) {
   if (issue && (issue.labels || []).length) {
     const labels = el("div", { cls: "card-sub" });
     for (const lab of issue.labels) {
-      labels.appendChild(el("span", { cls: "label-chip", text: lab }));
+      const name = (lab && lab.name) || lab || "";
+      const color = (lab && lab.color) || "";
+      const chip = el("span", { cls: "label-chip", text: name });
+      if (color) {
+        chip.style.color = "#" + color;
+        chip.style.borderColor = "#" + color;
+        chip.style.background = "#" + color + "18";
+      }
+      labels.appendChild(chip);
     }
     card.appendChild(labels);
   }
@@ -1420,18 +1456,14 @@ function buildIssueCard(issue, num, col) {
     if (!isCompleted) {
       controls.appendChild(makeIssueMoveBtn("issue-up", num, "↑", "Move up"));
       controls.appendChild(makeIssueMoveBtn("issue-down", num, "↓", "Move down"));
-      controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
-      controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
-      controls.appendChild(el("button", {
-        cls: "remove-btn",
-        attrs: {
-          type: "button",
-          "data-action": "issue-remove",
-          "data-number": String(num),
-          "aria-label": "Remove issue from queue",
-        },
-        text: "✕",
-      }));
+      var writableIssueCols = ["triage", "ready", "backlog"];
+      var colIdx = writableIssueCols.indexOf(col);
+      if (colIdx > 0) {
+        controls.appendChild(makeIssueMoveBtn("issue-left", num, "←", "Move to previous column"));
+      }
+      if (colIdx >= 0 && colIdx < writableIssueCols.length - 1) {
+        controls.appendChild(makeIssueMoveBtn("issue-right", num, "→", "Move to next column"));
+      }
     }
     const issueTitle = issue ? ("#" + num + " " + (issue.title || "")) : ("#" + num);
     controls.appendChild(makeCopyBtn(issueTitle));
@@ -1545,9 +1577,8 @@ function renderIssues(issues, queues) {
 // it is expanded first. The strip uses `data-action="section-nav-pill"` so
 // the shared delegated click handler in handleAction dispatches it.
 //
-// Sections:
-//   Plans:  Active (drafted+reviewed+ready), Backlog, Discarded, Completed
-//   Issues: Active (triage+ready), Backlog, Completed
+// Sections: one pill per column (Drafted, Reviewed, Ready, ... for plans;
+// Triage, Ready, Backlog, Completed for issues). Discarded skipped for issues.
 function buildSectionNavStrip(kind, queues) {
   const strip = el("nav", {
     cls: "section-nav-strip",
@@ -1559,22 +1590,14 @@ function buildSectionNavStrip(kind, queues) {
   const activeCols = (kind === "plan") ? ACTIVE_PLAN_COLUMNS : ACTIVE_ISSUE_COLUMNS;
   const labels = (kind === "plan") ? PLAN_COLUMN_LABELS : ISSUE_COLUMN_LABELS;
 
-  // Active section — aggregate count across the active columns.
-  let activeCount = 0;
-  for (const c of activeCols) {
-    activeCount += (queueDict[c] || []).length;
-  }
-  // The first active column's head id is the scroll target for the active
-  // section pill (top of the column grid).
-  const activeTarget = (kind === "plan" ? "plans" : "issues") + "-col-" + activeCols[0];
-  strip.appendChild(buildNavPill("Active", activeCount, activeTarget, kind, null));
-
-  // Below-band sections — one pill per BELOW_BAND_COLUMNS entry,
-  // skipping discarded for the issues panel (mirrors renderBelowPanelBand).
-  for (const c of BELOW_BAND_COLUMNS) {
+  // One pill per column — active columns first, then below-band.
+  var allCols = (kind === "plan") ? PLAN_COLUMNS : ISSUE_COLUMNS;
+  var prefix = (kind === "plan") ? "plans" : "issues";
+  for (var ci = 0; ci < allCols.length; ci++) {
+    var c = allCols[ci];
     if (c === "discarded" && kind !== "plan") continue;
-    const count = (queueDict[c] || []).length;
-    const headId = (kind === "plan" ? "plans" : "issues") + "-col-" + c;
+    var count = (queueDict[c] || []).length;
+    var headId = prefix + "-col-" + c;
     strip.appendChild(buildNavPill(labels[c], count, headId, kind, c));
   }
   return strip;
@@ -1936,8 +1959,8 @@ function renderRunStatus(ws) {
     root.appendChild(el("code", { cls: "run-cmd-snippet", text: cmd }));
     const copyBtn = el("button", {
       cls: "copy-btn",
-      attrs: { type: "button", "data-action": "copy-cmd", "data-cmd": cmd },
-      text: "Copy",
+      attrs: { type: "button", "data-action": "copy-cmd", "data-cmd": cmd, "aria-label": "Copy command" },
+      html: SVG_ICONS.copy,
     });
     root.appendChild(copyBtn);
   }
@@ -2125,21 +2148,22 @@ async function movePlan(slug, dCol, dIdxAdjust) {
   } else if (dCol === "down") {
     targetIdx = Math.min(next.plans[loc.col].length, loc.idx + 1);
   } else if (dCol === "left") {
-    const ci = PLAN_COLUMNS.indexOf(loc.col);
+    var writablePlanCols = ["drafted", "reviewed", "ready", "backlog", "discarded"];
+    const ci = writablePlanCols.indexOf(loc.col);
     if (ci <= 0) {
-      // Restore — no-op.
       next.plans[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = PLAN_COLUMNS[ci - 1];
+    targetCol = writablePlanCols[ci - 1];
     targetIdx = next.plans[targetCol].length;
   } else if (dCol === "right") {
-    const ci = PLAN_COLUMNS.indexOf(loc.col);
-    if (ci >= PLAN_COLUMNS.length - 1) {
+    var writablePlanCols2 = ["drafted", "reviewed", "ready", "backlog", "discarded"];
+    const ci = writablePlanCols2.indexOf(loc.col);
+    if (ci < 0 || ci >= writablePlanCols2.length - 1) {
       next.plans[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = PLAN_COLUMNS[ci + 1];
+    targetCol = writablePlanCols2[ci + 1];
     targetIdx = next.plans[targetCol].length;
   } else if (typeof dCol === "object" && dCol && dCol.col) {
     targetCol = dCol.col;
@@ -2183,20 +2207,22 @@ async function moveIssue(num, dCol) {
   } else if (dCol === "down") {
     targetIdx = Math.min(next.issues[loc.col].length, loc.idx + 1);
   } else if (dCol === "left") {
-    const ci = ISSUE_COLUMNS.indexOf(loc.col);
+    var writableIssueCols = ["triage", "ready", "backlog"];
+    const ci = writableIssueCols.indexOf(loc.col);
     if (ci <= 0) {
       next.issues[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = ISSUE_COLUMNS[ci - 1];
+    targetCol = writableIssueCols[ci - 1];
     targetIdx = next.issues[targetCol].length;
   } else if (dCol === "right") {
-    const ci = ISSUE_COLUMNS.indexOf(loc.col);
-    if (ci >= ISSUE_COLUMNS.length - 1) {
+    var writableIssueCols2 = ["triage", "ready", "backlog"];
+    const ci = writableIssueCols2.indexOf(loc.col);
+    if (ci < 0 || ci >= writableIssueCols2.length - 1) {
       next.issues[loc.col].splice(loc.idx, 0, entry);
       return;
     }
-    targetCol = ISSUE_COLUMNS[ci + 1];
+    targetCol = writableIssueCols2[ci + 1];
     targetIdx = next.issues[targetCol].length;
   } else if (typeof dCol === "object" && dCol && dCol.col) {
     targetCol = dCol.col;
@@ -2643,8 +2669,17 @@ function renderIssueModal(issue) {
   if ((issue.labels || []).length) {
     const labels = el("div");
     for (const lab of issue.labels) {
-      const name = (lab && lab.name) || lab;
-      if (name) labels.appendChild(el("span", { cls: "label-chip", text: name }));
+      const name = (lab && lab.name) || lab || "";
+      const color = (lab && lab.color) || "";
+      if (name) {
+        const chip = el("span", { cls: "label-chip", text: name });
+        if (color) {
+          chip.style.color = "#" + color;
+          chip.style.borderColor = "#" + color;
+          chip.style.background = "#" + color + "18";
+        }
+        labels.appendChild(chip);
+      }
     }
     modal.body.appendChild(labels);
   }
@@ -3009,6 +3044,18 @@ function boot() {
   setActiveTab(readTabFromHash(), { pushHash: false });  // NEW
   schedulePoll(0);
   scheduleWorkPoll(0);
+
+  // Persist activity-strip resize height across reloads.
+  var actStrip = document.getElementById("activity-strip");
+  if (actStrip) {
+    var savedH = localStorage.getItem("zskills:dashboard:activity-height");
+    if (savedH) actStrip.style.height = savedH;
+    if (typeof ResizeObserver !== "undefined") {
+      new ResizeObserver(function() {
+        localStorage.setItem("zskills:dashboard:activity-height", actStrip.style.height || (actStrip.offsetHeight + "px"));
+      }).observe(actStrip);
+    }
+  }
 }
 
 if (document.readyState === "loading") {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/index.html
@@ -10,7 +10,7 @@
 <body>
   <header class="topbar">
     <h1>Z Skills Dashboard</h1>
-    <span class="under-construction" title="Z Skills Dashboard is an early build — features are in flux">🚧 Under Construction</span>
+
     <div class="topbar-meta">
       <span id="updated-at" class="muted" aria-live="polite"></span>
     </div>

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>UI Sampler</title>
+  <link rel="stylesheet" href="/app.css"/>
+  <style>
+    body { padding: 24px; }
+    .sample-section { margin: 24px 0; padding: 16px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; }
+    .sample-section h2 { margin: 0 0 12px; font-size: 1rem; color: var(--accent); }
+    .sample-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin: 8px 0; }
+    .sample-label { color: var(--text-dim); font-size: 0.8rem; min-width: 120px; }
+  </style>
+</head>
+<body>
+  <h1 style="color:var(--accent)">UI Component Sampler</h1>
+
+  <div class="sample-section">
+    <h2>Pills — Status</h2>
+    <div class="sample-row">
+      <span class="pill pill-status-active">ACTIVE</span>
+      <span class="pill pill-status-done">DONE</span>
+      <span class="pill pill-status-blocked">BLOCKED</span>
+      <span class="pill pill-status-paused">PAUSED</span>
+      <span class="pill">UNKNOWN</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Plan mode</h2>
+    <div class="sample-row">
+      <span class="pill pill-mode-pr">PR</span>
+      <span class="pill pill-mode-direct">DIRECT</span>
+      <span class="pill pill-mode-unknown">UNKNOWN</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Landed (branches tab)</h2>
+    <div class="sample-row">
+      <span class="pill pill-landed-full">LANDED</span>
+      <span class="pill pill-landed-partial">PARTIAL</span>
+      <span class="pill pill-landed-pr-ready">PR-READY</span>
+      <span class="pill pill-landed-pr-needs-attention">NEEDS ATTENTION</span>
+      <span class="pill pill-landed-failed">FAILED</span>
+      <span class="pill pill-landed-not">NOT LANDED</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Activity status (recent activity)</h2>
+    <div class="sample-row activity-row">
+      <span class="pill a-status-pass">COMPLETE</span>
+      <span class="pill a-status-fail">FAILED</span>
+      <span class="pill a-status-running">RUNNING</span>
+      <span class="pill">UNKNOWN</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Closure reason</h2>
+    <div class="sample-row">
+      <span class="closure-chip">NOT PLANNED</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — GitHub labels (real colors)</h2>
+    <div class="sample-row">
+      <span class="label-chip" style="color:#d73a4a;border-color:#d73a4a;background:#d73a4a18">BUG</span>
+      <span class="label-chip" style="color:#a2eeef;border-color:#a2eeef;background:#a2eeef18">ENHANCEMENT</span>
+      <span class="label-chip" style="color:#0075ca;border-color:#0075ca;background:#0075ca18">DOCUMENTATION</span>
+      <span class="label-chip" style="color:#7057ff;border-color:#7057ff;background:#7057ff18">GOOD FIRST ISSUE</span>
+      <span class="label-chip" style="color:#008672;border-color:#008672;background:#00867218">HELP WANTED</span>
+      <span class="label-chip" style="color:#d876e3;border-color:#d876e3;background:#d876e318">QUESTION</span>
+      <span class="label-chip" style="color:#cfd3d7;border-color:#cfd3d7;background:#cfd3d718">DUPLICATE</span>
+      <span class="label-chip" style="color:#e4e669;border-color:#e4e669;background:#e4e66918">INVALID</span>
+      <span class="label-chip" style="color:#ffffff;border-color:#ffffff;background:#ffffff18">WONTFIX</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Pills — Plan card mode</h2>
+    <div class="sample-row">
+      <span class="mode-chip">PHASE</span>
+      <span class="mode-chip">FINISH</span>
+      <span class="mode-chip" data-source="inherit">PHASE (inherited)</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Chips — Skip reason (long-form annotations)</h2>
+    <div class="sample-row">
+      <span class="skip-chip">needs-decision — leave open as architectural memo</span>
+      <span class="skip-chip skip-chip--plan-scale">plan-scale — full skill interface redesign</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Chips — Claim (long-form annotations)</h2>
+    <div class="sample-row">
+      <span class="claim-chip claim-chip--in-flight">in-flight &middot; abc123 &middot; 5m ago</span>
+    </div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Column-header buttons</h2>
+    <div class="sample-row" id="col-btns"></div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Card action buttons</h2>
+    <div class="sample-row" id="card-btns"></div>
+  </div>
+
+  <div class="sample-section">
+    <h2>Nav pills (section strip)</h2>
+    <div class="sample-row">
+      <button class="section-nav-pill">Triage 5</button>
+      <button class="section-nav-pill">Ready 12</button>
+      <button class="section-nav-pill">Backlog 3</button>
+      <button class="section-nav-pill">Discarded 0</button>
+      <button class="section-nav-pill">Completed 7</button>
+    </div>
+  </div>
+
+  <script src="/app.js"></script>
+  <script>
+    var colRow = document.getElementById("col-btns");
+    ["chevronsLeft", "chevronsRight", "minus", "plus"].forEach(function(k) {
+      var b = document.createElement("button");
+      b.className = "column-head-btn " + (k === "minus" || k === "plus" ? "column-collapse-toggle" : "move-all-btn");
+      b.innerHTML = SVG_ICONS[k];
+      colRow.appendChild(b);
+    });
+
+    var cardRow = document.getElementById("card-btns");
+    ["arrowUp","arrowDown","arrowLeft","arrowRight"].forEach(function(k) {
+      var b = document.createElement("button");
+      b.className = "move-btn";
+      b.innerHTML = SVG_ICONS[k];
+      cardRow.appendChild(b);
+    });
+    var xBtn = document.createElement("button");
+    xBtn.className = "move-btn";
+    xBtn.innerHTML = SVG_ICONS.x;
+    cardRow.appendChild(xBtn);
+    var cpBtn = document.createElement("button");
+    cpBtn.className = "move-btn copy-btn";
+    cpBtn.innerHTML = SVG_ICONS.copy;
+    cardRow.appendChild(cpBtn);
+  </script>
+</body>
+</html>

--- a/tests/test-dashboard-completed-readonly.sh
+++ b/tests/test-dashboard-completed-readonly.sh
@@ -116,6 +116,8 @@ let repoUrl = "https://example.invalid/repo";
 let lastGoodQueues = null;
 if (typeof navigator === "undefined") globalThis.navigator = {};
 if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
+var SVG_ICONS = {chevronLeft:"",chevronsLeft:"",chevronRight:"",chevronsRight:"",arrowUp:"",arrowDown:"",arrowLeft:"",arrowRight:"",x:"",copy:"",minus:"",plus:""};
+var MOVE_ICON_MAP = {};
 
 ${elBlock}
 ${titleNodeBlock}
@@ -240,8 +242,8 @@ function findByClass(root, cls) {
     "T4.8.c ready issue retains draggable='true'");
   expectTrue(findByClass(card, "card-controls"),
     "T4.8.c ready issue emits .card-controls block");
-  expectTrue(findByClass(card, "remove-btn"),
-    "T4.8.c ready issue emits .remove-btn");
+  expect(findByClass(card, "remove-btn"), null,
+    "T4.8.c ready issue has no .remove-btn (issue X removed pending issues-side Discarded)");
 }
 {
   // file:"plans/live.md" supplies the planUrl, so titleNode emits the

--- a/tests/test-fix-issues-claim-render-dom.sh
+++ b/tests/test-fix-issues-claim-render-dom.sh
@@ -232,6 +232,8 @@ const harness = `
 let repoUrl = "https://example.invalid/repo";
 if (typeof navigator === "undefined") globalThis.navigator = {};
 if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
+var SVG_ICONS = {chevronLeft:"",chevronsLeft:"",chevronRight:"",chevronsRight:"",arrowUp:"",arrowDown:"",arrowLeft:"",arrowRight:"",x:"",copy:"",minus:"",plus:""};
+var MOVE_ICON_MAP = {};
 ${issueColumnsBlock}
 
 ${elBlock}
@@ -460,7 +462,7 @@ function findByClass(root, cls) {
     }
     return out;
   }
-  const actions = ["issue-up", "issue-down", "issue-left", "issue-right", "issue-remove"];
+  const actions = ["issue-up", "issue-down", "issue-left", "issue-right"];
   for (const action of actions) {
     const btns = findAllByAttr(card, "data-action", action);
     expectTrue(btns.length >= 1, "control button for " + action + " present");
@@ -500,13 +502,9 @@ function findByClass(root, cls) {
     const btn = findAllByAttr(card, "data-action", action)[0];
     dispatchIssueAction(action, btn);
   }
-  const rmBtn = findAllByAttr(card, "data-action", "issue-remove")[0];
-  dispatchIssueAction("issue-remove", rmBtn);
   const calls = globalThis.__getCalls();
   expect(calls.moveIssue.length, 4,
     "moveIssue called 4x for unclaimed card (up/down/left/right)");
-  expect(calls.removeIssue.length, 1,
-    "removeIssue called 1x for unclaimed card");
   expect(calls.showToast.length, 0,
     "no toast fired for unclaimed card actions");
 }

--- a/tests/test-plan-claim-handleaction-guard.sh
+++ b/tests/test-plan-claim-handleaction-guard.sh
@@ -153,6 +153,8 @@ const harness = `
 let repoUrl = "https://example.invalid/repo";
 if (typeof navigator === "undefined") globalThis.navigator = {};
 if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
+var SVG_ICONS = {chevronLeft:"",chevronsLeft:"",chevronRight:"",chevronsRight:"",arrowUp:"",arrowDown:"",arrowLeft:"",arrowRight:"",x:"",copy:"",minus:"",plus:""};
+var MOVE_ICON_MAP = {};
 function currentEntryMode(_slug) { return null; }
 
 ${elBlock}
@@ -242,7 +244,7 @@ function findAllByAttr(root, k, v) {
       pipeline_short: "blk-abc",
     },
   };
-  const card = buildPlanCard(plan, "blocked", "in-progress", "phase");
+  const card = buildPlanCard(plan, "blocked", "ready", "phase");
 
   const actions = ["plan-up", "plan-down", "plan-left", "plan-right", "plan-discard"];
   for (const action of actions) {
@@ -289,7 +291,7 @@ function findAllByAttr(root, k, v) {
     slug: "free", title: "P", status: "active", landing_mode: "pr",
     phase_count: 3, phases_done: 0,
   };
-  const card = buildPlanCard(plan, "free", "drafted", "phase");
+  const card = buildPlanCard(plan, "free", "ready", "phase");
   globalThis.__resetCalls();
   for (const action of ["plan-up", "plan-down", "plan-left", "plan-right"]) {
     const btn = findAllByAttr(card, "data-action", action)[0];

--- a/tests/test-plan-claim-render-dom.sh
+++ b/tests/test-plan-claim-render-dom.sh
@@ -163,6 +163,8 @@ const harness = `
 let repoUrl = "https://example.invalid/repo";
 if (typeof navigator === "undefined") globalThis.navigator = {};
 if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
+var SVG_ICONS = {chevronLeft:"",chevronsLeft:"",chevronRight:"",chevronsRight:"",arrowUp:"",arrowDown:"",arrowLeft:"",arrowRight:"",x:"",copy:"",minus:"",plus:""};
+var MOVE_ICON_MAP = {};
 function currentEntryMode(_slug) { return null; }
 
 ${elBlock}

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -161,11 +161,13 @@ else
   fail "AC: errors-banner missing"
 fi
 
-# AC: dim class is wired for backed-branch dedup.
-if grep -qE 'card[[:space:]]+dim|"card dim"' "$APP_JS" && grep -qE '\.card\.dim' "$APP_CSS"; then
-  pass "AC: dim CSS class wired in JS + CSS"
+# AC: dim class — CSS rule exists (available for future use); JS no longer
+# applies it to backed-branch cards (branches render at full opacity per
+# UI-polish round 2).
+if grep -qE '\.card\.dim' "$APP_CSS"; then
+  pass "AC: dim CSS class defined in stylesheet"
 else
-  fail "AC: dim class missing from JS or CSS"
+  fail "AC: dim CSS class missing from CSS"
 fi
 
 # AC: "Landed in <ref>" + "Pending" tokens for plan modal phase rows.
@@ -337,10 +339,12 @@ else
   fail "column_head_has_collapse_toggle: expected ≥3 appendCollapseToggle calls, got $TOGGLE_HITS"
 fi
 # Helper itself must construct a button with the class + data-action.
+# Since UI-polish round 2 the toggle carries both the shared base class
+# (.column-head-btn) and the toggle-specific class (.column-collapse-toggle).
 if grep -qE 'function appendCollapseToggle' "$APP_JS" \
-   && grep -qE 'cls:\s*"column-collapse-toggle"' "$APP_JS" \
+   && grep -qE 'cls:\s*"column-head-btn column-collapse-toggle"' "$APP_JS" \
    && grep -qE '"data-action":\s*"column-collapse-toggle"' "$APP_JS"; then
-  pass "appendCollapseToggle helper emits .column-collapse-toggle button with data-action"
+  pass "appendCollapseToggle helper emits .column-head-btn.column-collapse-toggle button with data-action"
 else
   fail "appendCollapseToggle helper missing or malformed (class / data-action)"
 fi
@@ -1841,40 +1845,41 @@ fi
 echo ""
 echo "=== Issue #700: collapse toggle, collapsed preview strip, move-all styling ==="
 
-# 700-1: Collapse toggle font-size increased to 1.1em (from 0.9em).
+# 700-1..5: Collapse toggle styling — shared base class .column-head-btn
+# carries padding, border-radius, transition, and hover background (UI-polish
+# round 2 unified column-header buttons into a single base).  The toggle also
+# has its own selector for margin-left + width.
+if grep -qE '\.column-head-btn\b' "$APP_CSS" \
+   && awk '/\.column-head-btn[[:space:]]*\{/{flag=1} flag && /padding:[[:space:]]*3px 7px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: column-head-btn base has padding 3px 7px"
+else
+  fail "#700: column-head-btn base padding missing"
+fi
+
+if awk '/\.column-head-btn[[:space:]]*\{/{flag=1} flag && /border-radius:[[:space:]]*6px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: column-head-btn border-radius is 6px"
+else
+  fail "#700: column-head-btn border-radius missing"
+fi
+
+if awk '/\.column-head-btn:hover/{flag=1} flag && /background:/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: column-head-btn hover has background"
+else
+  fail "#700: column-head-btn hover missing background"
+fi
+
+if awk '/\.column-head-btn[[:space:]]*\{/{flag=1} flag && /transition:/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: column-head-btn has CSS transition"
+else
+  fail "#700: column-head-btn missing CSS transition"
+fi
+
+# Collapse toggle retains its own selector for margin-left + width override.
 if grep -qE '\.column-collapse-toggle\b' "$APP_CSS" \
-   && awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /font-size:[[:space:]]*1\.1em/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: collapse toggle font-size is 1.1em"
+   && awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /width:[[:space:]]*28px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: collapse toggle retains width: 28px"
 else
-  fail "#700: collapse toggle font-size is NOT 1.1em"
-fi
-
-# 700-2: Collapse toggle padding increased to 2px 6px (from 0 0.2em).
-if awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /padding:[[:space:]]*2px 6px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: collapse toggle padding is 2px 6px"
-else
-  fail "#700: collapse toggle padding is NOT 2px 6px"
-fi
-
-# 700-3: Collapse toggle has border-radius: 4px.
-if awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /border-radius:[[:space:]]*4px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: collapse toggle border-radius is 4px"
-else
-  fail "#700: collapse toggle border-radius missing"
-fi
-
-# 700-4: Collapse toggle hover has background color.
-if awk '/\.column-collapse-toggle:hover/{flag=1} flag && /background:/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: collapse toggle hover has background"
-else
-  fail "#700: collapse toggle hover missing background"
-fi
-
-# 700-5: Collapse toggle has transition property.
-if awk '/\.column-collapse-toggle[[:space:]]*\{/{flag=1} flag && /transition:/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: collapse toggle has CSS transition"
-else
-  fail "#700: collapse toggle missing CSS transition"
+  fail "#700: collapse toggle width override missing"
 fi
 
 # 700-6: Collapsed-summary CSS rule defined.
@@ -1933,32 +1938,20 @@ else
   fail "#700: collapsed-summary missing data-action for click-to-expand"
 fi
 
-# 700-13: Move-all button border-radius increased to 6px (from 4px).
-if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /border-radius:[[:space:]]*6px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: move-all-btn border-radius is 6px"
+# 700-13..16: Move-all button inherits from .column-head-btn base (UI-polish
+# round 2).  The JS assigns cls: "column-head-btn move-all-btn".  All styling
+# comes from the base; no dedicated .move-all-btn {} block needed.
+if grep -qE 'cls:\s*"column-head-btn move-all-btn"' "$APP_JS"; then
+  pass "#700: move-all-btn carries column-head-btn base class in JS"
 else
-  fail "#700: move-all-btn border-radius is NOT 6px"
+  fail "#700: move-all-btn missing column-head-btn base class in JS"
 fi
 
-# 700-14: Move-all button padding increased to 2px 8px (from 0 6px).
-if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /padding:[[:space:]]*2px 8px/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: move-all-btn padding is 2px 8px"
+# Base provides border-radius, padding, transition, background.
+if awk '/\.column-head-btn[[:space:]]*\{/{flag=1} flag && /background:.*--surface2/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
+  pass "#700: column-head-btn background is var(--surface2)"
 else
-  fail "#700: move-all-btn padding is NOT 2px 8px"
-fi
-
-# 700-15: Move-all button has transition matching section-nav-pill pattern.
-if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /transition:.*border-color.*color.*background/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: move-all-btn has pill-style transition"
-else
-  fail "#700: move-all-btn missing pill-style transition"
-fi
-
-# 700-16: Move-all button background uses surface2 (consistent with pill pattern).
-if awk '/\.move-all-btn[[:space:]]*\{/{flag=1} flag && /background:.*--surface2/{found=1; exit} flag && /\}/{flag=0} END{exit !found}' "$APP_CSS"; then
-  pass "#700: move-all-btn background is var(--surface2)"
-else
-  fail "#700: move-all-btn background is NOT var(--surface2)"
+  fail "#700: column-head-btn background is NOT var(--surface2)"
 fi
 
 # Stop server cleanly via SIGTERM and verify port is released.


### PR DESCRIPTION
## Summary

Comprehensive dashboard UI polish, iterated interactively on a worktree-rooted preview server.

**Icons:** All Unicode text icons (↑↓←→, ✕, 📋, ▸/▾, «/») replaced with inline SVG. Consistent stroke weight, proper vertical centering via flexbox. Column-header buttons share `.column-head-btn` base class.

**Label colors:** GitHub label chips now use the label's own hex color from the API (collect.py preserves `{name, color}` objects). Labels pill-shaped and uppercase.

**Bug fixes:**
- Issue X button removed (bounced to Triage instead of dismissing — no issues-side Discarded yet)
- ←/→ arrows hidden when at column boundary (prevented → from Backlog to Completed bug)
- Plan X and → hidden on Discarded column
- Skip-reason chips show on all columns (was Ready-only)
- Nav strip shows per-column pills (was aggregated "Active")
- Activity pills get colored borders
- Closure chip (NOT_PLANNED) restyled as pill
- Branch cards no longer dimmed

**Other:** Under Construction badge removed. Activity strip height persists to localStorage. Collapsed-summary shows 3 titles. /sampler.html dev page for design review.

## Test plan

- [x] Full suite: 5949/5950 (1 pre-existing mirror artifact, cleaned)
- [x] 4 DOM test harnesses updated and passing (SVG_ICONS stubs, button assertion updates)
- [x] Dashboard UI test: 224/224 (13 CSS assertions updated for new architecture)
- [x] Visual verification via playwright on worktree-rooted server (screenshots taken)
- [x] Interactive design review with user on live preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
