### PR TITLE
feat(dashboard): Branches tab state pills, grouping, bulk copy, nav (#717)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+104fdd"
+  version: "2026.05.28+e38be2"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1271,3 +1271,133 @@ button svg { display: inline-block; vertical-align: middle; }
   outline: none;
 }
 
+/* Issue #717 — Branch state pills. Inline pill showing LOCAL/REMOTE state. */
+.branch-state-pill {
+  display: inline-block;
+  padding: 1px 8px;
+  margin-left: 6px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.branch-state-pill--local-remote { color: var(--green); border-color: var(--green); }
+.branch-state-pill--local        { color: var(--orange); border-color: var(--orange); }
+.branch-state-pill--remote       { color: var(--text-dim); border-color: var(--border); }
+
+/* Issue #717 — Branch section container. Each of Active/Landed/Remote-only
+   is a collapsible section within the branches panel. */
+.branch-section {
+  margin-bottom: 12px;
+}
+.branch-section-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  user-select: none;
+}
+.branch-section-head:hover {
+  background: rgba(88, 166, 255, 0.06);
+}
+.branch-section-label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+.branch-section-count {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.branch-section-toggle {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  padding: 2px 6px;
+  cursor: pointer;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.12s, color 0.12s;
+  margin-left: auto;
+}
+.branch-section-toggle:hover,
+.branch-section-toggle:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  outline: none;
+}
+.branch-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 0;
+}
+.branch-section.collapsed .branch-section-body {
+  display: none;
+}
+.branch-section.collapsed .branch-section-head {
+  border-radius: 6px;
+  opacity: 0.85;
+}
+
+/* Issue #717 — Bulk copy toolbar per branch section. */
+.branch-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.branch-bulk-bar label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.branch-bulk-bar label:hover {
+  color: var(--text);
+}
+.branch-bulk-copy-btn {
+  background: var(--surface);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+  white-space: nowrap;
+}
+.branch-bulk-copy-btn:hover,
+.branch-bulk-copy-btn:focus-visible {
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+  color: var(--text);
+  outline: none;
+}
+
+/* Issue #717 — Per-card checkbox for branch selection. */
+.branch-select-cb {
+  accent-color: var(--accent);
+  cursor: pointer;
+  margin-right: 4px;
+  flex-shrink: 0;
+}
+

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -105,7 +105,7 @@ function setCompletedWindow(kind, value) {
 // explicitly expands it. Per-user expand state still persists via
 // localStorage (setCollapsed removes the key on expand, so the default
 // applies only on first paint or after localStorage.clear()).
-const COLLAPSED_BY_DEFAULT = new Set(["discarded"]);
+const COLLAPSED_BY_DEFAULT = new Set(["discarded", "branch-landed", "branch-remote-only"]);
 
 function isCollapsed(kind, col) {
   try {
@@ -781,9 +781,12 @@ function fingerprintPlans(plans, queues, defaultMode) {
 
 function fingerprintBranches(branches, worktrees) {
   const wtSet = backedBranchSet(worktrees);
-  return JSON.stringify(branches.map(b => [
-    b.name, b.last_commit_at, b.last_commit_subject, b.upstream, wtSet.has(b.name),
-  ]));
+  const byBranch = worktreesByBranch(worktrees);
+  return JSON.stringify(branches.map(b => {
+    const w = byBranch.get(b.name);
+    const landedStatus = (w && w.landed) ? w.landed.status : null;
+    return [b.name, b.last_commit_at, b.last_commit_subject, b.upstream, wtSet.has(b.name), landedStatus];
+  }));
 }
 
 function fingerprintIssues(issues, queues) {
@@ -1267,74 +1270,263 @@ function worktreesByBranch(worktrees) {
   return m;
 }
 
+// Issue #717 — Branch grouping constants.
+var BRANCH_SECTIONS = ["active", "landed", "remote-only"];
+var BRANCH_SECTION_LABELS = {
+  "active": "Active",
+  "landed": "Landed",
+  "remote-only": "Remote only",
+};
+
+function classifyBranch(b, byBranch) {
+  var w = byBranch.get(b.name);
+  if (w && w.landed) return "landed";
+  if (w) return "active";
+  return "remote-only";
+}
+
+function branchStatePill(b, byBranch) {
+  var w = byBranch.get(b.name);
+  var hasWorktree = !!w;
+  var hasRemote = !!b.upstream;
+  if (hasWorktree && hasRemote) {
+    return el("span", {
+      cls: "branch-state-pill branch-state-pill--local-remote",
+      text: "LOCAL · REMOTE",
+      attrs: { title: "Has worktree and remote tracking branch" },
+    });
+  }
+  if (hasWorktree) {
+    return el("span", {
+      cls: "branch-state-pill branch-state-pill--local",
+      text: "LOCAL",
+      attrs: { title: "Has worktree, not pushed to remote" },
+    });
+  }
+  return el("span", {
+    cls: "branch-state-pill branch-state-pill--remote",
+    text: "REMOTE",
+    attrs: { title: "No worktree" },
+  });
+}
+
+function buildBranchCard(b, byBranch) {
+  var card = el("article", {
+    cls: "card",
+    attrs: {
+      tabindex: "0",
+      role: "button",
+      "data-kind": "branch",
+      "data-name": b.name,
+      "aria-label": "Branch " + b.name,
+    },
+  });
+  var head = el("div", { cls: "card-row" });
+  // Checkbox for bulk selection
+  var cb = el("input", {
+    cls: "branch-select-cb",
+    attrs: { type: "checkbox", "data-branch-name": b.name, "aria-label": "Select " + b.name },
+  });
+  head.appendChild(cb);
+  var url = branchUrl(b.name);
+  if (url) {
+    head.appendChild(el("a", {
+      cls: "card-title-link mono",
+      text: b.name,
+      attrs: {
+        href: url,
+        target: "_blank",
+        rel: "noopener noreferrer",
+        draggable: "false",
+      },
+    }));
+  } else {
+    head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+  }
+  // State pill
+  head.appendChild(branchStatePill(b, byBranch));
+  if (b.last_commit_at) {
+    head.appendChild(el("span", { cls: "card-sub", text: relativeTime(b.last_commit_at) }));
+  }
+  card.appendChild(head);
+  if (b.last_commit_subject) {
+    card.appendChild(el("div", { cls: "card-blurb", text: b.last_commit_subject }));
+  }
+  if (b.upstream) {
+    card.appendChild(el("div", { cls: "card-sub", text: "upstream: " + b.upstream }));
+  }
+  var w = byBranch.get(b.name);
+  if (w) {
+    var status = w.landed ? w.landed.status : "not-landed";
+    var wtRow = el("div", { cls: "card-row card-worktree-row" });
+    wtRow.appendChild(el("span", {
+      cls: "pill " + landedPillClass(status),
+      text: status,
+    }));
+    if (w.path) {
+      wtRow.appendChild(el("span", { cls: "mono card-sub", text: basename(w.path) }));
+    }
+    if (typeof w.age_seconds === "number") {
+      wtRow.appendChild(el("span", {
+        cls: "card-sub",
+        text: ageSecondsToText(w.age_seconds),
+      }));
+    }
+    card.appendChild(wtRow);
+  }
+  return card;
+}
+
+function buildBranchBulkBar(sectionKey, branchNames) {
+  var bar = el("div", { cls: "branch-bulk-bar" });
+  var label = el("label");
+  var selectAll = el("input", {
+    attrs: {
+      type: "checkbox",
+      "data-action": "branch-select-all",
+      "data-section": sectionKey,
+      "aria-label": "Select all in " + BRANCH_SECTION_LABELS[sectionKey],
+    },
+  });
+  label.appendChild(selectAll);
+  label.appendChild(document.createTextNode("Select all"));
+  bar.appendChild(label);
+  var copyBtn = el("button", {
+    cls: "branch-bulk-copy-btn",
+    attrs: {
+      type: "button",
+      "data-action": "branch-bulk-copy",
+      "data-section": sectionKey,
+      "aria-label": "Copy selected branch names",
+    },
+    text: "Copy 0 branch names",
+  });
+  bar.appendChild(copyBtn);
+  return bar;
+}
+
+function buildBranchSection(sectionKey, branchesInSection, byBranch) {
+  var sec = el("div", {
+    cls: "branch-section",
+    attrs: {
+      "data-branch-section": sectionKey,
+      id: "branch-section-" + sectionKey,
+    },
+  });
+  // Section header
+  var head = el("div", {
+    cls: "branch-section-head",
+    attrs: {
+      "data-action": "branch-section-toggle",
+      "data-section": sectionKey,
+      role: "button",
+      tabindex: "0",
+      "aria-expanded": "true",
+      "aria-label": BRANCH_SECTION_LABELS[sectionKey] + " " + branchesInSection.length + " branches",
+    },
+  });
+  head.appendChild(el("span", {
+    cls: "branch-section-label",
+    text: BRANCH_SECTION_LABELS[sectionKey],
+  }));
+  head.appendChild(el("span", {
+    cls: "branch-section-count",
+    text: "(" + branchesInSection.length + ")",
+  }));
+  var toggle = el("button", {
+    cls: "branch-section-toggle",
+    attrs: {
+      type: "button",
+      "data-action": "branch-section-toggle",
+      "data-section": sectionKey,
+      "aria-label": "Collapse " + BRANCH_SECTION_LABELS[sectionKey],
+      title: "Collapse / expand",
+    },
+    html: SVG_ICONS.minus,
+  });
+  head.appendChild(toggle);
+  sec.appendChild(head);
+  // Bulk copy bar
+  var names = branchesInSection.map(function(b) { return b.name; });
+  sec.appendChild(buildBranchBulkBar(sectionKey, names));
+  // Cards body
+  var body = el("div", { cls: "branch-section-body" });
+  for (var i = 0; i < branchesInSection.length; i++) {
+    body.appendChild(buildBranchCard(branchesInSection[i], byBranch));
+  }
+  sec.appendChild(body);
+  // Apply saved collapse state
+  applyBranchSectionCollapse(sec, sectionKey);
+  return sec;
+}
+
+function applyBranchSectionCollapse(secEl, sectionKey) {
+  var collapsed = isCollapsed("branch", sectionKey);
+  if (collapsed) {
+    secEl.classList.add("collapsed");
+  } else {
+    secEl.classList.remove("collapsed");
+  }
+  var toggle = secEl.querySelector(".branch-section-toggle");
+  if (toggle) {
+    toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    toggle.innerHTML = collapsed ? SVG_ICONS.plus : SVG_ICONS.minus; // chrome-only
+    toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + BRANCH_SECTION_LABELS[sectionKey]);
+  }
+  var head = secEl.querySelector(".branch-section-head");
+  if (head) {
+    head.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  }
+}
+
+function buildBranchNavStrip(groups) {
+  var strip = el("nav", {
+    cls: "section-nav-strip",
+    attrs: { "aria-label": "Branch sections", "data-kind": "branch" },
+  });
+  for (var i = 0; i < BRANCH_SECTIONS.length; i++) {
+    var key = BRANCH_SECTIONS[i];
+    var count = (groups[key] || []).length;
+    var pill = el("button", {
+      cls: "section-nav-pill",
+      attrs: {
+        type: "button",
+        "data-action": "branch-nav-pill",
+        "data-target": "branch-section-" + key,
+        "data-section": key,
+        "aria-label": BRANCH_SECTION_LABELS[key] + " " + count + " branches — click to scroll",
+      },
+      text: BRANCH_SECTION_LABELS[key] + " " + count,
+    });
+    strip.appendChild(pill);
+  }
+  return strip;
+}
+
 function renderBranches(branches, worktrees) {
-  const body = $("branches-body");
-  const empty = $("branches-empty");
+  var body = $("branches-body");
+  var empty = $("branches-empty");
   clear(body);
   if (!branches.length) {
     empty.hidden = false;
     return;
   }
   empty.hidden = true;
-  const backed = backedBranchSet(worktrees);
-  const byBranch = worktreesByBranch(worktrees);
-  for (const b of branches) {
-    const card = el("article", {
-      cls: "card",
-      attrs: {
-        tabindex: "0",
-        role: "button",
-        "data-kind": "branch",
-        "data-name": b.name,
-        "aria-label": "Branch " + b.name,
-      },
-    });
-    const head = el("div", { cls: "card-row" });
-    const url = branchUrl(b.name);
-    if (url) {
-      head.appendChild(el("a", {
-        cls: "card-title-link mono",
-        text: b.name,
-        attrs: {
-          href: url,
-          target: "_blank",
-          rel: "noopener noreferrer",
-          draggable: "false",
-        },
-      }));
-    } else {
-      head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
-    }
-    if (b.last_commit_at) {
-      head.appendChild(el("span", { cls: "card-sub", text: relativeTime(b.last_commit_at) }));
-    }
-    card.appendChild(head);
-    if (b.last_commit_subject) {
-      card.appendChild(el("div", { cls: "card-blurb", text: b.last_commit_subject }));
-    }
-    if (b.upstream) {
-      card.appendChild(el("div", { cls: "card-sub", text: "upstream: " + b.upstream }));
-    }
-    const w = byBranch.get(b.name);
-    if (w) {
-      const status = w.landed ? w.landed.status : "not-landed";
-      const wtRow = el("div", { cls: "card-row card-worktree-row" });
-      wtRow.appendChild(el("span", {
-        cls: "pill " + landedPillClass(status),
-        text: status,
-      }));
-      if (w.path) {
-        wtRow.appendChild(el("span", { cls: "mono card-sub", text: basename(w.path) }));
-      }
-      if (typeof w.age_seconds === "number") {
-        wtRow.appendChild(el("span", {
-          cls: "card-sub",
-          text: ageSecondsToText(w.age_seconds),
-        }));
-      }
-      card.appendChild(wtRow);
-    }
-    body.appendChild(card);
+  var byBranch = worktreesByBranch(worktrees);
+  // Group branches into sections
+  var groups = { "active": [], "landed": [], "remote-only": [] };
+  for (var i = 0; i < branches.length; i++) {
+    var section = classifyBranch(branches[i], byBranch);
+    groups[section].push(branches[i]);
+  }
+  // Nav strip at top
+  body.appendChild(buildBranchNavStrip(groups));
+  // Render each section
+  for (var si = 0; si < BRANCH_SECTIONS.length; si++) {
+    var key = BRANCH_SECTIONS[si];
+    var arr = groups[key];
+    if (!arr.length) continue;
+    body.appendChild(buildBranchSection(key, arr, byBranch));
   }
 }
 
@@ -2901,6 +3093,84 @@ async function handleAction(action, target) {
     targetEl.scrollIntoView({ behavior: "smooth", block: "start" });
     return;
   }
+
+  // Issue #717 — Branch section toggle (collapse/expand).
+  if (action === "branch-section-toggle") {
+    const sectionKey = target.getAttribute("data-section");
+    if (!sectionKey) return;
+    const secEl = target.closest(".branch-section") || document.querySelector('[data-branch-section="' + sectionKey + '"]');
+    if (!secEl) return;
+    const next = !isCollapsed("branch", sectionKey);
+    setCollapsed("branch", sectionKey, next);
+    applyBranchSectionCollapse(secEl, sectionKey);
+    return;
+  }
+
+  // Issue #717 — Branch nav pill: scroll to section, expand if collapsed.
+  if (action === "branch-nav-pill") {
+    const targetId = target.getAttribute("data-target");
+    const sectionKey = target.getAttribute("data-section");
+    const targetEl = $(targetId);
+    if (!targetEl) return;
+    if (sectionKey && isCollapsed("branch", sectionKey)) {
+      setCollapsed("branch", sectionKey, false);
+      applyBranchSectionCollapse(targetEl, sectionKey);
+    }
+    targetEl.scrollIntoView({ behavior: "smooth", block: "start" });
+    return;
+  }
+
+  // Issue #717 — Branch select-all checkbox.
+  if (action === "branch-select-all") {
+    const sectionKey = target.getAttribute("data-section");
+    if (!sectionKey) return;
+    const secEl = document.querySelector('[data-branch-section="' + sectionKey + '"]');
+    if (!secEl) return;
+    const checked = target.checked;
+    const cbs = secEl.querySelectorAll(".branch-select-cb");
+    for (let i = 0; i < cbs.length; i++) cbs[i].checked = checked;
+    _updateBranchCopyCount(secEl, sectionKey);
+    return;
+  }
+
+  // Issue #717 — Branch bulk copy.
+  if (action === "branch-bulk-copy") {
+    const sectionKey = target.getAttribute("data-section");
+    if (!sectionKey) return;
+    const secEl = document.querySelector('[data-branch-section="' + sectionKey + '"]');
+    if (!secEl) return;
+    const cbs = secEl.querySelectorAll(".branch-select-cb:checked");
+    const names = [];
+    for (let i = 0; i < cbs.length; i++) {
+      const n = cbs[i].getAttribute("data-branch-name");
+      if (n) names.push(n);
+    }
+    if (!names.length) {
+      showToast("No branches selected.", "info");
+      return;
+    }
+    const text = names.join("\n");
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        navigator.clipboard.writeText(text);
+        showToast("Copied " + names.length + " branch name" + (names.length === 1 ? "" : "s") + ".", "info");
+      } catch (_err) {
+        showToast("Copy failed — select text manually.", "err");
+      }
+    } else {
+      showToast("Clipboard API unavailable.", "err");
+    }
+    return;
+  }
+}
+
+// Issue #717 — Update the copy button label with the count of selected branches.
+function _updateBranchCopyCount(secEl, sectionKey) {
+  const cbs = secEl.querySelectorAll(".branch-select-cb:checked");
+  const btn = secEl.querySelector('.branch-bulk-copy-btn[data-section="' + sectionKey + '"]');
+  if (btn) {
+    btn.textContent = "Copy " + cbs.length + " branch name" + (cbs.length === 1 ? "" : "s");
+  }
 }
 
 function bindActionEvents() {
@@ -2928,6 +3198,17 @@ function bindActionEvents() {
     if (kind === "issue") lastFingerprint.issues = null;
     // Trigger an immediate poll so the UI updates now.
     schedulePoll(0);
+  });
+
+  // Issue #717 — Branch checkbox change handler. Updates per-section copy
+  // count when individual branch checkboxes are toggled.
+  document.body.addEventListener("change", (ev) => {
+    const cb = ev.target.closest && ev.target.closest(".branch-select-cb");
+    if (!cb) return;
+    const secEl = cb.closest(".branch-section");
+    if (!secEl) return;
+    const sectionKey = secEl.getAttribute("data-branch-section");
+    if (sectionKey) _updateBranchCopyCount(secEl, sectionKey);
   });
 
   // Default-mode segmented buttons.

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.27+104fdd"
+  version: "2026.05.28+e38be2"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1271,3 +1271,133 @@ button svg { display: inline-block; vertical-align: middle; }
   outline: none;
 }
 
+/* Issue #717 — Branch state pills. Inline pill showing LOCAL/REMOTE state. */
+.branch-state-pill {
+  display: inline-block;
+  padding: 1px 8px;
+  margin-left: 6px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.branch-state-pill--local-remote { color: var(--green); border-color: var(--green); }
+.branch-state-pill--local        { color: var(--orange); border-color: var(--orange); }
+.branch-state-pill--remote       { color: var(--text-dim); border-color: var(--border); }
+
+/* Issue #717 — Branch section container. Each of Active/Landed/Remote-only
+   is a collapsible section within the branches panel. */
+.branch-section {
+  margin-bottom: 12px;
+}
+.branch-section-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  user-select: none;
+}
+.branch-section-head:hover {
+  background: rgba(88, 166, 255, 0.06);
+}
+.branch-section-label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+.branch-section-count {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.branch-section-toggle {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  padding: 2px 6px;
+  cursor: pointer;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.12s, color 0.12s;
+  margin-left: auto;
+}
+.branch-section-toggle:hover,
+.branch-section-toggle:focus-visible {
+  color: var(--text);
+  border-color: var(--accent);
+  outline: none;
+}
+.branch-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 0;
+}
+.branch-section.collapsed .branch-section-body {
+  display: none;
+}
+.branch-section.collapsed .branch-section-head {
+  border-radius: 6px;
+  opacity: 0.85;
+}
+
+/* Issue #717 — Bulk copy toolbar per branch section. */
+.branch-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.branch-bulk-bar label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.branch-bulk-bar label:hover {
+  color: var(--text);
+}
+.branch-bulk-copy-btn {
+  background: var(--surface);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+  white-space: nowrap;
+}
+.branch-bulk-copy-btn:hover,
+.branch-bulk-copy-btn:focus-visible {
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+  color: var(--text);
+  outline: none;
+}
+
+/* Issue #717 — Per-card checkbox for branch selection. */
+.branch-select-cb {
+  accent-color: var(--accent);
+  cursor: pointer;
+  margin-right: 4px;
+  flex-shrink: 0;
+}
+

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -105,7 +105,7 @@ function setCompletedWindow(kind, value) {
 // explicitly expands it. Per-user expand state still persists via
 // localStorage (setCollapsed removes the key on expand, so the default
 // applies only on first paint or after localStorage.clear()).
-const COLLAPSED_BY_DEFAULT = new Set(["discarded"]);
+const COLLAPSED_BY_DEFAULT = new Set(["discarded", "branch-landed", "branch-remote-only"]);
 
 function isCollapsed(kind, col) {
   try {
@@ -781,9 +781,12 @@ function fingerprintPlans(plans, queues, defaultMode) {
 
 function fingerprintBranches(branches, worktrees) {
   const wtSet = backedBranchSet(worktrees);
-  return JSON.stringify(branches.map(b => [
-    b.name, b.last_commit_at, b.last_commit_subject, b.upstream, wtSet.has(b.name),
-  ]));
+  const byBranch = worktreesByBranch(worktrees);
+  return JSON.stringify(branches.map(b => {
+    const w = byBranch.get(b.name);
+    const landedStatus = (w && w.landed) ? w.landed.status : null;
+    return [b.name, b.last_commit_at, b.last_commit_subject, b.upstream, wtSet.has(b.name), landedStatus];
+  }));
 }
 
 function fingerprintIssues(issues, queues) {
@@ -1267,74 +1270,263 @@ function worktreesByBranch(worktrees) {
   return m;
 }
 
+// Issue #717 — Branch grouping constants.
+var BRANCH_SECTIONS = ["active", "landed", "remote-only"];
+var BRANCH_SECTION_LABELS = {
+  "active": "Active",
+  "landed": "Landed",
+  "remote-only": "Remote only",
+};
+
+function classifyBranch(b, byBranch) {
+  var w = byBranch.get(b.name);
+  if (w && w.landed) return "landed";
+  if (w) return "active";
+  return "remote-only";
+}
+
+function branchStatePill(b, byBranch) {
+  var w = byBranch.get(b.name);
+  var hasWorktree = !!w;
+  var hasRemote = !!b.upstream;
+  if (hasWorktree && hasRemote) {
+    return el("span", {
+      cls: "branch-state-pill branch-state-pill--local-remote",
+      text: "LOCAL · REMOTE",
+      attrs: { title: "Has worktree and remote tracking branch" },
+    });
+  }
+  if (hasWorktree) {
+    return el("span", {
+      cls: "branch-state-pill branch-state-pill--local",
+      text: "LOCAL",
+      attrs: { title: "Has worktree, not pushed to remote" },
+    });
+  }
+  return el("span", {
+    cls: "branch-state-pill branch-state-pill--remote",
+    text: "REMOTE",
+    attrs: { title: "No worktree" },
+  });
+}
+
+function buildBranchCard(b, byBranch) {
+  var card = el("article", {
+    cls: "card",
+    attrs: {
+      tabindex: "0",
+      role: "button",
+      "data-kind": "branch",
+      "data-name": b.name,
+      "aria-label": "Branch " + b.name,
+    },
+  });
+  var head = el("div", { cls: "card-row" });
+  // Checkbox for bulk selection
+  var cb = el("input", {
+    cls: "branch-select-cb",
+    attrs: { type: "checkbox", "data-branch-name": b.name, "aria-label": "Select " + b.name },
+  });
+  head.appendChild(cb);
+  var url = branchUrl(b.name);
+  if (url) {
+    head.appendChild(el("a", {
+      cls: "card-title-link mono",
+      text: b.name,
+      attrs: {
+        href: url,
+        target: "_blank",
+        rel: "noopener noreferrer",
+        draggable: "false",
+      },
+    }));
+  } else {
+    head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+  }
+  // State pill
+  head.appendChild(branchStatePill(b, byBranch));
+  if (b.last_commit_at) {
+    head.appendChild(el("span", { cls: "card-sub", text: relativeTime(b.last_commit_at) }));
+  }
+  card.appendChild(head);
+  if (b.last_commit_subject) {
+    card.appendChild(el("div", { cls: "card-blurb", text: b.last_commit_subject }));
+  }
+  if (b.upstream) {
+    card.appendChild(el("div", { cls: "card-sub", text: "upstream: " + b.upstream }));
+  }
+  var w = byBranch.get(b.name);
+  if (w) {
+    var status = w.landed ? w.landed.status : "not-landed";
+    var wtRow = el("div", { cls: "card-row card-worktree-row" });
+    wtRow.appendChild(el("span", {
+      cls: "pill " + landedPillClass(status),
+      text: status,
+    }));
+    if (w.path) {
+      wtRow.appendChild(el("span", { cls: "mono card-sub", text: basename(w.path) }));
+    }
+    if (typeof w.age_seconds === "number") {
+      wtRow.appendChild(el("span", {
+        cls: "card-sub",
+        text: ageSecondsToText(w.age_seconds),
+      }));
+    }
+    card.appendChild(wtRow);
+  }
+  return card;
+}
+
+function buildBranchBulkBar(sectionKey, branchNames) {
+  var bar = el("div", { cls: "branch-bulk-bar" });
+  var label = el("label");
+  var selectAll = el("input", {
+    attrs: {
+      type: "checkbox",
+      "data-action": "branch-select-all",
+      "data-section": sectionKey,
+      "aria-label": "Select all in " + BRANCH_SECTION_LABELS[sectionKey],
+    },
+  });
+  label.appendChild(selectAll);
+  label.appendChild(document.createTextNode("Select all"));
+  bar.appendChild(label);
+  var copyBtn = el("button", {
+    cls: "branch-bulk-copy-btn",
+    attrs: {
+      type: "button",
+      "data-action": "branch-bulk-copy",
+      "data-section": sectionKey,
+      "aria-label": "Copy selected branch names",
+    },
+    text: "Copy 0 branch names",
+  });
+  bar.appendChild(copyBtn);
+  return bar;
+}
+
+function buildBranchSection(sectionKey, branchesInSection, byBranch) {
+  var sec = el("div", {
+    cls: "branch-section",
+    attrs: {
+      "data-branch-section": sectionKey,
+      id: "branch-section-" + sectionKey,
+    },
+  });
+  // Section header
+  var head = el("div", {
+    cls: "branch-section-head",
+    attrs: {
+      "data-action": "branch-section-toggle",
+      "data-section": sectionKey,
+      role: "button",
+      tabindex: "0",
+      "aria-expanded": "true",
+      "aria-label": BRANCH_SECTION_LABELS[sectionKey] + " " + branchesInSection.length + " branches",
+    },
+  });
+  head.appendChild(el("span", {
+    cls: "branch-section-label",
+    text: BRANCH_SECTION_LABELS[sectionKey],
+  }));
+  head.appendChild(el("span", {
+    cls: "branch-section-count",
+    text: "(" + branchesInSection.length + ")",
+  }));
+  var toggle = el("button", {
+    cls: "branch-section-toggle",
+    attrs: {
+      type: "button",
+      "data-action": "branch-section-toggle",
+      "data-section": sectionKey,
+      "aria-label": "Collapse " + BRANCH_SECTION_LABELS[sectionKey],
+      title: "Collapse / expand",
+    },
+    html: SVG_ICONS.minus,
+  });
+  head.appendChild(toggle);
+  sec.appendChild(head);
+  // Bulk copy bar
+  var names = branchesInSection.map(function(b) { return b.name; });
+  sec.appendChild(buildBranchBulkBar(sectionKey, names));
+  // Cards body
+  var body = el("div", { cls: "branch-section-body" });
+  for (var i = 0; i < branchesInSection.length; i++) {
+    body.appendChild(buildBranchCard(branchesInSection[i], byBranch));
+  }
+  sec.appendChild(body);
+  // Apply saved collapse state
+  applyBranchSectionCollapse(sec, sectionKey);
+  return sec;
+}
+
+function applyBranchSectionCollapse(secEl, sectionKey) {
+  var collapsed = isCollapsed("branch", sectionKey);
+  if (collapsed) {
+    secEl.classList.add("collapsed");
+  } else {
+    secEl.classList.remove("collapsed");
+  }
+  var toggle = secEl.querySelector(".branch-section-toggle");
+  if (toggle) {
+    toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    toggle.innerHTML = collapsed ? SVG_ICONS.plus : SVG_ICONS.minus; // chrome-only
+    toggle.setAttribute("aria-label", (collapsed ? "Expand " : "Collapse ") + BRANCH_SECTION_LABELS[sectionKey]);
+  }
+  var head = secEl.querySelector(".branch-section-head");
+  if (head) {
+    head.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  }
+}
+
+function buildBranchNavStrip(groups) {
+  var strip = el("nav", {
+    cls: "section-nav-strip",
+    attrs: { "aria-label": "Branch sections", "data-kind": "branch" },
+  });
+  for (var i = 0; i < BRANCH_SECTIONS.length; i++) {
+    var key = BRANCH_SECTIONS[i];
+    var count = (groups[key] || []).length;
+    var pill = el("button", {
+      cls: "section-nav-pill",
+      attrs: {
+        type: "button",
+        "data-action": "branch-nav-pill",
+        "data-target": "branch-section-" + key,
+        "data-section": key,
+        "aria-label": BRANCH_SECTION_LABELS[key] + " " + count + " branches — click to scroll",
+      },
+      text: BRANCH_SECTION_LABELS[key] + " " + count,
+    });
+    strip.appendChild(pill);
+  }
+  return strip;
+}
+
 function renderBranches(branches, worktrees) {
-  const body = $("branches-body");
-  const empty = $("branches-empty");
+  var body = $("branches-body");
+  var empty = $("branches-empty");
   clear(body);
   if (!branches.length) {
     empty.hidden = false;
     return;
   }
   empty.hidden = true;
-  const backed = backedBranchSet(worktrees);
-  const byBranch = worktreesByBranch(worktrees);
-  for (const b of branches) {
-    const card = el("article", {
-      cls: "card",
-      attrs: {
-        tabindex: "0",
-        role: "button",
-        "data-kind": "branch",
-        "data-name": b.name,
-        "aria-label": "Branch " + b.name,
-      },
-    });
-    const head = el("div", { cls: "card-row" });
-    const url = branchUrl(b.name);
-    if (url) {
-      head.appendChild(el("a", {
-        cls: "card-title-link mono",
-        text: b.name,
-        attrs: {
-          href: url,
-          target: "_blank",
-          rel: "noopener noreferrer",
-          draggable: "false",
-        },
-      }));
-    } else {
-      head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
-    }
-    if (b.last_commit_at) {
-      head.appendChild(el("span", { cls: "card-sub", text: relativeTime(b.last_commit_at) }));
-    }
-    card.appendChild(head);
-    if (b.last_commit_subject) {
-      card.appendChild(el("div", { cls: "card-blurb", text: b.last_commit_subject }));
-    }
-    if (b.upstream) {
-      card.appendChild(el("div", { cls: "card-sub", text: "upstream: " + b.upstream }));
-    }
-    const w = byBranch.get(b.name);
-    if (w) {
-      const status = w.landed ? w.landed.status : "not-landed";
-      const wtRow = el("div", { cls: "card-row card-worktree-row" });
-      wtRow.appendChild(el("span", {
-        cls: "pill " + landedPillClass(status),
-        text: status,
-      }));
-      if (w.path) {
-        wtRow.appendChild(el("span", { cls: "mono card-sub", text: basename(w.path) }));
-      }
-      if (typeof w.age_seconds === "number") {
-        wtRow.appendChild(el("span", {
-          cls: "card-sub",
-          text: ageSecondsToText(w.age_seconds),
-        }));
-      }
-      card.appendChild(wtRow);
-    }
-    body.appendChild(card);
+  var byBranch = worktreesByBranch(worktrees);
+  // Group branches into sections
+  var groups = { "active": [], "landed": [], "remote-only": [] };
+  for (var i = 0; i < branches.length; i++) {
+    var section = classifyBranch(branches[i], byBranch);
+    groups[section].push(branches[i]);
+  }
+  // Nav strip at top
+  body.appendChild(buildBranchNavStrip(groups));
+  // Render each section
+  for (var si = 0; si < BRANCH_SECTIONS.length; si++) {
+    var key = BRANCH_SECTIONS[si];
+    var arr = groups[key];
+    if (!arr.length) continue;
+    body.appendChild(buildBranchSection(key, arr, byBranch));
   }
 }
 
@@ -2901,6 +3093,84 @@ async function handleAction(action, target) {
     targetEl.scrollIntoView({ behavior: "smooth", block: "start" });
     return;
   }
+
+  // Issue #717 — Branch section toggle (collapse/expand).
+  if (action === "branch-section-toggle") {
+    const sectionKey = target.getAttribute("data-section");
+    if (!sectionKey) return;
+    const secEl = target.closest(".branch-section") || document.querySelector('[data-branch-section="' + sectionKey + '"]');
+    if (!secEl) return;
+    const next = !isCollapsed("branch", sectionKey);
+    setCollapsed("branch", sectionKey, next);
+    applyBranchSectionCollapse(secEl, sectionKey);
+    return;
+  }
+
+  // Issue #717 — Branch nav pill: scroll to section, expand if collapsed.
+  if (action === "branch-nav-pill") {
+    const targetId = target.getAttribute("data-target");
+    const sectionKey = target.getAttribute("data-section");
+    const targetEl = $(targetId);
+    if (!targetEl) return;
+    if (sectionKey && isCollapsed("branch", sectionKey)) {
+      setCollapsed("branch", sectionKey, false);
+      applyBranchSectionCollapse(targetEl, sectionKey);
+    }
+    targetEl.scrollIntoView({ behavior: "smooth", block: "start" });
+    return;
+  }
+
+  // Issue #717 — Branch select-all checkbox.
+  if (action === "branch-select-all") {
+    const sectionKey = target.getAttribute("data-section");
+    if (!sectionKey) return;
+    const secEl = document.querySelector('[data-branch-section="' + sectionKey + '"]');
+    if (!secEl) return;
+    const checked = target.checked;
+    const cbs = secEl.querySelectorAll(".branch-select-cb");
+    for (let i = 0; i < cbs.length; i++) cbs[i].checked = checked;
+    _updateBranchCopyCount(secEl, sectionKey);
+    return;
+  }
+
+  // Issue #717 — Branch bulk copy.
+  if (action === "branch-bulk-copy") {
+    const sectionKey = target.getAttribute("data-section");
+    if (!sectionKey) return;
+    const secEl = document.querySelector('[data-branch-section="' + sectionKey + '"]');
+    if (!secEl) return;
+    const cbs = secEl.querySelectorAll(".branch-select-cb:checked");
+    const names = [];
+    for (let i = 0; i < cbs.length; i++) {
+      const n = cbs[i].getAttribute("data-branch-name");
+      if (n) names.push(n);
+    }
+    if (!names.length) {
+      showToast("No branches selected.", "info");
+      return;
+    }
+    const text = names.join("\n");
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        navigator.clipboard.writeText(text);
+        showToast("Copied " + names.length + " branch name" + (names.length === 1 ? "" : "s") + ".", "info");
+      } catch (_err) {
+        showToast("Copy failed — select text manually.", "err");
+      }
+    } else {
+      showToast("Clipboard API unavailable.", "err");
+    }
+    return;
+  }
+}
+
+// Issue #717 — Update the copy button label with the count of selected branches.
+function _updateBranchCopyCount(secEl, sectionKey) {
+  const cbs = secEl.querySelectorAll(".branch-select-cb:checked");
+  const btn = secEl.querySelector('.branch-bulk-copy-btn[data-section="' + sectionKey + '"]');
+  if (btn) {
+    btn.textContent = "Copy " + cbs.length + " branch name" + (cbs.length === 1 ? "" : "s");
+  }
 }
 
 function bindActionEvents() {
@@ -2928,6 +3198,17 @@ function bindActionEvents() {
     if (kind === "issue") lastFingerprint.issues = null;
     // Trigger an immediate poll so the UI updates now.
     schedulePoll(0);
+  });
+
+  // Issue #717 — Branch checkbox change handler. Updates per-section copy
+  // count when individual branch checkboxes are toggled.
+  document.body.addEventListener("change", (ev) => {
+    const cb = ev.target.closest && ev.target.closest(".branch-select-cb");
+    if (!cb) return;
+    const secEl = cb.closest(".branch-section");
+    if (!secEl) return;
+    const sectionKey = secEl.getAttribute("data-branch-section");
+    if (sectionKey) _updateBranchCopyCount(secEl, sectionKey);
   });
 
   // Default-mode segmented buttons.

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -1368,10 +1368,12 @@ fi
 # localStorage entry exists. Tests the structural contract from app.js
 # directly (JSDOM-style integration deferred to the playwright-cli
 # verification recipe in the issue body).
-if grep -qE 'COLLAPSED_BY_DEFAULT *= *new Set\(\["discarded"\]\)' "$APP_JS"; then
-  pass "#677 discarded_column_renders_collapsed_by_default: COLLAPSED_BY_DEFAULT = new Set([\"discarded\"])"
+# Issue #717 expanded the set with branch-section keys; the contract is
+# that "discarded" MUST be present (not necessarily the only member).
+if grep -qE 'COLLAPSED_BY_DEFAULT *= *new Set\(\[.*"discarded"' "$APP_JS"; then
+  pass "#677 discarded_column_renders_collapsed_by_default: COLLAPSED_BY_DEFAULT contains \"discarded\""
 else
-  fail "#677 discarded_column_renders_collapsed_by_default: COLLAPSED_BY_DEFAULT constant missing or wrong shape"
+  fail "#677 discarded_column_renders_collapsed_by_default: COLLAPSED_BY_DEFAULT constant missing or does not contain \"discarded\""
 fi
 # isCollapsed must consult COLLAPSED_BY_DEFAULT when no localStorage entry.
 ISCOLLAPSED_BODY=$(awk '


### PR DESCRIPTION
## Summary
- Dashboard Branches tab: 4 features — state pills (LOCAL·REMOTE/LOCAL/REMOTE), status grouping (Active/Landed/Remote-only with collapse), bulk copy (select-all + copy button per section), nav strip with counts
- Reuses existing collapse machinery (PR #668) and nav-strip pattern (PR #675)

## Test plan
- [x] 3-section grouping with collapse toggles
- [x] State pills color-coded; CSS selectors match rendered elements
- [x] Bulk select-all + copy per section
- [x] Visual verification via playwright-cli (all 4 features render)
- [x] Full test suite: 5957/5957 passed

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
