### PR TITLE
fix(dashboard): resolve shipped merge-conflict markers in app.css

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+738508"
+  version: "2026.05.28+7b149d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1368,7 +1368,6 @@ button svg { display: inline-block; vertical-align: middle; }
 .branch-state-pill--local        { color: var(--orange); border-color: var(--orange); }
 .branch-state-pill--remote       { color: var(--text-dim); border-color: var(--border); }
 
-<<<<<<< HEAD
 /* Config-protected shield (cleanup.protected_branches). Signals that
    /cleanup-merged skips this branch — NOT GitHub branch protection. */
 .branch-protected-shield {
@@ -1377,7 +1376,8 @@ button svg { display: inline-block; vertical-align: middle; }
   font-size: 0.82rem;
   line-height: 1;
   cursor: help;
-=======
+}
+
 /* Branch card layout — keep name + state pill flush-left next to the
    checkbox; push the timestamp / worktree age to the trailing edge so the
    row reads as "[✓ name PILL] ............ time" instead of space-between
@@ -1389,7 +1389,6 @@ button svg { display: inline-block; vertical-align: middle; }
 }
 .card[data-kind="branch"] .card-worktree-row {
   justify-content: flex-start;
->>>>>>> bcb67d9 (feat(dashboard): polish Branches tab — card layout, select-all, click-to-toggle)
 }
 
 /* Issue #717 — Branch section container. Each of Active/Landed/Remote-only

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+738508"
+  version: "2026.05.28+7b149d"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1368,7 +1368,6 @@ button svg { display: inline-block; vertical-align: middle; }
 .branch-state-pill--local        { color: var(--orange); border-color: var(--orange); }
 .branch-state-pill--remote       { color: var(--text-dim); border-color: var(--border); }
 
-<<<<<<< HEAD
 /* Config-protected shield (cleanup.protected_branches). Signals that
    /cleanup-merged skips this branch — NOT GitHub branch protection. */
 .branch-protected-shield {
@@ -1377,7 +1376,8 @@ button svg { display: inline-block; vertical-align: middle; }
   font-size: 0.82rem;
   line-height: 1;
   cursor: help;
-=======
+}
+
 /* Branch card layout — keep name + state pill flush-left next to the
    checkbox; push the timestamp / worktree age to the trailing edge so the
    row reads as "[✓ name PILL] ............ time" instead of space-between
@@ -1389,7 +1389,6 @@ button svg { display: inline-block; vertical-align: middle; }
 }
 .card[data-kind="branch"] .card-worktree-row {
   justify-content: flex-start;
->>>>>>> bcb67d9 (feat(dashboard): polish Branches tab — card layout, select-all, click-to-toggle)
 }
 
 /* Issue #717 — Branch section container. Each of Active/Landed/Remote-only


### PR DESCRIPTION
## Summary

Hotfix: the dashboard **Branches tab** shipped broken in #760 because **unresolved git merge-conflict markers were committed into `app.css`**. Conflict markers are invalid CSS, so the browser silently dropped the branch-card layout rules — the tab rendered with the old broken layout (name centered, state pill floating, status pill + worktree path stretched to opposite edges), and it was unfixable by hard-refresh or a fresh-port server because the served file itself was broken.

Closes #769.

## Root cause

#760's rebase onto `main` hit a conflict in `app.css` between `main`'s `.branch-protected-shield` rule and #760's branch-card rules. The resolution was botched — the literal `<<<<<<< / ======= / >>>>>>>` markers were left in the file (~lines 1371–1392) and `.branch-protected-shield` lost its closing `}` (brace imbalance 234/233). I committed it without grepping for markers; no test validates CSS syntax, so CI passed.

## Fix

Resolve the conflict keeping **both** rules (`.branch-protected-shield` with its restored `}` **and** the branch-card `margin-left: auto` / `flex-start` rules).

## Test plan

- [x] `grep` for conflict markers in `app.css`: 0
- [x] brace balance: 234 open / 234 close
- [x] Full suite `bash tests/run-all.sh`: **6055/6055 passed, 0 failed**
- [x] Manual (playwright): Branches tab renders correctly — name flush-left + state pill beside it, timestamp right, NOT-LANDED + worktree path grouped left; `getComputedStyle(.branch-time).marginLeft` resolves to ~788px (was 0px on broken main)
- [x] Mirror (`.claude/skills/zskills-dashboard`) re-synced

## Follow-up (separate issue to file)

Add a CI guard that fails on leftover conflict markers (`^<<<<<<< ` / `^>>>>>>> `) in shippable files — needs careful test-fixture exclusion, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
