### PR TITLE
feat(cleanup-merged): preview-default + positional tokens + remote + protected (#716)

### DIFF
--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[--dry-run | -n] [--review]"
+argument-hint: "[apply] [remote | all]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
-  upstream is gone or whose PR has merged. Bails on a dirty tree; skips
-  branches with unpushed commits. --dry-run previews. --review classifies
-  every local branch + worktree per merit rules and presents an
-  interactive picker for cleanup actions.
+  upstream is gone or whose PR has merged. Preview by default — run
+  `/cleanup-merged apply` to execute. `remote` adds remote branch cleanup;
+  `all` does both local + remote. Protected branches from config are
+  skipped automatically.
 metadata:
-  version: "2026.05.21+c788ef"
+  version: "2026.05.28+e42a2b"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -22,18 +22,43 @@ are gone or whose PRs are merged.
 
 **Ultrathink throughout.**
 
+**Preview by default.** Bare invocation shows what would be deleted.
+Run `/cleanup-merged apply` to execute.
+
 Safe to run any time. The skill bails on a dirty working tree and
 never deletes a branch with unpushed commits.
 
-## Arguments
+## Interface
 
-- `--dry-run` / `-n` — report what would happen without modifying
-  anything. Useful to preview deletions on the first run.
-- `--review` — opt into per-branch merit-based classification.
-  Enumerates every local branch + worktree, classifies each per the rule
-  table (see Phase 7), and prompts the user for actions via an
-  alphabetized letter-keyed picker. Mutually exclusive with `--dry-run`
-  (review mode is interactive — dry-run has no meaning).
+```
+/cleanup-merged              — preview local (show what would be deleted)
+/cleanup-merged apply        — execute local deletions (skip protected)
+/cleanup-merged remote       — preview remote branch deletions
+/cleanup-merged remote apply — execute remote deletions (skip protected)
+/cleanup-merged all          — preview both local + remote
+/cleanup-merged all apply    — execute both (skip protected)
+```
+
+- **Preview is default** — safe to run, self-documenting. Output shows
+  the plan and ends with "run `/cleanup-merged apply` to execute."
+- **`apply`** — positional token meaning "I saw the preview, do it."
+  Terraform precedent.
+- **`remote`** — adds `git push origin --delete` for branches whose PRs
+  are confirmed MERGED via `gh pr view`. Never deletes branches with
+  open PRs.
+- **`all`** — both local + remote.
+- **Protected branches** — config field in `.claude/zskills-config.json`:
+  ```json
+  { "cleanup": { "protected_branches": ["docs/run-order-guide"] } }
+  ```
+  Preview marks these as `PROTECTED (config)` and `apply` skips them
+  automatically.
+
+### Migration aliases
+
+For one release cycle, `--dry-run` / `-n` map to preview (the new
+default) and `--review` maps to `all` (preview both). Both emit a
+deprecation notice. Remove after 2026-07-01.
 
 ## Phase 1 — Preflight
 
@@ -54,24 +79,40 @@ fi
 
 ### WI 1.2 — Argument parse
 
+Positional tokens: `apply`, `remote`, `all`. Order-independent.
+Legacy flags `--dry-run`, `-n`, `--review` are accepted as migration
+aliases.
+
 ```bash
-DRY_RUN=0
-REVIEW=0
+APPLY=0
+SCOPE="local"  # "local", "remote", or "all"
+
 for arg in "$@"; do
   case "$arg" in
-    --dry-run|-n) DRY_RUN=1 ;;
-    --review) REVIEW=1 ;;
+    apply)  APPLY=1 ;;
+    remote) SCOPE="remote" ;;
+    all)    SCOPE="all" ;;
+    --dry-run|-n)
+      echo "DEPRECATED: --dry-run/-n is now the default. Just run /cleanup-merged (no args) for preview."
+      ;;
+    --review)
+      echo "DEPRECATED: --review is replaced by /cleanup-merged all. Treating as 'all'."
+      SCOPE="all"
+      ;;
     *)
-      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [--dry-run|-n] [--review]" >&2
+      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [apply] [remote | all]" >&2
       exit 2
       ;;
   esac
 done
 
-if [ "$DRY_RUN" -eq 1 ] && [ "$REVIEW" -eq 1 ]; then
-  echo "ERROR: --dry-run and --review are mutually exclusive (review is interactive)." >&2
-  exit 2
-fi
+DO_LOCAL=0
+DO_REMOTE=0
+case "$SCOPE" in
+  local)  DO_LOCAL=1 ;;
+  remote) DO_REMOTE=1 ;;
+  all)    DO_LOCAL=1; DO_REMOTE=1 ;;
+esac
 ```
 
 ### WI 1.3 — Locate main-repo root and detect main branch
@@ -87,18 +128,53 @@ if ! git show-ref --verify --quiet refs/heads/main \
 fi
 ```
 
-### WI 1.4 — Bail on dirty tree
+### WI 1.4 — Load protected branches from config
+
+Read `cleanup.protected_branches` from `.claude/zskills-config.json`.
+Default empty array.
+
+```bash
+CONFIG_FILE=".claude/zskills-config.json"
+PROTECTED_BRANCHES=()
+if [ -f "$CONFIG_FILE" ]; then
+  PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+  if [ -n "$PYTHON" ]; then
+    while IFS= read -r p; do
+      [ -n "$p" ] && PROTECTED_BRANCHES+=("$p")
+    done < <("$PYTHON" -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    pats = cfg.get("cleanup", {}).get("protected_branches", []) or []
+    for p in pats:
+        print(p)
+except Exception:
+    pass
+' "$CONFIG_FILE")
+  fi
+fi
+
+is_protected() {
+  local branch="$1"
+  for pb in "${PROTECTED_BRANCHES[@]:-}"; do
+    [ -z "$pb" ] && continue
+    if [ "$branch" = "$pb" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+```
+
+### WI 1.5 — Bail on dirty tree
 
 Untracked files count as dirty: `/cleanup-merged` will `git checkout
 main` and `git pull`, which would dump new untracked files back out or
 could conflict with an uncommitted edit the user hasn't saved yet.
 
-Review mode (`--review`) **does not** bail on a dirty tree — its job is
-to inspect and surface dirty worktrees. It still avoids any destructive
-operation on the dirty repo (no checkout, no pull, no auto-delete).
-
 ```bash
-if [ "$REVIEW" -eq 0 ] && [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain)" ]; then
   echo "ERROR: working tree is not clean. Commit, stash, or discard changes first." >&2
   git status --short >&2
   exit 3
@@ -115,7 +191,7 @@ if ! git fetch origin --prune; then
 fi
 
 # Drop orphaned worktree registrations (directories deleted from disk)
-# so Phase 5's worktree→branch map reflects only live worktrees.
+# so Phase 4's worktree->branch map reflects only live worktrees.
 git worktree prune
 ```
 
@@ -123,29 +199,21 @@ git worktree prune
 this, `git branch -vv` shows `: gone]` next to local branches whose
 remote was deleted — the primary signal for detecting merged PRs when
 GitHub's auto-delete-head-branches setting is on. `git worktree prune`
-clears stale worktree entries so Phase 5 can reliably decide whether a
+clears stale worktree entries so Phase 4 can reliably decide whether a
 merged branch is still held by a live worktree.
 
 ## Phase 3 — Switch off a merged feature branch (if applicable)
 
 If the current branch is not the main branch, check whether its PR is
 merged or its upstream is gone. If so, switch to main so we can delete
-the branch later. Review mode skips this phase (and Phases 4–6) and
-jumps straight to Phase 7.
+the branch later. In preview mode (no `apply`), report what would
+happen without switching.
 
 ```bash
-if [ "$REVIEW" -eq 1 ]; then
-  # Review-mode skips Phases 3–6; jump to Phase 7 directly.
-  SWITCHED=0
-  ON_MAIN=0
-  DELETED=0
-  SKIPPED=0
-fi
-
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
 SWITCHED=0
 
-if [ "$REVIEW" -eq 0 ] && [ "$CURRENT" != "$MAIN_BRANCH" ]; then
+if [ "$CURRENT" != "$MAIN_BRANCH" ]; then
   UPSTREAM_GONE=0
   if git branch -vv | grep -qE "^\* $CURRENT .*: gone\]"; then
     UPSTREAM_GONE=1
@@ -158,13 +226,15 @@ if [ "$REVIEW" -eq 0 ] && [ "$CURRENT" != "$MAIN_BRANCH" ]; then
 
   if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
     REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
-    echo "Current branch '$CURRENT' is safe to leave ($REASON). Switching to $MAIN_BRANCH..."
-    if [ "$DRY_RUN" -eq 0 ]; then
+    if [ "$APPLY" -eq 1 ]; then
+      echo "Current branch '$CURRENT' is safe to leave ($REASON). Switching to $MAIN_BRANCH..."
       if ! git checkout "$MAIN_BRANCH"; then
         echo "ERROR: failed to checkout $MAIN_BRANCH." >&2
         exit 5
       fi
       SWITCHED=1
+    else
+      echo "  WOULD-SWITCH from '$CURRENT' to $MAIN_BRANCH ($REASON)"
     fi
   else
     echo "Current branch '$CURRENT' is not merged (PR state: ${PR_STATE:-unknown}); staying here. Run from $MAIN_BRANCH or after merging to clean it up."
@@ -174,15 +244,14 @@ fi
 
 ## Phase 4 — Pull main
 
-Only pull if we are on the main branch. A dry-run skips the pull
-because we promised not to modify anything. Review mode skips this
-phase entirely.
+Only pull if we are on the main branch. Preview mode skips the pull
+because we promised not to modify anything.
 
 ```bash
 ON_MAIN=0
 [ "$(git rev-parse --abbrev-ref HEAD)" = "$MAIN_BRANCH" ] && ON_MAIN=1
 
-if [ "$REVIEW" -eq 0 ] && [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+if [ "$ON_MAIN" -eq 1 ] && [ "$APPLY" -eq 1 ]; then
   echo "Pulling $MAIN_BRANCH..."
   if ! git pull origin "$MAIN_BRANCH"; then
     echo "ERROR: git pull failed." >&2
@@ -191,11 +260,7 @@ if [ "$REVIEW" -eq 0 ] && [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
 fi
 ```
 
-## Phase 5 — Scan and delete merged branches
-
-Review mode skips this phase — its per-branch action logic lives in
-Phase 7 instead (the `if [ "$REVIEW" -eq 1 ]; then : else …` guard
-below wraps the original loop).
+## Phase 5 — Local branch scan
 
 For every local branch other than the main branch and the currently
 checked-out branch, check the same two signals (upstream gone, PR
@@ -212,132 +277,139 @@ is removed first (`git worktree remove`); a dirty worktree, or the main
 repo's own worktree, causes the branch to be skipped with a warning so
 the user can intervene manually.
 
+Protected branches (from `cleanup.protected_branches` config) are
+marked `PROTECTED (config)` in preview and skipped in apply.
+
 ```bash
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
-DELETED=0
-SKIPPED=0
+LOCAL_DELETED=0
+LOCAL_SKIPPED=0
+LOCAL_PROTECTED=0
+LOCAL_CANDIDATES=()  # branch names that are merged and deletable
 
-if [ "$REVIEW" -eq 1 ]; then
-  : # Phase 5 main loop is bypassed in review mode (handled by Phase 7).
-else
-while IFS= read -r branch; do
-  [ -z "$branch" ] && continue
-  [ "$branch" = "$MAIN_BRANCH" ] && continue
-  [ "$branch" = "$CURRENT" ] && continue
+if [ "$DO_LOCAL" -eq 1 ]; then
+  echo ""
+  echo "--- Local branches ---"
 
-  UPSTREAM_GONE=0
-  if git branch -vv | grep -qE "^  $branch .*: gone\]"; then
-    UPSTREAM_GONE=1
-  fi
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    [ "$branch" = "$MAIN_BRANCH" ] && continue
+    [ "$branch" = "$CURRENT" ] && continue
 
-  PR_STATE=""
-  if [ "$HAVE_GH" -eq 1 ]; then
-    PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
-  fi
-
-  MERGED=0
-  if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
-    MERGED=1
-  fi
-
-  [ "$MERGED" -eq 0 ] && continue
-
-  # Unpushed-commit guard (squash-merge still counts commits as unpushed
-  # because the squash SHA is different). Only honor the guard when the
-  # upstream is NOT gone — a gone upstream plus PR=MERGED means the
-  # commits reached main via squash.
-  UNPUSHED=""
-  if [ "$UPSTREAM_GONE" -eq 0 ]; then
-    UNPUSHED=$(git log "$branch" --not --remotes --oneline 2>/dev/null | head -1)
-  fi
-
-  if [ -n "$UNPUSHED" ]; then
-    echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional)"
-    SKIPPED=$((SKIPPED+1))
-    continue
-  fi
-
-  # Issue #516: ahead-count gate. `gh pr view` is sticky after merge, so
-  # PR=MERGED + ahead>0 means the local branch may carry post-merge
-  # commits that would be silently reaped by `git branch -D`. Only gate
-  # the PR=MERGED path (upstream-gone implies squash-merge, where ahead>0
-  # is expected and the unpushed-commit guard above already handles the
-  # un-squashed case).
-  if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ]; then
-    AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
-    [ -z "$AHEAD" ] && AHEAD=0
-    if [ "$AHEAD" -gt 0 ]; then
-      echo "  SKIP   $branch (PR merged but branch has $AHEAD commits not on main — investigate; do not auto-remove)"
-      SKIPPED=$((SKIPPED+1))
-      continue
-    fi
-  fi
-
-  # Worktree detection: does any registered worktree hold $branch?
-  # `git worktree list --porcelain` emits blocks like:
-  #     worktree /abs/path
-  #     HEAD <sha>
-  #     branch refs/heads/<name>
-  #     (blank line)
-  # Detached-HEAD worktrees have no "branch" line; the awk filter below
-  # pairs every "worktree" line with its following "branch" line (if any)
-  # and drops the unpaired detached ones.
-  WORKTREE_FOR_BRANCH=""
-  while IFS= read -r wt_path && IFS= read -r wt_branch; do
-    if [ "${wt_branch#branch refs/heads/}" = "$branch" ]; then
-      WORKTREE_FOR_BRANCH="${wt_path#worktree }"
-      break
-    fi
-  done < <(git worktree list --porcelain | awk '/^worktree /{wt=$0} /^branch /{print wt; print $0}')
-
-  REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
-
-  if [ -n "$WORKTREE_FOR_BRANCH" ]; then
-    if [ "$WORKTREE_FOR_BRANCH" = "$MAIN_ROOT" ]; then
-      echo "WARN: merged branch $branch is checked out in main repo; checkout main before cleanup-merged." >&2
-      SKIPPED=$((SKIPPED+1))
+    # Protected branch check
+    if is_protected "$branch"; then
+      echo "  PROTECTED (config) $branch"
+      LOCAL_PROTECTED=$((LOCAL_PROTECTED+1))
       continue
     fi
 
-    WT_DIRTY=$(git -C "$WORKTREE_FOR_BRANCH" status --porcelain 2>/dev/null)
-    if [ -n "$WT_DIRTY" ]; then
-      echo "WARN: worktree at $WORKTREE_FOR_BRANCH holds merged branch $branch but has uncommitted changes — inspect and remove manually." >&2
-      SKIPPED=$((SKIPPED+1))
+    UPSTREAM_GONE=0
+    if git branch -vv | grep -qE "^  $branch .*: gone\]"; then
+      UPSTREAM_GONE=1
+    fi
+
+    PR_STATE=""
+    if [ "$HAVE_GH" -eq 1 ]; then
+      PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
+    fi
+
+    MERGED=0
+    if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
+      MERGED=1
+    fi
+
+    [ "$MERGED" -eq 0 ] && continue
+
+    # Unpushed-commit guard (squash-merge still counts commits as unpushed
+    # because the squash SHA is different). Only honor the guard when the
+    # upstream is NOT gone — a gone upstream plus PR=MERGED means the
+    # commits reached main via squash.
+    UNPUSHED=""
+    if [ "$UPSTREAM_GONE" -eq 0 ]; then
+      UNPUSHED=$(git log "$branch" --not --remotes --oneline 2>/dev/null | head -1)
+    fi
+
+    if [ -n "$UNPUSHED" ]; then
+      echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional)"
+      LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
       continue
     fi
 
-    if [ "$DRY_RUN" -eq 1 ]; then
-      echo "  WOULD-REMOVE-WORKTREE $WORKTREE_FOR_BRANCH (holds $branch)"
+    # Issue #516: ahead-count gate. `gh pr view` is sticky after merge, so
+    # PR=MERGED + ahead>0 means the local branch may carry post-merge
+    # commits that would be silently reaped by `git branch -D`. Only gate
+    # the PR=MERGED path (upstream-gone implies squash-merge, where ahead>0
+    # is expected and the unpushed-commit guard above already handles the
+    # un-squashed case).
+    if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ]; then
+      AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
+      [ -z "$AHEAD" ] && AHEAD=0
+      if [ "$AHEAD" -gt 0 ]; then
+        echo "  SKIP   $branch (PR merged but branch has $AHEAD commits not on main — investigate; do not auto-remove)"
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+    fi
+
+    # Worktree detection: does any registered worktree hold $branch?
+    WORKTREE_FOR_BRANCH=""
+    while IFS= read -r wt_path && IFS= read -r wt_branch; do
+      if [ "${wt_branch#branch refs/heads/}" = "$branch" ]; then
+        WORKTREE_FOR_BRANCH="${wt_path#worktree }"
+        break
+      fi
+    done < <(git worktree list --porcelain | awk '/^worktree /{wt=$0} /^branch /{print wt; print $0}')
+
+    REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
+
+    if [ -n "$WORKTREE_FOR_BRANCH" ]; then
+      if [ "$WORKTREE_FOR_BRANCH" = "$MAIN_ROOT" ]; then
+        echo "  WARN: merged branch $branch is checked out in main repo; checkout main before cleanup-merged." >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+
+      WT_DIRTY=$(git -C "$WORKTREE_FOR_BRANCH" status --porcelain 2>/dev/null)
+      if [ -n "$WT_DIRTY" ]; then
+        echo "  WARN: worktree at $WORKTREE_FOR_BRANCH holds merged branch $branch but has uncommitted changes — inspect and remove manually." >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+
+      if [ "$APPLY" -eq 0 ]; then
+        echo "  WOULD-REMOVE-WORKTREE $WORKTREE_FOR_BRANCH (holds $branch)"
+        echo "  WOULD-DELETE $branch ($REASON)"
+        LOCAL_DELETED=$((LOCAL_DELETED+1))
+        LOCAL_CANDIDATES+=("$branch")
+        continue
+      fi
+
+      if ! git worktree remove "$WORKTREE_FOR_BRANCH"; then
+        echo "  FAILED  $branch (git worktree remove $WORKTREE_FOR_BRANCH exited non-zero)" >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+      echo "  REMOVED-WORKTREE $WORKTREE_FOR_BRANCH (held $branch)"
+    fi
+
+    if [ "$APPLY" -eq 0 ]; then
       echo "  WOULD-DELETE $branch ($REASON)"
-      DELETED=$((DELETED+1))
-      continue
-    fi
-
-    if ! git worktree remove "$WORKTREE_FOR_BRANCH"; then
-      echo "  FAILED  $branch (git worktree remove $WORKTREE_FOR_BRANCH exited non-zero)" >&2
-      SKIPPED=$((SKIPPED+1))
-      continue
-    fi
-    echo "  REMOVED-WORKTREE $WORKTREE_FOR_BRANCH (held $branch)"
-  fi
-
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "  WOULD-DELETE $branch ($REASON)"
-    DELETED=$((DELETED+1))
-  else
-    if git branch -D "$branch" >/dev/null; then
-      echo "  DELETED $branch ($REASON)"
-      DELETED=$((DELETED+1))
+      LOCAL_DELETED=$((LOCAL_DELETED+1))
+      LOCAL_CANDIDATES+=("$branch")
     else
-      echo "  FAILED  $branch (git branch -D exited non-zero)" >&2
-      SKIPPED=$((SKIPPED+1))
+      if git branch -D "$branch" >/dev/null; then
+        echo "  DELETED $branch ($REASON)"
+        LOCAL_DELETED=$((LOCAL_DELETED+1))
+      else
+        echo "  FAILED  $branch (git branch -D exited non-zero)" >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+      fi
     fi
-  fi
-done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
-fi  # /REVIEW guard
+  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+fi
 ```
 
-After the worktree-pruning loop, sweep any stale `/fix-issues` claim
+After the local branch loop, sweep any stale `/fix-issues` claim
 directories. When a PR merges via the GitHub web UI or a manual
 `gh pr merge` (bypassing `/land-pr`'s `STATUS=merged` release path), the
 per-issue claim under `.zskills/claims/issue-NNN/` leaks until its TTL
@@ -349,506 +421,138 @@ effort housekeeping; the surrounding cleanup-merged success criteria
 should not regress on a stale-claim sweep failure.
 
 ```bash
-bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" sweep || true
+if [ "$DO_LOCAL" -eq 1 ] && [ "$APPLY" -eq 1 ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" sweep || true
+fi
 ```
 
-## Phase 6 — Summary
+## Phase 6 — Remote branch scan
 
-Review mode skips this phase; its summary is part of Phase 7's table
-+ action report.
+When `remote` or `all` scope is active, scan remote-tracking branches
+for merged-PR candidates. For each `origin/<branch>` that is not the
+main branch:
+
+1. Check if the branch has a MERGED PR via `gh pr view`.
+2. Skip branches with OPEN PRs — never delete an active branch.
+3. Skip protected branches (from config).
+4. In preview, show `WOULD-DELETE-REMOTE`; in apply, run
+   `git push origin --delete <branch>`.
+
+Requires `gh` — if `gh` is unavailable and `remote`/`all` scope is
+requested, warn and skip.
 
 ```bash
-if [ "$REVIEW" -eq 0 ]; then
+REMOTE_DELETED=0
+REMOTE_SKIPPED=0
+REMOTE_PROTECTED=0
+
+if [ "$DO_REMOTE" -eq 1 ]; then
   echo ""
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "cleanup-merged (dry-run): would delete $DELETED, skip $SKIPPED. Nothing was modified."
+  echo "--- Remote branches ---"
+
+  if [ "$HAVE_GH" -eq 0 ]; then
+    echo "WARN: gh not available; remote branch cleanup requires gh for PR-state gating. Skipping." >&2
   else
-    echo "cleanup-merged: deleted $DELETED branches, skipped $SKIPPED."
-    if [ "$SWITCHED" -eq 1 ]; then
-      echo "(switched to $MAIN_BRANCH and pulled.)"
-    elif [ "$ON_MAIN" -eq 1 ]; then
-      echo "(on $MAIN_BRANCH, pulled latest.)"
-    fi
-  fi
-  exit 0
-fi
-```
+    while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      # Strip "origin/" prefix
+      branch="${ref#origin/}"
 
-## Phase 7 — Review mode (--review)
+      [ "$branch" = "$MAIN_BRANCH" ] && continue
+      [ "$branch" = "HEAD" ] && continue
 
-When `--review` is set, enumerate every local branch + worktree,
-classify each per the rule table below (first-match-wins), present an
-alphabetized table with letter IDs and verdicts, then prompt for action.
-
-### Classification rules (first-match wins)
-
-| # | Condition | Verdict | Rationale |
-|---|---|---|---|
-| 1 | Worktree is `locked` | **KEEP** | Live process; never touch |
-| 2 | Branch name matches `cleanup.long_running_patterns` config glob | **KEEP** | Explicitly preserved |
-| 11 | PR=MERGED AND commits ahead of main | **DECIDE** | `gh pr view` is sticky after merge; ahead>0 means possible post-merge commits (issue #516) — surface, don't auto-remove |
-| 3 | (upstream-gone OR PR=MERGED) AND worktree clean | **REMOVE** | Current `/cleanup-merged` default action |
-| 4 | (upstream-gone OR PR=MERGED) AND worktree dirty | **DECIDE** | Merged but uncommitted changes — inspect first |
-| 5 | Commits ahead AND PR=OPEN | **KEEP** | Active in-flight PR |
-| 6 | Commits ahead AND no PR AND clean | **MAYBE** | Drafted-but-not-pushed; review intent |
-| 7 | 0 commits ahead AND no PR AND clean AND `.landed status != landed` | **DECIDE** | Abandoned/failed sprint state |
-| 8 | 0 commits ahead AND no PR AND clean AND no `.landed` | **REMOVE** | Empty stub — typical orphaned cron artifact |
-| 9 | 0 commits ahead AND no PR AND tree dirty | **DECIDE** | Partial work or orphan; inspect diff |
-| 10 | Commits ahead AND tree dirty | **DECIDE** | Active uncommitted work |
-| — | (fallthrough) | **DECIDE** | Unclassified; manual review |
-
-### WI 7.1 — Load long_running_patterns from config
-
-Default empty array. Read via Python (zskills uses Python json, no jq).
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  CONFIG_FILE=".claude/zskills-config.json"
-  LONG_RUNNING_PATTERNS=()
-  if [ -f "$CONFIG_FILE" ]; then
-    PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
-    if [ -n "$PYTHON" ]; then
-      while IFS= read -r p; do
-        [ -n "$p" ] && LONG_RUNNING_PATTERNS+=("$p")
-      done < <("$PYTHON" -c '
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        cfg = json.load(f)
-    pats = cfg.get("cleanup", {}).get("long_running_patterns", []) or []
-    for p in pats:
-        print(p)
-except Exception:
-    pass
-' "$CONFIG_FILE")
-    fi
-  fi
-fi
-```
-
-### WI 7.2 — Enumerate branches + worktrees and classify
-
-Walk every local branch (`git for-each-ref refs/heads/`) and every
-worktree (`git worktree list --porcelain`). Build a unified row set
-keyed by `(worktree_path, branch_name)`. A worktree-less branch yields
-a row with `worktree=<none>`; a detached-HEAD worktree (no branch)
-yields a row with `branch=<detached>`.
-
-For each row, compute these signals:
-
-- `LOCKED` — worktree has a `locked` line in `git worktree list --porcelain`.
-- `AHEAD` — `git rev-list --count $MAIN_BRANCH..$branch` (0 if missing).
-- `UPSTREAM_GONE` — `git branch -vv` shows `: gone]` for the branch.
-- `PR_STATE` — `gh pr view $branch --json state` (empty if no PR).
-- `DIRTY` — `git -C $worktree status --porcelain` non-empty.
-- `LANDED_STATUS` — parse `status:` from `<worktree>/.landed`, or empty.
-
-Then walk the rule table top-to-bottom; the first matching rule sets
-`VERDICT` and `RULE_NUM`. `RULE_DESC` is a short one-liner from the
-table.
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  # Build worktree → (locked, branch) map via porcelain output.
-  # Format blocks: "worktree /path", then optional "HEAD <sha>",
-  # optional "branch refs/heads/<name>" OR "detached", optional "locked".
-  declare -A WT_BRANCH
-  declare -A WT_LOCKED
-  WT_PATHS=()
-
-  current_wt=""
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^worktree\ (.*)$ ]]; then
-      current_wt="${BASH_REMATCH[1]}"
-      WT_PATHS+=("$current_wt")
-      WT_BRANCH["$current_wt"]="<detached>"
-      WT_LOCKED["$current_wt"]=0
-    elif [[ "$line" =~ ^branch\ refs/heads/(.*)$ ]]; then
-      WT_BRANCH["$current_wt"]="${BASH_REMATCH[1]}"
-    elif [[ "$line" == "locked" || "$line" == locked\ * ]]; then
-      WT_LOCKED["$current_wt"]=1
-    fi
-  done < <(git worktree list --porcelain)
-
-  # Build branch → worktree reverse map.
-  declare -A BRANCH_WT
-  for wt in "${WT_PATHS[@]}"; do
-    br="${WT_BRANCH[$wt]}"
-    [ "$br" = "<detached>" ] && continue
-    BRANCH_WT["$br"]="$wt"
-  done
-
-  # Snapshot `git branch -vv` once for fast UPSTREAM_GONE lookup.
-  BRANCH_VV=$(git branch -vv)
-
-  # Glob-match a branch name against the long_running_patterns array.
-  # Uses bash's [[ "$name" == $pattern ]] glob (NOT regex).
-  matches_long_running() {
-    local name="$1" pat
-    for pat in "${LONG_RUNNING_PATTERNS[@]:-}"; do
-      [ -z "$pat" ] && continue
-      # shellcheck disable=SC2053
-      if [[ "$name" == $pat ]]; then
-        return 0
+      # Protected branch check
+      if is_protected "$branch"; then
+        echo "  PROTECTED (config) origin/$branch"
+        REMOTE_PROTECTED=$((REMOTE_PROTECTED+1))
+        continue
       fi
-    done
-    return 1
-  }
 
-  # Classifier — given branch + worktree-path + signals, sets
-  # VERDICT and RULE_NUM and RULE_DESC.
-  classify() {
-    local branch="$1" wt="$2" locked="$3" ahead="$4" upstream_gone="$5"
-    local pr_state="$6" dirty="$7" landed_status="$8"
+      PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
 
-    # Rule 1
-    if [ "$locked" = "1" ]; then
-      VERDICT="KEEP"; RULE_NUM=1
-      RULE_DESC="worktree locked; live process — never touch"
-      return
-    fi
-    # Rule 2
-    if [ "$branch" != "<detached>" ] && [ "$branch" != "<none>" ]; then
-      if matches_long_running "$branch"; then
-        VERDICT="KEEP"; RULE_NUM=2
-        RULE_DESC="matches cleanup.long_running_patterns"
-        return
+      if [ "$PR_STATE" = "OPEN" ]; then
+        continue  # Active PR — never delete
       fi
-    fi
 
-    local merged=0
-    if [ "$upstream_gone" = "1" ] || [ "$pr_state" = "MERGED" ]; then
-      merged=1
-    fi
-    local has_dirty=0
-    [ -n "$dirty" ] && has_dirty=1
-
-    # Rule 3a (issue #516) — PR=MERGED + ahead>0 means the local branch
-    # has commits not on main. `gh pr view` is sticky after merge, so a
-    # diverged branch still reports MERGED. Surface for manual review
-    # instead of silently reaping post-merge commits. Squash-merge alone
-    # ALSO shows ahead>0 (different SHA), but distinguishing post-merge
-    # divergence from squash-merge requires content comparison the
-    # classifier doesn't do; the safe action in either case is DECIDE.
-    if [ "$pr_state" = "MERGED" ] && [ "$ahead" -gt 0 ]; then
-      VERDICT="DECIDE"; RULE_NUM=11
-      RULE_DESC="PR merged but branch has $ahead commits not on main — investigate"
-      return
-    fi
-    # Rule 3
-    if [ "$merged" = "1" ] && [ "$has_dirty" = "0" ]; then
-      VERDICT="REMOVE"; RULE_NUM=3
-      RULE_DESC="merged (upstream-gone or PR=MERGED), worktree clean"
-      return
-    fi
-    # Rule 4
-    if [ "$merged" = "1" ] && [ "$has_dirty" = "1" ]; then
-      VERDICT="DECIDE"; RULE_NUM=4
-      RULE_DESC="merged but uncommitted changes — inspect first"
-      return
-    fi
-    # Rule 5
-    if [ "$ahead" -gt 0 ] && [ "$pr_state" = "OPEN" ]; then
-      VERDICT="KEEP"; RULE_NUM=5
-      RULE_DESC="active in-flight PR"
-      return
-    fi
-    # Rule 6
-    if [ "$ahead" -gt 0 ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ]; then
-      VERDICT="MAYBE"; RULE_NUM=6
-      RULE_DESC="drafted but not pushed — review intent"
-      return
-    fi
-    # Rule 7
-    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
-       && [ -n "$landed_status" ] && [ "$landed_status" != "landed" ] \
-       && [ "$landed_status" != "full" ]; then
-      VERDICT="DECIDE"; RULE_NUM=7
-      RULE_DESC="abandoned/failed sprint state (.landed=$landed_status)"
-      return
-    fi
-    # Rule 8
-    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
-       && [ -z "$landed_status" ]; then
-      VERDICT="REMOVE"; RULE_NUM=8
-      RULE_DESC="empty stub — typical orphaned cron artifact"
-      return
-    fi
-    # Rule 9
-    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "1" ]; then
-      VERDICT="DECIDE"; RULE_NUM=9
-      RULE_DESC="0-ahead + dirty — partial work or orphan; inspect diff"
-      return
-    fi
-    # Rule 10
-    if [ "$ahead" -gt 0 ] && [ "$has_dirty" = "1" ]; then
-      VERDICT="DECIDE"; RULE_NUM=10
-      RULE_DESC="commits ahead AND tree dirty — active uncommitted work"
-      return
-    fi
-    # Fallthrough
-    VERDICT="DECIDE"; RULE_NUM=0
-    RULE_DESC="unclassified; manual review"
-  }
-
-  # Build row list: every branch (with optional worktree) plus every
-  # detached worktree without a branch ref.
-  ROWS=()  # Each row: VERDICT|RULE_NUM|RULE_DESC|PATH|BRANCH|AHEAD|PR_STATE|DIRTY_COUNT|LANDED_STATUS
-  CLASSIFIED_BRANCHES=()
-
-  while IFS= read -r branch; do
-    [ -z "$branch" ] && continue
-    [ "$branch" = "$MAIN_BRANCH" ] && continue
-
-    wt="${BRANCH_WT[$branch]:-}"
-    locked=0
-    if [ -n "$wt" ]; then
-      locked="${WT_LOCKED[$wt]:-0}"
-    fi
-
-    ahead=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
-    [ -z "$ahead" ] && ahead=0
-
-    upstream_gone=0
-    if echo "$BRANCH_VV" | grep -qE "^[* ]+ ?$branch\b.*: gone\]"; then
-      upstream_gone=1
-    fi
-
-    pr_state=""
-    if [ "$HAVE_GH" -eq 1 ]; then
-      pr_state=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
-    fi
-
-    dirty=""
-    dirty_count=0
-    if [ -n "$wt" ]; then
-      dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
-      [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
-    fi
-
-    landed_status=""
-    if [ -n "$wt" ] && [ -f "$wt/.landed" ]; then
-      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
-        | head -1 | sed -E 's/^status:[[:space:]]*//')
-    fi
-
-    classify "$branch" "$wt" "$locked" "$ahead" "$upstream_gone" \
-             "$pr_state" "$dirty" "$landed_status"
-
-    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|${wt:-<no-worktree>}|$branch|$ahead|${pr_state:-none}|$dirty_count|${landed_status:-<none>}")
-    CLASSIFIED_BRANCHES+=("$branch")
-  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
-
-  # Detached-HEAD worktrees: not represented by any branch, but still
-  # worth surfacing in the table.
-  for wt in "${WT_PATHS[@]}"; do
-    [ "${WT_BRANCH[$wt]}" != "<detached>" ] && continue
-    locked="${WT_LOCKED[$wt]:-0}"
-    dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
-    dirty_count=0
-    [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
-    landed_status=""
-    if [ -f "$wt/.landed" ]; then
-      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
-        | head -1 | sed -E 's/^status:[[:space:]]*//')
-    fi
-    classify "<detached>" "$wt" "$locked" 0 0 "" "$dirty" "$landed_status"
-    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|$wt|<detached>|0|none|$dirty_count|${landed_status:-<none>}")
-  done
-fi
-```
-
-### WI 7.3 — Render the alphabetized table
-
-Sort rows by worktree path (stable, deterministic), assign letter IDs
-A-Z then AA, AB, … for >26 rows. Print the verdict/path/details/rule
-table; then a one-line summary by verdict.
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  # Sort rows alphabetically by the PATH field (column 4 after the
-  # verb). We use Python sort for stable Unicode behaviour.
-  PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
-  SORTED_ROWS=()
-  while IFS= read -r r; do
-    [ -n "$r" ] && SORTED_ROWS+=("$r")
-  done < <(printf '%s\n' "${ROWS[@]}" | "$PYTHON" -c '
-import sys
-rows = [l.rstrip("\n") for l in sys.stdin if l.strip()]
-rows.sort(key=lambda r: r.split("|")[3])
-for r in rows:
-    print(r)
-')
-
-  # Letter-ID generator: A, B, …, Z, AA, AB, …, AZ, BA, …
-  letter_for() {
-    local n="$1" out=""
-    while [ "$n" -ge 0 ]; do
-      out="$(printf "\\$(printf '%03o' $((65 + n % 26)))")$out"
-      n=$((n / 26 - 1))
-    done
-    printf '%s' "$out"
-  }
-
-  echo ""
-  echo "/cleanup-merged --review"
-  echo ""
-
-  declare -A ROW_BY_LETTER
-  declare -A SUGGESTED_BY_LETTER
-  KEEP_N=0; MAYBE_N=0; DECIDE_N=0; REMOVE_N=0
-  i=0
-  for row in "${SORTED_ROWS[@]}"; do
-    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
-    letter=$(letter_for "$i")
-    ROW_BY_LETTER["$letter"]="$row"
-    SUGGESTED_BY_LETTER["$letter"]="$verdict"
-
-    dirty_phrase="clean"
-    [ "$dirty_count" -gt 0 ] && dirty_phrase="dirty:${dirty_count} file$([ "$dirty_count" -ne 1 ] && echo s)"
-    pr_phrase="no PR"
-    [ "$pr_state" != "none" ] && pr_phrase="PR=$pr_state"
-
-    printf '  %s. %-6s %s\n' "$letter" "$verdict" "$path"
-    printf '       [%s, %s ahead, %s, %s' "$branch" "$ahead" "$pr_phrase" "$dirty_phrase"
-    [ "$landed_status" != "<none>" ] && printf ', .landed=%s' "$landed_status"
-    printf ']\n'
-    printf '       → rule %s: %s\n' "$rule_num" "$rule_desc"
-
-    case "$verdict" in
-      KEEP)   KEEP_N=$((KEEP_N+1)) ;;
-      MAYBE)  MAYBE_N=$((MAYBE_N+1)) ;;
-      DECIDE) DECIDE_N=$((DECIDE_N+1)) ;;
-      REMOVE) REMOVE_N=$((REMOVE_N+1)) ;;
-    esac
-    i=$((i+1))
-  done
-
-  TOTAL=${#SORTED_ROWS[@]}
-  echo ""
-  echo "$TOTAL total: $KEEP_N KEEP, $MAYBE_N MAYBE, $DECIDE_N DECIDE, $REMOVE_N REMOVE"
-fi
-```
-
-### WI 7.4 — Interactive picker
-
-Read one line of input from the user. Recognized forms:
-
-- blank (just Enter) OR `all-suggested` → apply all rows whose suggested
-  verdict is `REMOVE`. Other verdicts left alone.
-- `<letter>:<verb>` pairs separated by whitespace (e.g.,
-  `A:remove D:keep F:remove`) → per-row override. Recognized verbs:
-  `remove`, `keep`, `skip` (alias of `keep`). Unrecognized letters
-  produce a warning and are skipped.
-- `none` or empty stdin (e.g. pipe closed) → exit without action.
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  echo ""
-  echo "Pick action:"
-  echo "  [Enter] / all-suggested  apply suggested REMOVEs only"
-  echo "  <letter>:<verb> ...      per-row override (verbs: remove, keep, skip)"
-  echo "  none                     exit without action"
-  printf '  > '
-
-  USER_INPUT=""
-  if [ -t 0 ]; then
-    IFS= read -r USER_INPUT || USER_INPUT="none"
-  else
-    # Non-interactive (CI, pipe): default to dry-listing only.
-    USER_INPUT="none"
-  fi
-
-  USER_INPUT_TRIM=$(printf '%s' "$USER_INPUT" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
-
-  declare -A ACTION_BY_LETTER
-  if [ -z "$USER_INPUT_TRIM" ] || [ "$USER_INPUT_TRIM" = "all-suggested" ]; then
-    for letter in "${!SUGGESTED_BY_LETTER[@]}"; do
-      if [ "${SUGGESTED_BY_LETTER[$letter]}" = "REMOVE" ]; then
-        ACTION_BY_LETTER["$letter"]="remove"
+      if [ "$PR_STATE" != "MERGED" ]; then
+        continue  # Only delete branches with confirmed MERGED PRs
       fi
-    done
-  elif [ "$USER_INPUT_TRIM" = "none" ]; then
-    echo "Exiting without action."
-    exit 0
-  else
-    # Parse <letter>:<verb> pairs.
-    for token in $USER_INPUT_TRIM; do
-      if [[ "$token" =~ ^([A-Za-z]+):([a-z]+)$ ]]; then
-        letter="${BASH_REMATCH[1]}"
-        verb="${BASH_REMATCH[2]}"
-        letter=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
-        if [ -z "${ROW_BY_LETTER[$letter]:-}" ]; then
-          echo "  WARN: unknown letter '$letter' — skipped." >&2
-          continue
+
+      if [ "$APPLY" -eq 0 ]; then
+        echo "  WOULD-DELETE-REMOTE origin/$branch (PR merged)"
+        REMOTE_DELETED=$((REMOTE_DELETED+1))
+      else
+        if git push origin --delete "$branch" 2>/dev/null; then
+          echo "  DELETED-REMOTE origin/$branch (PR merged)"
+          REMOTE_DELETED=$((REMOTE_DELETED+1))
+        else
+          echo "  FAILED  origin/$branch (git push origin --delete exited non-zero)" >&2
+          REMOTE_SKIPPED=$((REMOTE_SKIPPED+1))
         fi
-        case "$verb" in
-          remove) ACTION_BY_LETTER["$letter"]="remove" ;;
-          keep|skip) ACTION_BY_LETTER["$letter"]="keep" ;;
-          *)
-            echo "  WARN: unknown verb '$verb' for $letter — skipped." >&2
-            ;;
-        esac
-      else
-        echo "  WARN: malformed token '$token' (want <letter>:<verb>) — skipped." >&2
       fi
-    done
+    done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin/)
+  fi
+fi
+```
+
+## Phase 7 — Summary
+
+```bash
+echo ""
+if [ "$APPLY" -eq 0 ]; then
+  # Preview summary
+  TOTAL_WOULD=0
+  MSG_PARTS=()
+  if [ "$DO_LOCAL" -eq 1 ]; then
+    MSG_PARTS+=("local: $LOCAL_DELETED to delete, $LOCAL_SKIPPED to skip, $LOCAL_PROTECTED protected")
+    TOTAL_WOULD=$((TOTAL_WOULD + LOCAL_DELETED))
+  fi
+  if [ "$DO_REMOTE" -eq 1 ]; then
+    MSG_PARTS+=("remote: $REMOTE_DELETED to delete, $REMOTE_SKIPPED to skip, $REMOTE_PROTECTED protected")
+    TOTAL_WOULD=$((TOTAL_WOULD + REMOTE_DELETED))
   fi
 
-  # Apply REMOVE actions. KEEP/skip are no-ops.
-  R_DONE=0
-  R_FAILED=0
-  for letter in "${!ACTION_BY_LETTER[@]}"; do
-    action="${ACTION_BY_LETTER[$letter]}"
-    [ "$action" != "remove" ] && continue
-    row="${ROW_BY_LETTER[$letter]}"
-    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
-
-    # Worktree removal — only if path is a registered worktree
-    # distinct from MAIN_ROOT. Dirty worktrees require --force or
-    # manual cleanup; for safety we skip them with a warning.
-    if [ "$path" != "<no-worktree>" ] && [ "$path" != "$MAIN_ROOT" ]; then
-      if [ "$dirty_count" -gt 0 ]; then
-        echo "  SKIP $letter: $path is dirty ($dirty_count file(s)); inspect manually." >&2
-        R_FAILED=$((R_FAILED+1))
-        continue
-      fi
-      if git worktree remove "$path"; then
-        echo "  REMOVED-WORKTREE $path"
-      else
-        echo "  FAILED to remove worktree $path" >&2
-        R_FAILED=$((R_FAILED+1))
-        continue
-      fi
-    fi
-
-    # Branch deletion (only if a real branch and not main / current).
-    if [ "$branch" != "<detached>" ] && [ "$branch" != "$MAIN_BRANCH" ] \
-       && [ "$branch" != "$(git rev-parse --abbrev-ref HEAD)" ]; then
-      if git branch -D "$branch" >/dev/null 2>&1; then
-        echo "  DELETED branch $branch"
-      else
-        echo "  WARN: could not delete branch $branch (may not exist locally)" >&2
-      fi
-    fi
-
-    R_DONE=$((R_DONE+1))
-  done
-
+  echo "cleanup-merged (preview): $(printf '%s; ' "${MSG_PARTS[@]}" | sed 's/; $//')"
   echo ""
-  echo "cleanup-merged --review: $R_DONE action(s) applied, $R_FAILED skipped/failed."
-  exit 0
+
+  if [ "$TOTAL_WOULD" -gt 0 ]; then
+    # Build the apply command hint
+    APPLY_CMD="/cleanup-merged"
+    [ "$SCOPE" != "local" ] && APPLY_CMD="$APPLY_CMD $SCOPE"
+    APPLY_CMD="$APPLY_CMD apply"
+    echo "Run \`$APPLY_CMD\` to execute."
+  else
+    echo "Nothing to clean up."
+  fi
+else
+  # Apply summary
+  MSG_PARTS=()
+  if [ "$DO_LOCAL" -eq 1 ]; then
+    MSG_PARTS+=("local: deleted $LOCAL_DELETED, skipped $LOCAL_SKIPPED, protected $LOCAL_PROTECTED")
+  fi
+  if [ "$DO_REMOTE" -eq 1 ]; then
+    MSG_PARTS+=("remote: deleted $REMOTE_DELETED, skipped $REMOTE_SKIPPED, protected $REMOTE_PROTECTED")
+  fi
+
+  echo "cleanup-merged: $(printf '%s; ' "${MSG_PARTS[@]}" | sed 's/; $//')"
+
+  if [ "$SWITCHED" -eq 1 ]; then
+    echo "(switched to $MAIN_BRANCH and pulled.)"
+  elif [ "$ON_MAIN" -eq 1 ]; then
+    echo "(on $MAIN_BRANCH, pulled latest.)"
+  fi
 fi
+exit 0
 ```
 
 ## Exit codes
 
 | rc | Meaning |
 |----|---------|
-| 0 | Success (or dry-run complete, or `--review` finished) |
+| 0 | Success (or preview complete) |
 | 1 | Missing required tool (git) |
-| 2 | Bad argument (or mutually-exclusive flag combo) |
-| 3 | Dirty working tree — refuses to proceed (default mode only; `--review` tolerates) |
+| 2 | Bad argument |
+| 3 | Dirty working tree — refuses to proceed |
 | 4 | `git fetch` failed |
 | 5 | `git checkout` or `git pull` failed |
 

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -93,8 +93,15 @@
           "type": "array",
           "items": { "type": "string" },
           "default": [],
-          "description": "Branch-name glob patterns that /cleanup-merged --review treats as KEEP regardless of merge / push state. Use for explicitly long-lived branches (e.g., docs/run-order-guide, release/*). Empty by default. Matched via bash glob semantics (NOT regex).",
+          "description": "DEPRECATED: Replaced by protected_branches. Branch-name glob patterns that /cleanup-merged treats as KEEP regardless of merge / push state. Empty by default. Matched via bash glob semantics (NOT regex).",
           "examples": [["docs/run-order-guide", "release/*"]]
+        },
+        "protected_branches": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Branch names that /cleanup-merged should never delete. Preview marks these as PROTECTED (config) and apply skips them automatically. Exact match (not glob).",
+          "examples": [["docs/run-order-guide"]]
         }
       }
     },

