### PR TITLE
fix(fix-issues): persist plan-scale skip decisions to monitor-state.json (closes #808)

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.29+03435d"
+  version: "2026.05.29+c47a59"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/plan.md
+++ b/.claude/skills/fix-issues/modes/plan.md
@@ -70,6 +70,15 @@ either fires, all candidate issues are selected without prompting.
    printf 'skill: draft-plan\nparent: fix-issues\nissue: %s\ndate: %s\n' \
      "$ISSUE_NUMBER" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
      > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.draft-plan.$ISSUE_NUMBER"
+   # #808: record the skip in monitor-state.json so subsequent sprint
+   # fires drop this issue BEFORE re-triage (the user explicitly chose
+   # /draft-plan here; that decision is now persistent state, symmetric
+   # with the sprint-mode plan-scale-decline path). `reconsider <N>`
+   # clears the entry if the user later changes their mind.
+   ZSKILLS_MAIN_ROOT="$MAIN_ROOT" bash \
+     "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/record-skip.sh" \
+     "$ISSUE_NUMBER" plan-scale \
+     || echo "WARN: fix-issues plan: record-skip.sh failed for #$ISSUE_NUMBER — sprint may re-pick" >&2
    ```
    Then dispatch `/draft-plan` with:
    - The issue number and full body (`gh issue view <N> --json body`)

--- a/.claude/skills/fix-issues/modes/sprint.md
+++ b/.claude/skills/fix-issues/modes/sprint.md
@@ -1856,6 +1856,34 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
       # (#606 tax fix). `too-vague` is intentionally left untouched (no
       # canonical dashboard skip-code; vague rows need user clarification,
       # not auto-tagging — re-classified next fire by design).
+      #
+      # #808 — persistent skip-state in monitor-state.json. The scratchpad
+      # write-back ONLY persists the decision when a tracker row lands
+      # (research blurb existed). For the raw dashboard-drag case (#803:
+      # issue dragged to Ready with no prior research, declined plan-scale
+      # before any blurb existed) there is no scratchpad → no row write →
+      # the next fire re-litigates the same decline indefinitely. Record
+      # the decline in monitor-state.json (gitignored, symmetric with
+      # `issues.reconsider`) so the filter drops the candidate next fire
+      # regardless of tracker-row presence. `too-vague` is excluded — vague
+      # rows need user clarification, not auto-tagging (kept for the next
+      # fire so the user can see and act). `author-decision` is aliased to
+      # `needs-decision` (the filter's canonical code).
+      MONITOR_SKIP_CODE=""
+      case "$CLASS" in
+        plan-scale)         MONITOR_SKIP_CODE="plan-scale" ;;
+        bug-unclear-cause)  MONITOR_SKIP_CODE="bug-unclear-cause" ;;
+        needs-decision|author-decision) MONITOR_SKIP_CODE="needs-decision" ;;
+        deferred)           MONITOR_SKIP_CODE="deferred" ;;
+        too-vague)          : ;;  # do not persist; re-triage next fire
+      esac
+      if [ -n "$MONITOR_SKIP_CODE" ]; then
+        ZSKILLS_MAIN_ROOT="$MAIN_ROOT" bash \
+          "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/record-skip.sh" \
+          "$ISSUE_NUM" "$MONITOR_SKIP_CODE" \
+          || echo "WARN: fix-issues: record-skip.sh failed for #$ISSUE_NUM ($MONITOR_SKIP_CODE) — next fire may re-litigate" >&2
+      fi
+
       SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
       if [ -f "$SCRATCH" ]; then
         NEW_ACTION_NOW=""
@@ -2113,6 +2141,30 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
       # here — the scratchpad is held in `.zskills/research-staging/` for
       # the end-of-loop batch sync-PR that mirrors the dashboard-empty
       # pattern at SKILL.md ~1303-1378.
+      #
+      # #808 — persistent skip-state in monitor-state.json. Symmetric with
+      # the cherry-pick-mode write-back above: record the decline in
+      # `monitor-state.json` (gitignored) so the next fire's filter drops
+      # the candidate BEFORE re-triage, even when the issue has no
+      # tracker row (raw dashboard-drag case — #803). `too-vague` is
+      # intentionally excluded (vague rows need user clarification, not
+      # auto-tagging); `author-decision` is aliased to `needs-decision`
+      # (the filter's canonical code).
+      MONITOR_SKIP_CODE=""
+      case "$CLASS" in
+        plan-scale)         MONITOR_SKIP_CODE="plan-scale" ;;
+        bug-unclear-cause)  MONITOR_SKIP_CODE="bug-unclear-cause" ;;
+        needs-decision|author-decision) MONITOR_SKIP_CODE="needs-decision" ;;
+        deferred)           MONITOR_SKIP_CODE="deferred" ;;
+        too-vague)          : ;;  # do not persist; re-triage next fire
+      esac
+      if [ -n "$MONITOR_SKIP_CODE" ]; then
+        ZSKILLS_MAIN_ROOT="$MAIN_ROOT" bash \
+          "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/record-skip.sh" \
+          "$ISSUE_NUM" "$MONITOR_SKIP_CODE" \
+          || echo "WARN: fix-issues PR-mode: record-skip.sh failed for #$ISSUE_NUM ($MONITOR_SKIP_CODE) — next fire may re-litigate" >&2
+      fi
+
       SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
       if [ -f "$SCRATCH" ]; then
         NEW_ACTION_NOW=""

--- a/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -54,13 +54,27 @@ if [ -z "${ZSKILLS_ISSUES_DIR:-}" ]; then
   exit 1
 fi
 
-# Read the reconsider list from monitor-state.json (one-shot signal).
-# Issues in this list have their skip-code suppressed so Phase 2
-# re-evaluates them. After emitting them as candidates, we remove them
-# from the list so the signal doesn't persist across sprints.
+# Read the reconsider list and the skipped map from monitor-state.json.
+#
+# `issues.reconsider` is a one-shot signal: issues here have their skip-
+# code suppressed so Phase 2 re-evaluates them. After emitting them as
+# candidates, we remove them from the list so the signal doesn't persist
+# across sprints. The same cleanup also removes any matching entries from
+# `issues.skipped` (reconsider and skipped are duals: reconsidering an
+# issue means "un-skip and re-triage").
+#
+# `issues.skipped` is the persistent skip-state added for issue #808: when
+# triage declines an issue as plan-scale / bug-unclear-cause /
+# needs-decision / deferred, the orchestrator records it here so the next
+# fire's filter drops it BEFORE re-triage — even when the issue has no
+# tracker row (raw dashboard-drag case). The map shape is
+# `{ "<issue-num>": "<skip-code>" }`, e.g. `{"803": "plan-scale"}`. This
+# is symmetric with `issues.reconsider`: monitor-state.json is gitignored,
+# so the skip-record never lands as a tracker-row commit on main.
 MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
 STATE_FILE="${MAIN_ROOT:+$MAIN_ROOT/.zskills/monitor-state.json}"
 RECONSIDER_NUMS=""
+declare -A MONITOR_SKIPPED_MAP=()
 if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
   RECONSIDER_NUMS=$(python3 -c "
 import json, sys
@@ -72,6 +86,24 @@ try:
 except Exception:
     pass
 " "$STATE_FILE" 2>/dev/null) || RECONSIDER_NUMS=""
+
+  # Read issues.skipped as `<num> <code>` pairs (newline-separated).
+  while IFS=$'\t' read -r _n _c; do
+    [ -n "$_n" ] && MONITOR_SKIPPED_MAP["$_n"]="$_c"
+  done < <(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    skipped = data.get('issues', {}).get('skipped', {}) or {}
+    # Accept both dict and list-of-pairs shapes defensively.
+    if isinstance(skipped, dict):
+        for k, v in skipped.items():
+            print(f'{k}\t{v}')
+except Exception:
+    pass
+" "$STATE_FILE" 2>/dev/null)
+  unset _n _c
 fi
 
 RESEARCHED=()
@@ -147,16 +179,48 @@ for N in "$@"; do
       break
     fi
   done
+  # Monitor-state skip override (#808): if monitor-state.json's
+  # `issues.skipped` map has this issue, emit SKIP_TAGGED with the
+  # recorded code EVEN WHEN no tracker row exists. This is the raw
+  # dashboard-drag case — the orchestrator declined plan-scale before
+  # any research blurb was written. The reconsider list still suppresses
+  # this (one-shot un-skip + re-triage).
+  monitor_skip_code="${MONITOR_SKIPPED_MAP[$N]:-}"
+  if [ "$is_reconsidered" -eq 1 ]; then
+    monitor_skip_code=""
+    # Track even an unresearched reconsidered issue so the one-shot
+    # cleanup below removes the monitor-state entries on this fire.
+    RECONSIDERED_PROCESSED+=("$N")
+  fi
+
   if [ "$found" -eq 1 ]; then
     RESEARCHED+=("$N")
     if [ -n "$skip_code" ]; then
       SKIP_TAGGED+=("$N:$skip_code")
+    elif [ -n "$monitor_skip_code" ]; then
+      # Tracker row exists but is not skip-tagged; monitor-state.json
+      # has a persisted decline (e.g. agent triaged plan-scale before
+      # the row's `Action now:` was rewritten). Honor the monitor-state
+      # decision so the issue drops from Phase 2.
+      SKIP_TAGGED+=("$N:$monitor_skip_code")
     fi
     if [ "$is_reconsidered" -eq 1 ]; then
-      RECONSIDERED_PROCESSED+=("$N")
+      # already appended above when we cleared monitor_skip_code
+      :
     fi
   else
-    MISSING+=("$N")
+    if [ -n "$monitor_skip_code" ]; then
+      # No tracker row, but monitor-state.json has a persisted skip.
+      # Count as RESEARCHED-for-filtering-purposes AND emit SKIP_TAGGED
+      # so Phase 2 drops the candidate without dispatching research.
+      # Treating it as MISSING would route through research-on-demand
+      # and re-litigate the same skip decision every fire — the bug
+      # this commit fixes.
+      RESEARCHED+=("$N")
+      SKIP_TAGGED+=("$N:$monitor_skip_code")
+    else
+      MISSING+=("$N")
+    fi
   fi
 done
 
@@ -165,28 +229,50 @@ printf 'MISSING="%s"\n' "${MISSING[*]}"
 printf 'SKIP_TAGGED="%s"\n' "${SKIP_TAGGED[*]}"
 
 # One-shot cleanup: remove processed reconsider entries from
-# monitor-state.json so the signal doesn't persist across sprints.
+# monitor-state.json so the signal doesn't persist across sprints. Also
+# remove any matching entries from `issues.skipped` — reconsider and
+# skipped are duals (see #808: reconsidering an issue un-skips it so
+# Phase 2 re-triages it cleanly on this fire).
 if [ "${#RECONSIDERED_PROCESSED[@]}" -gt 0 ] && [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
   REMOVE_LIST=$(printf '%s\n' "${RECONSIDERED_PROCESSED[@]}" | tr '\n' ' ' | sed 's/ $//')
   python3 -c "
 import json, sys, os, tempfile
 
 path = sys.argv[1]
-remove = set(int(x) for x in sys.argv[2:])
+remove_ints = set(int(x) for x in sys.argv[2:])
+remove_strs = set(str(x) for x in sys.argv[2:])
 
 with open(path) as f:
     data = json.load(f)
 
-cur = data.get('issues', {}).get('reconsider', [])
-after = [n for n in cur if n not in remove]
+issues = data.get('issues', {}) or {}
+changed = False
 
-if len(after) == len(cur):
+# reconsider: list of ints
+cur = issues.get('reconsider', [])
+after = [n for n in cur if n not in remove_ints]
+if len(after) != len(cur):
+    if after:
+        issues['reconsider'] = after
+    else:
+        issues.pop('reconsider', None)
+    changed = True
+
+# skipped: dict keyed by stringified issue num
+skipped = issues.get('skipped', {}) or {}
+if isinstance(skipped, dict):
+    new_skipped = {k: v for k, v in skipped.items() if k not in remove_strs}
+    if len(new_skipped) != len(skipped):
+        if new_skipped:
+            issues['skipped'] = new_skipped
+        else:
+            issues.pop('skipped', None)
+        changed = True
+
+if not changed:
     sys.exit(0)
 
-if after:
-    data['issues']['reconsider'] = after
-else:
-    data.get('issues', {}).pop('reconsider', None)
+data['issues'] = issues
 
 tmp = tempfile.NamedTemporaryFile('w', delete=False,
     dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')

--- a/.claude/skills/fix-issues/scripts/record-skip.sh
+++ b/.claude/skills/fix-issues/scripts/record-skip.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# record-skip.sh — persist a /fix-issues triage-decline as a skip-tag in
+# `$MAIN_ROOT/.zskills/monitor-state.json` under `issues.skipped`.
+#
+# Issue #808: When `/fix-issues` declines an issue as plan-scale (or any
+# other auto-skip tier — bug-unclear-cause, needs-decision, deferred),
+# that decision was only *reported* to SPRINT_REPORT.md, never persisted
+# as machine-readable skip-state. Every subsequent fire re-triaged and
+# re-declined the same issue indefinitely (acute in dashboard mode where
+# raw-dragged issues have no tracker row at all — #803 case).
+#
+# This helper writes the decline to `monitor-state.json` (gitignored,
+# symmetric with `issues.reconsider`) so the next fire's
+# `filter-unresearched-candidates.sh` drops the candidate BEFORE triage.
+# `reconsider <N>` clears the entry (the two are duals).
+#
+# `monitor-state.json` is gitignored by design — it holds operational
+# queue state. We deliberately do NOT write the skip-tag to a committed
+# tracker file from the main-checkout triage path: a one-line skip-write
+# during a fire would leave main's working tree dirty (gets swept into
+# the next commit; violates clean-tree rule) or trigger a worktree + PR +
+# land cycle per skip (absurd overhead). Researched-row promotion to
+# ISSUES_PLAN.md still happens via the existing scratchpad path inside
+# the per-issue worktree (sprint.md ~1888 / ~2106) — that path is durable
+# tracker knowledge; this script is operational queue state.
+#
+# Usage:
+#   bash record-skip.sh <issue-num> <skip-code> [<reason>]
+#
+# Arguments:
+#   <issue-num>   Positive integer (GitHub issue number). REQUIRED.
+#   <skip-code>   One of: plan-scale | bug-unclear-cause | needs-decision
+#                 | deferred. REQUIRED. These mirror the canonical
+#                 dashboard skip-codes the filter recognizes.
+#   <reason>      Optional short string (informational; not consumed by
+#                 the filter). Currently ignored; reserved for future use.
+#
+# Behavior:
+#   - Resolves `$MAIN_ROOT` from `$ZSKILLS_MAIN_ROOT` if set, else from
+#     `git rev-parse --git-common-dir`.
+#   - Creates `.zskills/monitor-state.json` with `{}` if absent.
+#   - Sets `data["issues"]["skipped"][str(N)] = "<skip-code>"`.
+#   - Idempotent: if the same code is already recorded, exits 0 silently;
+#     if a different code is recorded, overwrites (latest-classification
+#     wins — the orchestrator may re-triage and re-classify).
+#   - Atomic write via Python tempfile + `os.replace`.
+#
+# Exit:
+#   0 — write succeeded (or no-op idempotent re-write).
+#   1 — usage error (missing args, invalid skip-code, $MAIN_ROOT unresolvable).
+#   2 — JSON parse / IO error.
+
+set -u
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: record-skip.sh <issue-num> <skip-code> [<reason>]" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+SKIP_CODE="$2"
+# reason argument reserved for future use; not consumed yet.
+
+case "$ISSUE_NUM" in
+  ''|*[!0-9]*)
+    echo "record-skip.sh: invalid issue number '$ISSUE_NUM' (must be positive integer)" >&2
+    exit 1
+    ;;
+esac
+
+case "$SKIP_CODE" in
+  plan-scale|bug-unclear-cause|needs-decision|deferred) ;;
+  *)
+    echo "record-skip.sh: invalid skip-code '$SKIP_CODE' (expected plan-scale|bug-unclear-cause|needs-decision|deferred)" >&2
+    exit 1
+    ;;
+esac
+
+MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
+if [ -z "$MAIN_ROOT" ] || [ ! -d "$MAIN_ROOT" ]; then
+  echo "record-skip.sh: cannot resolve MAIN_ROOT (set ZSKILLS_MAIN_ROOT or run from inside a git repo)" >&2
+  exit 1
+fi
+
+STATE_DIR="$MAIN_ROOT/.zskills"
+STATE_FILE="$STATE_DIR/monitor-state.json"
+mkdir -p "$STATE_DIR"
+
+# Initialise empty state file if missing — symmetric with how
+# reconsider.md treats it.
+if [ ! -f "$STATE_FILE" ]; then
+  printf '{}\n' > "$STATE_FILE"
+fi
+
+python3 - "$STATE_FILE" "$ISSUE_NUM" "$SKIP_CODE" <<'PY' || exit 2
+import json, os, sys, tempfile
+
+path, num_s, code = sys.argv[1], sys.argv[2], sys.argv[3]
+
+try:
+    with open(path) as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        data = {}
+except (json.JSONDecodeError, FileNotFoundError):
+    data = {}
+
+issues = data.setdefault('issues', {})
+skipped = issues.setdefault('skipped', {})
+if not isinstance(skipped, dict):
+    # Defensive: replace malformed value with a fresh dict.
+    skipped = {}
+    issues['skipped'] = skipped
+
+# Idempotent — same code recorded already, exit silently.
+if skipped.get(num_s) == code:
+    print(f"/fix-issues: #{num_s} already recorded as skipped ({code}); no-op.", file=sys.stderr)
+    sys.exit(0)
+
+prev = skipped.get(num_s)
+skipped[num_s] = code
+
+tmp = tempfile.NamedTemporaryFile('w', delete=False,
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(data, tmp, indent=2)
+tmp.write('\n')
+tmp.close()
+os.replace(tmp.name, path)
+
+if prev:
+    print(f"/fix-issues: #{num_s} skip-state updated ({prev} -> {code}).", file=sys.stderr)
+else:
+    print(f"/fix-issues: #{num_s} recorded as skipped ({code}).", file=sys.stderr)
+PY

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.29+03435d"
+  version: "2026.05.29+c47a59"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/plan.md
+++ b/skills/fix-issues/modes/plan.md
@@ -70,6 +70,15 @@ either fires, all candidate issues are selected without prompting.
    printf 'skill: draft-plan\nparent: fix-issues\nissue: %s\ndate: %s\n' \
      "$ISSUE_NUMBER" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
      > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.draft-plan.$ISSUE_NUMBER"
+   # #808: record the skip in monitor-state.json so subsequent sprint
+   # fires drop this issue BEFORE re-triage (the user explicitly chose
+   # /draft-plan here; that decision is now persistent state, symmetric
+   # with the sprint-mode plan-scale-decline path). `reconsider <N>`
+   # clears the entry if the user later changes their mind.
+   ZSKILLS_MAIN_ROOT="$MAIN_ROOT" bash \
+     "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/record-skip.sh" \
+     "$ISSUE_NUMBER" plan-scale \
+     || echo "WARN: fix-issues plan: record-skip.sh failed for #$ISSUE_NUMBER — sprint may re-pick" >&2
    ```
    Then dispatch `/draft-plan` with:
    - The issue number and full body (`gh issue view <N> --json body`)

--- a/skills/fix-issues/modes/sprint.md
+++ b/skills/fix-issues/modes/sprint.md
@@ -1856,6 +1856,34 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
       # (#606 tax fix). `too-vague` is intentionally left untouched (no
       # canonical dashboard skip-code; vague rows need user clarification,
       # not auto-tagging — re-classified next fire by design).
+      #
+      # #808 — persistent skip-state in monitor-state.json. The scratchpad
+      # write-back ONLY persists the decision when a tracker row lands
+      # (research blurb existed). For the raw dashboard-drag case (#803:
+      # issue dragged to Ready with no prior research, declined plan-scale
+      # before any blurb existed) there is no scratchpad → no row write →
+      # the next fire re-litigates the same decline indefinitely. Record
+      # the decline in monitor-state.json (gitignored, symmetric with
+      # `issues.reconsider`) so the filter drops the candidate next fire
+      # regardless of tracker-row presence. `too-vague` is excluded — vague
+      # rows need user clarification, not auto-tagging (kept for the next
+      # fire so the user can see and act). `author-decision` is aliased to
+      # `needs-decision` (the filter's canonical code).
+      MONITOR_SKIP_CODE=""
+      case "$CLASS" in
+        plan-scale)         MONITOR_SKIP_CODE="plan-scale" ;;
+        bug-unclear-cause)  MONITOR_SKIP_CODE="bug-unclear-cause" ;;
+        needs-decision|author-decision) MONITOR_SKIP_CODE="needs-decision" ;;
+        deferred)           MONITOR_SKIP_CODE="deferred" ;;
+        too-vague)          : ;;  # do not persist; re-triage next fire
+      esac
+      if [ -n "$MONITOR_SKIP_CODE" ]; then
+        ZSKILLS_MAIN_ROOT="$MAIN_ROOT" bash \
+          "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/record-skip.sh" \
+          "$ISSUE_NUM" "$MONITOR_SKIP_CODE" \
+          || echo "WARN: fix-issues: record-skip.sh failed for #$ISSUE_NUM ($MONITOR_SKIP_CODE) — next fire may re-litigate" >&2
+      fi
+
       SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
       if [ -f "$SCRATCH" ]; then
         NEW_ACTION_NOW=""
