### PR TITLE
feat(plugin): Phase 1 — plugin scaffold (zs + zsbd manifests, marketplace, hooks.json)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://anthropic.com/schemas/claude-plugin-marketplace.json",
+  "name": "zskills",
+  "owner": { "name": "Rich Conlan", "url": "https://github.com/zeveck" },
+  "description": "Z Skills — agent-discipline skill framework",
+  "version": "1",
+  "plugins": [
+    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "prod/main" } },
+    { "name": "zsbd", "source": "./block-diagram" }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "zs",
+  "displayName": "Z Skills",
+  "version": "2026.05.0",
+  "description": "Agent-discipline skill framework: plans, fix-issues, draft-plan, run-plan, land-pr, and more.",
+  "author": { "name": "Rich Conlan", "url": "https://github.com/zeveck/zskills" },
+  "homepage": "https://github.com/zeveck/zskills",
+  "repository": "https://github.com/zeveck/zskills",
+  "license": "MIT",
+  "keywords": ["zskills", "agent", "claude-code", "skills", "plans"],
+  "skills": ["./skills/", "./block-diagram/"],
+  "hooks": "./hooks/hooks.json"
+}

--- a/.claude/hooks/block-agents.sh
+++ b/.claude/hooks/block-agents.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # Block Agent (subagent) dispatches that use a model below agents.min_model.
 # Registered under the Agent PreToolUse matcher in .claude/settings.json.
 #
@@ -13,6 +14,13 @@
 # dispatch site in run-plan, fix-issues, do) cover the residual case where
 # neither tool input nor agent definition specifies a model (subagent inherits
 # from parent session, which is typically Opus or Sonnet).
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat)
 

--- a/.claude/hooks/block-bad-cron.sh
+++ b/.claude/hooks/block-bad-cron.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# zskills-hook-version: 2026.05.0
 # block-bad-cron.sh — PreToolUse hook for the CronCreate tool.
 #
 # Closes a class of "the cron never fired" bugs caused by structurally-wrong
@@ -51,6 +52,13 @@
 # `/clear` (or restart Claude Code) and re-test with an intentionally
 # bad cron, e.g., a one-shot whose next fire is more than 7 days out.
 # The deny envelope's STOP message confirms the hook is wired.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 

--- a/.claude/hooks/block-bypassed-land-pr.sh
+++ b/.claude/hooks/block-bypassed-land-pr.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-bypassed-land-pr.sh — PreToolUse Bash hook.
 #
 # Unconditionally denies direct `gh pr create` and `gh pr merge --auto`
@@ -48,6 +49,13 @@
 # `bash scripts/pr-push-and-create.sh ...` invocation, not the inner
 # `gh pr create` inside that script — so the hook NEVER fires on
 # /land-pr's own gh invocation. No allowlist needed.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 
@@ -353,10 +361,14 @@ is_gh_pr_subcommand_in_wrappers "$COMMAND" "create" && deny=1
 is_gh_pr_subcommand_in_wrappers "$COMMAND" "merge" '^--auto$' && deny=1
 [ "${deny:-0}" -eq 0 ] && exit 0
 
-# Resolve message-enrichment script. Same `${X:-$PWD}` fallback pattern as
-# block-stale-skill-version.sh (guards against `set -u` + unset
-# CLAUDE_PROJECT_DIR).
-SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/land-pr-bypass-message.sh"
+# Resolve message-enrichment script. Lane-portable (W1.4 pattern 1): the
+# plugin lane resolves it under ${CLAUDE_PLUGIN_ROOT}/scripts/; the
+# /update-zskills lane resolves it under ${CLAUDE_PROJECT_DIR}/scripts/
+# (repo-root scripts/ — this is a consumer-customizable utility that stays
+# at scripts/, NOT under .claude/skills/update-zskills). The `${X:-$PWD}`
+# fallback (guards against `set -u` + unset CLAUDE_PROJECT_DIR) is preserved
+# on the legacy arm.
+SCRIPT="${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/land-pr-bypass-message.sh"
 
 # Static fallback STOP message — ASCII-only, 3 lines. Used when the
 # message-enrichment script is missing/broken (see sentinel check

--- a/.claude/hooks/block-fix-issue-unclaimed.sh
+++ b/.claude/hooks/block-fix-issue-unclaimed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-fix-issue-unclaimed.sh — PreToolUse hook on Bash.
 #
 # Backstops the /fix-issues inline-acquire prose discipline (plans/fix-issues-claims.md
@@ -36,6 +37,13 @@
 # No `2>/dev/null` on fallible ops — failures should be visible. The hook
 # is fail-open on its own infrastructure errors (defensive: never false-
 # deny on git-not-installed, Python-missing, etc.) but emits stderr.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat) || exit 0
 [ -z "$INPUT" ] && exit 0
@@ -207,12 +215,21 @@ if [ -d "$CLAIM_DIR" ]; then
 fi
 
 # ── Deny envelope (plan DA4.4 — locked text) ─────────────────────────────
+# Lane-portable recovery-command path (W1.4 pattern 2 / F-DA1-7): on the
+# plugin lane cite ${CLAUDE_PLUGIN_ROOT}/skills/fix-issues/scripts/...; on
+# the /update-zskills lane cite ${MAIN_ROOT}/.claude/skills/fix-issues/...
+# (the mirror). Resolve to whichever exists.
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/fix-issues/scripts/claim-issue.sh" ]; then
+  CLAIM_ISSUE_PATH="${CLAUDE_PLUGIN_ROOT}/skills/fix-issues/scripts/claim-issue.sh"
+else
+  CLAIM_ISSUE_PATH="${MAIN_ROOT}/.claude/skills/fix-issues/scripts/claim-issue.sh"
+fi
 STOP_MSG=$(cat <<EOF
 STOP: create-worktree.sh for fix-issue-${NNN} denied — no claim found at ${MAIN_ROOT}/.zskills/claims/issue-${NNN}/.
 
-The per-issue dispatch fence at SKILL.md:2161-2186 (cherry-pick/direct) or SKILL.md:2219-2243 (PR mode) MUST call:
+The per-issue dispatch fence in fix-issues modes/sprint.md (the "Worktree setup (cherry-pick and direct modes)" section, and the "PR mode (Phase 3)" section) MUST call:
 
-  bash ${MAIN_ROOT}/.claude/skills/fix-issues/scripts/claim-issue.sh acquire ${NNN} --pipeline-id "\$ZSKILLS_PIPELINE_ID" --sprint-id "\$SPRINT_ID"
+  bash ${CLAIM_ISSUE_PATH} acquire ${NNN} --pipeline-id "\$ZSKILLS_PIPELINE_ID" --sprint-id "\$SPRINT_ID"
 
 immediately above the create-worktree.sh invocation. If this hook fired during a sprint, the SKILL.md prose has drifted — STOP, do not retry, file an issue.
 

--- a/.claude/hooks/block-main-edits.sh
+++ b/.claude/hooks/block-main-edits.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-main-edits.sh — PreToolUse hook on Edit / Write.
 #
 # Honors execution.main_protected from .claude/zskills-config.json. When
@@ -27,6 +28,13 @@
 #                          "permissionDecisionReason":"<STOP message>"}}
 #
 # Test surface: tests/test-block-main-edits.sh
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat 2>/dev/null) || exit 0
 [ -z "$INPUT" ] && exit 0

--- a/.claude/hooks/block-run-plan-unclaimed.sh
+++ b/.claude/hooks/block-run-plan-unclaimed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-run-plan-unclaimed.sh — PreToolUse hook on Bash.
 #
 # Backstops the /run-plan claim-acquire prose discipline (Phase 2 of
@@ -43,6 +44,13 @@
 # NOTE: Per plan R2.5, the [0-9]+ validator pattern from the issue-side
 # hook is NOT applicable — plan slugs are kebab-case, not integers. The
 # slug validation here is a kebab-case regex match, not numeric.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat) || exit 0
 [ -z "$INPUT" ] && exit 0
