### PR TITLE
do: comprehensive skill documentation

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fix-issues
 disable-model-invocation: true
-argument-hint: "N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] | reconsider <N>"
+argument-hint: "N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next"
 description: >-
   Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue
   worktrees, verify, optionally auto-land via /land-pr. Recurring via
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.27+cc1460"
+  version: "2026.05.27+1f3da8"
 ---
 
-# /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] | reconsider <N> — Batch Bug-Fixing Sprint
+# /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
 
 Orchestrates large-scale bug fixing. Syncs trackers, prioritizes issues,
 dispatches agent teams in worktrees, verifies fixes, writes a persistent

--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "(no args = list ready queue) | [N|all] [phase|finish] [continue] | add <slug> [pos] | rank <slug> <pos> | remove <slug> | default <phase|finish> | every SCHEDULE [phase|finish] [--force] | stop | next"
+argument-hint: "(no args = list ready queue) | [N|all] [phase|finish] [continue] | default <phase|finish> | every SCHEDULE [phase|finish] | stop | next"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
@@ -9,7 +9,7 @@ description: >-
   queue (add/rank/remove/default) and recurring schedules. Mirrors
   /fix-issues for bugs.
 metadata:
-  version: "2026.05.26+961662"
+  version: "2026.05.27+11f2e4"
 ---
 
 # /work-on-plans — Batch Plan Executor

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,101 @@
+# Z Skills Reference
+
+Comprehensive documentation for all 28 user-invocable skills.
+
+## Quick Reference
+
+| Skill | Description | Docs |
+|-------|-------------|------|
+| [`/add-block`](add-block.md) | Step-by-step guide for adding new block types | [Details](add-block.md) |
+| [`/add-example`](add-example.md) | Create example models for block types | [Details](add-example.md) |
+| [`/briefing`](briefing.md) | Generate a project briefing with status, commits, worktrees | [Details](briefing.md) |
+| [`/cleanup-merged`](cleanup-merged.md) | Post-PR-merge local normalization | [Details](cleanup-merged.md) |
+| [`/commit`](commit.md) | Safe commit workflow with optional push, land, or PR | [Details](commit.md) |
+| [`/create-worktree`](create-worktree.md) | Create a git worktree for agent work | [Details](create-worktree.md) |
+| [`/do`](do.md) | Lightweight task dispatcher for ad-hoc work | [Details](do.md) |
+| [`/doc`](doc.md) | Audit and fix documentation gaps | [Details](doc.md) |
+| [`/draft-plan`](draft-plan.md) | Draft plans through iterative adversarial review | [Details](draft-plan.md) |
+| [`/draft-tests`](draft-tests.md) | Draft test specifications into existing plans | [Details](draft-tests.md) |
+| [`/fix-issues`](fix-issues.md) | Orchestrate batch bug-fixing sprints | [Details](fix-issues.md) |
+| [`/fix-report`](fix-report.md) | Review sprint results, land fixes, close issues | [Details](fix-report.md) |
+| [`/investigate`](investigate.md) | Deep debugging for complex bugs | [Details](investigate.md) |
+| [`/manual-testing`](manual-testing.md) | Browser-based manual testing recipes | [Details](manual-testing.md) |
+| [`/plans`](plans.md) | Plan dashboard: view status, find next ready plan | [Details](plans.md) |
+| [`/playwright-cli`](playwright-cli.md) | Browser automation with playwright-cli | [Details](playwright-cli.md) |
+| [`/qe-audit`](qe-audit.md) | Quality engineering audit for test coverage gaps | [Details](qe-audit.md) |
+| [`/quickfix`](quickfix.md) | Ship an in-flight edit as a one-commit PR | [Details](quickfix.md) |
+| [`/refine-plan`](refine-plan.md) | Refine in-progress plans against completed work | [Details](refine-plan.md) |
+| [`/research-and-go`](research-and-go.md) | Full pipeline: decompose, plan, and execute autonomously | [Details](research-and-go.md) |
+| [`/research-and-plan`](research-and-plan.md) | Decompose broad goals into executable sub-plans | [Details](research-and-plan.md) |
+| [`/review-feedback`](review-feedback.md) | Review exported feedback JSON and file GitHub issues | [Details](review-feedback.md) |
+| [`/run-plan`](run-plan.md) | Execute plan phases with verification and landing | [Details](run-plan.md) |
+| [`/session-report`](session-report.md) | Audit session intent vs. actual shipped state | [Details](session-report.md) |
+| [`/update-zskills`](update-zskills.md) | Install or update Z Skills infrastructure | [Details](update-zskills.md) |
+| [`/verify-changes`](verify-changes.md) | Verify recent changes: diffs, tests, manual checks | [Details](verify-changes.md) |
+| [`/work-on-plans`](work-on-plans.md) | Batch-execute prioritized plan queue from dashboard | [Details](work-on-plans.md) |
+| [`/zskills-dashboard`](zskills-dashboard.md) | Local web dashboard for plans, issues, and tracking | [Details](zskills-dashboard.md) |
+
+## Categories
+
+### Execution & Orchestration
+
+Core skills for running plans and fixing issues at scale.
+
+- [/run-plan](run-plan.md) -- Execute plan phases with implementation, verification, and landing
+- [/fix-issues](fix-issues.md) -- Batch bug-fixing sprints with per-issue worktrees
+- [/work-on-plans](work-on-plans.md) -- Batch-execute the prioritized ready queue from the dashboard
+- [/do](do.md) -- Lightweight task dispatcher for ad-hoc work
+- [/quickfix](quickfix.md) -- Ship an in-flight edit as a one-commit PR from main
+- [/research-and-go](research-and-go.md) -- Full autonomous pipeline: decompose, plan, execute
+
+### Planning & Design
+
+Skills for creating, refining, and decomposing plans before execution.
+
+- [/draft-plan](draft-plan.md) -- Draft plans through iterative adversarial review
+- [/draft-tests](draft-tests.md) -- Draft test specifications into existing plan phases
+- [/refine-plan](refine-plan.md) -- Refine in-progress plans against completed work
+- [/research-and-plan](research-and-plan.md) -- Decompose broad goals into executable sub-plans
+- [/plans](plans.md) -- Plan dashboard: view status, find the next ready plan
+
+### Verification & Quality
+
+Skills for testing, auditing, and verifying changes.
+
+- [/verify-changes](verify-changes.md) -- Full verification: diffs, test coverage, test runs, manual checks
+- [/qe-audit](qe-audit.md) -- Quality engineering audit for test coverage gaps and bugs
+- [/investigate](investigate.md) -- Deep root-cause debugging for complex bugs
+- [/manual-testing](manual-testing.md) -- Browser-based manual testing recipes with playwright-cli
+- [/playwright-cli](playwright-cli.md) -- Low-level browser automation commands
+
+### Git & Landing
+
+Skills for committing, landing, and cleaning up branches.
+
+- [/commit](commit.md) -- Safe commit workflow with push, land, or PR modes
+- [/cleanup-merged](cleanup-merged.md) -- Post-PR-merge local normalization and branch cleanup
+- [/create-worktree](create-worktree.md) -- Create isolated git worktrees for agent work
+
+### Content & Documentation
+
+Skills for managing documentation, examples, and block types.
+
+- [/doc](doc.md) -- Audit and fix documentation gaps across the project
+- [/add-block](add-block.md) -- Step-by-step guide for adding new block types
+- [/add-example](add-example.md) -- Create example models for block types
+
+### Reporting & Status
+
+Skills for generating reports and reviewing project state.
+
+- [/briefing](briefing.md) -- Generate a project briefing with worktrees, commits, checkboxes
+- [/session-report](session-report.md) -- Audit what this session shipped vs. what was planned
+- [/fix-report](fix-report.md) -- Review sprint results, land fixes, close issues
+- [/review-feedback](review-feedback.md) -- Review exported feedback JSON and file issues
+
+### Infrastructure & Configuration
+
+Skills for managing the Z Skills framework itself.
+
+- [/update-zskills](update-zskills.md) -- Install or update Z Skills infrastructure
+- [/zskills-dashboard](zskills-dashboard.md) -- Local web dashboard for plans, issues, and tracking

--- a/docs/skills/add-block.md
+++ b/docs/skills/add-block.md
@@ -1,0 +1,49 @@
+# /add-block
+
+> Step-by-step guide for adding new block types. Use when the user asks to "add a block", "create a new block", or "implement a block".
+
+## Usage
+
+```
+/add-block
+```
+
+No arguments -- the skill guides you through the interactive workflow after you provide the block name.
+
+## Workflow
+
+All implementation happens in a pre-created worktree. The skill follows a 13-step process:
+
+0. Research existing similar blocks
+1. Define the block interface (ports, parameters)
+2. Implement the block class
+3. Register the block in the block library
+4. Add unit tests
+5. Add codegen support
+6. Add codegen tests
+7. Create an example model
+8. Add block documentation
+9. Add block explorer entry
+10. Take screenshots
+11. Verify all tests pass
+12. Land the changes
+
+## Examples
+
+```
+/add-block
+```
+
+Then provide the block name when prompted (e.g., "PID Controller", "Integrator", "Derivative").
+
+## Common Patterns
+
+- **Single block:** `/add-block` then specify one block type
+- **After adding:** use `/add-example` to create additional example models for the new block
+
+## Tips & Gotchas
+
+- All 13 steps must be completed -- no partial implementations
+- The implementation agent runs in a worktree with `FIRST: cd $WORKTREE_PATH` as a mandatory first action
+- Dispatches an implementer subagent for the actual coding work
+- The worktree is created via `ensure-worktree.sh`, not manual `git worktree add`

