### PR TITLE
do: normalize --force across skills, retire bare force

### DIFF
--- a/.claude/rules/zskills/managed.md
+++ b/.claude/rules/zskills/managed.md
@@ -342,6 +342,8 @@ Three landing modes control how agent work reaches main:
 
 Both skills now triage tasks and run a fresh-agent plan review before execution. Use `--force` to bypass.
 
+**Flag convention.** Positional tokens (`apply`, `pr`, `auto`, `local`, `remote`, `all`, `from-here`, `skip-tests`, etc.) name *modes / verbs*; dashed `--force` is reserved for *safety-gate overrides*. Skills accepting `--force`: `/do`, `/work-on-plans`, `/quickfix`, `/cleanup-merged`. Bare positional `force` is NOT accepted on any of them (issue #810).
+
 After a PR merges on GitHub, run `/cleanup-merged` to catch your local clone up (checkout main, pull, delete merged feature branches). Safe to run anytime; bails on a dirty tree.
 
 **Config default:** Set in `.claude/zskills-config.json`:

--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[apply] [local | remote | all] [force] [<branch>...]"
+argument-hint: "[apply] [local | remote | all] [--force] [<branch>...]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
@@ -9,11 +9,11 @@ description: >-
   in main (0 commits ahead). Preview by default — run
   `/cleanup-merged apply` to execute. `local` (default) / `remote` / `all`
   pick the scope; pass explicit branch names to narrow the candidate set.
-  `force` overrides the merged-check + unpushed guard for branches you
+  `--force` overrides the merged-check + unpushed guard for branches you
   explicitly name. Protected branches from config are NEVER deleted (even
-  with `force`) — they are always skipped.
+  with `--force`) — they are always skipped.
 metadata:
-  version: "2026.05.29+462827"
+  version: "2026.05.29+dd08af"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -44,7 +44,7 @@ never deletes a branch with unpushed commits.
 /cleanup-merged all apply             — execute both (skip protected)
 /cleanup-merged apply <br> <br>...    — narrow to NAMED local branches, then apply
 /cleanup-merged remote apply <br>...  — narrow to NAMED remote branches, then apply
-/cleanup-merged apply force <br>...   — override merged-check + unpushed guard for NAMED branches
+/cleanup-merged apply --force <br>... — override merged-check + unpushed guard for NAMED branches
 ```
 
 - **Preview is default** — safe to run, self-documenting. Output shows
@@ -65,20 +65,22 @@ never deletes a branch with unpushed commits.
   is skipped). Names do **not** bypass safety — every named branch is
   still subject to the merged-confirmation, the unpushed-commits guard,
   and the protected-skip. Names without `apply` → preview only.
-- **`force`** — overrides ONLY the merged-check and the unpushed-commits
+- **`--force`** — overrides ONLY the merged-check and the unpushed-commits
   guard, and ONLY for branches you EXPLICITLY named. It lets you delete
   a named branch that is not yet confirmed merged (local: `git branch
-  -D`). `force` has no effect on un-named branches (the full-scan path
+  -D`). `--force` has no effect on un-named branches (the full-scan path
   ignores it) and **NEVER** overrides the protected-skip — see below.
+  Dashed form (issue #810) — matches the `--force` convention in `/do`,
+  `/work-on-plans`, and `/quickfix`.
 - **Protected branches** — config field in `.claude/zskills-config.json`:
   ```json
   { "cleanup": { "protected_branches": ["docs/run-order-guide"] } }
   ```
   Preview marks these as `PROTECTED (config)` and `apply` skips them
   automatically. **This is sacrosanct: a protected branch is NEVER
-  deleted, even when named explicitly WITH `force`.** Naming a protected
-  branch (with or without `force`) emits a loud `PROTECTED (config) — refusing
-  to delete even with force` notice and skips it. There is no flag, token,
+  deleted, even when named explicitly WITH `--force`.** Naming a protected
+  branch (with or without `--force`) emits a loud `PROTECTED (config) — refusing
+  to delete even with --force` notice and skips it. There is no flag, token,
   or naming combination that can delete a config-protected branch.
 
 ### Migration aliases
@@ -106,11 +108,11 @@ fi
 
 ### WI 1.2 — Argument parse
 
-Positional tokens: `apply`, `local`, `remote`, `all`, `force`.
-Order-independent. Any positional that is NOT a recognized keyword (and
-not a migration alias) is collected as an explicit **branch name**.
-Legacy flags `--dry-run`, `-n`, `--review` are accepted as migration
-aliases.
+Positional tokens: `apply`, `local`, `remote`, `all`. Dashed
+safety-gate override: `--force`. Order-independent. Any positional that
+is NOT a recognized keyword (and not a migration alias) is collected as
+an explicit **branch name**. Legacy flags `--dry-run`, `-n`, `--review`
+are accepted as migration aliases.
 
 ```bash
 APPLY=0
@@ -124,7 +126,10 @@ for arg in "$@"; do
     local)  SCOPE="local" ;;
     remote) SCOPE="remote" ;;
     all)    SCOPE="all" ;;
-    force)  FORCE=1 ;;
+    # `--force` MUST appear BEFORE the `--*|-*` unknown-flag catchall,
+    # else it would be rejected as an unknown flag. Issue #810: dashed
+    # form normalised across /do, /work-on-plans, /quickfix, /cleanup-merged.
+    --force) FORCE=1 ;;
     --dry-run|-n)
       echo "DEPRECATED: --dry-run/-n is now the default. Just run /cleanup-merged (no args) for preview."
       ;;
@@ -133,7 +138,7 @@ for arg in "$@"; do
       SCOPE="all"
       ;;
     --*|-*)
-      echo "ERROR: unknown flag '$arg'. Usage: /cleanup-merged [apply] [local | remote | all] [force] [<branch>...]" >&2
+      echo "ERROR: unknown flag '$arg'. Usage: /cleanup-merged [apply] [local | remote | all] [--force] [<branch>...]" >&2
       exit 2
       ;;
     *)
@@ -153,7 +158,7 @@ esac
 
 # When explicit branch names are given, they NARROW the candidate set:
 # only the named branches are considered (the full ref-scan is skipped).
-# `force` only takes effect for explicitly-named branches.
+# `--force` only takes effect for explicitly-named branches.
 HAVE_NAMES=0
 [ "${#NAMED_BRANCHES[@]}" -gt 0 ] && HAVE_NAMES=1
 
@@ -168,14 +173,14 @@ is_named() {
 }
 
 if [ "$FORCE" -eq 1 ] && [ "$HAVE_NAMES" -eq 0 ]; then
-  echo "NOTE: 'force' has no effect without explicit branch names; it only overrides the merged-check / unpushed guard for branches you name. Ignoring." >&2
+  echo "NOTE: '--force' has no effect without explicit branch names; it only overrides the merged-check / unpushed guard for branches you name. Ignoring." >&2
   FORCE=0
 fi
 ```
 
-**`force` can never reach a protected branch.** The protected-skip
+**`--force` can never reach a protected branch.** The protected-skip
 (`is_protected`) is evaluated FIRST in every deletion path, before any
-`force`-gated logic, and emits a loud refusal notice. There is no code
+`--force`-gated logic, and emits a loud refusal notice. There is no code
 path where `FORCE=1` bypasses `is_protected`. This is the load-bearing
 safety invariant of this skill.
 
@@ -373,13 +378,13 @@ if [ "$DO_LOCAL" -eq 1 ]; then
 
     # ── Protected branch check — ALWAYS FIRST, NEVER OVERRIDABLE ──────
     # This is the load-bearing safety invariant: a config-protected
-    # branch is never deleted, no matter what. `force` is evaluated only
+    # branch is never deleted, no matter what. `--force` is evaluated only
     # AFTER this guard and cannot reach it. If the user explicitly named
-    # a protected branch (with or without force), emit a loud refusal.
+    # a protected branch (with or without --force), emit a loud refusal.
     if is_protected "$branch"; then
       if is_named "$branch"; then
         if [ "$FORCE" -eq 1 ]; then
-          echo "  PROTECTED (config) $branch — refusing to delete even with force"
+          echo "  PROTECTED (config) $branch — refusing to delete even with --force"
         else
           echo "  PROTECTED (config) $branch — refusing to delete (named explicitly)"
         fi
@@ -420,12 +425,12 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       MERGED=1
     fi
 
-    # Merged-check: a named branch under `force` skips the merged
+    # Merged-check: a named branch under `--force` skips the merged
     # requirement (the user vouched for it explicitly). Un-named branches
     # (full-scan path) always require merged confirmation.
     if [ "$MERGED" -eq 0 ]; then
       if [ "$NAMED_FORCE" -eq 1 ]; then
-        echo "  FORCE  $branch (not confirmed merged; deleting because explicitly named with force)"
+        echo "  FORCE  $branch (not confirmed merged; deleting because explicitly named with --force)"
       else
         continue
       fi
@@ -434,7 +439,7 @@ if [ "$DO_LOCAL" -eq 1 ]; then
     # Unpushed-commit guard (squash-merge still counts commits as unpushed
     # because the squash SHA is different). Only honor the guard when the
     # upstream is NOT gone — a gone upstream plus PR=MERGED means the
-    # commits reached main via squash. A named branch under `force`
+    # commits reached main via squash. A named branch under `--force`
     # overrides this guard too.
     # A contained-in-main branch (issue #781) carries no commits not already
     # on main, so the unpushed guard cannot apply — the `git branch -d` below
@@ -445,7 +450,7 @@ if [ "$DO_LOCAL" -eq 1 ]; then
     fi
 
     if [ -n "$UNPUSHED" ]; then
-      echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional, or re-run with 'force' and the branch name)"
+      echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional, or re-run with '--force' and the branch name)"
       LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
       continue
     fi
