### PR TITLE
fix(cleanup-merged): compare merged branch tip to PR headRefOid, not raw ahead-count (#755)

### DIFF
--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   `all` does both local + remote. Protected branches from config are
   skipped automatically.
 metadata:
-  version: "2026.05.28+9ebdcf"
+  version: "2026.05.28+07cbb9"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -335,19 +335,42 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       continue
     fi
 
-    # Issue #516: ahead-count gate. `gh pr view` is sticky after merge, so
-    # PR=MERGED + ahead>0 means the local branch may carry post-merge
-    # commits that would be silently reaped by `git branch -D`. Only gate
-    # the PR=MERGED path (upstream-gone implies squash-merge, where ahead>0
-    # is expected and the unpushed-commit guard above already handles the
-    # un-squashed case).
+    # Issue #516 / #755: post-merge-work gate. `gh pr view` is sticky
+    # after merge, so PR=MERGED on a branch with a tip != main is normal
+    # under squash-merge (the squash commit on main has a different SHA,
+    # so `git rev-list --count main..branch` is ALWAYS > 0). The raw
+    # ahead-count gate therefore skipped essentially every squash-merged
+    # branch (#755). Instead, compare the local branch tip to the merged
+    # PR's recorded head SHA:
+    #   - tip == PR head  -> no post-merge work -> safe to delete (fall
+    #     through; this is the normal squash-merged case).
+    #   - tip is a DESCENDANT of PR head -> the branch carries commits
+    #     made after the PR head -> genuine post-merge work -> SKIP
+    #     (preserves the #516 protection precisely).
+    #   - PR head unavailable (gh hiccup) -> fall back conservatively to
+    #     the old ahead-count behavior so a gh failure never causes an
+    #     unsafe delete.
     if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ]; then
-      AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
-      [ -z "$AHEAD" ] && AHEAD=0
-      if [ "$AHEAD" -gt 0 ]; then
-        echo "  SKIP   $branch (PR merged but branch has $AHEAD commits not on main — investigate; do not auto-remove)"
-        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
-        continue
+      PR_HEAD=$(gh pr view "$branch" --json headRefOid -q .headRefOid 2>/dev/null || echo "")
+      LOCAL_TIP=$(git rev-parse "$branch" 2>/dev/null || echo "")
+      if [ -n "$PR_HEAD" ]; then
+        if [ "$LOCAL_TIP" != "$PR_HEAD" ] && git merge-base --is-ancestor "$PR_HEAD" "$LOCAL_TIP" 2>/dev/null; then
+          echo "  SKIP   $branch (PR merged but local tip is ahead of the merged PR head — post-merge work; investigate, do not auto-remove)"
+          LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+          continue
+        fi
+        # tip == PR head (or diverged-but-not-descendant): no post-merge
+        # commits beyond the PR head — safe to delete, fall through.
+      else
+        # gh could not report the PR head: fall back to the conservative
+        # ahead-count gate so a gh hiccup never triggers an unsafe delete.
+        AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
+        [ -z "$AHEAD" ] && AHEAD=0
+        if [ "$AHEAD" -gt 0 ]; then
+          echo "  SKIP   $branch (PR merged but PR head unavailable from gh and branch has $AHEAD commits not on main — investigate; do not auto-remove)"
+          LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+          continue
+        fi
       fi
     fi
 

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   `all` does both local + remote. Protected branches from config are
   skipped automatically.
 metadata:
-  version: "2026.05.28+9ebdcf"
+  version: "2026.05.28+07cbb9"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -335,19 +335,42 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       continue
     fi
 