@@ -209,7 +217,18 @@ fi
 # Source zskills-paths.sh to honour custom ZSKILLS_PLANS_DIR. Sourcing in
 # a subshell so the hook's environment stays clean.
 PLANS_DIR_RESOLVED=$(
-  ZSK_PATHS="${MAIN_ROOT}/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  # Lane-portable resolution (W1.4 pattern 2): plugin lane resolves
+  # zskills-paths.sh under ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/...;
+  # /update-zskills lane resolves it under the mirror
+  # (.claude/skills/update-zskills/...), then the zskills source-tree
+  # (skills/update-zskills/...).
+  ZSK_PATHS=""
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-paths.sh" ]; then
+    ZSK_PATHS="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-paths.sh"
+  fi
+  if [ -z "$ZSK_PATHS" ]; then
+    ZSK_PATHS="${MAIN_ROOT}/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  fi
   if [ ! -f "$ZSK_PATHS" ]; then
     ZSK_PATHS="${MAIN_ROOT}/skills/update-zskills/scripts/zskills-paths.sh"
   fi
@@ -236,12 +255,23 @@ if [ -d "$CLAIM_DIR" ]; then
 fi
 
 # ── Deny envelope ────────────────────────────────────────────────────────
+# Lane-portable recovery-command path (W1.4 pattern 2 / F-DA1-7): on the
+# plugin lane the recovery command must cite
+# ${CLAUDE_PLUGIN_ROOT}/skills/run-plan/scripts/claim-plan.sh; on the
+# /update-zskills lane it cites ${MAIN_ROOT}/.claude/skills/run-plan/...
+# (the mirror). Resolve to whichever exists so the agent is told a command
+# that actually resolves on its install lane.
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/run-plan/scripts/claim-plan.sh" ]; then
+  CLAIM_PLAN_PATH="${CLAUDE_PLUGIN_ROOT}/skills/run-plan/scripts/claim-plan.sh"
+else
+  CLAIM_PLAN_PATH="${MAIN_ROOT}/.claude/skills/run-plan/scripts/claim-plan.sh"
+fi
 STOP_MSG=$(cat <<EOF
 STOP: create-worktree.sh for /run-plan branch '${BRANCH}' (plan slug '${SLUG}') denied — no claim found at ${MAIN_ROOT}/.zskills/claims/plan-${SLUG}/.
 
 The /run-plan dispatch fence MUST call:
 
-  bash ${MAIN_ROOT}/.claude/skills/run-plan/scripts/claim-plan.sh acquire ${SLUG} --pipeline-id "run-plan.${SLUG}"
+  bash ${CLAIM_PLAN_PATH} acquire ${SLUG} --pipeline-id "run-plan.${SLUG}"
 
 immediately above the create-worktree.sh invocation. If this hook fired during a /run-plan invocation, the SKILL.md prose has drifted — STOP, do not retry, file an issue.
 

--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-stale-skill-version.sh — PreToolUse Bash hook.
 #
 # Denies `git commit` when a staged skill's content hash no longer matches
@@ -46,6 +47,13 @@
 # Pure bash at runtime (D4 in the reference doc) — no external JSON
 # parsers, no scripting-language interpreters. The unit-test harness MAY
 # use a separate JSON validator for assertions; the hook itself does not.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 
@@ -437,12 +445,17 @@ is_git_subcommand_in_wrappers() {
 }
 is_git_subcommand_in_wrappers "$COMMAND" commit || exit 0
 
-# Guard against `set -u` + unset `$CLAUDE_PROJECT_DIR` (rare but documented
-# harness edge case). `${X:-$PWD}` falls back to cwd; if the script is
-# absent under the fallback path, `[ -x ]` trips the fail-open below. Per
-# Round 2 N5: without the guard, `set -u` would crash the hook → nonzero
-# exit + empty stdout → silent failure mode worse than fail-open.
-SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/skill-version-stage-check.sh"
+# Lane-portable resolution (W1.4 pattern 1): the plugin lane resolves the
+# stage-check script under ${CLAUDE_PLUGIN_ROOT}/scripts/; the
+# /update-zskills lane resolves it under ${CLAUDE_PROJECT_DIR}/scripts/
+# (repo-root scripts/ — consumer-customizable utility that stays at
+# scripts/, NOT under .claude/skills/update-zskills). Guard against `set -u`
+# + unset `$CLAUDE_PROJECT_DIR` (rare but documented harness edge case):
+# `${X:-$PWD}` falls back to cwd on the legacy arm; if the script is absent
+# under the resolved path, `[ -x ]` trips the fail-open below. Per Round 2
+# N5: without the guard, `set -u` would crash the hook → nonzero exit +
+# empty stdout → silent failure mode worse than fail-open.
+SCRIPT="${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/skill-version-stage-check.sh"
 [ -x "$SCRIPT" ] || exit 0  # fail-open: script absent (consumer pre-/update-zskills)
 
 # Resolve effective worktree root for the stage-check subshell.

--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # Block unsafe commands that agents should never use.
 # GENERIC safety layer — works in any project with zero configuration.
 # No external dependencies — bash only.
@@ -20,6 +21,13 @@
 #   direct                 -> BLOCK_MAIN_PUSH=0
 # Default here is 1 so zskills-shipped configs fail closed (safer).
 # Installer flips this single line via Edit; do not inline-expand further below.
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
+
 BLOCK_MAIN_PUSH=1
 
 INPUT=$(cat)

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -8,6 +9,13 @@
 #
 # Register BOTH this file and block-unsafe-generic.sh in .claude/settings.json
 # on the PreToolUse event, Bash matcher. The generic layer runs first.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat)
 

--- a/.claude/hooks/inject-bash-timeout.sh
+++ b/.claude/hooks/inject-bash-timeout.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# zskills-hook-version: 2026.05.0
 # inject-bash-timeout.sh — PreToolUse hook for Bash (verifier subagent).
 #
 # Layer 0 of the VERIFIER_AGENT_FIX D'' architecture. Ensures `timeout` is at

--- a/.claude/hooks/verify-response-validate.sh
+++ b/.claude/hooks/verify-response-validate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# zskills-hook-version: 2026.05.0
 # verify-response-validate.sh — validates a verifier subagent's response
 # for signs of skipped work, hung-and-recovered, or other failure patterns.
 #

--- a/.claude/hooks/warn-config-drift.sh
+++ b/.claude/hooks/warn-config-drift.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # warn-config-drift.sh — PostToolUse hook, non-blocking warn.
 #
 # Two responsibilities:
@@ -20,6 +21,13 @@
 #
 # Non-blocking by contract: always exits 0, even on malformed input.
 # A PostToolUse warn hook must never halt the user.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,13 @@ DOC_PARTY_COMPARISON.md
 # Track only the cli.config.json that .devcontainer/setup.sh writes.
 .playwright/*
 !.playwright/cli.config.json
+
+# Plugin-distribution manifests (W1.7). The `.claude-plugin/` tree
+# (plugin.json + marketplace.json) and block-diagram/.claude-plugin/ MUST
+# be committable — they are the plugin lane's source-of-truth. They are NOT
+# ignored by any rule above; this allow-list entry makes that intent
+# explicit and guards against a future `.claude-plugin/` ignore rule.
+!.claude-plugin/
+!.claude-plugin/**
+!block-diagram/.claude-plugin/
+!block-diagram/.claude-plugin/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,12 @@ Skill distribution repo and presentation site for Z Skills.
 - `hooks/` — source hook scripts
 - `scripts/` — consumer-customizable stubs (stop-dev.sh, test-all.sh) and release-only repo tooling (build-prod.sh, mirror-skill.sh); skill machinery moved to `.claude/skills/<owner>/scripts/` (port.sh, clear-tracking.sh, statusline.sh in `update-zskills`; plan-drift-correct.sh in `run-plan`; full mapping in `skills/update-zskills/references/script-ownership.md`)
 - `CLAUDE_TEMPLATE.md` — template for CLAUDE.md generation in target projects
+- `.claude-plugin/` — plugin lane manifests: `plugin.json` (the `zs` plugin) + `marketplace.json` (lists `zs` and `zsbd`); `block-diagram/.claude-plugin/plugin.json` is the `zsbd` addon manifest
+- `hooks/hooks.json` — plugin-lane hook registrations (mirrors `.claude/settings.json` but points at `${CLAUDE_PLUGIN_ROOT}`); `hooks/_lib/plugin-hook-skip-if-mirrored.sh` is the D16(a) conditional-skip shim that prevents double-fire when both lanes are installed
 - `PRESENTATION.html` — main site (index.html redirects here)
 - `README.md`, `CHANGELOG.md` — documentation
+
+**Two install lanes — both first-class, neither retired.** zskills is distributed via (1) the **plugin lane** (`claude --plugin-dir .` loads `.claude-plugin/plugin.json` + `hooks/hooks.json`, resolving paths under `${CLAUDE_PLUGIN_ROOT}`) and (2) the legacy **`/update-zskills` lane** (mirrors `skills/`→`.claude/skills/`, `hooks/*.sh`→`.claude/hooks/`, registers hooks in `.claude/settings.json`, renders `CLAUDE_TEMPLATE.md`→`.claude/rules/zskills/managed.md`). We dogfood BOTH from this repo: plugin-lane via `claude --plugin-dir .` (iterate `edit → /reload-plugins → test`), legacy-lane via `/update-zskills install` (iterate `edit → /update-zskills --rerender → test`). See `RELEASING.md` "Dogfooding lanes" and `docs/plans/PLUGIN_DISTRIBUTION.md`. Shipped hook scripts carry a line-2 `# zskills-hook-version:` stamp the shim uses for version-skew defer; bump it when a hook's distribution version changes (Phase 1 introduced the convention; `tests/test-skill-conformance.sh` gates its presence).
 
 <!-- ## Dev Server -->
 <!-- No dev server — this is a static site / skill distribution repo. -->

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,37 @@ See CHANGELOG entry for `feat(paths)` and
 `.claude/skills/update-zskills/references/path-config-upgrade.md` for
 the long-tail customization upgrade prompt.
 
+## Dogfooding lanes (plugin + legacy)
+
+zskills is distributed via TWO permanent, first-class install lanes, and we
+dogfood BOTH from this repo:
+
+- **Plugin lane** — load the in-repo plugin in-place with
+  `claude --plugin-dir .`. Claude Code reads `.claude-plugin/plugin.json`
+  (the `zs` plugin) and `block-diagram/.claude-plugin/plugin.json` (the
+  `zsbd` addon), registers the hooks in `hooks/hooks.json`, and resolves
+  skill paths under `${CLAUDE_PLUGIN_ROOT}`. Iterate with
+  `edit → /reload-plugins → test`. No rendering/mirroring step is needed —
+  the plugin runs from source. Validate manifests with
+  `claude plugin validate . --strict` (marketplace) and
+  `claude plugin validate ./block-diagram --strict` (zsbd plugin).
+- **Legacy `/update-zskills` lane** — the bespoke installer that mirrors
+  `skills/` → `.claude/skills/`, copies `hooks/*.sh` → `.claude/hooks/`,
+  registers hooks in `.claude/settings.json`, and renders
+  `CLAUDE_TEMPLATE.md` → `.claude/rules/zskills/managed.md`. Dogfood it by
+  running `/update-zskills install` against the source tree; iterate with
+  `edit → /update-zskills --rerender → test`.
+
+Both lanes are exercised by CI (the plugin-lane CI job lands in Phase 5).
+Neither lane is retired; both are supported indefinitely. See
+`docs/plans/PLUGIN_DISTRIBUTION.md` for the full dual-path design.
+
+The D16(a) conditional-skip shim
+(`hooks/_lib/plugin-hook-skip-if-mirrored.sh`) makes it safe to have BOTH
+lanes installed at once in a consumer repo: each plugin-registered hook
+defers to a settings.json-registered copy of the same hook (basename match,
+with a `# zskills-hook-version:` skew guard) so hooks never double-fire.
+
 ## TL;DR
 
 1. Click **🚀 Ship to Prod** in the README (or go to Actions → "🚀 Ship to Prod" → Run workflow).

--- a/block-diagram/.claude-plugin/plugin.json
+++ b/block-diagram/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "zsbd",
+  "displayName": "Z Skills — Block Diagram Addons",
+  "version": "2026.05.0",
+  "description": "Block-diagram-editor skill addons (add-block, add-example, model-design, review-feedback).",
+  "author": { "name": "Rich Conlan", "url": "https://github.com/zeveck/zskills" },
+  "homepage": "https://github.com/zeveck/zskills",
+  "repository": "https://github.com/zeveck/zskills",
+  "license": "MIT",
+  "keywords": ["zskills", "block-diagram", "addons"],
+  "skills": ["./"],
+  "dependencies": [ { "name": "zs" } ]
+}

--- a/hooks/_lib/plugin-hook-skip-if-mirrored.sh
+++ b/hooks/_lib/plugin-hook-skip-if-mirrored.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# plugin-hook-skip-if-mirrored.sh — D16(a) conditional-skip shim.
+#
+# Sourced as the FIRST executable line of every plugin-registered hook
+# script (those listed in hooks/hooks.json). Prevents hook double-fire when
+# a consumer has BOTH install lanes active at once: the plugin lane
+# (hooks.json registers ${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh) AND the
+# /update-zskills lane (settings.json registers
+# $CLAUDE_PROJECT_DIR/.claude/hooks/<name>.sh). Plugin hooks.json and the
+# consumer's settings.json compose ADDITIVELY at the harness level
+# (research §13), so without this shim both copies of the same hook fire on
+# every matching tool call.
+#
+# Mechanism (D16(a), 7 steps — see docs/plans/PLUGIN_DISTRIBUTION.md):
+#   1. Plugin hook sources this shim as its first executable line.
+#   2. Shim computes MY_BASENAME from ${BASH_SOURCE[0]} — when sourced,
+#      [0] is the SOURCING hook's path (empirically confirmed under
+#      claude 2.1.149; NOT the shim's own path).
+#   3. Shim reads $CLAUDE_PROJECT_DIR/.claude/settings.json via Python and
+#      iterates hooks.<event>[].hooks[] entries.
+#   4. For each entry's command, extracts the last whitespace-separated
+#      token (the script path), strips quoting, basename-matches against
+#      MY_BASENAME. settings.json stores $CLAUDE_PROJECT_DIR / ${...} as a
+#      LITERAL string; basename works on the literal, but any disk
+#      existence-check / read substitutes the env var first.
+#   5. On basename match: version-skew compare via the line-2
+#      `# zskills-hook-version:` stamp on both copies. Plugin STRICTLY
+#      NEWER → one-time-per-session WARN to stderr + defer (exit 0).
+#   6. Plugin EQUAL/OLDER, or either stamp absent → silent defer (exit 0).
+#   7. No basename match → return (do not exit); calling hook continues.
+#
+# KNOWN COST: two legitimately-distinct hooks sharing a basename across
+# lanes would be conflated. zskills owns all its hook basenames (the source
+# tree is the single point of basename assignment), so this is safe in
+# practice. Env-sentinel races are explicitly out-of-scope; the
+# basename + version-stamp check is deterministic and stateless across
+# invocations.
+#
+# This shim must be sourced (not exec'd). When sourced and it decides to
+# defer, it calls `exit 0` which terminates the SOURCING hook — the
+# intended behaviour. When it decides "continue", it `return`s so the
+# sourcing hook resumes.
+
+# Resolve Python (per `## Python is required`).
+_PHSIM_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+
+# If we cannot resolve Python or settings.json, fail-open: the calling hook
+# continues normally (no skip). A missing settings.json means the consumer
+# is plugin-only (no /update-zskills lane) → no double-fire risk.
+_phsim_main() {
+  local my_path my_basename settings consumer_script plugin_ver consumer_ver marker
+
+  # Step 2: basename of the sourcing hook.
+  my_path="${BASH_SOURCE[0]}"
+  my_basename="$(basename "$my_path")"
+
+  # Need CLAUDE_PROJECT_DIR to find the consumer settings.json.
+  [ -n "${CLAUDE_PROJECT_DIR:-}" ] || return 0
+  settings="${CLAUDE_PROJECT_DIR}/.claude/settings.json"
+  [ -f "$settings" ] || return 0
+  [ -n "$_PHSIM_PYTHON" ] || return 0
+
+  # Steps 3-4: find a settings.json hook entry whose command path-token
+  # has the same basename as MY_BASENAME. Emit the RAW (unsubstituted)
+  # path-token so the shell can substitute env vars before any disk read.
+  consumer_script="$(
+    MY_BASENAME="$my_basename" "$_PHSIM_PYTHON" - "$settings" <<'PY'
+import json, os, sys
+settings_path = sys.argv[1]
+target = os.environ.get("MY_BASENAME", "")
+try:
+    with open(settings_path) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+hooks = data.get("hooks", {})
+if not isinstance(hooks, dict):
+    sys.exit(0)
+for event in hooks.values():
+    if not isinstance(event, list):
+        continue
+    for matcher in event:
+        if not isinstance(matcher, dict):
+            continue
+        for h in matcher.get("hooks", []):
+            if not isinstance(h, dict):
+                continue
+            cmd = h.get("command", "")
+            if not isinstance(cmd, str) or not cmd.strip():
+                continue
+            token = cmd.split()[-1].strip('"').strip("'")
+            if os.path.basename(token) == target:
+                print(token)
+                sys.exit(0)
+sys.exit(0)
+PY
+  )"
+
+  # Step 7: no basename match → continue (the calling hook runs).
+  [ -n "$consumer_script" ] || return 0
+
+  # Step 4 (substitution): settings.json stores $CLAUDE_PROJECT_DIR /
+  # ${CLAUDE_PROJECT_DIR} as a LITERAL. Substitute both forms before any
+  # disk read.
+  consumer_script="${consumer_script//\$\{CLAUDE_PROJECT_DIR\}/$CLAUDE_PROJECT_DIR}"
+  consumer_script="${consumer_script//\$CLAUDE_PROJECT_DIR/$CLAUDE_PROJECT_DIR}"
+
+  # Steps 5-6: version-skew compare. Read line-2-ish stamp from both copies.
+  plugin_ver="$(head -n 5 "$my_path" 2>/dev/null | grep -m1 'zskills-hook-version:' | sed -E 's/.*zskills-hook-version:[[:space:]]*//')"
+  consumer_ver=""
+  if [ -f "$consumer_script" ]; then
+    consumer_ver="$(head -n 5 "$consumer_script" 2>/dev/null | grep -m1 'zskills-hook-version:' | sed -E 's/.*zskills-hook-version:[[:space:]]*//')"
+  fi
+
+  # Step 6: either stamp absent → silent defer (settings.json wins; no
+  # version regression possible).
+  if [ -z "$plugin_ver" ] || [ -z "$consumer_ver" ]; then
+    exit 0
+  fi
+
+  # Step 5: plugin STRICTLY NEWER than consumer copy → one-time WARN + defer.
+  # Comparison is string-sort safe for the YYYY.MM.N scheme (zero-padded
+  # year/month; integer N). Use sort -V for robustness.
+  if [ "$plugin_ver" != "$consumer_ver" ]; then
+    local newer
+    newer="$(printf '%s\n%s\n' "$plugin_ver" "$consumer_ver" | sort -V | tail -n1)"
+    if [ "$newer" = "$plugin_ver" ]; then
+      # Plugin is newer. Emit once-per-session-per-hook WARN, then defer.
+      marker="${CLAUDE_PROJECT_DIR}/.zskills/hook-skew-warned-${my_basename}"
+      if [ ! -f "$marker" ]; then
+        mkdir -p "${CLAUDE_PROJECT_DIR}/.zskills" 2>/dev/null
+        : > "$marker" 2>/dev/null
+        printf 'zskills: settings.json hook %s is version %s but plugin ships %s; deferring to settings.json copy. Run /update-zskills install or bash scripts/switch-install-path.sh --to-plugin to consolidate.\n' \
+          "$my_basename" "$consumer_ver" "$plugin_ver" >&2
+      fi
+      exit 0
+    fi
+  fi
+
+  # Plugin EQUAL or OLDER than consumer copy → silent defer (settings.json
+  # wins — no version regression).
+  exit 0
+}
+
+_phsim_main

--- a/hooks/block-agents.sh.template
+++ b/hooks/block-agents.sh.template
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # Block Agent (subagent) dispatches that use a model below agents.min_model.
 # Registered under the Agent PreToolUse matcher in .claude/settings.json.
 #
@@ -13,6 +14,13 @@
 # dispatch site in run-plan, fix-issues, do) cover the residual case where
 # neither tool input nor agent definition specifies a model (subagent inherits
 # from parent session, which is typically Opus or Sonnet).
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat)
 