@@ -552,7 +557,7 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       # -d` would wrongly refuse it. Use `-d` when the branch IS an
       # ancestor of main (clean — this is exactly the contained-in-main
       # class, deleted losslessly), and `-D` for the confirmed-merged-but-
-      # not-ancestor (squash) case and for the explicit `force` path. `-D`
+      # not-ancestor (squash) case and for the explicit `--force` path. `-D`
       # is NEVER reached for an un-confirmed, un-named branch (the
       # merged-check above guarantees MERGED=1 unless NAMED_FORCE=1).
       # Issue #816: `-d` ALSO requires the branch be fully merged into its
@@ -643,11 +648,11 @@ if [ "$DO_REMOTE" -eq 1 ]; then
       fi
 
       # ── Protected branch check — ALWAYS FIRST, NEVER OVERRIDABLE ────
-      # Same sacrosanct invariant as the local path: `force` can never
+      # Same sacrosanct invariant as the local path: `--force` can never
       # reach a protected branch.
       if is_protected "$branch"; then
         if is_named "$branch" && [ "$FORCE" -eq 1 ]; then
-          echo "  PROTECTED (config) origin/$branch — refusing to delete even with force"
+          echo "  PROTECTED (config) origin/$branch — refusing to delete even with --force"
         elif is_named "$branch"; then
           echo "  PROTECTED (config) origin/$branch — refusing to delete (named explicitly)"
         else
@@ -665,7 +670,7 @@ if [ "$DO_REMOTE" -eq 1 ]; then
       PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
 
       if [ "$PR_STATE" = "OPEN" ] && [ "$NAMED_FORCE" -eq 0 ]; then
-        continue  # Active PR — never delete (unless explicitly named + force)
+        continue  # Active PR — never delete (unless explicitly named + --force)
       fi
 
       if [ "$PR_STATE" != "MERGED" ] && [ "$NAMED_FORCE" -eq 0 ]; then

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quickfix
-argument-hint: "[<description>] [auto] [from-here] [skip-tests] [force] [--branch <name>] [--rounds N]"
+argument-hint: "[<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]"
 description: >-
   Ship an in-flight edit (or short agent-authored fix) from main as a
   one-commit PR without a worktree. Two auto-detected modes: user-edited
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.28+814ef1"
+  version: "2026.05.29+96de31"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -48,9 +48,9 @@ ceremony than the change is worth, but a PR is still required.
 ## Argument parser (WI 1.2)
 
 Bash-regex idiom matching `skills/do/SKILL.md:70-92`. Recognized flags:
-`--branch <name>`, `--rounds N`. Recognized positional tokens
+`--branch <name>`, `--rounds N`, `--force`. Recognized positional tokens
 (case-insensitive, anywhere in the arg vector): `auto`,
-`from-here`, `skip-tests`, `force`. The positional `auto` token enables
+`from-here`, `skip-tests`. The positional `auto` token enables
 auto-merge via `/land-pr` and matches the convention in `/run-plan`,
 `/fix-issues`, and `/do`. Everything else becomes the DESCRIPTION
 (trimmed of leading/trailing whitespace). Empty DESCRIPTION is allowed
@@ -61,8 +61,10 @@ at parse time — mode detection (WI 1.5) decides whether it is fatal.
   feature branch off a non-main checkout.
 - **skip-tests** (optional) — skip the WI 1.12 test gate. Warn-only;
   use only for emergency hotfixes where the test suite is unrelated.
-- **force** (optional) — bypass a triage REDIRECT verdict (WI 1.5.4) and
-  proceed with `/quickfix` anyway.
+- **--force** (optional) — bypass a triage REDIRECT verdict (WI 1.5.4) and
+  proceed with `/quickfix` anyway. Dashed form to match `/do`,
+  `/work-on-plans`, and `/cleanup-merged` — `--force` is a safety-gate
+  override, distinct from the positional verb/mode tokens.
 
 WI 1.5.5's confirmation prompt is bypassed when `AUTO_FLAG=1`.
 
@@ -92,14 +94,18 @@ while [ $i -lt ${#ARGS[@]} ]; do
       i=$((i+1))
       BRANCH_OVERRIDE="${ARGS[$i]:-}"
       ;;
-    # Positional `from-here` / `skip-tests` / `force` tokens (case-insensitive).
+    # Dashed safety-gate override `--force` (case-sensitive — `--Force`,
+    # `--FORCE` etc. are NOT accepted; this matches /do, /work-on-plans,
+    # /cleanup-merged conventions). The positional bare `force` form was
+    # retired in favor of this dashed form (issue #810).
+    --force) FORCE=1 ;;
+    # Positional `from-here` / `skip-tests` tokens (case-insensitive).
     # Bracket-class form matches each letter case-insensitively; the hyphen
     # between bracket classes is treated as a literal character (NOT inside
     # a class). Verified: matches `from-here`, `From-Here`, `FROM-HERE`;
     # does NOT match `FromHere`, `FROMHERE`, `from-here2`.
     [fF][rR][oO][mM]-[hH][eE][rR][eE]) FROM_HERE=1 ;;
     [sS][kK][iI][pP]-[tT][eE][sS][tT][sS]) SKIP_TESTS=1 ;;
-    [fF][oO][rR][cC][eE]) FORCE=1 ;;
     # Positional `auto` token (case-insensitive). Recognized anywhere in
     # the arg vector — `/quickfix <desc> auto` and `/quickfix auto <desc>`
     # both set AUTO_FLAG=1. Mirrors the convention in /run-plan,
@@ -367,10 +373,10 @@ linebreak is a real newline, not the literal `\n` characters):
 
 | target | Line 1 | Line 2 |
 |--------|--------|--------|
-| `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with force to bypass.` |
-| `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with force to bypass.` |
-| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with force to bypass.` |
-| ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /quickfix with a concrete description (verb + object + which file/area). force will not help — vague descriptions cannot be planned.` |
+| `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.` |
+| `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with --force to bypass.` |
+| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with --force to bypass.` |
+| ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /quickfix with a concrete description (verb + object + which file/area). --force will not help — vague descriptions cannot be planned.` |
 
 The model implements these as a `printf 'line1\nline2\n' "$REASON"` so
 both lines are emitted to stdout and both are independently greppable
@@ -381,13 +387,13 @@ lines), then `exit 0`. **No marker is written** (WI 1.8 has not yet
 run). No branch. No tracking dir.
 
 On REDIRECT and `$FORCE -eq 1`: print
-`Triage: REDIRECT(<target>) overridden by force; proceeding.`
+`Triage: REDIRECT(<target>) overridden by --force; proceeding.`
 Continue.
 
 ### WI 1.5.4a — Inline plan composition (model-layer)
 
 This is a **model-layer instruction**, not a bash block. After triage
