### PR TITLE
fix(hooks): close here-string/heredoc interpreter destructive-op bypass (closes #772)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -48,6 +48,95 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 [ -z "$COMMAND" ] && COMMAND="$INPUT"
 
 # ──────────────────────────────────────────────────────────────
+# Interpreter-stdin re-injection (#772) — sibling of #399/#597
+# ──────────────────────────────────────────────────────────────
+# Pass-1 redaction below strips heredoc / here-string BODIES as inert
+# text — correct when the body is DATA (`cat <<EOF`, `gh pr create
+# --body-file=- <<EOF`, echo content, a commit message that mentions
+# `git clean -f`). But when the heredoc / here-string is the STDIN of an
+# INTERPRETER (`bash <<<"git clean -fdx"`, `sh <<EOF … EOF`,
+# `zsh -s <<<"…"`), the body is EXECUTED as a script — so a destructive
+# command smuggled that way must reach the deny scan. This is the
+# here-string/heredoc analogue of the `bash -c` / `eval` / `sh -c`
+# wrapper-bypass closed by #399 / #597.
+#
+# Discriminator (the make-or-break false-positive guard): we re-inject
+# the body as code ONLY when the command HEAD of the segment is an
+# interpreter (bash|sh|zsh|dash|ash|ksh) reading its stdin as a script —
+# i.e. the only tokens between the interpreter and the `<<<` / `<<DELIM`
+# operator are interpreter FLAGS (`-s`, `-`, `-x`, …), with NO script-file
+# positional. `cat <<EOF`, `echo`, `tee f <<EOF`, `gh pr create
+# --body-file=- <<EOF`, and `bash script.sh <<<data` (here-string is DATA
+# for script.sh, not code) all FAIL this test and are left for Pass-1 to
+# strip as inert — preserving the existing no-false-positive guarantee.
+#
+# Mechanism: when an interpreter-stdin body is detected, we APPEND it to
+# $COMMAND as a new `;`-separated shell segment. The existing
+# is_*_in_wrappers / is_*_in_chain scanners split on `;` (and the
+# JSON-escaped `\n`), so the re-injected body is scanned as a first-class
+# command. We append rather than replace so the original (now-redacted)
+# text is untouched and any chained ops after the heredoc stay visible.
+extract_interp_stdin_body() {
+  # Echoes the executed body (one per line) for every interpreter-stdin
+  # heredoc / here-string in $1. Empty output ⇒ nothing to re-inject.
+  local cmd="$1"
+  # The interpreter head must be a WHOLE-WORD token at a segment boundary:
+  # preceded by start-of-string or one of space / ; / & / | / backtick /
+  # `(` (the chars that delimit a fresh command position), and followed by
+  # zero or more interpreter FLAG tokens (`-s`, `-`, `-x`, …) and then the
+  # redirection operator with NO intervening non-flag positional.
+  #
+  # The left boundary is the make-or-break false-positive guard: it stops
+  #   * `script.sh <<<data`  — the `sh` here is preceded by `.`, not a
+  #     boundary, so the here-string is correctly treated as DATA, and
+  #   * a stray `bash`/`sh` earlier in the buffer from matching a
+  #     `cat <<EOF` heredoc that appears later.
+  # The "flags only, no positional" rule stops `bash script.sh <<<data`
+  # and `bash run.sh <<EOF` — there the body is stdin DATA for the script
+  # file, not code, so Pass-1 should strip it as inert.
+  local bnd='(^|[[:space:];&|`(])'
+  local head_re="${bnd}(bash|sh|zsh|dash|ash|ksh)([[:space:]]+-[A-Za-z]+)*[[:space:]]*"
+
+  # --- Here-strings: <interp> [flags] <<< "body" | '"'"'body'"'"' | body ---
+  # Quoted forms first so the body capture stops at the closing quote;
+  # bareword form last (body = run of non-space, non-redirect chars).
+  printf '%s' "$cmd" | grep -oE "${head_re}<<<[[:space:]]*\"[^\"]*\"" \
+    | sed -E "s/.*<<<[[:space:]]*\"([^\"]*)\".*/\1/"
+  printf '%s' "$cmd" | grep -oE "${head_re}<<<[[:space:]]*'[^']*'" \
+    | sed -E "s/.*<<<[[:space:]]*'([^']*)'.*/\1/"
+  printf '%s' "$cmd" | grep -oE "${head_re}<<<[[:space:]]*[^[:space:]\"';&|]+" \
+    | sed -E "s/.*<<<[[:space:]]*([^[:space:]\"';&|]+).*/\1/"
+
+  # --- Heredocs: <interp> [flags] <<[-]?['\"]?DELIM['\"]? \n body \n DELIM ---
+  # Body arrives with literal two-char `\n` separators (the extractor does
+  # not JSON-decode). We rewrite the body's `\n` back to real newlines so
+  # each re-injected line becomes its own scannable segment. The DELIM is
+  # backref-pinned to the opener; quoted-delim alts tried first. Capture
+  # groups: \1 boundary, \2 interp, \3 flags, \4 delim, \5 body.
+  printf '%s' "$cmd" | sed -nE \
+    "s/.*${head_re}<<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\"\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    | sed -E 's/\\n/\n/g'
+  printf '%s' "$cmd" | sed -nE \
+    "s/.*${head_re}<<-?[[:space:]]*'([A-Za-z_][A-Za-z0-9_]*)'\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    | sed -E 's/\\n/\n/g'
+  printf '%s' "$cmd" | sed -nE \
+    "s/.*${head_re}<<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    | sed -E 's/\\n/\n/g'
+}
+
+_INTERP_BODY=$(extract_interp_stdin_body "$COMMAND")
+if [ -n "$_INTERP_BODY" ]; then
+  # Append each extracted body line as its own `;`-delimited segment so
+  # the chain/wrapper scanners see it as a standalone command.
+  while IFS= read -r _line; do
+    [ -z "$_line" ] && continue
+    COMMAND="$COMMAND ; $_line"
+  done <<< "$_INTERP_BODY"
+  unset _line
+fi
+unset _INTERP_BODY
+
+# ──────────────────────────────────────────────────────────────
 # Data-region redaction
 # ──────────────────────────────────────────────────────────────
 # Destructive-op regex checks below scan $COMMAND as a single string.

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -48,6 +48,95 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)"
 [ -z "$COMMAND" ] && COMMAND="$INPUT"
 
 # ──────────────────────────────────────────────────────────────