--- a/docs/skills/cleanup-merged.md
+++ b/docs/skills/cleanup-merged.md
@@ -1,39 +1,58 @@
 # /cleanup-merged
 
-> Post-PR-merge local normalization: fetch-and-prune origin, switch off merged feature branches, pull main, and delete local branches whose upstream is gone or whose PR has merged.
+> Post-PR-merge local normalization: fetch-and-prune origin, switch off merged feature branches, pull main, and delete local branches whose upstream is gone or whose PR has merged. Preview by default.
 
 ## Usage
 
 ```
-/cleanup-merged [--dry-run | -n] [--review]
+/cleanup-merged              preview local branches
+/cleanup-merged apply        execute local deletions
+/cleanup-merged remote       preview remote branch deletions
+/cleanup-merged remote apply execute remote deletions
+/cleanup-merged all          preview both local + remote
+/cleanup-merged all apply    execute both
 ```
 
-## Arguments
+## Positional Tokens
 
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `--dry-run` / `-n` | No | Report what would happen without modifying anything |
-| `--review` | No | Per-branch merit-based classification with interactive picker |
+| Token | Description |
+|-------|-------------|
+| `apply` | Execute the deletions shown in preview |
+| `remote` | Scope to remote branches (requires `gh`) |
+| `all` | Scope to both local + remote branches |
+
+## Protected Branches
+
+Configure branches that should never be deleted in `.claude/zskills-config.json`:
+
+```json
+{ "cleanup": { "protected_branches": ["docs/run-order-guide"] } }
+```
+
+Protected branches are marked `PROTECTED (config)` in preview and skipped automatically during apply.
 
 ## Examples
 
 ```
-/cleanup-merged
-/cleanup-merged --dry-run
-/cleanup-merged -n
-/cleanup-merged --review
+/cleanup-merged                  preview what would be deleted locally
+/cleanup-merged apply            delete merged local branches
+/cleanup-merged remote           preview stale remote branches
+/cleanup-merged remote apply     delete merged remote branches
+/cleanup-merged all              preview everything
+/cleanup-merged all apply        clean up everything
 ```
 
 ## Common Patterns
 