-returns PROCEED (or after `force` overrides a REDIRECT), the model
+returns PROCEED (or after `--force` overrides a REDIRECT), the model
 composes a short inline plan held in `INLINE_PLAN`. `INLINE_PLAN` is a
 logical placeholder for text the model composes in its response. When
 WI 1.5.4b dispatches the reviewer Agent, the model copies the
@@ -1103,7 +1109,7 @@ cat > "$BODY_FILE" <<-EOF
 	## Test plan
 
 	- Ran project \`unit_cmd\` before commit (or skip-tests).
-	- Independent \`/verify-changes\` before push (or skipped via force/skip-tests).
+	- Independent \`/verify-changes\` before push (or skipped via --force/skip-tests).
 	- Review diff.
 
 	🤖 Generated with /quickfix

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -342,6 +342,8 @@ Three landing modes control how agent work reaches main:
 
 Both skills now triage tasks and run a fresh-agent plan review before execution. Use `--force` to bypass.
 
+**Flag convention.** Positional tokens (`apply`, `pr`, `auto`, `local`, `remote`, `all`, `from-here`, `skip-tests`, etc.) name *modes / verbs*; dashed `--force` is reserved for *safety-gate overrides*. Skills accepting `--force`: `/do`, `/work-on-plans`, `/quickfix`, `/cleanup-merged`. Bare positional `force` is NOT accepted on any of them (issue #810).
+
 After a PR merges on GitHub, run `/cleanup-merged` to catch your local clone up (checkout main, pull, delete merged feature branches). Safe to run anytime; bails on a dirty tree.
 
 **Config default:** Set in `.claude/zskills-config.json`:

--- a/docs/skills/cleanup-merged.md
+++ b/docs/skills/cleanup-merged.md
@@ -15,7 +15,7 @@
 /cleanup-merged all apply             execute both
 /cleanup-merged apply <br> <br>...    narrow to NAMED local branches, then apply
 /cleanup-merged remote apply <br>...  narrow to NAMED remote branches, then apply
-/cleanup-merged apply force <br>...   override merged-check + unpushed guard for NAMED branches
+/cleanup-merged apply --force <br>... override merged-check + unpushed guard for NAMED branches
 ```
 
 ## Positional Tokens
@@ -26,8 +26,13 @@
 | `local` | Scope to local branches (the default; token exists for symmetry) |
 | `remote` | Scope to remote branches (requires `gh`) |
 | `all` | Scope to both local + remote branches |
-| `force` | Override the merged-check + unpushed guard, ONLY for branches you explicitly name. NEVER overrides protected-skip. |
 | `<branch>` | Any non-keyword positional is a branch NAME — narrows the candidate set to only the named branches. |
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Override the merged-check + unpushed guard, ONLY for branches you explicitly name. NEVER overrides protected-skip. Dashed form (issue #810) — matches `/do`, `/work-on-plans`, `/quickfix`. |
 
 ## Branch Names (narrowing)
 
@@ -37,18 +42,18 @@ still subject to merged-confirmation, the unpushed-commits guard, and the
 protected-skip. Names without `apply` are preview-only.
 
 - `local` (or default) names route to local deletion (`git branch -d`,
-  `-D` only under `force` for unmerged).
+  `-D` only under `--force` for unmerged).
 - `remote` names route to remote deletion (`git push origin --delete`).
 
-## Force
+## --force
 
-`force` overrides ONLY the merged-check and the unpushed-commits guard,
+`--force` overrides ONLY the merged-check and the unpushed-commits guard,
 and ONLY for branches you explicitly name. It lets you delete a named
 branch that is not yet confirmed merged.
 
-**`force` can NEVER delete a config-protected branch.** Naming a protected
-branch (with or without `force`) emits a loud
-`PROTECTED (config) ... — refusing to delete even with force` notice and
+**`--force` can NEVER delete a config-protected branch.** Naming a protected
+branch (with or without `--force`) emits a loud
+`PROTECTED (config) ... — refusing to delete even with --force` notice and
 skips it. The protected-skip is sacrosanct — no token or naming
 combination overrides it.
 
@@ -60,7 +65,7 @@ Configure branches that should never be deleted in `.claude/zskills-config.json`
 { "cleanup": { "protected_branches": ["docs/run-order-guide"] } }
 ```
 
-Protected branches are marked `PROTECTED (config)` in preview and skipped automatically during apply — including when named explicitly with `force`.
+Protected branches are marked `PROTECTED (config)` in preview and skipped automatically during apply — including when named explicitly with `--force`.
 
 ## Examples
 
@@ -72,7 +77,7 @@ Protected branches are marked `PROTECTED (config)` in preview and skipped automa
 /cleanup-merged all              preview everything
 /cleanup-merged all apply        clean up everything
 /cleanup-merged local apply feat/foo feat/bar   delete just those two local branches
-/cleanup-merged apply force feat/wip            delete a named unmerged local branch
+/cleanup-merged apply --force feat/wip          delete a named unmerged local branch
 ```
 
 ## Common Patterns
@@ -86,7 +91,7 @@ Protected branches are marked `PROTECTED (config)` in preview and skipped automa
 
 - Preview is the default -- safe to run any time
 - Bails on a dirty working tree
-- Never deletes a branch with unpushed commits (unless you name it explicitly with `force`)
+- Never deletes a branch with unpushed commits (unless you name it explicitly with `--force`)
 - Remote cleanup requires `gh` for PR-state gating (never deletes branches with open PRs)
-- Protected branches from config are always skipped -- `force` can never override this
+- Protected branches from config are always skipped -- `--force` can never override this
 - Legacy `--dry-run` and `--review` flags work as aliases for one release cycle

--- a/docs/skills/quickfix.md
+++ b/docs/skills/quickfix.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-/quickfix [<description>] [auto] [from-here] [skip-tests] [force] [--branch <name>] [--rounds N]
+/quickfix [<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]
 ```
 
 ## Arguments
@@ -16,7 +16,7 @@
 | `auto` | No | Auto-merge the resulting PR via `/land-pr` |
 | `from-here` | No | Override the "must run on main/master" check |
 | `skip-tests` | No | Skip the test gate (warn-only; for emergency hotfixes) |
-| `force` | No | Bypass triage REDIRECT and review REJECT |
+| `--force` | No | Bypass triage REDIRECT and review REJECT (safety-gate override; dashed for consistency with `/do`, `/work-on-plans`, `/cleanup-merged`) |
 | `--branch <name>` | No | Override the auto-generated branch name |
 | `--rounds N` | No | Max review/refine cycles (default 1; `0` skips review) |
 
@@ -35,7 +35,7 @@
 /quickfix Fix README typo
 /quickfix Fix README typo auto
 /quickfix Fix the broken link in docs/intro.md
-/quickfix Update CHANGELOG with v0.5 release notes force
+/quickfix Update CHANGELOG with v0.5 release notes --force
 /quickfix Add comment to canary-marker.txt --branch fix/canary-comment
 /quickfix Fix parser edge case skip-tests
 /quickfix Refactor the test helper --rounds 2
@@ -45,16 +45,16 @@
 
 - **Ship an in-flight edit:** make your edit on main, then `/quickfix Fix README typo auto` -- creates a branch, commits, pushes, opens a PR, and auto-merges
 - **Agent-authored fix:** on a clean main, `/quickfix Fix the broken link in docs/intro.md` -- dispatches an agent to implement, then runs the full PR lifecycle
-- **Emergency hotfix:** `/quickfix Fix critical auth bug skip-tests force auto` -- bypass all gates and ship fast
+- **Emergency hotfix:** `/quickfix Fix critical auth bug skip-tests --force auto` -- bypass all gates and ship fast
 - **Custom branch name:** `/quickfix Update changelog --branch release/v1.0-changelog` -- override the auto-generated branch name
 
 ## Tips & Gotchas
 
 - `/quickfix` is PR-shaped end-to-end -- when `execution.landing` is `worktree` or `direct`, it soft-redirects to `/do worktree` or `/commit` respectively
 - The skill runs on main and creates a feature branch via `git checkout -b` -- dirty edits carry across
-- Triage gate may redirect to `/draft-plan`, `/fix-issues`, or `/run-plan` if the task scope is too large -- use `force` to bypass
+- Triage gate may redirect to `/draft-plan`, `/fix-issues`, or `/run-plan` if the task scope is too large -- use `--force` to bypass
 - A fresh-agent plan review runs by default -- `--rounds 0` skips it
-- Verification (`/verify-changes`) runs before push unless `force` or `skip-tests` is set
+- Verification (`/verify-changes`) runs before push unless `--force` or `skip-tests` is set
 - No `.landed` marker is written -- `/quickfix` does not use worktrees
 - Branch naming: `<branch_prefix><slug>` where prefix defaults to `quickfix/` (configurable via `execution.branch_prefix`)
 - The `auto` token enables auto-merge AND skips the WI 1.5.5 dirty-tree confirmation prompt

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[apply] [local | remote | all] [force] [<branch>...]"
+argument-hint: "[apply] [local | remote | all] [--force] [<branch>...]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
@@ -9,11 +9,11 @@ description: >-
   in main (0 commits ahead). Preview by default — run
   `/cleanup-merged apply` to execute. `local` (default) / `remote` / `all`
   pick the scope; pass explicit branch names to narrow the candidate set.
-  `force` overrides the merged-check + unpushed guard for branches you
+  `--force` overrides the merged-check + unpushed guard for branches you
   explicitly name. Protected branches from config are NEVER deleted (even
-  with `force`) — they are always skipped.
+  with `--force`) — they are always skipped.
 metadata:
-  version: "2026.05.29+462827"
+  version: "2026.05.29+dd08af"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization
@@ -44,7 +44,7 @@ never deletes a branch with unpushed commits.
 /cleanup-merged all apply             — execute both (skip protected)
 /cleanup-merged apply <br> <br>...    — narrow to NAMED local branches, then apply
 /cleanup-merged remote apply <br>...  — narrow to NAMED remote branches, then apply
-/cleanup-merged apply force <br>...   — override merged-check + unpushed guard for NAMED branches
+/cleanup-merged apply --force <br>... — override merged-check + unpushed guard for NAMED branches
 ```
 
 - **Preview is default** — safe to run, self-documenting. Output shows
