### PR TITLE
feat(dashboard): make Branches panel honest about local vs remote state

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+e38be2"
+  version: "2026.05.28+a10fbc"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -112,6 +112,16 @@ SNAPSHOT_CACHE_TTL_GIT_HISTORY = 10.0    # git log
 SNAPSHOT_CACHE_TTL_PLANS = 3.0           # parse_plan + parse_report + landing-mode
 SNAPSHOT_CACHE_TTL_TRACKING = 3.0        # .zskills/tracking/ walk + PR-number scan
 
+# Remote-tracking-ref freshness TTL (seconds). SEPARATE from (and far
+# longer than) SNAPSHOT_CACHE_TTL_BRANCHES: the 5s branch cache governs how
+# often we re-READ refs, while this governs how often we `git fetch --prune`
+# to REFRESH the remote-tracking refs from origin. A network round-trip is
+# expensive and origin moves slowly relative to the 2Hz client poll, so the
+# default is 120s. Override via `dashboard.branch_fetch_ttl_seconds` in
+# `.claude/zskills-config.json`. The fetch is non-fatal — a failure records
+# an `errors[]` entry and the last-known remote refs are rendered.
+BRANCH_FETCH_TTL = 120.0
+
 
 # ---------------------------------------------------------------------------
 # Module-level cache (per-Python-process; documented limitation per DA-14)
