### PR TITLE
fix(dashboard): display landed status full as LANDED in Branches pill (#776)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+6f6085"
+  version: "2026.05.28+c2690a"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1412,7 +1412,10 @@ function buildBranchCard(b, byBranch) {
     var wtRow = el("div", { cls: "card-row card-worktree-row" });
     wtRow.appendChild(el("span", {
       cls: "pill " + landedPillClass(status),
-      text: status,
+      // Display-only: `full` (cherry-pick landing) and `landed` (PR landing)
+      // both mean "everything is on main"; show "LANDED" for both. Stored
+      // marker status and landedPillClass color mapping are unchanged. (#776)
+      text: status === "full" ? "landed" : status,
     }));
     if (w.path) {
       wtRow.appendChild(el("span", { cls: "mono card-sub", text: basename(w.path) }));

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+6f6085"
+  version: "2026.05.28+c2690a"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1412,7 +1412,10 @@ function buildBranchCard(b, byBranch) {
     var wtRow = el("div", { cls: "card-row card-worktree-row" });
     wtRow.appendChild(el("span", {
       cls: "pill " + landedPillClass(status),
-      text: status,
+      // Display-only: `full` (cherry-pick landing) and `landed` (PR landing)
+      // both mean "everything is on main"; show "LANDED" for both. Stored
+      // marker status and landedPillClass color mapping are unchanged. (#776)
+      text: status === "full" ? "landed" : status,
     }));
     if (w.path) {
       wtRow.appendChild(el("span", { cls: "mono card-sub", text: basename(w.path) }));

--- a/tests/test-landed-status-vocabulary.sh
+++ b/tests/test-landed-status-vocabulary.sh
@@ -130,6 +130,51 @@ for status in "${WRITER_STATUSES[@]}"; do
   fi
 done
 
+# ---------------------------------------------------------------------
+# Part D: display normalization (issue #776).
+# `full` (cherry-pick landing) and `landed` (PR landing) both mean
+# "everything is on main"; the dashboard Branches pill must DISPLAY `full`
+# as "LANDED" so it reads the same. This is purely the human-readable label
+# — the STORED `.landed` status stays `full`, and the matching/color logic
+# (landedPillClass mapping `full` and `landed` to the same class) is
+# unchanged. `partial` is a distinct state and must NOT be collapsed.
+# ---------------------------------------------------------------------
+echo ""
+echo "--- Part D: display normalization (issue #776) ---"
+
+APP_JS="$REPO_ROOT/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js"
+
+if [[ ! -f "$APP_JS" ]]; then
+  fail "missing dashboard file: $APP_JS"
+else
+  APP_JS_BODY=$(cat "$APP_JS")
+
+  # D1: the worktree-row pill renders stored `full` as `landed` text.
+  if echo "$APP_JS_BODY" | grep -qE 'status === "full" \? "landed" : status'; then
+    pass "app.js displays stored 'full' as 'landed' text (#776)"
+  else
+    fail "app.js display gap: 'full' not normalized to 'landed' display text (#776)"
+  fi
+
+  # D2: STORED vocabulary preserved — landedPillClass still recognizes BOTH
+  # `full` and `landed` (same green class). The color/matching logic is
+  # explicitly out of scope for the display-only change.
+  if echo "$APP_JS_BODY" | grep -qE 's === "full" \|\| s === "landed"'; then
+    pass "app.js landedPillClass still maps 'full' AND 'landed' to the same class (matching logic unchanged)"
+  else
+    fail "app.js regression: landedPillClass no longer maps both 'full' and 'landed' (matching logic must be unchanged) (#776)"
+  fi
+
+  # D3: `partial` is NOT collapsed by the display normalization — it keeps
+  # its own label and its own class.
+  if echo "$APP_JS_BODY" | grep -qE 'text: status === "full" \? "landed" : status' \
+     && ! echo "$APP_JS_BODY" | grep -qE 'text: status === "partial"'; then
+    pass "app.js does not collapse 'partial' — it keeps its own PARTIAL label (#776)"
+  else
+    fail "app.js regression: 'partial' display label appears collapsed (#776)"
+  fi
+fi
+
 echo ""
 echo "---"
 printf 'Results: %d passed, %d failed (of %d)\n' \

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -2021,6 +2021,25 @@ else
   fail "branches: buildBranchCard missing protected-shield rendering: got '$BRANCHCARD_BODY'"
 fi
 
+# Issue #776 — display normalization: the worktree-row landed pill renders
+# stored `full` (cherry-pick landing) as "LANDED" text, so it reads the same
+# as the PR-flow `landed`. This is DISPLAY-ONLY — landedPillClass color
+# mapping and the stored marker status are unchanged. `partial` keeps its own
+# label and must NOT be collapsed.
+if echo "$BRANCHCARD_BODY" | grep -qE 'status === "full" \? "landed" : status'; then
+  pass "branches: landed pill displays stored 'full' as 'landed' text (#776)"
+else
+  fail "branches: buildBranchCard does not normalize 'full' -> 'landed' display text (#776): got '$BRANCHCARD_BODY'"
+fi
+# Guard: the display normalization must NOT collapse `partial` into landed —
+# `partial` is a distinct state that keeps its own label (rendered uppercase
+# as PARTIAL via the .pill text-transform).
+if echo "$BRANCHCARD_BODY" | grep -qE '=== "partial"'; then
+  fail "branches: display logic must not special-case 'partial' (it keeps its own label) (#776): got '$BRANCHCARD_BODY'"
+else
+  pass "branches: 'partial' is not collapsed by the display normalization — keeps PARTIAL label (#776)"
+fi
+
 # Stop server cleanly via SIGTERM and verify port is released.
 kill -TERM "$SERVER_PID" 2>/dev/null || true
 for _ in 1 2 3 4 5 6 7 8 9 10; do


### PR DESCRIPTION
## Summary

On the dashboard Branches tab, a fully-landed branch's pill read **FULL** (cherry-pick landing, `.landed status: full`) or **LANDED** (PR landing, `status: landed`) — same meaning, same green color, confusingly different label. This renders `full` as **LANDED** in user-facing text only.

## Change (display only)

- `app.js` `buildBranchCard` worktree-row pill: `text: status === "full" ? "landed" : status` (the `.pill` CSS uppercases it → "LANDED"). Color mapping (`landedPillClass`, which maps both `full`+`landed` to the same class) is unchanged. Mirrored to `.claude/`.
- `fix-report` left as-is (raw-marker diagnostic — intentionally shows the actual stored `status: full`; normalizing there would hide real state).

## Non-goals (unchanged)

- Stored `.landed` marker stays `status: full` for cherry-pick landing (writers untouched).
- Matching/categorization logic that keys off `full` (fix-report safe-to-remove, update-zskills landed check, briefing.py grouping, `landedPillClass` color) — all unchanged.
- `full` vs `partial` stays distinct — `partial` still displays **PARTIAL** with its own color.

## Test plan

- [x] `bash tests/run-all.sh` → 6095/6095 (pre-rebase); post-rebase onto #777: `test_zskills_monitor_dashboard_ui.sh` 232/232, `test-landed-status-vocabulary.sh` 36/36
- [x] Added assertions: `full`→"LANDED" display; `landedPillClass` still maps both; `partial` NOT collapsed; stored `status: full` unchanged
- [x] Mirror diff clean; version bumped

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)
