### PR TITLE
fix(fix-issues): move reconsider from ISSUES_PLAN.md to monitor-state.json

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.28+3ee00e"
+  version: "2026.05.27+9ed4c1"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -54,9 +54,30 @@ if [ -z "${ZSKILLS_ISSUES_DIR:-}" ]; then
   exit 1
 fi
 
+# Read the reconsider list from monitor-state.json (one-shot signal).
+# Issues in this list have their skip-code suppressed so Phase 2
+# re-evaluates them. After emitting them as candidates, we remove them
+# from the list so the signal doesn't persist across sprints.
+MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
+STATE_FILE="${MAIN_ROOT:+$MAIN_ROOT/.zskills/monitor-state.json}"
+RECONSIDER_NUMS=""
+if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
+  RECONSIDER_NUMS=$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    nums = data.get('issues', {}).get('reconsider', [])
+    print(' '.join(str(n) for n in nums))
+except Exception:
+    pass
+" "$STATE_FILE" 2>/dev/null) || RECONSIDER_NUMS=""
+fi
+
 RESEARCHED=()
 MISSING=()
 SKIP_TAGGED=()
+RECONSIDERED_PROCESSED=()
 
 for N in "$@"; do
   # Skip non-numeric tokens defensively.
@@ -77,19 +98,22 @@ for N in "$@"; do
   # Awk also extracts the Action-now value (substring after the bold
   # marker) and prints `SKIP=<code>` if it resolves to one of the three
   # canonical dashboard skip-codes via POSIX-portable boundary matching.