@@ -127,6 +137,12 @@ _ISSUE_CACHE: Dict[str, Any] = {
 # 60s TTL). Keyed by (days, limit) so a config change invalidates the
 # cache naturally instead of returning a stale narrower window.
 _CLOSED_ISSUE_CACHE: Dict[Tuple[int, int], Dict[str, Any]] = {}
+
+# Throttle clock for `git fetch --prune` (issue: Branches-panel remote
+# state). Keyed by main_root_str → last monotonic fetch timestamp. The fetch
+# only ever updates remote-tracking refs; it never touches the working tree,
+# index, or local branches.
+_BRANCH_FETCH_TS: Dict[str, float] = {}
 
 # Per-subsystem snapshot cache: maps (kind, main_root_str) →
 # (monotonic_ts, value, errors_from_that_call). On cache hit, the
@@ -146,6 +162,7 @@ def _reset_issue_cache_for_tests() -> None:
 def _reset_snapshot_cache_for_tests() -> None:
     """Reset the per-subsystem snapshot cache (test-only helper)."""
     _SNAPSHOT_CACHE.clear()
+    _BRANCH_FETCH_TS.clear()
 
 
 def _cached_subsystem(
@@ -1103,50 +1120,208 @@ def _list_worktrees(
     return out
 
 
-def _list_branches(
+def _read_protected_branches(main_root: pathlib.Path) -> set:
+    """Read `cleanup.protected_branches` from .claude/zskills-config.json.
+
+    This is the SAME set `/cleanup-merged` honors (exact-name match). Absent
+    config / block / non-list → empty set. Never raises.
+    """
+    cfg_path = main_root / ".claude" / "zskills-config.json"
+    text = _read_text(cfg_path)
+    if text is None:
+        return set()
+    try:
+        cfg = json.loads(text)
+    except Exception:
+        return set()
+    if not isinstance(cfg, dict):
+        return set()
+    cleanup = cfg.get("cleanup", {})
+    if not isinstance(cleanup, dict):
+        return set()
+    pats = cleanup.get("protected_branches", []) or []
+    if not isinstance(pats, list):
+        return set()
+    return {str(p) for p in pats if isinstance(p, (str,)) and p}
+
+
+def _branch_fetch_ttl(main_root: pathlib.Path) -> float:
+    """Resolve the git-fetch throttle TTL (seconds).
+
+    Default `BRANCH_FETCH_TTL`; overridable via
+    `dashboard.branch_fetch_ttl_seconds` in zskills-config.json. Malformed →
+    default.
+    """
+    cfg_path = main_root / ".claude" / "zskills-config.json"
+    text = _read_text(cfg_path)
+    if text is None:
+        return BRANCH_FETCH_TTL
+    try:
+        cfg = json.loads(text)
+    except Exception:
+        return BRANCH_FETCH_TTL
+    if not isinstance(cfg, dict):
+        return BRANCH_FETCH_TTL
+    dash = cfg.get("dashboard", {})
+    if not isinstance(dash, dict):
+        return BRANCH_FETCH_TTL
+    raw = dash.get("branch_fetch_ttl_seconds")
+    if isinstance(raw, (int, float)) and raw >= 0:
+        return float(raw)
+    return BRANCH_FETCH_TTL
+
+
+def _maybe_fetch_remote(
     main_root: pathlib.Path,
     errors: List[Dict[str, str]],
-) -> List[Dict[str, Any]]:
-    """Per plan: rich branch list with last commit + upstream."""
+    *,
+    _now: Optional[float] = None,
+    _runner: Optional[Any] = None,
+) -> None:
+    """Throttled, NON-FATAL `git fetch --prune`.
+
+    Refreshes remote-tracking refs at most once per `_branch_fetch_ttl`
+    seconds (monotonic clock). A plain `git fetch --prune` only updates
+    `refs/remotes/origin/*`; it never touches the working tree, index, or
+    local branches. On failure (network down, no remote, etc.) append a
+    descriptive `errors[]` entry and CONTINUE so the last-known
+    remote-tracking refs are still rendered. Never raises.
+
+    `_now` / `_runner` are test-only injection seams.
+    """
+    now = _now if _now is not None else time.monotonic()
+    key = str(main_root)
+    ttl = _branch_fetch_ttl(main_root)
+    last = _BRANCH_FETCH_TS.get(key)
+    if last is not None and ttl > 0 and (now - last) < ttl:
+        return
+    runner = _runner or subprocess.run
     try:
-        result = subprocess.run(
-            [
-                "git",
-                "for-each-ref",
-                "--format=%(refname:short)|%(committerdate:iso8601-strict)|%(upstream:short)|%(contents:subject)",
-                "refs/heads/",
-            ],
+        result = runner(
+            ["git", "fetch", "--prune"],
             cwd=str(main_root),
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
         )
-        if result.returncode != 0:
+        # Record the attempt regardless of outcome so a hard-down remote
+        # doesn't get retried on every 2Hz poll.
+        _BRANCH_FETCH_TS[key] = now
+        if getattr(result, "returncode", 1) != 0:
             errors.append({
-                "source": "git for-each-ref",
-                "message": result.stderr.strip() or "non-zero exit",
+                "source": "git fetch",
+                "message": (getattr(result, "stderr", "") or "non-zero exit").strip()
+                or "git fetch --prune failed; rendering last-known remote refs",
             })
-            return []
     except Exception as exc:
+        _BRANCH_FETCH_TS[key] = now
         errors.append({
-            "source": "git for-each-ref",
-            "message": str(exc),
+            "source": "git fetch",
+            "message": f"{exc}; rendering last-known remote refs",
         })
+
+
+def _list_branches(
+    main_root: pathlib.Path,
+    errors: List[Dict[str, str]],
+    *,
+    _now: Optional[float] = None,
+    _fetch_runner: Optional[Any] = None,
+) -> List[Dict[str, Any]]:
+    """Rich branch list: local + remote-only, with last commit + upstream.
+
+    Reads BOTH `refs/heads/` (local) and `refs/remotes/origin/`
+    (remote-tracking), refreshing the latter via a throttled non-fatal
+    `git fetch --prune` first. Local and remote entries are merged and
+    deduped by branch name — the LOCAL entry wins (keeps its
+    worktree/landed-classification data). Each entry carries:
+      - `locality`: "local" | "remote-only" | "both"
+      - `protected`: bool (from cleanup.protected_branches config)
+    """
+    protected = _read_protected_branches(main_root)
+
+    def _for_each_ref(ref_glob: str, source: str) -> Optional[List[List[str]]]:
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "for-each-ref",
+                    "--format=%(refname:short)|%(committerdate:iso8601-strict)|%(upstream:short)|%(contents:subject)",
+                    ref_glob,
+                ],
+                cwd=str(main_root),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                errors.append({
+                    "source": source,
+                    "message": result.stderr.strip() or "non-zero exit",
+                })
+                return None
+        except Exception as exc:
+            errors.append({"source": source, "message": str(exc)})
+            return None
+        rows: List[List[str]] = []
+        for line in result.stdout.split("\n"):
+            if not line.strip():
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            rows.append(parts)
+        return rows
+
+    # Local branches (refs/heads/). A None return means git itself failed.
+    local_rows = _for_each_ref("refs/heads/", "git for-each-ref")
+    if local_rows is None:
         return []
-    out: List[Dict[str, Any]] = []
-    for line in result.stdout.split("\n"):
-        if not line.strip():
-            continue
-        parts = line.split("|")
-        if len(parts) < 4:
-            continue
-        out.append({
-            "name": parts[0],
+
+    # Refresh + read remote-tracking refs (refs/remotes/origin/). The fetch
+    # is throttled + non-fatal; the read is non-fatal too.
+    _maybe_fetch_remote(
+        main_root, errors, _now=_now, _runner=_fetch_runner
+    )
+    remote_rows = _for_each_ref("refs/remotes/origin/", "git for-each-ref (remote)")
+    if remote_rows is None:
+        remote_rows = []
+
+    # Build the merged map, LOCAL first so it wins on collision.
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for parts in local_rows:
+        name = parts[0]
+        by_name[name] = {
+            "name": name,
             "last_commit_at": parts[1],
             "upstream": parts[2] or None,
             "last_commit_subject": "|".join(parts[3:]),
-        })
-    return out
+            "locality": "local",
+            "protected": name in protected,
+        }
+    for parts in remote_rows:
+        raw = parts[0]
+        # `%(refname:short)` yields e.g. "origin/feat/x" or "origin/HEAD".
+        if raw == "origin/HEAD" or not raw.startswith("origin/"):
+            continue
+        name = raw[len("origin/"):]
+        if not name or name == "HEAD":
+            continue
+        existing = by_name.get(name)
+        if existing is not None:
+            # Local entry wins; merging just flips locality to "both".
+            existing["locality"] = "both"
+            continue
+        by_name[name] = {
+            "name": name,
+            "last_commit_at": parts[1],
+            "upstream": parts[2] or None,
+            "last_commit_subject": "|".join(parts[3:]),
+            "locality": "remote-only",
+            "protected": name in protected,
+        }
+
+    return list(by_name.values())
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1290,6 +1290,16 @@ button svg { display: inline-block; vertical-align: middle; }
 .branch-state-pill--local        { color: var(--orange); border-color: var(--orange); }
 .branch-state-pill--remote       { color: var(--text-dim); border-color: var(--border); }
 
+/* Config-protected shield (cleanup.protected_branches). Signals that
+   /cleanup-merged skips this branch — NOT GitHub branch protection. */
+.branch-protected-shield {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 0.82rem;
+  line-height: 1;
+  cursor: help;
+}
+
 /* Issue #717 — Branch section container. Each of Active/Landed/Remote-only
    is a collapsible section within the branches panel. */
 .branch-section {

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -105,7 +105,7 @@ function setCompletedWindow(kind, value) {
 // explicitly expands it. Per-user expand state still persists via
 // localStorage (setCollapsed removes the key on expand, so the default
 // applies only on first paint or after localStorage.clear()).
-const COLLAPSED_BY_DEFAULT = new Set(["discarded", "branch-landed", "branch-remote-only"]);
+const COLLAPSED_BY_DEFAULT = new Set(["discarded", "branch-landed", "branch-local", "branch-remote-only"]);
 
 function isCollapsed(kind, col) {
   try {
@@ -1271,18 +1271,28 @@ function worktreesByBranch(worktrees) {
 }
 
 // Issue #717 — Branch grouping constants.
-var BRANCH_SECTIONS = ["active", "landed", "remote-only"];
+var BRANCH_SECTIONS = ["active", "landed", "local", "remote-only"];
 var BRANCH_SECTION_LABELS = {
   "active": "Active",
   "landed": "Landed",
+  "local": "Local (no worktree)",
   "remote-only": "Remote only",
 };
 
+// Four accurate buckets:
+//   active      — local branch WITH a live worktree, no .landed marker
+//   landed      — local branch WITH a worktree carrying a .landed marker
+//   local       — local branch with NO worktree (was mislabeled "remote-only")
+//   remote-only — branch on origin but NOT checked out locally (was invisible)
+// The collector tags each branch with `locality` ("local"|"remote-only"|
+// "both"); a worktree match implies the branch is local, so we only need
+// `locality === "remote-only"` to separate the genuinely-remote bucket.
 function classifyBranch(b, byBranch) {
   var w = byBranch.get(b.name);
   if (w && w.landed) return "landed";
   if (w) return "active";
-  return "remote-only";
+  if (b.locality === "remote-only") return "remote-only";
+  return "local";
 }
 
 function branchStatePill(b, byBranch) {
@@ -1342,6 +1352,18 @@ function buildBranchCard(b, byBranch) {
     }));
   } else {
     head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+  }
+  // Config-protected shield (zskills cleanup.protected_branches — NOT
+  // GitHub branch protection). Signals "/cleanup-merged skips this branch".
+  if (b.protected) {
+    head.appendChild(el("span", {
+      cls: "branch-protected-shield",
+      text: "🛡",
+      attrs: {
+        title: "Config-protected (cleanup.protected_branches) — /cleanup-merged skips this branch",
+        "aria-label": "Config-protected branch",
+      },
+    }));
   }
   // State pill
   head.appendChild(branchStatePill(b, byBranch));
@@ -1514,7 +1536,7 @@ function renderBranches(branches, worktrees) {
   empty.hidden = true;
   var byBranch = worktreesByBranch(worktrees);
   // Group branches into sections
-  var groups = { "active": [], "landed": [], "remote-only": [] };
+  var groups = { "active": [], "landed": [], "local": [], "remote-only": [] };
   for (var i = 0; i < branches.length; i++) {
     var section = classifyBranch(branches[i], byBranch);
     groups[section].push(branches[i]);

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+e38be2"
+  version: "2026.05.28+a10fbc"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -112,6 +112,16 @@ SNAPSHOT_CACHE_TTL_GIT_HISTORY = 10.0    # git log
 SNAPSHOT_CACHE_TTL_PLANS = 3.0           # parse_plan + parse_report + landing-mode
 SNAPSHOT_CACHE_TTL_TRACKING = 3.0        # .zskills/tracking/ walk + PR-number scan
 
+# Remote-tracking-ref freshness TTL (seconds). SEPARATE from (and far
+# longer than) SNAPSHOT_CACHE_TTL_BRANCHES: the 5s branch cache governs how
+# often we re-READ refs, while this governs how often we `git fetch --prune`
+# to REFRESH the remote-tracking refs from origin. A network round-trip is
+# expensive and origin moves slowly relative to the 2Hz client poll, so the
+# default is 120s. Override via `dashboard.branch_fetch_ttl_seconds` in
+# `.claude/zskills-config.json`. The fetch is non-fatal — a failure records
+# an `errors[]` entry and the last-known remote refs are rendered.
+BRANCH_FETCH_TTL = 120.0
+
 
 # ---------------------------------------------------------------------------
 # Module-level cache (per-Python-process; documented limitation per DA-14)
@@ -127,6 +137,12 @@ _ISSUE_CACHE: Dict[str, Any] = {
 # 60s TTL). Keyed by (days, limit) so a config change invalidates the
 # cache naturally instead of returning a stale narrower window.
 _CLOSED_ISSUE_CACHE: Dict[Tuple[int, int], Dict[str, Any]] = {}
+
+# Throttle clock for `git fetch --prune` (issue: Branches-panel remote
+# state). Keyed by main_root_str → last monotonic fetch timestamp. The fetch
+# only ever updates remote-tracking refs; it never touches the working tree,
+# index, or local branches.
+_BRANCH_FETCH_TS: Dict[str, float] = {}
 
 # Per-subsystem snapshot cache: maps (kind, main_root_str) →
 # (monotonic_ts, value, errors_from_that_call). On cache hit, the
@@ -146,6 +162,7 @@ def _reset_issue_cache_for_tests() -> None:
 def _reset_snapshot_cache_for_tests() -> None:
     """Reset the per-subsystem snapshot cache (test-only helper)."""
     _SNAPSHOT_CACHE.clear()
+    _BRANCH_FETCH_TS.clear()
 
 
 def _cached_subsystem(
@@ -1103,50 +1120,208 @@ def _list_worktrees(
     return out
 
 
-def _list_branches(
+def _read_protected_branches(main_root: pathlib.Path) -> set:
+    """Read `cleanup.protected_branches` from .claude/zskills-config.json.
+
+    This is the SAME set `/cleanup-merged` honors (exact-name match). Absent
+    config / block / non-list → empty set. Never raises.
+    """
+    cfg_path = main_root / ".claude" / "zskills-config.json"
+    text = _read_text(cfg_path)
+    if text is None:
+        return set()
+    try:
+        cfg = json.loads(text)
+    except Exception:
+        return set()
+    if not isinstance(cfg, dict):
+        return set()
+    cleanup = cfg.get("cleanup", {})
+    if not isinstance(cleanup, dict):
+        return set()
+    pats = cleanup.get("protected_branches", []) or []
+    if not isinstance(pats, list):
+        return set()
+    return {str(p) for p in pats if isinstance(p, (str,)) and p}
+
+
+def _branch_fetch_ttl(main_root: pathlib.Path) -> float:
+    """Resolve the git-fetch throttle TTL (seconds).
+
+    Default `BRANCH_FETCH_TTL`; overridable via
+    `dashboard.branch_fetch_ttl_seconds` in zskills-config.json. Malformed →
+    default.
+    """
+    cfg_path = main_root / ".claude" / "zskills-config.json"
+    text = _read_text(cfg_path)
+    if text is None:
+        return BRANCH_FETCH_TTL
+    try:
+        cfg = json.loads(text)
+    except Exception:
+        return BRANCH_FETCH_TTL
+    if not isinstance(cfg, dict):
+        return BRANCH_FETCH_TTL
+    dash = cfg.get("dashboard", {})
+    if not isinstance(dash, dict):
+        return BRANCH_FETCH_TTL
+    raw = dash.get("branch_fetch_ttl_seconds")
+    if isinstance(raw, (int, float)) and raw >= 0:
+        return float(raw)
+    return BRANCH_FETCH_TTL
+
+
+def _maybe_fetch_remote(
     main_root: pathlib.Path,
     errors: List[Dict[str, str]],
-) -> List[Dict[str, Any]]:
-    """Per plan: rich branch list with last commit + upstream."""
+    *,
+    _now: Optional[float] = None,
+    _runner: Optional[Any] = None,
+) -> None:
+    """Throttled, NON-FATAL `git fetch --prune`.
+
+    Refreshes remote-tracking refs at most once per `_branch_fetch_ttl`
+    seconds (monotonic clock). A plain `git fetch --prune` only updates
+    `refs/remotes/origin/*`; it never touches the working tree, index, or
+    local branches. On failure (network down, no remote, etc.) append a
+    descriptive `errors[]` entry and CONTINUE so the last-known
+    remote-tracking refs are still rendered. Never raises.
+
+    `_now` / `_runner` are test-only injection seams.
+    """
+    now = _now if _now is not None else time.monotonic()
+    key = str(main_root)
+    ttl = _branch_fetch_ttl(main_root)
+    last = _BRANCH_FETCH_TS.get(key)
+    if last is not None and ttl > 0 and (now - last) < ttl:
+        return
+    runner = _runner or subprocess.run
     try:
-        result = subprocess.run(
-            [
-                "git",
-                "for-each-ref",
-                "--format=%(refname:short)|%(committerdate:iso8601-strict)|%(upstream:short)|%(contents:subject)",
-                "refs/heads/",
-            ],
+        result = runner(
+            ["git", "fetch", "--prune"],
             cwd=str(main_root),
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=60,
         )
-        if result.returncode != 0:
+        # Record the attempt regardless of outcome so a hard-down remote
+        # doesn't get retried on every 2Hz poll.
+        _BRANCH_FETCH_TS[key] = now
+        if getattr(result, "returncode", 1) != 0:
             errors.append({
-                "source": "git for-each-ref",
-                "message": result.stderr.strip() or "non-zero exit",
+                "source": "git fetch",
+                "message": (getattr(result, "stderr", "") or "non-zero exit").strip()
+                or "git fetch --prune failed; rendering last-known remote refs",
             })
-            return []
     except Exception as exc:
+        _BRANCH_FETCH_TS[key] = now
         errors.append({
-            "source": "git for-each-ref",
-            "message": str(exc),
+            "source": "git fetch",
+            "message": f"{exc}; rendering last-known remote refs",
         })
+
+
+def _list_branches(
+    main_root: pathlib.Path,
+    errors: List[Dict[str, str]],
+    *,
+    _now: Optional[float] = None,
+    _fetch_runner: Optional[Any] = None,
+) -> List[Dict[str, Any]]:
+    """Rich branch list: local + remote-only, with last commit + upstream.
+
+    Reads BOTH `refs/heads/` (local) and `refs/remotes/origin/`
+    (remote-tracking), refreshing the latter via a throttled non-fatal
+    `git fetch --prune` first. Local and remote entries are merged and
+    deduped by branch name — the LOCAL entry wins (keeps its
+    worktree/landed-classification data). Each entry carries:
+      - `locality`: "local" | "remote-only" | "both"
+      - `protected`: bool (from cleanup.protected_branches config)
+    """
+    protected = _read_protected_branches(main_root)
+
+    def _for_each_ref(ref_glob: str, source: str) -> Optional[List[List[str]]]:
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "for-each-ref",
+                    "--format=%(refname:short)|%(committerdate:iso8601-strict)|%(upstream:short)|%(contents:subject)",
+                    ref_glob,
+                ],
+                cwd=str(main_root),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                errors.append({
+                    "source": source,
+                    "message": result.stderr.strip() or "non-zero exit",
+                })
+                return None
+        except Exception as exc:
+            errors.append({"source": source, "message": str(exc)})
+            return None
+        rows: List[List[str]] = []
+        for line in result.stdout.split("\n"):
+            if not line.strip():
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            rows.append(parts)
+        return rows
+
+    # Local branches (refs/heads/). A None return means git itself failed.
+    local_rows = _for_each_ref("refs/heads/", "git for-each-ref")
+    if local_rows is None:
         return []
-    out: List[Dict[str, Any]] = []
-    for line in result.stdout.split("\n"):
-        if not line.strip():
-            continue
-        parts = line.split("|")
-        if len(parts) < 4:
-            continue
-        out.append({
-            "name": parts[0],
+
+    # Refresh + read remote-tracking refs (refs/remotes/origin/). The fetch
+    # is throttled + non-fatal; the read is non-fatal too.
+    _maybe_fetch_remote(
+        main_root, errors, _now=_now, _runner=_fetch_runner
+    )
+    remote_rows = _for_each_ref("refs/remotes/origin/", "git for-each-ref (remote)")
+    if remote_rows is None:
+        remote_rows = []
+
+    # Build the merged map, LOCAL first so it wins on collision.
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for parts in local_rows:
+        name = parts[0]
+        by_name[name] = {
+            "name": name,
             "last_commit_at": parts[1],
             "upstream": parts[2] or None,
             "last_commit_subject": "|".join(parts[3:]),
-        })
-    return out
+            "locality": "local",
+            "protected": name in protected,
+        }
+    for parts in remote_rows:
+        raw = parts[0]
+        # `%(refname:short)` yields e.g. "origin/feat/x" or "origin/HEAD".
+        if raw == "origin/HEAD" or not raw.startswith("origin/"):
+            continue
+        name = raw[len("origin/"):]
+        if not name or name == "HEAD":
+            continue
+        existing = by_name.get(name)
+        if existing is not None:
+            # Local entry wins; merging just flips locality to "both".
+            existing["locality"] = "both"
+            continue
+        by_name[name] = {
+            "name": name,
+            "last_commit_at": parts[1],
+            "upstream": parts[2] or None,
+            "last_commit_subject": "|".join(parts[3:]),
+            "locality": "remote-only",
+            "protected": name in protected,
+        }
+
+    return list(by_name.values())
 
 
 # ---------------------------------------------------------------------------

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1290,6 +1290,16 @@ button svg { display: inline-block; vertical-align: middle; }
 .branch-state-pill--local        { color: var(--orange); border-color: var(--orange); }
 .branch-state-pill--remote       { color: var(--text-dim); border-color: var(--border); }
 
+/* Config-protected shield (cleanup.protected_branches). Signals that
+   /cleanup-merged skips this branch — NOT GitHub branch protection. */
+.branch-protected-shield {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 0.82rem;
+  line-height: 1;
+  cursor: help;
+}
+
 /* Issue #717 — Branch section container. Each of Active/Landed/Remote-only
    is a collapsible section within the branches panel. */
 .branch-section {

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -105,7 +105,7 @@ function setCompletedWindow(kind, value) {
 // explicitly expands it. Per-user expand state still persists via
 // localStorage (setCollapsed removes the key on expand, so the default
 // applies only on first paint or after localStorage.clear()).
-const COLLAPSED_BY_DEFAULT = new Set(["discarded", "branch-landed", "branch-remote-only"]);
+const COLLAPSED_BY_DEFAULT = new Set(["discarded", "branch-landed", "branch-local", "branch-remote-only"]);
 
 function isCollapsed(kind, col) {
   try {
@@ -1271,18 +1271,28 @@ function worktreesByBranch(worktrees) {
 }
 
 // Issue #717 — Branch grouping constants.
-var BRANCH_SECTIONS = ["active", "landed", "remote-only"];
+var BRANCH_SECTIONS = ["active", "landed", "local", "remote-only"];
 var BRANCH_SECTION_LABELS = {
   "active": "Active",
   "landed": "Landed",
+  "local": "Local (no worktree)",
   "remote-only": "Remote only",
 };
 
+// Four accurate buckets:
+//   active      — local branch WITH a live worktree, no .landed marker
+//   landed      — local branch WITH a worktree carrying a .landed marker
+//   local       — local branch with NO worktree (was mislabeled "remote-only")
+//   remote-only — branch on origin but NOT checked out locally (was invisible)
+// The collector tags each branch with `locality` ("local"|"remote-only"|
+// "both"); a worktree match implies the branch is local, so we only need
+// `locality === "remote-only"` to separate the genuinely-remote bucket.
 function classifyBranch(b, byBranch) {
   var w = byBranch.get(b.name);
   if (w && w.landed) return "landed";
   if (w) return "active";
-  return "remote-only";
+  if (b.locality === "remote-only") return "remote-only";
+  return "local";
 }
 
 function branchStatePill(b, byBranch) {
@@ -1342,6 +1352,18 @@ function buildBranchCard(b, byBranch) {
     }));
   } else {
     head.appendChild(el("span", { cls: "card-title mono", text: b.name }));
+  }
+  // Config-protected shield (zskills cleanup.protected_branches — NOT
+  // GitHub branch protection). Signals "/cleanup-merged skips this branch".
+  if (b.protected) {
+    head.appendChild(el("span", {
+      cls: "branch-protected-shield",
+      text: "🛡",
+      attrs: {
+        title: "Config-protected (cleanup.protected_branches) — /cleanup-merged skips this branch",
+        "aria-label": "Config-protected branch",
+      },
+    }));
   }
   // State pill
   head.appendChild(branchStatePill(b, byBranch));
@@ -1514,7 +1536,7 @@ function renderBranches(branches, worktrees) {
   empty.hidden = true;
   var byBranch = worktreesByBranch(worktrees);
   // Group branches into sections
-  var groups = { "active": [], "landed": [], "remote-only": [] };
+  var groups = { "active": [], "landed": [], "local": [], "remote-only": [] };
   for (var i = 0; i < branches.length; i++) {
     var section = classifyBranch(branches[i], byBranch);
     groups[section].push(branches[i]);

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -2126,6 +2126,154 @@ fi
 rm -rf "$_RMR_TMPDIR" "$_RMR_OVERRIDE_DIR"
 
 # ---------------------------------------------------------------------------
+# Branches panel: local+remote merge, dedup, protected flag, non-fatal fetch
+# (Branches-panel remote-state honesty fix)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Branches panel: local+remote merge / dedup / protected / non-fatal fetch ==="
+
+# Build a throwaway git repo with: a local-only branch, a branch present
+# both locally and on a (file://) origin, and a branch present only on
+# origin. Then drive _list_branches and assert the merge/dedup/locality and
+# protected-flag behavior. The fetch is real here (file:// remote), so it is
+# also an end-to-end check that `git fetch --prune` is non-destructive.
+BR_TMP=$(mktemp -d)
+(
+  set -e
+  cd "$BR_TMP"
+  # Bare origin.
+  git init -q --bare origin.git
+  # Working clone.
+  git clone -q ./origin.git work
+  cd work
+  git config user.email t@t && git config user.name t
+  git commit -q --allow-empty -m "root"
+  git branch -m main
+  git push -q origin main
+  # both-local-and-remote branch
+  git checkout -q -b feat/both
+  git commit -q --allow-empty -m "both work"
+  git push -q origin feat/both
+  # remote-only branch: push then delete the local ref
+  git checkout -q -b feat/remote-only
+  git commit -q --allow-empty -m "remote-only work"
+  git push -q origin feat/remote-only
+  git checkout -q main
+  git branch -q -D feat/remote-only
+  # local-only branch (never pushed)
+  git checkout -q -b feat/local-only
+  git commit -q --allow-empty -m "local-only work"
+  git checkout -q main
+  # config with a protected branch (same key /cleanup-merged reads)
+  mkdir -p .claude
+  cat > .claude/zskills-config.json <<'JSON'
+{ "cleanup": { "protected_branches": ["feat/both"] } }
+JSON
+) >/dev/null 2>&1
+BR_WORK="$BR_TMP/work"
+
+BR_RES=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import json, pathlib, sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._reset_snapshot_cache_for_tests()
+errs = []
+brs = c._list_branches(pathlib.Path("'"$BR_WORK"'"), errs)
+by = {b["name"]: b for b in brs}
+def loc(n): return by.get(n, {}).get("locality")
+def prot(n): return by.get(n, {}).get("protected")
+# dedup: feat/both appears exactly once
+both_count = sum(1 for b in brs if b["name"] == "feat/both")
+print("both_count=" + str(both_count))
+print("both_locality=" + str(loc("feat/both")))
+print("local_only_locality=" + str(loc("feat/local-only")))
+print("remote_only_locality=" + str(loc("feat/remote-only")))
+print("main_locality=" + str(loc("main")))
+print("both_protected=" + str(prot("feat/both")))
+print("local_only_protected=" + str(prot("feat/local-only")))
+print("remote_only_present=" + str("feat/remote-only" in by))
+print("errors=" + str(len(errs)))
+' 2>&1)
+
+if printf '%s\n' "$BR_RES" | grep -q "both_count=1" \
+    && printf '%s\n' "$BR_RES" | grep -q "both_locality=both" \
+    && printf '%s\n' "$BR_RES" | grep -q "local_only_locality=local" \
+    && printf '%s\n' "$BR_RES" | grep -q "remote_only_locality=remote-only" \
+    && printf '%s\n' "$BR_RES" | grep -q "remote_only_present=True"; then
+  pass "branches: local+remote merge, dedup (local wins), locality classification"
+else
+  fail "branches merge/dedup/locality: got '$BR_RES'"
+fi
+
+if printf '%s\n' "$BR_RES" | grep -q "both_protected=True" \
+    && printf '%s\n' "$BR_RES" | grep -q "local_only_protected=False"; then
+  pass "branches: protected flag derived from cleanup.protected_branches config"
+else
+  fail "branches protected flag: got '$BR_RES'"
+fi
+
+# Non-fatal fetch: inject a fetch runner that ALWAYS fails. The snapshot
+# must still return branches (from the existing refs) AND record a git-fetch
+# error — never crash, never empty.
+BR_FAIL=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import pathlib, sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._reset_snapshot_cache_for_tests()
+
+class FailResult:
+    returncode = 1
+    stdout = ""
+    stderr = "fatal: could not read from remote repository"
+def fail_runner(*a, **kw):
+    return FailResult()
+
+errs = []
+brs = c._list_branches(pathlib.Path("'"$BR_WORK"'"), errs, _fetch_runner=fail_runner)
+print("branch_count=" + str(len(brs)))
+print("fetch_error=" + str(any(e.get("source") == "git fetch" for e in errs)))
+# main must still be present despite the failed fetch
+print("main_present=" + str(any(b["name"] == "main" for b in brs)))
+' 2>&1)
+
+if printf '%s\n' "$BR_FAIL" | grep -q "fetch_error=True" \
+    && printf '%s\n' "$BR_FAIL" | grep -q "main_present=True" \
+    && printf '%s\n' "$BR_FAIL" | grep -qE "branch_count=[1-9]"; then
+  pass "branches: failed git fetch is non-fatal (branches still returned + error recorded)"
+else
+  fail "branches non-fatal fetch: got '$BR_FAIL'"
+fi
+
+# Fetch throttle: a second call within TTL must NOT re-invoke the runner.
+BR_THROTTLE=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import pathlib, sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._reset_snapshot_cache_for_tests()
+calls = {"n": 0}
+class OK:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+def runner(*a, **kw):
+    calls["n"] += 1
+    return OK()
+root = pathlib.Path("'"$BR_WORK"'")
+errs = []
+c._maybe_fetch_remote(root, errs, _now=1000.0, _runner=runner)
+c._maybe_fetch_remote(root, errs, _now=1001.0, _runner=runner)  # within 120s TTL
+c._maybe_fetch_remote(root, errs, _now=2000.0, _runner=runner)  # past TTL
+print("calls=" + str(calls["n"]))
+' 2>&1)
+if printf '%s\n' "$BR_THROTTLE" | grep -q "calls=2"; then
+  pass "branches: git fetch throttled by BRANCH_FETCH_TTL (2 calls across 3 attempts)"
+else
+  fail "branches fetch throttle: got '$BR_THROTTLE'"
+fi
+
+rm -rf "$BR_TMP"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -1956,6 +1956,71 @@ else
   fail "#700: column-head-btn background is NOT var(--surface2)"
 fi
 
+echo ""
+echo "=== Branches panel: 4 accurate buckets + protected shield ==="
+
+# BRANCH_SECTIONS must enumerate the 4 buckets in order.
+if grep -qE 'var BRANCH_SECTIONS = \["active", "landed", "local", "remote-only"\]' "$APP_JS"; then
+  pass "branches: BRANCH_SECTIONS = active/landed/local/remote-only"
+else
+  fail "branches: BRANCH_SECTIONS does not enumerate the 4 buckets"
+fi
+
+# Label map must carry all 4 labels, including the honest renames.
+if grep -qE '"local": "Local \(no worktree\)"' "$APP_JS" \
+   && grep -qE '"remote-only": "Remote only"' "$APP_JS" \
+   && grep -qE '"active": "Active"' "$APP_JS" \
+   && grep -qE '"landed": "Landed"' "$APP_JS"; then
+  pass "branches: BRANCH_SECTION_LABELS carries all 4 bucket labels"
+else
+  fail "branches: BRANCH_SECTION_LABELS missing one of the 4 bucket labels"
+fi
+
+# classifyBranch must resolve all 4 buckets: worktree+landed→landed,
+# worktree→active, locality==remote-only→remote-only, else→local.
+CLASSIFY_BODY=$(awk '
+  /^function classifyBranch\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$CLASSIFY_BODY" | grep -qE 'w && w\.landed.*return "landed"' \
+   && echo "$CLASSIFY_BODY" | grep -qE 'if \(w\) return "active"' \
+   && echo "$CLASSIFY_BODY" | grep -qE 'b\.locality === "remote-only".*return "remote-only"' \
+   && echo "$CLASSIFY_BODY" | grep -qE 'return "local"'; then
+  pass "branches: classifyBranch resolves active/landed/local/remote-only"
+else
+  fail "branches: classifyBranch missing one of the 4 bucket resolutions: got '$CLASSIFY_BODY'"
+fi
+
+# Both large/low-action buckets (local + remote-only) collapse by default.
+if grep -qE 'COLLAPSED_BY_DEFAULT *= *new Set\(\[.*"branch-local".*"branch-remote-only"' "$APP_JS"; then
+  pass "branches: local + remote-only buckets collapsed by default"
+else
+  fail "branches: COLLAPSED_BY_DEFAULT missing branch-local / branch-remote-only"
+fi
+
+# renderBranches groups object must seed all 4 buckets.
+if grep -qE 'var groups = \{ "active": \[\], "landed": \[\], "local": \[\], "remote-only": \[\] \}' "$APP_JS"; then
+  pass "branches: renderBranches groups object seeds all 4 buckets"
+else
+  fail "branches: renderBranches groups object does not seed all 4 buckets"
+fi
+
+# Protected shield: a branch card whose `protected` field is true renders a
+# shield indicator with a descriptive title (config protection, not GitHub).
+BRANCHCARD_BODY=$(awk '
+  /^function buildBranchCard\(/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "$APP_JS")
+if echo "$BRANCHCARD_BODY" | grep -qE 'b\.protected' \
+   && echo "$BRANCHCARD_BODY" | grep -q 'branch-protected-shield' \
+   && echo "$BRANCHCARD_BODY" | grep -qi 'cleanup.protected_branches'; then
+  pass "branches: protected shield rendered on protected cards (config-protection labeled)"
+else
+  fail "branches: buildBranchCard missing protected-shield rendering: got '$BRANCHCARD_BODY'"
+fi
+
 # Stop server cleanly via SIGTERM and verify port is released.
 kill -TERM "$SERVER_PID" 2>/dev/null || true
 for _ in 1 2 3 4 5 6 7 8 9 10; do


### PR DESCRIPTION
## Summary

Makes the dashboard Branches panel honest about local vs. remote state.

- **Collector** (`collect.py` `_list_branches`) now reads `refs/remotes/origin/` in addition to local `refs/heads/`, merges + dedups (local wins), and skips `origin/HEAD`. The ~112 genuinely-remote branches (on origin, never checked out) now surface instead of being invisible.
- Each branch carries a `protected` flag from `cleanup.protected_branches` config (the same list `/cleanup-merged` honors).
- A throttled `git fetch --prune` (120s TTL, `dashboard.branch_fetch_ttl_seconds` knob) keeps remote refs fresh; it's **non-fatal** — a failed fetch records an error and renders last-known refs, never crashes the snapshot, and never touches the working tree.
- **Frontend** (`app.js` `classifyBranch`) now uses 4 accurate buckets — `active` / `landed` / `local` / `remote-only` — fixing the misnomer where local-no-worktree branches were labeled "remote-only." Protected branches render a 🛡 shield (config protection, not a GitHub API call).

Out of scope (separate follow-up): `/cleanup-merged` changes and the Branches "copy names" button.

## Test plan

- [x] Collector tests: local+remote merge, dedup (local wins), protected flag, non-fatal-fetch-on-failure, fetch throttle
- [x] Frontend tests: 4-bucket classification, labels, collapse defaults, shield render
- [x] Full suite: 5936/5936 passed, 0 failed (run twice — implementer + independent verifier)
- [x] Mirror consistent; skill version bumped

🤖 Generated with /do (agent-dispatched)