-- **After merging a PR:** `/cleanup-merged` -- fetch, switch to main, pull, delete merged branches
-- **Preview first:** `/cleanup-merged --dry-run` -- see what would be deleted before committing
-- **Thorough cleanup:** `/cleanup-merged --review` -- classify every branch and worktree, then pick what to clean
+- **After merging a PR:** `/cleanup-merged` -- preview, then `/cleanup-merged apply` to execute
+- **Full cleanup:** `/cleanup-merged all apply` -- local + remote in one pass
+- **Remote only:** `/cleanup-merged remote apply` -- clean stale remote branches without touching local
 
 ## Tips & Gotchas
 
-- Safe to run any time -- bails on a dirty working tree
+- Preview is the default -- safe to run any time
+- Bails on a dirty working tree
 - Never deletes a branch with unpushed commits
-- `--dry-run` and `--review` are mutually exclusive
-- Review mode classifies branches per merit rules and presents an interactive picker
-- Uses `gh` for PR status checks when available; falls back gracefully without it
+- Remote cleanup requires `gh` for PR-state gating (never deletes branches with open PRs)
+- Protected branches from config are always skipped
+- Legacy `--dry-run` and `--review` flags work as aliases for one release cycle

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[--dry-run | -n] [--review]"
+argument-hint: "[apply] [remote | all]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
-  upstream is gone or whose PR has merged. Bails on a dirty tree; skips
-  branches with unpushed commits. --dry-run previews. --review classifies
-  every local branch + worktree per merit rules and presents an
-  interactive picker for cleanup actions.
+  upstream is gone or whose PR has merged. Preview by default — run
+  `/cleanup-merged apply` to execute. `remote` adds remote branch cleanup;
+  `all` does both local + remote. Protected branches from config are
+  skipped automatically.
 metadata:
-  version: "2026.05.21+c788ef"
+  version: "2026.05.28+e42a2b"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -22,18 +22,43 @@ are gone or whose PRs are merged.
 
 **Ultrathink throughout.**
 
+**Preview by default.** Bare invocation shows what would be deleted.
+Run `/cleanup-merged apply` to execute.
+
 Safe to run any time. The skill bails on a dirty working tree and
 never deletes a branch with unpushed commits.
 
-## Arguments
+## Interface
 
-- `--dry-run` / `-n` — report what would happen without modifying
-  anything. Useful to preview deletions on the first run.
-- `--review` — opt into per-branch merit-based classification.
-  Enumerates every local branch + worktree, classifies each per the rule
-  table (see Phase 7), and prompts the user for actions via an
-  alphabetized letter-keyed picker. Mutually exclusive with `--dry-run`
-  (review mode is interactive — dry-run has no meaning).
+```
+/cleanup-merged              — preview local (show what would be deleted)
+/cleanup-merged apply        — execute local deletions (skip protected)
+/cleanup-merged remote       — preview remote branch deletions
+/cleanup-merged remote apply — execute remote deletions (skip protected)
+/cleanup-merged all          — preview both local + remote
+/cleanup-merged all apply    — execute both (skip protected)
+```
+
+- **Preview is default** — safe to run, self-documenting. Output shows
+  the plan and ends with "run `/cleanup-merged apply` to execute."
+- **`apply`** — positional token meaning "I saw the preview, do it."
+  Terraform precedent.
+- **`remote`** — adds `git push origin --delete` for branches whose PRs
+  are confirmed MERGED via `gh pr view`. Never deletes branches with
+  open PRs.
+- **`all`** — both local + remote.
+- **Protected branches** — config field in `.claude/zskills-config.json`:
+  ```json
+  { "cleanup": { "protected_branches": ["docs/run-order-guide"] } }
+  ```
+  Preview marks these as `PROTECTED (config)` and `apply` skips them
+  automatically.
+
+### Migration aliases
+
+For one release cycle, `--dry-run` / `-n` map to preview (the new
+default) and `--review` maps to `all` (preview both). Both emit a
+deprecation notice. Remove after 2026-07-01.
 
 ## Phase 1 — Preflight
 
@@ -54,24 +79,40 @@ fi
 
 ### WI 1.2 — Argument parse
 
+Positional tokens: `apply`, `remote`, `all`. Order-independent.
+Legacy flags `--dry-run`, `-n`, `--review` are accepted as migration
+aliases.
+
 ```bash
-DRY_RUN=0
-REVIEW=0
+APPLY=0
+SCOPE="local"  # "local", "remote", or "all"
+
 for arg in "$@"; do
   case "$arg" in
-    --dry-run|-n) DRY_RUN=1 ;;
-    --review) REVIEW=1 ;;
+    apply)  APPLY=1 ;;
+    remote) SCOPE="remote" ;;
+    all)    SCOPE="all" ;;
+    --dry-run|-n)
+      echo "DEPRECATED: --dry-run/-n is now the default. Just run /cleanup-merged (no args) for preview."
+      ;;
+    --review)
+      echo "DEPRECATED: --review is replaced by /cleanup-merged all. Treating as 'all'."
+      SCOPE="all"
+      ;;
     *)
-      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [--dry-run|-n] [--review]" >&2
+      echo "ERROR: unknown argument '$arg'. Usage: /cleanup-merged [apply] [remote | all]" >&2
       exit 2
       ;;
   esac
 done
 
-if [ "$DRY_RUN" -eq 1 ] && [ "$REVIEW" -eq 1 ]; then
-  echo "ERROR: --dry-run and --review are mutually exclusive (review is interactive)." >&2
-  exit 2
-fi
+DO_LOCAL=0
+DO_REMOTE=0
+case "$SCOPE" in
+  local)  DO_LOCAL=1 ;;
+  remote) DO_REMOTE=1 ;;
+  all)    DO_LOCAL=1; DO_REMOTE=1 ;;
+esac
 ```
 
 ### WI 1.3 — Locate main-repo root and detect main branch
