### PR TITLE
feat(cleanup-merged): also delete 0-ahead-of-main branches (closes #781)

### DIFF
--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -5,14 +5,15 @@ argument-hint: "[apply] [local | remote | all] [force] [<branch>...]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
-  upstream is gone or whose PR has merged. Preview by default — run
+  upstream is gone, whose PR has merged, or whose tip is fully contained
+  in main (0 commits ahead). Preview by default — run
   `/cleanup-merged apply` to execute. `local` (default) / `remote` / `all`
   pick the scope; pass explicit branch names to narrow the candidate set.
   `force` overrides the merged-check + unpushed guard for branches you
   explicitly name. Protected branches from config are NEVER deleted (even
   with `force`) — they are always skipped.
 metadata:
-  version: "2026.05.28+8fec91"
+  version: "2026.05.28+88b007"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -326,11 +327,17 @@ fi
 ## Phase 5 — Local branch scan
 
 For every local branch other than the main branch and the currently
-checked-out branch, check the same two signals (upstream gone, PR
-merged). Skip branches with unpushed commits unless the upstream is
-gone — if the remote is gone, the commits were either squash-merged or
-the branch was abandoned; either way, the local commits match no live
-ref.
+checked-out branch, check three signals: upstream gone, PR merged, or
+the tip is fully contained in main (0 commits ahead —
+`git merge-base --is-ancestor <branch> main`, issue #781). The
+contained-in-main check is purely local and needs no `gh` call, so it
+is evaluated first and the PR-state lookup is skipped when it holds.
+Skip branches with unpushed commits unless the upstream is gone or the
+branch is contained in main — if the remote is gone, the commits were
+either squash-merged or the branch was abandoned; if the branch is
+contained in main it carries zero unique commits; either way the local
+commits match a ref already on main (the `git branch -d` below is the
+losslessness backstop).
 
 This phase is worktree-aware: if a merged branch is held by a worktree,
 `git branch -D` will refuse. Before attempting the delete, the loop
@@ -393,13 +400,23 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       UPSTREAM_GONE=1
     fi
 
+    # Issue #781: a branch whose tip is fully contained in main (0 commits
+    # ahead — `git merge-base --is-ancestor branch main` true) carries zero
+    # unique commits, so deleting it loses nothing (reflog-recoverable
+    # regardless). This is a LOCAL check needing NO `gh` call, so detect it
+    # before the PR-state lookup and skip the gh round-trip when it holds.
+    CONTAINED=0
+    if git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then
+      CONTAINED=1
+    fi
+
     PR_STATE=""
-    if [ "$HAVE_GH" -eq 1 ]; then
+    if [ "$HAVE_GH" -eq 1 ] && [ "$CONTAINED" -eq 0 ]; then
       PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
     fi
 
     MERGED=0
-    if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
+    if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ] || [ "$CONTAINED" -eq 1 ]; then
       MERGED=1
     fi
 
@@ -419,8 +436,11 @@ if [ "$DO_LOCAL" -eq 1 ]; then
     # upstream is NOT gone — a gone upstream plus PR=MERGED means the
     # commits reached main via squash. A named branch under `force`
     # overrides this guard too.
+    # A contained-in-main branch (issue #781) carries no commits not already
+    # on main, so the unpushed guard cannot apply — the `git branch -d` below
+    # is the losslessness backstop. Skip the guard for the contained class.
     UNPUSHED=""
-    if [ "$UPSTREAM_GONE" -eq 0 ] && [ "$NAMED_FORCE" -eq 0 ]; then
+    if [ "$UPSTREAM_GONE" -eq 0 ] && [ "$NAMED_FORCE" -eq 0 ] && [ "$CONTAINED" -eq 0 ]; then
       UNPUSHED=$(git log "$branch" --not --remotes --oneline 2>/dev/null | head -1)
     fi
 
@@ -480,8 +500,14 @@ if [ "$DO_LOCAL" -eq 1 ]; then
 
     if [ "$NAMED_FORCE" -eq 1 ] && [ "$MERGED" -eq 0 ]; then
       REASON="forced (named, not confirmed merged)"
+    elif [ "$PR_STATE" = "MERGED" ]; then
+      REASON="PR merged"
+    elif [ "$UPSTREAM_GONE" -eq 1 ]; then
+      REASON="upstream gone"
     else
-      REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
+      # Issue #781: contained-in-main (0 ahead) — the only remaining way
+      # MERGED=1 with no PR-merged / upstream-gone signal.
+      REASON="contained in main"
     fi
 
     if [ -n "$WORKTREE_FOR_BRANCH" ]; then
@@ -520,14 +546,15 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       LOCAL_CANDIDATES+=("$branch")
     else
       # Delete-flag selection. The default path only reaches here for
-      # branches already CONFIRMED merged (PR=MERGED or upstream-gone) —
-      # but squash-merge means the branch tip is NOT a fast-forward
-      # ancestor of main, so `git branch -d` would wrongly refuse it.
-      # Use `-d` when the branch IS a merged ancestor of main (clean),
-      # and `-D` for the confirmed-merged-but-not-ancestor (squash) case
-      # and for the explicit `force` path. `-D` is NEVER reached for an
-      # un-confirmed, un-named branch (the merged-check above guarantees
-      # MERGED=1 unless NAMED_FORCE=1).
+      # branches already CONFIRMED safe: PR=MERGED, upstream-gone, or
+      # contained-in-main (issue #781, 0 ahead). Squash-merge means the
+      # branch tip is NOT a fast-forward ancestor of main, so `git branch
+      # -d` would wrongly refuse it. Use `-d` when the branch IS an
+      # ancestor of main (clean — this is exactly the contained-in-main
+      # class, deleted losslessly), and `-D` for the confirmed-merged-but-
+      # not-ancestor (squash) case and for the explicit `force` path. `-D`
+      # is NEVER reached for an un-confirmed, un-named branch (the
+      # merged-check above guarantees MERGED=1 unless NAMED_FORCE=1).
       if [ "$NAMED_FORCE" -eq 1 ]; then
         DEL_FLAG="-D"   # user vouched for this named branch explicitly
       elif git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -5,14 +5,15 @@ argument-hint: "[apply] [local | remote | all] [force] [<branch>...]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
-  upstream is gone or whose PR has merged. Preview by default — run
+  upstream is gone, whose PR has merged, or whose tip is fully contained
+  in main (0 commits ahead). Preview by default — run
   `/cleanup-merged apply` to execute. `local` (default) / `remote` / `all`
   pick the scope; pass explicit branch names to narrow the candidate set.
   `force` overrides the merged-check + unpushed guard for branches you
   explicitly name. Protected branches from config are NEVER deleted (even
   with `force`) — they are always skipped.
 metadata:
-  version: "2026.05.28+8fec91"
+  version: "2026.05.28+88b007"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -326,11 +327,17 @@ fi
 ## Phase 5 — Local branch scan
 
 For every local branch other than the main branch and the currently
-checked-out branch, check the same two signals (upstream gone, PR
-merged). Skip branches with unpushed commits unless the upstream is
-gone — if the remote is gone, the commits were either squash-merged or
-the branch was abandoned; either way, the local commits match no live
-ref.
+checked-out branch, check three signals: upstream gone, PR merged, or
+the tip is fully contained in main (0 commits ahead —
+`git merge-base --is-ancestor <branch> main`, issue #781). The
+contained-in-main check is purely local and needs no `gh` call, so it
+is evaluated first and the PR-state lookup is skipped when it holds.
+Skip branches with unpushed commits unless the upstream is gone or the
+branch is contained in main — if the remote is gone, the commits were
+either squash-merged or the branch was abandoned; if the branch is
+contained in main it carries zero unique commits; either way the local
+commits match a ref already on main (the `git branch -d` below is the
+losslessness backstop).
 
 This phase is worktree-aware: if a merged branch is held by a worktree,
 `git branch -D` will refuse. Before attempting the delete, the loop
@@ -393,13 +400,23 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       UPSTREAM_GONE=1
     fi
 
+    # Issue #781: a branch whose tip is fully contained in main (0 commits
+    # ahead — `git merge-base --is-ancestor branch main` true) carries zero
+    # unique commits, so deleting it loses nothing (reflog-recoverable
+    # regardless). This is a LOCAL check needing NO `gh` call, so detect it
+    # before the PR-state lookup and skip the gh round-trip when it holds.
+    CONTAINED=0
+    if git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then
+      CONTAINED=1
+    fi
+
     PR_STATE=""
-    if [ "$HAVE_GH" -eq 1 ]; then
+    if [ "$HAVE_GH" -eq 1 ] && [ "$CONTAINED" -eq 0 ]; then
       PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
     fi
 
     MERGED=0
-    if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ]; then
+    if [ "$UPSTREAM_GONE" -eq 1 ] || [ "$PR_STATE" = "MERGED" ] || [ "$CONTAINED" -eq 1 ]; then
       MERGED=1
     fi
 
@@ -419,8 +436,11 @@ if [ "$DO_LOCAL" -eq 1 ]; then
     # upstream is NOT gone — a gone upstream plus PR=MERGED means the
     # commits reached main via squash. A named branch under `force`
     # overrides this guard too.
+    # A contained-in-main branch (issue #781) carries no commits not already
+    # on main, so the unpushed guard cannot apply — the `git branch -d` below
+    # is the losslessness backstop. Skip the guard for the contained class.
     UNPUSHED=""
-    if [ "$UPSTREAM_GONE" -eq 0 ] && [ "$NAMED_FORCE" -eq 0 ]; then
+    if [ "$UPSTREAM_GONE" -eq 0 ] && [ "$NAMED_FORCE" -eq 0 ] && [ "$CONTAINED" -eq 0 ]; then
       UNPUSHED=$(git log "$branch" --not --remotes --oneline 2>/dev/null | head -1)
     fi
 
@@ -480,8 +500,14 @@ if [ "$DO_LOCAL" -eq 1 ]; then
 
     if [ "$NAMED_FORCE" -eq 1 ] && [ "$MERGED" -eq 0 ]; then
       REASON="forced (named, not confirmed merged)"
+    elif [ "$PR_STATE" = "MERGED" ]; then
+      REASON="PR merged"
+    elif [ "$UPSTREAM_GONE" -eq 1 ]; then
+      REASON="upstream gone"
     else
-      REASON=$([ "$PR_STATE" = "MERGED" ] && echo "PR merged" || echo "upstream gone")
+      # Issue #781: contained-in-main (0 ahead) — the only remaining way
+      # MERGED=1 with no PR-merged / upstream-gone signal.
+      REASON="contained in main"
     fi
 
     if [ -n "$WORKTREE_FOR_BRANCH" ]; then
@@ -520,14 +546,15 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       LOCAL_CANDIDATES+=("$branch")
     else
       # Delete-flag selection. The default path only reaches here for
-      # branches already CONFIRMED merged (PR=MERGED or upstream-gone) —
-      # but squash-merge means the branch tip is NOT a fast-forward
-      # ancestor of main, so `git branch -d` would wrongly refuse it.
-      # Use `-d` when the branch IS a merged ancestor of main (clean),
-      # and `-D` for the confirmed-merged-but-not-ancestor (squash) case
-      # and for the explicit `force` path. `-D` is NEVER reached for an
-      # un-confirmed, un-named branch (the merged-check above guarantees
-      # MERGED=1 unless NAMED_FORCE=1).
+      # branches already CONFIRMED safe: PR=MERGED, upstream-gone, or
+      # contained-in-main (issue #781, 0 ahead). Squash-merge means the
+      # branch tip is NOT a fast-forward ancestor of main, so `git branch
+      # -d` would wrongly refuse it. Use `-d` when the branch IS an
+      # ancestor of main (clean — this is exactly the contained-in-main
+      # class, deleted losslessly), and `-D` for the confirmed-merged-but-
+      # not-ancestor (squash) case and for the explicit `force` path. `-D`
+      # is NEVER reached for an un-confirmed, un-named branch (the
+      # merged-check above guarantees MERGED=1 unless NAMED_FORCE=1).
       if [ "$NAMED_FORCE" -eq 1 ]; then
         DEL_FLAG="-D"   # user vouched for this named branch explicitly
       elif git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then

--- a/tests/test-cleanup-merged-ahead-gate.sh
+++ b/tests/test-cleanup-merged-ahead-gate.sh
@@ -205,6 +205,187 @@ STUB
   fi
 fi
 
+# ── Issue #781: contained-in-main (0-ahead) branches are deletable ──
+# A local branch whose tip is fully contained in main (0 commits ahead,
+# `git merge-base --is-ancestor branch main`) carries zero unique commits
+# and must be flagged WOULD-DELETE in preview / removed via `git branch -d`
+# on apply — even with NO PR and NO upstream-gone signal. The negative
+# case (a branch with commits NOT on main) must still be preserved, and a
+# protected branch that happens to be 0-ahead must still be SKIPPED.
+
+echo ""
+echo "=== Issue #781: contained-in-main (0-ahead) candidate gate ==="
+
+# Static: the candidate gate must add the contained-in-main signal and
+# route it through a LOCAL ancestor check (no gh) — the candidate gate is
+# the only place MERGED can flip to 1 without PR=MERGED / upstream-gone.
+if echo "$PHASE5_SLICE" | grep -qE 'CONTAINED=1' \
+   && echo "$PHASE5_SLICE" | grep -qE 'merge-base --is-ancestor "\$branch" "\$MAIN_BRANCH"'; then
+  pass "Phase 5: contained-in-main detected via local merge-base --is-ancestor (issue #781)"
+else
+  fail "Phase 5: contained-in-main (CONTAINED) local detection missing (issue #781)"
+fi
+
+# The contained class must feed the MERGED candidate gate.
+if echo "$PHASE5_SLICE" | grep -qE 'MERGED=1' \
+   && echo "$PHASE5_SLICE" | grep -qE '\[ "\$CONTAINED" -eq 1 \]'; then
+  pass "Phase 5: CONTAINED flips MERGED candidate gate (issue #781)"
+else
+  fail "Phase 5: CONTAINED does not feed the MERGED candidate gate (issue #781)"
+fi
+
+# The contained class must NOT require a gh call (the ancestor check is
+# local). The PR-state lookup is gated on CONTAINED -eq 0.
+if echo "$PHASE5_SLICE" | grep -qE 'HAVE_GH" -eq 1 \] && \[ "\$CONTAINED" -eq 0 \]'; then
+  pass "Phase 5: PR-state gh lookup skipped for contained branches (issue #781, no gh call)"
+else
+  fail "Phase 5: contained branch still gated behind a gh PR-state lookup (issue #781)"
+fi
+
+# Behavioral: drive the REAL candidate-gate + delete-flag logic extracted
+# from the skill against real git branches. We splice together the actual
+# snippets the skill uses (CONTAINED detection, MERGED gate, DEL_FLAG
+# selection) so we exercise real code, not a paraphrase.
+CONTAINED_BLOCK=$(echo "$PHASE5_SLICE" | awk '
+  /CONTAINED=0/{capture=1}
+  capture {print}
+  capture && /^    fi$/ && seen_merged{exit}
+  /MERGED=1/{seen_merged=1}
+')
+# Anchor the delete-flag extraction on the unique "Delete-flag selection."
+# comment so we do not collide with the merged-check `if NAMED_FORCE` block.
+DELFLAG_BLOCK=$(echo "$PHASE5_SLICE" | awk '
+  /# Delete-flag selection\./{capture=1}
+  capture {print}
+  capture && /git branch "\$DEL_FLAG" "\$branch"/{print_more=1}
+  capture && print_more && /^      fi$/{exit}
+')
+
+if [ -z "$CONTAINED_BLOCK" ] || [ -z "$DELFLAG_BLOCK" ]; then
+  fail "Issue #781: could not extract candidate/delete-flag blocks for behavioral test"
+else
+  pass "Issue #781: candidate + delete-flag blocks extracted for behavioral test"
+
+  TMP781=$(mktemp -d)
+  (
+    cd "$TMP781" || exit 1
+    git init -q -b main .
+    git config user.email t@t.t; git config user.name t
+    git commit -q --allow-empty -m base
+
+    # contained: 0 ahead of main — tip IS an ancestor of main. Create the
+    # branch, then advance main past it so the branch tip is contained.
+    git checkout -q -b contained
+    git checkout -q main
+    git commit -q --allow-empty -m "main advances; contained tip now in main"
+
+    # ahead: carries a commit NOT on main (must be preserved).
+    git checkout -q -b ahead
+    git commit -q --allow-empty -m "unique work not on main"
+
+    # protected-contained: 0 ahead AND in the protected list (must SKIP).
+    git checkout -q main
+    git checkout -q -b protected-contained
+    git checkout -q main
+    git commit -q --allow-empty -m "main advances; protected-contained tip now in main"
+
+    git checkout -q main
+
+    # Harness for the candidate gate: returns MERGED + REASON + CONTAINED.
+    MAIN_BRANCH=main
+    UPSTREAM_GONE=0
+    NAMED_FORCE=0
+    HAVE_GH=0   # no gh — proves the contained class needs no gh call
+
+    decide() {
+      branch="$1"
+      eval "$CONTAINED_BLOCK"
+      echo "MERGED=$MERGED CONTAINED=$CONTAINED"
+    }
+
+    # Scenario A: contained branch -> MERGED candidate gate flips to 1.
+    A=$(decide contained)
+    if echo "$A" | grep -q 'MERGED=1' && echo "$A" | grep -q 'CONTAINED=1'; then
+      echo "A_PASS"
+    else
+      echo "A_FAIL: $A"
+    fi
+
+    # Scenario B: ahead branch -> NOT a candidate (MERGED stays 0).
+    B=$(decide ahead)
+    if echo "$B" | grep -q 'MERGED=0' && echo "$B" | grep -q 'CONTAINED=0'; then
+      echo "B_PASS"
+    else
+      echo "B_FAIL: $B"
+    fi
+
+    # Scenario C: apply path deletes a contained branch via `git branch -d`
+    # (NOT -D). Drive the real DEL_FLAG selection block, then the delete.
+    branch=contained
+    PR_STATE=""
+    REASON="contained in main"
+    DEL_FLAG=""
+    LOCAL_DELETED=0
+    LOCAL_SKIPPED=0
+    eval "$DELFLAG_BLOCK" >/dev/null 2>&1
+    if [ "$DEL_FLAG" = "-d" ] && ! git show-ref --verify --quiet refs/heads/contained; then
+      echo "C_PASS"
+    else
+      echo "C_FAIL: DEL_FLAG=$DEL_FLAG still_exists=$(git show-ref --verify --quiet refs/heads/contained && echo yes || echo no)"
+    fi
+
+    # Scenario D: the ahead branch is NOT deletable with -d (safety: -d
+    # refuses a not-fully-merged branch). Confirms the negative case can
+    # never be lost via the safe-delete path.
+    if ! git branch -d ahead >/dev/null 2>&1 && git show-ref --verify --quiet refs/heads/ahead; then
+      echo "D_PASS"
+    else
+      echo "D_FAIL: ahead branch was deletable via -d (would lose unique commits)"
+    fi
+  ) > "$TMP781/out" 2>&1
+
+  if grep -q 'A_PASS' "$TMP781/out"; then
+    pass "Behavioral #781: contained-in-main branch (no PR, no upstream-gone) is a delete candidate"
+  else
+    fail "Behavioral #781: contained-in-main branch not flagged as candidate"
+    sed 's/^/    /' "$TMP781/out"
+  fi
+
+  if grep -q 'B_PASS' "$TMP781/out"; then
+    pass "Behavioral #781 (negative): branch with commits NOT on main is preserved (not a candidate)"
+  else
+    fail "Behavioral #781 (negative): a branch ahead of main was wrongly flagged"
+    sed 's/^/    /' "$TMP781/out"
+  fi
+
+  if grep -q 'C_PASS' "$TMP781/out"; then
+    pass "Behavioral #781: apply path deletes contained branch via git branch -d (not -D)"
+  else
+    fail "Behavioral #781: contained branch not removed via -d"
+    sed 's/^/    /' "$TMP781/out"
+  fi
+
+  if grep -q 'D_PASS' "$TMP781/out"; then
+    pass "Behavioral #781: -d refuses the ahead branch (negative case can never be lost)"
+  else
+    fail "Behavioral #781: -d wrongly deleted an ahead branch"
+    sed 's/^/    /' "$TMP781/out"
+  fi
+
+  rm -rf "$TMP781"
+fi
+
+# Protected + contained: a config-protected branch that is 0-ahead must
+# STILL be skipped (the protected check runs FIRST, before CONTAINED is
+# ever computed). Verify the protected-skip precedes the candidate gate.
+PROT_LINE=$(echo "$PHASE5_SLICE" | grep -n 'is_protected "\$branch"' | head -1 | cut -d: -f1)
+CONT_LINE=$(echo "$PHASE5_SLICE" | grep -n 'CONTAINED=0' | head -1 | cut -d: -f1)
+if [ -n "$PROT_LINE" ] && [ -n "$CONT_LINE" ] && [ "$PROT_LINE" -lt "$CONT_LINE" ]; then
+  pass "Issue #781: protected-skip precedes the contained-in-main candidate gate (protected 0-ahead branch still SKIPPED)"
+else
+  fail "Issue #781: protected-skip ordering wrong (protected line=$PROT_LINE, contained line=$CONT_LINE)"
+fi
+
 # ── Mirror sync ────────────────────────────────────────────────────
 MIRROR="$REPO_ROOT/.claude/skills/cleanup-merged/SKILL.md"
 if [ -f "$MIRROR" ]; then


### PR DESCRIPTION
## Summary
Widen `/cleanup-merged` Phase 5 deletion criterion to also delete local branches that are **0 commits ahead of main** (`git merge-base --is-ancestor <branch> main`) — not just MERGED-PR / upstream-gone branches. These (mostly empty `/fix-issues` sprint branches) accumulated against the skill's stated cleanup purpose; a clone had 46 of them.

- `PR == MERGED || upstream-gone || merge-base --is-ancestor <branch> main`. Default path — no new mode/flag/config (the issue's locked decision).
- **Provably lossless:** 0-ahead = main already contains the tip; deleted via safe `git branch -d` (refuses if not fully merged), reflog-recoverable. The contained class skips the `gh` PR lookup (local check) → also faster.
- **All safety preserved:** protected-branch skip fires first, never-delete-main/current intact, preview-by-default (`WOULD-DELETE <b> (contained in main)`), `-d` not `-D`.

Closes #781

## Test plan
- [x] Contained 0-ahead branch → WOULD-DELETE in preview, removed via `git branch -d` on apply
- [x] Negative: branch with commits not on main is preserved (and `-d` refuses it)
- [x] Protected 0-ahead branch still skipped (protected check precedes the gate)
- [x] New assertions fail against pre-fix criterion (CONTAINED absent pre-fix)
- [x] Source/mirror byte-identical, skill version bumped; full suite green (6120/6120); verified by fresh verifier agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