+# Interpreter-stdin re-injection (#772) — sibling of #399/#597
+# ──────────────────────────────────────────────────────────────
+# Pass-1 redaction below strips heredoc / here-string BODIES as inert
+# text — correct when the body is DATA (`cat <<EOF`, `gh pr create
+# --body-file=- <<EOF`, echo content, a commit message that mentions
+# `git clean -f`). But when the heredoc / here-string is the STDIN of an
+# INTERPRETER (`bash <<<"git clean -fdx"`, `sh <<EOF … EOF`,
+# `zsh -s <<<"…"`), the body is EXECUTED as a script — so a destructive
+# command smuggled that way must reach the deny scan. This is the
+# here-string/heredoc analogue of the `bash -c` / `eval` / `sh -c`
+# wrapper-bypass closed by #399 / #597.
+#
+# Discriminator (the make-or-break false-positive guard): we re-inject
+# the body as code ONLY when the command HEAD of the segment is an
+# interpreter (bash|sh|zsh|dash|ash|ksh) reading its stdin as a script —
+# i.e. the only tokens between the interpreter and the `<<<` / `<<DELIM`
+# operator are interpreter FLAGS (`-s`, `-`, `-x`, …), with NO script-file
+# positional. `cat <<EOF`, `echo`, `tee f <<EOF`, `gh pr create
+# --body-file=- <<EOF`, and `bash script.sh <<<data` (here-string is DATA
+# for script.sh, not code) all FAIL this test and are left for Pass-1 to
+# strip as inert — preserving the existing no-false-positive guarantee.
+#
+# Mechanism: when an interpreter-stdin body is detected, we APPEND it to
+# $COMMAND as a new `;`-separated shell segment. The existing
+# is_*_in_wrappers / is_*_in_chain scanners split on `;` (and the
+# JSON-escaped `\n`), so the re-injected body is scanned as a first-class
+# command. We append rather than replace so the original (now-redacted)
+# text is untouched and any chained ops after the heredoc stay visible.
+extract_interp_stdin_body() {
+  # Echoes the executed body (one per line) for every interpreter-stdin
+  # heredoc / here-string in $1. Empty output ⇒ nothing to re-inject.
+  local cmd="$1"
+  # The interpreter head must be a WHOLE-WORD token at a segment boundary:
+  # preceded by start-of-string or one of space / ; / & / | / backtick /
+  # `(` (the chars that delimit a fresh command position), and followed by
+  # zero or more interpreter FLAG tokens (`-s`, `-`, `-x`, …) and then the
+  # redirection operator with NO intervening non-flag positional.
+  #
+  # The left boundary is the make-or-break false-positive guard: it stops
+  #   * `script.sh <<<data`  — the `sh` here is preceded by `.`, not a
+  #     boundary, so the here-string is correctly treated as DATA, and
+  #   * a stray `bash`/`sh` earlier in the buffer from matching a
+  #     `cat <<EOF` heredoc that appears later.
+  # The "flags only, no positional" rule stops `bash script.sh <<<data`
+  # and `bash run.sh <<EOF` — there the body is stdin DATA for the script
+  # file, not code, so Pass-1 should strip it as inert.
+  local bnd='(^|[[:space:];&|`(])'
+  local head_re="${bnd}(bash|sh|zsh|dash|ash|ksh)([[:space:]]+-[A-Za-z]+)*[[:space:]]*"
+
+  # --- Here-strings: <interp> [flags] <<< "body" | '"'"'body'"'"' | body ---
+  # Quoted forms first so the body capture stops at the closing quote;
+  # bareword form last (body = run of non-space, non-redirect chars).
+  printf '%s' "$cmd" | grep -oE "${head_re}<<<[[:space:]]*\"[^\"]*\"" \
+    | sed -E "s/.*<<<[[:space:]]*\"([^\"]*)\".*/\1/"
+  printf '%s' "$cmd" | grep -oE "${head_re}<<<[[:space:]]*'[^']*'" \
+    | sed -E "s/.*<<<[[:space:]]*'([^']*)'.*/\1/"
+  printf '%s' "$cmd" | grep -oE "${head_re}<<<[[:space:]]*[^[:space:]\"';&|]+" \
+    | sed -E "s/.*<<<[[:space:]]*([^[:space:]\"';&|]+).*/\1/"
+
+  # --- Heredocs: <interp> [flags] <<[-]?['\"]?DELIM['\"]? \n body \n DELIM ---
+  # Body arrives with literal two-char `\n` separators (the extractor does
+  # not JSON-decode). We rewrite the body's `\n` back to real newlines so
+  # each re-injected line becomes its own scannable segment. The DELIM is
+  # backref-pinned to the opener; quoted-delim alts tried first. Capture
+  # groups: \1 boundary, \2 interp, \3 flags, \4 delim, \5 body.
+  printf '%s' "$cmd" | sed -nE \
+    "s/.*${head_re}<<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\"\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    | sed -E 's/\\n/\n/g'
+  printf '%s' "$cmd" | sed -nE \
+    "s/.*${head_re}<<-?[[:space:]]*'([A-Za-z_][A-Za-z0-9_]*)'\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    | sed -E 's/\\n/\n/g'
+  printf '%s' "$cmd" | sed -nE \
+    "s/.*${head_re}<<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    | sed -E 's/\\n/\n/g'
+}
+
+_INTERP_BODY=$(extract_interp_stdin_body "$COMMAND")
+if [ -n "$_INTERP_BODY" ]; then
+  # Append each extracted body line as its own `;`-delimited segment so
+  # the chain/wrapper scanners see it as a standalone command.
+  while IFS= read -r _line; do
+    [ -z "$_line" ] && continue
+    COMMAND="$COMMAND ; $_line"
+  done <<< "$_INTERP_BODY"
+  unset _line
+fi
+unset _INTERP_BODY
+
+# ──────────────────────────────────────────────────────────────
 # Data-region redaction
 # ──────────────────────────────────────────────────────────────
 # Destructive-op regex checks below scan $COMMAND as a single string.

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -257,6 +257,65 @@ expect_deny "WD11: bash -c \"sh -c 'kill -9 1234'\" (nested)" \
 expect_allow "WD12: bash -c 'echo killall' (wrapper allow ctrl)" \
   "bash -c 'echo killall'"
 