--- a/docs/skills/add-example.md
+++ b/docs/skills/add-example.md
@@ -1,0 +1,36 @@
+# /add-example
+
+> Create an example model for one or more block types. Handles model file construction, registration, unit + codegen tests, screenshots, and verification.
+
+## Usage
+
+```
+/add-example <block-type(s)> [concept hint]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `block-type(s)` | Yes | Which block(s) the example must feature (comma-separated for batch) |
+| `concept hint` | No | Real-world model concept (e.g., "PID temperature control") |
+
+## Examples
+
+```
+/add-example Integrator
+/add-example Integrator,Derivative PID temperature control
+/add-example Scope real-time signal monitoring
+```
+
+## Common Patterns
+
+- **Single block example:** `/add-example Integrator` -- create an example featuring the Integrator block
+- **Multi-block example:** `/add-example Integrator,Derivative PID temperature control` -- create an example that showcases multiple blocks in a real-world context
+- **After /add-block:** typically follows `/add-block` to create additional examples for newly added blocks
+
+## Tips & Gotchas
+
+- All implementation happens in a pre-created worktree via `ensure-worktree.sh`
+- When dispatched from `/add-block`, the worktree gate is a no-op (parent's worktree is reused)
+- The full workflow covers: research, model file construction, registration, unit tests, codegen tests, screenshots, and verification

--- a/docs/skills/briefing.md
+++ b/docs/skills/briefing.md
@@ -1,0 +1,55 @@
+# /briefing
+
+> Generate a project briefing: worktree status, open checkboxes, recent commits. Modes: summary (default), report, verify, current, worktrees. Period: 1h, 6h, 24h, 2d, 7d.
+
+## Usage
+
+```
+/briefing [report [period]] | verify | current | worktrees | [summary] | stop | next
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| (no args) | -- | Summary mode (default) |
+| `summary` | No | Explicit summary mode |
+| `report [period]` | No | Detailed report for a time period |
+| `verify` | No | Verify mode |
+| `current` | No | Current state mode |
+| `worktrees` | No | Worktree status mode |
+| `stop` | No | Cancel scheduled briefings |
+| `next` | No | Show next scheduled briefing time |
+
+### Period Shorthand
+
+Used with `report` mode: `1h`, `6h`, `24h` (default), `1d`, `2d`, `7d`
+
+## Examples
+
+```
+/briefing
+/briefing summary
+/briefing report
+/briefing report 7d
+/briefing report 24h every day at 9am
+/briefing verify
+/briefing current
+/briefing worktrees
+/briefing stop
+/briefing next
+```
+
+## Common Patterns
+
+- **Quick status check:** `/briefing` -- summary of project state
+- **Weekly report:** `/briefing report 7d` -- detailed report covering the last 7 days
+- **Daily scheduled briefing:** `/briefing report 24h every day at 9am` -- schedule a daily report
+- **Worktree inventory:** `/briefing worktrees` -- see all worktrees and their status
+
+## Tips & Gotchas
+
+- The briefing helper is a Python script (`briefing.py`) -- requires Python 3
+- Script output is presented verbatim -- it is not summarized or rephrased
+- Scheduling follows the same `every SCHEDULE` pattern as other skills
+- `stop` and `next` manage the scheduled briefing cron

--- a/docs/skills/cleanup-merged.md
+++ b/docs/skills/cleanup-merged.md
@@ -1,0 +1,39 @@
+# /cleanup-merged
+
+> Post-PR-merge local normalization: fetch-and-prune origin, switch off merged feature branches, pull main, and delete local branches whose upstream is gone or whose PR has merged.
+
+## Usage
+
+```
+/cleanup-merged [--dry-run | -n] [--review]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--dry-run` / `-n` | No | Report what would happen without modifying anything |
+| `--review` | No | Per-branch merit-based classification with interactive picker |
+
+## Examples
+
+```
+/cleanup-merged
+/cleanup-merged --dry-run
+/cleanup-merged -n
+/cleanup-merged --review
+```
+
+## Common Patterns
+
+- **After merging a PR:** `/cleanup-merged` -- fetch, switch to main, pull, delete merged branches
+- **Preview first:** `/cleanup-merged --dry-run` -- see what would be deleted before committing
+- **Thorough cleanup:** `/cleanup-merged --review` -- classify every branch and worktree, then pick what to clean
+
+## Tips & Gotchas
+
+- Safe to run any time -- bails on a dirty working tree
+- Never deletes a branch with unpushed commits
+- `--dry-run` and `--review` are mutually exclusive
+- Review mode classifies branches per merit rules and presents an interactive picker
+- Uses `gh` for PR status checks when available; falls back gracefully without it

--- a/docs/skills/commit.md
+++ b/docs/skills/commit.md
@@ -1,0 +1,65 @@
+# /commit
+
+> Safe commit workflow with optional scope hint. Inventories all changes, classifies related vs. unrelated files, traces dependencies, protects other agents' work, and optionally pushes, lands worktree commits, or opens a PR via `/land-pr`.
+
+## Usage
+
+```
+/commit [pr] [scope] [push|land] [auto]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `pr` | No | Push current branch and create a PR to main (must be FIRST token) |
+| `scope` | No | Free-text scope hint to guide which files to commit (e.g., `skill updates`, `parser reset button fix`) |
+| `push` | No | Commit and push to remote |
+| `land` | No | Cherry-pick worktree commits into main (worktree only) |
+| `auto` | No | Auto-merge the resulting PR (PR mode only) |
+
+## Subcommands
+
+### `pr`
+
+Push the current branch and create a PR to main. Requires a clean working tree. The `pr` token must be the first argument. Everything after `pr` is the scope hint.
+
+### `push`
+
+Commit all related changes and push to the remote.
+
+### `land`
+
+Cherry-pick worktree commits onto main. Only available when running in a worktree. Handles the full landing flow: cherry-pick, test suite, `.landed` marker.
+
+## Examples
+
+```
+/commit
+/commit skill updates
+/commit push
+/commit parser reset button fix push
+/commit land
+/commit pr
+/commit pr fix pr comments
+/commit pr auto
+```
+
+## Common Patterns
+
+- **Basic commit:** `/commit` -- inventories changes, classifies related vs. unrelated, commits related files
+- **Scoped commit:** `/commit skill updates` -- scope hint guides which files are related
+- **Commit and push:** `/commit push` -- commit then push to remote
+- **Land worktree work:** `/commit land` -- cherry-pick worktree commits to main, run tests, write `.landed` marker
+- **Open a PR:** `/commit pr` -- push branch and create a PR
+- **PR with auto-merge:** `/commit pr auto` -- push, create PR, request auto-merge
+
+## Tips & Gotchas
+
+- `pr` is recognized ONLY as the first token to prevent false-triggering on scope hints containing "pr"
+- When no mode token is supplied, the skill consults `execution.landing` in config
+- The skill traces import dependencies -- if file A imports file B and both are uncommitted, both are staged
+- Unrelated changes in the working tree are left alone -- only related files are staged
+- `auto` is only meaningful in PR mode; it has no effect with `push` or `land`
+- `/commit land` dispatches the full landing script: try cherry-pick (no stash), run tests, write `.landed` marker
+- Never uses `git add .` or `git add -A` -- stages files by name only

--- a/docs/skills/create-worktree.md
+++ b/docs/skills/create-worktree.md
@@ -1,0 +1,59 @@
+# /create-worktree
+
+> Create a git worktree for agent work. Thin wrapper around `create-worktree.sh` -- owns prefix-derived path, optional branch-name override, pre-flight prune+fetch+ff-merge, safe worktree-add, and sanitized tracking writes.
+
+## Usage
+
+```
+/create-worktree <slug> [--prefix P] [--branch-name REF] [--from B] [--root R]
+                 [--purpose TEXT] [--pipeline-id ID] [--allow-resume] [--no-preflight]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `slug` | Yes | Short identifier for the worktree |
+| `--prefix P` | No | Prefix for the worktree path (e.g., `fix-issue`, `add-block`) |
+| `--branch-name REF` | No | Override the auto-generated branch name |
+| `--from B` | No | Base branch to create the worktree from |
+| `--root R` | No | Root directory for the worktree |
+| `--purpose TEXT` | No | Human-readable purpose description |
+| `--pipeline-id ID` | No | Pipeline ID for tracking (required for Tier 1 callers) |
+| `--allow-resume` | No | Allow resuming an existing worktree |
+| `--no-preflight` | No | Skip the prune+fetch+ff-merge preflight |
+
+## Two-Tier Contract
+
+### Tier 1 -- Bash callers inside other skills
+
+Skills like `/run-plan`, `/fix-issues`, `/do` know their pipeline ID and **must pass it via `--pipeline-id`**. The script rejects invocations without the flag.
+
+### Tier 2 -- User / Claude slash command
+
+Users don't need to know about pipeline IDs. When omitted, Claude synthesizes `create-worktree.<slug>` automatically.
+
+## Examples
+
+```
+/create-worktree my-feature
+/create-worktree my-feature --prefix fix-issue --pipeline-id fix-issues.sprint-123
+/create-worktree my-feature --branch-name custom/branch-name
+/create-worktree my-feature --from develop --purpose "Experimental feature work"
+/create-worktree my-feature --allow-resume
+```
+
+## Common Patterns
+
+- **User worktree:** `/create-worktree my-feature` -- creates a worktree with auto-generated pipeline ID
+- **Skill integration:** called internally by `/run-plan`, `/fix-issues`, `/do`, `/add-block`, etc. with `--pipeline-id`
+- **Resume existing:** `/create-worktree my-feature --allow-resume` -- reuse an existing worktree if present
+
+## Tips & Gotchas
+
+- Prints the worktree path on stdout -- callers capture it to `cd` into
+- The script handles pre-flight (prune, fetch, ff-merge), worktree creation, and `.zskills-tracked` write
+- `--pipeline-id` is required for Tier 1 (skill) callers; script exits with rc 5 without it
+- `--no-preflight` skips the fetch/prune/ff-merge for speed when the caller has already done it
+- Worktrees are created under `/tmp/<project>-<prefix>-<slug>/` by default
+- The underlying script is at `.claude/skills/create-worktree/scripts/create-worktree.sh`