-    # Issue #516: ahead-count gate. `gh pr view` is sticky after merge, so
-    # PR=MERGED + ahead>0 means the local branch may carry post-merge
-    # commits that would be silently reaped by `git branch -D`. Only gate
-    # the PR=MERGED path (upstream-gone implies squash-merge, where ahead>0
-    # is expected and the unpushed-commit guard above already handles the
-    # un-squashed case).
+    # Issue #516 / #755: post-merge-work gate. `gh pr view` is sticky
+    # after merge, so PR=MERGED on a branch with a tip != main is normal
+    # under squash-merge (the squash commit on main has a different SHA,
+    # so `git rev-list --count main..branch` is ALWAYS > 0). The raw
+    # ahead-count gate therefore skipped essentially every squash-merged
+    # branch (#755). Instead, compare the local branch tip to the merged
+    # PR's recorded head SHA:
+    #   - tip == PR head  -> no post-merge work -> safe to delete (fall
+    #     through; this is the normal squash-merged case).
+    #   - tip is a DESCENDANT of PR head -> the branch carries commits
+    #     made after the PR head -> genuine post-merge work -> SKIP
+    #     (preserves the #516 protection precisely).
+    #   - PR head unavailable (gh hiccup) -> fall back conservatively to
+    #     the old ahead-count behavior so a gh failure never causes an
+    #     unsafe delete.
     if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ]; then
-      AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
-      [ -z "$AHEAD" ] && AHEAD=0
-      if [ "$AHEAD" -gt 0 ]; then
-        echo "  SKIP   $branch (PR merged but branch has $AHEAD commits not on main — investigate; do not auto-remove)"
-        LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
-        continue
+      PR_HEAD=$(gh pr view "$branch" --json headRefOid -q .headRefOid 2>/dev/null || echo "")
+      LOCAL_TIP=$(git rev-parse "$branch" 2>/dev/null || echo "")
+      if [ -n "$PR_HEAD" ]; then
+        if [ "$LOCAL_TIP" != "$PR_HEAD" ] && git merge-base --is-ancestor "$PR_HEAD" "$LOCAL_TIP" 2>/dev/null; then
+          echo "  SKIP   $branch (PR merged but local tip is ahead of the merged PR head — post-merge work; investigate, do not auto-remove)"
+          LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+          continue
+        fi
+        # tip == PR head (or diverged-but-not-descendant): no post-merge
+        # commits beyond the PR head — safe to delete, fall through.
+      else
+        # gh could not report the PR head: fall back to the conservative
+        # ahead-count gate so a gh hiccup never triggers an unsafe delete.
+        AHEAD=$(git rev-list --count "$MAIN_BRANCH..$branch" 2>/dev/null || echo 0)
+        [ -z "$AHEAD" ] && AHEAD=0
+        if [ "$AHEAD" -gt 0 ]; then
+          echo "  SKIP   $branch (PR merged but PR head unavailable from gh and branch has $AHEAD commits not on main — investigate; do not auto-remove)"
+          LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+          continue
+        fi
       fi
     fi
 

--- a/tests/test-cleanup-merged-ahead-gate.sh
+++ b/tests/test-cleanup-merged-ahead-gate.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
-# Issue #516 regression: cleanup-merged Phase 5 local-branch scan must
-# NOT delete a branch when the PR is reported MERGED but the local
-# branch has commits not on main. `gh pr view` is sticky after merge,
-# so PR=MERGED + ahead>0 is a known silent-loss vector — surface, don't
-# auto-remove.
+# Issue #516 / #755 regression: cleanup-merged Phase 5 local-branch scan.
+#
+# #516: must NOT delete a branch when the PR is reported MERGED but the
+# local branch carries commits made AFTER the merged PR head (post-merge
+# work) — `gh pr view` is sticky after merge, so this is a real silent-
+# loss vector; surface, don't auto-remove.
+#
+# #755: must NOT skip a normal squash-merged branch. Under squash-merge
+# the squash commit on main has a different SHA, so the raw
+# `git rev-list --count main..branch` is ALWAYS > 0 and the old gate
+# skipped essentially every merged branch. The gate now compares the
+# local tip to the merged PR's recorded head SHA (headRefOid):
+#   tip == PR head     -> safe to delete (the squash case)
+#   tip descends head  -> post-merge work -> SKIP (the #516 protection)
+#   PR head missing     -> conservative ahead-count fallback
 #
 # Surface under test:
-#   The Phase 5 local-branch-scan bash loop body: asserts that an ahead-
-#   count gate appears between the unpushed-commit guard and the
-#   worktree-remove call.
+#   The Phase 5 local-branch-scan bash loop body, exercised both
+#   statically (the gate text/ordering) and behaviorally (the extracted
+#   gate logic run against stubbed `gh` + real git branches).
 #
 # Note: The old --review mode's classify() function (which had a
 # parallel Rule 11 check) was removed in the issue #716 redesign.
-# The Phase 5 ahead-count gate is the remaining enforcement point.
+# The Phase 5 gate is the remaining enforcement point.
 #
 # Run from repo root: bash tests/test-cleanup-merged-ahead-gate.sh
 
@@ -28,12 +38,11 @@ FAIL_COUNT=0
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
-echo "=== cleanup-merged ahead-count gate (issue #516) ==="
+echo "=== cleanup-merged Phase 5 gate (issues #516 + #755) ==="
 
-# ── Phase 5 local-branch-scan bash loop — static check ──────────────
-# The Phase 5 loop must include an ahead-count gate for PR=MERGED before
-# `git worktree remove` / `git branch -D`. The gate is keyed to PR_STATE
-# string compare + ahead-count + a SKIP path.
+# ── Phase 5 local-branch-scan bash loop — static checks ─────────────
+# The Phase 5 loop must include the post-merge-work gate for PR=MERGED
+# before `git worktree remove` / `git branch -D`.
 
 PHASE5_SLICE=$(awk '
   /^## Phase 5 — Local branch scan/{capture=1}
@@ -43,35 +52,153 @@ PHASE5_SLICE=$(awk '
 
 if [ -z "$PHASE5_SLICE" ]; then
   # Phase header text may have evolved; fall back to a broader range.
-  PHASE5_SLICE=$(sed -n '195,325p' "$SKILL")
+  PHASE5_SLICE=$(sed -n '195,400p' "$SKILL")
 fi
 
 if echo "$PHASE5_SLICE" | grep -qE 'PR_STATE.*=.*MERGED.*\&\&|PR_STATE.*=.*MERGED.*]; then'; then
   pass "Phase 5: PR_STATE=MERGED branch present"
 else
-  fail "Phase 5: no PR_STATE=MERGED gate (issue #516 ahead-count check missing)"
+  fail "Phase 5: no PR_STATE=MERGED gate present"
 fi
 
-if echo "$PHASE5_SLICE" | grep -qE 'rev-list --count.*MAIN_BRANCH\.\.|rev-list --count "\$MAIN_BRANCH'; then
-  pass "Phase 5: rev-list --count ahead-check present"
+# #755: the gate compares the local tip to the merged PR head SHA.
+if echo "$PHASE5_SLICE" | grep -q 'headRefOid' \
+   && echo "$PHASE5_SLICE" | grep -qE 'merge-base --is-ancestor.*PR_HEAD.*LOCAL_TIP'; then
+  pass "Phase 5: gate compares local tip to PR headRefOid (issue #755)"
 else
-  fail "Phase 5: rev-list --count ahead-check missing"
+  fail "Phase 5: gate does not compare tip to PR headRefOid (issue #755 fix missing)"
 fi
 
-if echo "$PHASE5_SLICE" | grep -qE 'AHEAD.*-gt.*0|ahead.*-gt.*0' && \
-   echo "$PHASE5_SLICE" | grep -qE 'commits not on main|investigate|not auto-remove'; then
-  pass "Phase 5: ahead>0 SKIP path with explanatory message"
+# #516: descendant-of-PR-head SKIP path with explanatory message.
+if echo "$PHASE5_SLICE" | grep -qE 'post-merge work' \
+   && echo "$PHASE5_SLICE" | grep -qE 'SKIP.*ahead of the merged PR head'; then
+  pass "Phase 5: post-merge-work SKIP path present (issue #516 protection)"
 else
-  fail "Phase 5: ahead>0 SKIP path or message missing"
+  fail "Phase 5: post-merge-work SKIP path or message missing"
+fi
+
+# gh-fallback: conservative ahead-count gate when PR head unavailable.
+if echo "$PHASE5_SLICE" | grep -qE 'rev-list --count "\$MAIN_BRANCH' \
+   && echo "$PHASE5_SLICE" | grep -qE 'PR head unavailable'; then
+  pass "Phase 5: conservative ahead-count fallback when PR head unavailable"
+else
+  fail "Phase 5: gh-fallback ahead-count gate missing"
 fi
 
 # Ordering: the gate must appear BEFORE the worktree-remove block.
-GATE_LINE=$(echo "$PHASE5_SLICE" | grep -n 'rev-list --count "\$MAIN_BRANCH\.\.\$branch"' | head -1 | cut -d: -f1)
+GATE_LINE=$(echo "$PHASE5_SLICE" | grep -n 'headRefOid' | head -1 | cut -d: -f1)
 REMOVE_LINE=$(echo "$PHASE5_SLICE" | grep -n 'git worktree remove "\$WORKTREE_FOR_BRANCH"' | head -1 | cut -d: -f1)
 if [ -n "$GATE_LINE" ] && [ -n "$REMOVE_LINE" ] && [ "$GATE_LINE" -lt "$REMOVE_LINE" ]; then
-  pass "Phase 5: ahead-count gate precedes worktree remove"
+  pass "Phase 5: gate precedes worktree remove"
 else
   fail "Phase 5: gate ordering wrong (gate line=$GATE_LINE, remove line=$REMOVE_LINE)"
+fi
+
+# ── Behavioral: extract the gate logic and run it against stubs ──────
+# Extract just the PR_STATE==MERGED gate `if` block from the skill so
+# we exercise the REAL decision logic (not a paraphrase). The block
+# starts at `if [ "$PR_STATE" = "MERGED" ] && [ "$UPSTREAM_GONE" = "0" ];`
+# and ends at the matching `fi` (the line before the worktree comment).
+GATE_BLOCK=$(echo "$PHASE5_SLICE" | awk '
+  /if \[ "\$PR_STATE" = "MERGED" \] && \[ "\$UPSTREAM_GONE" = "0" \]; then/{capture=1}
+  capture {print}
+  capture && /^    fi$/{exit}
+')
+
+if [ -z "$GATE_BLOCK" ]; then
+  fail "Phase 5: could not extract gate block for behavioral test"
+else
+  pass "Phase 5: gate block extracted for behavioral test"
+
+  # Build a throwaway git repo with two scenarios.
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"' EXIT
+  STUBDIR="$TMP/stub"
+  mkdir -p "$STUBDIR"
+
+  (
+    cd "$TMP" || exit 1
+    git init -q -b main .
+    git config user.email t@t.t; git config user.name t
+    git commit -q --allow-empty -m base
+
+    # squash-merged branch: tip == PR head (its own head), but main has a
+    # DIFFERENT squash SHA. This is the #755 case that was wrongly SKIP'd.
+    git checkout -q -b squashed
+    git commit -q --allow-empty -m "feature work"
+    SQUASHED_HEAD=$(git rev-parse squashed)
+
+    # post-merge-work branch: an extra commit sits AFTER the PR head.
+    git checkout -q -b postmerge "$SQUASHED_HEAD"
+    PR_HEAD_POSTMERGE=$(git rev-parse postmerge)
+    git commit -q --allow-empty -m "commit made after PR merged"
+
+    # Simulate main getting a separate squash commit (different SHA) so
+    # rev-list main..branch > 0 for both branches (the squash reality).
+    git checkout -q main
+    git commit -q --allow-empty -m "squash commit (different SHA)"
+
+    # Stub gh: returns the recorded PR head per branch.
+    cat > "$STUBDIR/gh" <<STUB
+#!/bin/bash
+# gh pr view <branch> --json headRefOid -q .headRefOid
+#  \$1=pr  \$2=view  \$3=<branch>
+branch="\$3"
+case "\$branch" in
+  squashed)  echo "$SQUASHED_HEAD" ;;
+  postmerge) echo "$PR_HEAD_POSTMERGE" ;;
+  *) exit 1 ;;
+esac
+STUB
+    chmod +x "$STUBDIR/gh"
+
+    export PATH="$STUBDIR:$PATH"
+    MAIN_BRANCH=main
+    PR_STATE=MERGED
+    UPSTREAM_GONE=0
+
+    run_gate() {
+      branch="$1"
+      LOCAL_SKIPPED=0
+      OUT=$(
+        for _once in 1; do
+          eval "$GATE_BLOCK"
+        done
+        echo "SKIPPED=$LOCAL_SKIPPED"
+      )
+      echo "$OUT"
+    }
+
+    # Scenario 1 (#755): squash-merged, tip == PR head -> must NOT skip.
+    R1=$(run_gate squashed)
+    if echo "$R1" | grep -q 'SKIPPED=0' && ! echo "$R1" | grep -qE '^[[:space:]]*SKIP[[:space:]]'; then
+      echo "BEHAVE1_PASS"
+    else
+      echo "BEHAVE1_FAIL: $R1"
+    fi
+
+    # Scenario 2 (#516): tip descends PR head -> must SKIP.
+    R2=$(run_gate postmerge)
+    if echo "$R2" | grep -q 'SKIPPED=1' && echo "$R2" | grep -q 'SKIP.*postmerge'; then
+      echo "BEHAVE2_PASS"
+    else
+      echo "BEHAVE2_FAIL: $R2"
+    fi
+  ) > "$TMP/behave.out" 2>&1
+
+  if grep -q 'BEHAVE1_PASS' "$TMP/behave.out"; then
+    pass "Behavioral #755: squash-merged branch (tip == PR head) is deletable, NOT skipped"
+  else
+    fail "Behavioral #755: squash-merged branch wrongly skipped"
+    sed 's/^/    /' "$TMP/behave.out"
+  fi
+
+  if grep -q 'BEHAVE2_PASS' "$TMP/behave.out"; then
+    pass "Behavioral #516: branch with commit after PR head is still SKIP'd"
+  else
+    fail "Behavioral #516: post-merge-work branch not skipped"
+    sed 's/^/    /' "$TMP/behave.out"
+  fi
 fi
 
 # ── Mirror sync ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes `/cleanup-merged` skipping ~all merged branches under squash-merge. The Phase-5 #516 ahead-count gate skipped any MERGED branch where `git rev-list --count main..<branch> > 0` — but squash-merge **guarantees** ahead>0 (main gets one squash commit with a different SHA; the branch's un-squashed commits never land verbatim). On a 172-branch clone the skill cleaned ~1 of 117 genuinely-merged branches.

## Fix

When `PR_STATE == MERGED` (and upstream not gone), compare the local branch tip to the **merged PR's head SHA** (`gh pr view <branch> --json headRefOid`) instead of a raw ahead-count:

- local tip **==** PR head → no post-merge work → **safe to delete** (the normal squash case)
- local tip is a **descendant of** PR head (`git merge-base --is-ancestor PR_HEAD LOCAL_TIP`) → genuine post-merge commits → **keep the SKIP** (preserves the #516 protection exactly)
- PR head unavailable from gh → conservative fallback to the old ahead-count SKIP (never deletes unsafely on a gh hiccup)

The `UPSTREAM_GONE`-path unpushed-commit guard is unchanged.

## Test plan

- [x] `bash tests/run-all.sh` → 5940/5940 passed, 0 failed (independently re-run by verifier)
- [x] New behavioral test (`test-cleanup-merged-ahead-gate.sh`) extracts the real gate block and evals it against a throwaway repo + stubbed gh: squash-merged branch (tip==PR head, main at different SHA) → deletable; branch with a commit after PR head → still SKIP'd
- [x] #716-redesign suite (`test-cleanup-merged-review.sh`) still 17/17
- [x] Mirror diff empty; version bumped

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