--- a/hooks/block-bad-cron.sh
+++ b/hooks/block-bad-cron.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# zskills-hook-version: 2026.05.0
 # block-bad-cron.sh — PreToolUse hook for the CronCreate tool.
 #
 # Closes a class of "the cron never fired" bugs caused by structurally-wrong
@@ -51,6 +52,13 @@
 # `/clear` (or restart Claude Code) and re-test with an intentionally
 # bad cron, e.g., a one-shot whose next fire is more than 7 days out.
 # The deny envelope's STOP message confirms the hook is wired.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 

--- a/hooks/block-bypassed-land-pr.sh
+++ b/hooks/block-bypassed-land-pr.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-bypassed-land-pr.sh — PreToolUse Bash hook.
 #
 # Unconditionally denies direct `gh pr create` and `gh pr merge --auto`
@@ -48,6 +49,13 @@
 # `bash scripts/pr-push-and-create.sh ...` invocation, not the inner
 # `gh pr create` inside that script — so the hook NEVER fires on
 # /land-pr's own gh invocation. No allowlist needed.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 
@@ -353,10 +361,14 @@ is_gh_pr_subcommand_in_wrappers "$COMMAND" "create" && deny=1
 is_gh_pr_subcommand_in_wrappers "$COMMAND" "merge" '^--auto$' && deny=1
 [ "${deny:-0}" -eq 0 ] && exit 0
 