@@ -2113,6 +2141,30 @@ for ISSUE_NUM in "${CANDIDATE_ISSUES[@]}"; do
       # here — the scratchpad is held in `.zskills/research-staging/` for
       # the end-of-loop batch sync-PR that mirrors the dashboard-empty
       # pattern at SKILL.md ~1303-1378.
+      #
+      # #808 — persistent skip-state in monitor-state.json. Symmetric with
+      # the cherry-pick-mode write-back above: record the decline in
+      # `monitor-state.json` (gitignored) so the next fire's filter drops
+      # the candidate BEFORE re-triage, even when the issue has no
+      # tracker row (raw dashboard-drag case — #803). `too-vague` is
+      # intentionally excluded (vague rows need user clarification, not
+      # auto-tagging); `author-decision` is aliased to `needs-decision`
+      # (the filter's canonical code).
+      MONITOR_SKIP_CODE=""
+      case "$CLASS" in
+        plan-scale)         MONITOR_SKIP_CODE="plan-scale" ;;
+        bug-unclear-cause)  MONITOR_SKIP_CODE="bug-unclear-cause" ;;
+        needs-decision|author-decision) MONITOR_SKIP_CODE="needs-decision" ;;
+        deferred)           MONITOR_SKIP_CODE="deferred" ;;
+        too-vague)          : ;;  # do not persist; re-triage next fire
+      esac
+      if [ -n "$MONITOR_SKIP_CODE" ]; then
+        ZSKILLS_MAIN_ROOT="$MAIN_ROOT" bash \
+          "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/record-skip.sh" \
+          "$ISSUE_NUM" "$MONITOR_SKIP_CODE" \
+          || echo "WARN: fix-issues PR-mode: record-skip.sh failed for #$ISSUE_NUM ($MONITOR_SKIP_CODE) — next fire may re-litigate" >&2
+      fi
+
       SCRATCH=".zskills/research-staging/$PIPELINE_ID/issue-${ISSUE_NUM}.md"
       if [ -f "$SCRATCH" ]; then
         NEW_ACTION_NOW=""

