### PR TITLE
docs(skills): fix stale SKILL.md:NNN cross-references after extraction refactors (#742)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.28+ee6bd1"
+  version: "2026.05.28+09107c"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/pr.md
+++ b/.claude/skills/fix-issues/modes/pr.md
@@ -54,8 +54,8 @@ MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 # LAND_PR_BYPASS_HARDENING Phase 2). Written ONCE at sprint start
 # (i.e., at the top of the per-issue loop flow); finalized at sprint
 # end via explicit-finalize based on $SPRINT_OUTCOME below. Variables
-# $PIPELINE_ID and $SPRINT_ID are presumed set by the sprint-tracking
-# sentinel at skills/fix-issues/SKILL.md:445-470.
+# $PIPELINE_ID and $SPRINT_ID are presumed set by the "Sprint identity"
+# section at skills/fix-issues/modes/sprint.md:122-126.
 NOW_ISO=$(TZ="${TIMEZONE:-UTC}" date -Iseconds)
 mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 cat > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.fix-issues.$SPRINT_ID" <<MARK

--- a/.claude/skills/fix-issues/modes/sync.md
+++ b/.claude/skills/fix-issues/modes/sync.md
@@ -247,7 +247,7 @@ EOF
    monitors CI. The tracking marker is written on main_root so
    `/land-pr` can satisfy it with a `fulfilled.land-pr.<id>` marker on
    successful merge — mirrors `/run-plan` PR mode's pattern
-   (`skills/run-plan/modes/pr.md:339-348`, `skills/run-plan/SKILL.md:888`).
+   (`skills/run-plan/modes/pr.md:373-379`, `skills/run-plan/SKILL.md:874-878`).
 
    ```bash
    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.27+beade3"
+  version: "2026.05.28+b06b7e"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -820,9 +820,10 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    ```bash
    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
    # Re-derive BRANCH_PREFIX and PLAN_SLUG at fence-top (R-5-1):
-   # both were set in earlier disjoint fences (BRANCH_PREFIX@149-157,
-   # PLAN_SLUG@425-441) and do NOT survive cross-fence per
-   # SKILL.md:1326-1328 ("Resolve config-derived vars at fence-top").
+   # both were set in earlier disjoint fences (BRANCH_PREFIX@178-185,
+   # PLAN_SLUG@382) and do NOT survive cross-fence per the
+   # "Resolve config-derived vars at fence-top" convention
+   # (modes/execute-phase.md:425).
    # Needed below for the requires.land-pr.<id> marker's branch: field.
    BRANCH_PREFIX="feat/"
    if [ -f "$CLAUDE_PROJECT_DIR/.claude/zskills-config.json" ]; then

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -111,8 +111,8 @@ agent hasn't returned after 2 hours, declare it **failed**:
    fi
 
    # Resume detection: directory-based, symmetric to PR mode's check at
-   # SKILL.md:1206-1209. An existing plan-scoped cherry-pick worktree
-   # means we're resuming the same plan across cron turns.
+   # execute-phase.md:372-375 (below). An existing plan-scoped cherry-pick
+   # worktree means we're resuming the same plan across cron turns.
    if [ -d "$CP_WORKTREE_PATH" ]; then
      echo "Resuming existing cherry-pick worktree at $CP_WORKTREE_PATH"
      WORKTREE_PATH="$CP_WORKTREE_PATH"

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -287,7 +287,8 @@ Those move to `/land-pr` (see `skills/land-pr/SKILL.md`). `/run-plan`'s
 remaining responsibilities here are:
 
 1. Per-iteration body splice on existing PRs (caller-owned per WI 2.1; the
-   bash-regex `BASH_REMATCH` splice at `skills/run-plan/SKILL.md:1715-1745`
+   bash-regex `BASH_REMATCH` splice in
+   `skills/run-plan/scripts/sync-pr-body-progress.sh`
    stays as the source of truth and is invoked from
    `<CALLER_PRE_INVOKE_BODY_PREP>`).
 2. Agent-assisted rebase-conflict resolution when `STATUS=rebase-conflict`
@@ -306,7 +307,7 @@ hit `/run-plan`'s Step 0 pre-flight, increment the per-phase
 `in-progress-defers.<phase>` counter, and step the cadence down at boundary
 fires `C+1 ∈ {1, 10, 16, 26}`. The phase still finishes correctly — Step 0
 defers, the original turn writes `.landed` via `/land-pr`. No code change
-needed here; the adaptive machinery (`SKILL.md:439-573`) is correct by design.
+needed here; the adaptive machinery (`SKILL.md:421-566`) is correct by design.
 
 ```bash
 # === BEGIN CANONICAL /land-pr CALLER LOOP ===
@@ -348,8 +349,9 @@ while :; do
   # so this is the caller's only chance to refresh the progress checklist.
   #
   # The splice implementation is the bash-regex (`BASH_REMATCH`) splice
-  # owned by Phase 4 (Update Progress Tracking) at
-  # skills/run-plan/SKILL.md:1715-1745. It is the source of truth and is
+  # owned by Phase 4 (Update Progress Tracking), extracted to
+  # skills/run-plan/scripts/sync-pr-body-progress.sh (invoked from Phase 4
+  # at execute-phase.md:1018). It is the source of truth and is
   # NOT duplicated here — Phase 4 already runs before Phase 6's caller
   # loop on every phase iteration where a PR already exists.
   #
@@ -362,7 +364,8 @@ while :; do
   # the source of truth and the PR body is a convenience surface):
   #   - gh-pr-view-failed: NOTICE, retry once, NOTICE-and-skip on second fail.
   #   - body-markers-missing: NOTICE-and-skip ("expected for PRs not opened
-  #     by /run-plan PR mode"); design property at SKILL.md:1758-1761.
+  #     by /run-plan PR mode"); design property in
+  #     skills/run-plan/scripts/sync-pr-body-progress.sh:146-155.
   #   - gh-pr-edit-failed: WARN-and-continue.
 
   # Build /land-pr arg vector. --body-file is required; --auto and

--- a/.claude/skills/run-plan/references/finish-mode.md
+++ b/.claude/skills/run-plan/references/finish-mode.md
@@ -59,7 +59,7 @@ After Phase 6 (land) succeeds for the current phase AND
    exit this turn.
 
 2. **This plan is a sub-plan delegate** (detected via `tracking-index=N`
-   arg from research-and-go Step 1b — see `skills/research-and-go/SKILL.md:135`):
+   arg from research-and-go Step 1b — see `skills/research-and-go/SKILL.md:255-258`):
    after the last phase of this sub-plan lands, recover the meta-plan path
    from `requires.run-plan.N` marker content (or
    `pipeline.research-and-go.*` sentinel — see Step 1b). Schedule a

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.28+ee6bd1"
+  version: "2026.05.28+09107c"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/pr.md
+++ b/skills/fix-issues/modes/pr.md
@@ -54,8 +54,8 @@ MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 # LAND_PR_BYPASS_HARDENING Phase 2). Written ONCE at sprint start
 # (i.e., at the top of the per-issue loop flow); finalized at sprint
 # end via explicit-finalize based on $SPRINT_OUTCOME below. Variables
-# $PIPELINE_ID and $SPRINT_ID are presumed set by the sprint-tracking
-# sentinel at skills/fix-issues/SKILL.md:445-470.
+# $PIPELINE_ID and $SPRINT_ID are presumed set by the "Sprint identity"
+# section at skills/fix-issues/modes/sprint.md:122-126.
 NOW_ISO=$(TZ="${TIMEZONE:-UTC}" date -Iseconds)
 mkdir -p "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 cat > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/fulfilled.fix-issues.$SPRINT_ID" <<MARK

--- a/skills/fix-issues/modes/sync.md
+++ b/skills/fix-issues/modes/sync.md
@@ -247,7 +247,7 @@ EOF
    monitors CI. The tracking marker is written on main_root so
    `/land-pr` can satisfy it with a `fulfilled.land-pr.<id>` marker on
    successful merge — mirrors `/run-plan` PR mode's pattern
-   (`skills/run-plan/modes/pr.md:339-348`, `skills/run-plan/SKILL.md:888`).
+   (`skills/run-plan/modes/pr.md:373-379`, `skills/run-plan/SKILL.md:874-878`).
 
    ```bash
    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.27+beade3"
+  version: "2026.05.28+b06b7e"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -820,9 +820,10 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    ```bash
    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
    # Re-derive BRANCH_PREFIX and PLAN_SLUG at fence-top (R-5-1):
-   # both were set in earlier disjoint fences (BRANCH_PREFIX@149-157,
-   # PLAN_SLUG@425-441) and do NOT survive cross-fence per
-   # SKILL.md:1326-1328 ("Resolve config-derived vars at fence-top").
+   # both were set in earlier disjoint fences (BRANCH_PREFIX@178-185,
+   # PLAN_SLUG@382) and do NOT survive cross-fence per the
+   # "Resolve config-derived vars at fence-top" convention
+   # (modes/execute-phase.md:425).
    # Needed below for the requires.land-pr.<id> marker's branch: field.
    BRANCH_PREFIX="feat/"
    if [ -f "$CLAUDE_PROJECT_DIR/.claude/zskills-config.json" ]; then

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -111,8 +111,8 @@ agent hasn't returned after 2 hours, declare it **failed**:
    fi
 
    # Resume detection: directory-based, symmetric to PR mode's check at
-   # SKILL.md:1206-1209. An existing plan-scoped cherry-pick worktree
-   # means we're resuming the same plan across cron turns.
+   # execute-phase.md:372-375 (below). An existing plan-scoped cherry-pick
+   # worktree means we're resuming the same plan across cron turns.
    if [ -d "$CP_WORKTREE_PATH" ]; then
      echo "Resuming existing cherry-pick worktree at $CP_WORKTREE_PATH"
      WORKTREE_PATH="$CP_WORKTREE_PATH"

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -287,7 +287,8 @@ Those move to `/land-pr` (see `skills/land-pr/SKILL.md`). `/run-plan`'s
 remaining responsibilities here are:
 
 1. Per-iteration body splice on existing PRs (caller-owned per WI 2.1; the
-   bash-regex `BASH_REMATCH` splice at `skills/run-plan/SKILL.md:1715-1745`
+   bash-regex `BASH_REMATCH` splice in
+   `skills/run-plan/scripts/sync-pr-body-progress.sh`
    stays as the source of truth and is invoked from
    `<CALLER_PRE_INVOKE_BODY_PREP>`).
 2. Agent-assisted rebase-conflict resolution when `STATUS=rebase-conflict`
@@ -306,7 +307,7 @@ hit `/run-plan`'s Step 0 pre-flight, increment the per-phase
 `in-progress-defers.<phase>` counter, and step the cadence down at boundary
 fires `C+1 ∈ {1, 10, 16, 26}`. The phase still finishes correctly — Step 0
 defers, the original turn writes `.landed` via `/land-pr`. No code change
-needed here; the adaptive machinery (`SKILL.md:439-573`) is correct by design.
+needed here; the adaptive machinery (`SKILL.md:421-566`) is correct by design.
 
 ```bash
 # === BEGIN CANONICAL /land-pr CALLER LOOP ===
@@ -348,8 +349,9 @@ while :; do
   # so this is the caller's only chance to refresh the progress checklist.
   #
   # The splice implementation is the bash-regex (`BASH_REMATCH`) splice
-  # owned by Phase 4 (Update Progress Tracking) at
-  # skills/run-plan/SKILL.md:1715-1745. It is the source of truth and is
+  # owned by Phase 4 (Update Progress Tracking), extracted to
+  # skills/run-plan/scripts/sync-pr-body-progress.sh (invoked from Phase 4
+  # at execute-phase.md:1018). It is the source of truth and is
   # NOT duplicated here — Phase 4 already runs before Phase 6's caller
   # loop on every phase iteration where a PR already exists.
   #
@@ -362,7 +364,8 @@ while :; do
   # the source of truth and the PR body is a convenience surface):
   #   - gh-pr-view-failed: NOTICE, retry once, NOTICE-and-skip on second fail.
   #   - body-markers-missing: NOTICE-and-skip ("expected for PRs not opened
-  #     by /run-plan PR mode"); design property at SKILL.md:1758-1761.
+  #     by /run-plan PR mode"); design property in
+  #     skills/run-plan/scripts/sync-pr-body-progress.sh:146-155.
   #   - gh-pr-edit-failed: WARN-and-continue.
 
   # Build /land-pr arg vector. --body-file is required; --auto and

--- a/skills/run-plan/references/finish-mode.md
+++ b/skills/run-plan/references/finish-mode.md
@@ -59,7 +59,7 @@ After Phase 6 (land) succeeds for the current phase AND
    exit this turn.
 
 2. **This plan is a sub-plan delegate** (detected via `tracking-index=N`
-   arg from research-and-go Step 1b — see `skills/research-and-go/SKILL.md:135`):
+   arg from research-and-go Step 1b — see `skills/research-and-go/SKILL.md:255-258`):
    after the last phase of this sub-plan lands, recover the meta-plan path
    from `requires.run-plan.N` marker content (or
    `pipeline.research-and-go.*` sentinel — see Step 1b). Schedule a


