### PR TITLE
fix(hooks): close absolute-path + long-flag interpreter here-string bypass (closes #789)

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -94,8 +94,49 @@ extract_interp_stdin_body() {
   # The "flags only, no positional" rule stops `bash script.sh <<<data`
   # and `bash run.sh <<EOF` — there the body is stdin DATA for the script
   # file, not code, so Pass-1 should strip it as inert.
+  #
+  # #789 broadening (closure-incomplete on #772): the head must also match
+  #   * an absolute/relative interpreter PATH — `/bin/bash <<<…`,
+  #     `/usr/bin/bash <<<…`, `./bash <<<…` (agents invoke interpreters by
+  #     full path routinely, so the bare-token-only head left this open),
+  #     and
+  #   * LONG flags — `bash --norc <<<…`, `bash --posix <<<…` (the prior
+  #     `-[A-Za-z]+` flag clause matched single-dash short flags only, so a
+  #     `--word` broke the run-up to the redirect), and
+  #   * an OPTION-ARGUMENT word consumed by an arg-taking flag —
+  #     `bash -eo pipefail <<<…` / `bash -o pipefail <<<…` /
+  #     `bash --rcfile FILE <<<…` (the `pipefail` / FILE token is the
+  #     argument to `-o` / `--rcfile`, NOT a script positional, so stdin is
+  #     still the script → re-inject as code).
+  #
+  # The script-positional discriminator is PRESERVED: a free non-flag token
+  # (one NOT consumed as an option-argument) before the redirect — e.g.
+  # `bash script.sh <<<data`, `sh deploy.sh <<<data` — terminates the flag
+  # run before the `<<<`/`<<`, so the head does not reach the operator and
+  # the body is left for Pass-1 to strip as inert DATA. Only `-o`/`-*o`,
+  # `--rcfile`, and `--init-file` consume a following word; every other
+  # token that is not a flag stops the run.
+  #
+  # `pp` is an OPTIONAL path prefix: zero or more `dir/` segments. The
+  # interpreter basename is matched as the final segment, so `/bin/bash`,
+  # `/usr/bin/bash`, and `./bash` all resolve to the `bash` basename, while
+  # `myscript.sh`, `run-bash.sh`, and `foo/sh.txt` do NOT (the basename
+  # token must be exactly one of the interpreters, with no trailing word
+  # chars before the flags/redirect).
+  #
+  # Capture-group budget: keep head_re at a STABLE group count so the
+  # heredoc backrefs below (delim/body) stay correct. bnd(1) + pp(1) +
+  # interp(1) + flagrun-outer(1) = 4 capture groups — flagrun is written
+  # with a SINGLE capturing group (the outer `*` repeat); every alternative
+  # inside it uses flat alternation / char classes, no nested capture. So
+  # the heredoc delim = \5 and body = \6 (both single-digit, sed-safe).
+  # Verified empirically with a per-group sed dump during the fix.
   local bnd='(^|[[:space:];&|`(])'
-  local head_re="${bnd}(bash|sh|zsh|dash|ash|ksh)([[:space:]]+-[A-Za-z]+)*[[:space:]]*"
+  local pp='(/?[A-Za-z0-9_.+-]+/)*'
+  # Each `|`-alternative below is a complete `[[:space:]]+<flag-or-pair>`
+  # element; the outer parens + `*` are the only capturing group.
+  local flagrun='([[:space:]]+-[A-Za-z]*o[[:space:]]+[A-Za-z0-9_.+/-]+|[[:space:]]+--rcfile[[:space:]]+[A-Za-z0-9_.+/-]+|[[:space:]]+--init-file[[:space:]]+[A-Za-z0-9_.+/-]+|[[:space:]]+--[A-Za-z][-A-Za-z0-9]*=[^[:space:]]*|[[:space:]]+--[A-Za-z][-A-Za-z0-9]*|[[:space:]]+-[A-Za-z]+)*'
+  local head_re="${bnd}${pp}(bash|sh|zsh|dash|ash|ksh)${flagrun}[[:space:]]*"
 
   # --- Here-strings: <interp> [flags] <<< "body" | '"'"'body'"'"' | body ---
   # Quoted forms first so the body capture stops at the closing quote;
@@ -111,16 +152,25 @@ extract_interp_stdin_body() {
   # Body arrives with literal two-char `\n` separators (the extractor does
   # not JSON-decode). We rewrite the body's `\n` back to real newlines so
   # each re-injected line becomes its own scannable segment. The DELIM is
-  # backref-pinned to the opener; quoted-delim alts tried first. Capture
-  # groups: \1 boundary, \2 interp, \3 flags, \4 delim, \5 body.
+  # backref-pinned to the opener; quoted-delim alts tried first. With the
+  # #789 head_re broadening the head now has 4 capture groups (boundary,
+  # path-prefix, interp, flag-run), so the delim is \5 and the body is \6
+  # (was \4/\5 pre-#789, when head_re had 3 groups). Group numbering was
+  # confirmed empirically — see the per-group dump during the fix.
+  # NOTE: the sed substitution delimiter is `#`, NOT `/` — the #789 head_re
+  # broadening adds an optional path prefix (`pp`) that embeds literal `/`
+  # characters into the pattern, which would otherwise be parsed as the
+  # `s/.../.../`` delimiter and abort with "unknown option to `s'". `#` is
+  # absent from head_re; it is only a delimiter for the sed SCRIPT, so a `#`
+  # appearing in the matched heredoc BODY (a shell comment) is harmless.
   printf '%s' "$cmd" | sed -nE \
-    "s/.*${head_re}<<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\"\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    "s#.*${head_re}<<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\"\\\\n(.*)\\\\n\\5(\\\\n.*|\$)#\\6#p" \
     | sed -E 's/\\n/\n/g'
   printf '%s' "$cmd" | sed -nE \
-    "s/.*${head_re}<<-?[[:space:]]*'([A-Za-z_][A-Za-z0-9_]*)'\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    "s#.*${head_re}<<-?[[:space:]]*'([A-Za-z_][A-Za-z0-9_]*)'\\\\n(.*)\\\\n\\5(\\\\n.*|\$)#\\6#p" \
     | sed -E 's/\\n/\n/g'
   printf '%s' "$cmd" | sed -nE \
-    "s/.*${head_re}<<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    "s#.*${head_re}<<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)\\\\n(.*)\\\\n\\5(\\\\n.*|\$)#\\6#p" \
     | sed -E 's/\\n/\n/g'
 }
 

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -94,8 +94,49 @@ extract_interp_stdin_body() {
   # The "flags only, no positional" rule stops `bash script.sh <<<data`
   # and `bash run.sh <<EOF` — there the body is stdin DATA for the script
   # file, not code, so Pass-1 should strip it as inert.
+  #
+  # #789 broadening (closure-incomplete on #772): the head must also match
+  #   * an absolute/relative interpreter PATH — `/bin/bash <<<…`,
+  #     `/usr/bin/bash <<<…`, `./bash <<<…` (agents invoke interpreters by
+  #     full path routinely, so the bare-token-only head left this open),
+  #     and
+  #   * LONG flags — `bash --norc <<<…`, `bash --posix <<<…` (the prior
+  #     `-[A-Za-z]+` flag clause matched single-dash short flags only, so a
+  #     `--word` broke the run-up to the redirect), and
+  #   * an OPTION-ARGUMENT word consumed by an arg-taking flag —
+  #     `bash -eo pipefail <<<…` / `bash -o pipefail <<<…` /
+  #     `bash --rcfile FILE <<<…` (the `pipefail` / FILE token is the
+  #     argument to `-o` / `--rcfile`, NOT a script positional, so stdin is
+  #     still the script → re-inject as code).
+  #
+  # The script-positional discriminator is PRESERVED: a free non-flag token
+  # (one NOT consumed as an option-argument) before the redirect — e.g.
+  # `bash script.sh <<<data`, `sh deploy.sh <<<data` — terminates the flag
+  # run before the `<<<`/`<<`, so the head does not reach the operator and
+  # the body is left for Pass-1 to strip as inert DATA. Only `-o`/`-*o`,
+  # `--rcfile`, and `--init-file` consume a following word; every other
+  # token that is not a flag stops the run.
+  #
+  # `pp` is an OPTIONAL path prefix: zero or more `dir/` segments. The
+  # interpreter basename is matched as the final segment, so `/bin/bash`,
+  # `/usr/bin/bash`, and `./bash` all resolve to the `bash` basename, while
+  # `myscript.sh`, `run-bash.sh`, and `foo/sh.txt` do NOT (the basename
+  # token must be exactly one of the interpreters, with no trailing word
+  # chars before the flags/redirect).
+  #
+  # Capture-group budget: keep head_re at a STABLE group count so the
+  # heredoc backrefs below (delim/body) stay correct. bnd(1) + pp(1) +
+  # interp(1) + flagrun-outer(1) = 4 capture groups — flagrun is written
+  # with a SINGLE capturing group (the outer `*` repeat); every alternative
+  # inside it uses flat alternation / char classes, no nested capture. So
+  # the heredoc delim = \5 and body = \6 (both single-digit, sed-safe).
+  # Verified empirically with a per-group sed dump during the fix.
   local bnd='(^|[[:space:];&|`(])'
-  local head_re="${bnd}(bash|sh|zsh|dash|ash|ksh)([[:space:]]+-[A-Za-z]+)*[[:space:]]*"
+  local pp='(/?[A-Za-z0-9_.+-]+/)*'
+  # Each `|`-alternative below is a complete `[[:space:]]+<flag-or-pair>`
+  # element; the outer parens + `*` are the only capturing group.
+  local flagrun='([[:space:]]+-[A-Za-z]*o[[:space:]]+[A-Za-z0-9_.+/-]+|[[:space:]]+--rcfile[[:space:]]+[A-Za-z0-9_.+/-]+|[[:space:]]+--init-file[[:space:]]+[A-Za-z0-9_.+/-]+|[[:space:]]+--[A-Za-z][-A-Za-z0-9]*=[^[:space:]]*|[[:space:]]+--[A-Za-z][-A-Za-z0-9]*|[[:space:]]+-[A-Za-z]+)*'
+  local head_re="${bnd}${pp}(bash|sh|zsh|dash|ash|ksh)${flagrun}[[:space:]]*"
 
   # --- Here-strings: <interp> [flags] <<< "body" | '"'"'body'"'"' | body ---
   # Quoted forms first so the body capture stops at the closing quote;
@@ -111,16 +152,25 @@ extract_interp_stdin_body() {
   # Body arrives with literal two-char `\n` separators (the extractor does
   # not JSON-decode). We rewrite the body's `\n` back to real newlines so
   # each re-injected line becomes its own scannable segment. The DELIM is
-  # backref-pinned to the opener; quoted-delim alts tried first. Capture
-  # groups: \1 boundary, \2 interp, \3 flags, \4 delim, \5 body.
+  # backref-pinned to the opener; quoted-delim alts tried first. With the
+  # #789 head_re broadening the head now has 4 capture groups (boundary,
+  # path-prefix, interp, flag-run), so the delim is \5 and the body is \6
+  # (was \4/\5 pre-#789, when head_re had 3 groups). Group numbering was
+  # confirmed empirically — see the per-group dump during the fix.
+  # NOTE: the sed substitution delimiter is `#`, NOT `/` — the #789 head_re
+  # broadening adds an optional path prefix (`pp`) that embeds literal `/`
+  # characters into the pattern, which would otherwise be parsed as the
+  # `s/.../.../`` delimiter and abort with "unknown option to `s'". `#` is
+  # absent from head_re; it is only a delimiter for the sed SCRIPT, so a `#`
+  # appearing in the matched heredoc BODY (a shell comment) is harmless.
   printf '%s' "$cmd" | sed -nE \
-    "s/.*${head_re}<<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\"\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    "s#.*${head_re}<<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\"\\\\n(.*)\\\\n\\5(\\\\n.*|\$)#\\6#p" \
     | sed -E 's/\\n/\n/g'
   printf '%s' "$cmd" | sed -nE \
-    "s/.*${head_re}<<-?[[:space:]]*'([A-Za-z_][A-Za-z0-9_]*)'\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    "s#.*${head_re}<<-?[[:space:]]*'([A-Za-z_][A-Za-z0-9_]*)'\\\\n(.*)\\\\n\\5(\\\\n.*|\$)#\\6#p" \
     | sed -E 's/\\n/\n/g'
   printf '%s' "$cmd" | sed -nE \
-    "s/.*${head_re}<<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)\\\\n(.*)\\\\n\\4(\\\\n.*|$)/\\5/p" \
+    "s#.*${head_re}<<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)\\\\n(.*)\\\\n\\5(\\\\n.*|\$)#\\6#p" \
     | sed -E 's/\\n/\n/g'
 }
 

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -316,6 +316,47 @@ expect_allow "WHS-A6: bash run.sh <<EOF (heredoc is DATA for script)" \
 expect_allow "WHS-A7: bash <<<\"echo git clean -fdx\" (interpreter runs benign echo)" \
   "bash <<<\\\"echo git clean -fdx\\\""
 
+# WHS13-WHS20. Absolute-path + long-flag interpreter here-string/heredoc
+# bypass closure (#789) — closure-incomplete on #772. The #772 head regex
+# matched only a BARE interpreter token with single-dash short flags, so
+# `/bin/bash <<<…` (absolute path — the left boundary excluded `/`),
+# `bash --norc <<<…` (long flag broke the flag run), and
+# `bash -eo pipefail <<<…` (option-argument looked like a positional) all
+# slipped past the re-injection and Pass-1 stripped the body as inert.
+# `/bin/bash` is a completely non-adversarial form, so this defeated the
+# destructive-op fence for git reset --hard / rm -rf / git clean -fdx.
+#
+# The #789 head_re broadening adds an optional path prefix, accepts --long
+# flags, and consumes option-argument words after -o/--rcfile/--init-file
+# while STILL terminating the flag run at a free non-flag (script-file)
+# positional — so `bash script.sh <<<data` stays inert DATA.
+# Sanity: each WHS13+ DENY case ALLOWs against the pre-#789 hook (proving
+# the assertion exercises the broadened regex), verified manually.
+
+# --- DENY: absolute / relative interpreter PATH (#789) ---
+expect_deny "WHS13: /bin/bash <<<\"git reset --hard\" (absolute path)" \
+  "/bin/bash <<<\\\"git reset --hard\\\""
+expect_deny "WHS14: /usr/bin/bash <<<\"git clean -fdx\" (absolute path)" \
+  "/usr/bin/bash <<<\\\"git clean -fdx\\\""
+expect_deny "WHS15: cd /tmp && /bin/bash <<<\"git clean -fdx\" (cd-chain, abs path)" \
+  "cd /tmp && /bin/bash <<<\\\"git clean -fdx\\\""
+# --- DENY: long flags + option-argument before the redirect (#789) ---
+expect_deny "WHS16: bash --norc <<<\"git clean -fdx\" (long flag)" \
+  "bash --norc <<<\\\"git clean -fdx\\\""
+expect_deny "WHS17: bash -eo pipefail <<<\"git reset --hard\" (-o option-arg)" \
+  "bash -eo pipefail <<<\\\"git reset --hard\\\""
+expect_deny "WHS18: bash -o pipefail <<<\"git clean -fdx\" (-o option-arg)" \
+  "bash -o pipefail <<<\\\"git clean -fdx\\\""
+# --- DENY: absolute-path heredoc-to-interpreter (#789) ---
+expect_deny "WHS19: /bin/bash <<EOF git clean -fdx EOF (abs-path heredoc)" \
+  "/bin/bash <<EOF\\ngit clean -fdx\\nEOF"
+
+# --- ALLOW: script-positional still DATA, even with abs-path interpreter (#789) ---
+# The broadened head must NOT start denying a script-file positional: the
+# here-string/heredoc is stdin DATA for the script, not interpreter code.
+expect_allow "WHS20: /bin/bash script.sh <<<data (abs path + script positional)" \
+  "/bin/bash script.sh <<<\\\"git clean -fdx\\\""
+
 # 7b. kill-by-port/name anti-pattern — same hazard as fuser -k, different spelling.
 # The original incident was 'lsof -ti :8080 | xargs kill' taking out the docker container.
 # All spellings must be blocked; only explicit-PID kill and the sanctioned helper are allowed.

--- a/tests/test-tokenize-then-walk.sh
+++ b/tests/test-tokenize-then-walk.sh
@@ -410,6 +410,23 @@ assert_hook_allow "HSA4" 'bash script.sh <<<data (here-string is DATA for script
 assert_hook_allow "HSA5" 'bash run.sh <<EOF (heredoc is DATA for script)'      'bash run.sh <<EOF\nrm -rf /etc\nEOF'
 assert_hook_allow "HSA6" 'bash <<<"echo git clean -fdx" (interpreter runs benign echo)' 'bash <<<"echo git clean -fdx"'
 
+# ─── Absolute-path + long-flag interpreter here-string/heredoc (#789) ───
+# Closure-incomplete on #772: the head regex matched only a bare interpreter
+# token with single-dash short flags, so an absolute path (`/bin/bash`), a
+# `--long` flag, or an option-argument word (`-eo pipefail`) slipped past
+# re-injection and the body was stripped inert. These exercise the broadened
+# head end-to-end through the same envelope-piping harness as the #772 cases.
+
+# DENY: absolute/relative path, long flag, option-arg — all interpreter-stdin.
+assert_hook_deny "AHS1" '/bin/bash <<<"git reset --hard" (absolute path)'    '/bin/bash <<<"git reset --hard"'
+assert_hook_deny "AHS2" '/usr/bin/bash <<<"git clean -fdx" (absolute path)'  '/usr/bin/bash <<<"git clean -fdx"'
+assert_hook_deny "AHS3" 'bash --norc <<<"git clean -fdx" (long flag)'        'bash --norc <<<"git clean -fdx"'
+assert_hook_deny "AHS4" 'bash -eo pipefail <<<"git reset --hard" (-o arg)'   'bash -eo pipefail <<<"git reset --hard"'
+assert_hook_deny "AHD1" '/bin/bash heredoc -> git clean -fdx (abs-path heredoc)' '/bin/bash <<EOF\ngit clean -fdx\nEOF'
+
+# ALLOW: script-file positional is still DATA, even via absolute-path interp.
+assert_hook_allow "AHSA1" '/bin/bash script.sh <<<data (abs path + script positional)' '/bin/bash script.sh <<<"git clean -fdx"'
+
 # ─── Summary ───
 echo ""
 echo "Total: PASS=$PASS FAIL=$FAIL"


### PR DESCRIPTION
## Summary
The #772 interpreter-stdin re-injection in `block-unsafe-generic.sh` had a `head_re` that only matched a **bare** interpreter + short flags, so the destructive-op fence was bypassed by completely non-adversarial forms:
- `/bin/bash <<<"git reset --hard"` (absolute path)
- `bash --norc <<<"..."` (long flags)
- `bash -eo pipefail <<<"..."` (option-argument positional)

Fix broadens `head_re` to allow an optional path prefix, `--long` flags (incl. option-argument words like `-eo pipefail` / `--rcfile <f>`), while a **free non-flag token (script positional) still terminates the run** — so `bash script.sh <<<data` (body is stdin DATA for the script) stays inert. Heredoc backrefs renumbered for the grown head (3→4 groups); sed delimiters `/`→`#` (the path prefix embeds `/`).

Closes #789

## Test plan
- [x] Bypass closed (empirical DENY): `/bin/bash`, `/usr/bin/bash`, `bash --norc`, `bash -eo pipefail`, abs-path heredoc; #772 baseline `bash <<<` still DENY
- [x] No false-positives (empirical ALLOW): `bash script.sh <<<data`, `cat`/`gh`/`echo`/`tee` heredocs, `git status`; basename-exactness preserved (`bashx`, `run-bash.sh` not interpreters)
- [x] Backref renumbering + sed-delimiter change verified correct
- [x] Source/mirror byte-identical; full suite green 6134/6134; verified by fresh verifier agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
