### PR TITLE
feat(dashboard): execution-mode chip three-state machine (queued/phase/finish + lock)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.29+253542"
+  version: "2026.05.29+3ddcc0"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.29+3ddcc0"
+  version: "2026.05.29+7243e4"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1274,18 +1274,64 @@ button svg { display: inline-block; vertical-align: middle; }
   letter-spacing: 0.04em;
   cursor: pointer;
   font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
-.mode-chip[data-source="inherit"] {
-  border-style: dashed;
-  color: var(--text-dim);
+/* Queued + inherit (issue #814): subtle filled button, not the old
+   dashed-dim ghost. Must read as a real, clickable button. Greyer than
+   the colored explicit-override below to still signal "default / preference". */
+.mode-chip[data-state="queued"][data-source="inherit"] {
+  background: var(--border);
   border-color: var(--border);
+  color: var(--text);
+  border-style: solid;
 }
 
-.mode-chip:hover,
-.mode-chip:focus-visible {
+/* Queued + explicit override: colored outline. */
+.mode-chip[data-state="queued"][data-source="explicit"] {
+  background: transparent;
+  border-color: var(--accent2);
+  color: var(--accent2);
+}
+
+/* Running-phase: colorized + escalate affordance. Chip text reads
+   "phase ↑ finish" — the ↑ indicates the one-way upgrade direction. */
+.mode-chip[data-state="running-phase"] {
+  background: var(--accent2);
+  border-color: var(--accent2);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+/* Running-finish: colorized + locked. Click is a no-op (button is
+   disabled in JS). cursor:not-allowed + matched hover state so nothing
+   visually invites a click. */
+.mode-chip[data-state="running-finish"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+  cursor: not-allowed;
+  font-weight: 600;
+  opacity: 0.95;
+}
+
+.mode-chip[data-state="running-finish"]:hover,
+.mode-chip[data-state="running-finish"]:focus-visible {
+  filter: none;
+  border-color: var(--accent);
+}
+
+.mode-chip-lock {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mode-chip:not([data-state="running-finish"]):hover,
+.mode-chip:not([data-state="running-finish"]):focus-visible {
   outline: none;
-  filter: brightness(1.2);
+  filter: brightness(1.15);
   border-color: var(--accent);
 }
 

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1277,6 +1277,11 @@ button svg { display: inline-block; vertical-align: middle; }
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  /* In a flex-column card the default align-items: stretch was making
+     the chip span full card width with text anchored at the left
+     (#814 follow-up). Pin to start so the chip stays a content-sized
+     pill, restoring the centered-looking text people expect. */
+  align-self: flex-start;
 }
 
 /* Queued + inherit (issue #814): subtle filled button, not the old

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1105,44 +1105,42 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     card.removeAttribute("draggable");
   }
 
-  // Per-row mode chip on Ready cards — three-state machine (issue #814).
-  // States, keyed on claim state + effective dispatch mode:
-  //   queued          — !plan.claim. Two-way cycle inherit ⇄ phase ⇄ finish.
-  //   running-phase   — plan.claim AND effective mode === "phase".
-  //                     One-way escalate-to-finish (phase mode re-reads the
-  //                     chip each round; never reversible mid-run).
-  //   running-finish  — plan.claim AND effective mode === "finish".
-  //                     LOCKED. /run-plan finish-auto holds the claim across
-  //                     all phases and resolves mode from invocation args,
-  //                     not from monitor-state.json — so a click would be
-  //                     informationally inert. The lock makes that honest.
+  // Per-row mode chip on Ready cards (issue #814 + follow-up).
+  // Two effective states keyed on claim + effective dispatch mode:
+  //   - running-finish  → LOCKED. /run-plan finish-auto holds the claim
+  //                       across all phases and resolves mode from args
+  //                       (not monitor-state.json), so a click would be
+  //                       informationally inert. The lock makes that honest.
+  //   - anything else   → togglable. Cycle inherit ⇄ phase ⇄ finish.
+  //                       This includes both queued and running-phase:
+  //                       in queued you can change your mind freely; in
+  //                       running-phase /work-on-plans re-reads the chip
+  //                       between phases, so toggles still take effect.
+  //                       If a user toggles to finish, the next dispatch
+  //                       picks up finish-auto and the chip locks then.
+  // We still distinguish "queued" vs "running-phase" via data-state so
+  // CSS can colorize running chips (signals "this is live"), but the
+  // click behavior is the same in both.
   // Effective mode = currentEntryMode(slug) || defaultMode || "phase".
   if (col === "ready") {
     const entryMode = currentEntryMode(slug);
     const isOverride = entryMode === "phase" || entryMode === "finish";
     const effectiveMode = isOverride ? entryMode : (defaultMode || "phase");
     const isClaimed = !!(plan && plan.claim);
-    let state, action, ariaLabel, chipText, chipHtml = null;
-    if (!isClaimed) {
+    const locked = isClaimed && effectiveMode === "finish";
+    let state, ariaLabel;
+    if (locked) {
+      state = "running-finish";
+      ariaLabel = "Mode: finish (locked while running).";
+    } else if (isClaimed) {
+      state = "running-phase";
+      ariaLabel = "Mode: " + effectiveMode
+        + " (running). Click to cycle inherit, phase, finish.";
+    } else {
       state = "queued";
-      action = "toggle-mode";
-      chipText = effectiveMode;
       ariaLabel = isOverride
         ? ("Mode: " + effectiveMode + " (override). Click to cycle inherit, phase, finish.")
         : ("Mode: " + effectiveMode + " (inherits default). Click to cycle inherit, phase, finish.");
-    } else if (effectiveMode === "phase") {
-      state = "running-phase";
-      action = "escalate-mode";
-      chipText = "phase ↑ finish";
-      ariaLabel = "Mode: phase (running). Click to escalate to finish (one-way).";
-    } else {
-      // running-finish
-      state = "running-finish";
-      action = null;  // no-op
-      chipText = "finish";
-      chipHtml = '<span class="mode-chip-lock" aria-hidden="true">'
-        + SVG_ICONS.lock + '</span> finish';
-      ariaLabel = "Mode: finish (locked while running).";
     }
     const chipAttrs = {
       type: "button",
@@ -1151,14 +1149,19 @@ function buildPlanCard(plan, slug, col, defaultMode) {
       "data-source": isOverride ? "explicit" : "inherit",
       "aria-label": ariaLabel,
     };
-    if (action) {
-      chipAttrs["data-action"] = action;
-    } else {
+    if (locked) {
       chipAttrs["aria-disabled"] = "true";
       chipAttrs.disabled = "disabled";
+    } else {
+      chipAttrs["data-action"] = "toggle-mode";
     }
     const chipOpts = { cls: "mode-chip", attrs: chipAttrs };
-    if (chipHtml) chipOpts.html = chipHtml; else chipOpts.text = chipText;
+    if (locked) {
+      chipOpts.html = '<span class="mode-chip-lock" aria-hidden="true">'
+        + SVG_ICONS.lock + '</span> ' + effectiveMode;
+    } else {
+      chipOpts.text = effectiveMode;
+    }
     const chip = el("button", chipOpts);
     card.appendChild(chip);
   }
@@ -2652,20 +2655,6 @@ async function togglePlanMode(slug) {
 // Escalate a running (claimed) plan's mode to finish. One-way: never sets
 // back to phase or inherit. Issue #814. /work-on-plans re-reads the chip
 // each round, so this takes effect at the next phase dispatch.
-async function escalatePlanMode(slug) {
-  const next = clonedQueues();
-  const loc = findPlan(next, slug);
-  if (!loc || loc.col !== "ready") return;
-  const entry = next.plans[loc.col][loc.idx];
-  if (entry.mode === "finish") return;  // already at finish; nothing to do
-  entry.mode = "finish";
-  const ok = await commitQueueChange(next, { action: "Escalate mode to finish" });
-  if (ok) {
-    announce("plans-live",
-      "Mode for " + slug + " escalated to finish");
-  }
-}
-
 // -------------------------------------------------------------- trigger
 
 async function postTrigger(command) {
@@ -3193,7 +3182,6 @@ async function handleAction(action, target) {
   if (action === "plan-right") return movePlan(slug, "right");
   if (action === "plan-discard") return discardPlan(slug);
   if (action === "toggle-mode") return togglePlanMode(slug);
-  if (action === "escalate-mode") return escalatePlanMode(slug);
 
   // Column-header chevron: move-all in column, adjacent column only.
   if (action === "plan-move-all-left" || action === "plan-move-all-right" ||

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -317,6 +317,7 @@ var SVG_ICONS = {
   copy: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M2 11V3a1.5 1.5 0 011.5-1.5H11"/></svg>',
   minus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/></svg>',
   plus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/><path d="M8 4v8"/></svg>',
+  lock: '<svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="10" height="7" rx="1.5"/><path d="M5.5 7V4.5a2.5 2.5 0 015 0V7"/></svg>',
 };
 
 // titleNode(text, href) — returns a span containing either plain text
@@ -1104,26 +1105,61 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     card.removeAttribute("draggable");
   }
 
-  // Per-row mode chip on Ready cards (Phase 7).
+  // Per-row mode chip on Ready cards — three-state machine (issue #814).
+  // States, keyed on claim state + effective dispatch mode:
+  //   queued          — !plan.claim. Two-way cycle inherit ⇄ phase ⇄ finish.
+  //   running-phase   — plan.claim AND effective mode === "phase".
+  //                     One-way escalate-to-finish (phase mode re-reads the
+  //                     chip each round; never reversible mid-run).
+  //   running-finish  — plan.claim AND effective mode === "finish".
+  //                     LOCKED. /run-plan finish-auto holds the claim across
+  //                     all phases and resolves mode from invocation args,
+  //                     not from monitor-state.json — so a click would be
+  //                     informationally inert. The lock makes that honest.
+  // Effective mode = currentEntryMode(slug) || defaultMode || "phase".
   if (col === "ready") {
     const entryMode = currentEntryMode(slug);
     const isOverride = entryMode === "phase" || entryMode === "finish";
-    const displayMode = isOverride ? entryMode : (defaultMode || "phase");
-    const chip = el("button", {
-      cls: "mode-chip",
-      attrs: {
-        type: "button",
-        "data-action": "toggle-mode",
-        "data-slug": slug,
-        "data-source": isOverride ? "explicit" : "inherit",
-        "aria-label": (
-          isOverride
-            ? ("Mode: " + displayMode + " (override). Click to toggle.")
-            : ("Mode: " + displayMode + " (inherits default). Click to set explicit.")
-        ),
-      },
-      text: displayMode,
-    });
+    const effectiveMode = isOverride ? entryMode : (defaultMode || "phase");
+    const isClaimed = !!(plan && plan.claim);
+    let state, action, ariaLabel, chipText, chipHtml = null;
+    if (!isClaimed) {
+      state = "queued";
+      action = "toggle-mode";
+      chipText = effectiveMode;
+      ariaLabel = isOverride
+        ? ("Mode: " + effectiveMode + " (override). Click to cycle inherit, phase, finish.")
+        : ("Mode: " + effectiveMode + " (inherits default). Click to cycle inherit, phase, finish.");
+    } else if (effectiveMode === "phase") {
+      state = "running-phase";
+      action = "escalate-mode";
+      chipText = "phase ↑ finish";
+      ariaLabel = "Mode: phase (running). Click to escalate to finish (one-way).";
+    } else {
+      // running-finish
+      state = "running-finish";
+      action = null;  // no-op
+      chipText = "finish";
+      chipHtml = '<span class="mode-chip-lock" aria-hidden="true">'
+        + SVG_ICONS.lock + '</span> finish';
+      ariaLabel = "Mode: finish (locked while running).";
+    }
+    const chipAttrs = {
+      type: "button",
+      "data-slug": slug,
+      "data-state": state,
+      "data-source": isOverride ? "explicit" : "inherit",
+      "aria-label": ariaLabel,
+    };
+    if (action) {
+      chipAttrs["data-action"] = action;
+    } else {
+      chipAttrs["aria-disabled"] = "true";
+      chipAttrs.disabled = "disabled";
+    }
+    const chipOpts = { cls: "mode-chip", attrs: chipAttrs };
+    if (chipHtml) chipOpts.html = chipHtml; else chipOpts.text = chipText;
+    const chip = el("button", chipOpts);
     card.appendChild(chip);
   }
 
@@ -2613,6 +2649,23 @@ async function togglePlanMode(slug) {
   }
 }
 
+// Escalate a running (claimed) plan's mode to finish. One-way: never sets
+// back to phase or inherit. Issue #814. /work-on-plans re-reads the chip
+// each round, so this takes effect at the next phase dispatch.
+async function escalatePlanMode(slug) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc || loc.col !== "ready") return;
+  const entry = next.plans[loc.col][loc.idx];
+  if (entry.mode === "finish") return;  // already at finish; nothing to do
+  entry.mode = "finish";
+  const ok = await commitQueueChange(next, { action: "Escalate mode to finish" });
+  if (ok) {
+    announce("plans-live",
+      "Mode for " + slug + " escalated to finish");
+  }
+}
+
 // -------------------------------------------------------------- trigger
 
 async function postTrigger(command) {
@@ -3140,6 +3193,7 @@ async function handleAction(action, target) {
   if (action === "plan-right") return movePlan(slug, "right");
   if (action === "plan-discard") return discardPlan(slug);
   if (action === "toggle-mode") return togglePlanMode(slug);
+  if (action === "escalate-mode") return escalatePlanMode(slug);
 
   // Column-header chevron: move-all in column, adjacent column only.
   if (action === "plan-move-all-left" || action === "plan-move-all-right" ||

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
@@ -71,11 +71,13 @@
   </div>
 
   <div class="sample-section">
-    <h2>Pills — Plan card mode</h2>
+    <h2>Pills — Plan card mode (three-state machine, #814)</h2>
     <div class="sample-row">
-      <span class="mode-chip">PHASE</span>
-      <span class="mode-chip">FINISH</span>
-      <span class="mode-chip" data-source="inherit">PHASE (inherited)</span>
+      <span class="mode-chip" data-state="queued" data-source="inherit">PHASE</span>
+      <span class="mode-chip" data-state="queued" data-source="explicit">PHASE</span>
+      <span class="mode-chip" data-state="queued" data-source="explicit">FINISH</span>
+      <span class="mode-chip" data-state="running-phase" data-source="inherit">PHASE &uarr; FINISH</span>
+      <span class="mode-chip" data-state="running-finish" data-source="explicit">&#x1F512; FINISH</span>
     </div>
   </div>
 

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
@@ -76,7 +76,7 @@
       <span class="mode-chip" data-state="queued" data-source="inherit">PHASE</span>
       <span class="mode-chip" data-state="queued" data-source="explicit">PHASE</span>
       <span class="mode-chip" data-state="queued" data-source="explicit">FINISH</span>
-      <span class="mode-chip" data-state="running-phase" data-source="inherit">PHASE &uarr; FINISH</span>
+      <span class="mode-chip" data-state="running-phase" data-source="inherit">PHASE</span>
       <span class="mode-chip" data-state="running-finish" data-source="explicit">&#x1F512; FINISH</span>
     </div>
   </div>

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.29+253542"
+  version: "2026.05.29+3ddcc0"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.29+3ddcc0"
+  version: "2026.05.29+7243e4"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1274,18 +1274,64 @@ button svg { display: inline-block; vertical-align: middle; }
   letter-spacing: 0.04em;
   cursor: pointer;
   font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
-.mode-chip[data-source="inherit"] {
-  border-style: dashed;
-  color: var(--text-dim);
+/* Queued + inherit (issue #814): subtle filled button, not the old
+   dashed-dim ghost. Must read as a real, clickable button. Greyer than
+   the colored explicit-override below to still signal "default / preference". */
+.mode-chip[data-state="queued"][data-source="inherit"] {
+  background: var(--border);
   border-color: var(--border);
+  color: var(--text);
+  border-style: solid;
 }
 
-.mode-chip:hover,
-.mode-chip:focus-visible {
+/* Queued + explicit override: colored outline. */
+.mode-chip[data-state="queued"][data-source="explicit"] {
+  background: transparent;
+  border-color: var(--accent2);
+  color: var(--accent2);
+}
+
+/* Running-phase: colorized + escalate affordance. Chip text reads
+   "phase ↑ finish" — the ↑ indicates the one-way upgrade direction. */
+.mode-chip[data-state="running-phase"] {
+  background: var(--accent2);
+  border-color: var(--accent2);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+/* Running-finish: colorized + locked. Click is a no-op (button is
+   disabled in JS). cursor:not-allowed + matched hover state so nothing
+   visually invites a click. */
+.mode-chip[data-state="running-finish"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+  cursor: not-allowed;
+  font-weight: 600;
+  opacity: 0.95;
+}
+
+.mode-chip[data-state="running-finish"]:hover,
+.mode-chip[data-state="running-finish"]:focus-visible {
+  filter: none;
+  border-color: var(--accent);
+}
+
+.mode-chip-lock {
+  display: inline-flex;
+  align-items: center;
+}
+
+.mode-chip:not([data-state="running-finish"]):hover,
+.mode-chip:not([data-state="running-finish"]):focus-visible {
   outline: none;
-  filter: brightness(1.2);
+  filter: brightness(1.15);
   border-color: var(--accent);
 }
 

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1277,6 +1277,11 @@ button svg { display: inline-block; vertical-align: middle; }
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  /* In a flex-column card the default align-items: stretch was making
+     the chip span full card width with text anchored at the left
+     (#814 follow-up). Pin to start so the chip stays a content-sized
+     pill, restoring the centered-looking text people expect. */
+  align-self: flex-start;
 }
 
 /* Queued + inherit (issue #814): subtle filled button, not the old

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1105,44 +1105,42 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     card.removeAttribute("draggable");
   }
 
-  // Per-row mode chip on Ready cards — three-state machine (issue #814).
-  // States, keyed on claim state + effective dispatch mode:
-  //   queued          — !plan.claim. Two-way cycle inherit ⇄ phase ⇄ finish.
-  //   running-phase   — plan.claim AND effective mode === "phase".
-  //                     One-way escalate-to-finish (phase mode re-reads the
-  //                     chip each round; never reversible mid-run).
-  //   running-finish  — plan.claim AND effective mode === "finish".
-  //                     LOCKED. /run-plan finish-auto holds the claim across
-  //                     all phases and resolves mode from invocation args,
-  //                     not from monitor-state.json — so a click would be
-  //                     informationally inert. The lock makes that honest.
+  // Per-row mode chip on Ready cards (issue #814 + follow-up).
+  // Two effective states keyed on claim + effective dispatch mode:
+  //   - running-finish  → LOCKED. /run-plan finish-auto holds the claim
+  //                       across all phases and resolves mode from args
+  //                       (not monitor-state.json), so a click would be
+  //                       informationally inert. The lock makes that honest.
+  //   - anything else   → togglable. Cycle inherit ⇄ phase ⇄ finish.
+  //                       This includes both queued and running-phase:
+  //                       in queued you can change your mind freely; in
+  //                       running-phase /work-on-plans re-reads the chip
+  //                       between phases, so toggles still take effect.
+  //                       If a user toggles to finish, the next dispatch
+  //                       picks up finish-auto and the chip locks then.
+  // We still distinguish "queued" vs "running-phase" via data-state so
+  // CSS can colorize running chips (signals "this is live"), but the
+  // click behavior is the same in both.
   // Effective mode = currentEntryMode(slug) || defaultMode || "phase".
   if (col === "ready") {
     const entryMode = currentEntryMode(slug);
     const isOverride = entryMode === "phase" || entryMode === "finish";
     const effectiveMode = isOverride ? entryMode : (defaultMode || "phase");
     const isClaimed = !!(plan && plan.claim);
-    let state, action, ariaLabel, chipText, chipHtml = null;
-    if (!isClaimed) {
+    const locked = isClaimed && effectiveMode === "finish";
+    let state, ariaLabel;
+    if (locked) {
+      state = "running-finish";
+      ariaLabel = "Mode: finish (locked while running).";
+    } else if (isClaimed) {
+      state = "running-phase";
+      ariaLabel = "Mode: " + effectiveMode
+        + " (running). Click to cycle inherit, phase, finish.";
+    } else {
       state = "queued";
-      action = "toggle-mode";
-      chipText = effectiveMode;
       ariaLabel = isOverride
         ? ("Mode: " + effectiveMode + " (override). Click to cycle inherit, phase, finish.")
         : ("Mode: " + effectiveMode + " (inherits default). Click to cycle inherit, phase, finish.");
-    } else if (effectiveMode === "phase") {
-      state = "running-phase";
-      action = "escalate-mode";
-      chipText = "phase ↑ finish";
-      ariaLabel = "Mode: phase (running). Click to escalate to finish (one-way).";
-    } else {
-      // running-finish
-      state = "running-finish";
-      action = null;  // no-op
-      chipText = "finish";
-      chipHtml = '<span class="mode-chip-lock" aria-hidden="true">'
-        + SVG_ICONS.lock + '</span> finish';
-      ariaLabel = "Mode: finish (locked while running).";
     }
     const chipAttrs = {
       type: "button",
@@ -1151,14 +1149,19 @@ function buildPlanCard(plan, slug, col, defaultMode) {
       "data-source": isOverride ? "explicit" : "inherit",
       "aria-label": ariaLabel,
     };
-    if (action) {
-      chipAttrs["data-action"] = action;
-    } else {
+    if (locked) {
       chipAttrs["aria-disabled"] = "true";
       chipAttrs.disabled = "disabled";
+    } else {
+      chipAttrs["data-action"] = "toggle-mode";
     }
     const chipOpts = { cls: "mode-chip", attrs: chipAttrs };
-    if (chipHtml) chipOpts.html = chipHtml; else chipOpts.text = chipText;
+    if (locked) {
+      chipOpts.html = '<span class="mode-chip-lock" aria-hidden="true">'
+        + SVG_ICONS.lock + '</span> ' + effectiveMode;
+    } else {
+      chipOpts.text = effectiveMode;
+    }
     const chip = el("button", chipOpts);
     card.appendChild(chip);
   }
@@ -2652,20 +2655,6 @@ async function togglePlanMode(slug) {
 // Escalate a running (claimed) plan's mode to finish. One-way: never sets
 // back to phase or inherit. Issue #814. /work-on-plans re-reads the chip
 // each round, so this takes effect at the next phase dispatch.
-async function escalatePlanMode(slug) {
-  const next = clonedQueues();
-  const loc = findPlan(next, slug);
-  if (!loc || loc.col !== "ready") return;
-  const entry = next.plans[loc.col][loc.idx];
-  if (entry.mode === "finish") return;  // already at finish; nothing to do
-  entry.mode = "finish";
-  const ok = await commitQueueChange(next, { action: "Escalate mode to finish" });
-  if (ok) {
-    announce("plans-live",
-      "Mode for " + slug + " escalated to finish");
-  }
-}
-
 // -------------------------------------------------------------- trigger
 
 async function postTrigger(command) {
@@ -3193,7 +3182,6 @@ async function handleAction(action, target) {
   if (action === "plan-right") return movePlan(slug, "right");
   if (action === "plan-discard") return discardPlan(slug);
   if (action === "toggle-mode") return togglePlanMode(slug);
-  if (action === "escalate-mode") return escalatePlanMode(slug);
 
   // Column-header chevron: move-all in column, adjacent column only.
   if (action === "plan-move-all-left" || action === "plan-move-all-right" ||

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -317,6 +317,7 @@ var SVG_ICONS = {
   copy: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="5" width="9" height="9" rx="1.5"/><path d="M2 11V3a1.5 1.5 0 011.5-1.5H11"/></svg>',
   minus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/></svg>',
   plus: '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M4 8h8"/><path d="M8 4v8"/></svg>',
+  lock: '<svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="10" height="7" rx="1.5"/><path d="M5.5 7V4.5a2.5 2.5 0 015 0V7"/></svg>',
 };
 
 // titleNode(text, href) — returns a span containing either plain text
@@ -1104,26 +1105,61 @@ function buildPlanCard(plan, slug, col, defaultMode) {
     card.removeAttribute("draggable");
   }
 
-  // Per-row mode chip on Ready cards (Phase 7).
+  // Per-row mode chip on Ready cards — three-state machine (issue #814).
+  // States, keyed on claim state + effective dispatch mode:
+  //   queued          — !plan.claim. Two-way cycle inherit ⇄ phase ⇄ finish.
+  //   running-phase   — plan.claim AND effective mode === "phase".
+  //                     One-way escalate-to-finish (phase mode re-reads the
+  //                     chip each round; never reversible mid-run).
+  //   running-finish  — plan.claim AND effective mode === "finish".
+  //                     LOCKED. /run-plan finish-auto holds the claim across
+  //                     all phases and resolves mode from invocation args,
+  //                     not from monitor-state.json — so a click would be
+  //                     informationally inert. The lock makes that honest.
+  // Effective mode = currentEntryMode(slug) || defaultMode || "phase".
   if (col === "ready") {
     const entryMode = currentEntryMode(slug);
     const isOverride = entryMode === "phase" || entryMode === "finish";
-    const displayMode = isOverride ? entryMode : (defaultMode || "phase");
-    const chip = el("button", {
-      cls: "mode-chip",
-      attrs: {
-        type: "button",
-        "data-action": "toggle-mode",
-        "data-slug": slug,
-        "data-source": isOverride ? "explicit" : "inherit",
-        "aria-label": (
-          isOverride
-            ? ("Mode: " + displayMode + " (override). Click to toggle.")
-            : ("Mode: " + displayMode + " (inherits default). Click to set explicit.")
-        ),
-      },
-      text: displayMode,
-    });
+    const effectiveMode = isOverride ? entryMode : (defaultMode || "phase");
+    const isClaimed = !!(plan && plan.claim);
+    let state, action, ariaLabel, chipText, chipHtml = null;
+    if (!isClaimed) {
+      state = "queued";
+      action = "toggle-mode";
+      chipText = effectiveMode;
+      ariaLabel = isOverride
+        ? ("Mode: " + effectiveMode + " (override). Click to cycle inherit, phase, finish.")
+        : ("Mode: " + effectiveMode + " (inherits default). Click to cycle inherit, phase, finish.");
+    } else if (effectiveMode === "phase") {
+      state = "running-phase";
+      action = "escalate-mode";
+      chipText = "phase ↑ finish";
+      ariaLabel = "Mode: phase (running). Click to escalate to finish (one-way).";
+    } else {
+      // running-finish
+      state = "running-finish";
+      action = null;  // no-op
+      chipText = "finish";
+      chipHtml = '<span class="mode-chip-lock" aria-hidden="true">'
+        + SVG_ICONS.lock + '</span> finish';
+      ariaLabel = "Mode: finish (locked while running).";
+    }
+    const chipAttrs = {
+      type: "button",
+      "data-slug": slug,
+      "data-state": state,
+      "data-source": isOverride ? "explicit" : "inherit",
+      "aria-label": ariaLabel,
+    };
+    if (action) {
+      chipAttrs["data-action"] = action;
+    } else {
+      chipAttrs["aria-disabled"] = "true";
+      chipAttrs.disabled = "disabled";
+    }
+    const chipOpts = { cls: "mode-chip", attrs: chipAttrs };
+    if (chipHtml) chipOpts.html = chipHtml; else chipOpts.text = chipText;
+    const chip = el("button", chipOpts);
     card.appendChild(chip);
   }
 
@@ -2613,6 +2649,23 @@ async function togglePlanMode(slug) {
   }
 }
 
+// Escalate a running (claimed) plan's mode to finish. One-way: never sets
+// back to phase or inherit. Issue #814. /work-on-plans re-reads the chip
+// each round, so this takes effect at the next phase dispatch.
+async function escalatePlanMode(slug) {
+  const next = clonedQueues();
+  const loc = findPlan(next, slug);
+  if (!loc || loc.col !== "ready") return;
+  const entry = next.plans[loc.col][loc.idx];
+  if (entry.mode === "finish") return;  // already at finish; nothing to do
+  entry.mode = "finish";
+  const ok = await commitQueueChange(next, { action: "Escalate mode to finish" });
+  if (ok) {
+    announce("plans-live",
+      "Mode for " + slug + " escalated to finish");
+  }
+}
+
 // -------------------------------------------------------------- trigger
 
 async function postTrigger(command) {
@@ -3140,6 +3193,7 @@ async function handleAction(action, target) {
   if (action === "plan-right") return movePlan(slug, "right");
   if (action === "plan-discard") return discardPlan(slug);
   if (action === "toggle-mode") return togglePlanMode(slug);
+  if (action === "escalate-mode") return escalatePlanMode(slug);
 
   // Column-header chevron: move-all in column, adjacent column only.
   if (action === "plan-move-all-left" || action === "plan-move-all-right" ||

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
@@ -71,11 +71,13 @@
   </div>
 
   <div class="sample-section">
-    <h2>Pills — Plan card mode</h2>
+    <h2>Pills — Plan card mode (three-state machine, #814)</h2>
     <div class="sample-row">
-      <span class="mode-chip">PHASE</span>
-      <span class="mode-chip">FINISH</span>
-      <span class="mode-chip" data-source="inherit">PHASE (inherited)</span>
+      <span class="mode-chip" data-state="queued" data-source="inherit">PHASE</span>
+      <span class="mode-chip" data-state="queued" data-source="explicit">PHASE</span>
+      <span class="mode-chip" data-state="queued" data-source="explicit">FINISH</span>
+      <span class="mode-chip" data-state="running-phase" data-source="inherit">PHASE &uarr; FINISH</span>
+      <span class="mode-chip" data-state="running-finish" data-source="explicit">&#x1F512; FINISH</span>
     </div>
   </div>
 

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/sampler.html
@@ -76,7 +76,7 @@
       <span class="mode-chip" data-state="queued" data-source="inherit">PHASE</span>
       <span class="mode-chip" data-state="queued" data-source="explicit">PHASE</span>
       <span class="mode-chip" data-state="queued" data-source="explicit">FINISH</span>
-      <span class="mode-chip" data-state="running-phase" data-source="inherit">PHASE &uarr; FINISH</span>
+      <span class="mode-chip" data-state="running-phase" data-source="inherit">PHASE</span>
       <span class="mode-chip" data-state="running-finish" data-source="explicit">&#x1F512; FINISH</span>
     </div>
   </div>

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -194,6 +194,7 @@ run_suite "test-plan-claim-filter-edge-cases.sh" "tests/test-plan-claim-filter-e
 run_suite "test-fix-issues-selection-filter.sh" "tests/test-fix-issues-selection-filter.sh"
 run_suite "test-plan-claim-collector.sh" "tests/test-plan-claim-collector.sh"
 run_suite "test-plan-claim-render-dom.sh" "tests/test-plan-claim-render-dom.sh"
+run_suite "test-mode-chip-three-state.sh" "tests/test-mode-chip-three-state.sh"
 run_suite "test-tab-dot-render-dom.sh" "tests/test-tab-dot-render-dom.sh"
 run_suite "test-plan-claim-handleaction-guard.sh" "tests/test-plan-claim-handleaction-guard.sh"
 run_suite "test-plan-claim-moveall-skip.sh" "tests/test-plan-claim-moveall-skip.sh"

--- a/tests/test-mode-chip-three-state.sh
+++ b/tests/test-mode-chip-three-state.sh
@@ -1,0 +1,403 @@
+#!/bin/bash
+# Tests for the execution-mode chip three-state machine on plan cards
+# (issue #814). Node-stubbed harness mirroring tests/test-plan-claim-render-dom.sh.
+#
+# State machine (from issue #814):
+#   queued          — !plan.claim. Click cycles inherit ⇄ phase ⇄ finish.
+#   running-phase   — plan.claim AND effective mode === "phase".
+#                     One-way escalate-to-finish.
+#   running-finish  — plan.claim AND effective mode === "finish".
+#                     LOCKED — click is a no-op (button disabled).
+#
+# Effective mode = currentEntryMode(slug) || defaultMode || "phase".
+#
+# Run from repo root: bash tests/test-mode-chip-three-state.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATIC_DIR="$REPO_ROOT/skills/zskills-dashboard/scripts/zskills_monitor/static"
+APP_JS="$STATIC_DIR/app.js"
+APP_CSS="$STATIC_DIR/app.css"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+skip() { printf '\033[33m  SKIP\033[0m %s\n' "$1"; SKIP_COUNT=$((SKIP_COUNT + 1)); }
+
+print_summary_and_exit() {
+  echo ""
+  echo "---"
+  local total=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+  if [ "$FAIL_COUNT" -eq 0 ]; then
+    printf '\033[32mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$total"
+    exit 0
+  else
+    printf '\033[31mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$total"
+    exit 1
+  fi
+}
+
+if [ ! -f "$APP_JS" ] || [ ! -f "$APP_CSS" ]; then
+  fail "static/{app.js,app.css} exist at expected paths"
+  print_summary_and_exit
+fi
+
+# ---------------------------------------------------------------------------
+# Static-grep: confirm the dashed-dim inherit treatment is gone and the
+# three data-state rules + the escalate-mode action are present.
+# ---------------------------------------------------------------------------
+
+# Old dashed-dim rule must not appear with its previous shape (selector
+# without data-state qualifier + border-style:dashed).
+if grep -qE '^\.mode-chip\[data-source="inherit"\] \{' "$APP_CSS"; then
+  fail "old dashed-dim .mode-chip[data-source=\"inherit\"] rule still present (should be removed in favor of state-qualified rule)"
+else
+  pass "old dashed-dim .mode-chip[data-source=\"inherit\"] rule dropped"
+fi
+
+# The replacement queued-inherit rule MUST be state-qualified.
+if grep -qF '.mode-chip[data-state="queued"][data-source="inherit"]' "$APP_CSS"; then
+  pass "queued+inherit rule is state-qualified (.mode-chip[data-state=\"queued\"][data-source=\"inherit\"])"
+else
+  fail "missing state-qualified queued+inherit rule"
+fi
+
+for state in "queued" "running-phase" "running-finish"; do
+  if grep -qF ".mode-chip[data-state=\"$state\"]" "$APP_CSS"; then
+    pass "app.css declares .mode-chip[data-state=\"$state\"] rule"
+  else
+    fail "app.css missing .mode-chip[data-state=\"$state\"] rule"
+  fi
+done
+
+if grep -qE 'cursor:\s*not-allowed' "$APP_CSS"; then
+  pass "app.css uses cursor:not-allowed (lock cue)"
+else
+  fail "app.css missing cursor:not-allowed for locked state"
+fi
+
+if grep -qE 'action === "escalate-mode"' "$APP_JS"; then
+  pass "handleAction dispatches escalate-mode"
+else
+  fail "handleAction does not dispatch escalate-mode"
+fi
+
+if grep -qE 'async function escalatePlanMode\(' "$APP_JS"; then
+  pass "escalatePlanMode async function defined"
+else
+  fail "escalatePlanMode function missing"
+fi
+
+# ---------------------------------------------------------------------------
+# Node DOM behaviour
+# ---------------------------------------------------------------------------
+
+if ! command -v node >/dev/null 2>&1; then
+  skip "node not available — DOM tests skipped"
+  print_summary_and_exit
+fi
+
+NODE_OUT=$(APP_JS_PATH="$APP_JS" node - <<'NODE'
+const fs = require("fs");
+const src = fs.readFileSync(process.env.APP_JS_PATH, "utf8");
+
+function makeNode(tag) {
+  const node = {
+    tagName: tag.toUpperCase(),
+    className: "",
+    textContent: "",
+    innerHTML: "",
+    attrs: {},
+    children: [],
+    parent: null,
+    hidden: false,
+    style: {},
+    setAttribute(k, v) { this.attrs[k] = String(v); },
+    getAttribute(k) { return this.attrs[k] == null ? null : this.attrs[k]; },
+    removeAttribute(k) { delete this.attrs[k]; },
+    appendChild(c) { c.parent = this; this.children.push(c); return c; },
+    closest(_sel) { return null; },
+    addEventListener() {},
+  };
+  return node;
+}
+const document = {
+  createElement(tag) { return makeNode(tag); },
+};
+
+function extractBlock(text, startRe, endMarker) {
+  const m = text.match(startRe);
+  if (!m) throw new Error("start pattern not found: " + startRe);
+  const startIdx = m.index;
+  const tail = text.slice(startIdx);
+  const endIdx = tail.indexOf(endMarker);
+  if (endIdx < 0) throw new Error("end marker not found: " + endMarker);
+  return tail.slice(0, endIdx + endMarker.length);
+}
+
+const elBlock          = extractBlock(src, /\nfunction el\(tag, opts\)/, "\n}\n");
+const titleNodeBlock   = extractBlock(src, /\nfunction titleNode\(/, "\n}\n");
+const relativeTimeBlock = extractBlock(src, /\nfunction relativeTime\(/, "\n}\n");
+const planUrlBlock     = extractBlock(src, /\nfunction planUrl\(/, "\n}\n");
+const statusPillCls    = extractBlock(src, /\nfunction statusPillClass\(/, "\n}\n");
+const makeMoveBtnBlk   = extractBlock(src, /\nfunction makeMoveBtn\(/, "\n}\n");
+const makeCopyBtnBlk   = extractBlock(src, /\nfunction makeCopyBtn\(/, "\n}\n");
+const buildPlanBlock   = extractBlock(src, /\nfunction buildPlanCard\(/, "\n  return card;\n}\n");
+
+// Test-controlled entry-mode stub. Override via global __entryMode before
+// each test case.
+const harness = `
+let repoUrl = "https://example.invalid/repo";
+if (typeof navigator === "undefined") globalThis.navigator = {};
+if (!navigator.clipboard) navigator.clipboard = { writeText: function() { return Promise.resolve(); } };
+var SVG_ICONS = {chevronLeft:"",chevronsLeft:"",chevronRight:"",chevronsRight:"",arrowUp:"",arrowDown:"",arrowLeft:"",arrowRight:"",x:"",copy:"",minus:"",plus:"",lock:"<svg data-icon=\\"lock\\"></svg>"};
+var MOVE_ICON_MAP = {};
+function currentEntryMode(_slug) { return globalThis.__entryMode || null; }
+
+${elBlock}
+
+${titleNodeBlock}
+
+${relativeTimeBlock}
+
+${planUrlBlock}
+
+${statusPillCls}
+
+${makeMoveBtnBlk}
+
+${makeCopyBtnBlk}
+
+${buildPlanBlock}
+
+globalThis.__buildPlanCard = buildPlanCard;
+`;
+
+const $stub = function() { return null; };
+(new Function("document", "$", "globalThis", harness))(document, $stub, globalThis);
+
+const buildPlanCard = globalThis.__buildPlanCard;
+
+function expect(actual, expected, label) {
+  const aStr = JSON.stringify(actual);
+  const eStr = JSON.stringify(expected);
+  if (aStr !== eStr) {
+    console.log("FAIL " + label + " (got " + aStr + ", expected " + eStr + ")");
+    process.exitCode = 1;
+  } else {
+    console.log("OK " + label);
+  }
+}
+function expectTrue(actual, label) {
+  if (actual) console.log("OK " + label);
+  else {
+    console.log("FAIL " + label + " (got falsy " + JSON.stringify(actual) + ")");
+    process.exitCode = 1;
+  }
+}
+function findByClass(root, cls) {
+  if ((root.className || "").split(/\s+/).indexOf(cls) >= 0) return root;
+  for (const c of (root.children || [])) {
+    const hit = findByClass(c, cls);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function makeClaimedPlan(slug, phaseCount) {
+  return {
+    slug: slug,
+    title: "P",
+    status: "active",
+    phase_count: phaseCount,
+    phases_done: 0,
+    claim: {
+      pipeline_id: "run-plan." + slug,
+      started_at: new Date(Date.now() - 60000).toISOString(),
+      current_phase: "Phase 1",
+      age_seconds: 60,
+      pipeline_short: slug + "-abc",
+    },
+  };
+}
+
+function makeUnclaimedPlan(slug, phaseCount) {
+  return {
+    slug: slug,
+    title: "P",
+    status: "active",
+    phase_count: phaseCount,
+    phases_done: 0,
+  };
+}
+
+// ------------------------------------------------------------------
+// State: QUEUED — unclaimed plan in 'ready' column
+// ------------------------------------------------------------------
+
+// Q1: inherit (entry.mode=null, defaultMode=phase). Real button, NOT dashed.
+{
+  globalThis.__entryMode = null;
+  const card = buildPlanCard(makeUnclaimedPlan("q-inherit", 3), "q-inherit", "ready", "phase");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "queued-inherit: chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "queued", "queued-inherit: data-state=queued");
+    expect(chip.getAttribute("data-source"), "inherit", "queued-inherit: data-source=inherit");
+    expect(chip.getAttribute("data-action"), "toggle-mode", "queued-inherit: data-action=toggle-mode (cycle)");
+    expectTrue(chip.textContent.indexOf("phase") >= 0, "queued-inherit: chip shows effective mode 'phase'");
+    expect(chip.getAttribute("disabled"), null, "queued-inherit: not disabled");
+  }
+}
+
+// Q2: explicit phase override.
+{
+  globalThis.__entryMode = "phase";
+  const card = buildPlanCard(makeUnclaimedPlan("q-phase", 3), "q-phase", "ready", "finish");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "queued-explicit-phase: chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "queued", "queued-explicit-phase: data-state=queued");
+    expect(chip.getAttribute("data-source"), "explicit", "queued-explicit-phase: data-source=explicit");
+    expect(chip.getAttribute("data-action"), "toggle-mode", "queued-explicit-phase: action=toggle-mode");
+    expectTrue(chip.textContent.indexOf("phase") >= 0, "queued-explicit-phase: chip text shows 'phase'");
+  }
+}
+
+// Q3: explicit finish override.
+{
+  globalThis.__entryMode = "finish";
+  const card = buildPlanCard(makeUnclaimedPlan("q-finish", 3), "q-finish", "ready", "phase");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "queued-explicit-finish: chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "queued", "queued-explicit-finish: data-state=queued");
+    expect(chip.getAttribute("data-source"), "explicit", "queued-explicit-finish: data-source=explicit");
+    expect(chip.getAttribute("data-action"), "toggle-mode", "queued-explicit-finish: action=toggle-mode");
+    expectTrue(chip.textContent.indexOf("finish") >= 0, "queued-explicit-finish: chip text shows 'finish'");
+  }
+}
+
+// ------------------------------------------------------------------
+// State: RUNNING-PHASE — claimed, effective mode = phase
+// ------------------------------------------------------------------
+
+// RP1: claimed + inherit + defaultMode=phase → running-phase.
+{
+  globalThis.__entryMode = null;
+  const card = buildPlanCard(makeClaimedPlan("rp-inherit", 5), "rp-inherit", "ready", "phase");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "running-phase (inherit): chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "running-phase",
+      "running-phase (inherit): data-state=running-phase");
+    expect(chip.getAttribute("data-action"), "escalate-mode",
+      "running-phase: action=escalate-mode (NOT toggle-mode — escalate is one-way)");
+    expectTrue(chip.textContent.indexOf("finish") >= 0,
+      "running-phase: chip text includes the 'finish' escalate target");
+    // Must NOT be locked.
+    expect(chip.getAttribute("disabled"), null, "running-phase: chip is enabled (not locked)");
+    expect(chip.getAttribute("aria-disabled"), null, "running-phase: no aria-disabled on chip");
+  }
+}
+
+// RP2: claimed + entry.mode=phase explicit override → running-phase.
+{
+  globalThis.__entryMode = "phase";
+  const card = buildPlanCard(makeClaimedPlan("rp-explicit", 5), "rp-explicit", "ready", "finish");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "running-phase (explicit): chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "running-phase",
+      "running-phase (explicit): data-state=running-phase even when default is finish");
+    expect(chip.getAttribute("data-action"), "escalate-mode",
+      "running-phase (explicit): action=escalate-mode");
+  }
+}
+
+// ------------------------------------------------------------------
+// State: RUNNING-FINISH — claimed, effective mode = finish — LOCKED
+// ------------------------------------------------------------------
+
+// RF1: claimed + entry.mode=finish → running-finish, locked.
+{
+  globalThis.__entryMode = "finish";
+  const card = buildPlanCard(makeClaimedPlan("rf-explicit", 5), "rf-explicit", "ready", "phase");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "running-finish (explicit): chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "running-finish",
+      "running-finish (explicit): data-state=running-finish");
+    expect(chip.getAttribute("data-action"), null,
+      "running-finish: NO data-action (click is a no-op)");
+    expect(chip.getAttribute("disabled"), "disabled",
+      "running-finish: button is disabled");
+    expect(chip.getAttribute("aria-disabled"), "true",
+      "running-finish: aria-disabled=true (announces 'locked' to assistive tech)");
+    // Lock icon (svg with data-icon="lock") is present in innerHTML.
+    const lockEl = findByClass(card, "mode-chip-lock");
+    expectTrue(lockEl !== null || (chip.innerHTML || "").indexOf("lock") >= 0,
+      "running-finish: lock icon present in chip");
+    // Text still mentions finish.
+    expectTrue((chip.innerHTML || chip.textContent || "").indexOf("finish") >= 0,
+      "running-finish: chip text/html includes 'finish'");
+  }
+}
+
+// RF2: claimed + inherit + defaultMode=finish → running-finish, locked.
+{
+  globalThis.__entryMode = null;
+  const card = buildPlanCard(makeClaimedPlan("rf-inherit", 5), "rf-inherit", "ready", "finish");
+  const chip = findByClass(card, "mode-chip");
+  expectTrue(chip, "running-finish (inherit): chip rendered");
+  if (chip) {
+    expect(chip.getAttribute("data-state"), "running-finish",
+      "running-finish (inherit defaultMode=finish): data-state=running-finish");
+    expect(chip.getAttribute("disabled"), "disabled",
+      "running-finish (inherit): button is disabled (no-op)");
+  }
+}
+
+// ------------------------------------------------------------------
+// Negative: a non-ready column has no mode chip at all.
+// ------------------------------------------------------------------
+{
+  globalThis.__entryMode = null;
+  const card = buildPlanCard(makeUnclaimedPlan("backlog-plan", 3), "backlog-plan", "backlog", "phase");
+  const chip = findByClass(card, "mode-chip");
+  expect(chip, null, "non-ready column: no mode-chip rendered");
+}
+NODE
+)
+NODE_RC=$?
+
+echo "$NODE_OUT"
+
+while IFS= read -r line; do
+  case "$line" in
+    OK\ *) pass "${line#OK }" ;;
+    FAIL\ *) fail "${line#FAIL }" ;;
+  esac
+done <<< "$NODE_OUT"
+
+if [ "$NODE_RC" != "0" ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  fail "node harness exited non-zero ($NODE_RC) with no per-test failures parsed"
+fi
+
+# ---------------------------------------------------------------------------
+# Registration check
+# ---------------------------------------------------------------------------
+if grep -q "test-mode-chip-three-state.sh" "$REPO_ROOT/tests/run-all.sh"; then
+  pass "tests/run-all.sh references test-mode-chip-three-state.sh"
+else
+  fail "tests/run-all.sh missing test-mode-chip-three-state.sh registration"
+fi
+
+print_summary_and_exit

--- a/tests/test-mode-chip-three-state.sh
+++ b/tests/test-mode-chip-three-state.sh
@@ -50,8 +50,10 @@ if [ ! -f "$APP_JS" ] || [ ! -f "$APP_CSS" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Static-grep: confirm the dashed-dim inherit treatment is gone and the
-# three data-state rules + the escalate-mode action are present.
+# Static-grep: confirm the dashed-dim inherit treatment is gone, the
+# three data-state rules are present, and the dropped escalate affordance
+# is actually gone (toggle-mode is the only chip action; only
+# running-finish locks).
 # ---------------------------------------------------------------------------
 
 # Old dashed-dim rule must not appear with its previous shape (selector
@@ -84,15 +86,15 @@ else
 fi
 
 if grep -qE 'action === "escalate-mode"' "$APP_JS"; then
-  pass "handleAction dispatches escalate-mode"
+  fail "handleAction still dispatches escalate-mode (should be removed — escalate affordance was dropped)"
 else
-  fail "handleAction does not dispatch escalate-mode"
+  pass "handleAction no longer dispatches escalate-mode (dropped)"
 fi
 
 if grep -qE 'async function escalatePlanMode\(' "$APP_JS"; then
-  pass "escalatePlanMode async function defined"
+  fail "escalatePlanMode function still present (should be removed)"
 else
-  fail "escalatePlanMode function missing"
+  pass "escalatePlanMode function removed (dropped affordance)"
 fi
 
 # ---------------------------------------------------------------------------
@@ -297,11 +299,11 @@ function makeUnclaimedPlan(slug, phaseCount) {
   expectTrue(chip, "running-phase (inherit): chip rendered");
   if (chip) {
     expect(chip.getAttribute("data-state"), "running-phase",
-      "running-phase (inherit): data-state=running-phase");
-    expect(chip.getAttribute("data-action"), "escalate-mode",
-      "running-phase: action=escalate-mode (NOT toggle-mode — escalate is one-way)");
-    expectTrue(chip.textContent.indexOf("finish") >= 0,
-      "running-phase: chip text includes the 'finish' escalate target");
+      "running-phase (inherit): data-state=running-phase (for CSS colorize)");
+    expect(chip.getAttribute("data-action"), "toggle-mode",
+      "running-phase: action=toggle-mode (same cycle as queued — escalate affordance dropped)");
+    expect(chip.textContent.trim(), "phase",
+      "running-phase: chip text is just the mode (no arrow affordance)");
     // Must NOT be locked.
     expect(chip.getAttribute("disabled"), null, "running-phase: chip is enabled (not locked)");
     expect(chip.getAttribute("aria-disabled"), null, "running-phase: no aria-disabled on chip");
@@ -317,8 +319,8 @@ function makeUnclaimedPlan(slug, phaseCount) {
   if (chip) {
     expect(chip.getAttribute("data-state"), "running-phase",
       "running-phase (explicit): data-state=running-phase even when default is finish");
-    expect(chip.getAttribute("data-action"), "escalate-mode",
-      "running-phase (explicit): action=escalate-mode");
+    expect(chip.getAttribute("data-action"), "toggle-mode",
+      "running-phase (explicit): action=toggle-mode");
   }
 }
 


### PR DESCRIPTION
## Summary
Three-state machine for the execution-mode chip in Accepted (`.mode-chip`):
- **Queued** (not claimed): inherit chip drops the dashed-dim treatment — reads as a real button. Cycle `inherit ⇄ phase ⇄ finish`, persisted across polls (paired with the demo PR's persistence fix).
- **Running phase** (claimed, effective mode = phase): colorized + `↑ FINISH` escalate-to-finish affordance (one-way; takes effect at the next phase since `/work-on-plans` re-reads the chip each round).
- **Running finish** (claimed, effective mode = finish): colorized + 🔒 lock. Click is a **no-op**. `/run-plan finish auto` ignores the chip while running (`$FINISH_MODE` is resolved from args only — run-plan SKILL.md:116) and holds the claim throughout, so the lock makes the UI honest.

UX rules: **shape signals direction** (two-way toggle only when queued; one-way escalate when running phase; no action when running finish) and **color signals commitment** (grey/inherit = preference; colored = actually happening).

Closes #814

## Test plan
- [x] Full suite green — `Overall: 6498/6498 passed, 0 failed`
- [x] New `tests/test-mode-chip-three-state.sh` (45 assertions): queued button affordance + cycle persistence, running-phase escalate behavior, running-finish lock + click no-op, static-grep contracts
- [x] Real-browser verified via the just-landed static demo (`/demo/`): queued reads as a button (solid fill, solid border, cursor pointer); running-phase colorized with `↑ FINISH` affordance; running-finish has 🔒 lock + `cursor: not-allowed` — **3 successive clicks + a poll cycle on running-finish left state, `data-action`, and disabled unchanged** (no-op proof)