@@ -65,20 +65,22 @@ never deletes a branch with unpushed commits.
   is skipped). Names do **not** bypass safety — every named branch is
   still subject to the merged-confirmation, the unpushed-commits guard,
   and the protected-skip. Names without `apply` → preview only.
-- **`force`** — overrides ONLY the merged-check and the unpushed-commits
+- **`--force`** — overrides ONLY the merged-check and the unpushed-commits
   guard, and ONLY for branches you EXPLICITLY named. It lets you delete
   a named branch that is not yet confirmed merged (local: `git branch
-  -D`). `force` has no effect on un-named branches (the full-scan path
+  -D`). `--force` has no effect on un-named branches (the full-scan path
   ignores it) and **NEVER** overrides the protected-skip — see below.
+  Dashed form (issue #810) — matches the `--force` convention in `/do`,
+  `/work-on-plans`, and `/quickfix`.
 - **Protected branches** — config field in `.claude/zskills-config.json`:
   ```json
   { "cleanup": { "protected_branches": ["docs/run-order-guide"] } }
   ```
   Preview marks these as `PROTECTED (config)` and `apply` skips them
   automatically. **This is sacrosanct: a protected branch is NEVER
-  deleted, even when named explicitly WITH `force`.** Naming a protected
-  branch (with or without `force`) emits a loud `PROTECTED (config) — refusing
-  to delete even with force` notice and skips it. There is no flag, token,
+  deleted, even when named explicitly WITH `--force`.** Naming a protected
+  branch (with or without `--force`) emits a loud `PROTECTED (config) — refusing
+  to delete even with --force` notice and skips it. There is no flag, token,
   or naming combination that can delete a config-protected branch.
 
 ### Migration aliases
@@ -106,11 +108,11 @@ fi
 
 ### WI 1.2 — Argument parse
 
-Positional tokens: `apply`, `local`, `remote`, `all`, `force`.
-Order-independent. Any positional that is NOT a recognized keyword (and
-not a migration alias) is collected as an explicit **branch name**.
-Legacy flags `--dry-run`, `-n`, `--review` are accepted as migration
-aliases.
+Positional tokens: `apply`, `local`, `remote`, `all`. Dashed
+safety-gate override: `--force`. Order-independent. Any positional that
+is NOT a recognized keyword (and not a migration alias) is collected as
+an explicit **branch name**. Legacy flags `--dry-run`, `-n`, `--review`
+are accepted as migration aliases.
 
 ```bash
 APPLY=0
@@ -124,7 +126,10 @@ for arg in "$@"; do
     local)  SCOPE="local" ;;
     remote) SCOPE="remote" ;;
     all)    SCOPE="all" ;;
-    force)  FORCE=1 ;;
+    # `--force` MUST appear BEFORE the `--*|-*` unknown-flag catchall,
+    # else it would be rejected as an unknown flag. Issue #810: dashed
+    # form normalised across /do, /work-on-plans, /quickfix, /cleanup-merged.
+    --force) FORCE=1 ;;
     --dry-run|-n)
       echo "DEPRECATED: --dry-run/-n is now the default. Just run /cleanup-merged (no args) for preview."
       ;;
@@ -133,7 +138,7 @@ for arg in "$@"; do
       SCOPE="all"
       ;;
     --*|-*)
-      echo "ERROR: unknown flag '$arg'. Usage: /cleanup-merged [apply] [local | remote | all] [force] [<branch>...]" >&2
+      echo "ERROR: unknown flag '$arg'. Usage: /cleanup-merged [apply] [local | remote | all] [--force] [<branch>...]" >&2
       exit 2
       ;;
     *)
@@ -153,7 +158,7 @@ esac
 
 # When explicit branch names are given, they NARROW the candidate set:
 # only the named branches are considered (the full ref-scan is skipped).
-# `force` only takes effect for explicitly-named branches.
+# `--force` only takes effect for explicitly-named branches.
 HAVE_NAMES=0
 [ "${#NAMED_BRANCHES[@]}" -gt 0 ] && HAVE_NAMES=1
 
@@ -168,14 +173,14 @@ is_named() {
 }
 
 if [ "$FORCE" -eq 1 ] && [ "$HAVE_NAMES" -eq 0 ]; then
-  echo "NOTE: 'force' has no effect without explicit branch names; it only overrides the merged-check / unpushed guard for branches you name. Ignoring." >&2
+  echo "NOTE: '--force' has no effect without explicit branch names; it only overrides the merged-check / unpushed guard for branches you name. Ignoring." >&2
   FORCE=0
 fi
 ```
 
-**`force` can never reach a protected branch.** The protected-skip
+**`--force` can never reach a protected branch.** The protected-skip
 (`is_protected`) is evaluated FIRST in every deletion path, before any
-`force`-gated logic, and emits a loud refusal notice. There is no code
+`--force`-gated logic, and emits a loud refusal notice. There is no code
 path where `FORCE=1` bypasses `is_protected`. This is the load-bearing
 safety invariant of this skill.
 
@@ -373,13 +378,13 @@ if [ "$DO_LOCAL" -eq 1 ]; then
 
     # ── Protected branch check — ALWAYS FIRST, NEVER OVERRIDABLE ──────
     # This is the load-bearing safety invariant: a config-protected
-    # branch is never deleted, no matter what. `force` is evaluated only
+    # branch is never deleted, no matter what. `--force` is evaluated only
     # AFTER this guard and cannot reach it. If the user explicitly named
-    # a protected branch (with or without force), emit a loud refusal.
+    # a protected branch (with or without --force), emit a loud refusal.
     if is_protected "$branch"; then
       if is_named "$branch"; then
         if [ "$FORCE" -eq 1 ]; then
-          echo "  PROTECTED (config) $branch — refusing to delete even with force"
+          echo "  PROTECTED (config) $branch — refusing to delete even with --force"
         else
           echo "  PROTECTED (config) $branch — refusing to delete (named explicitly)"
         fi
@@ -420,12 +425,12 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       MERGED=1
     fi
 
-    # Merged-check: a named branch under `force` skips the merged
+    # Merged-check: a named branch under `--force` skips the merged
     # requirement (the user vouched for it explicitly). Un-named branches
     # (full-scan path) always require merged confirmation.
     if [ "$MERGED" -eq 0 ]; then
       if [ "$NAMED_FORCE" -eq 1 ]; then
-        echo "  FORCE  $branch (not confirmed merged; deleting because explicitly named with force)"
+        echo "  FORCE  $branch (not confirmed merged; deleting because explicitly named with --force)"
       else
         continue
       fi
@@ -434,7 +439,7 @@ if [ "$DO_LOCAL" -eq 1 ]; then
     # Unpushed-commit guard (squash-merge still counts commits as unpushed
     # because the squash SHA is different). Only honor the guard when the
     # upstream is NOT gone — a gone upstream plus PR=MERGED means the
-    # commits reached main via squash. A named branch under `force`
+    # commits reached main via squash. A named branch under `--force`
     # overrides this guard too.
     # A contained-in-main branch (issue #781) carries no commits not already
     # on main, so the unpushed guard cannot apply — the `git branch -d` below
@@ -445,7 +450,7 @@ if [ "$DO_LOCAL" -eq 1 ]; then
     fi
 
     if [ -n "$UNPUSHED" ]; then
-      echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional, or re-run with 'force' and the branch name)"
+      echo "  SKIP   $branch (has unpushed commits; delete manually with 'git branch -D $branch' if intentional, or re-run with '--force' and the branch name)"
       LOCAL_SKIPPED=$((LOCAL_SKIPPED+1))
       continue
     fi
@@ -552,7 +557,7 @@ if [ "$DO_LOCAL" -eq 1 ]; then
       # -d` would wrongly refuse it. Use `-d` when the branch IS an
       # ancestor of main (clean — this is exactly the contained-in-main
       # class, deleted losslessly), and `-D` for the confirmed-merged-but-