--- a/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -54,13 +54,27 @@ if [ -z "${ZSKILLS_ISSUES_DIR:-}" ]; then
   exit 1
 fi
 
-# Read the reconsider list from monitor-state.json (one-shot signal).
-# Issues in this list have their skip-code suppressed so Phase 2
-# re-evaluates them. After emitting them as candidates, we remove them
-# from the list so the signal doesn't persist across sprints.
+# Read the reconsider list and the skipped map from monitor-state.json.
+#
+# `issues.reconsider` is a one-shot signal: issues here have their skip-
+# code suppressed so Phase 2 re-evaluates them. After emitting them as
+# candidates, we remove them from the list so the signal doesn't persist
+# across sprints. The same cleanup also removes any matching entries from
+# `issues.skipped` (reconsider and skipped are duals: reconsidering an
+# issue means "un-skip and re-triage").
+#
+# `issues.skipped` is the persistent skip-state added for issue #808: when
+# triage declines an issue as plan-scale / bug-unclear-cause /
+# needs-decision / deferred, the orchestrator records it here so the next
+# fire's filter drops it BEFORE re-triage — even when the issue has no
+# tracker row (raw dashboard-drag case). The map shape is
+# `{ "<issue-num>": "<skip-code>" }`, e.g. `{"803": "plan-scale"}`. This
+# is symmetric with `issues.reconsider`: monitor-state.json is gitignored,
+# so the skip-record never lands as a tracker-row commit on main.
 MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
 STATE_FILE="${MAIN_ROOT:+$MAIN_ROOT/.zskills/monitor-state.json}"
 RECONSIDER_NUMS=""
