### PR TITLE
fix(dashboard): slow background poll while hidden instead of freezing (closes #778)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+c2690a"
+  version: "2026.05.28+e782e5"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1,8 +1,9 @@
 // Z Skills Dashboard — interactive dashboard renderer (Phase 7).
 //
 // Loaded as a single ES module from /app.js. Polls /api/state every 2s
-// via setTimeout recursion (NOT setInterval), pauses while document is
-// hidden, and force-loads on visibilitychange. Per-panel diff detection
+// via setTimeout recursion (NOT setInterval), slows to a ~60s heartbeat
+// while document is hidden (HIDDEN_POLL_INTERVAL_MS) rather than stopping,
+// and force-loads on visibilitychange. Per-panel diff detection
 // so unchanged panels are not re-rendered. All user-authored content
 // rendered via textContent / appendChild — no innerHTML except for
 // hardcoded chrome marked `// chrome-only`.
@@ -13,6 +14,18 @@
 // and POSTs to /api/trigger and /api/work-state/reset.
 
 const POLL_INTERVAL_MS = 2000;
+// While the tab is hidden we keep polling, just much more slowly. The
+// collector maintains a ~60s server-side snapshot cache, so a 60s hidden
+// poll mostly hits warm cache instead of re-shelling git/gh. This keeps the
+// open tab reasonably fresh (returning is near-instant) without paying the
+// 2s-cadence collection cost while nobody is watching. Tunable.
+const HIDDEN_POLL_INTERVAL_MS = 60000;
+// Reschedule delay for the recursive poll loops: fast when visible, slow
+// heartbeat when hidden. The loop is NEVER torn down — see pollOnce /
+// pollWorkOnce, which reschedule via this on every tick.
+function nextPollDelay() {
+  return document.hidden ? HIDDEN_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+}
 const STATE_URL = "/api/state";
 const WORK_STATE_URL = "/api/work-state";
 const QUEUE_URL = "/api/queue";
@@ -499,15 +512,12 @@ function scheduleWorkPoll(delay) {
 }
 
 async function pollOnce() {
-  if (document.hidden) {
-    pollTimer = null;
-    return;
-  }
   // Reconciliation: skip a single state poll right after a successful
   // POST, so a GET in flight before the POST lands cannot flash stale
-  // data over the user's just-applied reorder.
+  // data over the user's just-applied reorder. Still reschedule (at the
+  // current cadence) — never tear the loop down.
   if (Date.now() < suppressNextStatePollUntil) {
-    schedulePoll(POLL_INTERVAL_MS);
+    schedulePoll(nextPollDelay());
     return;
   }
   const snap = await fetchState();
@@ -515,20 +525,20 @@ async function pollOnce() {
     lastSnapshot = snap;
     applySnapshot(snap);
   }
-  schedulePoll(POLL_INTERVAL_MS);
+  // Slow heartbeat while hidden (HIDDEN_POLL_INTERVAL_MS), fast when
+  // visible (POLL_INTERVAL_MS). The loop is never stopped.
+  schedulePoll(nextPollDelay());
 }
 
 async function pollWorkOnce() {
-  if (document.hidden) {
-    workPollTimer = null;
-    return;
-  }
   const ws = await fetchWorkState();
   if (ws) {
     lastWorkState = ws;
     applyWorkState(ws);
   }
-  scheduleWorkPoll(POLL_INTERVAL_MS);
+  // Slow heartbeat while hidden (HIDDEN_POLL_INTERVAL_MS), fast when
+  // visible (POLL_INTERVAL_MS). The loop is never stopped.
+  scheduleWorkPoll(nextPollDelay());
 }
 
 function applySnapshot(snap) {

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+c2690a"
+  version: "2026.05.28+e782e5"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1,8 +1,9 @@
 // Z Skills Dashboard — interactive dashboard renderer (Phase 7).
 //
 // Loaded as a single ES module from /app.js. Polls /api/state every 2s
-// via setTimeout recursion (NOT setInterval), pauses while document is
-// hidden, and force-loads on visibilitychange. Per-panel diff detection
+// via setTimeout recursion (NOT setInterval), slows to a ~60s heartbeat
+// while document is hidden (HIDDEN_POLL_INTERVAL_MS) rather than stopping,
+// and force-loads on visibilitychange. Per-panel diff detection
 // so unchanged panels are not re-rendered. All user-authored content
 // rendered via textContent / appendChild — no innerHTML except for
 // hardcoded chrome marked `// chrome-only`.
@@ -13,6 +14,18 @@
 // and POSTs to /api/trigger and /api/work-state/reset.
 
 const POLL_INTERVAL_MS = 2000;
+// While the tab is hidden we keep polling, just much more slowly. The
+// collector maintains a ~60s server-side snapshot cache, so a 60s hidden
+// poll mostly hits warm cache instead of re-shelling git/gh. This keeps the
+// open tab reasonably fresh (returning is near-instant) without paying the
+// 2s-cadence collection cost while nobody is watching. Tunable.
+const HIDDEN_POLL_INTERVAL_MS = 60000;
+// Reschedule delay for the recursive poll loops: fast when visible, slow
+// heartbeat when hidden. The loop is NEVER torn down — see pollOnce /
+// pollWorkOnce, which reschedule via this on every tick.
+function nextPollDelay() {
+  return document.hidden ? HIDDEN_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+}
 const STATE_URL = "/api/state";
 const WORK_STATE_URL = "/api/work-state";
 const QUEUE_URL = "/api/queue";
@@ -499,15 +512,12 @@ function scheduleWorkPoll(delay) {
 }
 
 async function pollOnce() {
-  if (document.hidden) {
-    pollTimer = null;
-    return;
-  }
   // Reconciliation: skip a single state poll right after a successful
   // POST, so a GET in flight before the POST lands cannot flash stale
-  // data over the user's just-applied reorder.
+  // data over the user's just-applied reorder. Still reschedule (at the
+  // current cadence) — never tear the loop down.
   if (Date.now() < suppressNextStatePollUntil) {
-    schedulePoll(POLL_INTERVAL_MS);
+    schedulePoll(nextPollDelay());
     return;
   }
   const snap = await fetchState();
@@ -515,20 +525,20 @@ async function pollOnce() {
     lastSnapshot = snap;
     applySnapshot(snap);
   }
-  schedulePoll(POLL_INTERVAL_MS);
+  // Slow heartbeat while hidden (HIDDEN_POLL_INTERVAL_MS), fast when
+  // visible (POLL_INTERVAL_MS). The loop is never stopped.
+  schedulePoll(nextPollDelay());
 }
 
 async function pollWorkOnce() {
-  if (document.hidden) {
-    workPollTimer = null;
-    return;
-  }
   const ws = await fetchWorkState();
   if (ws) {
     lastWorkState = ws;
     applyWorkState(ws);
   }
-  scheduleWorkPoll(POLL_INTERVAL_MS);
+  // Slow heartbeat while hidden (HIDDEN_POLL_INTERVAL_MS), fast when
+  // visible (POLL_INTERVAL_MS). The loop is never stopped.
+  scheduleWorkPoll(nextPollDelay());
 }
 
 function applySnapshot(snap) {

--- a/tests/test_zskills_monitor_dashboard_ui.sh
+++ b/tests/test_zskills_monitor_dashboard_ui.sh
@@ -116,6 +116,59 @@ else
   fail "AC: missing visibilitychange handler"
 fi
 
+# AC (#778): visibilitychange still force-refreshes both loops on focus.
+if grep -A4 'addEventListener("visibilitychange"' "$APP_JS" | grep -q 'schedulePoll(0)' \
+  && grep -A4 'addEventListener("visibilitychange"' "$APP_JS" | grep -q 'scheduleWorkPoll(0)'; then
+  pass "AC #778: focus triggers immediate schedulePoll(0)+scheduleWorkPoll(0)"
+else
+  fail "AC #778: visibilitychange must force-refresh both loops on focus"
+fi
+
+# AC (#778): slow background poll while hidden — named hidden interval ≈ 60s.
+if grep -qE 'HIDDEN_POLL_INTERVAL_MS\s*=\s*60000' "$APP_JS"; then
+  pass "AC #778: HIDDEN_POLL_INTERVAL_MS = 60000 (slow hidden heartbeat)"
+else
+  fail "AC #778: missing HIDDEN_POLL_INTERVAL_MS = 60000"
+fi
+
+# AC (#778): reschedule delay is driven by document.hidden — visible→2s,
+# hidden→60s. The shared helper returns HIDDEN_POLL_INTERVAL_MS when hidden
+# and POLL_INTERVAL_MS otherwise.
+if grep -qE 'document\.hidden\s*\?\s*HIDDEN_POLL_INTERVAL_MS\s*:\s*POLL_INTERVAL_MS' "$APP_JS"; then
+  pass "AC #778: poll delay driven by document.hidden (hidden→60s, visible→2s)"
+else
+  fail "AC #778: poll delay must branch on document.hidden (hidden→HIDDEN_POLL_INTERVAL_MS, visible→POLL_INTERVAL_MS)"
+fi
+
+# AC (#778) REGRESSION GUARD: the old hard-stop teardown is GONE. Pre-fix
+# both pollOnce and pollWorkOnce did `if (document.hidden) { pollTimer =
+# null; return; }` / `workPollTimer = null; return;` which killed the loop
+# while hidden. Assert neither nulling-then-returning teardown remains.
+if grep -Pzoq 'pollTimer\s*=\s*null;\s*\n\s*return;' "$APP_JS"; then
+  fail "AC #778: pollOnce still tears down the loop (pollTimer = null; return;) when hidden"
+else
+  pass "AC #778: pollOnce hidden-teardown removed (loop not killed when hidden)"
+fi
+if grep -Pzoq 'workPollTimer\s*=\s*null;\s*\n\s*return;' "$APP_JS"; then
+  fail "AC #778: pollWorkOnce still tears down the loop (workPollTimer = null; return;) when hidden"
+else
+  pass "AC #778: pollWorkOnce hidden-teardown removed (loop not killed when hidden)"
+fi
+
+# AC (#778): BOTH loops reschedule via the hidden-aware delay. pollOnce must
+# call schedulePoll(nextPollDelay()) and pollWorkOnce scheduleWorkPoll(
+# nextPollDelay()) so each keeps ticking (slowly) while hidden.
+if grep -qE 'schedulePoll\(\s*nextPollDelay\(\)\s*\)' "$APP_JS"; then
+  pass "AC #778: pollOnce reschedules via schedulePoll(nextPollDelay())"
+else
+  fail "AC #778: pollOnce must reschedule via schedulePoll(nextPollDelay())"
+fi
+if grep -qE 'scheduleWorkPoll\(\s*nextPollDelay\(\)\s*\)' "$APP_JS"; then
+  pass "AC #778: pollWorkOnce reschedules via scheduleWorkPoll(nextPollDelay())"
+else
+  fail "AC #778: pollWorkOnce must reschedule via scheduleWorkPoll(nextPollDelay())"
+fi
+
 # AC: Esc handler present.
 if grep -qE '"Escape"' "$APP_JS"; then
   pass "AC: Escape key handler present"


### PR DESCRIPTION
## Summary
Dashboard poll loops hard-stopped when the browser tab was hidden (`if (document.hidden) { pollTimer = null; return; }`), so an open tab went arbitrarily stale and made you wait for a fetch on focus.

- Replace the teardown with a **slow heartbeat**: `HIDDEN_POLL_INTERVAL_MS = 60000` (hidden) vs `POLL_INTERVAL_MS = 2000` (visible), via a `nextPollDelay()` helper. Applied to BOTH `pollOnce` (state) and `pollWorkOnce` (work-state) loops — the loop is never torn down while hidden.
- Preserves the `suppressNextStatePollUntil` post-POST guard, `DISCONNECT_FAILURE_THRESHOLD`, and the `visibilitychange → schedulePoll(0)` focus refresh (hits the ~60s server-side snapshot cache → near-instant catch-up).

Closes #778

## Test plan
- [x] Both loops reschedule (no teardown) when hidden; interval driven by `document.hidden` (2s visible / 60s hidden)
- [x] Regression guards assert the old `pollTimer = null; return;` teardown is gone from both loops
- [x] New assertions fail against pre-fix code (genuinely exercise the fix)
- [x] Source + `.claude/` mirror byte-identical; `zskills-dashboard` skill version bumped
- [x] Full suite green (the one AC-7 plans failure is a pre-existing stale-local-cache artifact, CI-clean — confirmed regenerates+passes on fresh checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
