### PR TITLE
[update-zskills-lane-aware] Lane-aware /update-zskills (don't flip a plugin consumer)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths | --switch-install-path={to-plugin|to-update-zskills}] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.29+24f693"
+  version: "2026.05.29+90450f"
 ---
 
 # Update Z Skills Infrastructure
@@ -84,16 +84,17 @@ was found and what was done about it.
 
 **Preset keywords (bare word, anywhere in the args):**
 
-Presets control three things at once: `execution.landing`,
-`execution.main_protected`, and the `BLOCK_MAIN_PUSH` line in
-`.claude/hooks/block-unsafe-generic.sh`. Everything else in
-`zskills-config.json` is preserved.
+Presets are **config-only**: they set `execution.landing` and
+`execution.main_protected` in `.claude/zskills-config.json`. The
+main-push gate in `block-unsafe-generic.sh` is no longer set by the preset
+— the hook reads `execution.main_protected` from config at runtime
+(fail-closed). Everything else in `zskills-config.json` is preserved.
 
-| Preset | `execution.landing` | `execution.main_protected` | `BLOCK_MAIN_PUSH` |
+| Preset | `execution.landing` | `execution.main_protected` | push gate (derived at runtime) |
 |---|---|---|---|
-| `cherry-pick` (default) | `cherry-pick` | `false` | `0` |
-| `locked-main-pr` | `pr` | `true` | `1` |
-| `direct` | `direct` | `false` | `0` |
+| `cherry-pick` (default) | `cherry-pick` | `false` | allow |
+| `locked-main-pr` | `pr` | `true` | block |
+| `direct` | `direct` | `false` | allow |
 
 Behavior by invocation:
 - `/update-zskills <preset>` — apply that preset; no greenfield prompt.
@@ -429,13 +430,15 @@ installed, not landing behavior.
 Preset → field mapping (used wherever a preset is applied in later
 steps):
 
-| `$PRESET_ARG` | `execution.landing` | `execution.main_protected` | `BLOCK_MAIN_PUSH` |
-|---|---|---|---|
-| `cherry-pick` | `"cherry-pick"` | `false` | `0` |
-| `locked-main-pr` | `"pr"` | `true` | `1` |
-| `direct` | `"direct"` | `false` | `0` |
+| `$PRESET_ARG` | `execution.landing` | `execution.main_protected` |
+|---|---|---|
+| `cherry-pick` | `"cherry-pick"` | `false` |
+| `locked-main-pr` | `"pr"` | `true` |
+| `direct` | `"direct"` | `false` |
 
-The three affected fields are **preset-owned**. When `$PRESET_ARG` is
+These two config fields are **preset-owned**. (The main-push gate in
+`block-unsafe-generic.sh` derives from `main_protected` at runtime — it is
+not a value the preset writes.) When `$PRESET_ARG` is
 non-empty, every other field in `.claude/zskills-config.json`
 (`branch_prefix`, `testing.*`, `dev_server.*`, `ui.*`, `ci.*`,
 `timezone`, `agents.min_model`) is preserved unchanged.
@@ -585,13 +588,13 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    `$schema` reference in the config resolves correctly).
 5. **If `$PRESET_ARG` was set**, defer preset application to
    **Step F — Apply Preset** (invoked at the end of both install and
-   update paths). Step F runs `.claude/skills/update-zskills/scripts/apply-preset.sh` which handles
-   all three preset-owned fields (`execution.landing`,
-   `execution.main_protected`, `BLOCK_MAIN_PUSH`) atomically,
-   including idempotency, JSON formatting variance, missing
-   `execution` key, and legacy hooks without the `BLOCK_MAIN_PUSH=`
-   line. Don't attempt a manual `Edit` here — the script is the
-   single source of truth.
+   update paths). Step F runs `.claude/skills/update-zskills/scripts/apply-preset.sh` which is
+   **config-only** — it sets the two preset-owned config fields
+   (`execution.landing`, `execution.main_protected`) atomically,
+   including idempotency, JSON formatting variance, and a missing
+   `execution` key. It does NOT touch the hook; `block-unsafe-generic.sh`
+   reads `main_protected` from config at runtime. Don't attempt a manual
+   `Edit` here — the script is the single source of truth.
 
 **If it does not exist:**
 1. **If `$PRESET_ARG` is empty**, run the greenfield prompt (Step 0.6)
@@ -645,13 +648,12 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    left empty by auto-detection stay as empty strings — the install
    summary's test-setup blurb tells the user what to fill in later.
 
-4. **Hook toggle handled by Step F.** The config's `execution.landing`
+4. **No hook edit needed.** The config's `execution.landing`
    and `execution.main_protected` placeholders above are substituted