--- a/docs/skills/do.md
+++ b/docs/skills/do.md
@@ -1,0 +1,76 @@
+# /do
+
+> Lightweight task dispatcher for ad-hoc work: documentation, examples, refactoring, content updates. Worktree/direct/pr landing modes via flag or config. Recurring via `every SCHEDULE`; `stop`/`next` manage the schedule.
+
+## Usage
+
+```
+/do <description> [worktree|direct|pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N]
+/do stop [query]
+/do next [query]
+/do now [query]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `description` | Yes | What to do, in natural language |
+| `worktree` | No | Isolate work in a worktree, cherry-pick back to main |
+| `direct` | No | Work on main in place, no landing step |
+| `pr` | No | Named worktree + feature branch, push, create PR |
+| `auto` | No | Land autonomously (PR: auto-merge; worktree: cherry-pick+push; direct: push) |
+| `every SCHEDULE` | No | Self-schedule recurring runs (`4h`, `day at 9am`, `weekday at 9am`) |
+| `now` | No | Run immediately (with `every`: run now AND schedule) |
+| `--force` | No | Bypass triage redirect and review reject |
+| `--rounds N` | No | Max review/refine cycles (default 1; `0` skips review) |
+
+## Subcommands
+
+### `stop [query]`
+
+Cancel `/do` cron(s). Bare `/do stop` cancels all. With a query (`/do stop Check docs`), targets the matching cron via fuzzy description matching.
+
+### `next [query]`
+
+Check next fire time(s). Bare `/do next` shows all. With a query, shows the matching cron's schedule.
+
+### `now [query]`
+
+Trigger a cron immediately. Bare `/do now` triggers the single cron (or asks if multiple). With a query, triggers the matching cron.
+
+## Examples
+
+```
+/do Add example models for Integrator and Derivative blocks
+/do Sort the screenshots in session-sequence-snapshots
+/do Refactor color constants in main.css worktree
+/do Update the presentation with Phase 3 results auto
+/do Make sure docs are up to date every day at 9am
+/do Check for broken links in examples every 12h now
+/do Add dark mode to editor pr
+/do Add dark mode pr auto
+/do next
+/do next Check docs
+/do stop
+/do stop Check docs
+```
+
+## Common Patterns
+
+- **Quick content task:** `/do Sort the screenshots` -- direct mode, no ceremony
+- **Isolated refactor:** `/do Refactor color constants worktree` -- work in a worktree, verify, no auto-land
+- **PR with auto-merge:** `/do Add dark mode pr auto` -- create a PR and request auto-merge
+- **Recurring maintenance:** `/do Check for broken links every 12h now` -- schedule and run immediately
+- **Bypass gates:** `/do Fix the tooltip bug --force` -- skip triage and review for a known-simple fix
+
+## Tips & Gotchas
+
+- `/do` runs a triage gate (Phase 0a) that may redirect to `/draft-plan`, `/run-plan`, or `/fix-issues` if the task is too large or references issues/plans -- use `--force` to bypass
+- A fresh-agent review (Phase 0b) checks the inline plan before execution -- `--rounds 0` skips this
+- When no landing flag is given, the mode comes from `execution.landing` in config (`cherry-pick` maps to `worktree`, `pr` maps to `pr`, `direct` maps to `direct`)
+- `direct` mode is incompatible with `execution.main_protected: true`
+- Verification (`/verify-changes`) runs on all code changes regardless of the `auto` flag -- `auto` controls landing, not whether to verify
+- PR mode dispatches `/land-pr` for the full PR lifecycle (push, CI poll, fix cycle)
+- Quoted descriptions (`/do "Now fix the tooltip bug"`) bypass meta-command detection
+- `--force` and `--rounds N` persist into cron prompts verbatim when used with `every`

--- a/docs/skills/doc.md
+++ b/docs/skills/doc.md
@@ -1,0 +1,46 @@
+# /doc
+
+> Audit and fix documentation gaps: block library entries, example models, getting-started guides, presentations, README updates. Also handles newsletter entries.
+
+## Usage
+
+```
+/doc [blocks|examples|newsletter|<description>]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| (no args) | -- | Scan recent changes for missing docs and fix gaps |
+| `blocks` | No | Comprehensive audit of all blocks for doc completeness |
+| `examples` | No | Comprehensive audit of all examples for doc completeness |
+| `newsletter` | No | Write a NEWSLETTER.md entry for recent work |
+| `description` | No | Document a specific thing |
+
+## Examples
+
+```
+/doc
+/doc blocks
+/doc examples
+/doc newsletter
+/doc the new thermal blocks
+/doc update the presentation with recent results
+/doc update README with current block count and test numbers
+```
+
+## Common Patterns
+
+- **Post-feature audit:** `/doc` -- what documentation is missing since the last commit?
+- **Block audit:** `/doc blocks` -- which blocks lack explorer entries, examples, or docs?
+- **Example audit:** `/doc examples` -- which examples lack READMEs or screenshots?
+- **Newsletter:** `/doc newsletter` -- write a newsletter entry for recent features
+- **Targeted docs:** `/doc the new physics blocks` -- document a specific feature area
+
+## Tips & Gotchas
+
+- The no-argument mode scans `git log` for recent changes that lack documentation
+- Block audit checks all registered blocks against a documentation checklist
+- Example audit checks all example models against a documentation checklist
+- Free-form descriptions can target any documentation task (presentations, READMEs, guides)

