### PR TITLE
fix(fix-issues): restore accidentally-reverted staleness step in next section (closes #729)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.27+485965"
+  version: "2026.05.27+86e99a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -466,7 +466,16 @@ If `$ARGUMENTS` contains `next` (case-insensitive):
      > Next fix-issues sprint in ~2h 15m (~8:30 PM ET, cron XXXX).
      > Prompt: Run /fix-issues 5 auto every 4h
    - If none found: `No active /fix-issues cron in this session.`
-4. **Exit.** Do not proceed to any phase.
+4. Peek at the Ready queue in `.zskills/monitor-state.json`:
+   - If `issues.ready` is non-empty: report the count
+     (`N issues in Ready queue.`).
+   - If `issues.ready` is empty (or the file does not exist): read the
+     `updated_at` field (ISO 8601 timestamp written by every sync/snapshot
+     cycle), compute minutes since that timestamp, and report:
+     > Ready queue empty (last synced: N minutes ago). Run `/fix-issues sync` to refresh, or the next cron fire will sync automatically.
+     If the file is missing or has no `updated_at`, say:
+     > Ready queue empty (never synced). Run `/fix-issues sync` to populate.
+5. **Exit.** Do not proceed to any phase.
 
 ## Stop (if `stop` is present)
 

--- a/docs/issues/ISSUES_PLAN.md
+++ b/docs/issues/ISSUES_PLAN.md
@@ -1354,3 +1354,9 @@ Plus a structural conformance pin in `tests/test-skill-conformance.sh` (or new t
 6. Tests: update `tests/test-issues-skip-reason-parse.sh` (synthetic #100, real-tracker #67/#432 expectations) and `tests/test-fix-issues-phase2-source-filter.sh` (#703 expected output) to cover both codes.
 7. Mirror `.claude/skills/` copies + skill-version bumps for `fix-issues` and `zskills-dashboard`.
 **Complexity:** M. **Action now:** /do pr — split needs-decision skip-code into needs-decision vs deferred across fix-issues rubric, filter script, dashboard collect.py, CSS chip, and tests
+
+### #729 — 6c78aca accidentally reverted /fix-issues `next` staleness step from 3d8e120 — #719 closure-incomplete
+**Labels:** (none) | **Verdict:** actionable — mechanical restoration of accidentally-reverted prose
+**Problem.** Commit 6c78aca (#728, closing #720) overwrote the `next` subcommand's staleness step (lines 466-475) that 3d8e120 (#723, closing #719) had just added. On HEAD, line 469 is a bare `4. **Exit.** Do not proceed to any phase.` — the "Peek at the Ready queue" block that reports staleness from `.zskills/monitor-state.json` is gone. An agent running `/fix-issues next` with an empty Ready queue silently exits without surfacing staleness info. Second instance of the same accidental-revert pattern (#704 was the first).
+**Fix outline.** Restore the staleness step from 3d8e120 before the `**Exit.**` line at SKILL.md:469 in the `next` section. The block adds steps 4 (peek at Ready queue, report count or staleness) and renumbers Exit to step 5. Bump `metadata.version`. Mirror source to `.claude/skills/fix-issues/SKILL.md`. Two files changed, zero logic — pure prose restoration.
+**Complexity:** S. **Action now:** /do pr — restore accidentally-reverted staleness step in /fix-issues `next` section from 3d8e120 + version bump + mirror

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.27+485965"
+  version: "2026.05.27+86e99a"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -466,7 +466,16 @@ If `$ARGUMENTS` contains `next` (case-insensitive):
      > Next fix-issues sprint in ~2h 15m (~8:30 PM ET, cron XXXX).
      > Prompt: Run /fix-issues 5 auto every 4h
    - If none found: `No active /fix-issues cron in this session.`
-4. **Exit.** Do not proceed to any phase.
+4. Peek at the Ready queue in `.zskills/monitor-state.json`:
+   - If `issues.ready` is non-empty: report the count
+     (`N issues in Ready queue.`).
+   - If `issues.ready` is empty (or the file does not exist): read the
+     `updated_at` field (ISO 8601 timestamp written by every sync/snapshot
+     cycle), compute minutes since that timestamp, and report:
+     > Ready queue empty (last synced: N minutes ago). Run `/fix-issues sync` to refresh, or the next cron fire will sync automatically.
+     If the file is missing or has no `updated_at`, say:
+     > Ready queue empty (never synced). Run `/fix-issues sync` to populate.
+5. **Exit.** Do not proceed to any phase.
 
 ## Stop (if `stop` is present)
 


### PR DESCRIPTION
## Summary

Restores the accidentally-reverted staleness step in `/fix-issues` `## Next` section. PR #728 (closes #720) was based on a branch predating PR #723 (closes #719), so the squash-merge overwrote the staleness-peek block.

Closes #729.

## Test plan

- [x] Full suite: 3447 passed, 0 failed
- [x] Mirror byte-identical
- [x] metadata.version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
