### PR TITLE
feat(dashboard): live phase progress on in-flight plan cards

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+e782e5"
+  version: "2026.05.28+6a6b57"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -2158,19 +2158,36 @@ _CLAIM_DIR_RE = re.compile(r"^issue-(\d+)$")
 _PLAN_CLAIM_DIR_RE = re.compile(r"^plan-(.+)$")
 
 
-def _derive_pipeline_short(pipeline_id: str) -> str:
-    """Derive a short, sprint-distinguishing label from a pipeline id.
+def _derive_pipeline_short(pipeline_id: str, maxlen: int = 28) -> str:
+    """Derive a short, human-meaningful label from a pipeline id.
 
-    DA4 lock — `"fix-issues.sprint-20260521-010731-foo"` yields
-    `"010731-foo"` (the time+slug tail), NOT the useless `"sprint-2"`
-    that a naive 8-char prefix slice would produce for every concurrent
-    sprint.
+    The leading pipeline-type prefix (`run-plan.`, `fix-issues.`, `do.`)
+    is dropped first via rsplit on `.`.
+
+    Sprint ids — `"fix-issues.sprint-20260521-010731-foo"` — yield
+    `"010731-foo"` (the time+slug tail), NOT the useless `"sprint-2"` an
+    8-char prefix slice would give, NOR the garbage an 8-char SUFFIX slice
+    gives. The sprint branch is gated on the real sprint shape
+    (`sprint-<digits>-<digits>-...`) — NOT a bare `len(parts) >= 4` count,
+    which mis-fired on multi-hyphen plan slugs (e.g.
+    `dashboard-tabs-and-rename-5a-diagnosis` -> "and-rename").
+
+    Everything else (plan slugs like `plugin-distribution`) shows the WHOLE
+    slug, front-truncated with an ellipsis only when it exceeds `maxlen`.
+    The old `[-8:]` suffix slice butchered `plugin-distribution` -> "ribution".
     """
-    sprint_id_tail = pipeline_id.rsplit(".", 1)[-1]
-    parts = sprint_id_tail.split("-")
-    if len(parts) >= 4:
-        return "-".join(parts[2:4])
-    return sprint_id_tail[-8:]
+    tail = pipeline_id.rsplit(".", 1)[-1]
+    parts = tail.split("-")
+    is_sprint = (
+        len(parts) >= 4
+        and parts[0] == "sprint"
+        and parts[1].isdigit()
+        and parts[2].isdigit()
+    )
+    short = "-".join(parts[2:4]) if is_sprint else tail
+    if len(short) > maxlen:
+        short = short[: maxlen - 1] + "…"
+    return short
 
 
 def _read_claims(main_root: pathlib.Path) -> Dict[int, Dict[str, Any]]:

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -963,13 +963,24 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   }
 
   if (plan) {
+    // Phase progress. Prefer the live claim's current_phase when the plan
+    // is claimed (in-flight). For main_protected PR-mode /run-plan the plan
+    // tracker on main shows ~0-1 done for the ENTIRE run (all phases land in
+    // one PR at the end), so phases_done is structurally stale the whole
+    // time work is in flight. The claim's current_phase is the live truth.
+    // Fall back to phases_done for unclaimed plans (direct mode, or work
+    // already landed to main).
+    const total = plan.phase_count || 0;
+    let done = plan.phases_done || 0;
+    if (plan.claim && typeof plan.claim.current_phase === "string") {
+      const cm = plan.claim.current_phase.match(/Phase\s+(\d+)/i);
+      if (cm) done = parseInt(cm[1], 10);
+    }
     const meta = el("div", { cls: "card-row card-sub" });
-    const ratio = (plan.phases_done || 0) + " / " + (plan.phase_count || 0) + " phases";
+    const ratio = done + " / " + total + " phases";
     meta.appendChild(el("span", { text: ratio }));
     card.appendChild(meta);
 
-    const total = plan.phase_count || 0;
-    const done = plan.phases_done || 0;
     if (total > 0) {
       const bar = el("div", { cls: "progress" });
       const fill = el("div", { cls: "progress-fill" });
@@ -981,13 +992,18 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   }
 
   // Claim chip (run-plan claim — plans/plans-claim-chip-parity.md Phase 3).
-  // Mirrors buildIssueCard's chip with three plan-context differences:
-  //   1. Chip text adds a phase fragment: "phase N/M" parsed from
-  //      claim.current_phase ("Phase 3" → N=3); falls back to "phase ?/M"
-  //      for unparseable section-name headers (e.g. "Parse plan").
+  // The chip is the liveness/activity indicator: "working on phase N ·
+  // <slug> · <age>". The N/M progress framing lives on the bar above (which
+  // is driven from this same claim.current_phase when claimed), so the chip
+  // drops the redundant "/M" denominator. Notes:
+  //   1. Phase fragment: "working on phase N" parsed from current_phase
+  //      ("Phase 3" → N=3). Non-numeric section headers (e.g. "Parse plan")
+  //      show "working on <header>" verbatim; absent → bare "in-flight".
   //   2. Age string is derived from started_at (post-#684 cleanup
   //      removed last_heartbeat_at as a duplicate of started_at).
-  //   3. data-kind="plan" is already encoded; the aria-disabled +
+  //   3. The .claim-chip--in-flight class is retained — the collapsed-column
+  //      footer badges aggregate by that class, not the visible text.
+  //   4. data-kind="plan" is already encoded; the aria-disabled +
   //      removeAttribute("draggable") block is identical to the issue
   //      side and is honored by moveAllInColumn (kind-generic) and the
   //      plan-up/down/left/right/plan-discard guard in handleAction.
@@ -997,16 +1013,12 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     const rt = startedAt ? relativeTime(startedAt) : "";
     const ageStr = rt || "?";
     const pidShort = c.pipeline_short || "?";
-    // Parse "Phase N" from current_phase. Section-name headers like
-    // "Parse plan" or "Post-landing tracking" yield NaN → fallback "?".
-    let curN = "?";
     const cp = c.current_phase;
+    let phaseFragment = "in-flight";
     if (typeof cp === "string" && cp) {
       const m = cp.match(/Phase\s+(\d+)/i);
-      if (m) curN = m[1];
+      phaseFragment = m ? "working on phase " + m[1] : "working on " + cp;
     }
-    const totalPhases = (plan.phase_count != null) ? plan.phase_count : "?";
-    const phaseStr = "phase " + curN + "/" + totalPhases;
     const tip = c.pipeline_id
       ? "claim pipeline=" + c.pipeline_id +
         " started=" + (c.started_at || "?") +
@@ -1016,7 +1028,7 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     row.appendChild(el("span", {
       cls: "claim-chip claim-chip--in-flight",
       attrs: { title: tip },
-      text: "in-flight · " + pidShort + " · " + phaseStr + " · " + ageStr,
+      text: phaseFragment + " · " + pidShort + " · " + ageStr,
     }));
     card.appendChild(row);
     card.setAttribute("aria-disabled", "true");

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.28+e782e5"
+  version: "2026.05.28+6a6b57"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -2158,19 +2158,36 @@ _CLAIM_DIR_RE = re.compile(r"^issue-(\d+)$")
 _PLAN_CLAIM_DIR_RE = re.compile(r"^plan-(.+)$")
 
 
-def _derive_pipeline_short(pipeline_id: str) -> str:
-    """Derive a short, sprint-distinguishing label from a pipeline id.
+def _derive_pipeline_short(pipeline_id: str, maxlen: int = 28) -> str:
+    """Derive a short, human-meaningful label from a pipeline id.
 
-    DA4 lock — `"fix-issues.sprint-20260521-010731-foo"` yields
-    `"010731-foo"` (the time+slug tail), NOT the useless `"sprint-2"`
-    that a naive 8-char prefix slice would produce for every concurrent
-    sprint.
+    The leading pipeline-type prefix (`run-plan.`, `fix-issues.`, `do.`)
+    is dropped first via rsplit on `.`.
+
+    Sprint ids — `"fix-issues.sprint-20260521-010731-foo"` — yield
+    `"010731-foo"` (the time+slug tail), NOT the useless `"sprint-2"` an
+    8-char prefix slice would give, NOR the garbage an 8-char SUFFIX slice
+    gives. The sprint branch is gated on the real sprint shape
+    (`sprint-<digits>-<digits>-...`) — NOT a bare `len(parts) >= 4` count,
+    which mis-fired on multi-hyphen plan slugs (e.g.
+    `dashboard-tabs-and-rename-5a-diagnosis` -> "and-rename").
+
+    Everything else (plan slugs like `plugin-distribution`) shows the WHOLE
+    slug, front-truncated with an ellipsis only when it exceeds `maxlen`.
+    The old `[-8:]` suffix slice butchered `plugin-distribution` -> "ribution".
     """