--- a/docs/skills/draft-plan.md
+++ b/docs/skills/draft-plan.md
@@ -1,0 +1,43 @@
+# /draft-plan
+
+> Draft a high-quality plan through iterative adversarial review: research, draft, review, devil's-advocate, refine -- repeated until convergence. Output is a plan file ready for `/run-plan` execution.
+
+## Usage
+
+```
+/draft-plan [output FILE] [rounds N] [auto] <description...>
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `description` | Yes | What the plan should accomplish, in natural language |
+| `output FILE` | No | Output path for the plan file (default: auto-derived from description) |
+| `rounds N` | No | Maximum adversarial review rounds (default: 3) |
+| `auto` | No | Skip the decomposition confirmation checkpoint |
+
+## Examples
+
+```
+/draft-plan Add dark mode support to the editor
+/draft-plan output plans/DARK_MODE.md Add dark mode support
+/draft-plan rounds 5 Redesign the solver architecture
+/draft-plan auto Implement undo/redo for the block editor
+```
+
+## Common Patterns
+
+- **Standard plan drafting:** `/draft-plan Implement physics simulation blocks` -- research, draft, review cycles until convergence
+- **Custom output:** `/draft-plan output plans/PHYSICS_BLOCKS.md Implement physics simulation blocks`
+- **More review rounds:** `/draft-plan rounds 5 Redesign the state machine` -- allow up to 5 adversarial review rounds
+- **Autonomous (from /research-and-go):** `/draft-plan auto <description>` -- skip confirmation checkpoints
+
+## Tips & Gotchas
+
+- Must run at top level -- internally dispatches reviewer, devil's-advocate, and refiner sub-agents in parallel
+- The plan output is designed to be executed by `/run-plan` -- each phase has clear acceptance criteria
+- Adversarial review means multiple agents poke holes in the plan from different angles before convergence
+- Completed phases from a prior `/run-plan` execution are never modified during refinement
+- If the goal is broad enough to decompose into multiple sub-plans, consider `/research-and-plan` instead
+- Reserve `/draft-plan` for skills/workflows with non-trivial design surface (integration points, multiple commands, hook interactions) -- thin prompt changes don't need adversarial review

--- a/docs/skills/draft-tests.md
+++ b/docs/skills/draft-tests.md
@@ -1,0 +1,42 @@
+# /draft-tests
+
+> Draft test specifications into an existing plan through iterative adversarial review. Appends a `### Tests` subsection per pending phase via a senior-QE reviewer + devil's-advocate + refiner loop. Completed phases are never modified (checksum-gated).
+
+## Usage
+
+```
+/draft-tests <plan-file> [rounds N] [auto] [guidance...]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `plan-file` | Yes | Path to the existing plan file |
+| `rounds N` | No | Maximum adversarial review rounds |
+| `auto` | No | Skip confirmation checkpoints |
+| `guidance` | No | Additional guidance for the test spec drafting |
+
+## Examples
+
+```
+/draft-tests plans/FEATURE_PLAN.md
+/draft-tests plans/FEATURE_PLAN.md rounds 5
+/draft-tests plans/FEATURE_PLAN.md auto
+/draft-tests plans/FEATURE_PLAN.md Focus on edge cases in the parser
+```
+
+## Common Patterns
+
+- **Standard test drafting:** `/draft-tests plans/X.md` -- draft test specs for all pending phases
+- **With guidance:** `/draft-tests plans/X.md Focus on error handling and edge cases`
+- **After /draft-plan:** run `/draft-tests` on the plan to add test specifications before `/run-plan` execution
+
+## Tips & Gotchas
+
+- Must run at top level -- internally dispatches reviewer, devil's-advocate, and refiner sub-agents
+- Sister skill to `/draft-plan` -- same adversarial machinery, scoped to test specifications
+- Completed phases are NEVER modified -- checksum-gated immutability
+- Test gaps in completed phases are surfaced as a new backfill phase, not by modifying existing phases
+- The test specs ride along inside the plan phases that `/run-plan` executes -- no companion document needed
+- Trailing non-phase sections are preserved byte-identical (stricter than `/refine-plan`)

--- a/docs/skills/fix-issues.md
+++ b/docs/skills/fix-issues.md
@@ -1,0 +1,115 @@
+# /fix-issues
+
+> Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue worktrees, verify, optionally auto-land via /land-pr. Recurring via `every SCHEDULE`; `stop`/`next` manage it. `sync` updates trackers and closes already-fixed issues; `plan` drafts plans for skipped ones.
+
+## Usage
+
+```
+/fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct]
+/fix-issues sync
+/fix-issues plan [auto]
+/fix-issues stop
+/fix-issues next
+/fix-issues add <N> [column] [pos]
+/fix-issues remove <N> [column]
+/fix-issues reconsider <N>
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `N` | Yes (sprints) | Number of issues to fix (e.g., `30`) |
+| `focus` | No | Prioritize a specific domain (`new`, `correctness`, `codegen`, `ui`, `tests`, etc.) |
+| `dashboard` | No | Source candidates from the dashboard Ready queue instead of the model-layer rubric |
+| `auto` | No | Bypass confirmation gates; auto-land per-issue fix PRs; auto-merge sprint-report PR |
+| `every SCHEDULE` | No | Self-schedule recurring runs (`4h`, `30m`, `day at 9am`, `weekday at 9am`) |
+| `now` | No | Run immediately (with `every`: run now AND schedule) |
+| `pr` | No | Land each fix via a per-issue PR on a named branch |
+| `direct` | No | Land each fix by fast-forward-merging into main (no PR) |
+
+## Subcommands
+
+### `sync`
+
+Update all issue tracker files from GitHub, research new issues, and verify/close issues that appear already fixed. Always interactive -- presents findings and asks before closing. Steps:
+
+1. Fetch and update trackers from GitHub
+2. Dispatch research agents for unresearched issues (also checks if issues are already fixed)
+3. Present findings with verdicts (FIXED, LIKELY FIXED, NOT FIXED, UNCLEAR)
+4. Stage local tracker and sprint-report updates for approved issues
+5. Commit, dispatch `/land-pr` for the sync PR, then close approved issues on GitHub (only after PR merges)
+
+### `plan [auto]`
+
+Draft plans for issues previously skipped as "too complex." Scans the sprint report for skipped items and dispatches `/draft-plan` for each. No fixing -- just creates plans for `/run-plan` to execute later. With `auto`, plans all found issues without selection.
+
+### `stop`
+
+Cancel any existing `/fix-issues` cron and exit. Takes precedence over all other arguments.
+
+### `next`
+
+Check when the next scheduled run will fire. Shows relative and absolute time.
+
+### `add <N> [column] [pos]`
+
+Add an issue to a dashboard queue column. Early-exit subcommand that mutates `.zskills/monitor-state.json` and exits.
+
+- `<N>` -- GitHub issue number (required)
+- `[column]` -- One of `triage`, `ready`, `backlog` (default: `ready`)
+- `[pos]` -- 1-based insertion position (default: append)
+
+### `remove <N> [column]`
+
+Remove an issue from a dashboard queue column.
+
+- `<N>` -- GitHub issue number (required)
+- `[column]` -- One of `triage`, `ready`, `backlog` (default: `ready`)
+
+### `reconsider <N>`
+
+Flag a previously-skipped issue for re-evaluation on the next sprint. Annotates the issue's section in `ISSUES_PLAN.md` with a reconsidered marker so Phase 2 re-triages it independently.
+
+## Examples
+
+```
+/fix-issues 30
+/fix-issues 10 correctness
+/fix-issues 5 auto
+/fix-issues 5 auto every 4h
+/fix-issues 5 auto every 4h now
+/fix-issues 10 auto every day at 9am
+/fix-issues sync
+/fix-issues plan
+/fix-issues plan auto
+/fix-issues stop
+/fix-issues next
+/fix-issues 5 auto pr
+/fix-issues 3 auto direct
+/fix-issues 1 every 30m dashboard auto
+/fix-issues 3 dashboard
+/fix-issues add 700
+/fix-issues add 700 triage
+/fix-issues add 700 ready 1
+/fix-issues remove 700
+/fix-issues reconsider 717
+```
+
+## Common Patterns
+
+- **Queue-worker pattern:** `/fix-issues 1 every 30m dashboard auto` -- fix one issue every 30 minutes from the dashboard Ready queue
+- **Daily sprint:** `/fix-issues 10 auto every day at 9am now` -- schedule daily at 9am and run immediately
+- **One-time burst:** `/fix-issues 5 auto pr` -- fix 5 issues autonomously, each as a separate PR
+- **Sync hygiene:** `/fix-issues sync` before starting a sprint to ensure trackers are up to date
+- **Plan complex issues:** after a sprint skips issues, `/fix-issues plan auto` to draft plans for them
+
+## Tips & Gotchas
+
+- `auto` does NOT bypass the human-approval gate on `gh issue close` in sync mode -- only the tracker-PR auto-merge is unconditional
+- `dashboard` is mutually exclusive with `focus`, `sync`, `plan`, `stop`, `next`, `add`, `remove`, and `reconsider`
+- `direct` mode is incompatible with `execution.main_protected: true`
+- Cron is session-scoped -- it dies when the session dies
+- `every SCHEDULE` implies `auto` (scheduling only makes sense for autonomous runs)
+- Landing mode resolution: explicit argument > config default (`execution.landing`) > `cherry-pick` fallback
+- The skill runs at the top level -- it cannot be dispatched from a subagent

--- a/docs/skills/fix-report.md
+++ b/docs/skills/fix-report.md
@@ -1,0 +1,40 @@
+# /fix-report
+
+> Review ALL unreported sprint results: walk through manual verifications, land fixes to main, close GitHub issues, update trackers, clean up worktrees.
+
+## Usage
+
+```
+/fix-report
+```
+
+No arguments -- the skill is always interactive and guides you through each step.
+
+## Workflow
+
+1. **Read sprint report** -- scan all entries from recent sprints
+2. **Present findings** -- show each fix with its status, verification state, and worktree
+3. **Manual verification** -- for each fix, verify it works correctly
+4. **Land fixes** -- cherry-pick verified fixes to main
+5. **Close issues** -- close GitHub issues for landed fixes
+6. **Update trackers** -- mark issues as resolved in tracker files
+7. **Clean up** -- remove worktrees for landed fixes
+
+## Examples
+
+```
+/fix-report
+```
+
+## Common Patterns
+
+- **After autonomous sprints:** if `/fix-issues auto` has been running on a cron, `/fix-report` presents everything from those runs
+- **Interactive companion:** always interactive -- the human review counterpart to `/fix-issues auto`
+
+## Tips & Gotchas
+
+- Always interactive -- no `auto` flag. Every step ends with STOP AND WAIT for user approval
+- Covers ALL unreported sprint results, not just the latest report
+- If sprints have been running on a cron for hours, this skill presents everything accumulated
+- Works in a pre-created worktree under `execution.main_protected: true`
+- The final landing of changes is the user's call (typically `/commit pr` from the worktree)

--- a/docs/skills/investigate.md
+++ b/docs/skills/investigate.md
@@ -1,0 +1,59 @@
+# /investigate
+
+> Deep debugging for one complex bug at a time. Disciplined workflow: reproduce, trace, state root cause, fix, verify. The agent must PROVE root-cause understanding before writing a fix.
+
+## Usage
+
+```
+/investigate <description or #issue>
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `description` | Yes | Description of the bug, or a GitHub issue number |
+
+## Examples
+
+```
+/investigate #387
+/investigate Scope block shows NaN after 10 seconds of simulation
+/investigate test failure in tests/blocks/pid.test.js "derivative term"
+```
+
+## Workflow
+
+### Phase 1 -- Reproduce
+
+See the bug. Confirm it exists. Get a reproducible test case or steps.
+
+### Phase 2 -- Trace
+
+Follow the execution path. Read the code. Identify where the behavior diverges from expectations.
+
+### Phase 3 -- Root Cause
+
+State the root cause explicitly. You may not write a fix until this phase is complete.
+
+### Phase 4 -- Fix
+
+Write the minimal fix that addresses the root cause.
+
+### Phase 5 -- Verify
+
+Confirm the fix resolves the issue. Run tests. Check for regressions.
+
+## Common Patterns
+
+- **GitHub issue:** `/investigate #387` -- fetches the issue body and comments as the starting point
+- **Error message:** `/investigate Scope block shows NaN after 10 seconds` -- start from a symptom description
+- **Test failure:** `/investigate test failure in tests/blocks/pid.test.js` -- start from a specific failing test
+- **After /fix-issues skip:** when `/fix-issues` skips an issue as too complex, `/investigate` is the follow-up
+
+## Tips & Gotchas
+
+- One bug at a time -- this is not `/fix-issues`. For batch fixing, redirect to `/fix-issues`
+- Every phase is gated -- you cannot skip to writing a fix without proving root-cause understanding
+- `/fix-issues` should escalate here when a fix agent fails after 2 attempts
+- The escalation boundary is the user's decision -- no automatic escalation from `/fix-issues`

