### PR TITLE
fix(fix-issues,run-plan): assign $PROJECT_ROOT before landing-mode config read (closes #791)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.28+09107c"
+  version: "2026.05.28+3a3b40"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -130,6 +130,11 @@ fi
 
 ```bash
 # Detect landing mode (same logic as /run-plan)
+# Resolve repo root before any config read. $PROJECT_ROOT is never exported
+# into a SKILL.md fence (it is only set inside post-run-invariants.sh, a
+# separate process), so anchor it on $CLAUDE_PROJECT_DIR -- the established
+# peer pattern used elsewhere in this skill family (#791).
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 LANDING_MODE="cherry-pick"
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]) ]]; then
   LANDING_MODE="pr"

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.28+b06b7e"
+  version: "2026.05.28+722e14"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -93,6 +93,11 @@ through multi-phase plans autonomously.
 
 ```bash
 # Detect landing mode
+# Resolve repo root before any config read. $PROJECT_ROOT is never exported
+# into a SKILL.md fence (it is only set inside post-run-invariants.sh, a
+# separate process), so anchor it on $CLAUDE_PROJECT_DIR -- the established
+# peer pattern used elsewhere in this skill (#791).
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 LANDING_MODE="cherry-pick"  # default
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]) ]]; then
   LANDING_MODE="pr"
@@ -159,6 +164,7 @@ fi
 
 ```bash
 # direct + main_protected -> error
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 if [[ "$LANDING_MODE" == "direct" ]]; then
   CONFIG_FILE="$PROJECT_ROOT/.claude/zskills-config.json"
   if [ -f "$CONFIG_FILE" ]; then
@@ -175,6 +181,7 @@ fi
 
 ```bash
 # Read branch prefix from config (default: feat/)
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 BRANCH_PREFIX="feat/"
 if [ -f "$PROJECT_ROOT/.claude/zskills-config.json" ]; then
   CONFIG_CONTENT=$(cat "$PROJECT_ROOT/.claude/zskills-config.json")
@@ -192,6 +199,7 @@ verbatim to every impl/verifier/fix-agent dispatch prompt. Three-case
 decision tree (same contract as `/verify-changes`):
 
 ```bash
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 FULL_TEST_CMD=""
 if [ -f "$PROJECT_ROOT/.claude/zskills-config.json" ]; then
   CONFIG_CONTENT=$(cat "$PROJECT_ROOT/.claude/zskills-config.json")

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.28+09107c"
+  version: "2026.05.28+3a3b40"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -130,6 +130,11 @@ fi
 
 ```bash
 # Detect landing mode (same logic as /run-plan)
+# Resolve repo root before any config read. $PROJECT_ROOT is never exported
+# into a SKILL.md fence (it is only set inside post-run-invariants.sh, a
+# separate process), so anchor it on $CLAUDE_PROJECT_DIR -- the established
+# peer pattern used elsewhere in this skill family (#791).
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 LANDING_MODE="cherry-pick"
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]) ]]; then
   LANDING_MODE="pr"

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.28+b06b7e"
+  version: "2026.05.28+722e14"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -93,6 +93,11 @@ through multi-phase plans autonomously.
 
 ```bash
 # Detect landing mode
+# Resolve repo root before any config read. $PROJECT_ROOT is never exported
+# into a SKILL.md fence (it is only set inside post-run-invariants.sh, a
+# separate process), so anchor it on $CLAUDE_PROJECT_DIR -- the established
+# peer pattern used elsewhere in this skill (#791).
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 LANDING_MODE="cherry-pick"  # default
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[pP][rR]($|[[:space:]]) ]]; then
   LANDING_MODE="pr"
@@ -159,6 +164,7 @@ fi
 
 ```bash
 # direct + main_protected -> error
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 if [[ "$LANDING_MODE" == "direct" ]]; then
   CONFIG_FILE="$PROJECT_ROOT/.claude/zskills-config.json"
   if [ -f "$CONFIG_FILE" ]; then
@@ -175,6 +181,7 @@ fi
 
 ```bash
 # Read branch prefix from config (default: feat/)
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 BRANCH_PREFIX="feat/"
 if [ -f "$PROJECT_ROOT/.claude/zskills-config.json" ]; then
   CONFIG_CONTENT=$(cat "$PROJECT_ROOT/.claude/zskills-config.json")
@@ -192,6 +199,7 @@ verbatim to every impl/verifier/fix-agent dispatch prompt. Three-case
 decision tree (same contract as `/verify-changes`):
 
 ```bash
+PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 FULL_TEST_CMD=""
 if [ -f "$PROJECT_ROOT/.claude/zskills-config.json" ]; then
   CONFIG_CONTENT=$(cat "$PROJECT_ROOT/.claude/zskills-config.json")


### PR DESCRIPTION
## Summary
The landing-mode config-resolution fences in `/fix-issues` and `/run-plan` read `$PROJECT_ROOT` to locate `.claude/zskills-config.json`, but it was **never assigned** in any SKILL.md fence — so it was empty, `CONFIG_FILE` resolved off filesystem root, the `execution.landing` default was silently dropped (falling through to `cherry-pick`), and the `direct`+`main_protected` guard never fired. A plain `/fix-issues 5` (no explicit `pr`/`direct`) thus mis-defaulted to cherry-pick → hook-blocked in a `main_protected: true` repo.

- Fix: add `PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"` textually before each `$PROJECT_ROOT` read, in the same fence — 1 fence in `/fix-issues`, 4 in `/run-plan`. Matches the established `$CLAUDE_PROJECT_DIR` convention used throughout these skills.
- Read-before-assign family sibling of #606/#629 (which missed `PROJECT_ROOT`). Extending the `FAMILY_VARS_RE` conformance scan repo-wide is a noted follow-up (it surfaced 4 mode files — out of scope here).

Closes #791

## Test plan
- [x] `PROJECT_ROOT` assigned before read, same fence, both skills (all 5 fences)
- [x] Runtime confirmed: `CONFIG_FILE` resolves to the real config, reads `landing: "pr"` (was silently cherry-pick)
- [x] Both skill versions bumped; source/mirror byte-identical
- [x] Full suite green: 6120/6120; verified by fresh verifier agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