-      # not-ancestor (squash) case and for the explicit `force` path. `-D`
+      # not-ancestor (squash) case and for the explicit `--force` path. `-D`
       # is NEVER reached for an un-confirmed, un-named branch (the
       # merged-check above guarantees MERGED=1 unless NAMED_FORCE=1).
       # Issue #816: `-d` ALSO requires the branch be fully merged into its
@@ -643,11 +648,11 @@ if [ "$DO_REMOTE" -eq 1 ]; then
       fi
 
       # ── Protected branch check — ALWAYS FIRST, NEVER OVERRIDABLE ────
-      # Same sacrosanct invariant as the local path: `force` can never
+      # Same sacrosanct invariant as the local path: `--force` can never
       # reach a protected branch.
       if is_protected "$branch"; then
         if is_named "$branch" && [ "$FORCE" -eq 1 ]; then
-          echo "  PROTECTED (config) origin/$branch — refusing to delete even with force"
+          echo "  PROTECTED (config) origin/$branch — refusing to delete even with --force"
         elif is_named "$branch"; then
           echo "  PROTECTED (config) origin/$branch — refusing to delete (named explicitly)"
         else
@@ -665,7 +670,7 @@ if [ "$DO_REMOTE" -eq 1 ]; then
       PR_STATE=$(gh pr view "$branch" --json state -q .state 2>/dev/null || echo "")
 
       if [ "$PR_STATE" = "OPEN" ] && [ "$NAMED_FORCE" -eq 0 ]; then
-        continue  # Active PR — never delete (unless explicitly named + force)
+        continue  # Active PR — never delete (unless explicitly named + --force)
       fi
 
       if [ "$PR_STATE" != "MERGED" ] && [ "$NAMED_FORCE" -eq 0 ]; then

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quickfix
-argument-hint: "[<description>] [auto] [from-here] [skip-tests] [force] [--branch <name>] [--rounds N]"
+argument-hint: "[<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]"
 description: >-
   Ship an in-flight edit (or short agent-authored fix) from main as a
   one-commit PR without a worktree. Two auto-detected modes: user-edited
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.28+814ef1"
+  version: "2026.05.29+96de31"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -48,9 +48,9 @@ ceremony than the change is worth, but a PR is still required.
 ## Argument parser (WI 1.2)
 
 Bash-regex idiom matching `skills/do/SKILL.md:70-92`. Recognized flags:
-`--branch <name>`, `--rounds N`. Recognized positional tokens
+`--branch <name>`, `--rounds N`, `--force`. Recognized positional tokens
 (case-insensitive, anywhere in the arg vector): `auto`,
-`from-here`, `skip-tests`, `force`. The positional `auto` token enables
+`from-here`, `skip-tests`. The positional `auto` token enables
 auto-merge via `/land-pr` and matches the convention in `/run-plan`,
 `/fix-issues`, and `/do`. Everything else becomes the DESCRIPTION
 (trimmed of leading/trailing whitespace). Empty DESCRIPTION is allowed
@@ -61,8 +61,10 @@ at parse time — mode detection (WI 1.5) decides whether it is fatal.
   feature branch off a non-main checkout.
 - **skip-tests** (optional) — skip the WI 1.12 test gate. Warn-only;
   use only for emergency hotfixes where the test suite is unrelated.
-- **force** (optional) — bypass a triage REDIRECT verdict (WI 1.5.4) and
-  proceed with `/quickfix` anyway.
+- **--force** (optional) — bypass a triage REDIRECT verdict (WI 1.5.4) and
+  proceed with `/quickfix` anyway. Dashed form to match `/do`,
+  `/work-on-plans`, and `/cleanup-merged` — `--force` is a safety-gate
+  override, distinct from the positional verb/mode tokens.
 
 WI 1.5.5's confirmation prompt is bypassed when `AUTO_FLAG=1`.
 
@@ -92,14 +94,18 @@ while [ $i -lt ${#ARGS[@]} ]; do
       i=$((i+1))
       BRANCH_OVERRIDE="${ARGS[$i]:-}"
       ;;
-    # Positional `from-here` / `skip-tests` / `force` tokens (case-insensitive).
+    # Dashed safety-gate override `--force` (case-sensitive — `--Force`,
+    # `--FORCE` etc. are NOT accepted; this matches /do, /work-on-plans,
+    # /cleanup-merged conventions). The positional bare `force` form was
+    # retired in favor of this dashed form (issue #810).
+    --force) FORCE=1 ;;
+    # Positional `from-here` / `skip-tests` tokens (case-insensitive).
     # Bracket-class form matches each letter case-insensitively; the hyphen
     # between bracket classes is treated as a literal character (NOT inside
     # a class). Verified: matches `from-here`, `From-Here`, `FROM-HERE`;
     # does NOT match `FromHere`, `FROMHERE`, `from-here2`.
     [fF][rR][oO][mM]-[hH][eE][rR][eE]) FROM_HERE=1 ;;
     [sS][kK][iI][pP]-[tT][eE][sS][tT][sS]) SKIP_TESTS=1 ;;
-    [fF][oO][rR][cC][eE]) FORCE=1 ;;
     # Positional `auto` token (case-insensitive). Recognized anywhere in
     # the arg vector — `/quickfix <desc> auto` and `/quickfix auto <desc>`
     # both set AUTO_FLAG=1. Mirrors the convention in /run-plan,
@@ -367,10 +373,10 @@ linebreak is a real newline, not the literal `\n` characters):
 
 | target | Line 1 | Line 2 |
 |--------|--------|--------|
-| `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with force to bypass.` |
-| `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with force to bypass.` |
-| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with force to bypass.` |
-| ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /quickfix with a concrete description (verb + object + which file/area). force will not help — vague descriptions cannot be planned.` |
+| `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.` |
+| `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with --force to bypass.` |
+| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with --force to bypass.` |
+| ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /quickfix with a concrete description (verb + object + which file/area). --force will not help — vague descriptions cannot be planned.` |
 
 The model implements these as a `printf 'line1\nline2\n' "$REASON"` so
 both lines are emitted to stdout and both are independently greppable
@@ -381,13 +387,13 @@ lines), then `exit 0`. **No marker is written** (WI 1.8 has not yet
 run). No branch. No tracking dir.
 
 On REDIRECT and `$FORCE -eq 1`: print