--- a/docs/skills/manual-testing.md
+++ b/docs/skills/manual-testing.md
@@ -1,0 +1,45 @@
+# /manual-testing
+
+> Block-diagram editor manual testing recipes for playwright-cli using real mouse/keyboard events (add blocks, connect ports, run simulations, edit parameters).
+
+## Usage
+
+```
+/manual-testing
+```
+
+No arguments -- the skill provides testing recipes for the block-diagram editor.
+
+## Prerequisites
+
+1. Start the dev server
+2. Open the browser with playwright-cli
+3. Bypass the auth gate
+
+## Workflow
+
+The skill provides recipes for testing with real mouse/keyboard events:
+
+- Adding blocks to the canvas
+- Connecting ports between blocks
+- Running simulations
+- Editing block parameters
+- Verifying UI behavior
+
+## Examples
+
+```
+/manual-testing
+```
+
+## Common Patterns
+
+- **After UI changes:** use `/manual-testing` recipes to verify the editor works correctly
+- **Verification complement:** used alongside automated tests for visual/interactive verification
+
+## Tips & Gotchas
+
+- Uses **real mouse/keyboard events** (`click`, `type`, `press`, `drag`) -- never `page.evaluate()` for user actions
+- `eval`/JS is only for setup and assertions (auth bypass, reading state, querying DOM)
+- Requires the dev server to be running and playwright-cli to be available
+- The auth gate must be bypassed before testing

--- a/docs/skills/plans.md
+++ b/docs/skills/plans.md
@@ -1,0 +1,42 @@
+# /plans
+
+> Plan dashboard. View plan status, find the next ready plan. For batch execution, see `/work-on-plans`.
+
+## Usage
+
+```
+/plans [rebuild | next | details]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| (no args) | -- | Display the current plan index (highlights top-priority ready plan) |
+| `rebuild` | No | Scan all plans, classify, and regenerate the index |
+| `next` | No | Show the highest-priority ready-to-run plan with command |
+| `details` | No | Show every plan with a one-line description |
+
+## Examples
+
+```
+/plans
+/plans rebuild
+/plans next
+/plans details
+```
+
+## Common Patterns
+
+- **Check what's ready:** `/plans next` -- see the highest-priority plan ready for execution
+- **Full overview:** `/plans details` -- see all plans with descriptions
+- **Refresh index:** `/plans rebuild` -- rescan and reclassify all plans
+- **Before /work-on-plans:** use `/plans` to review the queue before batch execution
+
+## Tips & Gotchas
+
+- All modes consume the Phase 4 Python aggregator (`collect.py`) -- never re-parses plan frontmatter directly
+- The aggregator is the canonical classifier -- this skill is a thin renderer
+- For batch execution of plans, use `/work-on-plans` instead
+- Plans are classified by category: canary, issue_tracker, reference, executable
+- Plan status comes from frontmatter: `active`, `complete`, `landed`, `conflict`

--- a/docs/skills/playwright-cli.md
+++ b/docs/skills/playwright-cli.md
@@ -1,0 +1,69 @@
+# /playwright-cli
+
+> Browser automation with playwright-cli. Navigate websites, interact with pages, fill forms, take screenshots, test web applications, and extract information.
+
+## Usage
+
+```
+/playwright-cli
+```
+
+The skill provides the `playwright-cli` tool for browser automation.
+
+## Commands
+
+### Core
+
+```
+playwright-cli open                        # Open new browser
+playwright-cli open https://example.com    # Open and navigate
+playwright-cli goto https://playwright.dev # Navigate to URL
+playwright-cli type "search query"         # Type text
+playwright-cli click e3                    # Click element by ref
+playwright-cli dblclick e7                 # Double-click
+playwright-cli fill e5 "user@example.com" # Fill input field
+playwright-cli drag e2 e8                 # Drag element
+playwright-cli hover e4                   # Hover over element
+playwright-cli press Enter                # Press key
+playwright-cli screenshot                 # Take screenshot
+playwright-cli close                      # Close browser
+```
+
+### Navigation
+
+```
+playwright-cli goto <url>     # Navigate to URL
+playwright-cli back           # Go back
+playwright-cli forward        # Go forward
+playwright-cli reload         # Reload page
+```
+
+### Interaction
+
+```
+playwright-cli click <ref>       # Click element
+playwright-cli dblclick <ref>    # Double-click
+playwright-cli type <text>       # Type text
+playwright-cli fill <ref> <text> # Fill input
+playwright-cli press <key>       # Press key
+playwright-cli drag <from> <to>  # Drag element
+playwright-cli hover <ref>       # Hover
+```
+
+## Examples
+
+```
+playwright-cli open https://example.com
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+playwright-cli screenshot
+playwright-cli close
+```
+
+## Tips & Gotchas
+
+- Use `playwright-cli screenshot` without `--filename` to save to the configured output directory (`.playwright/output/`)
+- Using `--filename` bypasses the output directory and saves to the working directory
+- Element references (e.g., `e3`, `e15`) come from the page snapshot
+- This is a tool allowlist skill -- it enables `Bash(playwright-cli:*)` commands

--- a/docs/skills/qe-audit.md
+++ b/docs/skills/qe-audit.md
@@ -1,0 +1,60 @@
+# /qe-audit
+
+> QE audit: check recent commits for test coverage gaps, or bash/stress-test features to find bugs. Files GitHub issues for findings. Recurring via `every SCHEDULE`; `stop`/`next` manage it.
+
+## Usage
+
+```
+/qe-audit [bash [area]] [every SCHEDULE] [now]
+/qe-audit stop
+/qe-audit next
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `bash` | No | Switch to bash/stress-test mode instead of commit audit |
+| `area` | No (with bash) | Specific feature area to stress-test (e.g., `undo/redo`, `solver`, `codegen`) |
+| `every SCHEDULE` | No | Self-schedule recurring runs (`4h`, `day at 9am`, etc.) |
+| `now` | No | Run immediately (with `every`: run now AND schedule) |
+| `stop` | No | Cancel the recurring cron |
+| `next` | No | Check when the next run will fire |
+
+## Modes
+
+### Commit Audit (default)
+
+Review recent commits for test coverage gaps, missing tests, and bugs. Files GitHub issues for findings.
+
+### Bash Mode
+
+Adversarial stress-testing of features. Pick a specific area or let the agent choose under-tested areas. Try to break things with edge cases, unusual inputs, and unexpected workflows.
+
+## Examples
+
+```
+/qe-audit
+/qe-audit bash
+/qe-audit bash undo/redo
+/qe-audit bash solver
+/qe-audit every day at 9am
+/qe-audit every 4h now
+/qe-audit bash every 12h
+/qe-audit stop
+/qe-audit next
+```
+
+## Common Patterns
+
+- **Daily audit:** `/qe-audit every day at 9am` -- schedule a daily commit audit
+- **Targeted stress test:** `/qe-audit bash solver` -- stress-test the solver specifically
+- **Quality feedback loop:** `/qe-audit` finds gaps, `/fix-issues` fixes them, `/qe-audit` validates
+
+## Tips & Gotchas
+
+- Both modes file GitHub issues and update the QE issues tracker
+- The commit audit mode examines recent commits, not the entire codebase
+- Bash mode is adversarial -- it actively tries to break features
+- Scheduling follows the same `every SCHEDULE` pattern as other skills
+- Cron is session-scoped -- it dies when the session dies