-# Resolve message-enrichment script. Same `${X:-$PWD}` fallback pattern as
-# block-stale-skill-version.sh (guards against `set -u` + unset
-# CLAUDE_PROJECT_DIR).
-SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/land-pr-bypass-message.sh"
+# Resolve message-enrichment script. Lane-portable (W1.4 pattern 1): the
+# plugin lane resolves it under ${CLAUDE_PLUGIN_ROOT}/scripts/; the
+# /update-zskills lane resolves it under ${CLAUDE_PROJECT_DIR}/scripts/
+# (repo-root scripts/ — this is a consumer-customizable utility that stays
+# at scripts/, NOT under .claude/skills/update-zskills). The `${X:-$PWD}`
+# fallback (guards against `set -u` + unset CLAUDE_PROJECT_DIR) is preserved
+# on the legacy arm.
+SCRIPT="${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/land-pr-bypass-message.sh"
 
 # Static fallback STOP message — ASCII-only, 3 lines. Used when the
 # message-enrichment script is missing/broken (see sentinel check

--- a/hooks/block-fix-issue-unclaimed.sh
+++ b/hooks/block-fix-issue-unclaimed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-fix-issue-unclaimed.sh — PreToolUse hook on Bash.
 #
 # Backstops the /fix-issues inline-acquire prose discipline (plans/fix-issues-claims.md