-   in at write time. The `BLOCK_MAIN_PUSH` line in the hook is set by
-   **Step F — Apply Preset** at the end of the install path, after
-   Step C has copied the hook. Step F idempotently flips the value
-   (or splices the line, on a legacy hook without it) to match the
-   preset target. Nothing to do here.
+   in at write time, and `block-unsafe-generic.sh` reads
+   `main_protected` from config at runtime to decide whether to block
+   a push to `main`/`master` (fail-closed). **Step F — Apply Preset** is
+   config-only and does not touch the hook. Nothing to do here.
 
 **Merge algorithm pseudocode:**
 ```
@@ -722,12 +724,13 @@ Map the reply:
   then proceed. Never re-ask the prompt; never invent a 4th option.
 
 Set `$PRESET_ARG` to the chosen preset and proceed. No follow-up
-questions — the three-field mapping (landing + main_protected +
-BLOCK_MAIN_PUSH) in Step 0.25 is final. In particular, we do **not**
-ask "do you want the main-push block on?" for `locked-main-pr`:
-`main_protected=true` already makes `block-unsafe-project.sh` block
-agent commits, cherry-picks, and pushes on main, so the generic hook's
-`BLOCK_MAIN_PUSH=1` is belt-and-suspenders, not a user-facing choice.
+questions — the two-field config mapping (landing + main_protected) in
+Step 0.25 is final. In particular, we do **not** ask "do you want the
+main-push block on?" for `locked-main-pr`: `main_protected=true` is the
+single source of truth — `block-unsafe-project.sh` blocks agent commits,
+cherry-picks, and pushes on main, and `block-unsafe-generic.sh` derives
+its push gate from the same `main_protected` value at runtime, so the
+push block is not a separate user-facing choice.
 
 ---
 
@@ -823,7 +826,7 @@ Look in `scripts/` for these files (all required by installed skills):
 - `worktree-add-safe.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for safe worktree creation (discriminates fresh vs poisoned stale branches)
 - `create-worktree.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for unified worktree creation
 - `sanitize-pipeline-id.sh` — shared PIPELINE_ID sanitizer (used by `/run-plan`, `/fix-issues`, `/do`, `/quickfix` before persisting ID)
-- `apply-preset.sh` — required by the preset UX (Step F); splices/flips the `BLOCK_MAIN_PUSH` line in `block-unsafe-generic.sh` and updates `execution.landing`/`execution.main_protected` in config
+- `apply-preset.sh` — required by the preset UX (Step F); **config-only** — updates `execution.landing`/`execution.main_protected` in config (the hook reads `main_protected` at runtime; apply-preset does not touch it)
 - `compute-cron-fire.sh` — required by `/run-plan` (Phase 5c chunked finish-auto, verify-pending retry, re-entry) for computing one-shot cron expressions with correct minute/hour/day/month/year rollover
 - `stop-dev.sh` — sanctioned SIGTERM-only dev-server stopper (reads `.zskills/dev-server.pid`). The approved way for agents to stop a dev server without reaching for `kill -9` / `fuser -k` / `lsof -ti | xargs kill`
 - `statusline.sh` — session statusline helper (optional but should be installed if the user has it)
@@ -942,6 +945,94 @@ Overall: Y/Y dependencies satisfied. Nothing to install.
 If there are gaps and the skill is running in default or install mode,
 proceed to fill them (see below). The audit report is always shown first
 so the user sees what was found before any modifications.
+
+---
+
+## Step 0.7 — Lane check (plugin-lane short-circuit)
+
+This branch sits on the **bare / default path only** — it runs after the
+arg parser (Step 0.25), config read (Step 0.5), and the greenfield prompt
+(Step 0.6), and **at/above** the Default-Mode Smart-Detection fork below.
+Explicit `--migrate-paths` already short-circuited at Step 0.1; explicit
+`install`, `--with-addons`, `--rerender`, and `--switch-install-path` are a
+user *forcing* a legacy/mirror action and are **not** intercepted here
+(typing the flag is opt-in). The destructive case this branch prevents is
+the *silent* flip of a pure-plugin consumer on a **bare** `/update-zskills`
+call: with no `.claude/skills/` mirror, the audit would see every skill/hook
+as "missing" and the gap-fill would copy them all in, flipping the consumer
+onto the legacy lane.
+
+**Signal = `detect_install_state == plugin`**, NOT `$CLAUDE_PLUGIN_ROOT`.
+`lane == plugin` means "plugin-materialised artifacts present AND no legacy
+`.claude/skills` mirror" — the exact flip-risk. `$CLAUDE_PLUGIN_ROOT` is
+rejected: it is set in any `claude --plugin-dir .` session (including the
+dev repo's legacy-lane dogfooding), so keying on it would make
+`/update-zskills install` wrongly hit this branch and refuse to install.
+`detect_install_state` answers "what's installed on disk", not "how was I
+invoked." The dev repo has its legacy mirror present, so it classifies as
+`update-zskills` and this branch **never fires** there.
+
+**Resolve the lane (dual-locate + fail-soft).** `detect-install-state.sh`
+is NOT mirrored into `.claude/hooks/_lib/` on the legacy lane, so locate it
+under `$CLAUDE_PLUGIN_ROOT` or `$PORTABLE`; if it is unreachable, default
+`LANE=update-zskills` (legacy behavior — safe, because the only unreachable
+case is a pure-legacy session, which *should* proceed with legacy behavior
+anyway; a pure-plugin consumer always has `$CLAUDE_PLUGIN_ROOT` set):
+
+```bash
+MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+DIS=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/detect-install-state.sh" ]; then
+  DIS="${CLAUDE_PLUGIN_ROOT}/hooks/_lib/detect-install-state.sh"
+elif [ -n "${PORTABLE:-}" ] && [ -f "${PORTABLE}/hooks/_lib/detect-install-state.sh" ]; then
+  DIS="${PORTABLE}/hooks/_lib/detect-install-state.sh"
+fi
+LANE="update-zskills"   # fail-soft default = legacy behavior (safe)
+if [ -n "$DIS" ]; then . "$DIS"; LANE="$(detect_install_state "$MAIN_ROOT")"; fi
+```
+
+**If `LANE == plugin`:** do NOT run Step 0 asset-locate, the audit's
+gap-fill (Steps A–G below), or any `.claude/`-mirroring step.
+
+- **If a preset arg was parsed (`$PRESET_ARG` non-empty):** apply it
+  **config-only** via the existing **Step F — Apply Preset** call (it is
+  lane-portable — it edits only `.claude/zskills-config.json`, never the
+  mirror):
+
+  ```bash
+  bash "${CLAUDE_PLUGIN_ROOT:-$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills}/scripts/apply-preset.sh" "$PRESET_ARG"
+  ```
+
+  Report the result verbatim per Step F's exit-code table (0 applied / 1
+  no-change / 2 usage / 3 missing config / 4 malformed config), then exit
+  with the script's exit code. Do not proceed to the audit or any fill
+  step.
+
+- **Else (bare call, no preset):** print the plugin-lane explanation and
+  exit 0:
+
+  ```
+  You're on the plugin lane. Skills, hooks, and rules are plugin-managed —
+  update them with `/plugin marketplace update`, not `/update-zskills`. To
+  change landing mode here, run
+  `/zs:update-zskills <cherry-pick|locked-main-pr|direct>` or edit
+  `.claude/zskills-config.json` directly (config is the single source of
+  truth for mode). To switch install lanes, use
+  `scripts/switch-install-path.sh` (or
+  `/update-zskills --switch-install-path=...`).
+  ```
+
+**Else** (`LANE` is `update-zskills`, `dual`, or `fresh`, OR detection was
+unreachable): proceed to the existing behavior **unchanged**. The `dual`
+case is intentionally NOT given its own arm — the mirror already exists, so
+gap-fill is a non-destructive update, and the materialiser +
+`switch-install-path` already own dual detection/warning/recovery;
+`/update-zskills` must not add its own dual handling.
+
+`managed.md` is not touched by this branch — because the plugin arm skips
+the entire gap-fill (including Step B's render), the sentinel-clobber
+landmine (a sentinel-less re-render shifting `detect_install_state`) cannot
+occur on this path.
 
 ---
 
@@ -1224,12 +1315,14 @@ runtime. No install-time fill needed. Only copy the source template.
 >
 > See the canonical table below for the full hook set (additionally: PreToolUse `Agent` matcher → `block-agents.sh`; PostToolUse `Edit`/`Write` matchers → `warn-config-drift.sh`).
 
-**Main-push block (preset-controlled):** `block-unsafe-generic.sh`
-blocks `git push` to `main`/`master` when `BLOCK_MAIN_PUSH=1`, the
-top-of-file variable. The preset controls this value via
-**Step F — Apply Preset** at the end of the install/update path; no
-action here in Step C. Preset mapping: `cherry-pick` → `0`,
-`locked-main-pr` → `1`, `direct` → `0`.
+**Main-push block (config-derived):** `block-unsafe-generic.sh`
+blocks `git push` to `main`/`master` when `BLOCK_MAIN_PUSH=1` — a value the
+hook **derives at runtime** from `execution.main_protected` in
+`.claude/zskills-config.json` (fail-closed: defaults to `1`/block when the
+config is absent or unreadable). The preset sets `main_protected` in config
+(Step F is config-only); the hook reads it. No hook edit here in Step C.
+Effective mapping: `cherry-pick`/`direct` → `main_protected:false` → allow
+push; `locked-main-pr` → `main_protected:true` → block push.
 
 **Note on tracking enforcement:** The tracking enforcement section in
 `block-unsafe-project.sh` (protecting `.zskills/tracking/`, blocking
@@ -1707,16 +1800,17 @@ Capture stdout and the exit code. Report to the user verbatim:
   the script reported.
 - Exit 1: "Preset '<name>' already applied — no changes needed."
 - Exit 2/3/4: print the script's error message and halt; these only
-  fire when the config file is missing, the hook file is missing, the
-  config JSON is malformed, or an unknown preset was somehow passed.
-  In that case, advise the user and do not continue.
+  fire when an unknown preset was somehow passed (2), the config file is
+  missing (3), or the config JSON is malformed (4). apply-preset is
+  config-only — it does not read or edit the hook. In that case, advise
+  the user and do not continue.
 
 **Why a script and not a series of `Edit` calls in the SKILL.md?**
 The script is deterministic, idempotent, and unit-tested
-(`tests/test-apply-preset.sh`, 16 cases covering legacy hooks,
-missing `execution` keys, compact JSON, idempotency, error paths).
+(`tests/test-apply-preset.sh` covers missing `execution` keys, compact
+JSON, idempotency, error paths, and asserts the hook is left untouched).
 A prompt-side sequence of `Edit` calls is fragile against JSON
-formatting variance and legacy hook versions. Delegate to the script.
+formatting variance. Delegate to the script.
 
 #### Step F.5 — Mirror the source-repo tag into config
 
@@ -1951,12 +2045,10 @@ These rules are inviolable. They apply to all modes:
    AND the template's ±2-line context around that value. No other
    cross-writes.
 2. **NEVER overwrite existing hooks or scripts** — if a file already
-   exists, skip it. The user may have customized it.
-   (Exception: `.claude/skills/update-zskills/scripts/apply-preset.sh` performs targeted in-place
-   edits to `block-unsafe-generic.sh` — splicing a missing
-   `BLOCK_MAIN_PUSH=` line or flipping its value. This is a
-   deterministic, non-destructive operation limited to that one line;
-   the rest of the hook is preserved byte-for-byte.)
+   exists, skip it. The user may have customized it. (Presets do not edit
+   any hook: `apply-preset.sh` is config-only, and
+   `block-unsafe-generic.sh` derives its main-push gate from
+   `execution.main_protected` at runtime.)
 3. **Explain what hooks do when installing them** — don't just list
    filenames. The user needs to understand what each hook does.
 4. **Show the user what will be installed BEFORE doing it** — no silent

--- a/docs/plans/UPDATE_ZSKILLS_LANE_AWARE.md
+++ b/docs/plans/UPDATE_ZSKILLS_LANE_AWARE.md
@@ -1,7 +1,8 @@
 ---
 title: Lane-aware /update-zskills (don't flip a plugin consumer)
 created: 2026-05-29
-status: active
+status: "complete"
+completed: "2026-05-29T16:29:41Z"
 ---
 
 # Plan: Lane-aware `/update-zskills`
@@ -30,7 +31,7 @@ classifies as `update-zskills` (verified) — the branch **never fires** there, 
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Lane-aware plugin-context branch + doc-drift + tests | ⬚ | | |
+| 1 — Lane-aware plugin-context branch + doc-drift + tests | ✅ Done | `30f38bf` | Step 0.7 lane branch; #801 doc-drift; +17 tests; 6421/6421 |
 
 ## Phase 1 — Lane-aware plugin-context branch
 

--- a/docs/reports/plan-update-zskills-lane-aware.md
+++ b/docs/reports/plan-update-zskills-lane-aware.md
@@ -1,0 +1,26 @@
+# Plan Report — Lane-aware /update-zskills
+
+## Phase — 1 Lane-aware plugin-context branch + doc-drift + tests
+
+**Plan:** docs/plans/UPDATE_ZSKILLS_LANE_AWARE.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-update-zskills-lane-aware (branch `feat/update-zskills-lane-aware`)
+**Commits:** 30f38bf (implementation + tests + doc-drift)
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| W1 | Lane-aware branch (Step 0.7) keyed on `detect_install_state == plugin` | Done | 30f38bf |
+| W2 | #801 doc-drift fixes (apply-preset config-only; push gate derives from `main_protected`) | Done | 30f38bf |
+| W3 | Mirror parity (`skills/` ↔ `.claude/skills/` byte-equal) + `metadata.version` bump | Done | 30f38bf |
+| W4 | `tests/test-update-zskills-lane-aware.sh` (17 cases) wired into `run-all.sh` | Done | 30f38bf |
+
+### Verification
+- Test suite: PASSED by exit code — `Overall: 6421/6421 passed, 0 failed` (baseline 6404 + 17 new cases, zero regressions).
+- `test-skills-mirror-parity.sh` green; source ↔ `.claude` mirror byte-equal; `metadata.version: "2026.05.29+90450f"` in both copies.
+- Acceptance criteria AC1–AC6: all met (verified by a separate verifier agent, independently re-checked).
+- **AC3 (load-bearing dogfooding-safety):** `detect_install_state /workspaces/zskills` → `update-zskills` (NOT `plugin`), so the lane branch provably never fires in this dev repo — `/update-zskills install` / `--rerender` dogfooding is preserved.
+- Anti-overbuild constraints honored: no `CLAUDE_PLUGIN_ROOT` keying, no `dual` arm, no new flags/strings/scripts, no hook edits, no create-config path.
+
+### Notes
+- Drift: the implementer flagged a stale "16 cases" count for `tests/test-apply-preset.sh` in the SKILL.md prose (actual 18) and resolved it by dropping the count rather than re-pinning a drift-prone number. No plan acceptance-criterion drift (the token referenced SKILL.md prose, not a plan AC bullet).

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths | --switch-install-path={to-plugin|to-update-zskills}] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.05.29+24f693"
+  version: "2026.05.29+90450f"
 ---
 
 # Update Z Skills Infrastructure
@@ -84,16 +84,17 @@ was found and what was done about it.
 
 **Preset keywords (bare word, anywhere in the args):**
 
-Presets control three things at once: `execution.landing`,
-`execution.main_protected`, and the `BLOCK_MAIN_PUSH` line in
-`.claude/hooks/block-unsafe-generic.sh`. Everything else in
-`zskills-config.json` is preserved.
+Presets are **config-only**: they set `execution.landing` and
+`execution.main_protected` in `.claude/zskills-config.json`. The
+main-push gate in `block-unsafe-generic.sh` is no longer set by the preset
+— the hook reads `execution.main_protected` from config at runtime
+(fail-closed). Everything else in `zskills-config.json` is preserved.
 
-| Preset | `execution.landing` | `execution.main_protected` | `BLOCK_MAIN_PUSH` |
+| Preset | `execution.landing` | `execution.main_protected` | push gate (derived at runtime) |
 |---|---|---|---|
-| `cherry-pick` (default) | `cherry-pick` | `false` | `0` |
-| `locked-main-pr` | `pr` | `true` | `1` |
-| `direct` | `direct` | `false` | `0` |
+| `cherry-pick` (default) | `cherry-pick` | `false` | allow |
+| `locked-main-pr` | `pr` | `true` | block |
+| `direct` | `direct` | `false` | allow |
 
 Behavior by invocation:
 - `/update-zskills <preset>` — apply that preset; no greenfield prompt.
@@ -429,13 +430,15 @@ installed, not landing behavior.
 Preset → field mapping (used wherever a preset is applied in later
 steps):
 
-| `$PRESET_ARG` | `execution.landing` | `execution.main_protected` | `BLOCK_MAIN_PUSH` |
-|---|---|---|---|
-| `cherry-pick` | `"cherry-pick"` | `false` | `0` |
-| `locked-main-pr` | `"pr"` | `true` | `1` |
-| `direct` | `"direct"` | `false` | `0` |
+| `$PRESET_ARG` | `execution.landing` | `execution.main_protected` |
+|---|---|---|
+| `cherry-pick` | `"cherry-pick"` | `false` |
+| `locked-main-pr` | `"pr"` | `true` |
+| `direct` | `"direct"` | `false` |
 
-The three affected fields are **preset-owned**. When `$PRESET_ARG` is
+These two config fields are **preset-owned**. (The main-push gate in
+`block-unsafe-generic.sh` derives from `main_protected` at runtime — it is
+not a value the preset writes.) When `$PRESET_ARG` is
 non-empty, every other field in `.claude/zskills-config.json`
 (`branch_prefix`, `testing.*`, `dev_server.*`, `ui.*`, `ci.*`,
 `timezone`, `agents.min_model`) is preserved unchanged.
@@ -585,13 +588,13 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    `$schema` reference in the config resolves correctly).
 5. **If `$PRESET_ARG` was set**, defer preset application to
    **Step F — Apply Preset** (invoked at the end of both install and
-   update paths). Step F runs `.claude/skills/update-zskills/scripts/apply-preset.sh` which handles
-   all three preset-owned fields (`execution.landing`,
-   `execution.main_protected`, `BLOCK_MAIN_PUSH`) atomically,
-   including idempotency, JSON formatting variance, missing
-   `execution` key, and legacy hooks without the `BLOCK_MAIN_PUSH=`
-   line. Don't attempt a manual `Edit` here — the script is the
-   single source of truth.
+   update paths). Step F runs `.claude/skills/update-zskills/scripts/apply-preset.sh` which is
+   **config-only** — it sets the two preset-owned config fields
+   (`execution.landing`, `execution.main_protected`) atomically,
+   including idempotency, JSON formatting variance, and a missing
+   `execution` key. It does NOT touch the hook; `block-unsafe-generic.sh`
+   reads `main_protected` from config at runtime. Don't attempt a manual
+   `Edit` here — the script is the single source of truth.
 
 **If it does not exist:**
 1. **If `$PRESET_ARG` is empty**, run the greenfield prompt (Step 0.6)
@@ -645,13 +648,12 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    left empty by auto-detection stay as empty strings — the install
    summary's test-setup blurb tells the user what to fill in later.
 
-4. **Hook toggle handled by Step F.** The config's `execution.landing`
+4. **No hook edit needed.** The config's `execution.landing`
    and `execution.main_protected` placeholders above are substituted
-   in at write time. The `BLOCK_MAIN_PUSH` line in the hook is set by
-   **Step F — Apply Preset** at the end of the install path, after
-   Step C has copied the hook. Step F idempotently flips the value
-   (or splices the line, on a legacy hook without it) to match the
-   preset target. Nothing to do here.
+   in at write time, and `block-unsafe-generic.sh` reads
+   `main_protected` from config at runtime to decide whether to block
+   a push to `main`/`master` (fail-closed). **Step F — Apply Preset** is
+   config-only and does not touch the hook. Nothing to do here.
 
 **Merge algorithm pseudocode:**
 ```