--- a/docs/skills/quickfix.md
+++ b/docs/skills/quickfix.md
@@ -1,0 +1,61 @@
+# /quickfix
+
+> Ship an in-flight edit (or short agent-authored fix) from main as a one-commit PR without a worktree. Lifecycle: triage, review, commit, verify, push, PR, CI poll, fix cycle (dispatched via `/land-pr`).
+
+## Usage
+
+```
+/quickfix [<description>] [auto] [from-here] [skip-tests] [force] [--branch <name>] [--rounds N]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `description` | Conditional | Required when tree is clean (agent-dispatched mode); describes what to fix |
+| `auto` | No | Auto-merge the resulting PR via `/land-pr` |
+| `from-here` | No | Override the "must run on main/master" check |
+| `skip-tests` | No | Skip the test gate (warn-only; for emergency hotfixes) |
+| `force` | No | Bypass triage REDIRECT and review REJECT |
+| `--branch <name>` | No | Override the auto-generated branch name |
+| `--rounds N` | No | Max review/refine cycles (default 1; `0` skips review) |
+
+## Modes (auto-detected)
+
+| Dirty tree? | Description? | Mode | Behavior |
+|-------------|-------------|------|----------|
+| Yes | Yes | **user-edited** | Pick up dirty tree edits, commit under description |
+| Yes | No | -- | Exit 2 (description required in user-edited mode) |
+| No | Yes | **agent-dispatched** | Dispatch an agent to implement, then commit |
+| No | No | -- | Exit 2 (need edits or description) |
+
+## Examples
+
+```
+/quickfix Fix README typo
+/quickfix Fix README typo auto
+/quickfix Fix the broken link in docs/intro.md
+/quickfix Update CHANGELOG with v0.5 release notes force
+/quickfix Add comment to canary-marker.txt --branch fix/canary-comment
+/quickfix Fix parser edge case skip-tests
+/quickfix Refactor the test helper --rounds 2
+```
+
+## Common Patterns
+
+- **Ship an in-flight edit:** make your edit on main, then `/quickfix Fix README typo auto` -- creates a branch, commits, pushes, opens a PR, and auto-merges
+- **Agent-authored fix:** on a clean main, `/quickfix Fix the broken link in docs/intro.md` -- dispatches an agent to implement, then runs the full PR lifecycle
+- **Emergency hotfix:** `/quickfix Fix critical auth bug skip-tests force auto` -- bypass all gates and ship fast
+- **Custom branch name:** `/quickfix Update changelog --branch release/v1.0-changelog` -- override the auto-generated branch name
+
+## Tips & Gotchas
+
+- `/quickfix` is PR-shaped end-to-end -- when `execution.landing` is `worktree` or `direct`, it soft-redirects to `/do worktree` or `/commit` respectively
+- The skill runs on main and creates a feature branch via `git checkout -b` -- dirty edits carry across
+- Triage gate may redirect to `/draft-plan`, `/fix-issues`, or `/run-plan` if the task scope is too large -- use `force` to bypass
+- A fresh-agent plan review runs by default -- `--rounds 0` skips it
+- Verification (`/verify-changes`) runs before push unless `force` or `skip-tests` is set
+- No `.landed` marker is written -- `/quickfix` does not use worktrees
+- Branch naming: `<branch_prefix><slug>` where prefix defaults to `quickfix/` (configurable via `execution.branch_prefix`)
+- The `auto` token enables auto-merge AND skips the WI 1.5.5 dirty-tree confirmation prompt
+- On test failure: edits stay in the working tree, but the branch is deleted and you return to the base branch

--- a/docs/skills/refine-plan.md
+++ b/docs/skills/refine-plan.md
@@ -1,0 +1,42 @@
+# /refine-plan
+
+> Refine an in-progress plan by reviewing remaining phases against completed work. Dispatches reviewer + devil's-advocate agents to surface stale references, invalidated assumptions, and specification gaps, then refines until convergence.
+
+## Usage
+
+```
+/refine-plan <plan-file> [rounds N] [auto] [guidance...]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `plan-file` | Yes | Path to the existing plan file |
+| `rounds N` | No | Maximum adversarial review rounds |
+| `auto` | No | Skip confirmation checkpoints; dispatch `/land-pr` for results |
+| `guidance` | No | Additional guidance for the refinement |
+
+## Examples
+
+```
+/refine-plan plans/FEATURE_PLAN.md
+/refine-plan plans/FEATURE_PLAN.md rounds 5
+/refine-plan plans/FEATURE_PLAN.md auto
+/refine-plan plans/FEATURE_PLAN.md The solver API changed since Phase 2
+```
+
+## Common Patterns
+
+- **Mid-execution refresh:** `/refine-plan plans/X.md` -- update remaining phases based on what was actually built
+- **With context:** `/refine-plan plans/X.md The API signature changed in Phase 3`
+- **Auto (from /run-plan):** `/refine-plan plans/X.md auto` -- used when `/run-plan` detects staleness
+
+## Tips & Gotchas
+
+- Must run at top level -- internally dispatches reviewer, devil's-advocate, and refiner sub-agents
+- Completed phases are NEVER modified -- they are read-only context, not modification targets
+- Immutability is verified mechanically: completed phase sections must be byte-identical before and after
+- The key insight: plans drift during execution. Completed phases may have built something different from what was specified. This skill closes that gap.
+- Appends a Drift Log and Plan Review section to the plan
+- `/run-plan` auto-dispatches `/refine-plan` when it detects staleness markers in the plan

--- a/docs/skills/research-and-go.md
+++ b/docs/skills/research-and-go.md
@@ -1,0 +1,36 @@
+# /research-and-go
+
+> Full pipeline: decompose a broad goal into sub-plans, draft each with adversarial review, then execute all of them autonomously via `/run-plan`. One command, walk away.
+
+## Usage
+
+```
+/research-and-go <description>
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `description` | Yes | The broad goal, in natural language |
+
+## Examples
+
+```
+/research-and-go Build a complete physics simulation engine
+/research-and-go Add dark mode support with theme persistence
+/research-and-go Implement undo/redo for the block editor with state snapshots
+```
+
+## Common Patterns
+
+- **Full autonomous execution:** `/research-and-go Build an RPG` -- decompose, plan, review, and execute everything
+- **When you trust the pipeline:** use when you want end-to-end execution from a single description without checkpoints
+
+## Tips & Gotchas
+
+- Must run at top level -- internally dispatches multiple sub-agents
+- Same as `/research-and-plan` but continues into execution via `/run-plan` after planning
+- For more control, use `/research-and-plan` (plan only) then `/run-plan` (execute) separately
+- The planning phase uses adversarial review -- multiple agents research, draft, and review each sub-plan
+- Execution happens via `/run-plan` for each sub-plan in dependency order

--- a/docs/skills/research-and-plan.md
+++ b/docs/skills/research-and-plan.md
@@ -1,0 +1,39 @@
+# /research-and-plan
+
+> Decompose a broad goal into a sequence of executable sub-plans. Researches the domain, identifies sub-problems and dependencies, produces a meta-plan whose phases each delegate to `/run-plan`.
+
+## Usage
+
+```
+/research-and-plan [output FILE] [auto] <broad goal description>
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `description` | Yes | The broad goal, in natural language |
+| `output FILE` | No | Meta-plan output path (default: auto-derived `<slug>_META.md`) |
+| `auto` | No | Skip the decomposition confirmation checkpoint |
+
+## Examples
+
+```
+/research-and-plan Build a complete physics simulation engine
+/research-and-plan output plans/PHYSICS_META.md Build physics simulation
+/research-and-plan auto Implement undo/redo for the block editor
+```
+
+## Common Patterns
+
+- **Standard decomposition:** `/research-and-plan Build physics blocks` -- research, decompose, draft each sub-plan
+- **Custom output:** `/research-and-plan output plans/PHYSICS_META.md Build physics blocks`
+- **Review before execution:** use `/research-and-plan` to produce the meta-plan, review it, then `/run-plan` to execute
+
+## Tips & Gotchas
+
+- Must run at top level -- internally dispatches reviewer, devil's-advocate, and refiner sub-agents
+- The output is a meta-plan whose phases are pure delegation -- each phase invokes `/run-plan` on a sub-plan
+- No drafting happens during execution -- all sub-plans are drafted upfront
+- For fully autonomous operation (plan + execute), use `/research-and-go` instead
+- If escalated from `/draft-plan` (the goal is too broad for a single plan), the escalation context is preserved