@@ -36,6 +37,13 @@
 # No `2>/dev/null` on fallible ops — failures should be visible. The hook
 # is fail-open on its own infrastructure errors (defensive: never false-
 # deny on git-not-installed, Python-missing, etc.) but emits stderr.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat) || exit 0
 [ -z "$INPUT" ] && exit 0
@@ -207,12 +215,21 @@ if [ -d "$CLAIM_DIR" ]; then
 fi
 
 # ── Deny envelope (plan DA4.4 — locked text) ─────────────────────────────
+# Lane-portable recovery-command path (W1.4 pattern 2 / F-DA1-7): on the
+# plugin lane cite ${CLAUDE_PLUGIN_ROOT}/skills/fix-issues/scripts/...; on
+# the /update-zskills lane cite ${MAIN_ROOT}/.claude/skills/fix-issues/...
+# (the mirror). Resolve to whichever exists.
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/fix-issues/scripts/claim-issue.sh" ]; then
+  CLAIM_ISSUE_PATH="${CLAUDE_PLUGIN_ROOT}/skills/fix-issues/scripts/claim-issue.sh"
+else
+  CLAIM_ISSUE_PATH="${MAIN_ROOT}/.claude/skills/fix-issues/scripts/claim-issue.sh"
+fi
 STOP_MSG=$(cat <<EOF
 STOP: create-worktree.sh for fix-issue-${NNN} denied — no claim found at ${MAIN_ROOT}/.zskills/claims/issue-${NNN}/.
 
-The per-issue dispatch fence at SKILL.md:2161-2186 (cherry-pick/direct) or SKILL.md:2219-2243 (PR mode) MUST call:
+The per-issue dispatch fence in fix-issues modes/sprint.md (the "Worktree setup (cherry-pick and direct modes)" section, and the "PR mode (Phase 3)" section) MUST call:
 
-  bash ${MAIN_ROOT}/.claude/skills/fix-issues/scripts/claim-issue.sh acquire ${NNN} --pipeline-id "\$ZSKILLS_PIPELINE_ID" --sprint-id "\$SPRINT_ID"
+  bash ${CLAIM_ISSUE_PATH} acquire ${NNN} --pipeline-id "\$ZSKILLS_PIPELINE_ID" --sprint-id "\$SPRINT_ID"
 
 immediately above the create-worktree.sh invocation. If this hook fired during a sprint, the SKILL.md prose has drifted — STOP, do not retry, file an issue.
 

--- a/hooks/block-main-edits.sh
+++ b/hooks/block-main-edits.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-main-edits.sh — PreToolUse hook on Edit / Write.
 #
 # Honors execution.main_protected from .claude/zskills-config.json. When
@@ -27,6 +28,13 @@
 #                          "permissionDecisionReason":"<STOP message>"}}
 #
 # Test surface: tests/test-block-main-edits.sh
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat 2>/dev/null) || exit 0
 [ -z "$INPUT" ] && exit 0

--- a/hooks/block-run-plan-unclaimed.sh
+++ b/hooks/block-run-plan-unclaimed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-run-plan-unclaimed.sh — PreToolUse hook on Bash.
 #
 # Backstops the /run-plan claim-acquire prose discipline (Phase 2 of
@@ -43,6 +44,13 @@
 # NOTE: Per plan R2.5, the [0-9]+ validator pattern from the issue-side
 # hook is NOT applicable — plan slugs are kebab-case, not integers. The
 # slug validation here is a kebab-case regex match, not numeric.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat) || exit 0
 [ -z "$INPUT" ] && exit 0
@@ -209,7 +217,18 @@ fi
 # Source zskills-paths.sh to honour custom ZSKILLS_PLANS_DIR. Sourcing in
 # a subshell so the hook's environment stays clean.
 PLANS_DIR_RESOLVED=$(
-  ZSK_PATHS="${MAIN_ROOT}/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  # Lane-portable resolution (W1.4 pattern 2): plugin lane resolves
+  # zskills-paths.sh under ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/...;
+  # /update-zskills lane resolves it under the mirror
+  # (.claude/skills/update-zskills/...), then the zskills source-tree
+  # (skills/update-zskills/...).
+  ZSK_PATHS=""
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-paths.sh" ]; then
+    ZSK_PATHS="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-paths.sh"
+  fi
+  if [ -z "$ZSK_PATHS" ]; then
+    ZSK_PATHS="${MAIN_ROOT}/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+  fi
   if [ ! -f "$ZSK_PATHS" ]; then
     ZSK_PATHS="${MAIN_ROOT}/skills/update-zskills/scripts/zskills-paths.sh"
   fi
@@ -236,12 +255,23 @@ if [ -d "$CLAIM_DIR" ]; then
 fi
 
 # ── Deny envelope ────────────────────────────────────────────────────────
+# Lane-portable recovery-command path (W1.4 pattern 2 / F-DA1-7): on the
+# plugin lane the recovery command must cite
+# ${CLAUDE_PLUGIN_ROOT}/skills/run-plan/scripts/claim-plan.sh; on the
+# /update-zskills lane it cites ${MAIN_ROOT}/.claude/skills/run-plan/...
+# (the mirror). Resolve to whichever exists so the agent is told a command
+# that actually resolves on its install lane.
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/run-plan/scripts/claim-plan.sh" ]; then
+  CLAIM_PLAN_PATH="${CLAUDE_PLUGIN_ROOT}/skills/run-plan/scripts/claim-plan.sh"
+else
+  CLAIM_PLAN_PATH="${MAIN_ROOT}/.claude/skills/run-plan/scripts/claim-plan.sh"
+fi
 STOP_MSG=$(cat <<EOF
 STOP: create-worktree.sh for /run-plan branch '${BRANCH}' (plan slug '${SLUG}') denied — no claim found at ${MAIN_ROOT}/.zskills/claims/plan-${SLUG}/.
 
 The /run-plan dispatch fence MUST call:
 
-  bash ${MAIN_ROOT}/.claude/skills/run-plan/scripts/claim-plan.sh acquire ${SLUG} --pipeline-id "run-plan.${SLUG}"
+  bash ${CLAIM_PLAN_PATH} acquire ${SLUG} --pipeline-id "run-plan.${SLUG}"
 
 immediately above the create-worktree.sh invocation. If this hook fired during a /run-plan invocation, the SKILL.md prose has drifted — STOP, do not retry, file an issue.
 

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # block-stale-skill-version.sh — PreToolUse Bash hook.
 #
 # Denies `git commit` when a staged skill's content hash no longer matches
@@ -46,6 +47,13 @@
 # Pure bash at runtime (D4 in the reference doc) — no external JSON
 # parsers, no scripting-language interpreters. The unit-test harness MAY
 # use a separate JSON validator for assertions; the hook itself does not.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 
@@ -437,12 +445,17 @@ is_git_subcommand_in_wrappers() {
 }
 is_git_subcommand_in_wrappers "$COMMAND" commit || exit 0
 
-# Guard against `set -u` + unset `$CLAUDE_PROJECT_DIR` (rare but documented
-# harness edge case). `${X:-$PWD}` falls back to cwd; if the script is
-# absent under the fallback path, `[ -x ]` trips the fail-open below. Per
-# Round 2 N5: without the guard, `set -u` would crash the hook → nonzero
-# exit + empty stdout → silent failure mode worse than fail-open.
-SCRIPT="${CLAUDE_PROJECT_DIR:-$PWD}/scripts/skill-version-stage-check.sh"
+# Lane-portable resolution (W1.4 pattern 1): the plugin lane resolves the
+# stage-check script under ${CLAUDE_PLUGIN_ROOT}/scripts/; the
+# /update-zskills lane resolves it under ${CLAUDE_PROJECT_DIR}/scripts/
+# (repo-root scripts/ — consumer-customizable utility that stays at
+# scripts/, NOT under .claude/skills/update-zskills). Guard against `set -u`
+# + unset `$CLAUDE_PROJECT_DIR` (rare but documented harness edge case):
+# `${X:-$PWD}` falls back to cwd on the legacy arm; if the script is absent
+# under the resolved path, `[ -x ]` trips the fail-open below. Per Round 2
+# N5: without the guard, `set -u` would crash the hook → nonzero exit +
+# empty stdout → silent failure mode worse than fail-open.
+SCRIPT="${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-$PWD}}/scripts/skill-version-stage-check.sh"
 [ -x "$SCRIPT" ] || exit 0  # fail-open: script absent (consumer pre-/update-zskills)
 
 # Resolve effective worktree root for the stage-check subshell.

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # Block unsafe commands that agents should never use.
 # GENERIC safety layer — works in any project with zero configuration.
 # No external dependencies — bash only.
@@ -20,6 +21,13 @@
 #   direct                 -> BLOCK_MAIN_PUSH=0
 # Default here is 1 so zskills-shipped configs fail closed (safer).
 # Installer flips this single line via Edit; do not inline-expand further below.
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
+
 BLOCK_MAIN_PUSH=1
 
 INPUT=$(cat)

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -8,6 +9,13 @@
 #
 # Register BOTH this file and block-unsafe-generic.sh in .claude/settings.json
 # on the PreToolUse event, Bash matcher. The generic layer runs first.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 INPUT=$(cat)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,56 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-unsafe-generic.sh\"", "timeout": 5 },
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-unsafe-project.sh\"", "timeout": 5 },
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-stale-skill-version.sh\"", "timeout": 5 },
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-bypassed-land-pr.sh\"", "timeout": 5 },
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-fix-issue-unclaimed.sh\"", "timeout": 5 },
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-run-plan-unclaimed.sh\"", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-agents.sh\"", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "CronCreate",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-bad-cron.sh\"", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/block-main-edits.sh\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/warn-config-drift.sh\"", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/warn-config-drift.sh\"", "timeout": 5 }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-materialise.sh\"", "timeout": 30 }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/inject-bash-timeout.sh
+++ b/hooks/inject-bash-timeout.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# zskills-hook-version: 2026.05.0
 # inject-bash-timeout.sh — PreToolUse hook for Bash (verifier subagent).
 #
 # Layer 0 of the VERIFIER_AGENT_FIX D'' architecture. Ensures `timeout` is at