+# WHS1-WHS12. Here-string / heredoc-to-INTERPRETER bypass closure (#772) —
+# sibling of the #399/#597 `bash -c` / `eval` / `sh -c` wrapper closure.
+# When the heredoc / here-string is the STDIN of an interpreter
+# (bash|sh|zsh|dash|ash|ksh, optionally `-s`), the body is EXECUTED, so a
+# destructive command smuggled that way must reach the deny scan. The
+# pre-scan re-injection step in block-unsafe-generic.sh extracts the body
+# and appends it as a `;`-segment for the existing wrapper/chain scanners.
+#
+# CRITICAL discriminator (no-false-positive guard): re-inject ONLY when
+# the segment head is an interpreter reading stdin as a script (flags-only
+# between interpreter and `<<<`/`<<`, no script-file positional). DATA
+# heredocs (cat/echo/tee/--body-file, and `bash script.sh <<<data` where
+# the here-string is stdin for the script) must STILL be stripped inert.
+# Sanity: each WHS DENY case ALLOWs against pre-#772 hook (proving the
+# assertion exercises the new logic), verified manually during the fix.
+
+# --- DENY: interpreter-stdin here-strings (the reported bug) ---
+expect_deny "WHS1: bash <<<\"git clean -fdx\"" \
+  "bash <<<\\\"git clean -fdx\\\""
+expect_deny "WHS2: bash <<<'git clean -fdx' (single-quoted body)" \
+  "bash <<<'git clean -fdx'"
+expect_deny "WHS3: sh <<<\"git reset --hard HEAD~5\"" \
+  "sh <<<\\\"git reset --hard HEAD~5\\\""
+expect_deny "WHS4: zsh <<<\"git checkout -- .\"" \
+  "zsh <<<\\\"git checkout -- .\\\""
+expect_deny "WHS5: bash -s <<<\"git clean -fdx\" (-s flag)" \
+  "bash -s <<<\\\"git clean -fdx\\\""
+expect_deny "WHS6: bash <<<\"kill -9 1234\" (destruct verb)" \
+  "bash <<<\\\"kill -9 1234\\\""
+expect_deny "WHS7: cd /tmp && bash <<<\"git clean -fdx\" (cd-chain)" \
+  "cd /tmp && bash <<<\\\"git clean -fdx\\\""
+
+# --- DENY: interpreter-stdin heredocs ---
+expect_deny "WHS8: bash <<EOF git clean -fdx EOF (heredoc to bash)" \
+  "bash <<EOF\\ngit clean -fdx\\nEOF"
+expect_deny "WHS9: sh <<EOF rm -rf /etc EOF (heredoc to sh)" \
+  "sh <<EOF\\nrm -rf /etc\\nEOF"
+expect_deny "WHS10: bash <<'EOF' git reset --hard EOF (quoted-delim)" \
+  "bash <<'EOF'\\ngit reset --hard HEAD~5\\nEOF"
+
+# --- ALLOW: DATA heredocs / here-strings (no false-positives) ---
+# The discriminator must keep these inert: head is NOT an interpreter
+# reading stdin as code (cat/echo/tee/gh body), OR there is a script-file
+# positional so the body is stdin DATA for that script.
+expect_allow "WHS-A1: cat <<EOF data heredoc mentioning git clean -f" \
+  "cat <<EOF\\ngit clean -fdx is dangerous\\nEOF"
+expect_allow "WHS-A2: echo <<<\"git clean -fdx\" (echo, not interpreter)" \
+  "echo <<<\\\"git clean -fdx\\\""
+expect_allow "WHS-A3: tee f.txt <<EOF rm -rf /etc EOF (data to tee)" \
+  "tee f.txt <<EOF\\nrm -rf /etc\\nEOF"
+expect_allow "WHS-A4: gh pr create --body-file=- <<EOF mentions git clean -f" \
+  "gh pr create --body-file=- <<EOF\\nnote: git clean -f purges untracked\\nEOF"
+expect_allow "WHS-A5: bash script.sh <<<data (here-string is DATA for script)" \
+  "bash script.sh <<<\\\"git clean -fdx\\\""
+expect_allow "WHS-A6: bash run.sh <<EOF (heredoc is DATA for script)" \
+  "bash run.sh <<EOF\\nrm -rf /etc\\nEOF"
+expect_allow "WHS-A7: bash <<<\"echo git clean -fdx\" (interpreter runs benign echo)" \
+  "bash <<<\\\"echo git clean -fdx\\\""
+
 # 7b. kill-by-port/name anti-pattern — same hazard as fuser -k, different spelling.
 # The original incident was 'lsof -ti :8080 | xargs kill' taking out the docker container.
 # All spellings must be blocked; only explicit-PID kill and the sanctioned helper are allowed.