@@ -87,18 +128,53 @@ if ! git show-ref --verify --quiet refs/heads/main \
 fi
 ```
 
-### WI 1.4 — Bail on dirty tree
+### WI 1.4 — Load protected branches from config
+
+Read `cleanup.protected_branches` from `.claude/zskills-config.json`.
+Default empty array.
+
+```bash
+CONFIG_FILE=".claude/zskills-config.json"
+PROTECTED_BRANCHES=()
+if [ -f "$CONFIG_FILE" ]; then
+  PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+  if [ -n "$PYTHON" ]; then
+    while IFS= read -r p; do
+      [ -n "$p" ] && PROTECTED_BRANCHES+=("$p")
+    done < <("$PYTHON" -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    pats = cfg.get("cleanup", {}).get("protected_branches", []) or []
+    for p in pats:
+        print(p)
+except Exception:
+    pass
+' "$CONFIG_FILE")
+  fi
+fi
+
+is_protected() {
+  local branch="$1"
+  for pb in "${PROTECTED_BRANCHES[@]:-}"; do
+    [ -z "$pb" ] && continue
+    if [ "$branch" = "$pb" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+```
+
+### WI 1.5 — Bail on dirty tree
 
 Untracked files count as dirty: `/cleanup-merged` will `git checkout
 main` and `git pull`, which would dump new untracked files back out or
 could conflict with an uncommitted edit the user hasn't saved yet.
 
-Review mode (`--review`) **does not** bail on a dirty tree — its job is
-to inspect and surface dirty worktrees. It still avoids any destructive
-operation on the dirty repo (no checkout, no pull, no auto-delete).
-
 ```bash
-if [ "$REVIEW" -eq 0 ] && [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain)" ]; then
   echo "ERROR: working tree is not clean. Commit, stash, or discard changes first." >&2
   git status --short >&2
   exit 3
@@ -115,7 +191,7 @@ if ! git fetch origin --prune; then
 fi
 
 # Drop orphaned worktree registrations (directories deleted from disk)
-# so Phase 5's worktree→branch map reflects only live worktrees.
+# so Phase 4's worktree->branch map reflects only live worktrees.
 git worktree prune
 ```
 
@@ -123,29 +199,21 @@ git worktree prune
 this, `git branch -vv` shows `: gone]` next to local branches whose
 remote was deleted — the primary signal for detecting merged PRs when
 GitHub's auto-delete-head-branches setting is on. `git worktree prune`
-clears stale worktree entries so Phase 5 can reliably decide whether a
+clears stale worktree entries so Phase 4 can reliably decide whether a
 merged branch is still held by a live worktree.
 
 ## Phase 3 — Switch off a merged feature branch (if applicable)
 
 If the current branch is not the main branch, check whether its PR is
 merged or its upstream is gone. If so, switch to main so we can delete
-the branch later. Review mode skips this phase (and Phases 4–6) and
-jumps straight to Phase 7.
+the branch later. In preview mode (no `apply`), report what would
+happen without switching.
 
 ```bash
-if [ "$REVIEW" -eq 1 ]; then
-  # Review-mode skips Phases 3–6; jump to Phase 7 directly.
-  SWITCHED=0
-  ON_MAIN=0
-  DELETED=0
-  SKIPPED=0
-fi
-
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
 SWITCHED=0
 
-if [ "$REVIEW" -eq 0 ] && [ "$CURRENT" != "$MAIN_BRANCH" ]; then
+if [ "$CURRENT" != "$MAIN_BRANCH" ]; then
   UPSTREAM_GONE=0
   if git branch -vv | grep -qE "^\* $CURRENT .*: gone\]"; then
     UPSTREAM_GONE=1
@@ -158,13 +226,15 @@ if [ "$REVIEW" -eq 0 ] && [ "$CURRENT" != "$MAIN_BRANCH" ]; then
 
   if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
     REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
-    echo "Current branch '$CURRENT' is safe to leave ($REASON). Switching to $MAIN_BRANCH..."
-    if [ "$DRY_RUN" -eq 0 ]; then
+    if [ "$APPLY" -eq 1 ]; then
+      echo "Current branch '$CURRENT' is safe to leave ($REASON). Switching to $MAIN_BRANCH..."
       if ! git checkout "$MAIN_BRANCH"; then
         echo "ERROR: failed to checkout $MAIN_BRANCH." >&2
         exit 5
       fi
       SWITCHED=1
+    else
+      echo "  WOULD-SWITCH from '$CURRENT' to $MAIN_BRANCH ($REASON)"
     fi
   else
     echo "Current branch '$CURRENT' is not merged (PR state: ${PR_STATE:-unknown}); staying here. Run from $MAIN_BRANCH or after merging to clean it up."
@@ -174,15 +244,14 @@ fi
 
 ## Phase 4 — Pull main
 
-Only pull if we are on the main branch. A dry-run skips the pull
-because we promised not to modify anything. Review mode skips this
-phase entirely.
+Only pull if we are on the main branch. Preview mode skips the pull
+because we promised not to modify anything.
 
 ```bash
 ON_MAIN=0
 [ "$(git rev-parse --abbrev-ref HEAD)" = "$MAIN_BRANCH" ] && ON_MAIN=1
 
-if [ "$REVIEW" -eq 0 ] && [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+if [ "$ON_MAIN" -eq 1 ] && [ "$APPLY" -eq 1 ]; then
   echo "Pulling $MAIN_BRANCH..."
   if ! git pull origin "$MAIN_BRANCH"; then
     echo "ERROR: git pull failed." >&2
@@ -191,11 +260,7 @@ if [ "$REVIEW" -eq 0 ] && [ "$ON_MAIN" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
 fi
 ```
 
-## Phase 5 — Scan and delete merged branches
-
-Review mode skips this phase — its per-branch action logic lives in
-Phase 7 instead (the `if [ "$REVIEW" -eq 1 ]; then : else …` guard
-below wraps the original loop).
+## Phase 5 — Local branch scan
 
 For every local branch other than the main branch and the currently
 checked-out branch, check the same two signals (upstream gone, PR
@@ -212,132 +277,139 @@ is removed first (`git worktree remove`); a dirty worktree, or the main
 repo's own worktree, causes the branch to be skipped with a warning so
 the user can intervene manually.
 
+Protected branches (from `cleanup.protected_branches` config) are
+marked `PROTECTED (config)` in preview and skipped in apply.
+
 ```bash
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
-DELETED=0
-SKIPPED=0
+LOCAL_DELETED=0
+LOCAL_SKIPPED=0
+LOCAL_PROTECTED=0
+LOCAL_CANDIDATES=()  # branch names that are merged and deletable
 
-if [ "$REVIEW" -eq 1 ]; then
-  : # Phase 5 main loop is bypassed in review mode (handled by Phase 7).
-else
-while IFS= read -r branch; do
-  [ -z "$branch" ] && continue
-  [ "$branch" = "$MAIN_BRANCH" ] && continue
-  [ "$branch" = "$CURRENT" ] && continue
+if [ "$DO_LOCAL" -eq 1 ]; then
+  echo ""
+  echo "--- Local branches ---"
 
-  UPSTREAM_GONE=0
-  if git branch -vv | grep -qE "^  $branch .*: gone\]"; then
-    UPSTREAM_GONE=1
-  fi
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    [ "$branch" = "$MAIN_BRANCH" ] && continue
+    [ "$branch" = "$CURRENT" ] && continue
 
-  PR_STATE=""
-  if [ "$HAVE_GH" -eq 1 ]; then
-    PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
-  fi
-
-  MERGED=0
-  if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
-    MERGED=1
-  fi
-
-  [ "$MERGED" -eq 0 ] && continue
-
-  # Unpushed-commit guard (squash-merge still counts commits as unpushed
-  # because the squash SHA is different). Only honor the guard when the
-  # upstream is NOT gone — a gone upstream plus PR=MERGED means the
-  # commits reached main via squash.
-  UNPUSHED=""
-  if [ "$UPSTREAM_GONE" -eq 0 ]; then
-    UNPUSHED=$(git log "$branch" --not --remotes --oneline 2>/dev/null | head -1)
-  fi
-
-  if [ -n "$UNPUSHED" ]; then
-    echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional)"
-    SKIPPED=$((SKIPPED+1))
-    continue
-  fi
-
-  # Issue #516: ahead-count gate. `gh pr view` is sticky after merge, so
-  # PR=MERGED + ahead>0 means the local branch may carry post-merge
-  # commits that would be silently reaped by `git branch -D`. Only gate
-  # the PR=MERGED path (upstream-gone implies squash-merge, where ahead>0
-  # is expected and the unpushed-commit guard above already handles the
-  # un-squashed case).
-  if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ]; then
-    AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
-    [ -z "$AHEAD" ] && AHEAD=0
-    if [ "$AHEAD" -gt 0 ]; then
-      echo "  SKIP   $branch (PR merged but branch has $AHEAD commits not on main — investigate; do not auto-remove)"
-      SKIPPED=$((SKIPPED+1))
-      continue
-    fi
-  fi
-
-  # Worktree detection: does any registered worktree hold $branch?
-  # `git worktree list --porcelain` emits blocks like:
-  #     worktree /abs/path
-  #     HEAD <sha>
-  #     branch refs/heads/<name>
-  #     (blank line)
-  # Detached-HEAD worktrees have no "branch" line; the awk filter below
-  # pairs every "worktree" line with its following "branch" line (if any)
-  # and drops the unpaired detached ones.
-  WORKTREE_FOR_BRANCH=""
-  while IFS= read -r wt_path && IFS= read -r wt_branch; do
-    if [ "${wt_branch#branch refs/heads/}" = "$branch" ]; then
-      WORKTREE_FOR_BRANCH="${wt_path#worktree }"
-      break
-    fi
-  done < <(git worktree list --porcelain | awk '/^worktree /{wt=$0} /^branch /{print wt; print $0}')
-
-  REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
-
-  if [ -n "$WORKTREE_FOR_BRANCH" ]; then
-    if [ "$WORKTREE_FOR_BRANCH" = "$MAIN_ROOT" ]; then
-      echo "WARN: merged branch $branch is checked out in main repo; checkout main before cleanup-merged." >&2
-      SKIPPED=$((SKIPPED+1))
+    # Protected branch check
+    if is_protected "$branch"; then
+      echo "  PROTECTED (config) $branch"
+      LOCAL_PROTECTED=$((LOCAL_PROTECTED+1))
       continue
     fi
 
-    WT_DIRTY=$(git -C "$WORKTREE_FOR_BRANCH" status --porcelain 2>/dev/null)
-    if [ -n "$WT_DIRTY" ]; then
-      echo "WARN: worktree at $WORKTREE_FOR_BRANCH holds merged branch $branch but has uncommitted changes — inspect and remove manually." >&2
-      SKIPPED=$((SKIPPED+1))
+    UPSTREAM_GONE=0
+    if git branch -vv | grep -qE "^  $branch .*: gone\]"; then
+      UPSTREAM_GONE=1
+    fi
+
+    PR_STATE=""
+    if [ "$HAVE_GH" -eq 1 ]; then
+      PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
+    fi
+
+    MERGED=0
+    if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
+      MERGED=1
+    fi
+
+    [ "$MERGED" -eq 0 ] && continue
+
+    # Unpushed-commit guard (squash-merge still counts commits as unpushed
+    # because the squash SHA is different). Only honor the guard when the
+    # upstream is NOT gone — a gone upstream plus PR=MERGED means the
+    # commits reached main via squash.
+    UNPUSHED=""
+    if [ "$UPSTREAM_GONE" -eq 0 ]; then
+      UNPUSHED=$(git log "$branch" --not --remotes --oneline 2>/dev/null | head -1)
+    fi
+
+    if [ -n "$UNPUSHED" ]; then
+      echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional)"
+      LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
       continue
     fi
 
-    if [ "$DRY_RUN" -eq 1 ]; then
-      echo "  WOULD-REMOVE-WORKTREE $WORKTREE_FOR_BRANCH (holds $branch)"
+    # Issue #516: ahead-count gate. `gh pr view` is sticky after merge, so
+    # PR=MERGED + ahead>0 means the local branch may carry post-merge
+    # commits that would be silently reaped by `git branch -D`. Only gate
+    # the PR=MERGED path (upstream-gone implies squash-merge, where ahead>0
+    # is expected and the unpushed-commit guard above already handles the
+    # un-squashed case).
+    if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ]; then
+      AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
+      [ -z "$AHEAD" ] && AHEAD=0
+      if [ "$AHEAD" -gt 0 ]; then
+        echo "  SKIP   $branch (PR merged but branch has $AHEAD commits not on main — investigate; do not auto-remove)"
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+    fi
+
+    # Worktree detection: does any registered worktree hold $branch?
+    WORKTREE_FOR_BRANCH=""
+    while IFS= read -r wt_path && IFS= read -r wt_branch; do
+      if [ "${wt_branch#branch refs/heads/}" = "$branch" ]; then
+        WORKTREE_FOR_BRANCH="${wt_path#worktree }"
+        break
+      fi
+    done < <(git worktree list --porcelain | awk '/^worktree /{wt=$0} /^branch /{print wt; print $0}')
+
+    REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
+
+    if [ -n "$WORKTREE_FOR_BRANCH" ]; then
+      if [ "$WORKTREE_FOR_BRANCH" = "$MAIN_ROOT" ]; then
+        echo "  WARN: merged branch $branch is checked out in main repo; checkout main before cleanup-merged." >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+
+      WT_DIRTY=$(git -C "$WORKTREE_FOR_BRANCH" status --porcelain 2>/dev/null)
+      if [ -n "$WT_DIRTY" ]; then
+        echo "  WARN: worktree at $WORKTREE_FOR_BRANCH holds merged branch $branch but has uncommitted changes — inspect and remove manually." >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+
+      if [ "$APPLY" -eq 0 ]; then
+        echo "  WOULD-REMOVE-WORKTREE $WORKTREE_FOR_BRANCH (holds $branch)"
+        echo "  WOULD-DELETE $branch ($REASON)"
+        LOCAL_DELETED=$((LOCAL_DELETED+1))
+        LOCAL_CANDIDATES+=("$branch")
+        continue
+      fi
+
+      if ! git worktree remove "$WORKTREE_FOR_BRANCH"; then
+        echo "  FAILED  $branch (git worktree remove $WORKTREE_FOR_BRANCH exited non-zero)" >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        continue
+      fi
+      echo "  REMOVED-WORKTREE $WORKTREE_FOR_BRANCH (held $branch)"
+    fi
+
+    if [ "$APPLY" -eq 0 ]; then
       echo "  WOULD-DELETE $branch ($REASON)"
-      DELETED=$((DELETED+1))
-      continue
-    fi
-
-    if ! git worktree remove "$WORKTREE_FOR_BRANCH"; then
-      echo "  FAILED  $branch (git worktree remove $WORKTREE_FOR_BRANCH exited non-zero)" >&2
-      SKIPPED=$((SKIPPED+1))
-      continue
-    fi
-    echo "  REMOVED-WORKTREE $WORKTREE_FOR_BRANCH (held $branch)"
-  fi
-
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "  WOULD-DELETE $branch ($REASON)"
-    DELETED=$((DELETED+1))
-  else
-    if git branch -D "$branch" >/dev/null; then
-      echo "  DELETED $branch ($REASON)"
-      DELETED=$((DELETED+1))
+      LOCAL_DELETED=$((LOCAL_DELETED+1))
+      LOCAL_CANDIDATES+=("$branch")
     else
-      echo "  FAILED  $branch (git branch -D exited non-zero)" >&2
-      SKIPPED=$((SKIPPED+1))
+      if git branch -D "$branch" >/dev/null; then
+        echo "  DELETED $branch ($REASON)"
+        LOCAL_DELETED=$((LOCAL_DELETED+1))
+      else
+        echo "  FAILED  $branch (git branch -D exited non-zero)" >&2
+        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+      fi
     fi
-  fi
-done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
-fi  # /REVIEW guard
+  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+fi
 ```
 
-After the worktree-pruning loop, sweep any stale `/fix-issues` claim
+After the local branch loop, sweep any stale `/fix-issues` claim
 directories. When a PR merges via the GitHub web UI or a manual
 `gh pr merge` (bypassing `/land-pr`'s `STATUS=merged` release path), the
 per-issue claim under `.zskills/claims/issue-NNN/` leaks until its TTL
@@ -349,506 +421,138 @@ effort housekeeping; the surrounding cleanup-merged success criteria
 should not regress on a stale-claim sweep failure.
 
 ```bash
-bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" sweep || true
+if [ "$DO_LOCAL" -eq 1 ] && [ "$APPLY" -eq 1 ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" sweep || true
+fi
 ```
 
-## Phase 6 — Summary
+## Phase 6 — Remote branch scan
 
-Review mode skips this phase; its summary is part of Phase 7's table
-+ action report.
+When `remote` or `all` scope is active, scan remote-tracking branches
+for merged-PR candidates. For each `origin/<branch>` that is not the
+main branch:
+
+1. Check if the branch has a MERGED PR via `gh pr view`.
+2. Skip branches with OPEN PRs — never delete an active branch.
+3. Skip protected branches (from config).
+4. In preview, show `WOULD-DELETE-REMOTE`; in apply, run
+   `git push origin --delete <branch>`.
+
+Requires `gh` — if `gh` is unavailable and `remote`/`all` scope is
+requested, warn and skip.
 
 ```bash
-if [ "$REVIEW" -eq 0 ]; then
+REMOTE_DELETED=0
+REMOTE_SKIPPED=0
+REMOTE_PROTECTED=0
+
+if [ "$DO_REMOTE" -eq 1 ]; then
   echo ""
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "cleanup-merged (dry-run): would delete $DELETED, skip $SKIPPED. Nothing was modified."
+  echo "--- Remote branches ---"
+
+  if [ "$HAVE_GH" -eq 0 ]; then
+    echo "WARN: gh not available; remote branch cleanup requires gh for PR-state gating. Skipping." >&2
   else
-    echo "cleanup-merged: deleted $DELETED branches, skipped $SKIPPED."
-    if [ "$SWITCHED" -eq 1 ]; then
-      echo "(switched to $MAIN_BRANCH and pulled.)"
-    elif [ "$ON_MAIN" -eq 1 ]; then
-      echo "(on $MAIN_BRANCH, pulled latest.)"
-    fi
-  fi
-  exit 0
-fi
-```
+    while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      # Strip "origin/" prefix
+      branch="${ref#origin/}"
 
-## Phase 7 — Review mode (--review)
+      [ "$branch" = "$MAIN_BRANCH" ] && continue
+      [ "$branch" = "HEAD" ] && continue
 
-When `--review` is set, enumerate every local branch + worktree,
-classify each per the rule table below (first-match-wins), present an
-alphabetized table with letter IDs and verdicts, then prompt for action.
-
-### Classification rules (first-match wins)
-
-| # | Condition | Verdict | Rationale |
-|---|---|---|---|
-| 1 | Worktree is `locked` | **KEEP** | Live process; never touch |
-| 2 | Branch name matches `cleanup.long_running_patterns` config glob | **KEEP** | Explicitly preserved |
-| 11 | PR=MERGED AND commits ahead of main | **DECIDE** | `gh pr view` is sticky after merge; ahead>0 means possible post-merge commits (issue #516) — surface, don't auto-remove |
-| 3 | (upstream-gone OR PR=MERGED) AND worktree clean | **REMOVE** | Current `/cleanup-merged` default action |
-| 4 | (upstream-gone OR PR=MERGED) AND worktree dirty | **DECIDE** | Merged but uncommitted changes — inspect first |
-| 5 | Commits ahead AND PR=OPEN | **KEEP** | Active in-flight PR |
-| 6 | Commits ahead AND no PR AND clean | **MAYBE** | Drafted-but-not-pushed; review intent |
-| 7 | 0 commits ahead AND no PR AND clean AND `.landed status != landed` | **DECIDE** | Abandoned/failed sprint state |
-| 8 | 0 commits ahead AND no PR AND clean AND no `.landed` | **REMOVE** | Empty stub — typical orphaned cron artifact |
-| 9 | 0 commits ahead AND no PR AND tree dirty | **DECIDE** | Partial work or orphan; inspect diff |
-| 10 | Commits ahead AND tree dirty | **DECIDE** | Active uncommitted work |
-| — | (fallthrough) | **DECIDE** | Unclassified; manual review |
-
-### WI 7.1 — Load long_running_patterns from config
-
-Default empty array. Read via Python (zskills uses Python json, no jq).
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  CONFIG_FILE=".claude/zskills-config.json"
-  LONG_RUNNING_PATTERNS=()
-  if [ -f "$CONFIG_FILE" ]; then
-    PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
-    if [ -n "$PYTHON" ]; then
-      while IFS= read -r p; do
-        [ -n "$p" ] && LONG_RUNNING_PATTERNS+=("$p")
-      done < <("$PYTHON" -c '
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        cfg = json.load(f)
-    pats = cfg.get("cleanup", {}).get("long_running_patterns", []) or []
-    for p in pats:
-        print(p)
-except Exception:
-    pass
-' "$CONFIG_FILE")
-    fi
-  fi
-fi
-```
-
-### WI 7.2 — Enumerate branches + worktrees and classify
-
-Walk every local branch (`git for-each-ref refs/heads/`) and every
-worktree (`git worktree list --porcelain`). Build a unified row set
-keyed by `(worktree_path, branch_name)`. A worktree-less branch yields
-a row with `worktree=<none>`; a detached-HEAD worktree (no branch)
-yields a row with `branch=<detached>`.
-
-For each row, compute these signals:
-
-- `LOCKED` — worktree has a `locked` line in `git worktree list --porcelain`.
-- `AHEAD` — `git rev-list --count $MAIN_BRANCH..$branch` (0 if missing).
-- `UPSTREAM_GONE` — `git branch -vv` shows `: gone]` for the branch.
-- `PR_STATE` — `gh pr view $branch --json state` (empty if no PR).
-- `DIRTY` — `git -C $worktree status --porcelain` non-empty.
-- `LANDED_STATUS` — parse `status:` from `<worktree>/.landed`, or empty.
-
-Then walk the rule table top-to-bottom; the first matching rule sets
-`VERDICT` and `RULE_NUM`. `RULE_DESC` is a short one-liner from the
-table.
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  # Build worktree → (locked, branch) map via porcelain output.
-  # Format blocks: "worktree /path", then optional "HEAD <sha>",
-  # optional "branch refs/heads/<name>" OR "detached", optional "locked".
-  declare -A WT_BRANCH
-  declare -A WT_LOCKED
-  WT_PATHS=()
-
-  current_wt=""
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^worktree\ (.*)$ ]]; then
-      current_wt="${BASH_REMATCH[1]}"
-      WT_PATHS+=("$current_wt")
-      WT_BRANCH["$current_wt"]="<detached>"
-      WT_LOCKED["$current_wt"]=0
-    elif [[ "$line" =~ ^branch\ refs/heads/(.*)$ ]]; then
-      WT_BRANCH["$current_wt"]="${BASH_REMATCH[1]}"
-    elif [[ "$line" == "locked" || "$line" == locked\ * ]]; then
-      WT_LOCKED["$current_wt"]=1
-    fi
-  done < <(git worktree list --porcelain)
-
-  # Build branch → worktree reverse map.
-  declare -A BRANCH_WT
-  for wt in "${WT_PATHS[@]}"; do
-    br="${WT_BRANCH[$wt]}"
-    [ "$br" = "<detached>" ] && continue
-    BRANCH_WT["$br"]="$wt"
-  done
-
-  # Snapshot `git branch -vv` once for fast UPSTREAM_GONE lookup.
-  BRANCH_VV=$(git branch -vv)
-
-  # Glob-match a branch name against the long_running_patterns array.
-  # Uses bash's [[ "$name" == $pattern ]] glob (NOT regex).
-  matches_long_running() {
-    local name="$1" pat
-    for pat in "${LONG_RUNNING_PATTERNS[@]:-}"; do
-      [ -z "$pat" ] && continue
-      # shellcheck disable=SC2053
-      if [[ "$name" == $pat ]]; then
-        return 0
+      # Protected branch check
+      if is_protected "$branch"; then
+        echo "  PROTECTED (config) origin/$branch"
+        REMOTE_PROTECTED=$((REMOTE_PROTECTED+1))
+        continue
       fi
-    done
-    return 1
-  }
 
-  # Classifier — given branch + worktree-path + signals, sets
-  # VERDICT and RULE_NUM and RULE_DESC.
-  classify() {
-    local branch="$1" wt="$2" locked="$3" ahead="$4" upstream_gone="$5"
-    local pr_state="$6" dirty="$7" landed_status="$8"
+      PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
 
-    # Rule 1
-    if [ "$locked" = "1" ]; then
-      VERDICT="KEEP"; RULE_NUM=1
-      RULE_DESC="worktree locked; live process — never touch"
-      return
-    fi
-    # Rule 2
-    if [ "$branch" != "<detached>" ] && [ "$branch" != "<none>" ]; then
-      if matches_long_running "$branch"; then
-        VERDICT="KEEP"; RULE_NUM=2
-        RULE_DESC="matches cleanup.long_running_patterns"
-        return
+      if [ "$PR_STATE" = "OPEN" ]; then
+        continue  # Active PR — never delete
       fi
-    fi
 
-    local merged=0
-    if [ "$upstream_gone" = "1" ] || [ "$pr_state" = "MERGED" ]; then
-      merged=1
-    fi
-    local has_dirty=0
-    [ -n "$dirty" ] && has_dirty=1
-
-    # Rule 3a (issue #516) — PR=MERGED + ahead>0 means the local branch
-    # has commits not on main. `gh pr view` is sticky after merge, so a
-    # diverged branch still reports MERGED. Surface for manual review
-    # instead of silently reaping post-merge commits. Squash-merge alone
-    # ALSO shows ahead>0 (different SHA), but distinguishing post-merge
-    # divergence from squash-merge requires content comparison the
-    # classifier doesn't do; the safe action in either case is DECIDE.
-    if [ "$pr_state" = "MERGED" ] && [ "$ahead" -gt 0 ]; then
-      VERDICT="DECIDE"; RULE_NUM=11
-      RULE_DESC="PR merged but branch has $ahead commits not on main — investigate"
-      return
-    fi
-    # Rule 3
-    if [ "$merged" = "1" ] && [ "$has_dirty" = "0" ]; then
-      VERDICT="REMOVE"; RULE_NUM=3
-      RULE_DESC="merged (upstream-gone or PR=MERGED), worktree clean"
-      return
-    fi
-    # Rule 4
-    if [ "$merged" = "1" ] && [ "$has_dirty" = "1" ]; then
-      VERDICT="DECIDE"; RULE_NUM=4
-      RULE_DESC="merged but uncommitted changes — inspect first"
-      return
-    fi
-    # Rule 5
-    if [ "$ahead" -gt 0 ] && [ "$pr_state" = "OPEN" ]; then
-      VERDICT="KEEP"; RULE_NUM=5
-      RULE_DESC="active in-flight PR"
-      return
-    fi
-    # Rule 6
-    if [ "$ahead" -gt 0 ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ]; then
-      VERDICT="MAYBE"; RULE_NUM=6
-      RULE_DESC="drafted but not pushed — review intent"
-      return
-    fi
-    # Rule 7
-    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
-       && [ -n "$landed_status" ] && [ "$landed_status" != "landed" ] \
-       && [ "$landed_status" != "full" ]; then
-      VERDICT="DECIDE"; RULE_NUM=7
-      RULE_DESC="abandoned/failed sprint state (.landed=$landed_status)"
-      return
-    fi
-    # Rule 8
-    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "0" ] \
-       && [ -z "$landed_status" ]; then
-      VERDICT="REMOVE"; RULE_NUM=8
-      RULE_DESC="empty stub — typical orphaned cron artifact"
-      return
-    fi
-    # Rule 9
-    if [ "$ahead" = "0" ] && [ -z "$pr_state" ] && [ "$has_dirty" = "1" ]; then
-      VERDICT="DECIDE"; RULE_NUM=9
-      RULE_DESC="0-ahead + dirty — partial work or orphan; inspect diff"
-      return
-    fi
-    # Rule 10
-    if [ "$ahead" -gt 0 ] && [ "$has_dirty" = "1" ]; then
-      VERDICT="DECIDE"; RULE_NUM=10
-      RULE_DESC="commits ahead AND tree dirty — active uncommitted work"
-      return
-    fi
-    # Fallthrough
-    VERDICT="DECIDE"; RULE_NUM=0
-    RULE_DESC="unclassified; manual review"
-  }
-
-  # Build row list: every branch (with optional worktree) plus every
-  # detached worktree without a branch ref.
-  ROWS=()  # Each row: VERDICT|RULE_NUM|RULE_DESC|PATH|BRANCH|AHEAD|PR_STATE|DIRTY_COUNT|LANDED_STATUS
-  CLASSIFIED_BRANCHES=()
-
-  while IFS= read -r branch; do
-    [ -z "$branch" ] && continue
-    [ "$branch" = "$MAIN_BRANCH" ] && continue
-
-    wt="${BRANCH_WT[$branch]:-}"
-    locked=0
-    if [ -n "$wt" ]; then
-      locked="${WT_LOCKED[$wt]:-0}"
-    fi
-
-    ahead=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
-    [ -z "$ahead" ] && ahead=0
-
-    upstream_gone=0
-    if echo "$BRANCH_VV" | grep -qE "^[* ]+ ?$branch\b.*: gone\]"; then
-      upstream_gone=1
-    fi
-
-    pr_state=""
-    if [ "$HAVE_GH" -eq 1 ]; then
-      pr_state=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
-    fi
-
-    dirty=""
-    dirty_count=0
-    if [ -n "$wt" ]; then
-      dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
-      [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
-    fi
-
-    landed_status=""
-    if [ -n "$wt" ] && [ -f "$wt/.landed" ]; then
-      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
-        | head -1 | sed -E 's/^status:[[:space:]]*//')
-    fi
-
-    classify "$branch" "$wt" "$locked" "$ahead" "$upstream_gone" \
-             "$pr_state" "$dirty" "$landed_status"
-
-    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|${wt:-<no-worktree>}|$branch|$ahead|${pr_state:-none}|$dirty_count|${landed_status:-<none>}")
-    CLASSIFIED_BRANCHES+=("$branch")
-  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
-
-  # Detached-HEAD worktrees: not represented by any branch, but still
-  # worth surfacing in the table.
-  for wt in "${WT_PATHS[@]}"; do
-    [ "${WT_BRANCH[$wt]}" != "<detached>" ] && continue
-    locked="${WT_LOCKED[$wt]:-0}"
-    dirty=$(git -C "$wt" status --porcelain 2>/dev/null)
-    dirty_count=0
-    [ -n "$dirty" ] && dirty_count=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
-    landed_status=""
-    if [ -f "$wt/.landed" ]; then
-      landed_status=$(grep -E '^status:' "$wt/.landed" 2>/dev/null \
-        | head -1 | sed -E 's/^status:[[:space:]]*//')
-    fi
-    classify "<detached>" "$wt" "$locked" 0 0 "" "$dirty" "$landed_status"
-    ROWS+=("$VERDICT|$RULE_NUM|$RULE_DESC|$wt|<detached>|0|none|$dirty_count|${landed_status:-<none>}")
-  done
-fi
-```
-
-### WI 7.3 — Render the alphabetized table
-
-Sort rows by worktree path (stable, deterministic), assign letter IDs
-A-Z then AA, AB, … for >26 rows. Print the verdict/path/details/rule
-table; then a one-line summary by verdict.
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  # Sort rows alphabetically by the PATH field (column 4 after the
-  # verb). We use Python sort for stable Unicode behaviour.
-  PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
-  SORTED_ROWS=()
-  while IFS= read -r r; do
-    [ -n "$r" ] && SORTED_ROWS+=("$r")
-  done < <(printf '%s\n' "${ROWS[@]}" | "$PYTHON" -c '
-import sys
-rows = [l.rstrip("\n") for l in sys.stdin if l.strip()]
-rows.sort(key=lambda r: r.split("|")[3])
-for r in rows:
-    print(r)
-')
-
-  # Letter-ID generator: A, B, …, Z, AA, AB, …, AZ, BA, …
-  letter_for() {
-    local n="$1" out=""
-    while [ "$n" -ge 0 ]; do
-      out="$(printf "\\$(printf '%03o' $((65 + n % 26)))")$out"
-      n=$((n / 26 - 1))
-    done
-    printf '%s' "$out"
-  }
-
-  echo ""
-  echo "/cleanup-merged --review"
-  echo ""
-
-  declare -A ROW_BY_LETTER
-  declare -A SUGGESTED_BY_LETTER
-  KEEP_N=0; MAYBE_N=0; DECIDE_N=0; REMOVE_N=0
-  i=0
-  for row in "${SORTED_ROWS[@]}"; do
-    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
-    letter=$(letter_for "$i")
-    ROW_BY_LETTER["$letter"]="$row"
-    SUGGESTED_BY_LETTER["$letter"]="$verdict"
-
-    dirty_phrase="clean"
-    [ "$dirty_count" -gt 0 ] && dirty_phrase="dirty:${dirty_count} file$([ "$dirty_count" -ne 1 ] && echo s)"
-    pr_phrase="no PR"
-    [ "$pr_state" != "none" ] && pr_phrase="PR=$pr_state"
-
-    printf '  %s. %-6s %s\n' "$letter" "$verdict" "$path"
-    printf '       [%s, %s ahead, %s, %s' "$branch" "$ahead" "$pr_phrase" "$dirty_phrase"
-    [ "$landed_status" != "<none>" ] && printf ', .landed=%s' "$landed_status"
-    printf ']\n'
-    printf '       → rule %s: %s\n' "$rule_num" "$rule_desc"
-
-    case "$verdict" in
-      KEEP)   KEEP_N=$((KEEP_N+1)) ;;
-      MAYBE)  MAYBE_N=$((MAYBE_N+1)) ;;
-      DECIDE) DECIDE_N=$((DECIDE_N+1)) ;;
-      REMOVE) REMOVE_N=$((REMOVE_N+1)) ;;
-    esac
-    i=$((i+1))
-  done
-
-  TOTAL=${#SORTED_ROWS[@]}
-  echo ""
-  echo "$TOTAL total: $KEEP_N KEEP, $MAYBE_N MAYBE, $DECIDE_N DECIDE, $REMOVE_N REMOVE"
-fi
-```
-
-### WI 7.4 — Interactive picker
-
-Read one line of input from the user. Recognized forms:
-
-- blank (just Enter) OR `all-suggested` → apply all rows whose suggested
-  verdict is `REMOVE`. Other verdicts left alone.
-- `<letter>:<verb>` pairs separated by whitespace (e.g.,
-  `A:remove D:keep F:remove`) → per-row override. Recognized verbs:
-  `remove`, `keep`, `skip` (alias of `keep`). Unrecognized letters
-  produce a warning and are skipped.
-- `none` or empty stdin (e.g. pipe closed) → exit without action.
-
-```bash
-if [ "$REVIEW" -eq 1 ]; then
-  echo ""
-  echo "Pick action:"
-  echo "  [Enter] / all-suggested  apply suggested REMOVEs only"
-  echo "  <letter>:<verb> ...      per-row override (verbs: remove, keep, skip)"
-  echo "  none                     exit without action"
-  printf '  > '
-
-  USER_INPUT=""
-  if [ -t 0 ]; then
-    IFS= read -r USER_INPUT || USER_INPUT="none"
-  else
-    # Non-interactive (CI, pipe): default to dry-listing only.
-    USER_INPUT="none"
-  fi
-
-  USER_INPUT_TRIM=$(printf '%s' "$USER_INPUT" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
-
-  declare -A ACTION_BY_LETTER
-  if [ -z "$USER_INPUT_TRIM" ] || [ "$USER_INPUT_TRIM" = "all-suggested" ]; then
-    for letter in "${!SUGGESTED_BY_LETTER[@]}"; do
-      if [ "${SUGGESTED_BY_LETTER[$letter]}" = "REMOVE" ]; then
-        ACTION_BY_LETTER["$letter"]="remove"
+      if [ "$PR_STATE" != "MERGED" ]; then
+        continue  # Only delete branches with confirmed MERGED PRs
       fi
-    done
-  elif [ "$USER_INPUT_TRIM" = "none" ]; then
-    echo "Exiting without action."
-    exit 0
-  else
-    # Parse <letter>:<verb> pairs.
-    for token in $USER_INPUT_TRIM; do
-      if [[ "$token" =~ ^([A-Za-z]+):([a-z]+)$ ]]; then
-        letter="${BASH_REMATCH[1]}"
-        verb="${BASH_REMATCH[2]}"
-        letter=$(printf '%s' "$letter" | tr '[:lower:]' '[:upper:]')
-        if [ -z "${ROW_BY_LETTER[$letter]:-}" ]; then
-          echo "  WARN: unknown letter '$letter' — skipped." >&2
-          continue
+
+      if [ "$APPLY" -eq 0 ]; then
+        echo "  WOULD-DELETE-REMOTE origin/$branch (PR merged)"
+        REMOTE_DELETED=$((REMOTE_DELETED+1))
+      else
+        if git push origin --delete "$branch" 2>/dev/null; then
+          echo "  DELETED-REMOTE origin/$branch (PR merged)"
+          REMOTE_DELETED=$((REMOTE_DELETED+1))
+        else
+          echo "  FAILED  origin/$branch (git push origin --delete exited non-zero)" >&2
+          REMOTE_SKIPPED=$((REMOTE_SKIPPED+1))
         fi
-        case "$verb" in
-          remove) ACTION_BY_LETTER["$letter"]="remove" ;;
-          keep|skip) ACTION_BY_LETTER["$letter"]="keep" ;;
-          *)
-            echo "  WARN: unknown verb '$verb' for $letter — skipped." >&2
-            ;;
-        esac
-      else
-        echo "  WARN: malformed token '$token' (want <letter>:<verb>) — skipped." >&2
       fi
-    done
+    done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin/)
+  fi
+fi
+```
+
+## Phase 7 — Summary
+
+```bash
+echo ""
+if [ "$APPLY" -eq 0 ]; then
+  # Preview summary
+  TOTAL_WOULD=0
+  MSG_PARTS=()
+  if [ "$DO_LOCAL" -eq 1 ]; then
+    MSG_PARTS+=("local: $LOCAL_DELETED to delete, $LOCAL_SKIPPED to skip, $LOCAL_PROTECTED protected")
+    TOTAL_WOULD=$((TOTAL_WOULD + LOCAL_DELETED))
+  fi
+  if [ "$DO_REMOTE" -eq 1 ]; then
+    MSG_PARTS+=("remote: $REMOTE_DELETED to delete, $REMOTE_SKIPPED to skip, $REMOTE_PROTECTED protected")
+    TOTAL_WOULD=$((TOTAL_WOULD + REMOTE_DELETED))
   fi
 