--- a/docs/skills/review-feedback.md
+++ b/docs/skills/review-feedback.md
@@ -1,0 +1,42 @@
+# /review-feedback
+
+> Review exported feedback JSON from the in-app feedback panel, evaluate each pending entry, and selectively file GitHub issues.
+
+## Usage
+
+```
+/review-feedback [path-to-feedback.json]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `path-to-feedback.json` | No | Path to the exported feedback file (default: `feedback.json` in repo root) |
+
+## Workflow
+
+1. **Read** the feedback JSON file
+2. **Evaluate** each pending entry: is it actionable? Check for duplicates via `gh issue list --search`
+3. **Re-rate severity** independently (impact: data loss > crash > broken feature > polish > nit)
+4. **Present** findings in a table with severity, category, and recommendation
+5. **File issues** for approved entries on GitHub
+
+## Examples
+
+```
+/review-feedback
+/review-feedback exports/feedback-2026-05-27.json
+```
+
+## Common Patterns
+
+- **Regular triage:** `/review-feedback` -- review feedback exported from the app's feedback panel
+- **Custom file:** `/review-feedback path/to/feedback.json` -- specify a non-default export file
+
+## Tips & Gotchas
+
+- The feedback JSON is exported from the app via **Feedback Panel > History > Export JSON**
+- Severity is independently re-rated -- the reporter's self-rated severity is a hint, not authoritative
+- Duplicate detection uses `gh issue list --search` to check for existing issues
+- Filed issues include the original feedback text and the agent's severity assessment

--- a/docs/skills/run-plan.md
+++ b/docs/skills/run-plan.md
@@ -1,0 +1,84 @@
+# /run-plan
+
+> Execute the next phase of a plan: parse status, dispatch implementation in a worktree, verify via a separate agent, update progress, write the plan report, and optionally auto-land to main. Self-schedules via cron; use `next` to check, `stop` to cancel.
+
+## Usage
+
+```
+/run-plan <plan-file> [phase|finish|status] [auto] [pr|direct] [every SCHEDULE] [now]
+/run-plan stop
+/run-plan next
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `plan-file` | Yes | Path to plan file (e.g., `plans/FEATURE_PLAN.md`) |
+| `phase` | No | Specific phase to run (e.g., `4a`). If omitted, auto-detects next incomplete phase |
+| `finish` | No | Run ALL remaining phases sequentially until the plan is complete |
+| `status` | No | Show plan progress (read-only, no agents dispatched) |
+| `auto` | No | Skip approval prompts, auto-merge resulting PRs |
+| `pr` | No | Land via PR on a named branch |
+| `direct` | No | Work directly on main (no PR, no cherry-pick) |
+| `every SCHEDULE` | No | Self-schedule recurring runs (`4h`, `30m`, `day at 9am`) |
+| `now` | No | Run immediately (with `every`: run now AND schedule) |
+
+## Subcommands
+
+### `status`
+
+Show plan progress: all phases, their status (Done, In Progress, Not Started, Blocked), and what's next. Read-only -- no agents dispatched. If a cron is active, also shows the schedule.
+
+### `finish`
+
+Run all remaining phases sequentially. Without `auto`: pauses between phases to show results and ask "continue?" With `auto` (`finish auto`): each phase runs as its own cron-fired turn with ~5 min between phases. If any phase fails, stops there.
+
+### `stop`
+
+Cancel any existing `/run-plan` cron, release all plan claims, and exit. Takes precedence over all other arguments.
+
+### `next`
+
+Check when the next scheduled run will fire. Shows both relative and absolute time.
+
+### `now` (standalone)
+
+Trigger the active cron's plan immediately. Extracts N, plan-file, auto, and schedule from the cron's prompt and runs. The cron stays active.
+
+## Examples
+
+```
+/run-plan plans/FEATURE_PLAN.md
+/run-plan plans/FEATURE_PLAN.md 4b
+/run-plan plans/FEATURE_PLAN.md finish
+/run-plan plans/FEATURE_PLAN.md finish auto
+/run-plan plans/FEATURE_PLAN.md auto every 4h
+/run-plan plans/FEATURE_PLAN.md auto every 4h now
+/run-plan plans/FEATURE_PLAN.md finish auto pr
+/run-plan plans/FEATURE_PLAN.md direct
+/run-plan plans/FEATURE_PLAN.md status
+/run-plan now
+/run-plan stop
+/run-plan next
+```
+
+## Common Patterns
+
+- **Single phase:** `/run-plan plans/X.md` -- run the next incomplete phase interactively
+- **Full autonomous execution:** `/run-plan plans/X.md finish auto pr` -- run all remaining phases, each as a PR, auto-merged
+- **Scheduled execution:** `/run-plan plans/X.md auto every 4h now` -- schedule recurring runs and start immediately
+- **Check progress:** `/run-plan plans/X.md status` -- see which phases are done, in progress, or blocked
+- **Resume after pause:** `/run-plan now` -- trigger the active cron early without waiting for the next fire
+
+## Tips & Gotchas
+
+- `finish` and `every` are mutually exclusive -- `finish auto` schedules its own internal one-shot crons
+- `finish auto` is a composite alias: it sets both `FINISH_MODE=finish-auto` and `AUTO_FLAG=1`
+- Landing mode resolution: explicit argument > config default (`execution.landing`) > `cherry-pick` fallback
+- `direct` mode is incompatible with `execution.main_protected: true`
+- The plan file is parsed using LLM comprehension, not rigid regex -- it handles progress tracker tables, numbered phase sections, checklists, and narrative formats
+- Cron is session-scoped -- it dies when the session dies
+- In PR mode, plan tracker updates commit on the feature branch (not main) until the squash merge lands
+- Phase dependencies are checked before execution -- if a prerequisite phase is not Done, the skill stops
+- An adaptive backoff mechanism handles "in progress" phases: the cron cadence slows from `*/1` to `*/10` to `*/30` to `*/60` based on consecutive defers

--- a/docs/skills/session-report.md
+++ b/docs/skills/session-report.md
@@ -1,0 +1,51 @@
+# /session-report
+
+> Audit what THIS session said it would do vs. what's actually shipped. Verifies session-mentioned items against ground truth (git, PRs, plans, worktrees), not conversation memory.
+
+## Usage
+
+```
+/session-report
+```
+
+No arguments.
+
+## Workflow
+
+### Step 1 -- Enumerate session intent
+
+List every concrete deliverable discussed in the current conversation:
+- Features to add, bugs to fix, plans to draft
+- PRs opened, fixed, or merged
+- Skills, scripts, or hooks to write
+- Queued actions
+
+### Step 2 -- Verify against ground truth
+
+For each intent item, verify against the filesystem and git:
+- Does the commit exist?
+- Is the PR merged?
+- Is the file present?
+- Did the plan land?
+
+### Step 3 -- Report
+
+Present a structured comparison of intent vs. actual state.
+
+## Examples
+
+```
+/session-report
+```
+
+## Common Patterns
+
+- **End-of-session audit:** `/session-report` -- check if everything discussed was actually shipped
+- **After long sessions:** especially useful after sessions with context compaction, where items may have been lost
+
+## Tips & Gotchas
+
+- Scope is limited to THIS conversation -- not a repo-wide audit
+- Verifies against filesystem and git, not conversation memory (memory is unreliable due to compaction)
+- Items completed in a different session still show as "done" (verified against ground truth)
+- Items never committed, reverted, or stuck in worktrees show as "not shipped"

--- a/docs/skills/update-zskills.md
+++ b/docs/skills/update-zskills.md
@@ -1,0 +1,67 @@
+# /update-zskills
+
+> Install or update Z Skills supporting infrastructure: CLAUDE.md agent rules, safety hooks, helper scripts, and skill dependencies.
+
+## Usage
+
+```
+/update-zskills [install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct]
+                [--with-addons | --with-block-diagram-addons]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `install` | No | Force a full first-time setup (skip detection step) |
+| `--rerender` | No | Regenerate `.claude/rules/zskills/managed.md` from current config |
+| `--migrate-paths` | No | One-shot relocation of legacy artifacts into path-config layout |
+| `cherry-pick` | No | Landing mode: cherry-pick changes |
+| `locked-main-pr` | No | Landing mode: PR when main is protected |
+| `direct` | No | Landing mode: direct to main |
+| `--with-addons` | No | Include add-on skills |
+| `--with-block-diagram-addons` | No | Include block-diagram add-on skills |
+
+## Modes
+
+### Default (no argument)
+
+Smart detection: if nothing is installed, does a full install. If already installed, pulls latest, updates changed skills, and fills new gaps. Always begins with an audit.
+
+### `install`
+
+Force a full first-time setup, skipping the detection step.
+
+### `--rerender`
+
+Regenerate `.claude/rules/zskills/managed.md` against the current config. Simple full-file rewrite. No audit, no preset, no hooks/scripts touched.
+
+### `--migrate-paths`
+
+One-shot deterministic relocation of legacy artifacts into the path-config layout (`docs/plans/` for plan files, `.zskills/audit/` for reports, `docs/issues/` for issue trackers). Idempotent -- refuses to re-run if the migration manifest already exists.
+
+## Examples
+
+```
+/update-zskills
+/update-zskills install
+/update-zskills --rerender
+/update-zskills --migrate-paths
+/update-zskills install --with-addons
+/update-zskills install --with-block-diagram-addons
+/update-zskills install direct
+```
+
+## Common Patterns
+
+- **First install:** `/update-zskills install` -- set up Z Skills infrastructure from scratch
+- **Update existing:** `/update-zskills` -- pull latest changes and update
+- **After config change:** `/update-zskills --rerender` -- regenerate managed rules from config
+- **Migrate legacy layout:** `/update-zskills --migrate-paths` -- move artifacts to the standard path-config layout
+
+## Tips & Gotchas
+
+- The default mode audits the current state and reports what was found and what was done
+- `--rerender` only touches `.claude/rules/zskills/managed.md` -- it never modifies `./CLAUDE.md`
+- `--migrate-paths` writes a `.pre-paths-migration` manifest as a write-once idempotency lock
+- Add-on skills (`--with-addons`) provide domain-specific functionality (e.g., block-diagram skills)

--- a/docs/skills/verify-changes.md
+++ b/docs/skills/verify-changes.md
@@ -1,0 +1,44 @@
+# /verify-changes
+
+> Verify all recent changes: review diffs, check that unit/e2e tests cover the changes, run all tests, manually verify UI changes with playwright-cli, fix problems, re-verify until clean, then report with recommendations.
+
+## Usage
+
+```
+/verify-changes [scope: worktree | branch | last [N]]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `worktree` | No | Verify changes in the current worktree |
+| `branch` | No | Verify all commits on the current branch |
+| `last N` | No | Verify the last N commits |
+
+When no scope is given, defaults to verifying the current working tree changes.
+
+## Examples
+
+```
+/verify-changes
+/verify-changes worktree
+/verify-changes branch
+/verify-changes last 3
+```
+
+## Common Patterns
+
+- **Pre-commit verification:** `/verify-changes` -- verify everything before committing
+- **Worktree review:** `/verify-changes worktree` -- review all changes in a worktree before landing
+- **Branch audit:** `/verify-changes branch` -- verify all commits on the current feature branch
+
+## Tips & Gotchas
+
+- When invoked at top level (with the Agent tool), dispatches fresh sub-agents for each verification phase -- strongest fresh-eyes guarantee
+- When invoked from within a verifier subagent, falls through to inline single-context verification
+- The 7-phase verification covers: diff review, test coverage audit, full test suite, manual UI verification (if applicable), fix problems, re-verify, report
+- Never verifies from memory -- always reads actual diffs and runs actual tests
+- Dispatched verification agents use `subagent_type: "verifier"` with Layer 3 response validation
+- UI changes require visual verification via playwright-cli screenshots and interactive testing
+- The skill resolves `$FULL_TEST_CMD` from config -- does not hardcode test commands