--- a/hooks/verify-response-validate.sh
+++ b/hooks/verify-response-validate.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# zskills-hook-version: 2026.05.0
 # verify-response-validate.sh — validates a verifier subagent's response
 # for signs of skipped work, hung-and-recovered, or other failure patterns.
 #

--- a/hooks/warn-config-drift.sh
+++ b/hooks/warn-config-drift.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# zskills-hook-version: 2026.05.0
 # warn-config-drift.sh — PostToolUse hook, non-blocking warn.
 #
 # Two responsibilities:
@@ -20,6 +21,13 @@
 #
 # Non-blocking by contract: always exits 0, even on malformed input.
 # A PostToolUse warn hook must never halt the user.
+
+# D16(a) plugin-lane conditional-skip shim. No-op on the /update-zskills
+# lane (CLAUDE_PLUGIN_ROOT unset → guard below skips the source). On the
+# plugin lane it defers to a settings.json-registered copy of this hook to
+# prevent double-fire when both install lanes are active. Must be the first
+# executable line; the shim controls its own exit/return.
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
 set -u
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -191,6 +191,9 @@ run_suite "test-plan-claim-moveall-skip.sh" "tests/test-plan-claim-moveall-skip.
 run_suite "test-plan-claim-fingerprint.sh" "tests/test-plan-claim-fingerprint.sh"
 run_suite "test-plan-claim-conformance.sh" "tests/test-plan-claim-conformance.sh"
 run_suite "test-demo-server-interactive.sh" "tests/test-demo-server-interactive.sh"
+run_suite "test-plugin-manifest.sh" "tests/test-plugin-manifest.sh"
+run_suite "test-plugin-marketplace.sh" "tests/test-plugin-marketplace.sh"
+run_suite "test-plugin-self-load.sh" "tests/test-plugin-self-load.sh"
 
 # Opt-in end-to-end smoke for parallel pipelines. Heavier than unit tests
 # (real git repos, concurrent writes), so it runs only when RUN_E2E is set.

--- a/tests/test-plugin-manifest.sh
+++ b/tests/test-plugin-manifest.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# tests/test-plugin-manifest.sh
+#
+# W1.5 (D8 / D2) — validates the two plugin manifests:
+#   .claude-plugin/plugin.json                 (the `zs` plugin)
+#   block-diagram/.claude-plugin/plugin.json   (the `zsbd` addon plugin)
+#
+# Uses Python JSONSchema-style validation (no jq — per `## Python is
+# required`). Asserts:
+#   - both manifests parse as JSON and carry the required top-level fields;
+#   - plugin names are exactly `zs` / `zsbd`;
+#   - `dependencies` is PRESENT on zsbd (declares {name: zs}) and ABSENT on
+#     zs (D2 / F-DA2-1 orphan-install closure);
+#   - the zsbd `skills` field is `["./"]` and the zsbd skill roster on disk
+#     enumerates exactly the 4 SKILL.md-bearing block-diagram dirs
+#     (RE-DERIVED at run time via find — NOT a frozen list, per D2);
+#   - the zs `skills` field references both ./skills/ and ./block-diagram/
+#     and `hooks` points at ./hooks/hooks.json; NO `agents` field on either.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+echo "=== plugin manifest validation (zs + zsbd) ==="
+
+# Re-derive the expected zsbd skill roster from disk (D2: not a frozen list).
+EXPECTED_BD_SKILLS=$(find block-diagram -mindepth 2 -name SKILL.md -printf '%h\n' | sed 's#^block-diagram/##' | sort | tr '\n' ',' )
+
+# Run all structural assertions in one Python pass; emit PASS/FAIL lines the
+# shell tallies.
+RESULT=$(EXPECTED_BD_SKILLS="$EXPECTED_BD_SKILLS" "$PYTHON" - <<'PY'
+import json, os, sys
+
+def out(ok, label, detail=""):
+    tag = "PASS" if ok else "FAIL"
+    print(f"{tag}\t{label}\t{detail}")
+
+ZS = ".claude-plugin/plugin.json"
+ZSBD = "block-diagram/.claude-plugin/plugin.json"
+
+# ---- load + parse ----
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f), None
+    except Exception as e:
+        return None, str(e)
+
+zs, zs_err = load(ZS)
+out(zs is not None, f"{ZS} parses as JSON", zs_err or "")
+zsbd, zsbd_err = load(ZSBD)
+out(zsbd is not None, f"{ZSBD} parses as JSON", zsbd_err or "")
+
+# Minimal JSONSchema-style validator (required keys + types). No external
+# deps — per `## Python is required`, json stdlib only.
+REQUIRED = {
+    "name": str, "version": str, "description": str, "author": dict,
+}
+def check_required(doc, label):
+    if doc is None:
+        return
+    for k, t in REQUIRED.items():
+        present = k in doc
+        out(present, f"{label}: required field '{k}' present")
+        if present:
+            out(isinstance(doc[k], t), f"{label}: field '{k}' is {t.__name__}")
+
+check_required(zs, "zs")
+check_required(zsbd, "zsbd")
+
+# ---- names ----
+if zs is not None:
+    out(zs.get("name") == "zs", "zs: name == 'zs'", repr(zs.get("name")))
+if zsbd is not None:
+    out(zsbd.get("name") == "zsbd", "zsbd: name == 'zsbd'", repr(zsbd.get("name")))
+
+# ---- dependencies: present on zsbd, absent on zs ----
+if zsbd is not None:
+    deps = zsbd.get("dependencies")
+    ok = isinstance(deps, list) and any(
+        isinstance(d, dict) and d.get("name") == "zs" for d in deps
+    )
+    out(ok, "zsbd: dependencies present and declares {name: zs}", repr(deps))
+if zs is not None:
+    out("dependencies" not in zs, "zs: dependencies ABSENT", repr(zs.get("dependencies")))
+
+# ---- agents field absent on both (D11) ----
+if zs is not None:
+    out("agents" not in zs, "zs: no 'agents' field (D11)")
+if zsbd is not None:
+    out("agents" not in zsbd, "zsbd: no 'agents' field (D11)")
+
+# ---- zs skills + hooks ----
+if zs is not None:
+    skills = zs.get("skills")
+    out(isinstance(skills, list) and "./skills/" in skills and "./block-diagram/" in skills,
+        "zs: skills references ./skills/ and ./block-diagram/", repr(skills))
+    out(zs.get("hooks") == "./hooks/hooks.json",
+        "zs: hooks points at ./hooks/hooks.json", repr(zs.get("hooks")))
+
+# ---- zsbd skills field + roster re-derivation ----
+if zsbd is not None:
+    out(zsbd.get("skills") == ["./"], "zsbd: skills == ['./']", repr(zsbd.get("skills")))
+    out("hooks" not in zsbd, "zsbd: no 'hooks' field (rides with zs)", repr(zsbd.get("hooks")))
+
+# zsbd roster: re-derived list passed in via env must be exactly the 4
+# block-diagram SKILL.md-bearing dirs.
+expected = [s for s in os.environ.get("EXPECTED_BD_SKILLS", "").split(",") if s]
+expected_set = set(expected)
+canonical = {"add-block", "add-example", "model-design", "review-feedback"}
+out(expected_set == canonical,
+    "zsbd roster: disk has exactly add-block/add-example/model-design/review-feedback",
+    repr(sorted(expected_set)))
+PY
+)
+
+# Tally.
+while IFS=$'\t' read -r tag label detail; do
+  [ -z "$tag" ] && continue
+  if [ "$tag" = "PASS" ]; then
+    pass "$label"
+  else
+    fail "$label ${detail:+— $detail}"
+  fi
+done <<< "$RESULT"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+exit "$FAIL_COUNT"