-  # Apply REMOVE actions. KEEP/skip are no-ops.
-  R_DONE=0
-  R_FAILED=0
-  for letter in "${!ACTION_BY_LETTER[@]}"; do
-    action="${ACTION_BY_LETTER[$letter]}"
-    [ "$action" != "remove" ] && continue
-    row="${ROW_BY_LETTER[$letter]}"
-    IFS='|' read -r verdict rule_num rule_desc path branch ahead pr_state dirty_count landed_status <<<"$row"
-
-    # Worktree removal — only if path is a registered worktree
-    # distinct from MAIN_ROOT. Dirty worktrees require --force or
-    # manual cleanup; for safety we skip them with a warning.
-    if [ "$path" != "<no-worktree>" ] && [ "$path" != "$MAIN_ROOT" ]; then
-      if [ "$dirty_count" -gt 0 ]; then
-        echo "  SKIP $letter: $path is dirty ($dirty_count file(s)); inspect manually." >&2
-        R_FAILED=$((R_FAILED+1))
-        continue
-      fi
-      if git worktree remove "$path"; then
-        echo "  REMOVED-WORKTREE $path"
-      else
-        echo "  FAILED to remove worktree $path" >&2
-        R_FAILED=$((R_FAILED+1))
-        continue
-      fi
-    fi
-
-    # Branch deletion (only if a real branch and not main / current).
-    if [ "$branch" != "<detached>" ] && [ "$branch" != "$MAIN_BRANCH" ] \
-       && [ "$branch" != "$(git rev-parse --abbrev-ref HEAD)" ]; then
-      if git branch -D "$branch" >/dev/null 2>&1; then
-        echo "  DELETED branch $branch"
-      else
-        echo "  WARN: could not delete branch $branch (may not exist locally)" >&2
-      fi
-    fi
-
-    R_DONE=$((R_DONE+1))
-  done
-
+  echo "cleanup-merged (preview): $(printf '%s; ' "${MSG_PARTS[@]}" | sed 's/; $//')"
   echo ""