@@ -722,12 +724,13 @@ Map the reply:
   then proceed. Never re-ask the prompt; never invent a 4th option.
 
 Set `$PRESET_ARG` to the chosen preset and proceed. No follow-up
-questions — the three-field mapping (landing + main_protected +
-BLOCK_MAIN_PUSH) in Step 0.25 is final. In particular, we do **not**
-ask "do you want the main-push block on?" for `locked-main-pr`:
-`main_protected=true` already makes `block-unsafe-project.sh` block
-agent commits, cherry-picks, and pushes on main, so the generic hook's
-`BLOCK_MAIN_PUSH=1` is belt-and-suspenders, not a user-facing choice.
+questions — the two-field config mapping (landing + main_protected) in
+Step 0.25 is final. In particular, we do **not** ask "do you want the
+main-push block on?" for `locked-main-pr`: `main_protected=true` is the
+single source of truth — `block-unsafe-project.sh` blocks agent commits,
+cherry-picks, and pushes on main, and `block-unsafe-generic.sh` derives
+its push gate from the same `main_protected` value at runtime, so the
+push block is not a separate user-facing choice.
 
 ---
 
@@ -823,7 +826,7 @@ Look in `scripts/` for these files (all required by installed skills):
 - `worktree-add-safe.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for safe worktree creation (discriminates fresh vs poisoned stale branches)
 - `create-worktree.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for unified worktree creation
 - `sanitize-pipeline-id.sh` — shared PIPELINE_ID sanitizer (used by `/run-plan`, `/fix-issues`, `/do`, `/quickfix` before persisting ID)