--- a/tests/test-plugin-marketplace.sh
+++ b/tests/test-plugin-marketplace.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# tests/test-plugin-marketplace.sh
+#
+# W1.5 (D8 / D1 / D2) — validates the marketplace manifest at
+# .claude-plugin/marketplace.json. Covers BOTH plugin entries (zs + zsbd).
+#
+# Uses Python json (no jq — per `## Python is required`). Asserts:
+#   - manifest parses + carries required top-level fields (name, owner,
+#     plugins, and — strict-mode requirement — a top-level `description`);
+#   - exactly two plugin entries named `zs` and `zsbd`;
+#   - the `zs` entry's source is the github object form the current
+#     validator accepts: { "source": "github", "repo": ..., "ref": ... }
+#     (the plan's nested-`github` example form is rejected by claude
+#     2.1.153 — see W1.5 implementer note);
+#   - the `zsbd` entry's source is the relative-path string "./block-diagram"
+#     (D1 / F-R2-1);
+#   - `dependencies` lives on the zsbd PLUGIN manifest (cross-checked here
+#     against block-diagram/.claude-plugin/plugin.json), present on zsbd and
+#     absent on zs.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+echo "=== marketplace manifest validation ==="
+
+RESULT=$("$PYTHON" - <<'PY'
+import json, sys
+
+def out(ok, label, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}\t{label}\t{detail}")
+
+MP = ".claude-plugin/marketplace.json"
+ZSBD_PLUGIN = "block-diagram/.claude-plugin/plugin.json"
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f), None
+    except Exception as e:
+        return None, str(e)
+
+mp, err = load(MP)
+out(mp is not None, f"{MP} parses as JSON", err or "")
+if mp is None:
+    sys.exit(0)
+
+# Required top-level fields. Strict mode requires a top-level `description`.
+for k, t in (("name", str), ("owner", dict), ("plugins", list), ("description", str)):
+    present = k in mp
+    out(present, f"marketplace: required field '{k}' present")
+    if present:
+        out(isinstance(mp[k], t), f"marketplace: field '{k}' is {t.__name__}")
+
+out(mp.get("name") == "zskills", "marketplace: name == 'zskills'", repr(mp.get("name")))
+
+plugins = mp.get("plugins", [])
+by_name = {p.get("name"): p for p in plugins if isinstance(p, dict)}
+out(set(by_name) == {"zs", "zsbd"},
+    "marketplace: exactly two plugins (zs, zsbd)", repr(sorted(by_name)))
+
+# zs source — github object form accepted by the current validator:
+# { "source": "github", "repo": ..., "ref": ... }
+zs = by_name.get("zs", {})
+zs_src = zs.get("source")
+ok_zs = (isinstance(zs_src, dict)
+         and zs_src.get("source") == "github"
+         and zs_src.get("repo") == "zeveck/zskills"
+         and zs_src.get("ref") == "prod/main")
+out(ok_zs, "marketplace: zs source is github {source,repo,ref}", repr(zs_src))
+
+# zsbd source — relative-path string (D1).
+zsbd = by_name.get("zsbd", {})
+out(zsbd.get("source") == "./block-diagram",
+    "marketplace: zsbd source is './block-diagram' relative path", repr(zsbd.get("source")))
+
+# dependencies live on the PLUGIN manifest (cross-check): present on zsbd,
+# absent on zs.
+zsbd_plugin, perr = load(ZSBD_PLUGIN)
+out(zsbd_plugin is not None, f"{ZSBD_PLUGIN} parses as JSON", perr or "")
+if zsbd_plugin is not None:
+    deps = zsbd_plugin.get("dependencies")
+    out(isinstance(deps, list) and any(isinstance(d, dict) and d.get("name") == "zs" for d in deps),
+        "zsbd plugin: dependencies declares {name: zs}", repr(deps))
+
+zs_plugin, zerr = load(".claude-plugin/plugin.json")
+if zs_plugin is not None:
+    out("dependencies" not in zs_plugin, "zs plugin: dependencies ABSENT", repr(zs_plugin.get("dependencies")))
+PY
+)
+
+while IFS=$'\t' read -r tag label detail; do
+  [ -z "$tag" ] && continue
+  if [ "$tag" = "PASS" ]; then
+    pass "$label"
+  else
+    fail "$label ${detail:+— $detail}"
+  fi
+done <<< "$RESULT"
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+exit "$FAIL_COUNT"