-    sprint_id_tail = pipeline_id.rsplit(".", 1)[-1]
-    parts = sprint_id_tail.split("-")
-    if len(parts) >= 4:
-        return "-".join(parts[2:4])
-    return sprint_id_tail[-8:]
+    tail = pipeline_id.rsplit(".", 1)[-1]
+    parts = tail.split("-")
+    is_sprint = (
+        len(parts) >= 4
+        and parts[0] == "sprint"
+        and parts[1].isdigit()
+        and parts[2].isdigit()
+    )
+    short = "-".join(parts[2:4]) if is_sprint else tail
+    if len(short) > maxlen:
+        short = short[: maxlen - 1] + "…"
+    return short
 
 
 def _read_claims(main_root: pathlib.Path) -> Dict[int, Dict[str, Any]]:

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -963,13 +963,24 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   }
 
   if (plan) {
+    // Phase progress. Prefer the live claim's current_phase when the plan
+    // is claimed (in-flight). For main_protected PR-mode /run-plan the plan
+    // tracker on main shows ~0-1 done for the ENTIRE run (all phases land in
+    // one PR at the end), so phases_done is structurally stale the whole
+    // time work is in flight. The claim's current_phase is the live truth.
+    // Fall back to phases_done for unclaimed plans (direct mode, or work
+    // already landed to main).
+    const total = plan.phase_count || 0;
+    let done = plan.phases_done || 0;
+    if (plan.claim && typeof plan.claim.current_phase === "string") {
+      const cm = plan.claim.current_phase.match(/Phase\s+(\d+)/i);
+      if (cm) done = parseInt(cm[1], 10);
+    }
     const meta = el("div", { cls: "card-row card-sub" });
-    const ratio = (plan.phases_done || 0) + " / " + (plan.phase_count || 0) + " phases";
+    const ratio = done + " / " + total + " phases";
     meta.appendChild(el("span", { text: ratio }));
     card.appendChild(meta);
 
-    const total = plan.phase_count || 0;
-    const done = plan.phases_done || 0;
     if (total > 0) {
       const bar = el("div", { cls: "progress" });
       const fill = el("div", { cls: "progress-fill" });
@@ -981,13 +992,18 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   }
 
   // Claim chip (run-plan claim — plans/plans-claim-chip-parity.md Phase 3).
-  // Mirrors buildIssueCard's chip with three plan-context differences:
-  //   1. Chip text adds a phase fragment: "phase N/M" parsed from
-  //      claim.current_phase ("Phase 3" → N=3); falls back to "phase ?/M"
-  //      for unparseable section-name headers (e.g. "Parse plan").
+  // The chip is the liveness/activity indicator: "working on phase N ·
+  // <slug> · <age>". The N/M progress framing lives on the bar above (which
+  // is driven from this same claim.current_phase when claimed), so the chip
+  // drops the redundant "/M" denominator. Notes:
+  //   1. Phase fragment: "working on phase N" parsed from current_phase
+  //      ("Phase 3" → N=3). Non-numeric section headers (e.g. "Parse plan")
+  //      show "working on <header>" verbatim; absent → bare "in-flight".
   //   2. Age string is derived from started_at (post-#684 cleanup
   //      removed last_heartbeat_at as a duplicate of started_at).
-  //   3. data-kind="plan" is already encoded; the aria-disabled +
+  //   3. The .claim-chip--in-flight class is retained — the collapsed-column
+  //      footer badges aggregate by that class, not the visible text.
+  //   4. data-kind="plan" is already encoded; the aria-disabled +
   //      removeAttribute("draggable") block is identical to the issue
   //      side and is honored by moveAllInColumn (kind-generic) and the
   //      plan-up/down/left/right/plan-discard guard in handleAction.
@@ -997,16 +1013,12 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     const rt = startedAt ? relativeTime(startedAt) : "";
     const ageStr = rt || "?";
     const pidShort = c.pipeline_short || "?";
-    // Parse "Phase N" from current_phase. Section-name headers like
-    // "Parse plan" or "Post-landing tracking" yield NaN → fallback "?".
-    let curN = "?";
     const cp = c.current_phase;
+    let phaseFragment = "in-flight";
     if (typeof cp === "string" && cp) {
       const m = cp.match(/Phase\s+(\d+)/i);
-      if (m) curN = m[1];
+      phaseFragment = m ? "working on phase " + m[1] : "working on " + cp;
     }
-    const totalPhases = (plan.phase_count != null) ? plan.phase_count : "?";
-    const phaseStr = "phase " + curN + "/" + totalPhases;
     const tip = c.pipeline_id
       ? "claim pipeline=" + c.pipeline_id +
         " started=" + (c.started_at || "?") +
@@ -1016,7 +1028,7 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     row.appendChild(el("span", {
       cls: "claim-chip claim-chip--in-flight",
       attrs: { title: tip },
-      text: "in-flight · " + pidShort + " · " + phaseStr + " · " + ageStr,
+      text: phaseFragment + " · " + pidShort + " · " + ageStr,
     }));
     card.appendChild(row);
     card.setAttribute("aria-disabled", "true");

--- a/tests/test-plan-claim-collector.py
+++ b/tests/test-plan-claim-collector.py
@@ -265,5 +265,64 @@ class AnnotatePlansQueueGatingTests(unittest.TestCase):
         self.assertNotIn("claim", plans[1])
 
 
+class DerivePipelineShortTests(unittest.TestCase):
+    """_derive_pipeline_short: human-meaningful short label from a pipeline id.
+
+    Regression coverage for the bug where `run-plan.plugin-distribution`
+    rendered as "ribution" (blind [-8:] suffix slice) and multi-hyphen plan
+    slugs were mangled by a bare `len(parts) >= 4` sprint heuristic.
+    """
+
+    def test_run_plan_slug_shown_whole(self):
+        # Was the bug: "ribution". Now the whole slug.
+        self.assertEqual(
+            collect._derive_pipeline_short("run-plan.plugin-distribution"),
+            "plugin-distribution",
+        )
+
+    def test_sprint_id_keeps_time_slug_tail(self):
+        # Real sprint shape (sprint-<digits>-<digits>-...) still distinguishes
+        # concurrent sprints by the time+slug tail.
+        self.assertEqual(
+            collect._derive_pipeline_short(
+                "fix-issues.sprint-20260521-010731-foo"),
+            "010731-foo",
+        )
+
+    def test_multi_hyphen_plan_slug_not_mangled(self):
+        # Pre-fix this hit the `len(parts) >= 4` branch and returned
+        # "and-rename". Now the whole slug (capped — see length test).
+        self.assertEqual(
+            collect._derive_pipeline_short(
+                "run-plan.dashboard-tabs-and-rename-5a"),
+            "dashboard-tabs-and-rename-5a",
+        )
+
+    def test_short_three_part_slug_whole(self):
+        # Pre-fix the `[-8:]` fallback gave "xecution".
+        self.assertEqual(
+            collect._derive_pipeline_short("run-plan.restore-chunked-execution"),
+            "restore-chunked-execution",
+        )
+
+    def test_long_slug_front_truncated_with_ellipsis(self):
+        out = collect._derive_pipeline_short(
+            "run-plan.a-really-long-plan-slug-that-exceeds-the-cap", maxlen=28)
+        self.assertEqual(len(out), 28)
+        self.assertTrue(out.endswith("…"))
+        self.assertTrue(out.startswith("a-really-long-plan-slug-"))
+
+    def test_prefix_dropped(self):
+        # The pipeline-type prefix before the last '.' is not part of the label.
+        self.assertEqual(collect._derive_pipeline_short("do.x"), "x")
+
+    def test_non_sprint_four_part_not_treated_as_sprint(self):
+        # 4 parts but parts[0] != "sprint" and parts[1] not digits → whole slug.
+        self.assertEqual(
+            collect._derive_pipeline_short("run-plan.alpha-beta-gamma-delta"),
+            "alpha-beta-gamma-delta",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test-plan-claim-render-dom.sh
+++ b/tests/test-plan-claim-render-dom.sh
@@ -5,8 +5,9 @@
 # Node-stubbed JS harness — mirrors tests/test-fix-issues-claim-render-dom.sh
 # for the issue-side chip. Concerns:
 #   T3.11.a  buildPlanCard renders claim chip + aria-disabled
-#   T3.11.b  Chip text format: "in-flight · <pidShort> · phase N/M · <ageStr>"
-#   T3.11.c  Unparseable current_phase falls back to "phase ?/M"
+#   T3.11.b  Chip text: "working on phase N · <pidShort> · <ageStr>" (no /M,
+#            no "in-flight" prefix); progress bar reads N/M from the claim.
+#   T3.11.c  Non-numeric current_phase → "working on <header>" verbatim
 #   T3.11.d  Null pipeline_short / started_at fall back to "?"
 #   T3.11.e  Unclaimed plan retains draggable + no chip
 #
@@ -216,6 +217,14 @@ function findByClass(root, cls) {
   return null;
 }
 
+// The stub's textContent is per-node (not aggregated over descendants),
+// so collect all descendant text to assert on labels held by child spans.
+function collectText(node) {
+  let s = node.textContent || "";
+  for (const c of (node.children || [])) s += collectText(c);
+  return s;
+}
+
 // ------------------------------------------------------------------
 // T3.11.a — claim chip renders + aria-disabled + draggable removed
 // ------------------------------------------------------------------
@@ -249,7 +258,10 @@ function findByClass(root, cls) {
 }
 
 // ------------------------------------------------------------------
-// T3.11.b — chip text format "in-flight · <pid> · phase N/M · <age>"
+// T3.11.b — chip text format "working on phase N · <pid> · <age>"
+// The N/M progress framing now lives on the bar (driven from the same
+// claim.current_phase); the chip is the liveness/activity indicator and
+// drops the redundant "/M" denominator and the "in-flight" prefix.
 // ------------------------------------------------------------------
 {
   const plan = {
@@ -267,19 +279,28 @@ function findByClass(root, cls) {
   const chip = findByClass(card, "claim-chip");
   expectTrue(chip, "chip exists for format-spec check");
   if (chip) {
-    expectTrue(chip.textContent.indexOf("in-flight") >= 0,
-      "chip text starts with 'in-flight'");
+    expectTrue(chip.textContent.indexOf("working on phase 3") >= 0,
+      "chip text contains 'working on phase 3'");
     expectTrue(chip.textContent.indexOf("bar-xyz") >= 0,
       "chip text contains pipeline_short 'bar-xyz'");
-    expectTrue(chip.textContent.indexOf("phase 3/5") >= 0,
-      "chip text contains 'phase 3/5'");
+    expectTrue(chip.textContent.indexOf("/5") < 0 &&
+               chip.textContent.indexOf("in-flight") < 0,
+      "chip drops the redundant '/M' denominator and 'in-flight' prefix");
     expectTrue(/(s|m|h|d) ago/.test(chip.textContent) ||
                chip.textContent.indexOf("just now") >= 0,
       "chip text contains a non-empty age suffix");
-    // Strict format spec: "in-flight · <pidShort> · phase N/M · <ageStr>"
-    expectTrue(/^in-flight · bar-xyz · phase 3\/5 · /.test(chip.textContent),
-      "chip text matches format spec prefix 'in-flight · <pid> · phase N/M · '");
+    // Strict format spec: "working on phase N · <pidShort> · <ageStr>"
+    expectTrue(/^working on phase 3 · bar-xyz · /.test(chip.textContent),
+      "chip text matches format spec prefix 'working on phase N · <pid> · '");
   }
+  // Bar is driven from the claim's current_phase when claimed (NOT the
+  // stale main-tracker phases_done): phases_done=0 but current_phase=Phase 3
+  // → ratio "3 / 5 phases".
+  const cardText = collectText(card);
+  expectTrue(cardText.indexOf("3 / 5 phases") >= 0,
+    "progress bar reads '3 / 5 phases' from claim.current_phase, not '0 / 5'");
+  expectTrue(cardText.indexOf("0 / 5 phases") < 0,
+    "progress bar does NOT show stale phases_done '0 / 5'");
 }
 
 // ------------------------------------------------------------------
@@ -301,8 +322,11 @@ function findByClass(root, cls) {
   const chip = findByClass(card, "claim-chip");
   expectTrue(chip, "chip exists with section-name current_phase");
   if (chip) {
-    expectTrue(chip.textContent.indexOf("phase ?/6") >= 0,
-      "section-name current_phase falls back to 'phase ?/6'");
+    // Non-numeric current_phase: show the raw header verbatim, not "phase ?".
+    expectTrue(chip.textContent.indexOf("working on Parse plan") >= 0,
+      "section-name current_phase shows 'working on Parse plan' verbatim");
+    expectTrue(chip.textContent.indexOf("phase ?") < 0,
+      "no 'phase ?' fragment for non-numeric current_phase");
   }
 }
 
@@ -325,8 +349,11 @@ function findByClass(root, cls) {
   const chip = findByClass(card, "claim-chip");
   expectTrue(chip, "chip exists with null current_phase");
   if (chip) {
-    expectTrue(chip.textContent.indexOf("phase ?/4") >= 0,
-      "null current_phase falls back to 'phase ?/4'");
+    // Null/absent current_phase: bare "in-flight" fallback, no phase fragment.
+    expectTrue(/^in-flight · /.test(chip.textContent),
+      "null current_phase falls back to bare 'in-flight · ...'");
+    expectTrue(chip.textContent.indexOf("phase") < 0,
+      "no 'phase' fragment when current_phase is null");
   }
 }
 
@@ -349,8 +376,9 @@ function findByClass(root, cls) {
   const chip = findByClass(card, "claim-chip");
   expectTrue(chip, "chip rendered for null-metadata claim");
   if (chip) {
-    expect(chip.textContent, "in-flight · ? · phase ?/3 · ?",
-      "all-null claim chip text is 'in-flight · ? · phase ?/3 · ?'");
+    // Null current_phase → bare "in-flight"; null pid/age → "?".
+    expect(chip.textContent, "in-flight · ? · ?",
+      "all-null claim chip text is 'in-flight · ? · ?'");
   }
 }
 


### PR DESCRIPTION
## Summary

Make the in-flight plan card show **live** phase progress instead of stale main-tracker state. Three fixes, all keyed off the active claim:

- **Progress bar from the claim.** When a plan is claimed, the bar numerator comes from `claim.current_phase` (falls back to `phases_done` when unclaimed). Under `main_protected` PR-mode `/run-plan`, the tracker on `main` shows ~0–1 done for the whole run (phases land in one PR at the end), so `phases_done` was structurally stale while work was in flight. plugin-distribution now reads **`4 / 6 phases`** instead of `1 / 6`.
- **Chip reframed.** `in-flight · <pid> · phase N/M · <age>` → **`working on phase N · <slug> · <age>`**. The N/M framing lives on the bar now, so the chip drops the redundant denominator; non-numeric phases show `working on <header>`. The `.claim-chip--in-flight` class is retained so the collapsed-column "N in-flight" footer still aggregates.
- **`pipeline_short` fix.** `_derive_pipeline_short` was butchering run-plan plan slugs via a blind `[-8:]` suffix slice (`plugin-distribution` → `ribution`) and mangling multi-hyphen slugs via a bare `len(parts) >= 4` sprint heuristic. Now gates the sprint branch on the real sprint shape and shows the **whole slug**, front-truncated past `maxlen`.

## Test plan

- [x] Full suite `bash tests/run-all.sh`: **6103/6104** — the one failure is **pre-existing on `main`** (`test_plans_rebuild_uses_collect.sh` AC-7, dangling CANARY plan refs from #783's canary disposition), filed as #787. Unrelated to this diff (dashboard + claim-label only).
- [x] `tests/test-plan-claim-render-dom.sh` (29/29) — updated chip+bar assertions to the new format; added a bar-from-claim check.
- [x] `tests/test-plan-claim-collector.py` (16/16) — new `_derive_pipeline_short` cases: run-plan slug whole, sprint id tail, multi-hyphen slug not mangled, long slug ellipsized, prefix dropped.
- [x] Manual (playwright, live data on `:8083`): bar `4 / 6 phases`, chip `working on phase 4 · plugin-distribution · 6h ago`.
- [x] Mirror (`.claude/skills/zskills-dashboard`) synced; skill version bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
