### PR TITLE
do: cleanup-merged: escalate -d → -D (closes #816)

### DIFF
--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   explicitly name. Protected branches from config are NEVER deleted (even
   with `force`) — they are always skipped.
 metadata:
-  version: "2026.05.28+88b007"
+  version: "2026.05.29+462827"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -555,6 +555,11 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       # not-ancestor (squash) case and for the explicit `force` path. `-D`
       # is NEVER reached for an un-confirmed, un-named branch (the
       # merged-check above guarantees MERGED=1 unless NAMED_FORCE=1).
+      # Issue #816: `-d` ALSO requires the branch be fully merged into its
+      # configured upstream; when the remote-tracking ref still holds the
+      # un-squashed PR head, `-d` refuses. In that case, if the branch is
+      # an ancestor of main (the local content IS on main), escalate to
+      # `-D` — lossless by construction.
       if [ "$NAMED_FORCE" -eq 1 ]; then
         DEL_FLAG="-D"   # user vouched for this named branch explicitly
       elif git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then
@@ -565,6 +570,19 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       if git branch "$DEL_FLAG" "$branch" >/dev/null; then
         echo "  DELETED $branch ($REASON)"
         LOCAL_DELETED=$((LOCAL_DELETED+1))
+      elif [ "$DEL_FLAG" = "-d" ] && git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then
+        # Issue #816: -d refused — typically because the branch has a configured
+        # upstream whose remote-tracking ref still holds the un-squashed PR head
+        # (different SHA from the squash on main). But ancestor-of-main is the
+        # strongest safety signal git has — the local content IS on main, so -D
+        # loses nothing. Escalate.
+        if git branch -D "$branch" >/dev/null; then
+          echo "  DELETED $branch ($REASON; escalated -d → -D after upstream-divergence refusal)"
+          LOCAL_DELETED=$((LOCAL_DELETED+1))
+        else
+          echo "  FAILED  $branch (escalation to -D also failed)" >&2
+          LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        fi
       else
         echo "  FAILED  $branch (git branch $DEL_FLAG exited non-zero)" >&2
         LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   explicitly name. Protected branches from config are NEVER deleted (even
   with `force`) — they are always skipped.
 metadata:
-  version: "2026.05.28+88b007"
+  version: "2026.05.29+462827"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -555,6 +555,11 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       # not-ancestor (squash) case and for the explicit `force` path. `-D`
       # is NEVER reached for an un-confirmed, un-named branch (the
       # merged-check above guarantees MERGED=1 unless NAMED_FORCE=1).
+      # Issue #816: `-d` ALSO requires the branch be fully merged into its
+      # configured upstream; when the remote-tracking ref still holds the
+      # un-squashed PR head, `-d` refuses. In that case, if the branch is
+      # an ancestor of main (the local content IS on main), escalate to
+      # `-D` — lossless by construction.
       if [ "$NAMED_FORCE" -eq 1 ]; then
         DEL_FLAG="-D"   # user vouched for this named branch explicitly
       elif git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then
@@ -565,6 +570,19 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       if git branch "$DEL_FLAG" "$branch" >/dev/null; then
         echo "  DELETED $branch ($REASON)"
         LOCAL_DELETED=$((LOCAL_DELETED+1))
+      elif [ "$DEL_FLAG" = "-d" ] && git merge-base --is-ancestor "$branch" "$MAIN_BRANCH" 2>/dev/null; then
+        # Issue #816: -d refused — typically because the branch has a configured
+        # upstream whose remote-tracking ref still holds the un-squashed PR head
+        # (different SHA from the squash on main). But ancestor-of-main is the
+        # strongest safety signal git has — the local content IS on main, so -D
+        # loses nothing. Escalate.
+        if git branch -D "$branch" >/dev/null; then
+          echo "  DELETED $branch ($REASON; escalated -d → -D after upstream-divergence refusal)"
+          LOCAL_DELETED=$((LOCAL_DELETED+1))
+        else
+          echo "  FAILED  $branch (escalation to -D also failed)" >&2
+          LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
+        fi
       else
         echo "  FAILED  $branch (git branch $DEL_FLAG exited non-zero)" >&2
         LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -292,6 +292,8 @@ check "cleanup-merged: dirty-skip warning phrase" \
   "grep -q 'uncommitted changes — inspect and remove manually' '$CM_SRC'"
 check "cleanup-merged: MAIN_ROOT comparison guard" \
   "grep -q 'MAIN_ROOT' '$CM_SRC'"
+check "cleanup-merged: #816 -d → -D escalation block" \
+  "grep -q 'escalated -d → -D after upstream-divergence refusal' '$CM_SRC'"
 # Mirror the source too, so drift is caught immediately.
 if [ -d ".claude/skills/cleanup-merged" ]; then
   check "mirror sync: cleanup-merged" \


### PR DESCRIPTION
## Summary
- Adds an `elif` arm to the Phase 5 apply-path delete-flag block in `skills/cleanup-merged/SKILL.md`: when `git branch -d` refuses (typically because the branch's configured upstream still holds the un-squashed PR head) and the branch is still an ancestor of main, escalate to `-D`.
- Bumps `metadata.version` to today's date + new content hash; mirrors source → `.claude/skills/cleanup-merged/SKILL.md`.
- Adds a conformance grep in `tests/test-skill-invariants.sh` pinning the escalation block.

## Why
Pre-#781 the contained-in-main path didn't exist, so `-d` was never used and this gap never showed. Post-#781, any branch where the local ref sits on main's history while the remote ref still has the un-squashed PR head trips `-d`'s upstream-divergence check. Ancestor-of-main is git's strongest safety signal — the local content is already on main, so `-D` is provably lossless in that case.

Observed 2026-05-29 on `qf-p1-tracker-1779970201` (the only `FAILED` in a full `/cleanup-merged all apply` of 234 deletions).

## Test plan
- [x] `bash tests/run-all.sh` passes locally (6471/6471).
- [x] New conformance assertion fires on the escalation block.
- [ ] Post-merge: re-run `/cleanup-merged apply` on the host repo and verify it picks up the stuck `qf-p1-tracker-1779970201` via the new escalation path (validates the fix end-to-end on the same instance that triggered the bug).

Closes #816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