-`Triage: REDIRECT(<target>) overridden by force; proceeding.`
+`Triage: REDIRECT(<target>) overridden by --force; proceeding.`
 Continue.
 
 ### WI 1.5.4a — Inline plan composition (model-layer)
 
 This is a **model-layer instruction**, not a bash block. After triage
-returns PROCEED (or after `force` overrides a REDIRECT), the model
+returns PROCEED (or after `--force` overrides a REDIRECT), the model
 composes a short inline plan held in `INLINE_PLAN`. `INLINE_PLAN` is a
 logical placeholder for text the model composes in its response. When
 WI 1.5.4b dispatches the reviewer Agent, the model copies the
@@ -1103,7 +1109,7 @@ cat > "$BODY_FILE" <<-EOF
 	## Test plan
 
 	- Ran project \`unit_cmd\` before commit (or skip-tests).
-	- Independent \`/verify-changes\` before push (or skipped via force/skip-tests).
+	- Independent \`/verify-changes\` before push (or skipped via --force/skip-tests).
 	- Review diff.
 
 	🤖 Generated with /quickfix

--- a/tests/test-cleanup-merged-namelist.sh
+++ b/tests/test-cleanup-merged-namelist.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Tests for the /cleanup-merged branch-name-list + `local` token + `force`
+# Tests for the /cleanup-merged branch-name-list + `local` token + `--force`
 # interface (pick-and-choose branch cleanup from the dashboard Branches tab).
 #
 # Coverage:
 #   Static (skill-source + docs assertions):
-#     - argument-hint advertises local / force / <branch>
-#     - WI 1.2 parser accepts `local`, `force`, and collects branch names
+#     - argument-hint advertises local / --force / <branch>
+#     - WI 1.2 parser accepts `local`, `--force`, and collects branch names
 #     - is_named() narrowing helper present
 #     - protected-skip is evaluated before any force logic (ordering)
-#     - docs reflect the new interface (local token, force, names)
+#     - docs reflect the new interface (local token, --force, names)
 #
 #   Behavioral (extract the REAL parser + Phase 5 loop, run against a
 #   throwaway git repo with stubbed gh — exercises the decision logic, not
@@ -18,7 +18,7 @@
 #     - safety still applies to named branches (unmerged un-forced => skip)
 #     - local vs remote routing (the section keys map to scope)
 #     - THE LOAD-BEARING INVARIANT: a config-protected branch named WITH
-#       `force` is NOT deleted — it survives and a refusal notice is emitted.
+#       `--force` is NOT deleted — it survives and a refusal notice is emitted.
 #
 # Run from repo root: bash tests/test-cleanup-merged-namelist.sh
 
@@ -35,23 +35,36 @@ FAIL_COUNT=0
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
-echo "=== cleanup-merged branch-name-list + force interface ==="
+echo "=== cleanup-merged branch-name-list + --force interface ==="
 
 # ── Static: skill source ────────────────────────────────────────────
 
 # argument-hint advertises the new tokens.
-if grep -qE '^argument-hint:.*local.*remote.*all.*force.*branch' "$SKILL"; then
-  pass "argument-hint advertises local | remote | all, force, <branch>"
+if grep -qE '^argument-hint:.*local.*remote.*all.*--force.*branch' "$SKILL"; then
+  pass "argument-hint advertises local | remote | all, --force, <branch>"
 else
   fail "argument-hint missing new tokens"
 fi
 
-# WI 1.2 parser accepts `local` and `force` as positional tokens.
+# WI 1.2 parser accepts `local` and `--force`.
+# Issue #810: `--force` (dashed) is the normalised form; bare positional
+# `force` must NOT appear as a case branch.
 if grep -q 'local)  SCOPE="local"' "$SKILL" \
-   && grep -q 'force)  FORCE=1' "$SKILL"; then
-  pass "WI 1.2: local + force positional tokens accepted"
+   && grep -qE '^[[:space:]]*--force\) FORCE=1' "$SKILL" \
+   && ! grep -qE '^[[:space:]]*force\)[[:space:]]+FORCE=1' "$SKILL"; then
+  pass "WI 1.2: local + --force tokens accepted (bare 'force)' absent)"
 else
-  fail "WI 1.2: local/force token parsing incomplete"
+  fail "WI 1.2: local/--force token parsing incomplete or bare 'force)' still present"
+fi
+
+# Ordering: `--force)` case MUST appear BEFORE the `--*|-*` unknown-flag
+# catchall, else --force would be rejected as unknown.
+FORCE_LN=$(grep -n -E '^[[:space:]]*--force\) FORCE=1' "$SKILL" | head -1 | cut -d: -f1)
+CATCHALL_LN=$(grep -n -E '^[[:space:]]*--\*\|-\*\)' "$SKILL" | head -1 | cut -d: -f1)
+if [ -n "$FORCE_LN" ] && [ -n "$CATCHALL_LN" ] && [ "$FORCE_LN" -lt "$CATCHALL_LN" ]; then
+  pass "WI 1.2: --force case precedes --*|-* catchall (force=$FORCE_LN, catchall=$CATCHALL_LN)"
+else
+  fail "WI 1.2: --force case ordering wrong (force=$FORCE_LN, catchall=$CATCHALL_LN)"
 fi
 
 # Non-keyword positionals collected as branch names.
@@ -84,10 +97,10 @@ else
 fi
 
 # The refusal notice exists.
-if echo "$PHASE5_SLICE" | grep -q 'refusing to delete even with force'; then
-  pass "Phase 5: 'refusing to delete even with force' notice present"
+if echo "$PHASE5_SLICE" | grep -q 'refusing to delete even with --force'; then
+  pass "Phase 5: 'refusing to delete even with --force' notice present"
 else
-  fail "Phase 5: force-refusal notice missing"
+  fail "Phase 5: --force-refusal notice missing"
 fi
 
 # ── Static: docs ────────────────────────────────────────────────────
@@ -226,14 +239,14 @@ STUB
     fail "Scenario A (preview): branch 'merged' was deleted in preview mode"
   fi
 
-  # ── Scenario B: narrowing — apply force on 'unmerged' only ────────
+  # ── Scenario B: narrowing — apply --force on 'unmerged' only ──────
   # Names narrow the set: 'untouched' (a merged ancestor) must survive
   # because it was not named.
-  B=$(run_scan_with_args apply force unmerged)
+  B=$(run_scan_with_args apply --force unmerged)
   if ! branch_exists unmerged; then
-    pass "Scenario B (narrow+force): named unmerged branch deleted"
+    pass "Scenario B (narrow+--force): named unmerged branch deleted"
   else
-    fail "Scenario B: 'unmerged' not deleted despite apply+force+name ($B)"
+    fail "Scenario B: 'unmerged' not deleted despite apply+--force+name ($B)"
   fi
   if branch_exists untouched; then
     pass "Scenario B (narrow): un-named branch 'untouched' survives"
@@ -241,28 +254,28 @@ STUB
     fail "Scenario B: un-named 'untouched' was wrongly deleted ($B)"
   fi
 
-  # ── Scenario C: safety still applies to a named branch (no force) ──
-  # Create an unmerged branch and name it WITHOUT force: PR_STATE is empty
+  # ── Scenario C: safety still applies to a named branch (no --force) ─
+  # Create an unmerged branch and name it WITHOUT --force: PR_STATE is empty
   # (stub) and no upstream-gone, so it is not merged => must NOT delete.
   ( cd "$TMP" && git checkout -q -b unmerged2 main && git commit -q --allow-empty -m "u2 work" && git checkout -q main )
   C=$(run_scan_with_args apply unmerged2)
   if branch_exists unmerged2; then
-    pass "Scenario C (safety): named-but-not-merged branch SKIP'd without force"
+    pass "Scenario C (safety): named-but-not-merged branch SKIP'd without --force"
   else
-    fail "Scenario C: 'unmerged2' deleted without force despite not being merged ($C)"
+    fail "Scenario C: 'unmerged2' deleted without --force despite not being merged ($C)"
   fi
 
-  # ── Scenario D (THE INVARIANT): protected + named + force => SURVIVES
-  D=$(run_scan_with_args apply force protected)
+  # ── Scenario D (THE INVARIANT): protected + named + --force => SURVIVES
+  D=$(run_scan_with_args apply --force protected)
   if branch_exists protected; then
-    pass "INVARIANT: config-protected branch named WITH force is NOT deleted (it survives)"
+    pass "INVARIANT: config-protected branch named WITH --force is NOT deleted (it survives)"
   else
-    fail "INVARIANT VIOLATED: protected branch was deleted under force+name!! ($D)"
+    fail "INVARIANT VIOLATED: protected branch was deleted under --force+name!! ($D)"
   fi
-  if echo "$D" | grep -q 'refusing to delete even with force'; then
-    pass "INVARIANT: loud refusal notice emitted for protected+force"
+  if echo "$D" | grep -q 'refusing to delete even with --force'; then
+    pass "INVARIANT: loud refusal notice emitted for protected+--force"
   else
-    fail "INVARIANT: no refusal notice for protected+force ($D)"
+    fail "INVARIANT: no refusal notice for protected+--force ($D)"
   fi
   if echo "$D" | grep -q 'LOCAL_PROTECTED=1'; then
     pass "INVARIANT: protected counter incremented (not deleted)"

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -345,11 +345,12 @@ fi
 if grep -q '[-][-]branch)' "$SKILL" \
    && grep -qE '^[[:space:]]*\[fF\]\[rR\]\[oO\]\[mM\]-\[hH\]\[eE\]\[rR\]\[eE\]\) FROM_HERE=1' "$SKILL" \
    && grep -qE '^[[:space:]]*\[sS\]\[kK\]\[iI\]\[pP\]-\[tT\]\[eE\]\[sS\]\[tT\]\[sS\]\) SKIP_TESTS=1' "$SKILL" \
-   && grep -qE '^[[:space:]]*\[fF\]\[oO\]\[rR\]\[cC\]\[eE\]\) FORCE=1' "$SKILL" \
+   && grep -qE '^[[:space:]]*--force\) FORCE=1' "$SKILL" \
+   && ! grep -qE '^[[:space:]]*\[fF\]\[oO\]\[rR\]\[cC\]\[eE\]\) FORCE=1' "$SKILL" \
    && grep -qE '^[[:space:]]*\[aA\]\[uU\]\[tT\]\[oO\]\)' "$SKILL"; then
-  pass "2  argument parser: --branch + positional from-here/skip-tests/force/auto (Phase 4 grammar)"
+  pass "2  argument parser: --branch + positional from-here/skip-tests/auto + --force (dashed; issue #810)"
 else
-  fail "2  argument parser: one or more arms missing (--branch + positional bracket-class tokens)"
+  fail "2  argument parser: one or more arms missing OR bare 'force' bracket-class arm still present"
 fi
 
 # ────────────────────────────────────────────────────────────────────
@@ -1254,20 +1255,31 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
-# Case 44 — positional `force` parsed → FORCE=1.
+# Case 44 — `--force` (dashed) parsed → FORCE=1.
 #
 # Exercises WI 1.2's parser fence in isolation (no preflight side
-# effects). Asserts the new positional `[fF][oO][rR][cC][eE]) FORCE=1`
-# arm sets FORCE=1 and does not consume any positional arg as a value.
-# Phase 4 grammar: positional `force` is the working form.
+# effects). Asserts the dashed `--force) FORCE=1` arm sets FORCE=1
+# and does not consume any positional arg as a value. Bare positional
+# `force` is now treated as DESCRIPTION text (issue #810: normalised
+# on dashed --force across /do, /work-on-plans, /quickfix, /cleanup-merged).
 # ────────────────────────────────────────────────────────────────────
-OUT=$(bash "$PARSER_SCRIPT" force "fix typo")
+OUT=$(bash "$PARSER_SCRIPT" --force "fix typo")
 if echo "$OUT" | grep -q '^FORCE=1$' \
    && echo "$OUT" | grep -q '^ROUNDS=1$' \
    && echo "$OUT" | grep -q '^DESCRIPTION=fix typo$'; then
-  pass "44 positional force: FORCE=1, ROUNDS default 1, DESCRIPTION='fix typo' (no positional consumed)"
+  pass "44 --force: FORCE=1, ROUNDS default 1, DESCRIPTION='fix typo' (no positional consumed)"
 else
-  fail "44 positional force parse: $(echo "$OUT" | tr '\n' '|')"
+  fail "44 --force parse: $(echo "$OUT" | tr '\n' '|')"
+fi
+
+# Sub-case 44b — bare positional `force` is NO LONGER a force token; it
+# falls through to DESCRIPTION (issue #810 — no backwards-compat alias).
+OUT_B=$(bash "$PARSER_SCRIPT" force "fix typo")
+if echo "$OUT_B" | grep -q '^FORCE=0$' \
+   && echo "$OUT_B" | grep -qE '^DESCRIPTION=.*force.*fix typo$'; then
+  pass "44b bare 'force' falls through to DESCRIPTION (no longer a force token; issue #810)"
+else
+  fail "44b bare 'force' still treated as force token: $(echo "$OUT_B" | tr '\n' '|')"
 fi
 
 # ────────────────────────────────────────────────────────────────────
@@ -1355,19 +1367,19 @@ case "$VERDICT" in
   REDIRECT:/draft-plan:*)
     REASON="${VERDICT#REDIRECT:/draft-plan:}"
     printf 'Triage: redirecting to /draft-plan. Reason: %s\n' "$REASON"
-    printf 'This task spans more than one concept; /draft-plan will research and decompose it. Run `/draft-plan <description>` instead, or re-invoke with force to bypass.\n'
+    printf 'This task spans more than one concept; /draft-plan will research and decompose it. Run `/draft-plan <description>` instead, or re-invoke with --force to bypass.\n'
     exit 0
     ;;
   REDIRECT:/run-plan:*)
     REASON="${VERDICT#REDIRECT:/run-plan:}"
     printf 'Triage: redirecting to /run-plan. Reason: %s\n' "$REASON"
-    printf 'This task references an existing plan file. Run `/run-plan <plan-path>` to execute it, or re-invoke with force to bypass.\n'
+    printf 'This task references an existing plan file. Run `/run-plan <plan-path>` to execute it, or re-invoke with --force to bypass.\n'
     exit 0
     ;;
   REDIRECT:/fix-issues:*)
     REASON="${VERDICT#REDIRECT:/fix-issues:}"
     printf 'Triage: redirecting to /fix-issues. Reason: %s\n' "$REASON"
-    printf 'This task references a GitHub issue. Run `/fix-issues <issue-number>` instead, or re-invoke with force to bypass.\n'
+    printf 'This task references a GitHub issue. Run `/fix-issues <issue-number>` instead, or re-invoke with --force to bypass.\n'
     exit 0
     ;;
   PROCEED|*)
@@ -1817,35 +1829,36 @@ else
   fail "64 positional SKIP-TESTS: $(echo "$OUT64" | tr '\n' '|')"
 fi
 
-# Case 65 — positional FORCE (case-insensitive bracket form).
+# Case 65 — Issue #810: bare positional `Force` (mixed-case) MUST now fall
+# through to DESCRIPTION; the dashed --force form is the only force token.
 OUT65=$(bash "$PARSER_SCRIPT" "fix typo" Force 2>&1)
-if echo "$OUT65" | grep -q '^FORCE=1$' \
-   && echo "$OUT65" | grep -q '^DESCRIPTION=fix typo$'; then
-  pass "65 positional Force (mixed-case): FORCE=1, DESCRIPTION clean"
+if echo "$OUT65" | grep -q '^FORCE=0$' \
+   && echo "$OUT65" | grep -qE '^DESCRIPTION=fix typo Force$'; then
+  pass "65 bare 'Force' (mixed-case) falls through to DESCRIPTION (issue #810)"
 else
-  fail "65 positional Force: $(echo "$OUT65" | tr '\n' '|')"
+  fail "65 bare 'Force' (mixed-case): $(echo "$OUT65" | tr '\n' '|')"
 fi
 
-# Case 66 — `--branch force fix typo` → BRANCH_OVERRIDE="force",
-# DESCRIPTION="fix typo", FORCE=0 (--branch consumes next arg
-# unconditionally; positional `force` does NOT fire) (AC4.6).
-OUT66=$(bash "$PARSER_SCRIPT" --branch force fix typo 2>&1)
-if echo "$OUT66" | grep -q '^BRANCH_OVERRIDE=force$' \
+# Case 66 — `--branch --force fix typo` → BRANCH_OVERRIDE="--force"
+# (--branch consumes next arg unconditionally), DESCRIPTION="fix typo",
+# FORCE=0 (the --force token was consumed by --branch).
+OUT66=$(bash "$PARSER_SCRIPT" --branch myfeat --force fix typo 2>&1)
+if echo "$OUT66" | grep -q '^BRANCH_OVERRIDE=myfeat$' \
    && echo "$OUT66" | grep -q '^DESCRIPTION=fix typo$' \
-   && echo "$OUT66" | grep -q '^FORCE=0$'; then
-  pass "66 --branch consumes 'force' as branch value; positional force does NOT fire (AC4.6)"
+   && echo "$OUT66" | grep -q '^FORCE=1$'; then
+  pass "66 --branch myfeat --force: BRANCH_OVERRIDE=myfeat, FORCE=1, DESCRIPTION clean"
 else
-  fail "66 --branch force fix typo: $(echo "$OUT66" | tr '\n' '|')"
+  fail "66 --branch myfeat --force fix typo: $(echo "$OUT66" | tr '\n' '|')"
 fi
 
-# Case 67 — `fix bug --rounds force` → greedy-fallthrough leaves
-# --rounds as prose, FORCE=1 from positional match, ROUNDS=1 default
-# (AC4.7).
+# Case 67 — Issue #810: bare positional 'force' is no longer a token, so
+# `fix bug --rounds force` keeps --rounds and trailing 'force' as
+# DESCRIPTION prose; FORCE stays 0.
 OUT67=$(bash "$PARSER_SCRIPT" fix bug --rounds force 2>&1)
-if echo "$OUT67" | grep -q '^DESCRIPTION=fix bug --rounds$' \
-   && echo "$OUT67" | grep -q '^FORCE=1$' \
+if echo "$OUT67" | grep -qE '^DESCRIPTION=fix bug --rounds force$' \
+   && echo "$OUT67" | grep -q '^FORCE=0$' \
    && echo "$OUT67" | grep -q '^ROUNDS=1$'; then
-  pass "67 greedy-fallthrough: --rounds w/ non-numeric next → prose; trailing 'force' → FORCE=1 (AC4.7)"
+  pass "67 greedy-fallthrough: --rounds w/ non-numeric next → all prose; bare 'force' no longer a token (issue #810)"
 else
   fail "67 fix bug --rounds force: $(echo "$OUT67" | tr '\n' '|')"
 fi
@@ -1862,10 +1875,11 @@ else
 fi
 
 # Case 69 — argument-hint shape (AC4.9): exact positional hint.
+# Issue #810: bare `force` → dashed `--force` for cross-skill consistency.
 HINT=$(grep '^argument-hint' "$SKILL" | sed -E 's/^argument-hint: "(.*)"$/\1/')
-EXPECTED='[<description>] [auto] [from-here] [skip-tests] [force] [--branch <name>] [--rounds N]'
+EXPECTED='[<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]'
 if [ "$HINT" = "$EXPECTED" ]; then
-  pass "69 argument-hint (AC4.9, AC4.12): positional shape (len=${#HINT})"
+  pass "69 argument-hint (AC4.9, AC4.12, #810): positional shape (len=${#HINT})"
 else
   fail "69 argument-hint: got='$HINT' expected='$EXPECTED'"
 fi

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -561,15 +561,40 @@ echo "=== auto grammar (QUICKFIX_GRAMMAR_REDESIGN Phase 2) ==="
 check_fixed quickfix    "AUTO_FLAG init"        'AUTO_FLAG=0'
 
 # QUICKFIX_GRAMMAR_REDESIGN Phase 4 (AC4.12, AC4.13) — positional
-# from-here/skip-tests/force replace --`-prefixed flags; --yes was
+# from-here/skip-tests replace --`-prefixed flags; --yes was
 # removed entirely; WI 1.10 `read -r` block was deleted.
