### PR TITLE
test(conformance): pin recently-reverted SKILL.md content blocks (#735)

### DIFF
--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -524,6 +524,14 @@ check_in_file .claude/skills/fix-issues modes/sprint.md "mirror has summary sect
 # stays there.
 check_in_file land-pr scripts/pr-merge.sh "auto-merge AUTO_FLAG guard" 'if \[ "\$AUTO_FLAG" != "true" \]; then'
 
+# Guard recently-reverted content (see #704, #729, #735).
+# These blocks have been lost-then-restored across rapid PR landings; pin
+# them so any future accidental deletion fails CI. The `check` helper greps
+# the whole skill tree recursively, so each pin survives RESTRUCTURE moves
+# (e.g. the staleness step now lives in subcommands/stop-next.md after #740).
+check fix-issues        "next-section staleness step (#729/#735)"  'Peek at the Ready queue'
+check zskills-dashboard "ZSKILLS_DASHBOARD_ROOT contract (#704/#735)" 'ZSKILLS_DASHBOARD_ROOT'
+
 echo ""
 echo "=== auto grammar (QUICKFIX_GRAMMAR_REDESIGN Phase 2) ==="
 # AC2.2 — AUTO_FLAG initializer present in all 4 PR-landing callers.


### PR DESCRIPTION
## Summary

Adds two CI conformance pins guarding SKILL.md content blocks that have been accidentally lost-then-restored across rapid PR landings (#704, #729). A pin fails the build if either block is ever deleted again.

- `skills/fix-issues/` next-section staleness step (`Peek at the Ready queue`) — previously reverted (#729), now relocated to `subcommands/stop-next.md` by the #740 extraction.
- `skills/zskills-dashboard/SKILL.md` `ZSKILLS_DASHBOARD_ROOT` wiring — previously reverted (#704).

Both pins use the conformance harness's existing tree-recursive `check` helper, so they survive future RESTRUCTURE moves (e.g. the staleness step's relocation under #740) instead of pinning a literal `SKILL.md` path that a refactor would break.

## Note on scope

The issue assumed both guarded blocks currently existed on main. That held — the staleness step is present at `subcommands/stop-next.md` (preserved through the #740 extraction), so no content restoration was needed; the change is purely additive (2 pins).

## Test plan

- [x] `bash tests/run-all.sh` → 5935/5935 passed, 0 failed
- [x] Both new pins pass: `PASS [fix-issues] next-section staleness step` and `PASS [zskills-dashboard] ZSKILLS_DASHBOARD_ROOT contract`
- [x] No skill file modified → no version bump required

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