--- a/tests/test-plugin-self-load.sh
+++ b/tests/test-plugin-self-load.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# tests/test-plugin-self-load.sh
+#
+# W1.6 (D9) — plugin self-load is a real load test, not bash-lint. Three
+# parts, covering BOTH plugins (zs + zsbd):
+#
+#   (a) `claude plugin validate --strict` if the CLI is available, else
+#       SKIP-with-reason. Validates the marketplace manifest (which covers
+#       both plugin entries) AND the zsbd plugin manifest directly.
+#   (b) Python json validation of both plugin.json files (zs + zsbd):
+#       parse + required top-level fields.
+#   (c) `bash -n` on every hook + helper script under hooks/, with an
+#       explicit case-branch exclusion for hooks/canary*-bad.sh (the
+#       deliberately-broken syntax fixtures).
+#
+# No jq — Python json per `## Python is required`.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+skip() { printf '\033[33m  SKIP\033[0m %s\n' "$1"; SKIP_COUNT=$((SKIP_COUNT+1)); }
+
+echo "=== plugin self-load (zs + zsbd) ==="
+
+# ── (a) claude plugin validate --strict ──────────────────────────────────
+if command -v claude >/dev/null 2>&1; then
+  # Marketplace manifest (covers both plugin entries).
+  if claude plugin validate "$REPO_ROOT" --strict 2>&1 | grep -q 'Validation passed'; then
+    pass "(a) claude plugin validate --strict: marketplace manifest passes"
+  else
+    fail "(a) claude plugin validate --strict: marketplace manifest"
+    claude plugin validate "$REPO_ROOT" --strict 2>&1 | sed 's/^/      /'
+  fi
+  # zsbd plugin manifest directly.
+  if claude plugin validate "$REPO_ROOT/block-diagram" --strict 2>&1 | grep -q 'Validation passed'; then
+    pass "(a) claude plugin validate --strict: zsbd plugin manifest passes"
+  else
+    fail "(a) claude plugin validate --strict: zsbd plugin manifest"
+    claude plugin validate "$REPO_ROOT/block-diagram" --strict 2>&1 | sed 's/^/      /'
+  fi
+else
+  skip "(a) claude plugin validate --strict — claude CLI not on PATH"
+fi
+
+# ── (b) Python json validation of both plugin.json ───────────────────────
+for MANIFEST in ".claude-plugin/plugin.json" "block-diagram/.claude-plugin/plugin.json"; do
+  if "$PYTHON" - "$MANIFEST" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    doc = json.load(f)
+required = ["name", "version", "description", "author"]
+missing = [k for k in required if k not in doc]
+if missing:
+    print(f"missing required fields: {missing}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+  then
+    pass "(b) python json: $MANIFEST parses + required fields present"
+  else
+    fail "(b) python json: $MANIFEST"
+  fi
+done
+
+# ── (c) bash -n on every hook + helper, excluding canary*-bad.sh ─────────
+shopt -s nullglob
+LINT_TARGETS=( hooks/*.sh hooks/*.sh.template hooks/_lib/*.sh )
+shopt -u nullglob
+for f in "${LINT_TARGETS[@]}"; do
+  bn="$(basename "$f")"
+  # Literal case-branch exclusion for the deliberately-broken canary
+  # fixtures (D9): hooks/canary*-bad.sh.
+  case "$bn" in
+    canary*-bad.sh)
+      skip "(c) bash -n: $f (canary syntax-error fixture, excluded)"
+      continue
+      ;;
+  esac
+  if bash -n "$f" 2>/dev/null; then
+    pass "(c) bash -n: $f"
+  else
+    fail "(c) bash -n: $f"
+    bash -n "$f" 2>&1 | sed 's/^/      /'
+  fi
+done
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed, $SKIP_COUNT skipped (of $((PASS_COUNT + FAIL_COUNT + SKIP_COUNT)))"
+exit "$FAIL_COUNT"

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -3074,6 +3074,37 @@ check       fix-issues  "impl-prompt scope-grep enforcement"             '[Ss]co
 check       fix-issues  "impl-prompt verifies each file in diff"         'git diff origin/main\.\.HEAD --name-only'
 
 echo ""
+echo "=== plugin hooks — line-2 # zskills-hook-version: stamp (W1.3 / D16(a)) ==="
+# Every shipped non-canary hook script under hooks/ (all *.sh except
+# canary*) PLUS the two *.template hooks must carry a line-2
+# `# zskills-hook-version:` stamp. The shim's version-skew check
+# (hooks/_lib/plugin-hook-skip-if-mirrored.sh) reads this stamp from both
+# the plugin copy and the settings.json-registered copy; an absent stamp on
+# either side forces a silent defer (D16(a) step 6), so a missing stamp is a
+# correctness regression for dual-install hook double-fire prevention.
+HOOK_STAMP_TARGETS=()
+shopt -s nullglob
+for _h in "$REPO_ROOT"/hooks/*.sh; do
+  case "$(basename "$_h")" in
+    canary*) continue ;;
+  esac
+  HOOK_STAMP_TARGETS+=("$_h")
+done
+for _h in "$REPO_ROOT"/hooks/*.sh.template; do
+  HOOK_STAMP_TARGETS+=("$_h")
+done
+shopt -u nullglob
+for _h in "${HOOK_STAMP_TARGETS[@]}"; do
+  _bn="$(basename "$_h")"
+  _line2="$(sed -n '2p' "$_h")"
+  if printf '%s' "$_line2" | grep -q '^# zskills-hook-version:[[:space:]]*[0-9]'; then
+    pass "hook $_bn carries line-2 # zskills-hook-version: stamp"
+  else
+    fail "hook $_bn carries line-2 # zskills-hook-version: stamp" "expected '# zskills-hook-version: <ver>' on line 2, got: $_line2"
+  fi
+done
+
+echo ""
 echo "---"
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if [ $FAIL_COUNT -eq 0 ]; then


### PR DESCRIPTION
## Summary — Phase 1 of PLUGIN_DISTRIBUTION (plugin scaffold, additive)

First phase of the dual-path plugin-distribution plan, executed via `/run-plan ... finish auto`. Purely additive — no existing behavior changes.

- **Plugin manifests:** `.claude-plugin/plugin.json` (`zs`), `block-diagram/.claude-plugin/plugin.json` (`zsbd`, with `dependencies: [{name: zs}]`), `.claude-plugin/marketplace.json` listing both.
- **`hooks/hooks.json`:** registers all current settings.json hooks under `${CLAUDE_PLUGIN_ROOT}` (excludes the 2 materialized hooks per D11); includes the SessionStart materializer entry.
- **D16(a) conditional-skip shim:** new `hooks/_lib/plugin-hook-skip-if-mirrored.sh` + `# zskills-hook-version:` line-2 stamps on all non-canary `.sh` hooks + 2 `.template` hooks.
- **W1.4 path-fallback:** `${CLAUDE_PLUGIN_ROOT:-...}` dual-resolution in hook self-references + claim-hook recovery paths (F-DA1-7) + stale SKILL.md:NNN ref fix in block-fix-issue-unclaimed.sh (F-DA1-4).
- **3 new tests:** test-plugin-manifest, test-plugin-marketplace, test-plugin-self-load.
- **Docs:** RELEASING.md + CLAUDE.md document both dogfood lanes (`claude --plugin-dir .` and `/update-zskills install`).

## Plan-spec correction made during implementation

The plan's W1.2 marketplace example used `"source": { "github": {...} }` (nested), which `claude plugin validate --strict` (2.1.153) REJECTS. Corrected to the validator-accepted discriminator form `"source": { "source": "github", "repo": "zeveck/zskills", "ref": "prod/main" }`. The `zsbd` relative-path source, the `dependencies` declaration, and the Agent/CronCreate hook matchers all pass strict validation.

## Verification

- 3 new plugin tests: green (manifest 29/0, marketplace 16/0, self-load 19/0/1-skip).
- `claude plugin validate --strict` passes for both `zs` and `zsbd`.
- Scope clean: no skill-body edits, no scripts/ moves, no _lib core-helper edits (mirror-parity + helper-drift gates green).
- Separate verifier agent confirmed 7/8 criteria clean; the 2 full-suite failures (`test_zskills_monitor_collect.sh`, `test_plans_rebuild_uses_collect.sh`) are stale-local-cache / stale-base artifacts proven independent of this diff — both resolved by rebasing onto current main (#762 archived the canaries that drove the plans-rebuild mismatch). Main CI is green on these tests.

## Test plan

- [x] 3 new plugin tests green
- [x] `claude plugin validate --strict` green (both plugins)
- [x] scope-checked: additive only, mirror-parity + helper-drift green
- [x] rebased onto current main (a386fba5); artifacts resolved
- [ ] CI green (this PR) — /land-pr monitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