-- `apply-preset.sh` — required by the preset UX (Step F); splices/flips the `BLOCK_MAIN_PUSH` line in `block-unsafe-generic.sh` and updates `execution.landing`/`execution.main_protected` in config
+- `apply-preset.sh` — required by the preset UX (Step F); **config-only** — updates `execution.landing`/`execution.main_protected` in config (the hook reads `main_protected` at runtime; apply-preset does not touch it)
 - `compute-cron-fire.sh` — required by `/run-plan` (Phase 5c chunked finish-auto, verify-pending retry, re-entry) for computing one-shot cron expressions with correct minute/hour/day/month/year rollover
 - `stop-dev.sh` — sanctioned SIGTERM-only dev-server stopper (reads `.zskills/dev-server.pid`). The approved way for agents to stop a dev server without reaching for `kill -9` / `fuser -k` / `lsof -ti | xargs kill`
 - `statusline.sh` — session statusline helper (optional but should be installed if the user has it)
@@ -942,6 +945,94 @@ Overall: Y/Y dependencies satisfied. Nothing to install.
 If there are gaps and the skill is running in default or install mode,
 proceed to fill them (see below). The audit report is always shown first
 so the user sees what was found before any modifications.
+
+---
+
+## Step 0.7 — Lane check (plugin-lane short-circuit)
+
+This branch sits on the **bare / default path only** — it runs after the
+arg parser (Step 0.25), config read (Step 0.5), and the greenfield prompt
+(Step 0.6), and **at/above** the Default-Mode Smart-Detection fork below.
+Explicit `--migrate-paths` already short-circuited at Step 0.1; explicit
+`install`, `--with-addons`, `--rerender`, and `--switch-install-path` are a
+user *forcing* a legacy/mirror action and are **not** intercepted here
+(typing the flag is opt-in). The destructive case this branch prevents is
+the *silent* flip of a pure-plugin consumer on a **bare** `/update-zskills`
+call: with no `.claude/skills/` mirror, the audit would see every skill/hook
+as "missing" and the gap-fill would copy them all in, flipping the consumer
+onto the legacy lane.
+
+**Signal = `detect_install_state == plugin`**, NOT `$CLAUDE_PLUGIN_ROOT`.
+`lane == plugin` means "plugin-materialised artifacts present AND no legacy
+`.claude/skills` mirror" — the exact flip-risk. `$CLAUDE_PLUGIN_ROOT` is
+rejected: it is set in any `claude --plugin-dir .` session (including the
+dev repo's legacy-lane dogfooding), so keying on it would make
+`/update-zskills install` wrongly hit this branch and refuse to install.
+`detect_install_state` answers "what's installed on disk", not "how was I
+invoked." The dev repo has its legacy mirror present, so it classifies as
+`update-zskills` and this branch **never fires** there.
+
+**Resolve the lane (dual-locate + fail-soft).** `detect-install-state.sh`
+is NOT mirrored into `.claude/hooks/_lib/` on the legacy lane, so locate it
+under `$CLAUDE_PLUGIN_ROOT` or `$PORTABLE`; if it is unreachable, default
+`LANE=update-zskills` (legacy behavior — safe, because the only unreachable
+case is a pure-legacy session, which *should* proceed with legacy behavior
+anyway; a pure-plugin consumer always has `$CLAUDE_PLUGIN_ROOT` set):
+
+```bash
+MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+DIS=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/detect-install-state.sh" ]; then
+  DIS="${CLAUDE_PLUGIN_ROOT}/hooks/_lib/detect-install-state.sh"
+elif [ -n "${PORTABLE:-}" ] && [ -f "${PORTABLE}/hooks/_lib/detect-install-state.sh" ]; then
+  DIS="${PORTABLE}/hooks/_lib/detect-install-state.sh"
+fi
+LANE="update-zskills"   # fail-soft default = legacy behavior (safe)
+if [ -n "$DIS" ]; then . "$DIS"; LANE="$(detect_install_state "$MAIN_ROOT")"; fi
+```
+
+**If `LANE == plugin`:** do NOT run Step 0 asset-locate, the audit's
+gap-fill (Steps A–G below), or any `.claude/`-mirroring step.
+
+- **If a preset arg was parsed (`$PRESET_ARG` non-empty):** apply it
+  **config-only** via the existing **Step F — Apply Preset** call (it is
+  lane-portable — it edits only `.claude/zskills-config.json`, never the
+  mirror):
+
+  ```bash
+  bash "${CLAUDE_PLUGIN_ROOT:-$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills}/scripts/apply-preset.sh" "$PRESET_ARG"
+  ```
+
+  Report the result verbatim per Step F's exit-code table (0 applied / 1
+  no-change / 2 usage / 3 missing config / 4 malformed config), then exit
+  with the script's exit code. Do not proceed to the audit or any fill
+  step.
+
+- **Else (bare call, no preset):** print the plugin-lane explanation and
+  exit 0:
+
+  ```
+  You're on the plugin lane. Skills, hooks, and rules are plugin-managed —
+  update them with `/plugin marketplace update`, not `/update-zskills`. To
+  change landing mode here, run
+  `/zs:update-zskills <cherry-pick|locked-main-pr|direct>` or edit
+  `.claude/zskills-config.json` directly (config is the single source of
+  truth for mode). To switch install lanes, use
+  `scripts/switch-install-path.sh` (or
+  `/update-zskills --switch-install-path=...`).
+  ```
+
+**Else** (`LANE` is `update-zskills`, `dual`, or `fresh`, OR detection was
+unreachable): proceed to the existing behavior **unchanged**. The `dual`
+case is intentionally NOT given its own arm — the mirror already exists, so
+gap-fill is a non-destructive update, and the materialiser +
+`switch-install-path` already own dual detection/warning/recovery;
+`/update-zskills` must not add its own dual handling.
+
+`managed.md` is not touched by this branch — because the plugin arm skips
+the entire gap-fill (including Step B's render), the sentinel-clobber
+landmine (a sentinel-less re-render shifting `detect_install_state`) cannot
+occur on this path.
 
 ---
 
@@ -1224,12 +1315,14 @@ runtime. No install-time fill needed. Only copy the source template.
 >
 > See the canonical table below for the full hook set (additionally: PreToolUse `Agent` matcher → `block-agents.sh`; PostToolUse `Edit`/`Write` matchers → `warn-config-drift.sh`).
 
-**Main-push block (preset-controlled):** `block-unsafe-generic.sh`
-blocks `git push` to `main`/`master` when `BLOCK_MAIN_PUSH=1`, the
-top-of-file variable. The preset controls this value via
-**Step F — Apply Preset** at the end of the install/update path; no
-action here in Step C. Preset mapping: `cherry-pick` → `0`,
-`locked-main-pr` → `1`, `direct` → `0`.
+**Main-push block (config-derived):** `block-unsafe-generic.sh`
+blocks `git push` to `main`/`master` when `BLOCK_MAIN_PUSH=1` — a value the
+hook **derives at runtime** from `execution.main_protected` in
+`.claude/zskills-config.json` (fail-closed: defaults to `1`/block when the
+config is absent or unreadable). The preset sets `main_protected` in config
+(Step F is config-only); the hook reads it. No hook edit here in Step C.
+Effective mapping: `cherry-pick`/`direct` → `main_protected:false` → allow
+push; `locked-main-pr` → `main_protected:true` → block push.
 
 **Note on tracking enforcement:** The tracking enforcement section in
 `block-unsafe-project.sh` (protecting `.zskills/tracking/`, blocking
@@ -1707,16 +1800,17 @@ Capture stdout and the exit code. Report to the user verbatim:
   the script reported.
 - Exit 1: "Preset '<name>' already applied — no changes needed."
 - Exit 2/3/4: print the script's error message and halt; these only
-  fire when the config file is missing, the hook file is missing, the
-  config JSON is malformed, or an unknown preset was somehow passed.
-  In that case, advise the user and do not continue.
+  fire when an unknown preset was somehow passed (2), the config file is
+  missing (3), or the config JSON is malformed (4). apply-preset is
+  config-only — it does not read or edit the hook. In that case, advise
+  the user and do not continue.
 
 **Why a script and not a series of `Edit` calls in the SKILL.md?**
 The script is deterministic, idempotent, and unit-tested
-(`tests/test-apply-preset.sh`, 16 cases covering legacy hooks,
-missing `execution` keys, compact JSON, idempotency, error paths).
+(`tests/test-apply-preset.sh` covers missing `execution` keys, compact
+JSON, idempotency, error paths, and asserts the hook is left untouched).
 A prompt-side sequence of `Edit` calls is fragile against JSON
-formatting variance and legacy hook versions. Delegate to the script.
+formatting variance. Delegate to the script.
 
 #### Step F.5 — Mirror the source-repo tag into config
 
@@ -1951,12 +2045,10 @@ These rules are inviolable. They apply to all modes:
    AND the template's ±2-line context around that value. No other
    cross-writes.
 2. **NEVER overwrite existing hooks or scripts** — if a file already
-   exists, skip it. The user may have customized it.
-   (Exception: `.claude/skills/update-zskills/scripts/apply-preset.sh` performs targeted in-place
-   edits to `block-unsafe-generic.sh` — splicing a missing
-   `BLOCK_MAIN_PUSH=` line or flipping its value. This is a
-   deterministic, non-destructive operation limited to that one line;
-   the rest of the hook is preserved byte-for-byte.)
+   exists, skip it. The user may have customized it. (Presets do not edit
+   any hook: `apply-preset.sh` is config-only, and
+   `block-unsafe-generic.sh` derives its main-push gate from
+   `execution.main_protected` at runtime.)
 3. **Explain what hooks do when installing them** — don't just list
    filenames. The user needs to understand what each hook does.
 4. **Show the user what will be installed BEFORE doing it** — no silent

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -125,6 +125,7 @@ run_suite "test-update-zskills-agent-install" "tests/test-update-zskills-agent-i
 run_suite "test-update-zskills-paths-migration.sh" "tests/test-update-zskills-paths-migration.sh"
 run_suite "test-migrate-paths-awk.sh" "tests/test-migrate-paths-awk.sh"
 run_suite "test-update-zskills-rerender.sh" "tests/test-update-zskills-rerender.sh"
+run_suite "test-update-zskills-lane-aware.sh" "tests/test-update-zskills-lane-aware.sh"
 run_suite "test-managed-md-up-to-date.sh" "tests/test-managed-md-up-to-date.sh"
 run_suite "test-mirror-skill.sh" "tests/test-mirror-skill.sh"
 run_suite "test-cleanup-merged-ahead-gate.sh" "tests/test-cleanup-merged-ahead-gate.sh"

--- a/tests/test-update-zskills-lane-aware.sh
+++ b/tests/test-update-zskills-lane-aware.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# tests/test-update-zskills-lane-aware.sh
+#
+# Phase 1 (UPDATE_ZSKILLS_LANE_AWARE) — the lane-aware plugin-context
+# branch (Step 0.7) in skills/update-zskills/SKILL.md.
+#
+# SKILL.md is a prose+bash procedure executed by an LLM orchestrator, not
+# a runnable script. The load-bearing primitives the branch keys on ARE
+# testable here:
+#   - detect_install_state() classification per lane fixture (the signal),
+#   - the dual-locate + fail-soft sourcing logic (LANE defaults to
+#     update-zskills when detect-install-state.sh is unreachable),
+#   - apply-preset.sh's config-only behavior on a pure-plugin fixture
+#     (no mirror written; exit code reflects apply-preset),
+#   - structural pins that the branch prose + plugin-lane explanation are
+#     present in BOTH the source SKILL.md and its byte-equal mirror.
+#
+# Acceptance cases:
+#   AC1 — pure-plugin (sentinelled artifacts, NO .claude/skills mirror) →
+#         detect == plugin; no mirror present; SKILL.md prints the
+#         plugin-lane explanation on a bare call.
+#   AC2 — plugin lane + <preset> → apply-preset.sh edits config only
+#         (execution.landing/main_protected); NO mirror created; exit code
+#         reflects apply-preset's code.
+#   AC3 — dogfooding/legacy NOT intercepted: a fixture with a legacy mirror
+#         (update-zskills) and the dev-repo-shaped case both classify as
+#         NON-plugin → branch does not fire.
+#   AC4 — fail-soft: detect-install-state.sh unreachable → LANE defaults to
+#         update-zskills → legacy behavior; no crash.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+SKILL="skills/update-zskills/SKILL.md"
+MIRROR=".claude/skills/update-zskills/SKILL.md"
+DETECT="hooks/_lib/detect-install-state.sh"
+APPLY="skills/update-zskills/scripts/apply-preset.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck source=/dev/null
+. "$REPO_ROOT/$DETECT"
+
+# A fresh project with config (no .claude artifacts).
+base_fixture() {
+  local p="$1"
+  mkdir -p "$p/.claude"
+  cp "$REPO_ROOT/.claude/zskills-config.json" "$p/.claude/zskills-config.json"
+}
+# Write a plugin-materialised (sentinelled) artifact.
+write_sentinelled_hook() {
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' '#!/usr/bin/env bash' '# zskills-materialised: 2026.05.0' 'echo hi' > "$1"
+}
+write_sentinelled_managed() {
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' '<!-- zskills-materialised: 2026.05.0 -->' '# rules' > "$1"
+}
+# Write an update-zskills-installed (UN-sentinelled) SKILL.md mirror.
+write_unsentinelled_skill() {
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' '---' 'name: x' '---' 'body' > "$1"
+}
+# Count .claude/skills/*/SKILL.md mirror files under a project.
+mirror_skill_count() {
+  local p="$1" n=0 f
+  for f in "$p"/.claude/skills/*/SKILL.md; do
+    [ -f "$f" ] && n=$((n+1))
+  done
+  echo "$n"
+}
+
+echo "=== lane-aware /update-zskills branch (Step 0.7) ==="
+
+# ── Structural pins: the branch + explanation are present in BOTH copies ──
+for f in "$SKILL" "$MIRROR"; do
+  if grep -q '## Step 0.7 — Lane check' "$REPO_ROOT/$f"; then
+    pass "branch section 'Step 0.7 — Lane check' present in $f"
+  else
+    fail "branch section 'Step 0.7 — Lane check' MISSING from $f"
+  fi
+done
+
+# The signal is detect_install_state == plugin, NOT $CLAUDE_PLUGIN_ROOT keying.
+if grep -q 'detect_install_state' "$REPO_ROOT/$SKILL" \
+   && grep -qE 'LANE[[:space:]]*==[[:space:]]*plugin|LANE.*plugin' "$REPO_ROOT/$SKILL"; then
+  pass "branch keys on detect_install_state == plugin (signal correct)"
+else
+  fail "branch does not reference detect_install_state / LANE==plugin"
+fi
+
+# Fail-soft default LANE=update-zskills is present in the dual-locate snippet.
+if grep -q 'LANE="update-zskills"' "$REPO_ROOT/$SKILL"; then
+  pass "dual-locate snippet sets fail-soft default LANE=update-zskills"
+else
+  fail "fail-soft default LANE=update-zskills missing"
+fi
+
+# The plugin-lane explanation text is present (reuse existing phrasing).
+if grep -q "plugin-managed" "$REPO_ROOT/$SKILL" \
+   && grep -q "plugin marketplace update" "$REPO_ROOT/$SKILL"; then
+  pass "plugin-lane explanation text present in branch"
+else
+  fail "plugin-lane explanation text missing"
+fi
+
+# ── AC1 — pure-plugin not flipped ─────────────────────────────────────────
+P1="$TMP/plugin"
+base_fixture "$P1"
+write_sentinelled_hook "$P1/.claude/hooks/inject-bash-timeout.sh"
+write_sentinelled_managed "$P1/.claude/rules/zskills/managed.md"
+got="$(detect_install_state "$P1")"
+[ "$got" = plugin ] && pass "AC1a. pure-plugin fixture → detect_install_state == plugin" \
+  || fail "AC1a. expected plugin, got $got"
+# No legacy skills mirror exists on the plugin fixture (the branch must
+# skip the gap-fill rather than create one).
+[ "$(mirror_skill_count "$P1")" -eq 0 ] \
+  && pass "AC1b. pure-plugin fixture has NO .claude/skills mirror (gap-fill would flip it)" \
+  || fail "AC1b. .claude/skills mirror unexpectedly present on plugin fixture"
+
+# ── AC2 — preset config-only on plugin lane ───────────────────────────────
+P2="$TMP/plugin-preset"
+base_fixture "$P2"
+write_sentinelled_hook "$P2/.claude/hooks/inject-bash-timeout.sh"
+write_sentinelled_managed "$P2/.claude/rules/zskills/managed.md"
+got="$(detect_install_state "$P2")"
+[ "$got" = plugin ] && pass "AC2a. plugin+preset fixture → detect == plugin" \
+  || fail "AC2a. expected plugin, got $got"
+# Run the SAME apply-preset.sh the branch calls. It must edit ONLY config.
+out2=$(PROJECT_ROOT="$P2" bash "$REPO_ROOT/$APPLY" direct 2>&1); rc2=$?
+if [ "$rc2" -eq 0 ]; then
+  pass "AC2b. apply-preset.sh direct exits 0 (applied) on plugin fixture"
+else
+  fail "AC2b. apply-preset.sh direct exit=$rc2, output: $out2"
+fi
+if grep -q '"landing"[[:space:]]*:[[:space:]]*"direct"' "$P2/.claude/zskills-config.json" \
+   && grep -q '"main_protected"[[:space:]]*:[[:space:]]*false' "$P2/.claude/zskills-config.json"; then
+  pass "AC2c. config updated to landing=direct, main_protected=false (config-only)"
+else
+  fail "AC2c. config not updated as expected: $(grep -E 'landing|main_protected' "$P2/.claude/zskills-config.json")"
+fi
+# NO mirror was created by applying the preset (config-only invariant).
+[ "$(mirror_skill_count "$P2")" -eq 0 ] \
+  && pass "AC2d. applying preset created NO .claude/skills mirror" \
+  || fail "AC2d. preset apply created a skills mirror (should be config-only)"
+# Idempotent re-apply returns rc=1 (no change), still no mirror.
+out2b=$(PROJECT_ROOT="$P2" bash "$REPO_ROOT/$APPLY" direct 2>&1); rc2b=$?
+[ "$rc2b" -eq 1 ] \
+  && pass "AC2e. re-apply same preset exits 1 (no-change, idempotent)" \
+  || fail "AC2e. re-apply exit=$rc2b (expected 1), output: $out2b"
+
+# ── AC3 — dogfooding/legacy NOT intercepted ───────────────────────────────
+# (a) legacy-mirror fixture classifies update-zskills.
+P3="$TMP/uz"
+base_fixture "$P3"
+write_unsentinelled_skill "$P3/.claude/skills/update-zskills/SKILL.md"
+got="$(detect_install_state "$P3")"
+[ "$got" = update-zskills ] && pass "AC3a. legacy-mirror fixture → update-zskills (branch does NOT fire)" \
+  || fail "AC3a. expected update-zskills, got $got"
+[ "$got" != plugin ] && pass "AC3b. legacy fixture is NOT classified plugin" \
+  || fail "AC3b. legacy fixture wrongly classified plugin"
+
+# (b) dual fixture (sentinelled + un-sentinelled evidence) classifies dual,
+#     which is also NON-plugin → branch does not fire.
+P3d="$TMP/dual"
+base_fixture "$P3d"
+write_sentinelled_hook "$P3d/.claude/hooks/inject-bash-timeout.sh"
+write_unsentinelled_skill "$P3d/.claude/skills/run-plan/SKILL.md"
+got="$(detect_install_state "$P3d")"
+[ "$got" = dual ] && pass "AC3c. dual fixture → dual (NON-plugin, branch does NOT fire)" \
+  || fail "AC3c. expected dual, got $got"
+
+# (c) dev-repo-shaped case: the zskills dev repo dogfoods BOTH lanes but the
+#     legacy mirror is present, so it MUST classify NON-plugin (update-zskills
+#     or dual) — never plugin. Assert against the real repo root.
+got="$(detect_install_state "$REPO_ROOT")"
+if [ "$got" != plugin ]; then
+  pass "AC3d. dev-repo-shaped (real REPO_ROOT) classifies $got (NON-plugin) — never intercepted"
+else
+  fail "AC3d. dev repo wrongly classified plugin (would break dogfooding)"
+fi
+
+# ── AC4 — fail-soft when detect-install-state.sh unreachable ──────────────
+# Replicate the branch's dual-locate + fail-soft snippet with BOTH
+# $CLAUDE_PLUGIN_ROOT and $PORTABLE unset → DIS stays empty → LANE defaults
+# to update-zskills (legacy behavior), no crash.
+LANE_OUT=$(
+  env -u CLAUDE_PLUGIN_ROOT -u PORTABLE bash -c '
+    set -u
+    MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+    DIS=""
+    if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/detect-install-state.sh" ]; then
+      DIS="${CLAUDE_PLUGIN_ROOT}/hooks/_lib/detect-install-state.sh"
+    elif [ -n "${PORTABLE:-}" ] && [ -f "${PORTABLE}/hooks/_lib/detect-install-state.sh" ]; then
+      DIS="${PORTABLE}/hooks/_lib/detect-install-state.sh"
+    fi
+    LANE="update-zskills"
+    if [ -n "$DIS" ]; then . "$DIS"; LANE="$(detect_install_state "$MAIN_ROOT")"; fi
+    echo "$LANE"
+  '
+); rc4=$?
+if [ "$rc4" -eq 0 ] && [ "$LANE_OUT" = "update-zskills" ]; then
+  pass "AC4. detect unreachable → LANE fail-soft to update-zskills (legacy), no crash"
+else
+  fail "AC4. fail-soft failed: rc=$rc4 LANE=$LANE_OUT"
+fi
+
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+exit "$FAIL_COUNT"


### PR DESCRIPTION
## Plan: Lane-aware /update-zskills (don't flip a plugin consumer)

A bare `/update-zskills` on a **pure-plugin** consumer used to see an empty `.claude/` mirror, treat every skill/hook as "missing", and gap-fill them in — silently flipping the consumer onto the legacy lane. This adds one early lane check (Step 0.7) keyed on `detect_install_state == plugin` that, on the bare/default path only, skips the mirror/gap-fill and instead applies a preset config-only (if given) or prints a plugin-lane explanation. Reuses `detect-install-state.sh` (#799) + config-only `apply-preset.sh` (#801); adds no new scripts/flags/strings/subcommands.

Keyed on `detect_install_state` (not `CLAUDE_PLUGIN_ROOT`) and fail-soft to legacy, so it **never fires in this dev repo** (classifies `update-zskills`) — dogfooding of `/update-zskills install` / `--rerender` is preserved. Also folds in #801 doc-drift fixes (apply-preset is config-only; the push gate derives from `execution.main_protected` at runtime).

<!-- run-plan:progress:start -->
**Phases completed:**
1 — Lane-aware plugin-context branch + doc-drift + tests ✅ Done `30f38bf` Step 0.7 lane branch; #801 doc-drift; +17 tests; 6421/6421
<!-- run-plan:progress:end -->

### Test plan
- [x] Full suite green: `Overall: 6421/6421 passed, 0 failed` (baseline 6404 + 17 new lane-aware cases, zero regressions)
- [x] `tests/test-update-zskills-lane-aware.sh` (17 cases) covers AC1–AC4; wired into `run-all.sh`
- [x] `test-skills-mirror-parity.sh` green; source ↔ `.claude` mirror byte-equal; `metadata.version` bumped in both
- [x] AC3 dogfooding-safety: `detect_install_state /workspaces/zskills` → `update-zskills` (branch never fires here)
- [x] Re-verified green after rebase onto current main

**Report:** See `docs/reports/plan-update-zskills-lane-aware.md`.

---
Generated by `/run-plan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