--- a/docs/skills/work-on-plans.md
+++ b/docs/skills/work-on-plans.md
@@ -1,0 +1,97 @@
+# /work-on-plans
+
+> Batch-execute the prioritized ready queue from the dashboard: reads `.zskills/monitor-state.json` (`plans.ready`) and dispatches `/run-plan auto [finish]` per entry, honoring each plan's queued mode. Also manages the queue (`add`/`rank`/`remove`/`default`) and recurring schedules.
+
+## Usage
+
+```
+/work-on-plans
+/work-on-plans N [phase|finish] [continue]
+/work-on-plans all [phase|finish] [continue]
+/work-on-plans add <slug> [pos]
+/work-on-plans rank <slug> <pos>
+/work-on-plans remove <slug>
+/work-on-plans default <phase|finish>
+/work-on-plans every SCHEDULE [phase|finish] [--force]
+/work-on-plans stop
+/work-on-plans next
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| (no args) | -- | List the ready queue (read-only) |
+| `N` | No | Number of plans to execute from the ready queue |
+| `all` | No | Execute all plans in the ready queue |
+| `phase` | No | Override dispatch mode to single-phase per plan |
+| `finish` | No | Override dispatch mode to finish-all-phases per plan |
+| `continue` | No | Continue to next plan on failure instead of stopping |
+| `next` | No | Print active schedule (read-only) |
+| `stop` | No | Cancel any active cron |
+
+## Subcommands
+
+### `add <slug> [pos]`
+
+Add a plan to the ready queue. The slug must match `^[a-z][a-z0-9-]*$` (no digit-prefix). Optional 1-based position for insertion; default appends.
+
+### `rank <slug> <pos>`
+
+Move an existing ready-queue entry to a new 1-based position.
+
+### `remove <slug>`
+
+Remove a plan from the ready queue. Idempotent -- missing slug exits cleanly.
+
+### `default <phase|finish>`
+
+Set the top-level `default_mode` for newly added entries. Does not mutate saved per-entry modes.
+
+### `every SCHEDULE [phase|finish] [--force]`
+
+Register a recurring cron. Each fire dispatches `/work-on-plans all <schedule_mode>`. Mode is captured at registration (CLI flag > current `default_mode` > `"phase"`). Finish mode requires SCHEDULE >= 1h to avoid collision with `/run-plan`'s phase-chaining crons. Use `--force` to take over a schedule owned by another session.
+
+### `stop`
+
+Cancel the active cron and reset state to idle.
+
+## Examples
+
+```
+/work-on-plans
+/work-on-plans 3
+/work-on-plans all finish
+/work-on-plans 5 phase continue
+/work-on-plans add my-feature-plan
+/work-on-plans add my-feature-plan 1
+/work-on-plans rank my-feature-plan 3
+/work-on-plans remove my-feature-plan
+/work-on-plans default finish
+/work-on-plans every 4h
+/work-on-plans every 2h phase
+/work-on-plans every day at 9am finish --force
+/work-on-plans stop
+/work-on-plans next
+```
+
+## Common Patterns
+
+- **Check queue:** `/work-on-plans` -- see what's queued and the default mode
+- **Run top 3:** `/work-on-plans 3` -- execute the first 3 plans from the ready queue
+- **Run everything:** `/work-on-plans all finish` -- finish all phases of every queued plan
+- **Resilient batch:** `/work-on-plans all continue` -- if one plan fails, skip it and continue
+- **Scheduled execution:** `/work-on-plans every 4h phase` -- run one phase per plan every 4 hours
+- **Priority management:** use `add`, `rank`, `remove` to curate the queue; use `default` to set the baseline mode
+
+## Tips & Gotchas
+
+- Must run at top level (needs the Agent tool to dispatch `/run-plan` via the Skill tool)
+- Mode override (`phase`/`finish`) is per-batch only -- it does not mutate saved per-entry modes or `default_mode`
+- `phase` and `finish` are mutually exclusive
+- Finish-mode schedules require intervals >= 1h to avoid nested cron collision
+- All read-modify-write operations against `monitor-state.json` are serialized via `flock -x`
+- If `monitor-state.json` is missing, it is auto-created (seeded from `PLAN_INDEX.md` or plan frontmatter)
+- Unknown slugs fail loud -- the skill never silently skips a queued slug whose plan file is missing
+- `/run-plan` resolves its own landing mode from config -- `/work-on-plans` does not pass landing-mode flags
+- Schedule mode is captured at registration and persists -- to change mode, `stop` and re-register

--- a/docs/skills/zskills-dashboard.md
+++ b/docs/skills/zskills-dashboard.md
@@ -1,0 +1,46 @@
+# /zskills-dashboard
+
+> Local web dashboard -- plans, issues, worktrees, branches, tracking activity, drag-and-drop priority queue. Starts a detached Python HTTP server; stop sends SIGTERM; restart = stop+start.
+
+## Usage
+
+```
+/zskills-dashboard [start|stop|status|restart]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `start` | No | Launch detached server, write PID file |
+| `stop` | No | SIGTERM the server, remove PID file |
+| `status` | No | Report PID, port, uptime, log path (default when no args) |
+| `restart` | No | Stop then start (pick up Python code changes) |
+
+## Examples
+
+```
+/zskills-dashboard
+/zskills-dashboard start
+/zskills-dashboard stop
+/zskills-dashboard status
+/zskills-dashboard restart
+```
+
+## Common Patterns
+
+- **Start the dashboard:** `/zskills-dashboard start` -- launch the web dashboard
+- **Check status:** `/zskills-dashboard status` (or just `/zskills-dashboard`) -- see if the server is running
+- **After code changes:** `/zskills-dashboard restart` -- pick up Python changes
+- **Clean shutdown:** `/zskills-dashboard stop` -- SIGTERM the server
+
+## Tips & Gotchas
+
+- The server is a stdlib-only Python HTTP server, localhost-bound
+- State is stored in `.zskills/monitor-state.json` with atomic writes
+- PID file is at `.zskills/dashboard-server.pid`
+- Port resolution uses `DEV_PORT` env var, `dev_server.default_port` from config, or `port.sh`
+- Stop uses SIGTERM only -- never escalates to SIGKILL (per CLAUDE.md process-kill rules)
+- Process identity checks verify both command name AND cwd to avoid killing wrong processes
+- The dashboard survives the parent shell (runs detached)
+- `ZSKILLS_DASHBOARD_ROOT` env var overrides the default main-checkout anchor

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fix-issues
 disable-model-invocation: true
-argument-hint: "N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] | reconsider <N>"
+argument-hint: "N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next"
 description: >-
   Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue
   worktrees, verify, optionally auto-land via /land-pr. Recurring via
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.27+cc1460"
+  version: "2026.05.27+1f3da8"
 ---
 
-# /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] | reconsider <N> — Batch Bug-Fixing Sprint
+# /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next — Batch Bug-Fixing Sprint
 
 Orchestrates large-scale bug fixing. Syncs trackers, prioritizes issues,
 dispatches agent teams in worktrees, verifies fixes, writes a persistent

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "(no args = list ready queue) | [N|all] [phase|finish] [continue] | add <slug> [pos] | rank <slug> <pos> | remove <slug> | default <phase|finish> | every SCHEDULE [phase|finish] [--force] | stop | next"
+argument-hint: "(no args = list ready queue) | [N|all] [phase|finish] [continue] | default <phase|finish> | every SCHEDULE [phase|finish] | stop | next"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
@@ -9,7 +9,7 @@ description: >-
   queue (add/rank/remove/default) and recurring schedules. Mirrors
   /fix-issues for bugs.
 metadata:
-  version: "2026.05.26+961662"
+  version: "2026.05.27+11f2e4"
 ---
 
 # /work-on-plans — Batch Plan Executor

--- a/tests/test-work-on-plans.sh
+++ b/tests/test-work-on-plans.sh
@@ -245,11 +245,14 @@ else
   fail "SKILL.md regressed Phase 1 sections"
 fi
 
-# --- Test 4: argument-hint frontmatter advertises full surface ---------
-if grep -q 'argument-hint:.*add <slug>.*every SCHEDULE.*stop' "$SKILL"; then
-  pass "argument-hint advertises full Phase 3 surface"
+# --- Test 4: argument-hint frontmatter advertises core surface ----------
+# Queue-mutation subcommands (add/rank/remove) were moved to the detail
+# docs page to shorten the hint under 120 chars. The hint still covers
+# the execution, default, schedule, and control subcommands.
+if grep -q 'argument-hint:.*default.*every SCHEDULE.*stop' "$SKILL"; then
+  pass "argument-hint advertises core surface (default/every/stop)"
 else
-  fail "argument-hint missing one or more Phase 3 subcommands"
+  fail "argument-hint missing one or more core subcommands"
 fi
 
 # --- Test 5: AC-1 (add bootstraps + appends) ---------------------------


### PR DESCRIPTION
## Summary
- Create `docs/skills/` with comprehensive documentation for all 28 user-invocable skills
- Top-level README.md with categorized table (7 categories) linking to per-skill detail pages
- Each detail page covers: purpose, syntax, arguments, subcommands, examples, patterns, tips
- Shorten `argument-hint` for `/fix-issues` (160→97 chars) and `/work-on-plans` (200→88 chars) to fix Claude Code UI truncation

## Test plan
- [x] 28 detail pages + 1 index created
- [x] argument-hint shortened for fix-issues and work-on-plans (both under 120 chars)
- [x] Mirrors updated for both skills
- [x] Full test suite: 5953/5953 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
