### PR TITLE
config: raise max_concurrent_worktrees to 4

### DIFF
--- a/.claude/zskills-config.json
+++ b/.claude/zskills-config.json
@@ -6,6 +6,7 @@
     "landing": "pr",
     "main_protected": true,
     "branch_prefix": "feat/",
+    "max_concurrent_worktrees": 4,
     "dashboard_completed_days": 14,
     "dashboard_completed_limit": 500
   },


### PR DESCRIPTION
## Summary
Raise `execution.max_concurrent_worktrees` from the default 3 to **4** in `.claude/zskills-config.json` — lifts the `/fix-issues` sprint-wide live-worktree cap so up to 4 `fix/issue-*` worktrees can run concurrently on this host.

The field is already defined in `config/zskills-config.schema.json` (default 3, minimum 1); this is a single-field addition to the existing `execution` block. No schema change, no mirror, no skill-version bump (config, not a skill file).

## Test plan
- [x] `.claude/zskills-config.json` is valid JSON
- [x] resolver regex in `zskills-resolve-config.sh` extracts `4` from the new config
- [x] `tests/test-zskills-resolve-config.sh` passes (32/32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