-  echo "cleanup-merged --review: $R_DONE action(s) applied, $R_FAILED skipped/failed."
-  exit 0
+
+  if [ "$TOTAL_WOULD" -gt 0 ]; then
+    # Build the apply command hint
+    APPLY_CMD="/cleanup-merged"
+    [ "$SCOPE" != "local" ] && APPLY_CMD="$APPLY_CMD $SCOPE"
+    APPLY_CMD="$APPLY_CMD apply"
+    echo "Run \`$APPLY_CMD\` to execute."
+  else
+    echo "Nothing to clean up."
+  fi
+else
+  # Apply summary
+  MSG_PARTS=()
+  if [ "$DO_LOCAL" -eq 1 ]; then
+    MSG_PARTS+=("local: deleted $LOCAL_DELETED, skipped $LOCAL_SKIPPED, protected $LOCAL_PROTECTED")
+  fi
+  if [ "$DO_REMOTE" -eq 1 ]; then
+    MSG_PARTS+=("remote: deleted $REMOTE_DELETED, skipped $REMOTE_SKIPPED, protected $REMOTE_PROTECTED")
+  fi
+
+  echo "cleanup-merged: $(printf '%s; ' "${MSG_PARTS[@]}" | sed 's/; $//')"
+
+  if [ "$SWITCHED" -eq 1 ]; then
+    echo "(switched to $MAIN_BRANCH and pulled.)"
+  elif [ "$ON_MAIN" -eq 1 ]; then
+    echo "(on $MAIN_BRANCH, pulled latest.)"
+  fi
 fi