+# Issue #810: `--force` (dashed) replaces the bare positional `force` form
+# for cross-skill consistency (also pinned on /do, /work-on-plans,
+# /cleanup-merged in the "--force form normalization" block below).
 check_fixed quickfix    "positional from-here arm"   '[fF][rR][oO][mM]-[hH][eE][rR][eE]) FROM_HERE=1'
 check_fixed quickfix    "positional skip-tests arm"  '[sS][kK][iI][pP]-[tT][eE][sS][tT][sS]) SKIP_TESTS=1'
-check_fixed quickfix    "positional force arm"       '[fF][oO][rR][cC][eE]) FORCE=1'
+check_fixed quickfix    "--force arm (issue #810)"   '--force) FORCE=1'
+check_not   quickfix    "no bare 'force)' arm (#810)" '^[[:space:]]*\[fF\]\[oO\]\[rR\]\[cC\]\[eE\]\) FORCE=1'
 check_not   quickfix    "no YES_FLAG variable (AC4.13)"          'YES_FLAG'
 check_not   quickfix    "no `read -r answer` block (AC4.13)"     'read -r answer'
 check       quickfix    "argument-hint [from-here]"  'argument-hint:.*\[from-here\]'
 check_not   quickfix    "argument-hint NO [--yes]"   'argument-hint:.*\[--yes\]'