+  # Check if this issue is in the reconsider list (monitor-state.json).
+  is_reconsidered=0
+  case " $RECONSIDER_NUMS " in
+    *" $N "*) is_reconsidered=1 ;;
+  esac
+
   found=0
   skip_code=""
   for f in "$ZSKILLS_ISSUES_DIR"/*.md; do
     [ -f "$f" ] || continue
-    out=$(awk -v n="$N" '
+    out=$(awk -v n="$N" -v recon="$is_reconsidered" '
       $0 ~ "^### #" n " " { in_sec=1; next }
       in_sec && /^### / { exit }
-      # If **Reconsidered:** appears in this section, suppress skip-code
-      # emission — the user has flagged this issue for re-evaluation.
-      in_sec && index($0, "**Reconsidered:**") > 0 { reconsidered=1 }
       in_sec && index($0, "**Action now:**") > 0 {
         print "HIT"
-        if (reconsidered) { exit }
+        if (recon) { exit }
         if (match($0, /\*\*Action now:\*\*[[:space:]]*/)) {
           val = substr($0, RSTART + RLENGTH)
           # Lowercase for case-insensitive prefix matching.
@@ -128,6 +152,9 @@ for N in "$@"; do
     if [ -n "$skip_code" ]; then
       SKIP_TAGGED+=("$N:$skip_code")
     fi
+    if [ "$is_reconsidered" -eq 1 ]; then
+      RECONSIDERED_PROCESSED+=("$N")
+    fi
   else
     MISSING+=("$N")
   fi
@@ -136,3 +163,36 @@ done
 printf 'RESEARCHED="%s"\n' "${RESEARCHED[*]}"
 printf 'MISSING="%s"\n' "${MISSING[*]}"
 printf 'SKIP_TAGGED="%s"\n' "${SKIP_TAGGED[*]}"
+
+# One-shot cleanup: remove processed reconsider entries from
+# monitor-state.json so the signal doesn't persist across sprints.
+if [ "${#RECONSIDERED_PROCESSED[@]}" -gt 0 ] && [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
+  REMOVE_LIST=$(printf '%s\n' "${RECONSIDERED_PROCESSED[@]}" | tr '\n' ' ' | sed 's/ $//')
+  python3 -c "
+import json, sys, os, tempfile
+
+path = sys.argv[1]
+remove = set(int(x) for x in sys.argv[2:])
+
+with open(path) as f:
+    data = json.load(f)
+
+cur = data.get('issues', {}).get('reconsider', [])
+after = [n for n in cur if n not in remove]
+
+if len(after) == len(cur):
+    sys.exit(0)
+
+if after:
+    data['issues']['reconsider'] = after
+else:
+    data.get('issues', {}).pop('reconsider', None)
+
+tmp = tempfile.NamedTemporaryFile('w', delete=False,
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(data, tmp, indent=2)
+tmp.write('\n')
+tmp.close()
+os.replace(tmp.name, path)
+" "$STATE_FILE" ${RECONSIDERED_PROCESSED[*]} 2>/dev/null || true
+fi

--- a/.claude/skills/fix-issues/subcommands/reconsider.md
+++ b/.claude/skills/fix-issues/subcommands/reconsider.md
@@ -1,88 +1,59 @@
 ## Reconsider (if `reconsider` is present)
 
 Flag a previously-skipped issue for re-evaluation on the next sprint. This
-is an early-exit subcommand that annotates the issue's section in
-`$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md` and exits — it does NOT proceed to
-Phase 0/1/2.
+is an early-exit subcommand that adds the issue number to the
+`issues.reconsider` list in `.zskills/monitor-state.json` and exits — it
+does NOT proceed to Phase 0/1/2.
 
 **Syntax:** `reconsider <N>`
 - `<N>` — positive integer (GitHub issue number). REQUIRED.
 
 **Behavior:**
-- Finds the `### #<N> ` section in `$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md`.
-- Appends `**Reconsidered:** user flagged prior classification as incorrect — re-evaluate independently.` after the `**Action now:**` line.
-- Idempotent: if the section already contains `**Reconsidered:**`, exit 0 with a note.
-- If `### #<N> ` is not found in ISSUES_PLAN.md, exit 1 with an error.
+- Adds `<N>` to the `issues.reconsider` array in `.zskills/monitor-state.json`.
+- Creates the `issues.reconsider` key if absent; deduplicates.
+- Idempotent: if the number is already in the list, exit 0 with a note.
+- Atomic write via Python tempfile + `os.replace`.
 
-The annotation does NOT delete the existing blurb (keeps original research
-for context). On the next `/fix-issues` fire, `filter-unresearched-candidates.sh`
-sees the `**Reconsidered:**` marker and suppresses skip-code emission for
-that issue, allowing Phase 2 to re-triage it independently.
+The reconsider list is a one-shot signal. On the next `/fix-issues` fire,
+`filter-unresearched-candidates.sh` reads the list and suppresses
+skip-code emission for listed issues, allowing Phase 2 to re-triage them
+independently. After the sprint processes the issue, the filter script
+removes it from the list (one-shot: flag once, re-evaluate once, clear).
 
-<!-- allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /ISSUES_PLAN.md tail -->
 ```bash
 if [ "$RECONSIDER_MODE" = "1" ]; then
   ISSUE_NUM="$RECONSIDER_ISSUE_NUM"
 
-  # Resolve paths
-  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
-  PLAN_FILE="$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
-  if [ ! -f "$PLAN_FILE" ]; then
-    echo "ERROR: $PLAN_FILE does not exist. Run /fix-issues sync first." >&2
+  MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+  STATE_FILE="$MAIN_ROOT/.zskills/monitor-state.json"
+  if [ ! -f "$STATE_FILE" ]; then
+    echo "ERROR: $STATE_FILE does not exist. Run /fix-issues sync first." >&2
     exit 1
   fi
 
-  python3 - "$PLAN_FILE" "$ISSUE_NUM" <<'PY'
-import sys, os, tempfile
+  python3 - "$STATE_FILE" "$ISSUE_NUM" <<'PY'
+import sys, os, json, tempfile
 
 path, num_s = sys.argv[1], sys.argv[2]
-header = f"### #{num_s} "
-reconsidered_marker = "**Reconsidered:**"
-action_now_marker = "**Action now:**"
-annotation = f"{reconsidered_marker} user flagged prior classification as incorrect — re-evaluate independently."
+num = int(num_s)
 
 with open(path, 'r') as f:
-    lines = f.readlines()
+    data = json.load(f)
 
-# Find the section for this issue
-in_sec = False
-sec_start = -1
-action_line = -1
-already_annotated = False
+issues = data.setdefault("issues", {})
+reconsider = issues.get("reconsider", [])
 
-for i, line in enumerate(lines):
-    if line.startswith(header):
-        in_sec = True
-        sec_start = i
-        continue
-    if in_sec and line.startswith("### "):
-        break
-    if in_sec:
-        if reconsidered_marker in line:
-            already_annotated = True
-            break
-        if action_now_marker in line:
-            action_line = i
-
-if sec_start == -1:
-    print(f"ERROR: section '{header.strip()}' not found in {path}", file=sys.stderr)
-    sys.exit(1)
-
-if already_annotated:
-    print(f"/fix-issues: #{num_s} already has Reconsidered annotation (no-op).", file=sys.stderr)
+if num in reconsider:
+    print(f"/fix-issues: #{num_s} already in reconsider list (no-op).", file=sys.stderr)
     sys.exit(0)
 
-if action_line == -1:
-    # No Action-now line — issue was never classified as skip; append after header
-    insert_at = sec_start + 1
-else:
-    insert_at = action_line + 1
-
-lines.insert(insert_at, f"{annotation}\n")
+reconsider.append(num)
+issues["reconsider"] = reconsider
 
 tmp = tempfile.NamedTemporaryFile('w', delete=False,
-    dir=os.path.dirname(path), prefix='.ISSUES_PLAN.', suffix='.tmp')
-tmp.writelines(lines)
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(data, tmp, indent=2)
+tmp.write('\n')
 tmp.close()
 os.replace(tmp.name, path)
 print(f"/fix-issues: #{num_s} flagged for reconsideration on next sprint.")

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.28+3ee00e"
+  version: "2026.05.27+9ed4c1"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -54,9 +54,30 @@ if [ -z "${ZSKILLS_ISSUES_DIR:-}" ]; then
   exit 1
 fi
 
+# Read the reconsider list from monitor-state.json (one-shot signal).
+# Issues in this list have their skip-code suppressed so Phase 2
+# re-evaluates them. After emitting them as candidates, we remove them
+# from the list so the signal doesn't persist across sprints.
+MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
+STATE_FILE="${MAIN_ROOT:+$MAIN_ROOT/.zskills/monitor-state.json}"
+RECONSIDER_NUMS=""
+if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
+  RECONSIDER_NUMS=$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    nums = data.get('issues', {}).get('reconsider', [])
+    print(' '.join(str(n) for n in nums))
+except Exception:
+    pass
+" "$STATE_FILE" 2>/dev/null) || RECONSIDER_NUMS=""
+fi
+
 RESEARCHED=()
 MISSING=()
 SKIP_TAGGED=()
+RECONSIDERED_PROCESSED=()
 
 for N in "$@"; do
   # Skip non-numeric tokens defensively.
@@ -77,19 +98,22 @@ for N in "$@"; do
   # Awk also extracts the Action-now value (substring after the bold
   # marker) and prints `SKIP=<code>` if it resolves to one of the three
   # canonical dashboard skip-codes via POSIX-portable boundary matching.
+  # Check if this issue is in the reconsider list (monitor-state.json).
+  is_reconsidered=0
+  case " $RECONSIDER_NUMS " in
+    *" $N "*) is_reconsidered=1 ;;
+  esac
+
   found=0
   skip_code=""
   for f in "$ZSKILLS_ISSUES_DIR"/*.md; do
     [ -f "$f" ] || continue
-    out=$(awk -v n="$N" '
+    out=$(awk -v n="$N" -v recon="$is_reconsidered" '
       $0 ~ "^### #" n " " { in_sec=1; next }
       in_sec && /^### / { exit }
-      # If **Reconsidered:** appears in this section, suppress skip-code
-      # emission — the user has flagged this issue for re-evaluation.
-      in_sec && index($0, "**Reconsidered:**") > 0 { reconsidered=1 }
       in_sec && index($0, "**Action now:**") > 0 {
         print "HIT"
-        if (reconsidered) { exit }
+        if (recon) { exit }
         if (match($0, /\*\*Action now:\*\*[[:space:]]*/)) {
           val = substr($0, RSTART + RLENGTH)
           # Lowercase for case-insensitive prefix matching.
@@ -128,6 +152,9 @@ for N in "$@"; do
     if [ -n "$skip_code" ]; then
       SKIP_TAGGED+=("$N:$skip_code")
     fi
+    if [ "$is_reconsidered" -eq 1 ]; then
+      RECONSIDERED_PROCESSED+=("$N")
+    fi
   else
     MISSING+=("$N")
   fi
@@ -136,3 +163,36 @@ done
 printf 'RESEARCHED="%s"\n' "${RESEARCHED[*]}"
 printf 'MISSING="%s"\n' "${MISSING[*]}"
 printf 'SKIP_TAGGED="%s"\n' "${SKIP_TAGGED[*]}"
+
+# One-shot cleanup: remove processed reconsider entries from
+# monitor-state.json so the signal doesn't persist across sprints.
+if [ "${#RECONSIDERED_PROCESSED[@]}" -gt 0 ] && [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
+  REMOVE_LIST=$(printf '%s\n' "${RECONSIDERED_PROCESSED[@]}" | tr '\n' ' ' | sed 's/ $//')
+  python3 -c "
+import json, sys, os, tempfile
+
+path = sys.argv[1]
+remove = set(int(x) for x in sys.argv[2:])
+
+with open(path) as f:
+    data = json.load(f)
+
+cur = data.get('issues', {}).get('reconsider', [])
+after = [n for n in cur if n not in remove]
+
+if len(after) == len(cur):
+    sys.exit(0)
+
+if after:
+    data['issues']['reconsider'] = after
+else:
+    data.get('issues', {}).pop('reconsider', None)
+
+tmp = tempfile.NamedTemporaryFile('w', delete=False,
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(data, tmp, indent=2)
+tmp.write('\n')
+tmp.close()
+os.replace(tmp.name, path)
+" "$STATE_FILE" ${RECONSIDERED_PROCESSED[*]} 2>/dev/null || true
+fi

--- a/skills/fix-issues/subcommands/reconsider.md
+++ b/skills/fix-issues/subcommands/reconsider.md
@@ -1,88 +1,59 @@
 ## Reconsider (if `reconsider` is present)
 
 Flag a previously-skipped issue for re-evaluation on the next sprint. This
-is an early-exit subcommand that annotates the issue's section in
-`$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md` and exits — it does NOT proceed to
-Phase 0/1/2.
+is an early-exit subcommand that adds the issue number to the
+`issues.reconsider` list in `.zskills/monitor-state.json` and exits — it
+does NOT proceed to Phase 0/1/2.
 
 **Syntax:** `reconsider <N>`
 - `<N>` — positive integer (GitHub issue number). REQUIRED.
 
 **Behavior:**
-- Finds the `### #<N> ` section in `$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md`.
-- Appends `**Reconsidered:** user flagged prior classification as incorrect — re-evaluate independently.` after the `**Action now:**` line.
-- Idempotent: if the section already contains `**Reconsidered:**`, exit 0 with a note.
-- If `### #<N> ` is not found in ISSUES_PLAN.md, exit 1 with an error.
+- Adds `<N>` to the `issues.reconsider` array in `.zskills/monitor-state.json`.
+- Creates the `issues.reconsider` key if absent; deduplicates.
+- Idempotent: if the number is already in the list, exit 0 with a note.
+- Atomic write via Python tempfile + `os.replace`.
 
-The annotation does NOT delete the existing blurb (keeps original research
-for context). On the next `/fix-issues` fire, `filter-unresearched-candidates.sh`
-sees the `**Reconsidered:**` marker and suppresses skip-code emission for
-that issue, allowing Phase 2 to re-triage it independently.
+The reconsider list is a one-shot signal. On the next `/fix-issues` fire,
+`filter-unresearched-candidates.sh` reads the list and suppresses
+skip-code emission for listed issues, allowing Phase 2 to re-triage them
+independently. After the sprint processes the issue, the filter script
+removes it from the list (one-shot: flag once, re-evaluate once, clear).
 
-<!-- allow-hardcoded: (^|[^A-Za-z0-9_])ISSUES_PLAN\.md reason: filename basename suffixed onto $ZSKILLS_ISSUES_DIR (resolved via zskills-paths.sh); the basename token remains literal so the regex still flags the /ISSUES_PLAN.md tail -->
 ```bash
 if [ "$RECONSIDER_MODE" = "1" ]; then
   ISSUE_NUM="$RECONSIDER_ISSUE_NUM"
 
-  # Resolve paths
-  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-paths.sh"
-  PLAN_FILE="$ZSKILLS_ISSUES_DIR/ISSUES_PLAN.md"
-  if [ ! -f "$PLAN_FILE" ]; then
-    echo "ERROR: $PLAN_FILE does not exist. Run /fix-issues sync first." >&2
+  MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+  STATE_FILE="$MAIN_ROOT/.zskills/monitor-state.json"
+  if [ ! -f "$STATE_FILE" ]; then
+    echo "ERROR: $STATE_FILE does not exist. Run /fix-issues sync first." >&2
     exit 1
   fi
 
-  python3 - "$PLAN_FILE" "$ISSUE_NUM" <<'PY'
-import sys, os, tempfile
+  python3 - "$STATE_FILE" "$ISSUE_NUM" <<'PY'
+import sys, os, json, tempfile
 
 path, num_s = sys.argv[1], sys.argv[2]
-header = f"### #{num_s} "
-reconsidered_marker = "**Reconsidered:**"
-action_now_marker = "**Action now:**"
-annotation = f"{reconsidered_marker} user flagged prior classification as incorrect — re-evaluate independently."
+num = int(num_s)
 
 with open(path, 'r') as f:
-    lines = f.readlines()
+    data = json.load(f)
 
-# Find the section for this issue
-in_sec = False
-sec_start = -1
-action_line = -1
-already_annotated = False
+issues = data.setdefault("issues", {})
+reconsider = issues.get("reconsider", [])
 
-for i, line in enumerate(lines):
-    if line.startswith(header):
-        in_sec = True
-        sec_start = i
-        continue
-    if in_sec and line.startswith("### "):
-        break
-    if in_sec:
-        if reconsidered_marker in line:
-            already_annotated = True
-            break
-        if action_now_marker in line:
-            action_line = i
-
-if sec_start == -1:
-    print(f"ERROR: section '{header.strip()}' not found in {path}", file=sys.stderr)
-    sys.exit(1)
-
-if already_annotated:
-    print(f"/fix-issues: #{num_s} already has Reconsidered annotation (no-op).", file=sys.stderr)
+if num in reconsider:
+    print(f"/fix-issues: #{num_s} already in reconsider list (no-op).", file=sys.stderr)
     sys.exit(0)
 
-if action_line == -1:
-    # No Action-now line — issue was never classified as skip; append after header
-    insert_at = sec_start + 1
-else:
-    insert_at = action_line + 1
-
-lines.insert(insert_at, f"{annotation}\n")
+reconsider.append(num)
+issues["reconsider"] = reconsider
 
 tmp = tempfile.NamedTemporaryFile('w', delete=False,
-    dir=os.path.dirname(path), prefix='.ISSUES_PLAN.', suffix='.tmp')
-tmp.writelines(lines)
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(data, tmp, indent=2)
+tmp.write('\n')
 tmp.close()
 os.replace(tmp.name, path)
 print(f"/fix-issues: #{num_s} flagged for reconsideration on next sprint.")


### PR DESCRIPTION
## Summary

- Moves `/fix-issues reconsider` storage from tracked `ISSUES_PLAN.md` to untracked `.zskills/monitor-state.json`
- Reconsider is now a local state change (no git footprint, no PR required just to flag an issue)
- Filter script reads the `issues.reconsider` array from monitor-state.json and auto-clears entries after the sprint processes them (one-shot signal)

Closes #722's implementation bug — the original spec offered both storage paths and the implementation picked the tracked-file path, which defeated the design goal of avoiding PRs for reconsider operations.

## Test plan

- [x] reconsider.md writes to monitor-state.json instead of ISSUES_PLAN.md
- [x] filter script reads reconsider list from JSON, suppresses skip-code for listed issues
- [x] One-shot cleanup removes processed entries after sprint uses them
- [x] Skill version bumped, mirrors clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