+exit 0
 ```
 
 ## Exit codes
 
 | rc | Meaning |
 |----|---------|
-| 0 | Success (or dry-run complete, or `--review` finished) |
+| 0 | Success (or preview complete) |
 | 1 | Missing required tool (git) |
-| 2 | Bad argument (or mutually-exclusive flag combo) |
-| 3 | Dirty working tree — refuses to proceed (default mode only; `--review` tolerates) |
+| 2 | Bad argument |
+| 3 | Dirty working tree — refuses to proceed |
 | 4 | `git fetch` failed |
 | 5 | `git checkout` or `git pull` failed |
 

--- a/tests/test-cleanup-merged-ahead-gate.sh
+++ b/tests/test-cleanup-merged-ahead-gate.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
-# Issue #516 regression: cleanup-merged classifier and Phase 5 default
-# mode must NOT classify a branch as REMOVE when the PR is reported
-# MERGED but the local branch has commits not on main. `gh pr view` is
-# sticky after merge, so PR=MERGED + ahead>0 is a known silent-loss
-# vector — surface, don't auto-remove.
+# Issue #516 regression: cleanup-merged Phase 5 local-branch scan must
+# NOT delete a branch when the PR is reported MERGED but the local
+# branch has commits not on main. `gh pr view` is sticky after merge,
+# so PR=MERGED + ahead>0 is a known silent-loss vector — surface, don't
+# auto-remove.
 #
-# Two surfaces under test:
-#   A. The classify() function (Phase 7 --review mode): asserts Rule 11
-#      fires (DECIDE) for PR=MERGED + ahead>0, instead of Rule 3 (REMOVE).
-#   B. The Phase 5 default-mode bash loop body: asserts that an ahead-
-#      count gate appears between the unpushed-commit guard and the
-#      worktree-remove call.
+# Surface under test:
+#   The Phase 5 local-branch-scan bash loop body: asserts that an ahead-
+#   count gate appears between the unpushed-commit guard and the
+#   worktree-remove call.
+#
+# Note: The old --review mode's classify() function (which had a
+# parallel Rule 11 check) was removed in the issue #716 redesign.
+# The Phase 5 ahead-count gate is the remaining enforcement point.
 #
 # Run from repo root: bash tests/test-cleanup-merged-ahead-gate.sh
 
@@ -28,90 +30,13 @@ fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1));
 
 echo "=== cleanup-merged ahead-count gate (issue #516) ==="
 
-# ── A. Phase 7 classify() — dynamic check ─────────────────────────────
-# Reuse the shim-extraction technique from test-cleanup-merged-review.sh.
-
-WORK="/tmp/zskills-tests/$(basename "$REPO_ROOT")/cleanup-ahead-gate-$$"
-rm -rf "$WORK"
-mkdir -p "$WORK"
-trap 'rm -rf "$WORK"' EXIT
-
-awk '
-  /^  # Classifier — given branch/ { capturing = 1 }
-  capturing { print }
-  capturing && /^  \}$/ { exit }
-' "$SKILL" > "$WORK/classify-fn-body.txt"
-
-awk '
-  /^  matches_long_running\(\) \{/ { capturing = 1 }
-  capturing { print }
-  capturing && /^  \}$/ { count++; if (count >= 1) exit }
-' "$SKILL" > "$WORK/matches-fn-body.txt"
-
-CLASSIFIER_SHIM="$WORK/classifier-shim.sh"
-{
-  echo "#!/bin/bash"
-  echo "set -u"
-  echo "LONG_RUNNING_PATTERNS=()"
-  cat "$WORK/matches-fn-body.txt"
-  cat "$WORK/classify-fn-body.txt"
-  echo ""
-  echo 'VERDICT=""; RULE_NUM=""; RULE_DESC=""'
-  echo 'classify "$BR" "$WT" "$LK" "$AH" "$UG" "$PR" "$DT" "$LS"'
-  echo 'echo "VERDICT=$VERDICT RULE_NUM=$RULE_NUM RULE_DESC=$RULE_DESC"'
-} > "$CLASSIFIER_SHIM"
-chmod +x "$CLASSIFIER_SHIM"
-
-if ! grep -q 'VERDICT="DECIDE"' "$WORK/classify-fn-body.txt"; then
-  fail "extracted classify() body looks empty/malformed — aborting"
-  echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
-  exit 1
-fi
-
-run_classify() {
-  local desc="$1" want_v="$2" want_n="$3"
-  shift 3
-  local out
-  out=$("$@" bash "$CLASSIFIER_SHIM" 2>&1)
-  if echo "$out" | grep -q "VERDICT=$want_v RULE_NUM=$want_n"; then
-    pass "rule $want_n: $desc → $want_v"
-  else
-    fail "rule $want_n: $desc → expected $want_v/$want_n, got: $out"
-  fi
-}
-
-# Core regression: PR=MERGED + ahead>0 must NOT be REMOVE.
-run_classify "PR=MERGED + ahead=1 (one post-merge commit) → DECIDE rule 11" \
-  "DECIDE" "11" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="1" UG="0" PR="MERGED" DT="" LS=""
-
-run_classify "PR=MERGED + ahead=5 (several post-merge commits) → DECIDE rule 11" \
-  "DECIDE" "11" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="5" UG="0" PR="MERGED" DT="" LS=""
-
-# Boundary: PR=MERGED + ahead=0 still REMOVE (rule 3).
-run_classify "PR=MERGED + ahead=0 → REMOVE rule 3 (unchanged)" \
-  "REMOVE" "3" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="MERGED" DT="" LS=""
-
-# Boundary: rule 11 must NOT fire on upstream-gone alone (squash-merge
-# case — ahead>0 is expected when the squash creates a different SHA;
-# the Phase 5 unpushed-commit guard handles the un-squashed leak path).
-run_classify "upstream-gone + ahead=3 (squash-merge) → REMOVE rule 3" \
-  "REMOVE" "3" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="3" UG="1" PR="" DT="" LS=""
-
-# Rule 11 must yield to rule 1 (locked) and rule 2 (long-running).
-run_classify "locked beats rule 11" "KEEP" "1" \
-  env BR="feat/x" WT="/tmp/x" LK="1" AH="3" UG="0" PR="MERGED" DT="" LS=""
-
-# ── B. Phase 5 default-mode bash loop — static check ──────────────────
+# ── Phase 5 local-branch-scan bash loop — static check ──────────────
 # The Phase 5 loop must include an ahead-count gate for PR=MERGED before
 # `git worktree remove` / `git branch -D`. The gate is keyed to PR_STATE
 # string compare + ahead-count + a SKIP path.
 
 PHASE5_SLICE=$(awk '
-  /^## Phase 5 — Default mode/{capture=1}
+  /^## Phase 5 — Local branch scan/{capture=1}
   /^## Phase 6 —/{exit}
   capture {print}
 ' "$SKILL")
@@ -149,7 +74,7 @@ else
   fail "Phase 5: gate ordering wrong (gate line=$GATE_LINE, remove line=$REMOVE_LINE)"
 fi
 
-# ── C. Mirror sync ────────────────────────────────────────────────────
+# ── Mirror sync ────────────────────────────────────────────────────
 MIRROR="$REPO_ROOT/.claude/skills/cleanup-merged/SKILL.md"
 if [ -f "$MIRROR" ]; then
   if diff -q "$SKILL" "$MIRROR" >/dev/null; then

--- a/tests/test-cleanup-merged-review.sh
+++ b/tests/test-cleanup-merged-review.sh
@@ -1,30 +1,23 @@
 #!/bin/bash
-# Tests for skills/cleanup-merged/SKILL.md --review flag (issue #355).
+# Tests for skills/cleanup-merged/SKILL.md redesign (issue #716).
 #
 # Coverage:
 #   Static (skill-source assertions):
-#     1.  argument-hint contains --review
-#     2.  --review flag accepted by Phase 1.2 case statement
-#     3.  --dry-run + --review mutual-exclusion check present
-#     4.  Phase 7 heading present
-#     5.  All 10 rule numbers (1–10) appear in the rule table
-#     6.  Long-running-patterns loaded from cleanup.long_running_patterns
-#     7.  Interactive picker recognizes all-suggested / none / <letter>:<verb>
-#     8.  Mirror sync: skills/cleanup-merged/ == .claude/skills/cleanup-merged/
-#     9.  Existing --dry-run semantics still intact (Phase 5 loop preserved)
-#    10.  Schema: cleanup.long_running_patterns array field present
-#
-#   Dynamic (classifier behaviour via extracted function):
-#    R1. locked worktree → KEEP rule 1
-#    R2. branch matching pattern → KEEP rule 2
-#    R3. PR=MERGED + clean → REMOVE rule 3
-#    R4. PR=MERGED + dirty → DECIDE rule 4
-#    R5. commits ahead + PR=OPEN → KEEP rule 5
-#    R6. commits ahead + no PR + clean → MAYBE rule 6
-#    R7. 0 ahead + no PR + clean + .landed=partial → DECIDE rule 7
-#    R8. 0 ahead + no PR + clean + no .landed → REMOVE rule 8
-#    R9. 0 ahead + no PR + dirty → DECIDE rule 9
-#    R10. commits ahead + dirty → DECIDE rule 10
+#     1.  argument-hint contains new tokens (apply, remote, all)
+#     2.  Positional token parsing: apply, remote, all accepted
+#     3.  Migration aliases: --dry-run/-n and --review accepted with deprecation
+#     4.  Phase 5 heading present (local branch scan)
+#     5.  Phase 6 heading present (remote branch scan)
+#     6.  Phase 7 heading present (summary)
+#     7.  Protected branches loaded from cleanup.protected_branches config
+#     8.  is_protected() function present
+#     9.  Mirror sync: skills/cleanup-merged/ == .claude/skills/cleanup-merged/
+#    10.  Preview/apply output strings preserved (WOULD-DELETE, WOULD-REMOVE-WORKTREE)
+#    11.  Schema: cleanup.protected_branches array field present
+#    12.  Remote cleanup: git push origin --delete present
+#    13.  gh pr view gating for remote branches
+#    14.  PROTECTED (config) label in output
+#    15.  Apply command hint in preview summary
 #
 # Run from repo root: bash tests/test-cleanup-merged-review.sh
 
@@ -41,65 +34,71 @@ FAIL_COUNT=0
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
-echo "=== cleanup-merged --review tests ==="
+echo "=== cleanup-merged redesign tests (issue #716) ==="
 
-# ── Static checks ────────────────────────────────────────────────────
+# -- Static checks --
 
-# 1. argument-hint contains --review
-if grep -qE '^argument-hint:.*--review' "$SKILL"; then
-  pass "argument-hint advertises --review"
+# 1. argument-hint contains new tokens
+if grep -qE '^argument-hint:.*apply.*remote.*all' "$SKILL"; then
+  pass "argument-hint advertises apply/remote/all"
 else
-  fail "argument-hint missing --review"
+  fail "argument-hint missing new tokens"
 fi
 
-# 2. --review accepted in arg parse
-if grep -q -- '--review) REVIEW=1' "$SKILL"; then
-  pass "Phase 1.2: --review case branch present"
+# 2. Positional token parsing
+if grep -q 'apply)  APPLY=1' "$SKILL" \
+   && grep -q 'remote) SCOPE="remote"' "$SKILL" \
+   && grep -q 'all)    SCOPE="all"' "$SKILL"; then
+  pass "Phase 1.2: positional tokens apply/remote/all accepted"
 else
-  fail "Phase 1.2: --review case branch missing"
+  fail "Phase 1.2: positional token parsing incomplete"
 fi
 
-# 3. --dry-run + --review mutual exclusion
-if grep -q 'mutually exclusive' "$SKILL"; then
-  pass "mutual-exclusion check between --dry-run and --review"
+# 3. Migration aliases: --dry-run and --review emit deprecation notice
+if grep -q 'DEPRECATED.*--dry-run' "$SKILL" \
+   && grep -q 'DEPRECATED.*--review' "$SKILL"; then
+  pass "migration aliases --dry-run/--review present with deprecation"
 else
-  fail "mutual-exclusion check missing"
+  fail "migration aliases missing deprecation notices"
 fi
 
-# 4. Phase 7 heading present
-if grep -qE '^## Phase 7 — Review mode' "$SKILL"; then
-  pass "Phase 7 heading present"
+# 4. Phase 5 heading (local branch scan)
+if grep -qE '^## Phase 5 — Local branch scan' "$SKILL"; then
+  pass "Phase 5 heading present (local branch scan)"
+else
+  fail "Phase 5 heading missing"
+fi
+
+# 5. Phase 6 heading (remote branch scan)
+if grep -qE '^## Phase 6 — Remote branch scan' "$SKILL"; then
+  pass "Phase 6 heading present (remote branch scan)"
+else
+  fail "Phase 6 heading missing"
+fi
+
+# 6. Phase 7 heading (summary)
+if grep -qE '^## Phase 7 — Summary' "$SKILL"; then
+  pass "Phase 7 heading present (summary)"
 else
   fail "Phase 7 heading missing"
 fi
 
-# 5. All rules present in rule table (1–10 plus rule 11 added for issue #516)
-for n in 1 2 3 4 5 6 7 8 9 10 11; do
-  if grep -qE "^\| $n \|" "$SKILL"; then
-    pass "rule table row $n present"
-  else
-    fail "rule table row $n missing"
-  fi
-done
-
-# 6. long_running_patterns config consumed
-if grep -q 'cleanup.long_running_patterns' "$SKILL" \
-   && grep -q 'LONG_RUNNING_PATTERNS' "$SKILL"; then
-  pass "cleanup.long_running_patterns wired into classifier"
+# 7. Protected branches loaded from cleanup.protected_branches
+if grep -q 'cleanup.*protected_branches' "$SKILL" \
+   && grep -q 'PROTECTED_BRANCHES' "$SKILL"; then
+  pass "cleanup.protected_branches wired into preflight"
 else
-  fail "cleanup.long_running_patterns not wired"
+  fail "cleanup.protected_branches not wired"
 fi
 
-# 7. Picker recognizes all-suggested / none / letter:verb
-if grep -q 'all-suggested' "$SKILL" \
-   && grep -q '"none"' "$SKILL" \
-   && grep -q '\[A-Za-z\]+):(\[a-z\]+)' "$SKILL"; then
-  pass "picker accepts all-suggested, none, and <letter>:<verb>"
+# 8. is_protected function present
+if grep -q 'is_protected()' "$SKILL"; then
+  pass "is_protected() function present"
 else
-  fail "picker forms incomplete"
+  fail "is_protected() function missing"
 fi
 
-# 8. Mirror sync
+# 9. Mirror sync
 MIRROR="$REPO_ROOT/.claude/skills/cleanup-merged"
 if [ -d "$MIRROR" ]; then
   if diff -q "$SKILL" "$MIRROR/SKILL.md" >/dev/null; then
@@ -111,164 +110,64 @@ else
   fail "mirror directory .claude/skills/cleanup-merged absent"
 fi
 
-# 9. --dry-run path preserved (Phase 5 unchanged for non-review)
+# 10. Preview/apply output strings preserved
 if grep -q 'WOULD-DELETE' "$SKILL" && grep -q 'WOULD-REMOVE-WORKTREE' "$SKILL"; then
-  pass "Phase 5 dry-run output strings preserved"
+  pass "preview output strings preserved (WOULD-DELETE, WOULD-REMOVE-WORKTREE)"
 else
-  fail "Phase 5 dry-run output regressed"
+  fail "preview output strings regressed"
 fi
 
-# 10. Schema field
-if grep -q '"long_running_patterns"' "$SCHEMA" \
+# 11. Schema: cleanup.protected_branches field
+if grep -q '"protected_branches"' "$SCHEMA" \
    && grep -q '"cleanup"' "$SCHEMA"; then
-  pass "schema: cleanup.long_running_patterns defined"
+  pass "schema: cleanup.protected_branches defined"
 else
-  fail "schema: cleanup.long_running_patterns missing"
+  fail "schema: cleanup.protected_branches missing"
 fi
 
-# ── Dynamic checks (extract classify() and exercise each rule) ───────
-#
-# The classify() function is embedded inside the Phase 7 WI 7.2 bash
-# fence. Extract it into a temporary shim script, source it, and call
-# it with synthetic signal values for each of the 10 rules.
-
-WORK="/tmp/zskills-tests/$(basename "$REPO_ROOT")/cleanup-merged-review"
-rm -rf "$WORK"
-mkdir -p "$WORK"
-
-CLASSIFIER_SHIM="$WORK/classifier-shim.sh"
-
-# AWK extracts everything from the `# Classifier — given branch ...`
-# comment line through the closing `}` of the function.
-awk '
-  /^  # Classifier — given branch/ { capturing = 1 }
-  capturing { print }
-  capturing && /^  \}$/ { exit }
-' "$SKILL" > "$WORK/classify-fn-body.txt"
-
-# matches_long_running helper is also needed — extract it the same way.
-awk '
-  /^  matches_long_running\(\) \{/ { capturing = 1 }
-  capturing { print }
-  capturing && /^  \}$/ { count++; if (count >= 1) exit }
-' "$SKILL" > "$WORK/matches-fn-body.txt"
-
-{
-  echo "#!/bin/bash"
-  echo "set -u"
-  echo "LONG_RUNNING_PATTERNS=(\"\${@:1}\")"
-  # Source the matches_long_running fn body.
-  cat "$WORK/matches-fn-body.txt"
-  # Source the classify fn body.
-  cat "$WORK/classify-fn-body.txt"
-  echo ""
-  # Reset positional args before invoking classify (re-used via env).
-  echo "VERDICT=\"\"; RULE_NUM=\"\"; RULE_DESC=\"\""
-  echo "classify \"\$BR\" \"\$WT\" \"\$LK\" \"\$AH\" \"\$UG\" \"\$PR\" \"\$DT\" \"\$LS\""
-  echo "echo \"VERDICT=\$VERDICT RULE_NUM=\$RULE_NUM\""
-} > "$CLASSIFIER_SHIM"
-chmod +x "$CLASSIFIER_SHIM"
-
-# Sanity: the extracted classify body must contain `VERDICT=` assignments.
-if ! grep -q 'VERDICT="KEEP"' "$WORK/classify-fn-body.txt"; then
-  fail "extracted classify() body looks empty/malformed — aborting dynamic checks"
-  echo ""
-  echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
-  [ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1
-fi
-
-# Helper to call the shim with named signal vars.
-run_classify() {
-  local desc="$1" want_v="$2" want_n="$3"
-  shift 3
-  local out
-  out=$("$@" bash "$CLASSIFIER_SHIM" 2>&1)
-  if echo "$out" | grep -q "VERDICT=$want_v RULE_NUM=$want_n"; then
-    pass "rule $want_n: $desc → $want_v"
-  else
-    fail "rule $want_n: $desc → expected $want_v/$want_n, got: $out"
-  fi
-}
-
-# Rule 1: locked worktree → KEEP rule 1
-run_classify "locked worktree" "KEEP" "1" \
-  env BR="feat/x" WT="/tmp/x" LK="1" AH="0" UG="0" PR="" DT="" LS=""
-
-# Rule 2: branch matches long_running pattern (docs/run-order-guide)
-LRP=("docs/run-order-guide" "release/*")
-out=$(env BR="docs/run-order-guide" WT="/tmp/x" LK="0" AH="5" UG="0" PR="" DT="" LS="" \
-  bash "$CLASSIFIER_SHIM" "${LRP[@]}" 2>&1)
-if echo "$out" | grep -q "VERDICT=KEEP RULE_NUM=2"; then
-  pass "rule 2: long_running_patterns exact match → KEEP"
+# 12. Remote cleanup via git push origin --delete
+if grep -q 'git push origin --delete' "$SKILL"; then
+  pass "remote cleanup: git push origin --delete present"
 else
-  fail "rule 2: expected KEEP/2, got: $out"
+  fail "remote cleanup: git push origin --delete missing"
 fi
-out=$(env BR="release/1.2" WT="/tmp/x" LK="0" AH="5" UG="0" PR="" DT="" LS="" \
-  bash "$CLASSIFIER_SHIM" "${LRP[@]}" 2>&1)
-if echo "$out" | grep -q "VERDICT=KEEP RULE_NUM=2"; then
-  pass "rule 2: long_running_patterns glob match (release/*) → KEEP"
+
+# 13. gh pr view gating for remote branches
+if grep -q 'gh pr view' "$SKILL" \
+   && grep -q 'PR_STATE.*OPEN' "$SKILL"; then
+  pass "gh pr view gating for remote branches"
 else
-  fail "rule 2 glob: expected KEEP/2, got: $out"
+  fail "gh pr view gating missing for remote branches"
 fi
 
-# Rule 3: PR=MERGED + clean + ahead=0 (issue #516 — ahead>0 is gated by rule 11)
-run_classify "PR=MERGED + clean + ahead=0" "REMOVE" "3" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="MERGED" DT="" LS=""
-# Rule 3 via upstream-gone (squash-merge is fine; unpushed guard handles
-# the un-squashed leak path in Phase 5)
-run_classify "upstream-gone + clean" "REMOVE" "3" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="3" UG="1" PR="" DT="" LS=""
+# 14. PROTECTED (config) label in output
+if grep -q 'PROTECTED (config)' "$SKILL"; then
+  pass "PROTECTED (config) label in output"
+else
+  fail "PROTECTED (config) label missing"
+fi
 
-# Rule 11 (issue #516): PR=MERGED + ahead>0 → DECIDE (was previously
-# silently classified REMOVE — the silent-commit-loss bug)
-run_classify "PR=MERGED + ahead>0 (diverged)" "DECIDE" "11" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="3" UG="0" PR="MERGED" DT="" LS=""
+# 15. Apply command hint in preview summary
+if grep -q 'APPLY_CMD' "$SKILL" \
+   && grep -q 'to execute' "$SKILL"; then
+  pass "apply command hint in preview summary"
+else
+  fail "apply command hint missing in preview summary"
+fi
 
-# Rule 4: merged + dirty (Rule 11 short-circuits if ahead>0, so use ahead=0)
-run_classify "PR=MERGED + dirty + ahead=0" "DECIDE" "4" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="MERGED" DT="M f.txt" LS=""
+# 16. WOULD-DELETE-REMOTE for remote preview
+if grep -q 'WOULD-DELETE-REMOTE' "$SKILL"; then
+  pass "WOULD-DELETE-REMOTE output string present"
+else
+  fail "WOULD-DELETE-REMOTE output string missing"
+fi
 
-# Rule 5: commits ahead + PR=OPEN
-run_classify "commits ahead + PR=OPEN" "KEEP" "5" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="OPEN" DT="" LS=""
-
-# Rule 6: commits ahead + no PR + clean
-run_classify "ahead + no PR + clean" "MAYBE" "6" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="" DT="" LS=""
-
-# Rule 7: 0 ahead + no PR + clean + .landed=partial
-run_classify "0 ahead + .landed=partial" "DECIDE" "7" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS="partial"
-
-# Rule 8: 0 ahead + no PR + clean + no .landed
-run_classify "0 ahead + no PR + clean + no .landed" "REMOVE" "8" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS=""
-
-# Rule 9: 0 ahead + no PR + dirty
-run_classify "0 ahead + dirty" "DECIDE" "9" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="M f.txt" LS=""
-
-# Rule 10: commits ahead + dirty (no OPEN PR — rule 5 takes priority otherwise)
-run_classify "ahead + dirty" "DECIDE" "10" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="" DT="M f.txt" LS=""
-# Wait — rule 6 (ahead + no PR + clean) is "MAYBE", but ahead + no PR + dirty
-# falls through 6 (dirty), 7 (ahead>0), 8 (ahead>0), 9 (ahead>0), to 10. Good.
-
-# Bonus: rule 5 + dirty should still hit rule 5 (PR=OPEN beats dirty).
-run_classify "rule 5 wins over dirty (PR=OPEN + dirty)" "KEEP" "5" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="2" UG="0" PR="OPEN" DT="M f.txt" LS=""
-
-# .landed=landed: rule 7 doesn't fire (condition is `!= landed`); rule 8
-# requires absence of .landed → so this falls through to DECIDE/0.
-# This is safe-by-design: an unrecognised .landed value is surfaced for
-# manual review rather than silently removed.
-run_classify ".landed=landed → fallthrough DECIDE" "DECIDE" "0" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS="landed"
-
-# .landed=full: similar — rule 7 skips (we treat 'full' like 'landed' as
-# a success marker), rule 8 needs empty .landed, so this also DECIDEs.
-run_classify ".landed=full → fallthrough DECIDE" "DECIDE" "0" \
-  env BR="feat/x" WT="/tmp/x" LK="0" AH="0" UG="0" PR="" DT="" LS="full"
+# 17. DELETED-REMOTE for remote apply
+if grep -q 'DELETED-REMOTE' "$SKILL"; then
+  pass "DELETED-REMOTE output string present"
+else
+  fail "DELETED-REMOTE output string missing"
+fi
 
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"


### PR DESCRIPTION
## Summary
- Redesign `/cleanup-merged`: preview-by-default, positional `apply`/`remote`/`all` tokens, remote branch cleanup (gh-pr-view gated), `cleanup.protected_branches` config field
- Replaces the destructive-by-default `--dry-run`/`--review` flag interface with the repo's positional-token convention

## Test plan
- [x] Preview is default; `apply` required to execute
- [x] Protected branches read from config and skipped
- [x] Remote cleanup gated on merged-PR confirmation
- [x] Schema + docs updated; mirror consistent
- [x] Full test suite: 5933/5933 passed

Fixes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