### PR DESCRIPTION
## Summary

Fixes stale `SKILL.md:NNN` line-number cross-references in `/run-plan` and `/fix-issues` mode files that pointed past EOF or to content relocated by the #724/#725/#726/#740 decomposition refactors. These are documentation pointers (in prose/comments), not executable references — low severity, but an agent following them lands on the wrong content or hits EOF.

Every `SKILL.md:NNN` reference across both skill trees was traced against the *current* files (the issue's reported line numbers had themselves drifted). Each new target was verified by opening the destination and confirming the cited content is there.

## References corrected (9)

- `run-plan/modes/execute-phase.md:114` → resume-detection block now same-file at `execute-phase.md:372-375`
- `run-plan/modes/pr.md:290,352,365` → BASH_REMATCH PR-body splice extracted to `scripts/sync-pr-body-progress.sh`; invocation at `execute-phase.md:1018`
- `run-plan/modes/pr.md:309` → adaptive-cron-backoff block (`SKILL.md:421-566`)
- `run-plan/SKILL.md:822-825` → fence-top config-resolve at `execute-phase.md:425`; BRANCH_PREFIX/PLAN_SLUG defs
- `fix-issues/modes/pr.md:58` → `$SPRINT_ID`/`$PIPELINE_ID` now in `modes/sprint.md:122-126`
- `fix-issues/modes/sync.md:250` → `--tracking-id` pattern at `pr.md:373-379`; `requires.land-pr` marker at `SKILL.md:874-878`
- `run-plan/references/finish-mode.md:62` → `research-and-go/SKILL.md:255-258`

One reference (`fix-issues/modes/sprint.md:494` → `work-on-plans/SKILL.md:128-154`) was verified still-accurate and left unchanged.

## Test plan

- [x] `bash tests/run-all.sh` → 5926/5926 passed, 0 failed, 0 skipped
- [x] Conformance line-number invariants still pass (comment edits shifted no line-pinned content)
- [x] Spot-checked target line numbers against current files
- [x] Mirror diffs empty; `run-plan` + `fix-issues` versions bumped

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)