+check       quickfix    "argument-hint [--force] (issue #810)" 'argument-hint:.*\[--force\]'
+check_not   quickfix    "argument-hint NO bare [force] (issue #810)" 'argument-hint:.*\[force\]'
+
+# Issue #810 — --force form normalization across all four skills.
+# Bare positional `force` was the form on /quickfix and /cleanup-merged;
+# /do and /work-on-plans were already on the dashed form. Now all four
+# accept `--force`. This block pins the dashed parser arm on every
+# skill that accepts a force override, and pins the absence of any
+# bare-`force)` case branch on the two that previously had one.
+#
+# /do — pre-flight bash-regex parser detects --force out of $ARGUMENTS.
+check_fixed do            "--force pre-flight parser (issue #810)" '(^|[[:space:]])--force($|[[:space:]])'
+
+# /work-on-plans — synopsis advertises --force.
+check_fixed work-on-plans "--force in synopsis (issue #810)" '[--force]'
+
+# /cleanup-merged — dashed parser arm; no bare 'force)' arm; --force
+# advertised in argument-hint.
+check_fixed cleanup-merged "--force) parser arm (issue #810)" '--force) FORCE=1'
+check_not   cleanup-merged "no bare 'force)' arm (issue #810)" '^[[:space:]]*force\)[[:space:]]+FORCE=1'
+check       cleanup-merged "argument-hint [--force] (issue #810)" 'argument-hint:.*\[--force\]'
 
 check_fixed run-plan    "AUTO_FLAG init"        'AUTO_FLAG=0'
 


### PR DESCRIPTION
## Summary

Normalize the `force` flag form across all four skills that accept it: `/do`, `/work-on-plans` (already on `--force`), `/quickfix` and `/cleanup-merged` (switched from bare `force` to `--force`). Positional tokens (`apply`, `pr`, `auto`, `local`, `remote`) name modes/verbs; dashed `--force` is reserved for safety-gate overrides.

Closes #810

## Test plan

- [x] `bash tests/run-all.sh` — 6518/6518 passed locally (0 failed, 0 skipped).
- [x] `tests/test-skill-conformance.sh` extended to pin `--force` parsers on all four skills and assert bare `force)` is absent on `/quickfix` and `/cleanup-merged`.
- [x] `tests/test-quickfix.sh` updated for new triage redirect messages; new Case 44b confirms bare `force` falls through to DESCRIPTION.
- [x] `tests/test-cleanup-merged-namelist.sh` scenarios B/D invoke `apply --force ...`; refusal-notice grep checks for `refusing to delete even with --force`.
- [x] `tests/test-managed-md-up-to-date.sh` passes (managed.md regenerated from CLAUDE_TEMPLATE.md).
- [x] `metadata.version` bumped on `skills/quickfix/SKILL.md` and `skills/cleanup-merged/SKILL.md` per skill-versioning rule.
- [ ] CI re-runs the suite against origin/main as ground truth.

## Commits

f926a66 feat(skills): normalize --force (dashed) across all skills, retire bare force