--- a/tests/test-tokenize-then-walk.sh
+++ b/tests/test-tokenize-then-walk.sh
@@ -352,6 +352,64 @@ assert_destruct_match "XRS1" "rsync -av src/ dst/ --delete (baseline)" "rsync -a
 # XRS2 — `grep "rsync --delete" notes.md` → no match
 assert_destruct_nomatch "XRS2" "grep \"rsync --delete\" notes.md" "grep \"rsync --delete\" notes.md" "rsync" '^--delete$'
 
+# ─── Interpreter-stdin re-injection (#772) ───
+# The here-string / heredoc-to-INTERPRETER bypass closure is hook-body
+# logic (extract_interp_stdin_body in block-unsafe-generic.sh), not a
+# git-tokenwalk.sh classifier helper — so it is exercised end-to-end by
+# piping a real PreToolUse envelope through the hook and asserting the
+# deny/allow decision. This proves the interpreter-stdin body actually
+# reaches the tokenize-walk scanners above (it is appended as a
+# `;`-segment) while DATA heredocs stay inert. `<<<` was previously
+# untested in this file (issue #772).
+HOOK_BIN="$SCRIPT_DIR/../hooks/block-unsafe-generic.sh"
+
+# Wrap a raw command string as a JSON value. We escape only `"` — the
+# heredoc cases embed a literal two-char `\n` (backslash + n) which is
+# exactly the wire form a real envelope carries (Claude Code JSON-encodes
+# a real newline as `\n`, and this hook does NOT JSON-decode, so $COMMAND
+# keeps the backslash-n). Escaping the backslash here would corrupt that
+# to `\\n` and the heredoc body regex would not match.
+_json_quote() { printf '%s' "$1" | sed 's/"/\\"/g; s/^/"/; s/$/"/'; }
+
+assert_hook_deny() {
+  local id="$1" desc="$2" cmd="$3" out
+  out=$(printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(_json_quote "$cmd")" | bash "$HOOK_BIN")
+  if [[ "$out" == *'"permissionDecision":"deny"'* ]]; then
+    echo "PASS $id — $desc"; PASS=$((PASS + 1))
+  else
+    echo "FAIL $id — $desc (expected deny, got: $out) cmd=[$cmd]"; FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_hook_allow() {
+  local id="$1" desc="$2" cmd="$3" out
+  out=$(printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(_json_quote "$cmd")" | bash "$HOOK_BIN")
+  if [[ -z "$out" ]]; then
+    echo "PASS $id — $desc"; PASS=$((PASS + 1))
+  else
+    echo "FAIL $id — $desc (expected allow, got: $out) cmd=[$cmd]"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# DENY: interpreter reads stdin as a script → body is executed code.
+assert_hook_deny "HS1" 'bash <<<"git clean -fdx" (here-string to bash)' 'bash <<<"git clean -fdx"'
+assert_hook_deny "HS2" "bash <<<'git clean -fdx' (single-quoted body)"  "bash <<<'git clean -fdx'"
+assert_hook_deny "HS3" 'sh <<<"git reset --hard HEAD~5"'                'sh <<<"git reset --hard HEAD~5"'
+assert_hook_deny "HS4" 'zsh <<<"git checkout -- ." (zsh here-string)'   'zsh <<<"git checkout -- ."'
+assert_hook_deny "HS5" 'bash -s <<<"git clean -fdx" (-s flag)'          'bash -s <<<"git clean -fdx"'
+assert_hook_deny "HS6" 'bash <<<"kill -9 1234" (destruct verb)'         'bash <<<"kill -9 1234"'
+# heredoc-to-interpreter (printf supplies literal two-char \n separators).
+assert_hook_deny "HD1" 'bash heredoc -> git clean -fdx' 'bash <<EOF\ngit clean -fdx\nEOF'
+assert_hook_deny "HD2" 'sh heredoc -> rm -rf /etc'      'sh <<EOF\nrm -rf /etc\nEOF'
+
+# ALLOW: body is DATA, not code → must stay inert (no false-positive).
+assert_hook_allow "HSA1" 'cat <<EOF data heredoc w/ git clean -f prose'        'cat <<EOF\ngit clean -fdx danger\nEOF'
+assert_hook_allow "HSA2" 'echo <<<"git clean -fdx" (echo is not interpreter)'  'echo <<<"git clean -fdx"'
+assert_hook_allow "HSA3" 'gh pr create --body-file=- heredoc w/ banned prose'  'gh pr create --body-file=- <<EOF\nnote: git clean -f purges\nEOF'
+assert_hook_allow "HSA4" 'bash script.sh <<<data (here-string is DATA for script)' 'bash script.sh <<<"git clean -fdx"'
+assert_hook_allow "HSA5" 'bash run.sh <<EOF (heredoc is DATA for script)'      'bash run.sh <<EOF\nrm -rf /etc\nEOF'
+assert_hook_allow "HSA6" 'bash <<<"echo git clean -fdx" (interpreter runs benign echo)' 'bash <<<"echo git clean -fdx"'
+
 # ─── Summary ───
 echo ""
 echo "Total: PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
## Summary
Close the here-string / heredoc-to-interpreter destructive-op bypass in `block-unsafe-generic.sh` (sibling of the `bash -c`/`eval`/`sh -c` bypass closed by #399/#597).

- The hook's Pass-1 strips heredoc/here-string bodies as inert — correct for DATA heredocs (`cat <<EOF`, `gh --body-file`, echo content), but `bash <<<"git clean -fdx"` *executes* the body, so destructive ops leaked past the deny scan.
- Fix: `extract_interp_stdin_body` re-injects the body as a scanned command **only** when the segment head is a whole-word interpreter (`bash|sh|zsh|dash|ash|ksh`) with flags-only before the `<<<`/`<<DELIM` operator (no script-file positional). Data heredocs and `bash script.sh <<<data` stay inert — no false-positives.
- Tests: +17 in `test-hooks.sh` (10 DENY + 7 ALLOW), +14 in `test-tokenize-then-walk.sh` (8 DENY + 6 ALLOW). `<<<` was previously untested in both.

Closes #772

## Test plan
- [x] Bypass empirically closed: `bash/sh/zsh/dash/ksh <<<"<destructive>"`, `bash -s`, cd-chain, `bash <<EOF…EOF` all DENY
- [x] No false-positives: `cat <<EOF`, `gh --body-file` heredoc, `bash script.sh <<<data`, `git status` all ALLOW
- [x] Pre-fix hook confirmed the bug (ALLOW pre-fix → DENY post-fix)
- [x] Source + `.claude/` mirror byte-identical
- [x] Full suite: 6090/6090 passed, 0 failed; verified by fresh verifier agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