+declare -A MONITOR_SKIPPED_MAP=()
 if [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
   RECONSIDER_NUMS=$(python3 -c "
 import json, sys
@@ -72,6 +86,24 @@ try:
 except Exception:
     pass
 " "$STATE_FILE" 2>/dev/null) || RECONSIDER_NUMS=""
+
+  # Read issues.skipped as `<num> <code>` pairs (newline-separated).
+  while IFS=$'\t' read -r _n _c; do
+    [ -n "$_n" ] && MONITOR_SKIPPED_MAP["$_n"]="$_c"
+  done < <(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    skipped = data.get('issues', {}).get('skipped', {}) or {}
+    # Accept both dict and list-of-pairs shapes defensively.
+    if isinstance(skipped, dict):
+        for k, v in skipped.items():
+            print(f'{k}\t{v}')
+except Exception:
+    pass
+" "$STATE_FILE" 2>/dev/null)
+  unset _n _c
 fi
 
 RESEARCHED=()
@@ -147,16 +179,48 @@ for N in "$@"; do
       break
     fi
   done
+  # Monitor-state skip override (#808): if monitor-state.json's
+  # `issues.skipped` map has this issue, emit SKIP_TAGGED with the
+  # recorded code EVEN WHEN no tracker row exists. This is the raw
+  # dashboard-drag case — the orchestrator declined plan-scale before
+  # any research blurb was written. The reconsider list still suppresses
+  # this (one-shot un-skip + re-triage).
+  monitor_skip_code="${MONITOR_SKIPPED_MAP[$N]:-}"
+  if [ "$is_reconsidered" -eq 1 ]; then
+    monitor_skip_code=""
+    # Track even an unresearched reconsidered issue so the one-shot
+    # cleanup below removes the monitor-state entries on this fire.
+    RECONSIDERED_PROCESSED+=("$N")
+  fi
+
   if [ "$found" -eq 1 ]; then
     RESEARCHED+=("$N")
     if [ -n "$skip_code" ]; then
       SKIP_TAGGED+=("$N:$skip_code")
+    elif [ -n "$monitor_skip_code" ]; then
+      # Tracker row exists but is not skip-tagged; monitor-state.json
+      # has a persisted decline (e.g. agent triaged plan-scale before
+      # the row's `Action now:` was rewritten). Honor the monitor-state
+      # decision so the issue drops from Phase 2.
+      SKIP_TAGGED+=("$N:$monitor_skip_code")
     fi
     if [ "$is_reconsidered" -eq 1 ]; then
-      RECONSIDERED_PROCESSED+=("$N")
+      # already appended above when we cleared monitor_skip_code
+      :
     fi
   else
-    MISSING+=("$N")
+    if [ -n "$monitor_skip_code" ]; then
+      # No tracker row, but monitor-state.json has a persisted skip.
+      # Count as RESEARCHED-for-filtering-purposes AND emit SKIP_TAGGED
+      # so Phase 2 drops the candidate without dispatching research.
+      # Treating it as MISSING would route through research-on-demand
+      # and re-litigate the same skip decision every fire — the bug
+      # this commit fixes.
+      RESEARCHED+=("$N")
+      SKIP_TAGGED+=("$N:$monitor_skip_code")
+    else
+      MISSING+=("$N")
+    fi
   fi
 done
 
@@ -165,28 +229,50 @@ printf 'MISSING="%s"\n' "${MISSING[*]}"
 printf 'SKIP_TAGGED="%s"\n' "${SKIP_TAGGED[*]}"
 
 # One-shot cleanup: remove processed reconsider entries from
-# monitor-state.json so the signal doesn't persist across sprints.
+# monitor-state.json so the signal doesn't persist across sprints. Also
+# remove any matching entries from `issues.skipped` — reconsider and
+# skipped are duals (see #808: reconsidering an issue un-skips it so
+# Phase 2 re-triages it cleanly on this fire).
 if [ "${#RECONSIDERED_PROCESSED[@]}" -gt 0 ] && [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
   REMOVE_LIST=$(printf '%s\n' "${RECONSIDERED_PROCESSED[@]}" | tr '\n' ' ' | sed 's/ $//')
   python3 -c "
 import json, sys, os, tempfile
 
 path = sys.argv[1]
-remove = set(int(x) for x in sys.argv[2:])
+remove_ints = set(int(x) for x in sys.argv[2:])
+remove_strs = set(str(x) for x in sys.argv[2:])
 
 with open(path) as f:
     data = json.load(f)
 
-cur = data.get('issues', {}).get('reconsider', [])
-after = [n for n in cur if n not in remove]
+issues = data.get('issues', {}) or {}
+changed = False
 
-if len(after) == len(cur):
+# reconsider: list of ints
+cur = issues.get('reconsider', [])
+after = [n for n in cur if n not in remove_ints]
+if len(after) != len(cur):
+    if after:
+        issues['reconsider'] = after
+    else:
+        issues.pop('reconsider', None)
+    changed = True
+
+# skipped: dict keyed by stringified issue num
+skipped = issues.get('skipped', {}) or {}
+if isinstance(skipped, dict):
+    new_skipped = {k: v for k, v in skipped.items() if k not in remove_strs}
+    if len(new_skipped) != len(skipped):
+        if new_skipped:
+            issues['skipped'] = new_skipped
+        else:
+            issues.pop('skipped', None)
+        changed = True
+
+if not changed:
     sys.exit(0)
 
-if after:
-    data['issues']['reconsider'] = after
-else:
-    data.get('issues', {}).pop('reconsider', None)
+data['issues'] = issues
 
 tmp = tempfile.NamedTemporaryFile('w', delete=False,
     dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')

--- a/skills/fix-issues/scripts/record-skip.sh
+++ b/skills/fix-issues/scripts/record-skip.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# record-skip.sh — persist a /fix-issues triage-decline as a skip-tag in
+# `$MAIN_ROOT/.zskills/monitor-state.json` under `issues.skipped`.
+#
+# Issue #808: When `/fix-issues` declines an issue as plan-scale (or any
+# other auto-skip tier — bug-unclear-cause, needs-decision, deferred),
+# that decision was only *reported* to SPRINT_REPORT.md, never persisted
+# as machine-readable skip-state. Every subsequent fire re-triaged and
+# re-declined the same issue indefinitely (acute in dashboard mode where
+# raw-dragged issues have no tracker row at all — #803 case).
+#
+# This helper writes the decline to `monitor-state.json` (gitignored,
+# symmetric with `issues.reconsider`) so the next fire's
+# `filter-unresearched-candidates.sh` drops the candidate BEFORE triage.
+# `reconsider <N>` clears the entry (the two are duals).
+#
+# `monitor-state.json` is gitignored by design — it holds operational
+# queue state. We deliberately do NOT write the skip-tag to a committed
+# tracker file from the main-checkout triage path: a one-line skip-write
+# during a fire would leave main's working tree dirty (gets swept into
+# the next commit; violates clean-tree rule) or trigger a worktree + PR +
+# land cycle per skip (absurd overhead). Researched-row promotion to
+# ISSUES_PLAN.md still happens via the existing scratchpad path inside
+# the per-issue worktree (sprint.md ~1888 / ~2106) — that path is durable
+# tracker knowledge; this script is operational queue state.
+#
+# Usage:
+#   bash record-skip.sh <issue-num> <skip-code> [<reason>]
+#
+# Arguments:
+#   <issue-num>   Positive integer (GitHub issue number). REQUIRED.
+#   <skip-code>   One of: plan-scale | bug-unclear-cause | needs-decision
+#                 | deferred. REQUIRED. These mirror the canonical
+#                 dashboard skip-codes the filter recognizes.
+#   <reason>      Optional short string (informational; not consumed by
+#                 the filter). Currently ignored; reserved for future use.
+#
+# Behavior:
+#   - Resolves `$MAIN_ROOT` from `$ZSKILLS_MAIN_ROOT` if set, else from
+#     `git rev-parse --git-common-dir`.
+#   - Creates `.zskills/monitor-state.json` with `{}` if absent.
+#   - Sets `data["issues"]["skipped"][str(N)] = "<skip-code>"`.
+#   - Idempotent: if the same code is already recorded, exits 0 silently;
+#     if a different code is recorded, overwrites (latest-classification
+#     wins — the orchestrator may re-triage and re-classify).
+#   - Atomic write via Python tempfile + `os.replace`.
+#
+# Exit:
+#   0 — write succeeded (or no-op idempotent re-write).
+#   1 — usage error (missing args, invalid skip-code, $MAIN_ROOT unresolvable).
+#   2 — JSON parse / IO error.
+
+set -u
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: record-skip.sh <issue-num> <skip-code> [<reason>]" >&2
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+SKIP_CODE="$2"
+# reason argument reserved for future use; not consumed yet.
+
+case "$ISSUE_NUM" in
+  ''|*[!0-9]*)
+    echo "record-skip.sh: invalid issue number '$ISSUE_NUM' (must be positive integer)" >&2
+    exit 1
+    ;;
+esac
+
+case "$SKIP_CODE" in
+  plan-scale|bug-unclear-cause|needs-decision|deferred) ;;
+  *)
+    echo "record-skip.sh: invalid skip-code '$SKIP_CODE' (expected plan-scale|bug-unclear-cause|needs-decision|deferred)" >&2
+    exit 1
+    ;;
+esac
+
+MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
+if [ -z "$MAIN_ROOT" ] || [ ! -d "$MAIN_ROOT" ]; then
+  echo "record-skip.sh: cannot resolve MAIN_ROOT (set ZSKILLS_MAIN_ROOT or run from inside a git repo)" >&2
+  exit 1
+fi
+
+STATE_DIR="$MAIN_ROOT/.zskills"
+STATE_FILE="$STATE_DIR/monitor-state.json"
+mkdir -p "$STATE_DIR"
+
+# Initialise empty state file if missing — symmetric with how
+# reconsider.md treats it.
+if [ ! -f "$STATE_FILE" ]; then
+  printf '{}\n' > "$STATE_FILE"
+fi
+
+python3 - "$STATE_FILE" "$ISSUE_NUM" "$SKIP_CODE" <<'PY' || exit 2
+import json, os, sys, tempfile
+
+path, num_s, code = sys.argv[1], sys.argv[2], sys.argv[3]
+
+try:
+    with open(path) as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        data = {}
+except (json.JSONDecodeError, FileNotFoundError):
+    data = {}
+
+issues = data.setdefault('issues', {})
+skipped = issues.setdefault('skipped', {})
+if not isinstance(skipped, dict):
+    # Defensive: replace malformed value with a fresh dict.
+    skipped = {}
+    issues['skipped'] = skipped
+
+# Idempotent — same code recorded already, exit silently.
+if skipped.get(num_s) == code:
+    print(f"/fix-issues: #{num_s} already recorded as skipped ({code}); no-op.", file=sys.stderr)
+    sys.exit(0)
+
+prev = skipped.get(num_s)
+skipped[num_s] = code
+
+tmp = tempfile.NamedTemporaryFile('w', delete=False,
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(data, tmp, indent=2)
+tmp.write('\n')
+tmp.close()
+os.replace(tmp.name, path)
+
+if prev:
+    print(f"/fix-issues: #{num_s} skip-state updated ({prev} -> {code}).", file=sys.stderr)
+else:
+    print(f"/fix-issues: #{num_s} recorded as skipped ({code}).", file=sys.stderr)
+PY

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -105,6 +105,7 @@ run_suite "test-fix-issues-worktree-cap.sh" "tests/test-fix-issues-worktree-cap.
 run_suite "test-fix-issues-sprint-worktree-gate.sh" "tests/test-fix-issues-sprint-worktree-gate.sh"
 run_suite "test-fix-issues-sprint-land-pr.sh" "tests/test-fix-issues-sprint-land-pr.sh"
 run_suite "test-fix-issues-phase2-source-filter.sh" "tests/test-fix-issues-phase2-source-filter.sh"
+run_suite "test-fix-issues-skip-persistence.sh" "tests/test-fix-issues-skip-persistence.sh"
 run_suite "test-do.sh" "tests/test-do.sh"
 run_suite "test-commit.sh" "tests/test-commit.sh"
 run_suite "test-fix-report-smoke.sh" "tests/test-fix-report-smoke.sh"

--- a/tests/test-fix-issues-skip-persistence.sh
+++ b/tests/test-fix-issues-skip-persistence.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+# test-fix-issues-skip-persistence.sh — coverage for issue #808:
+# persist /fix-issues triage-decline decisions as machine-readable skip-
+# state in `$MAIN_ROOT/.zskills/monitor-state.json` so subsequent fires
+# drop the candidate BEFORE re-triage.
+#
+# Pre-#808 the plan-scale (and any auto-skip tier) decline path only
+# reported the decision to SPRINT_REPORT.md. The next fire re-triaged
+# the same issue, re-declined, and repeated indefinitely — acute in
+# dashboard mode where raw-dragged issues had no tracker row at all
+# (#803 case).
+#
+# The fix has two halves:
+#   (1) record-skip.sh writes `issues.skipped[<N>] = <code>` into
+#       monitor-state.json (atomic, idempotent, gitignored).
+#   (2) filter-unresearched-candidates.sh reads `issues.skipped` and
+#       unions matching entries into SKIP_TAGGED — even when the issue
+#       has no tracker row at all (the raw-dashboard-drag case the
+#       previous filter would emit as MISSING and route through
+#       research-on-demand).
+#
+# Plus: sprint.md's Phase 3 triage-decline write-back (both cherry-pick
+# and PR mode arms) MUST invoke record-skip.sh alongside the existing
+# scratchpad `**Action now:**` rewrite. The latter persistence layer
+# (committed `ISSUES_PLAN.md` row) was already in place; we assert it
+# is PRESERVED so the new monitor-state write-back doesn't displace
+# the canonical tracker row.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FILTER="$REPO_ROOT/skills/fix-issues/scripts/filter-unresearched-candidates.sh"
+RECORD="$REPO_ROOT/skills/fix-issues/scripts/record-skip.sh"
+SKILL="$REPO_ROOT/skills/fix-issues/modes/sprint.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRATCH="/tmp/test-fix-issues-skip-persistence-$$"
+cleanup() {
+  [ -n "${TEST_KEEP_SCRATCH:-}" ] && return
+  if [ -d "$SCRATCH" ]; then
+    find "$SCRATCH" -type d -exec chmod u+rwx {} \; 2>/dev/null || true
+    rm -rf "$SCRATCH"
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH"
+
+echo "=== /fix-issues skip-state persistence (#808) ==="
+
+# --- Sanity: both scripts exist and are executable -----------------------
+test_scripts_present() {
+  if [ -f "$RECORD" ] && [ -x "$RECORD" ]; then
+    pass "record-skip.sh exists and is executable"
+  else
+    fail "record-skip.sh exists and is executable" "missing: $RECORD"
+  fi
+  if [ -f "$FILTER" ] && [ -x "$FILTER" ]; then
+    pass "filter-unresearched-candidates.sh exists and is executable"
+  else
+    fail "filter-unresearched-candidates.sh exists and is executable" "missing: $FILTER"
+  fi
+}
+
+# Helper: build a minimal MAIN_ROOT with a git repo so record-skip's
+# git-rev-parse fallback works the same as the rest-of-skill paths.
+make_main_root() {
+  local d="$1"
+  mkdir -p "$d"
+  ( cd "$d" && git init -q && git config user.email t@t && git config user.name t \
+      && git commit --allow-empty -q -m init ) >/dev/null
+}
+
+# Helper: read issues.skipped[<n>] from a monitor-state.json file.
+read_skip() {
+  python3 -c "
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+    print((data.get('issues', {}).get('skipped', {}) or {}).get(sys.argv[2], ''))
+except Exception:
+    pass
+" "$1" "$2"
+}
+
+# --- 1. record-skip.sh writes the issues.skipped entry -------------------
+test_record_skip_writes_entry() {
+  local d="$SCRATCH/record-basic"
+  make_main_root "$d"
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+  local got
+  got=$(read_skip "$d/.zskills/monitor-state.json" 803)
+  if [ "$got" = "plan-scale" ]; then
+    pass "record-skip writes issues.skipped[803] = plan-scale"
+  else
+    fail "record-skip writes issues.skipped[803] = plan-scale" "got '$got'"
+  fi
+}
+
+# --- 1b. record-skip is idempotent (same code re-recorded) ---------------
+test_record_skip_idempotent() {
+  local d="$SCRATCH/record-idem"
+  make_main_root "$d"
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+  local rc=$?
+  local got
+  got=$(read_skip "$d/.zskills/monitor-state.json" 803)
+  if [ "$rc" -eq 0 ] && [ "$got" = "plan-scale" ]; then
+    pass "record-skip idempotent re-write: rc=0, value unchanged"
+  else
+    fail "record-skip idempotent re-write" "rc=$rc got '$got'"
+  fi
+}
+
+# --- 1c. record-skip overwrites with new code (re-classification) --------
+test_record_skip_overwrite() {
+  local d="$SCRATCH/record-over"
+  make_main_root "$d"
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" 803 deferred   >/dev/null 2>&1
+  local got
+  got=$(read_skip "$d/.zskills/monitor-state.json" 803)
+  if [ "$got" = "deferred" ]; then
+    pass "record-skip overwrites with new code (plan-scale -> deferred)"
+  else
+    fail "record-skip overwrites with new code" "got '$got'"
+  fi
+}
+
+# --- 1d. record-skip rejects invalid skip-code ---------------------------
+test_record_skip_rejects_bogus_code() {
+  local d="$SCRATCH/record-bogus"
+  make_main_root "$d"
+  local rc=0
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" 803 bogus-code >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 1 ]; then
+    pass "record-skip rejects invalid skip-code (rc=1)"
+  else
+    fail "record-skip rejects invalid skip-code" "expected rc=1, got rc=$rc"
+  fi
+}
+
+# --- 1e. record-skip rejects non-integer issue-num -----------------------
+test_record_skip_rejects_bogus_num() {
+  local d="$SCRATCH/record-bogus2"
+  make_main_root "$d"
+  local rc=0
+  ZSKILLS_MAIN_ROOT="$d" bash "$RECORD" "8x3" plan-scale >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq 1 ]; then
+    pass "record-skip rejects non-integer issue-num (rc=1)"
+  else
+    fail "record-skip rejects non-integer issue-num" "expected rc=1, got rc=$rc"
+  fi
+}
+
+# --- 2. Filter sees monitor-state skip even WITHOUT tracker row ----------
+# This is the raw-dashboard-drag case (#803) — the issue has no row in
+# any *.md under ZSKILLS_ISSUES_DIR, but issues.skipped has it.
+test_filter_drops_unrowed_via_monitor_state() {
+  local issues_dir="$SCRATCH/filter-unrowed/issues"
+  local main_root="$SCRATCH/filter-unrowed/main"
+  mkdir -p "$issues_dir"
+  make_main_root "$main_root"
+  # Tracker dir intentionally empty (no rows for 803).
+  : > "$issues_dir/ISSUES.md"
+  # Seed monitor-state via record-skip.
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+
+  local out skip_tagged researched missing
+  out=$(ZSKILLS_ISSUES_DIR="$issues_dir" ZSKILLS_MAIN_ROOT="$main_root" bash "$FILTER" 803)
+  skip_tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  researched=$(echo "$out" | grep '^RESEARCHED=' | sed -e 's/^RESEARCHED=//' -e 's/^"//' -e 's/"$//')
+  missing=$(echo "$out" | grep '^MISSING=' | sed -e 's/^MISSING=//' -e 's/^"//' -e 's/"$//')
+
+  if [ "$skip_tagged" = "803:plan-scale" ] && [ "$researched" = "803" ] && [ -z "$missing" ]; then
+    pass "filter drops unrowed candidate via monitor-state (#803 raw dashboard-drag case)"
+  else
+    fail "filter drops unrowed candidate via monitor-state" \
+         "SKIP_TAGGED=[$skip_tagged] RESEARCHED=[$researched] MISSING=[$missing]"
+  fi
+}
+
+# --- 2b. Filter unions monitor-state skip with tracker-row skip ----------
+# Rowed issue WITH plan-scale tracker-tag already (the legacy path).
+# Pre-#808 this path was the only one that worked. Confirm it still does
+# (regression guard) AND that adding a monitor-state entry for the same
+# issue stays consistent (filter must not double-emit).
+test_filter_rowed_plus_monitor_state() {
+  local issues_dir="$SCRATCH/filter-rowed/issues"
+  local main_root="$SCRATCH/filter-rowed/main"
+  mkdir -p "$issues_dir"
+  make_main_root "$main_root"
+  cat > "$issues_dir/ISSUES.md" <<'EOF'
+### #700 — plan-scale rowed
+**Action now:** /draft-plan — needs design review.
+EOF
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 700 plan-scale >/dev/null 2>&1
+
+  local out skip_tagged
+  out=$(ZSKILLS_ISSUES_DIR="$issues_dir" ZSKILLS_MAIN_ROOT="$main_root" bash "$FILTER" 700)
+  skip_tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  # Tracker-row skip-tag wins (canonical); monitor-state agrees; expect
+  # exactly one 700:plan-scale entry.
+  if [ "$skip_tagged" = "700:plan-scale" ]; then
+    pass "filter unions rowed + monitor-state without double-emit"
+  else
+    fail "filter unions rowed + monitor-state" "SKIP_TAGGED=[$skip_tagged]"
+  fi
+}
+
+# --- 2c. Reconsider list still suppresses monitor-state skip -------------
+# `reconsider <N>` is the deliberate un-skip lever — it must override
+# both the row-derived skip-tag and the monitor-state skip-tag, so the
+# issue re-enters triage on the current fire.
+test_filter_reconsider_overrides_monitor_state() {
+  local issues_dir="$SCRATCH/filter-recon/issues"
+  local main_root="$SCRATCH/filter-recon/main"
+  mkdir -p "$issues_dir"
+  make_main_root "$main_root"
+  : > "$issues_dir/ISSUES.md"
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+  # Seed reconsider with 803.
+  python3 -c "
+import json
+p = '$main_root/.zskills/monitor-state.json'
+data = json.load(open(p))
+data.setdefault('issues', {})['reconsider'] = [803]
+json.dump(data, open(p, 'w'), indent=2)
+"
+  local out skip_tagged missing
+  out=$(ZSKILLS_ISSUES_DIR="$issues_dir" ZSKILLS_MAIN_ROOT="$main_root" bash "$FILTER" 803)
+  skip_tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  missing=$(echo "$out" | grep '^MISSING=' | sed -e 's/^MISSING=//' -e 's/^"//' -e 's/"$//')
+  if [ -z "$skip_tagged" ] && [ "$missing" = "803" ]; then
+    pass "reconsider overrides monitor-state skip (issue re-enters triage as MISSING)"
+  else
+    fail "reconsider overrides monitor-state" \
+         "expected SKIP_TAGGED=[] MISSING=[803], got SKIP_TAGGED=[$skip_tagged] MISSING=[$missing]"
+  fi
+}
+
+# --- 2d. Reconsider one-shot cleanup ALSO removes issues.skipped entry --
+# After the filter emits a reconsidered issue, both `issues.reconsider`
+# AND any matching `issues.skipped` entries are removed so the un-skip
+# decision sticks (the issue can be re-classified on its merits).
+test_reconsider_cleanup_removes_skip() {
+  local issues_dir="$SCRATCH/filter-cleanup/issues"
+  local main_root="$SCRATCH/filter-cleanup/main"
+  mkdir -p "$issues_dir"
+  make_main_root "$main_root"
+  : > "$issues_dir/ISSUES.md"
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 803 plan-scale >/dev/null 2>&1
+  python3 -c "
+import json
+p = '$main_root/.zskills/monitor-state.json'
+data = json.load(open(p))
+data.setdefault('issues', {})['reconsider'] = [803]
+json.dump(data, open(p, 'w'), indent=2)
+"
+  ZSKILLS_ISSUES_DIR="$issues_dir" ZSKILLS_MAIN_ROOT="$main_root" bash "$FILTER" 803 >/dev/null
+  local after
+  after=$(read_skip "$main_root/.zskills/monitor-state.json" 803)
+  local recon_after
+  recon_after=$(python3 -c "
+import json
+data = json.load(open('$main_root/.zskills/monitor-state.json'))
+print(','.join(str(x) for x in data.get('issues', {}).get('reconsider', [])))
+")
+  if [ -z "$after" ] && [ -z "$recon_after" ]; then
+    pass "reconsider one-shot cleanup removes BOTH issues.reconsider AND issues.skipped entries"
+  else
+    fail "reconsider one-shot cleanup" \
+         "expected both empty, got skipped=[$after] reconsider=[$recon_after]"
+  fi
+}
+
+# --- 3. SKILL.md sprint mode invokes record-skip in BOTH Phase 3 arms ---
+test_skill_invokes_record_skip_both_arms() {
+  local count
+  count=$(grep -c 'record-skip.sh' "$SKILL")
+  if [ "$count" -ge 2 ]; then
+    pass "sprint.md invokes record-skip.sh in BOTH triage-decline arms ($count refs >=2)"
+  else
+    fail "sprint.md invokes record-skip.sh in both arms" \
+         "expected >=2 (cherry-pick + PR-mode), got $count"
+  fi
+}
+
+# --- 3b. SKILL.md preserves existing scratchpad rewrite -----------------
+# Phase 3 in-loop write-back (existing) MUST still rewrite the
+# scratchpad `**Action now:**` line — record-skip is ADDITIVE, not a
+# replacement. Lock both sed-i Action-now rewrites and >=10 NEW_ACTION_NOW
+# assignments (5 cases × 2 modes) per the canonical literal set.
+test_skill_preserves_phase3_writeback() {
+  local sed_count nan_count
+  sed_count=$(grep -c 'sed -i.*Action now' "$SKILL")
+  nan_count=$(grep -c '^[[:space:]]*NEW_ACTION_NOW=' "$SKILL")
+  if [ "$sed_count" -eq 2 ] && [ "$nan_count" -ge 10 ]; then
+    pass "sprint.md preserves existing Phase 3 scratchpad rewrite (sed=2, NEW_ACTION_NOW=$nan_count)"
+  else
+    fail "sprint.md preserves Phase 3 scratchpad rewrite" \
+         "expected sed=2 NEW_ACTION_NOW>=10, got sed=$sed_count NEW_ACTION_NOW=$nan_count"
+  fi
+}
+
+# --- 3c. SKILL.md preserves canonical /draft-plan literal --------------
+# The canonical literal the Phase 3 write-back uses for plan-scale is
+# load-bearing: filter-unresearched-candidates.sh greps the tracker row
+# for `Action now:.*draft-plan` to derive the `:plan-scale` skip-tag.
+# Lock the exact substring so a stylistic edit doesn't desync the two.
+test_skill_canonical_draft_plan_literal() {
+  local hits
+  hits=$(grep -c '\*\*Action now:\*\* /draft-plan — plan-scale design surface; needs adversarial plan review before any fix\.' "$SKILL")
+  if [ "$hits" -ge 2 ]; then
+    pass "sprint.md preserves canonical /draft-plan write-back literal ($hits hits, expected >=2)"
+  else
+    fail "sprint.md canonical /draft-plan literal" "expected >=2 hits, got $hits"
+  fi
+}
+
+# --- 4. record-skip uses atomic temp+replace (not in-place write) ------
+# Lock the atomic-write pattern so a future "simplification" doesn't
+# leave half-written state files on crash.
+test_record_uses_atomic_write() {
+  if grep -qF 'tempfile.NamedTemporaryFile' "$RECORD" \
+     && grep -qF 'os.replace' "$RECORD"; then
+    pass "record-skip.sh uses tempfile + os.replace (atomic write)"
+  else
+    fail "record-skip.sh atomic write" "missing tempfile.NamedTemporaryFile or os.replace"
+  fi
+}
+
+# --- Run all -----------------------------------------------------------
+test_scripts_present
+test_record_skip_writes_entry
+test_record_skip_idempotent
+test_record_skip_overwrite
+test_record_skip_rejects_bogus_code
+test_record_skip_rejects_bogus_num
+test_filter_drops_unrowed_via_monitor_state
+test_filter_rowed_plus_monitor_state
+test_filter_reconsider_overrides_monitor_state
+test_reconsider_cleanup_removes_skip
+test_skill_invokes_record_skip_both_arms
+test_skill_preserves_phase3_writeback
+test_skill_canonical_draft_plan_literal
+test_record_uses_atomic_write
+
+echo ""
+echo "---"
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary
`/fix-issues` plan-scale skip decisions weren't persisted anywhere the next fire would look — they were only reported to `SPRINT_REPORT.md`. So a plan-scale-classified issue (especially a raw dashboard drag without a tracker row, like #803) re-surfaced every fire and got re-litigated indefinitely. We just lived through this exact loop in this session (~8 consecutive no-op fires re-litigating the same #790/#792).

- Fix follows the **issue body's prescribed approach**: write skip decisions to `.zskills/monitor-state.json` `issues.skipped` (gitignored, no dirty-main-per-skip), **NOT** ISSUES_PLAN.md tracker rows. Symmetric with the existing `issues.reconsider` mechanism.
- New `scripts/record-skip.sh` (atomic Python tempfile + `os.replace` writer).
- `filter-unresearched-candidates.sh` reads `issues.skipped` and emits `SKIP_TAGGED` for unrowed entries (the #803 case), routing them to `RESEARCHED` so research-on-demand doesn't redundantly fire.
- Three write-back points: cherry-pick mode triage-decline, PR mode triage-decline, `/fix-issues plan #N` after `/draft-plan` dispatch.
- Reconsider cleanup removes BOTH `issues.reconsider` (list) and `issues.skipped` (dict) — type-aware.
- Phase 3 in-loop scratchpad write-back **preserved** (additive, not replaced).
- 4 tier classifications persisted: `plan-scale`, `bug-unclear-cause`, `needs-decision`, `deferred`. `too-vague` correctly excluded (routes to user-clarification, not auto-skip).

Closes #808

## Test plan
- [x] Raw-dashboard-drag case (#803): filter drops unrowed candidate via monitor-state
- [x] Reconsider clears BOTH maps
- [x] In-loop scratchpad write-back preserved (NEW_ACTION_NOW blocks intact, additive)
- [x] Canonical Action-now literal matches verbatim in both arms
- [x] Atomic writer (tempfile + os.replace)
- [x] Sanity-revert confirms 15 tests genuinely exercise (2 specific FAILs on revert: #803 drop + reconsider cleanup)
- [x] Full suite green: 6436/6436; verified by fresh verifier agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
