### PR TITLE
test(monitor-collect): strip volatile claim.age_seconds from worktree-portability subset (#759)

### DIFF
--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -676,7 +676,7 @@ trap cleanup_tmp_wt EXIT
 
 if git -C "$REPO_ROOT" worktree add --detach --quiet "$TMP_WT" HEAD 2>/dev/null; then
   PORTABLE=$(PYTHONPATH="$PKG_PARENT" python3 -c '
-import sys, json
+import sys, json, copy
 sys.path.insert(0, "'"$PKG_PARENT"'")
 from zskills_monitor.collect import collect_snapshot
 
@@ -685,9 +685,24 @@ from zskills_monitor.collect import collect_snapshot
 # subset that worktree-portability protects: repo_root, plans, queues,
 # state_file_path.
 def stable(snap):
+    # #759: a held plan claim adds a per-plan claim.age_seconds field that is
+    # a live "now - started_at" value, so it ticks between the two sequential
+    # collect_snapshot() reads and breaks the byte-identity check. Strip ONLY
+    # age_seconds (deep-copied so we never mutate the source snapshot); the
+    # rest of the claim (pipeline_id, started_at, current_phase,
+    # pipeline_short) is fixed between back-to-back reads and stays in the
+    # comparison. Worktree-portability is about MAIN_ROOT resolution, not
+    # claim age.
+    plans = copy.deepcopy(snap["plans"])
+    if isinstance(plans, list):
+        for plan in plans:
+            if isinstance(plan, dict):
+                claim = plan.get("claim")
+                if isinstance(claim, dict) and "age_seconds" in claim:
+                    del claim["age_seconds"]
     return {
         "repo_root": snap["repo_root"],
-        "plans": snap["plans"],
+        "plans": plans,
         "queues": snap["queues"],
         "state_file_path": snap["state_file_path"],
     }


### PR DESCRIPTION
## Summary

Fixes a flaky test: `tests/test_zskills_monitor_collect.sh` worktree-portability AC failed whenever a live pipeline held a **plan claim**. The test compares two back-to-back `collect_snapshot()` reads for byte-identity on a "stable subset" but did not drop the per-plan `claim.age_seconds` — a live `now − started_at` value that ticks between the two reads. So a held claim made exactly one plan's `claim.age_seconds` differ and the byte-identity check failed (intermittent: passed only when no claim was held).

## Fix

In the test's `stable()` projection, deep-copy the plans and strip **only** `claim.age_seconds` from each plan (mirroring how `updated_at` is already dropped). The rest of the claim (`pipeline_id`, `started_at`, `current_phase`, `pipeline_short`) is fixed between back-to-back reads and stays in the comparison, so the invariant ("MAIN_ROOT resolves identically from primary vs worktree") is preserved, not hollowed out. Deep-copy avoids mutating the source snapshot.

## Test plan

- [x] Race reproduced under a held plan claim: old projection → `byte_id=False`; new projection → `byte_id=True` (age advanced 89.5s→110.8s between reads)
- [x] Over-strip guard: tampering a non-volatile field (`claim.pipeline_id`) still yields `byte_id=False` — comparison not hollowed
- [x] Deep-copy verified: source snapshot retains `age_seconds` after projection
- [x] `bash tests/run-all.sh` → 6055/6055 passed, 0 failed; `test_zskills_monitor_collect.sh` 19/19

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)
