### PR TITLE
[claim-work-item] Ownership-aware work-item claims (self-re-entry in the twin claim scripts)

### DIFF
--- a/.claude/rules/zskills/managed.md
+++ b/.claude/rules/zskills/managed.md
@@ -364,3 +364,7 @@ to main. Use PR mode or feature branches.
 ## Tracking Enforcement
 
 Tracking file enforcement is active when `.zskills/tracking/` exists and the session is associated with a pipeline (via `.zskills-tracked` file or transcript). Skills create tracking files during pipeline execution; hooks check them before allowing `git commit`, `git cherry-pick`, and `git push`. Pipeline scoping (suffix matching on pipeline ID) ensures one pipeline's markers don't block another. The orchestrator writes `.zskills-tracked` (single-line pipeline ID) in both the worktree and main repo roots before dispatching agents, and removes it after pipeline completion. The `.claude/skills/update-zskills/scripts/clear-tracking.sh` script lets the user manually clear stale tracking state -- agents are blocked from running it directly.
+
+## Claiming work items
+
+Claim any tracked work-item (issue or plan) before working it; the claim is held for the work's full lifetime INCLUDING idle gaps, and released only on resolve/abandon, NEVER per-step. The discipline applies recursively: a pipeline holding a plan claim that works the plan's issue ALSO holds the issue claim. Foreign-held (acquire exit 10) -> decline (one-shot consumers) or WARN-and-proceed (a plan whose linked issue is foreign-held still runs -- the plan owns the plan); self-re-entry (exit 0) -> proceed; there is NO TTL -- release is always explicit. Issues are claimed via `claim-issue.sh`, plans via `claim-plan.sh`; both are ownership-aware (they recognize the caller's own claim and return success on re-acquire).

--- a/.claude/skills/create-worktree/SKILL.md
+++ b/.claude/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.05.20+606912"
+  version: "2026.05.29+8159fb"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/.claude/skills/create-worktree/scripts/claim-self-reentry.sh
+++ b/.claude/skills/create-worktree/scripts/claim-self-reentry.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# claim-self-reentry.sh — Ownership-aware self-re-entry decision for the
+# twin claim primitives (claim-issue.sh / claim-plan.sh).
+#
+# Invoked ONLY on the already-exists (EEXIST) branch of cmd_acquire in
+# either twin, as a bash SUBPROCESS — NEVER sourced for the decision (the
+# exit 10 / exit 0 contract below would terminate a sourcing caller).
+#
+# Usage:
+#   bash claim-self-reentry.sh <claim_dir> <caller_pipeline_id>
+#
+# Given an ABSOLUTE <claim_dir> (the caller has already resolved MAIN_ROOT
+# via `git rev-parse --git-common-dir` parent — this helper does NOT
+# re-resolve MAIN_ROOT, it operates on the path it is handed) and the
+# caller's pipeline_id, decide whether the existing claim is the caller's
+# OWN (self-re-entry → proceed) or another pipeline's (foreign → decline).
+#
+# Exit-code contract:
+#   0  — self-re-entry: the existing claim's stored pipeline_id matches the
+#        caller's; the caller already owns this claim and may proceed.
+#   10 — foreign / never-steal: either claim.json is ABSENT (an in-flight
+#        acquire window or a crashed-mkdir stub — not ours to claim), the
+#        stored pipeline_id differs from the caller's, OR claim.json is
+#        truncated/malformed (read yields empty → "" != caller → foreign).
+#        Returned deterministically; NEVER a python traceback or non-10
+#        exit on a malformed claim.json.
+#   2  — usage error (wrong number of args).
+#
+# Logic (D3): if <claim_dir>/claim.json is absent → 10 (never steal). Else
+# read the stored pipeline_id via Python stdlib json (NO jq) with a
+# try/except → print('') reader captured into a shell variable (mirrors the
+# release-style readers at claim-issue.sh / claim-plan.sh — NOT the bare
+# json.load() in set-phase which raises on truncation). A truncated /
+# half-written / malformed claim.json therefore yields an empty captured
+# string → "" != caller → 10. Exit 0 iff the captured pipeline_id equals
+# the caller's, else 10.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Python interpreter resolution. Honours the project's documented
+# ZSKILLS_PYTHON override (see CLAUDE.md "Python is required" section).
+# ---------------------------------------------------------------------------
+_CLAIM_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$_CLAIM_PYTHON" ]; then
+  echo "claim-self-reentry.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
+  exit 127
+fi
+
+claim_dir="${1:-}"
+caller_pipeline_id="${2:-}"
+
+if [ -z "$claim_dir" ] || [ "$#" -ne 2 ]; then
+  echo "Usage: claim-self-reentry.sh <claim_dir> <caller_pipeline_id>" >&2
+  exit 2
+fi
+
+claim_file="${claim_dir}/claim.json"
+
+# claim.json absent → never steal (in-flight acquire window or crashed mkdir
+# stub). Foreign.
+if [ ! -f "$claim_file" ]; then
+  exit 10
+fi
+
+# Read the stored pipeline_id with the SAFE release-style reader: a
+# try/except that prints '' on any failure (missing key, truncated JSON,
+# malformed JSON). A malformed claim.json therefore yields an empty string,
+# never a traceback — so "" != caller → foreign (10), deterministically.
+stored=$("$_CLAIM_PYTHON" -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('pipeline_id', ''))
+except Exception:
+    print('')
+" "$claim_file")
+
+if [ "$stored" = "$caller_pipeline_id" ] && [ -n "$caller_pipeline_id" ]; then
+  exit 0
+fi
+exit 10

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.28+091ad6"
+  version: "2026.05.29+f085ff"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -227,6 +227,19 @@ fi
 AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
+fi
+# Issue-number parse (claim-work-item Phase 2 / W2.2). /do is normally
+# REDIRECTed to /fix-issues when the description references an issue
+# (Phase 0a triage); the number is only reachable here when --force
+# overrides that redirect. Extract the FIRST bare positive integer from a
+# `#N` / `closes #N` / `fix #N` reference into ISSUE_NUM so the mode files
+# can claim the issue via claim-issue.sh. When no issue number is present
+# (the common /do case) ISSUE_NUM stays empty and the mode files claim
+# nothing. The number is stripped to a bare integer (claim-issue.sh
+# rejects non-numeric input with exit 2).
+ISSUE_NUM=""
+if [[ "$ARGUMENTS" =~ \#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
 fi
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
@@ -724,6 +737,13 @@ procedure end-to-end**. Do not proceed until you have read the file.
 | `worktree`     | B    | [modes/worktree.md](modes/worktree.md) |
 | `direct`       | C    | [modes/direct.md](modes/direct.md) |
 
+**`$ISSUE_NUM` propagates into the mode files** (set in the Pre-flight
+pre-parse). When non-empty, the mode file claims the issue via
+`claim-issue.sh` AFTER it constructs its `PIPELINE_ID` (the C1/M1 rule —
+never acquire before a non-empty PIPELINE_ID exists). The acquire is NEVER
+placed here in SKILL.md before mode dispatch: PIPELINE_ID is empty at this
+point, so `--pipeline-id ""` would fail usage-error exit 2.
+
 ## Phase 3 — Verify
 
 Verification intensity matches the change type (from Phase 1):
@@ -858,6 +878,25 @@ Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invoca
 
 ## Phase 5 — Report
 
+**Release the issue claim (worktree/direct modes).** Phase 5 is the
+universal terminal reached on BOTH the `auto` and non-`auto` exits of
+worktree and direct modes — so the issue claim (acquired by the mode file
+when `$ISSUE_NUM` was non-empty) is released HERE, not in Phase 4 Land
+(which is `AUTO_FLAG=1`-gated and would leak the claim on the dominant
+non-auto path). PR mode (Path A) handles its own release inside
+`modes/pr.md`'s finalize block and exits before reaching this section.
+Skip when no issue claim was acquired (the common /do case — `$ISSUE_NUM`
+empty):
+
+```bash
+# $ISSUE_NUM (Pre-flight pre-parse) and $PIPELINE_ID (set in the mode file:
+# do.${TASK_SLUG}) survive in the persistent shell. The release is
+# ownership-safe via --require-pipeline.
+if [ -n "${ISSUE_NUM:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+fi
+```
+
 Brief inline output. No persistent report file.
 
 **On main (no worktree, no auto):**
@@ -924,6 +963,14 @@ Status: pr-ready | pr-ci-failing | landed
   `.landed` with `status: conflict` and exit with an error message.
 - **If stuck on anything:** report the state and ask the user for
   guidance. Do not retry the same approach in a loop.
+- **Release the issue claim on every abandon path (worktree/direct modes).**
+  When `$ISSUE_NUM` was non-empty and the mode file acquired a
+  `claim-issue.sh` claim, any error exit above (test failure, content
+  issue, cherry-pick conflict, push failure, task-too-big) MUST release it
+  before stopping so the next pipeline can pick the issue up:
+  `bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"`
+  (only if an issue claim was acquired — skip when `$ISSUE_NUM` is empty).
+  PR mode's abandon-path releases live inside `modes/pr.md`.
 
 ## Key Rules
 

--- a/.claude/skills/do/modes/direct.md
+++ b/.claude/skills/do/modes/direct.md
@@ -7,6 +7,33 @@ Selected when the user passes `direct` explicitly, when `execution.landing`
 in `.claude/zskills-config.json` is `"direct"`, or as the fallback when
 no config is present. Work directly on main.
 
+**Claim the issue (when `$ISSUE_NUM` is non-empty).** Direct mode
+constructs no `TASK_SLUG`/`PIPELINE_ID` of its own, so synthesize a minimal
+`PIPELINE_ID="do.<bare-issue>"` (routed through the shared sanitizer)
+BEFORE acquiring the `claim-issue.sh` claim. This stops a concurrent
+`/fix-issues` cron from double-working the same issue. `$ISSUE_NUM` is
+propagated from `/do`'s Pre-flight pre-parse (set only when the description
+referenced an issue and `--force` overrode the `/fix-issues` redirect).
+Skip entirely when `$ISSUE_NUM` is empty (the common /do direct case —
+direct mode is rarely issue-driven). The claim is released in `/do` Phase 5
+Report.
+
+```bash
+if [ -n "${ISSUE_NUM:-}" ]; then
+  PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "do.$ISSUE_NUM")
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+```
+
 **Follow existing conventions in all paths:**
 - Example models → `/model-design` skill guidelines
 - Newsletter entries → existing NEWSLETTER.md format

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -86,6 +86,37 @@ fi
 ```
 Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` as shell output in the main session — the `.zskills-tracked` file in the worktree is the single source of truth.
 
+**Step A5.5 — Claim the issue (when `$ISSUE_NUM` is non-empty).** Now that
+`PIPELINE_ID="do.${TASK_SLUG}"` is set (A4) and the worktree exists (A5),
+acquire the `claim-issue.sh` claim BEFORE dispatching the implementation
+agent (A6). This stops a concurrent `/fix-issues` cron from double-working
+the same issue. `$ISSUE_NUM` is propagated from `/do`'s Pre-flight
+pre-parse (set only when the description referenced an issue and `--force`
+overrode the `/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is
+empty (the common /do pr case). The A1 slug guards and A5's `exit "$RC"`
+are PRE-acquire, so they need no release. The claim is released in the
+explicit-finalize block at the end of the caller loop (Step A8), and
+inline before every post-acquire-pre-finalize early exit.
+
+```bash
+if [ -n "${ISSUE_NUM:-}" ]; then
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+```
+
+Do NOT copy `/fix-issues`'s HOLD-on-`created` arm: `/do pr` is one-shot
+(no later sprint fire re-runs `/land-pr` to release), so a HOLD would leak
+the claim forever.
+
 **Step A6 — Dispatch implementation agent (wait for completion):**
 
 **Dispatch shape.** Use the `Agent` tool with `subagent_type: "implementer"`.
@@ -150,10 +181,19 @@ cd "$WORKTREE_PATH"
 # $TASK_DESCRIPTION.
 if [ -z "${PR_TITLE:-}" ]; then
   echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
+  # C2 inline-release: this exit is AFTER the Step A5.5 acquire and BEFORE
+  # the explicit-finalize block, so release the issue claim (only if one
+  # was acquired) before bailing or it leaks.
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 5
 fi
 if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 60 ] || [[ "$PR_TITLE" != do:\ * ]]; then
   echo "ERROR: PR_TITLE must be a single line ≤60 chars starting with 'do: ' (got '$PR_TITLE')." >&2
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 2
 fi
 
@@ -271,6 +311,11 @@ while :; do
     # explicit-finalize block at end-of-fence). Variables in scope (same fence).
     rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
     sed -i "s/^status: started$/status: failed/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
+    # C2 inline-release: post-acquire, pre-finalize early exit — release
+    # the issue claim (only if one was acquired) or it leaks.
+    if [ -n "${ISSUE_NUM:-}" ]; then
+      bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    fi
     exit 1
   fi
 
@@ -436,6 +481,16 @@ case "$LAND_OUTCOME" in
 esac
 sed -i "s/^status: started$/status: $FINAL/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
 rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
+
+# Release the issue claim regardless of created vs merged vs failed
+# (release-on-resolution — the /do pr invocation is terminating either way,
+# and /do is one-shot so there is no later fire to re-release). Only if an
+# issue claim was acquired in Step A5.5. $PIPELINE_ID = do.$TASK_SLUG is
+# re-resolved at the tracking-setup fence-top above and survives in this
+# fence.
+if [ -n "${ISSUE_NUM:-}" ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+fi
 ```
 
 **Note on the `.landed` schema:** `/land-pr` writes the canonical schema

--- a/.claude/skills/do/modes/worktree.md
+++ b/.claude/skills/do/modes/worktree.md
@@ -56,5 +56,30 @@ if [ "${rc:-0}" = "2" ]; then
 fi
 ```
 
+**Claim the issue (when `$ISSUE_NUM` is non-empty).** After the worktree
+exists and `PIPELINE_ID="do.${TASK_SLUG}"` is set, acquire the
+`claim-issue.sh` claim BEFORE dispatching the implementation agent — this
+stops a concurrent `/fix-issues` cron from double-working the same issue.
+`$ISSUE_NUM` is propagated from `/do`'s Pre-flight pre-parse (set only when
+the description referenced an issue and `--force` overrode the
+`/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is empty (the
+common /do case). The claim is released in `/do` Phase 5 Report (the
+universal terminal for both auto and non-auto exits).
+
+```bash
+if [ -n "${ISSUE_NUM:-}" ]; then
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+```
+
 Do the work inside the worktree. The verification agent commits after tests pass (one logical unit per commit).
 

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.29+c47a59"
+  version: "2026.05.29+abab96"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/scripts/claim-issue.sh
+++ b/.claude/skills/fix-issues/scripts/claim-issue.sh
@@ -9,12 +9,24 @@
 #
 # Subcommands:
 #   acquire <N> --pipeline-id <id> --sprint-id <id>
-#     Exit 0  — acquired (claim.json atomically written).
-#     Exit 10 — EEXIST: claim already held by another pipeline.
-#     Exit 11 — non-EEXIST mkdir failure (EACCES/ENOSPC/EDQUOT/EROFS/...).
+#     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
+#               claim — the stored pipeline_id matches --pipeline-id).
+#     Exit 2  — usage error.
+#     Exit 10 — foreign-held by another pipeline (OR claim already exists
+#               but claim.json absent/malformed — never steal).
+#     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
+#               (EACCES/ENOSPC/EDQUOT/EROFS/...).
 #   release <N> [--require-pipeline <id>]
 #     Exit 0  — released (or already absent — idempotent).
-#     Exit 12 — pipeline-id mismatch (refused; claim left intact).
+#     Exit 2  — usage error.
+#     Exit 12 — release pipeline-id mismatch (claim left intact).
+#
+# Self-re-entry: the EEXIST arm of acquire delegates to
+# create-worktree/scripts/claim-self-reentry.sh (a bash subprocess). A
+# pipeline re-acquiring its OWN claim (same pipeline_id) gets exit 0; a
+# foreign claim, an absent claim.json, or a malformed claim.json gets exit
+# 10 (never steal). No TTL/heartbeat/sweep — is-stale stays the 30s
+# crash-window check only.
 #   is-stale <N>
 #     Race-tolerance check ONLY: stale iff the claim dir exists without
 #     claim.json and is older than 30s (mkdir-succeeded-then-crashed).
@@ -51,6 +63,38 @@ if [ -z "$_CLAIM_PYTHON" ]; then
   echo "fix-issues claim-issue.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
   exit 127
 fi
+
+# ---------------------------------------------------------------------------
+# Resolve script-bundle directory for sibling lookups
+# (claim-self-reentry.sh lives in the create-worktree bundle).
+# ---------------------------------------------------------------------------
+_CLAIM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Locate claim-self-reentry.sh — prefer sibling create-worktree skill
+# layout, fall back to repo source tree, then to .claude/skills/ mirror.
+# Mirrors claim-plan.sh's _locate_sanitizer() precedence verbatim. SOURCED
+# at script load; the resolved PATH is invoked as a bash subprocess from
+# the EEXIST arm of cmd_acquire.
+_locate_self_reentry() {
+  local candidates=(
+    "$_CLAIM_SCRIPT_DIR/../../create-worktree/scripts/claim-self-reentry.sh"
+    "$_CLAIM_SCRIPT_DIR/../../../skills/create-worktree/scripts/claim-self-reentry.sh"
+  )
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    candidates+=(
+      "${CLAUDE_PROJECT_DIR}/.claude/skills/create-worktree/scripts/claim-self-reentry.sh"
+      "${CLAUDE_PROJECT_DIR}/skills/create-worktree/scripts/claim-self-reentry.sh"
+    )
+  fi
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -f "$c" ]; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
 
 # ---------------------------------------------------------------------------
 # MAIN_ROOT resolution (DA4.1 — round 4b).
@@ -137,9 +181,25 @@ cmd_acquire() {
   mkdir_err=$(mkdir "$claim_dir" 2>&1)
   local mkdir_status=$?
   if [ "$mkdir_status" -ne 0 ]; then
-    # Map "File exists" -> 10; anything else -> 11.
+    # Map "File exists" -> self-re-entry decision (0 self / 10 foreign);
+    # anything else -> 11.
     case "$mkdir_err" in
       *"File exists"*)
+        # Ownership-aware self-re-entry: delegate to the shared helper as a
+        # bash SUBPROCESS (its exit 10/0 contract would terminate a sourcing
+        # caller). Helper exit 0 → self → return 0; exit 10 → foreign →
+        # return 10. If the helper cannot be located, fail conservative
+        # (return 10, never silently steal) with a one-line WARN.
+        local sr_helper
+        if ! sr_helper=$(_locate_self_reentry); then
+          echo "fix-issues claim-issue.sh acquire: cannot locate claim-self-reentry.sh (looked in create-worktree bundle); treating existing claim as foreign" >&2
+          return 10
+        fi
+        bash "$sr_helper" "$claim_dir" "$pipeline_id"
+        local sr_rc=$?
+        if [ "$sr_rc" -eq 0 ]; then
+          return 0
+        fi
         return 10
         ;;
       *)

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   reproduce, trace, state root cause, fix, verify. The agent must PROVE
   root-cause understanding before writing a fix.
 metadata:
-  version: "2026.05.28+93a842"
+  version: "2026.05.29+c324f6"
 ---
 
 # /investigate \<description or #issue> — Root-Cause Debugging
@@ -56,6 +56,39 @@ Examples:
    interpreted as "clear canvas" instead of "reset mappings to defaults"
    because only the title was read).
 
+   **Claim the issue (when the input IS an issue number).** `/investigate`
+   has no pipeline id of its own, so synthesize one and acquire the
+   `claim-issue.sh` claim BEFORE any reproduction work — this prevents a
+   concurrent `/fix-issues` cron (or another `/investigate`) from
+   double-working the same issue. **Skip this entirely for a bare-text
+   description** (no issue number → nothing to claim). Extract the bare
+   positive integer (strip a leading `#` and any quotes) into `$N` and
+   synthesize the pipeline id through the shared sanitizer:
+
+   ```bash
+   # Only when the input is an issue reference. $N = bare positive integer
+   # (claim-issue.sh rejects non-numeric / decorated input with exit 2).
+   N="${N#\#}"          # strip a leading '#'
+   N="${N//\"/}"        # strip any quotes
+   MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+   PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "investigate.issue-$N")
+   CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+   bash "$CLAIM_HELPER" acquire "$N" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+   ACQ_RC=$?
+   case "$ACQ_RC" in
+     0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+     10) echo "issue #$N is being worked by another pipeline; declining." >&2 ;;
+     11) echo "claim-issue.sh: filesystem error acquiring issue #$N; stopping." >&2 ;;
+     2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric N=$N) — internal bug; stopping." >&2 ;;
+   esac
+   ```
+
+   On `ACQ_RC` 10 / 11 / 2 → **STOP this invocation** (print the message
+   above and do not proceed — this is a one-shot skill, not a sprint loop).
+   On `ACQ_RC=0` continue. The claim is released on every terminal path
+   below (success-path bash block at the Report, and the explicit per-STOP
+   release prose at each abandon point).
+
 2. **Reproduce the bug** based on its type:
 
    | Bug type | How to reproduce |
@@ -85,6 +118,8 @@ Examples:
    reproducing), "reproduction would take too long" (then you're guessing).
 
    If you skip, flag the investigation as lower confidence in the report.
+   (This is not an abandon — you proceed. The claim is held until the
+   terminal Report releases it.)
 
 ## Phase 2 — Trace
 
@@ -189,6 +224,9 @@ included in the final report.
    - Why each attempt failed
    - What you think is actually happening
    Let the user decide the next step. Do not guess a third time.
+   **Before stopping, release the issue claim** (only if you acquired one
+   in Phase 1 — i.e. the input was an issue number):
+   `bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"`.
 
 ## Phase 5 — Verify
 
@@ -212,6 +250,12 @@ included in the final report.
    fi
    if [ -z "$FULL_TEST_CMD" ]; then
      echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+     # Release the issue claim before bailing (only if one was acquired
+     # in Phase 1 — i.e. the input was an issue number; $N / $PIPELINE_ID
+     # are set there and survive in the persistent shell).
+     if [ -n "${N:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
+       bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"
+     fi
      exit 1
    fi
    TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
@@ -233,6 +277,21 @@ included in the final report.
 ## Report
 
 Output an inline report. No persistent report file.
+
+**Release the issue claim (success path).** When the input was an issue
+number (Phase 1 acquired a claim), release it now that the investigation
+has reached its terminal Report — the work is resolved, the claim should
+not persist. Skip when the input was a bare description (no claim was
+acquired):
+
+```bash
+# $N and $PIPELINE_ID were set in Phase 1 step 1 (issue-number path only)
+# and survive in the persistent shell. The release is ownership-safe
+# (--require-pipeline refuses to release a claim another pipeline owns).
+if [ -n "${N:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"
+fi
+```
 
 ```
 ## Investigation: <title>
@@ -260,6 +319,13 @@ Output an inline report. No persistent report file.
 
 If the investigation was abandoned (couldn't reproduce, couldn't find root
 cause, fix failed twice), report what was learned and what remains unknown.
+**Before stopping on any abandon path, release the issue claim** (only if
+the input was an issue number and Phase 1 acquired a claim):
+`bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"`.
+This covers the couldn't-reproduce STOP (Phase 1), the couldn't-find-root
+STOP (Phase 2/3 — when you cannot state the causal chain), and the
+two-attempt-limit STOP (Phase 4). A released claim lets the next pipeline
+pick up the issue cleanly.
 
 ## Key Rules
 

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.29+a8614b"
+  version: "2026.05.29+aa461b"
 ---
 
 # /quickfix — In-Flight Fix → PR

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.29+96de31"
+  version: "2026.05.29+a8614b"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -144,6 +144,19 @@ done
 # Trim
 DESCRIPTION="${DESCRIPTION#"${DESCRIPTION%%[![:space:]]*}"}"
 DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
+
+# Issue-number parse (claim-work-item Phase 2 / W2.4). /quickfix usually
+# works an in-flight edit, not an issue — but a description that references
+# an issue (`#N` / `closes #N` / `fix #N`) is normally REDIRECTed to
+# /fix-issues by triage (WI 1.5.4) and only proceeds here under `force`.
+# Extract the FIRST bare positive integer into ISSUE_NUM so WI 1.8 can
+# claim the issue via claim-issue.sh. When no issue number is present (the
+# common case) ISSUE_NUM stays empty and nothing is claimed. The number is
+# a bare integer (claim-issue.sh rejects non-numeric input with exit 2).
+ISSUE_NUM=""
+if [[ "$DESCRIPTION" =~ \#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+fi
 ```
 
 ## Phase 1 — Pre-flight
@@ -686,6 +699,26 @@ branch: $BRANCH
 date: $NOW_ISO
 MARK
 
+# Issue claim (claim-work-item Phase 2 / W2.4). Acquire here — where
+# PIPELINE_ID is established and the `started` marker is written — and
+# BEFORE branch creation (WI 1.9). Only when the description referenced an
+# issue (ISSUE_NUM non-empty, parsed in WI 1.2); skip otherwise (the common
+# /quickfix case). This stops a concurrent /fix-issues cron from
+# double-working the same issue. Released in the Phase 7 explicit-finalize
+# and the fail-finalize abandon sites (test fail, commit fail, push fail).
+if [ -n "${ISSUE_NUM:-}" ]; then
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+
 # Explicit-finalize pattern (Plan LAND_PR_BYPASS_HARDENING Phase 2; issue
 # #241 — matches /commit pr / /do pr / /fix-issues pr). The marker
 # starts as `status: started`; each terminal path (test fail at Phase 4,
@@ -857,6 +890,11 @@ else
     fi
     # Explicit fail-finalize (issue #241).
     [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
+    # Release the issue claim (only if one was acquired at WI 1.8) — this
+    # abandon path is after the acquire and before the Phase 7 finalize.
+    if [ -n "${ISSUE_NUM:-}" ]; then
+      bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    fi
     exit 4
   fi
 fi
@@ -991,6 +1029,10 @@ if ! git commit -m "$COMMIT_BODY"; then
   fi
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
+  # Release the issue claim (only if one was acquired at WI 1.8).
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 5
 fi
 ```
@@ -1055,6 +1097,10 @@ if ! git push -u origin "$BRANCH"; then
   echo "ERROR: git push failed. Branch '$BRANCH' and its commit are intact locally; retry manually once the remote is reachable." >&2
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
+  # Release the issue claim (only if one was acquired at WI 1.8).
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 5
 fi
 ```
@@ -1184,6 +1230,11 @@ while :; do
     # and runs correctly when called by a parent pipeline. Mirrors the
     # `[ -n "${ZSKILLS_PIPELINE_ID:-}" ]` guard at line 1310 below.
     [ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
+    # Release the issue claim (only if one was acquired at WI 1.8). This
+    # early exit bypasses the end-of-fence explicit-finalize release.
+    if [ -n "${ISSUE_NUM:-}" ]; then
+      bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    fi
     exit 5
   fi
 
@@ -1408,6 +1459,19 @@ else
   find "$MAIN_ROOT/.zskills/tracking" \
     -maxdepth 2 -type d -name 'quickfix.*' \
     -exec sh -c 'rm -f "$1"/requires.land-pr.*' _ {} \;
+fi
+
+# Release the issue claim (claim-work-item Phase 2 / W2.4) — only if one
+# was acquired at WI 1.8 (ISSUE_NUM survives in the persistent shell).
+# Release-on-resolution regardless of created vs merged vs pr-ready: the
+# /quickfix invocation is terminating either way and /quickfix is one-shot
+# (no later fire re-releases). $PIPELINE_ID = quickfix.$SLUG; reconstruct
+# from $ZSKILLS_PIPELINE_ID if it didn't survive across fences.
+if [ -n "${ISSUE_NUM:-}" ]; then
+  _RELEASE_PIPELINE="${PIPELINE_ID:-${ZSKILLS_PIPELINE_ID:-}}"
+  if [ -n "$_RELEASE_PIPELINE" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$_RELEASE_PIPELINE"
+  fi
 fi
 ```
 

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+cf90e3"
+  version: "2026.05.29+8f131b"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -589,6 +589,22 @@ the plan and our session must not double-fire `/run-plan` for it.
 `run-plan.$TRACKING_ID` pipeline_id succeeds — exit 10 here therefore means
 ONLY a truly-foreign pipeline holds the plan, which is exactly when
 "declined" is the correct verdict (D8 / #803).
+
+### Self-re-entry contract (twins: claim-plan.sh / claim-issue.sh)
+
+Both twin primitives share one ownership-aware self-re-entry decision,
+implemented by the helper `skills/create-worktree/scripts/claim-self-reentry.sh`
+(invoked as a bash subprocess on each twin's already-exists branch — NEVER
+sourced, since its exit codes would terminate a sourcing caller). The
+exit-code contract is: **acquire** — `0` = fresh-OR-self (the existing claim
+is the caller's own pipeline_id, or there was no claim and we just took it →
+proceed), `10` = foreign-OR-absent/malformed (another pipeline holds it, or
+claim.json is missing/truncated → never steal), `11` = filesystem
+infrastructure failure, `2` = usage error; **release** — `12` = ownership
+mismatch (the claim is held by a different pipeline_id; release refuses).
+There is NO TTL — a claim is released ONLY by an explicit `release` call, so
+a re-entering self always sees its own claim and proceeds (`0`), and a
+foreign holder is honored until that holder explicitly releases.
 
 ```bash
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+ca3f3d"
+  version: "2026.05.29+f08ed3"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+f08ed3"
+  version: "2026.05.29+cf90e3"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -584,6 +584,12 @@ On race-lost (exit 10) this fence terminates cleanly; the orchestrator
 reports "declined" and exits the turn — a second pipeline already owns
 the plan and our session must not double-fire `/run-plan` for it.
 
+`claim-plan.sh` is ownership-aware (self-re-entry returns 0), so a chunked
+`finish auto` re-fire re-acquiring its OWN plan claim with the stable
+`run-plan.$TRACKING_ID` pipeline_id succeeds — exit 10 here therefore means
+ONLY a truly-foreign pipeline holds the plan, which is exactly when
+"declined" is the correct verdict (D8 / #803).
+
 ```bash
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
@@ -599,6 +605,67 @@ case "$rc" in
   2)  echo "claim-plan.sh acquire usage error"; exit 2 ;;
   *)  echo "claim-plan.sh acquire unexpected rc=$rc"; exit 1 ;;
 esac
+```
+
+**Issue-claim acquire (W3.1/W3.2/W3.5, #803 execution-window protection).**
+If the plan's frontmatter carries one or more `issue: N` fields, claim each
+linked `issue-<N>` for the plan's FULL lifetime — held across idle gaps
+between chunked fires (filesystem + no-TTL + self-re-entry make this
+automatic) and released ONLY at the plan's terminal release points
+(execute-phase.md terminal merge, the already-complete no-op, and the
+operator-stop sweep — NEVER per-phase). The issue claim uses run-plan's OWN
+`$PIPELINE_ID` (same as the plan claim) and `--sprint-id "$PIPELINE_ID"`.
+
+This arm is **DELIBERATELY different from the plan-claim decline arm above**:
+issue-foreign-at-start is **WARN-and-PROCEED**, never abort. #739 removed
+auto-expiry, so a possibly-stale issue claim must not block a deliberately-run
+plan — the plan owns the plan; the issue contention is a softer operator
+signal. On rc=10 we log loudly and CONTINUE, and we NEVER release the
+legitimately-won plan claim (no plan-claim leak).
+
+Parse the bare-integer issue number(s) from `$PLAN_FILE_FOR_READ`'s
+frontmatter (the PR-mode-worktree-aware read authority — NOT bare
+`$PLAN_FILE`). Strip `#` and surrounding quotes to a bare positive integer
+(`claim-issue.sh validate_issue_number` rejects non-numeric input with
+exit 2), aligning with the Close-linked-issue parser's tolerance for
+`issue: 42` and `issue: "#42"`.
+
+```bash
+# Parse issue:N field(s) from the plan frontmatter (the leading `---`
+# delimited YAML block only), normalized to bare positive integers.
+# Tolerates `issue: 42`, `issue: "#42"`, `issue: '#42'`. Multiple
+# `issue:` lines → multiple claims.
+ISSUE_NUMS=()
+while IFS= read -r raw; do
+  # strip surrounding quotes and a leading '#', keep only digits
+  n=$(printf '%s' "$raw" | tr -d '"'\''#[:space:]')
+  case "$n" in
+    ''|*[!0-9]*) continue ;;   # skip non-numeric (defensive)
+  esac
+  [ "$n" -gt 0 ] 2>/dev/null && ISSUE_NUMS+=("$n")
+done < <(awk '
+  NR==1 && $0 != "---" { exit }            # no frontmatter → nothing to do
+  NR==1 { infm=1; next }
+  infm && $0 == "---" { exit }             # end of frontmatter block
+  infm && /^[[:space:]]*issue:[[:space:]]*/ {
+    sub(/^[[:space:]]*issue:[[:space:]]*/, "", $0); print $0
+  }
+' "$PLAN_FILE_FOR_READ" 2>/dev/null)
+
+for N in "${ISSUE_NUMS[@]}"; do
+  set +e
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+    acquire "$N" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  irc=$?
+  set -e
+  case "$irc" in
+    0)  : ;;   # acquired-fresh OR self-re-entry — proceed, issue claim held
+    10) echo "issue #$N is claimed by another pipeline; proceeding with plan execution, issue claim NOT held" >&2 ;;  # WARN-and-PROCEED (D9) — do NOT abort, do NOT release the plan claim
+    11) echo "claim-issue.sh acquire infrastructure failure for issue #$N"; exit 1 ;;   # Failure Protocol
+    2)  echo "claim-issue.sh acquire usage error for issue #$N (un-stripped #N / empty PIPELINE_ID — internal bug)"; exit 2 ;;
+    *)  echo "claim-issue.sh acquire unexpected rc=$irc for issue #$N"; exit 1 ;;
+  esac
+done
 ```
 
 1. **In-progress git operation?**

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -1203,6 +1203,29 @@ bash "$CLAUDE_PROJECT_DIR/.claude/skills/run-plan/scripts/claim-plan.sh" \
   release "$PLAN_SLUG" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
 ```
 
+**Issue-claim release (W3.3 / W3.5 — already-complete no-op).** Release any
+linked `issue-<N>` claim alongside the plan claim on this no-op exit path,
+re-parsing the bare-integer issue number(s) from `$PLAN_FILE_FOR_READ`'s
+frontmatter (same normalization as the acquire fence). Without this, the
+issue claim leaks until `/run-plan stop` or a manual release.
+```bash
+ISSUE_NUMS=()
+while IFS= read -r raw; do
+  n=$(printf '%s' "$raw" | tr -d '"'\''#[:space:]')
+  case "$n" in ''|*[!0-9]*) continue ;; esac
+  [ "$n" -gt 0 ] 2>/dev/null && ISSUE_NUMS+=("$n")
+done < <(awk '
+  NR==1 && $0 != "---" { exit }
+  NR==1 { infm=1; next }
+  infm && $0 == "---" { exit }
+  infm && /^[[:space:]]*issue:[[:space:]]*/ { sub(/^[[:space:]]*issue:[[:space:]]*/, "", $0); print $0 }
+' "$PLAN_FILE_FOR_READ" 2>/dev/null)
+for N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+    release "$N" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+done
+```
+
 Exit cleanly without re-committing. Output "Plan already complete (no-op)."
 
 ### 0b. Final-verify gate
@@ -1606,6 +1629,31 @@ if [ "$rc" -eq 12 ]; then
 elif [ "$rc" -ne 0 ]; then
   echo "Release failed (rc=$rc)" >&2; exit 1
 fi
+```
+
+**Issue-claim release (W3.3 / W3.5 — terminal merge).** Release every
+linked `issue-<N>` claim run-plan held for this plan's lifetime, alongside
+the plan claim above. Re-parse the bare-integer issue number(s) from
+`$PLAN_FILE_FOR_READ`'s frontmatter (same normalization as the acquire fence
+in SKILL.md). Exit 12 (pipeline mismatch) is tolerated per-issue — it means
+another pipeline owns that issue claim (e.g., the WARN-and-PROCEED path
+never won it) and we must not clobber it.
+```bash
+ISSUE_NUMS=()
+while IFS= read -r raw; do
+  n=$(printf '%s' "$raw" | tr -d '"'\''#[:space:]')
+  case "$n" in ''|*[!0-9]*) continue ;; esac
+  [ "$n" -gt 0 ] 2>/dev/null && ISSUE_NUMS+=("$n")
+done < <(awk '
+  NR==1 && $0 != "---" { exit }
+  NR==1 { infm=1; next }
+  infm && $0 == "---" { exit }
+  infm && /^[[:space:]]*issue:[[:space:]]*/ { sub(/^[[:space:]]*issue:[[:space:]]*/, "", $0); print $0 }
+' "$PLAN_FILE_FOR_READ" 2>/dev/null)
+for N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+    release "$N" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+done
 ```
 
 Remove the worktree's `.zskills-tracked` to avoid associating future agents with a dead pipeline:

--- a/.claude/skills/run-plan/scripts/claim-plan.sh
+++ b/.claude/skills/run-plan/scripts/claim-plan.sh
@@ -13,13 +13,25 @@
 #
 # Subcommands:
 #   acquire <slug> --pipeline-id <id>
-#     Exit 0  — acquired (claim.json atomically written).
+#     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
+#               claim — the stored pipeline_id matches --pipeline-id).
 #     Exit 2  — usage error (bad slug, missing flags).
-#     Exit 10 — EEXIST: claim already held by another pipeline.
-#     Exit 11 — non-EEXIST mkdir failure (EACCES/ENOSPC/EDQUOT/EROFS/...).
+#     Exit 10 — foreign-held by another pipeline (OR claim already exists
+#               but claim.json absent/malformed — never steal).
+#     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
+#               (EACCES/ENOSPC/EDQUOT/EROFS/...).
 #   release <slug> --require-pipeline <id>
 #     Exit 0  — released (or already absent — idempotent).
-#     Exit 12 — pipeline-id mismatch (refused; claim left intact).
+#     Exit 2  — usage error.
+#     Exit 12 — release pipeline-id mismatch (claim left intact).
+#
+# Self-re-entry: the EEXIST arm of acquire delegates to
+# create-worktree/scripts/claim-self-reentry.sh (a bash subprocess). A
+# pipeline re-acquiring its OWN claim (same pipeline_id) gets exit 0; a
+# foreign claim, an absent claim.json, or a malformed claim.json gets exit
+# 10 (never steal). This makes a chunked `finish auto` re-fire re-acquiring
+# the same plan return 0 instead of self-colliding on rc=10. No
+# TTL/heartbeat/sweep.
 #   set-phase <slug> --require-pipeline <id> --current-phase "<str>"
 #     Exit 0  — current_phase updated (atomic write).
 #     Exit 2  — claim.json missing for slug.
@@ -81,6 +93,31 @@ _locate_sanitizer() {
     candidates+=(
       "${CLAUDE_PROJECT_DIR}/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
       "${CLAUDE_PROJECT_DIR}/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+    )
+  fi
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -f "$c" ]; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Locate claim-self-reentry.sh — same precedence as _locate_sanitizer,
+# reusing the _CLAIM_SCRIPT_DIR anchor. SOURCED at script load; the
+# resolved PATH is invoked as a bash subprocess from the EEXIST arm of
+# cmd_acquire.
+_locate_self_reentry() {
+  local candidates=(
+    "$_CLAIM_SCRIPT_DIR/../../create-worktree/scripts/claim-self-reentry.sh"
+    "$_CLAIM_SCRIPT_DIR/../../../skills/create-worktree/scripts/claim-self-reentry.sh"
+  )
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    candidates+=(
+      "${CLAUDE_PROJECT_DIR}/.claude/skills/create-worktree/scripts/claim-self-reentry.sh"
+      "${CLAUDE_PROJECT_DIR}/skills/create-worktree/scripts/claim-self-reentry.sh"
     )
   fi
   local c
@@ -188,6 +225,21 @@ cmd_acquire() {
   if [ "$mkdir_status" -ne 0 ]; then
     case "$mkdir_err" in
       *"File exists"*)
+        # Ownership-aware self-re-entry: delegate to the shared helper as a
+        # bash SUBPROCESS (its exit 10/0 contract would terminate a sourcing
+        # caller). Helper exit 0 → self → return 0; exit 10 → foreign →
+        # return 10. If the helper cannot be located, fail conservative
+        # (return 10, never silently steal) with a one-line WARN.
+        local sr_helper
+        if ! sr_helper=$(_locate_self_reentry); then
+          echo "run-plan claim-plan.sh acquire: cannot locate claim-self-reentry.sh (looked in create-worktree bundle); treating existing claim as foreign" >&2
+          return 10
+        fi
+        bash "$sr_helper" "$claim_dir" "$pipeline_id"
+        local sr_rc=$?
+        if [ "$sr_rc" -eq 0 ]; then
+          return 0
+        fi
         return 10
         ;;
       *)

--- a/.claude/skills/run-plan/subcommands/stop-next-status.md
+++ b/.claude/skills/run-plan/subcommands/stop-next-status.md
@@ -113,14 +113,18 @@ If `$ARGUMENTS` contains `stop` (case-insensitive):
    rm -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/in-progress-defers."*
    rm -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/cron-recovery-needed."*
    ```
-3.5. **Release all run-plan plan claims (W2a.4 site 1; Option A walk).**
-   /run-plan stop is a session-wide halt by design (step 2 above already
-   deletes ALL `Run /run-plan` crons, not just this plan's). Iterate
-   `.zskills/claims/plan-*/` and call `claim-plan.sh release <slug>
-   --require-pipeline run-plan.<slug>` for every claim whose
-   `pipeline_id` starts with `run-plan.`. Mismatched pipelines are
-   skipped (exit 12) — those claims belong to other in-flight runs and
-   must not be clobbered.
+3.5. **Release all run-plan plan AND issue claims (W2a.4 site 1 + W3.4;
+   Option A walk).** /run-plan stop is a session-wide halt by design
+   (step 2 above already deletes ALL `Run /run-plan` crons, not just this
+   plan's). Iterate `.zskills/claims/plan-*/` and call `claim-plan.sh
+   release <slug> --require-pipeline run-plan.<slug>` for every claim whose
+   `pipeline_id` starts with `run-plan.`; THEN iterate
+   `.zskills/claims/issue-*/` and call `claim-issue.sh release <N>
+   --require-pipeline run-plan.<slug>` for every issue claim whose
+   `pipeline_id` starts with `run-plan.` (the #803 execution-window
+   claims run-plan now holds). Mismatched pipelines are skipped (exit 12)
+   — those claims belong to other in-flight runs (or to /fix-issues, which
+   owns its own `issue-*/` claims) and must not be clobbered.
    ```bash
    CLAIMS_ROOT="$MAIN_ROOT/.zskills/claims"
    RELEASED=0
@@ -152,6 +156,45 @@ except Exception:
        set +e
        bash "$CLAUDE_PROJECT_DIR/.claude/skills/run-plan/scripts/claim-plan.sh" \
          release "$slug" --require-pipeline "$claim_pid"
+       rc=$?
+       set -e
+       case "$rc" in
+         0) RELEASED=$((RELEASED + 1)) ;;
+         12) SKIPPED=$((SKIPPED + 1)) ;;  # mismatched pipeline (multi-session)
+         *) SKIPPED=$((SKIPPED + 1)) ;;
+       esac
+     done
+     # ISSUE-CLAIM SWEEP (W3.4 / M2/M3): run-plan now ALSO owns issue-<N>
+     # claims (the #803 execution-window protection). The plan-* loop above
+     # is structurally blind to issue-*/ dirs, so this PARALLEL loop releases
+     # every issue-<N> whose pipeline_id starts with `run-plan.` — mirroring
+     # the plan-* guard, mismatch-skip (exit 12), and tally. /fix-issues-owned
+     # issue claims (pipeline_id `fix-issues.*`) are skipped, never clobbered.
+     for d in "$CLAIMS_ROOT"/issue-*; do
+       [ -d "$d" ] || continue
+       n=$(basename "$d" | sed 's/^issue-//')
+       [ -n "$n" ] || continue
+       claim_file="$d/claim.json"
+       if [ ! -f "$claim_file" ]; then
+         continue
+       fi
+       claim_pid=$("${ZSKILLS_PYTHON:-python3}" -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('pipeline_id', ''))
+except Exception:
+    pass
+" "$claim_file" 2>/dev/null)
+       # Only touch run-plan-owned issue claims; never clobber /fix-issues'
+       # (or any other pipeline's) issue claim.
+       case "$claim_pid" in
+         run-plan.*) ;;
+         *) continue ;;
+       esac
+       set +e
+       bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+         release "$n" --require-pipeline "$claim_pid"
        rc=$?
        set -e
        case "$rc" in

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -364,3 +364,7 @@ to main. Use PR mode or feature branches.
 ## Tracking Enforcement
 
 Tracking file enforcement is active when `.zskills/tracking/` exists and the session is associated with a pipeline (via `.zskills-tracked` file or transcript). Skills create tracking files during pipeline execution; hooks check them before allowing `git commit`, `git cherry-pick`, and `git push`. Pipeline scoping (suffix matching on pipeline ID) ensures one pipeline's markers don't block another. The orchestrator writes `.zskills-tracked` (single-line pipeline ID) in both the worktree and main repo roots before dispatching agents, and removes it after pipeline completion. The `.claude/skills/update-zskills/scripts/clear-tracking.sh` script lets the user manually clear stale tracking state -- agents are blocked from running it directly.
+
+## Claiming work items
+
+Claim any tracked work-item (issue or plan) before working it; the claim is held for the work's full lifetime INCLUDING idle gaps, and released only on resolve/abandon, NEVER per-step. The discipline applies recursively: a pipeline holding a plan claim that works the plan's issue ALSO holds the issue claim. Foreign-held (acquire exit 10) -> decline (one-shot consumers) or WARN-and-proceed (a plan whose linked issue is foreign-held still runs -- the plan owns the plan); self-re-entry (exit 0) -> proceed; there is NO TTL -- release is always explicit. Issues are claimed via `claim-issue.sh`, plans via `claim-plan.sh`; both are ownership-aware (they recognize the caller's own claim and return success on re-acquire).

--- a/docs/plans/claim-work-item.md
+++ b/docs/plans/claim-work-item.md
@@ -384,7 +384,7 @@ not "around `gh issue close`."
 |-------|--------|--------|-------|
 | Phase 1 — Shared self-re-entry helper + wire into both twins + tests | ✅ | `49e705a` | helper + both EEXIST arms wired; +15 test cases; 6485/6485 green |
 | Phase 2 — Wire /do, /quickfix, /investigate onto claim-issue.sh | ✅ | `bffe378` | 3 consumers wired (C1/M1 placement, C2 inline-releases); +17 conformance sentinels; 6502/6502 green |
-| Phase 3 — run-plan issue-claim (execution-window protection) + operator-stop sweep + optional :597 cleanup | ⬚ | | |
+| Phase 3 — run-plan issue-claim (execution-window protection) + operator-stop sweep + optional :597 cleanup | ✅ | `7751be6` | issue acquire (D9 WARN-and-PROCEED) + 3 terminal releases + operator-stop `issue-*` arm; +3 conformance assertions; 6505/6505 green |
 | Phase 4 — CLAUDE_TEMPLATE recursive claim discipline + docs | ⬚ | | |
 
 ---

--- a/docs/plans/claim-work-item.md
+++ b/docs/plans/claim-work-item.md
@@ -383,7 +383,7 @@ not "around `gh issue close`."
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | Phase 1 — Shared self-re-entry helper + wire into both twins + tests | ✅ | `49e705a` | helper + both EEXIST arms wired; +15 test cases; 6485/6485 green |
-| Phase 2 — Wire /do, /quickfix, /investigate onto claim-issue.sh | ⬚ | | |
+| Phase 2 — Wire /do, /quickfix, /investigate onto claim-issue.sh | ✅ | `bffe378` | 3 consumers wired (C1/M1 placement, C2 inline-releases); +17 conformance sentinels; 6502/6502 green |
 | Phase 3 — run-plan issue-claim (execution-window protection) + operator-stop sweep + optional :597 cleanup | ⬚ | | |
 | Phase 4 — CLAUDE_TEMPLATE recursive claim discipline + docs | ⬚ | | |
 

--- a/docs/plans/claim-work-item.md
+++ b/docs/plans/claim-work-item.md
@@ -8,8 +8,16 @@ status: active
 # Plan: Ownership-aware work-item claims — self-re-entry in the twin claim scripts
 
 > **Landing mode: PR** — `.claude/zskills-config.json` has `main_protected: true`,
-> so every phase works in a named worktree on a feature branch and lands via
-> `/land-pr` (one PR per phase). No commit/cherry-pick to main.
+> so the plan works in a named worktree on a feature branch and lands via
+> `/land-pr`. No commit/cherry-pick to main.
+>
+> **Execution note (2026-05-29):** run via `/run-plan … finish auto`, which
+> accumulates all phases on one branch (`feat/claim-work-item`) and opens a
+> SINGLE PR for the whole plan — deliberately superseding the original
+> per-phase-PR intent (the phases form one coherent #803 feature in a
+> single-maintainer, agent-facing repo; one bundled PR is lower-overhead and
+> all phases are verified+tested before merge). The per-phase "Lands its own
+> PR" lines below are historical design notes, not the executed landing shape.
 
 ## Overview
 
@@ -374,7 +382,7 @@ not "around `gh issue close`."
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| Phase 1 — Shared self-re-entry helper + wire into both twins + tests | ⬚ | | |
+| Phase 1 — Shared self-re-entry helper + wire into both twins + tests | ✅ | `49e705a` | helper + both EEXIST arms wired; +15 test cases; 6485/6485 green |
 | Phase 2 — Wire /do, /quickfix, /investigate onto claim-issue.sh | ⬚ | | |
 | Phase 3 — run-plan issue-claim (execution-window protection) + operator-stop sweep + optional :597 cleanup | ⬚ | | |
 | Phase 4 — CLAUDE_TEMPLATE recursive claim discipline + docs | ⬚ | | |

--- a/docs/plans/claim-work-item.md
+++ b/docs/plans/claim-work-item.md
@@ -2,7 +2,8 @@
 issue: 803
 title: Ownership-aware work-item claims (self-re-entry in the two twin scripts)
 created: 2026-05-29
-status: active
+status: "complete"
+completed: "2026-05-30T00:49:15Z"
 ---
 
 # Plan: Ownership-aware work-item claims — self-re-entry in the twin claim scripts
@@ -385,7 +386,7 @@ not "around `gh issue close`."
 | Phase 1 — Shared self-re-entry helper + wire into both twins + tests | ✅ | `49e705a` | helper + both EEXIST arms wired; +15 test cases; 6485/6485 green |
 | Phase 2 — Wire /do, /quickfix, /investigate onto claim-issue.sh | ✅ | `bffe378` | 3 consumers wired (C1/M1 placement, C2 inline-releases); +17 conformance sentinels; 6502/6502 green |
 | Phase 3 — run-plan issue-claim (execution-window protection) + operator-stop sweep + optional :597 cleanup | ✅ | `7751be6` | issue acquire (D9 WARN-and-PROCEED) + 3 terminal releases + operator-stop `issue-*` arm; +3 conformance assertions; 6505/6505 green |
-| Phase 4 — CLAUDE_TEMPLATE recursive claim discipline + docs | ⬚ | | |
+| Phase 4 — CLAUDE_TEMPLATE recursive claim discipline + docs | ✅ | `4f10cd7` | recursive claim rule in CLAUDE_TEMPLATE + re-rendered managed.md + self-re-entry contract doc; 6505/6505 green |
 
 ---
 

--- a/docs/reports/plan-claim-work-item.md
+++ b/docs/reports/plan-claim-work-item.md
@@ -1,5 +1,29 @@
 # Plan Report — Ownership-aware work-item claims (#803)
 
+## Phase — 3 run-plan issue-claim + operator-stop sweep + :597 cleanup
+
+**Plan:** docs/plans/claim-work-item.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-claim-work-item (branch `feat/claim-work-item`)
+**Commit:** `7751be6`
+
+### Work Items
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| W3.1 | Parse `issue:` from frontmatter (bare int, multi) | Done | reads `$PLAN_FILE_FOR_READ`; leading-`---` block only; strips `#`/quotes |
+| W3.2 | Acquire `issue-<N>` in acquire fence | Done | **D9 rc=10 = WARN-and-PROCEED** (continues, no exit, no plan-claim leak); rc=11→Failure, rc=2→STOP |
+| W3.3 | Release at 3 terminal sites only | Done | terminal-merge + no-op + operator-stop; never per-phase; not near `gh issue close` |
+| W3.4 | operator-stop `issue-*` arm | Done | parallel loop, gates `run-plan.*`, mismatch-skip (12), folds into tally |
+| W3.5 | Multi-issue loop | Done | acquire + both releases + operator-stop loop `ISSUE_NUMS[]` |
+| W3.6 | Optional `:597` cleanup | Done (minimal) | plan-claim decline arm INTACT; only clarifying prose added |
+| W3.7 | Version bump + mirror run-plan | Done | `2026.05.29+cf90e3`; mirror byte-equal |
+| W3.8 | New positive conformance assertions | Done | I1/I2/I3 added; existing A11 untouched; `test-plan-claim-conformance.sh` 11 passed |
+
+### Verification
+- Full suite: **`Overall: 6505/6505 passed, 0 failed`** (baseline 6502 + 3). Separate verifier; Layer 3 passed; known flake did not fire.
+- D9 correctness confirmed: WARN-and-PROCEED arm is NOT a copy of the plan-claim decline arm and does not leak the plan claim; plan-claim decline arm (`rc=10 → exit 0`) intact.
+- No conformance assertion weakened. No drift.
+
 ## Phase — 2 Wire /do, /quickfix, /investigate onto claim-issue.sh
 
 **Plan:** docs/plans/claim-work-item.md

--- a/docs/reports/plan-claim-work-item.md
+++ b/docs/reports/plan-claim-work-item.md
@@ -1,5 +1,26 @@
 # Plan Report — Ownership-aware work-item claims (#803)
 
+> **Plan COMPLETE** (all 4 phases) — bundled PR on `feat/claim-work-item`, `6505/6505` tests green.
+
+## Phase — 4 CLAUDE_TEMPLATE recursive claim discipline + docs
+
+**Plan:** docs/plans/claim-work-item.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-claim-work-item (branch `feat/claim-work-item`)
+**Commit:** `4f10cd7`
+
+### Work Items
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| W4.1 | Recursive claim rule in `CLAUDE_TEMPLATE.md` | Done | `## Claiming work items`; decline-vs-WARN distinction; no `{{...}}` token |
+| W4.2 | Re-render `managed.md` | Done | via `render-managed-rules.py` (true render, independently reproduced byte-identical) |
+| W4.3 | `test-managed-md-up-to-date.sh` passes | Done | sync gate green |
+| W4.4 | Self-re-entry contract doc | Done | `### Self-re-entry contract` in run-plan SKILL.md; helper path + exit-code contract |
+| W4.5 | Version bump + mirror | Done | run-plan `2026.05.29+8f131b` (W4.4 touched its bundle); mirror byte-equal; CLAUDE_TEMPLATE not bumped (not a skill) |
+
+### Verification
+- Full suite: **`Overall: 6505/6505 passed, 0 failed`** (baseline 6505, docs-only). Separate verifier; Layer 3 passed; known flake did not fire. No drift.
+
 ## Phase — 3 run-plan issue-claim + operator-stop sweep + :597 cleanup
 
 **Plan:** docs/plans/claim-work-item.md

--- a/docs/reports/plan-claim-work-item.md
+++ b/docs/reports/plan-claim-work-item.md
@@ -1,5 +1,29 @@
 # Plan Report — Ownership-aware work-item claims (#803)
 
+## Phase — 2 Wire /do, /quickfix, /investigate onto claim-issue.sh
+
+**Plan:** docs/plans/claim-work-item.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-claim-work-item (branch `feat/claim-work-item`)
+**Commit:** `bffe378`
+
+### Work Items
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| W2.1 | /investigate acquire/release | Done | synth `investigate.issue-$N`; acquire before reproduction; success-path + per-STOP releases |
+| W2.2 | /do worktree+direct | Done | issue parsed via `--force`; acquire after `do.${TASK_SLUG}`+worktree; release in **Phase 5 Report** (not Phase 4 Land); direct synthesizes `do.<issue>` |
+| W2.3 | /do PR mode | Done | acquire at A5.5; finalize release; **C2 inline-releases at all 3 pre-finalize exits** (exit 5/2/1); no HOLD-on-created |
+| W2.4 | /quickfix | Done | reuse `quickfix.$SLUG`; acquire at Tracking-setup before branch; release in Phase 7 finalize + fail sites |
+| W2.5 | Version bump + mirror (do/quickfix/investigate) | Done | `2026.05.29` ×3; hashes match; mirrors byte-equal |
+| W2.6 | Conformance sentinels | Done | +17 positive assertions; FAIL if wiring dropped; no existing assertion weakened |
+
+### Verification
+- Full suite: **`Overall: 6502/6502 passed, 0 failed`** (baseline 6485 + 17 sentinels). Verified by separate agent; Layer 3 validation passed; known monitor-collect flake did not fire.
+- C1/M1 (no acquire before non-empty PIPELINE_ID + bare-integer issue) holds at all 5 acquire sites; foreign→STOP (not next-candidate); no jq; no forbidden literals.
+
+### Advisory note (plan-text drift, non-numeric — not auto-corrected)
+The plan's W2.1 calls `/investigate`'s reproduction-skip (≈:74-88) an "abandon point" needing a release. In reality that gate **proceeds** with lower confidence (not an abandon); the genuine couldn't-reproduce abandon is covered by the Report-section catch-all release. Release coverage is therefore complete. Minor plan-accuracy note; no behavioral gap.
+
 ## Phase — 1 Shared self-re-entry helper + wire into both twins + tests
 
 **Plan:** docs/plans/claim-work-item.md

--- a/docs/reports/plan-claim-work-item.md
+++ b/docs/reports/plan-claim-work-item.md
@@ -1,0 +1,30 @@
+# Plan Report — Ownership-aware work-item claims (#803)
+
+## Phase — 1 Shared self-re-entry helper + wire into both twins + tests
+
+**Plan:** docs/plans/claim-work-item.md
+**Status:** Completed (verified)
+**Worktree:** /tmp/zskills-pr-claim-work-item (branch `feat/claim-work-item`)
+**Commit:** `49e705a`
+
+### Work Items
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| W1.1 | Helper `claim-self-reentry.sh` | Done | bash subprocess; absent/malformed claim.json → 10 (never steal); release-style try/except reader; no jq |
+| W1.2 | `_locate_self_reentry()` in both twins | Done | mirrors `_locate_sanitizer()` precedence verbatim |
+| W1.3 | Wire `claim-issue.sh` EEXIST arm | Done | helper subprocess; not-locatable → WARN + return 10 |
+| W1.4 | Wire `claim-plan.sh` EEXIST arm | Done | identical shape |
+| W1.5 | Both headers: D3 exit-code contract | Done | acquire 0/2/10/11, release 0/2/12 |
+| W1.6 | `tests/test-claim-self-reentry.sh` | Done | 15 cases: helper unit (incl. truncated→10), both-kind integration, worktree-cwd MAIN_ROOT proof |
+| W1.7 | Version bump + mirror (create-worktree, fix-issues, run-plan) | Done | `2026.05.29` ×3; hashes match; mirrors byte-equal |
+| W1.8 | No script-ownership / STALE_LIST churn | Done | `grep claim script-ownership.md` = 0 |
+
+### Verification
+- Full suite: **`Overall: 6485/6485 passed, 0 failed`** (baseline 6470 + 15 new cases).
+- Verifier (separate agent) confirmed each W-item; Layer 3 response-validation passed.
+- Known pre-existing flake (`test_zskills_monitor_collect.sh` worktree-portable case, #150/#759) reads the live claim during dogfooding; did NOT fire on the committed run; green standalone (71/71) and on a clean full-suite re-run.
+- No plan-text drift detected.
+- Constraints honored: no jq; MAIN_ROOT via caller's git-common-dir (never `$PWD`); no TTL/heartbeat/sweep; no caller-interface/schema/script-name changes; no conformance assertion weakened.
+
+### Landing
+Bundled-PR mode (`finish auto`): commits accumulate on `feat/claim-work-item`; PR opens/merges once after the final phase.

--- a/skills/create-worktree/SKILL.md
+++ b/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.05.20+606912"
+  version: "2026.05.29+8159fb"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/skills/create-worktree/scripts/claim-self-reentry.sh
+++ b/skills/create-worktree/scripts/claim-self-reentry.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# claim-self-reentry.sh — Ownership-aware self-re-entry decision for the
+# twin claim primitives (claim-issue.sh / claim-plan.sh).
+#
+# Invoked ONLY on the already-exists (EEXIST) branch of cmd_acquire in
+# either twin, as a bash SUBPROCESS — NEVER sourced for the decision (the
+# exit 10 / exit 0 contract below would terminate a sourcing caller).
+#
+# Usage:
+#   bash claim-self-reentry.sh <claim_dir> <caller_pipeline_id>
+#
+# Given an ABSOLUTE <claim_dir> (the caller has already resolved MAIN_ROOT
+# via `git rev-parse --git-common-dir` parent — this helper does NOT
+# re-resolve MAIN_ROOT, it operates on the path it is handed) and the
+# caller's pipeline_id, decide whether the existing claim is the caller's
+# OWN (self-re-entry → proceed) or another pipeline's (foreign → decline).
+#
+# Exit-code contract:
+#   0  — self-re-entry: the existing claim's stored pipeline_id matches the
+#        caller's; the caller already owns this claim and may proceed.
+#   10 — foreign / never-steal: either claim.json is ABSENT (an in-flight
+#        acquire window or a crashed-mkdir stub — not ours to claim), the
+#        stored pipeline_id differs from the caller's, OR claim.json is
+#        truncated/malformed (read yields empty → "" != caller → foreign).
+#        Returned deterministically; NEVER a python traceback or non-10
+#        exit on a malformed claim.json.
+#   2  — usage error (wrong number of args).
+#
+# Logic (D3): if <claim_dir>/claim.json is absent → 10 (never steal). Else
+# read the stored pipeline_id via Python stdlib json (NO jq) with a
+# try/except → print('') reader captured into a shell variable (mirrors the
+# release-style readers at claim-issue.sh / claim-plan.sh — NOT the bare
+# json.load() in set-phase which raises on truncation). A truncated /
+# half-written / malformed claim.json therefore yields an empty captured
+# string → "" != caller → 10. Exit 0 iff the captured pipeline_id equals
+# the caller's, else 10.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Python interpreter resolution. Honours the project's documented
+# ZSKILLS_PYTHON override (see CLAUDE.md "Python is required" section).
+# ---------------------------------------------------------------------------
+_CLAIM_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$_CLAIM_PYTHON" ]; then
+  echo "claim-self-reentry.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
+  exit 127
+fi
+
+claim_dir="${1:-}"
+caller_pipeline_id="${2:-}"
+
+if [ -z "$claim_dir" ] || [ "$#" -ne 2 ]; then
+  echo "Usage: claim-self-reentry.sh <claim_dir> <caller_pipeline_id>" >&2
+  exit 2
+fi
+
+claim_file="${claim_dir}/claim.json"
+
+# claim.json absent → never steal (in-flight acquire window or crashed mkdir
+# stub). Foreign.
+if [ ! -f "$claim_file" ]; then
+  exit 10
+fi
+
+# Read the stored pipeline_id with the SAFE release-style reader: a
+# try/except that prints '' on any failure (missing key, truncated JSON,
+# malformed JSON). A malformed claim.json therefore yields an empty string,
+# never a traceback — so "" != caller → foreign (10), deterministically.
+stored=$("$_CLAIM_PYTHON" -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('pipeline_id', ''))
+except Exception:
+    print('')
+" "$claim_file")
+
+if [ "$stored" = "$caller_pipeline_id" ] && [ -n "$caller_pipeline_id" ]; then
+  exit 0
+fi
+exit 10

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.28+091ad6"
+  version: "2026.05.29+f085ff"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -227,6 +227,19 @@ fi
 AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
+fi
+# Issue-number parse (claim-work-item Phase 2 / W2.2). /do is normally
+# REDIRECTed to /fix-issues when the description references an issue
+# (Phase 0a triage); the number is only reachable here when --force
+# overrides that redirect. Extract the FIRST bare positive integer from a
+# `#N` / `closes #N` / `fix #N` reference into ISSUE_NUM so the mode files
+# can claim the issue via claim-issue.sh. When no issue number is present
+# (the common /do case) ISSUE_NUM stays empty and the mode files claim
+# nothing. The number is stripped to a bare integer (claim-issue.sh
+# rejects non-numeric input with exit 2).
+ISSUE_NUM=""
+if [[ "$ARGUMENTS" =~ \#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
 fi
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
@@ -724,6 +737,13 @@ procedure end-to-end**. Do not proceed until you have read the file.
 | `worktree`     | B    | [modes/worktree.md](modes/worktree.md) |
 | `direct`       | C    | [modes/direct.md](modes/direct.md) |
 
+**`$ISSUE_NUM` propagates into the mode files** (set in the Pre-flight
+pre-parse). When non-empty, the mode file claims the issue via
+`claim-issue.sh` AFTER it constructs its `PIPELINE_ID` (the C1/M1 rule —
+never acquire before a non-empty PIPELINE_ID exists). The acquire is NEVER
+placed here in SKILL.md before mode dispatch: PIPELINE_ID is empty at this
+point, so `--pipeline-id ""` would fail usage-error exit 2.
+
 ## Phase 3 — Verify
 
 Verification intensity matches the change type (from Phase 1):
@@ -858,6 +878,25 @@ Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invoca
 
 ## Phase 5 — Report
 
+**Release the issue claim (worktree/direct modes).** Phase 5 is the
+universal terminal reached on BOTH the `auto` and non-`auto` exits of
+worktree and direct modes — so the issue claim (acquired by the mode file
+when `$ISSUE_NUM` was non-empty) is released HERE, not in Phase 4 Land
+(which is `AUTO_FLAG=1`-gated and would leak the claim on the dominant
+non-auto path). PR mode (Path A) handles its own release inside
+`modes/pr.md`'s finalize block and exits before reaching this section.
+Skip when no issue claim was acquired (the common /do case — `$ISSUE_NUM`
+empty):
+
+```bash
+# $ISSUE_NUM (Pre-flight pre-parse) and $PIPELINE_ID (set in the mode file:
+# do.${TASK_SLUG}) survive in the persistent shell. The release is
+# ownership-safe via --require-pipeline.
+if [ -n "${ISSUE_NUM:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+fi
+```
+
 Brief inline output. No persistent report file.
 
 **On main (no worktree, no auto):**
@@ -924,6 +963,14 @@ Status: pr-ready | pr-ci-failing | landed
   `.landed` with `status: conflict` and exit with an error message.
 - **If stuck on anything:** report the state and ask the user for
   guidance. Do not retry the same approach in a loop.
+- **Release the issue claim on every abandon path (worktree/direct modes).**
+  When `$ISSUE_NUM` was non-empty and the mode file acquired a
+  `claim-issue.sh` claim, any error exit above (test failure, content
+  issue, cherry-pick conflict, push failure, task-too-big) MUST release it
+  before stopping so the next pipeline can pick the issue up:
+  `bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"`
+  (only if an issue claim was acquired — skip when `$ISSUE_NUM` is empty).
+  PR mode's abandon-path releases live inside `modes/pr.md`.
 
 ## Key Rules
 

--- a/skills/do/modes/direct.md
+++ b/skills/do/modes/direct.md
@@ -7,6 +7,33 @@ Selected when the user passes `direct` explicitly, when `execution.landing`
 in `.claude/zskills-config.json` is `"direct"`, or as the fallback when
 no config is present. Work directly on main.
 
+**Claim the issue (when `$ISSUE_NUM` is non-empty).** Direct mode
+constructs no `TASK_SLUG`/`PIPELINE_ID` of its own, so synthesize a minimal
+`PIPELINE_ID="do.<bare-issue>"` (routed through the shared sanitizer)
+BEFORE acquiring the `claim-issue.sh` claim. This stops a concurrent
+`/fix-issues` cron from double-working the same issue. `$ISSUE_NUM` is
+propagated from `/do`'s Pre-flight pre-parse (set only when the description
+referenced an issue and `--force` overrode the `/fix-issues` redirect).
+Skip entirely when `$ISSUE_NUM` is empty (the common /do direct case —
+direct mode is rarely issue-driven). The claim is released in `/do` Phase 5
+Report.
+
+```bash
+if [ -n "${ISSUE_NUM:-}" ]; then
+  PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "do.$ISSUE_NUM")
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+```
+
 **Follow existing conventions in all paths:**
 - Example models → `/model-design` skill guidelines
 - Newsletter entries → existing NEWSLETTER.md format

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -86,6 +86,37 @@ fi
 ```
 Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` as shell output in the main session — the `.zskills-tracked` file in the worktree is the single source of truth.
 
+**Step A5.5 — Claim the issue (when `$ISSUE_NUM` is non-empty).** Now that
+`PIPELINE_ID="do.${TASK_SLUG}"` is set (A4) and the worktree exists (A5),
+acquire the `claim-issue.sh` claim BEFORE dispatching the implementation
+agent (A6). This stops a concurrent `/fix-issues` cron from double-working
+the same issue. `$ISSUE_NUM` is propagated from `/do`'s Pre-flight
+pre-parse (set only when the description referenced an issue and `--force`
+overrode the `/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is
+empty (the common /do pr case). The A1 slug guards and A5's `exit "$RC"`
+are PRE-acquire, so they need no release. The claim is released in the
+explicit-finalize block at the end of the caller loop (Step A8), and
+inline before every post-acquire-pre-finalize early exit.
+
+```bash
+if [ -n "${ISSUE_NUM:-}" ]; then
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+```
+
+Do NOT copy `/fix-issues`'s HOLD-on-`created` arm: `/do pr` is one-shot
+(no later sprint fire re-runs `/land-pr` to release), so a HOLD would leak
+the claim forever.
+
 **Step A6 — Dispatch implementation agent (wait for completion):**
 
 **Dispatch shape.** Use the `Agent` tool with `subagent_type: "implementer"`.
@@ -150,10 +181,19 @@ cd "$WORKTREE_PATH"
 # $TASK_DESCRIPTION.
 if [ -z "${PR_TITLE:-}" ]; then
   echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
+  # C2 inline-release: this exit is AFTER the Step A5.5 acquire and BEFORE
+  # the explicit-finalize block, so release the issue claim (only if one
+  # was acquired) before bailing or it leaks.
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 5
 fi
 if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 60 ] || [[ "$PR_TITLE" != do:\ * ]]; then
   echo "ERROR: PR_TITLE must be a single line ≤60 chars starting with 'do: ' (got '$PR_TITLE')." >&2
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 2
 fi
 
@@ -271,6 +311,11 @@ while :; do
     # explicit-finalize block at end-of-fence). Variables in scope (same fence).
     rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
     sed -i "s/^status: started$/status: failed/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
+    # C2 inline-release: post-acquire, pre-finalize early exit — release
+    # the issue claim (only if one was acquired) or it leaks.
+    if [ -n "${ISSUE_NUM:-}" ]; then
+      bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    fi
     exit 1
   fi
 
@@ -436,6 +481,16 @@ case "$LAND_OUTCOME" in
 esac
 sed -i "s/^status: started$/status: $FINAL/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
 rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
+
+# Release the issue claim regardless of created vs merged vs failed
+# (release-on-resolution — the /do pr invocation is terminating either way,
+# and /do is one-shot so there is no later fire to re-release). Only if an
+# issue claim was acquired in Step A5.5. $PIPELINE_ID = do.$TASK_SLUG is
+# re-resolved at the tracking-setup fence-top above and survives in this
+# fence.
+if [ -n "${ISSUE_NUM:-}" ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+fi
 ```
 
 **Note on the `.landed` schema:** `/land-pr` writes the canonical schema

--- a/skills/do/modes/worktree.md
+++ b/skills/do/modes/worktree.md
@@ -56,5 +56,30 @@ if [ "${rc:-0}" = "2" ]; then
 fi
 ```
 
+**Claim the issue (when `$ISSUE_NUM` is non-empty).** After the worktree
+exists and `PIPELINE_ID="do.${TASK_SLUG}"` is set, acquire the
+`claim-issue.sh` claim BEFORE dispatching the implementation agent — this
+stops a concurrent `/fix-issues` cron from double-working the same issue.
+`$ISSUE_NUM` is propagated from `/do`'s Pre-flight pre-parse (set only when
+the description referenced an issue and `--force` overrode the
+`/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is empty (the
+common /do case). The claim is released in `/do` Phase 5 Report (the
+universal terminal for both auto and non-auto exits).
+
+```bash
+if [ -n "${ISSUE_NUM:-}" ]; then
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+```
+
 Do the work inside the worktree. The verification agent commits after tests pass (one logical unit per commit).
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.29+c47a59"
+  version: "2026.05.29+abab96"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/scripts/claim-issue.sh
+++ b/skills/fix-issues/scripts/claim-issue.sh
@@ -9,12 +9,24 @@
 #
 # Subcommands:
 #   acquire <N> --pipeline-id <id> --sprint-id <id>
-#     Exit 0  — acquired (claim.json atomically written).
-#     Exit 10 — EEXIST: claim already held by another pipeline.
-#     Exit 11 — non-EEXIST mkdir failure (EACCES/ENOSPC/EDQUOT/EROFS/...).
+#     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
+#               claim — the stored pipeline_id matches --pipeline-id).
+#     Exit 2  — usage error.
+#     Exit 10 — foreign-held by another pipeline (OR claim already exists
+#               but claim.json absent/malformed — never steal).
+#     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
+#               (EACCES/ENOSPC/EDQUOT/EROFS/...).
 #   release <N> [--require-pipeline <id>]
 #     Exit 0  — released (or already absent — idempotent).
-#     Exit 12 — pipeline-id mismatch (refused; claim left intact).
+#     Exit 2  — usage error.
+#     Exit 12 — release pipeline-id mismatch (claim left intact).
+#
+# Self-re-entry: the EEXIST arm of acquire delegates to
+# create-worktree/scripts/claim-self-reentry.sh (a bash subprocess). A
+# pipeline re-acquiring its OWN claim (same pipeline_id) gets exit 0; a
+# foreign claim, an absent claim.json, or a malformed claim.json gets exit
+# 10 (never steal). No TTL/heartbeat/sweep — is-stale stays the 30s
+# crash-window check only.
 #   is-stale <N>
 #     Race-tolerance check ONLY: stale iff the claim dir exists without
 #     claim.json and is older than 30s (mkdir-succeeded-then-crashed).
@@ -51,6 +63,38 @@ if [ -z "$_CLAIM_PYTHON" ]; then
   echo "fix-issues claim-issue.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
   exit 127
 fi
+
+# ---------------------------------------------------------------------------
+# Resolve script-bundle directory for sibling lookups
+# (claim-self-reentry.sh lives in the create-worktree bundle).
+# ---------------------------------------------------------------------------
+_CLAIM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Locate claim-self-reentry.sh — prefer sibling create-worktree skill
+# layout, fall back to repo source tree, then to .claude/skills/ mirror.
+# Mirrors claim-plan.sh's _locate_sanitizer() precedence verbatim. SOURCED
+# at script load; the resolved PATH is invoked as a bash subprocess from
+# the EEXIST arm of cmd_acquire.
+_locate_self_reentry() {
+  local candidates=(
+    "$_CLAIM_SCRIPT_DIR/../../create-worktree/scripts/claim-self-reentry.sh"
+    "$_CLAIM_SCRIPT_DIR/../../../skills/create-worktree/scripts/claim-self-reentry.sh"
+  )
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    candidates+=(
+      "${CLAUDE_PROJECT_DIR}/.claude/skills/create-worktree/scripts/claim-self-reentry.sh"
+      "${CLAUDE_PROJECT_DIR}/skills/create-worktree/scripts/claim-self-reentry.sh"
+    )
+  fi
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -f "$c" ]; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
 
 # ---------------------------------------------------------------------------
 # MAIN_ROOT resolution (DA4.1 — round 4b).
@@ -137,9 +181,25 @@ cmd_acquire() {
   mkdir_err=$(mkdir "$claim_dir" 2>&1)
   local mkdir_status=$?
   if [ "$mkdir_status" -ne 0 ]; then
-    # Map "File exists" -> 10; anything else -> 11.
+    # Map "File exists" -> self-re-entry decision (0 self / 10 foreign);
+    # anything else -> 11.
     case "$mkdir_err" in
       *"File exists"*)
+        # Ownership-aware self-re-entry: delegate to the shared helper as a
+        # bash SUBPROCESS (its exit 10/0 contract would terminate a sourcing
+        # caller). Helper exit 0 → self → return 0; exit 10 → foreign →
+        # return 10. If the helper cannot be located, fail conservative
+        # (return 10, never silently steal) with a one-line WARN.
+        local sr_helper
+        if ! sr_helper=$(_locate_self_reentry); then
+          echo "fix-issues claim-issue.sh acquire: cannot locate claim-self-reentry.sh (looked in create-worktree bundle); treating existing claim as foreign" >&2
+          return 10
+        fi
+        bash "$sr_helper" "$claim_dir" "$pipeline_id"
+        local sr_rc=$?
+        if [ "$sr_rc" -eq 0 ]; then
+          return 0
+        fi
         return 10
         ;;
       *)

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   reproduce, trace, state root cause, fix, verify. The agent must PROVE
   root-cause understanding before writing a fix.
 metadata:
-  version: "2026.05.28+93a842"
+  version: "2026.05.29+c324f6"
 ---
 
 # /investigate \<description or #issue> — Root-Cause Debugging
@@ -56,6 +56,39 @@ Examples:
    interpreted as "clear canvas" instead of "reset mappings to defaults"
    because only the title was read).
 
+   **Claim the issue (when the input IS an issue number).** `/investigate`
+   has no pipeline id of its own, so synthesize one and acquire the
+   `claim-issue.sh` claim BEFORE any reproduction work — this prevents a
+   concurrent `/fix-issues` cron (or another `/investigate`) from
+   double-working the same issue. **Skip this entirely for a bare-text
+   description** (no issue number → nothing to claim). Extract the bare
+   positive integer (strip a leading `#` and any quotes) into `$N` and
+   synthesize the pipeline id through the shared sanitizer:
+
+   ```bash
+   # Only when the input is an issue reference. $N = bare positive integer
+   # (claim-issue.sh rejects non-numeric / decorated input with exit 2).
+   N="${N#\#}"          # strip a leading '#'
+   N="${N//\"/}"        # strip any quotes
+   MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+   PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "investigate.issue-$N")
+   CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+   bash "$CLAIM_HELPER" acquire "$N" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+   ACQ_RC=$?
+   case "$ACQ_RC" in
+     0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+     10) echo "issue #$N is being worked by another pipeline; declining." >&2 ;;
+     11) echo "claim-issue.sh: filesystem error acquiring issue #$N; stopping." >&2 ;;
+     2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric N=$N) — internal bug; stopping." >&2 ;;
+   esac
+   ```
+
+   On `ACQ_RC` 10 / 11 / 2 → **STOP this invocation** (print the message
+   above and do not proceed — this is a one-shot skill, not a sprint loop).
+   On `ACQ_RC=0` continue. The claim is released on every terminal path
+   below (success-path bash block at the Report, and the explicit per-STOP
+   release prose at each abandon point).
+
 2. **Reproduce the bug** based on its type:
 
    | Bug type | How to reproduce |
@@ -85,6 +118,8 @@ Examples:
    reproducing), "reproduction would take too long" (then you're guessing).
 
    If you skip, flag the investigation as lower confidence in the report.
+   (This is not an abandon — you proceed. The claim is held until the
+   terminal Report releases it.)
 
 ## Phase 2 — Trace
 
@@ -189,6 +224,9 @@ included in the final report.
    - Why each attempt failed
    - What you think is actually happening
    Let the user decide the next step. Do not guess a third time.
+   **Before stopping, release the issue claim** (only if you acquired one
+   in Phase 1 — i.e. the input was an issue number):
+   `bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"`.
 
 ## Phase 5 — Verify
 
@@ -212,6 +250,12 @@ included in the final report.
    fi
    if [ -z "$FULL_TEST_CMD" ]; then
      echo "ERROR: testing.full_cmd not configured. Run /update-zskills." >&2
+     # Release the issue claim before bailing (only if one was acquired
+     # in Phase 1 — i.e. the input was an issue number; $N / $PIPELINE_ID
+     # are set there and survive in the persistent shell).
+     if [ -n "${N:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
+       bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"
+     fi
      exit 1
    fi
    TEST_OUT="/tmp/zskills-tests/$(basename "$(pwd)")"
@@ -233,6 +277,21 @@ included in the final report.
 ## Report
 
 Output an inline report. No persistent report file.
+
+**Release the issue claim (success path).** When the input was an issue
+number (Phase 1 acquired a claim), release it now that the investigation
+has reached its terminal Report — the work is resolved, the claim should
+not persist. Skip when the input was a bare description (no claim was
+acquired):
+
+```bash
+# $N and $PIPELINE_ID were set in Phase 1 step 1 (issue-number path only)
+# and survive in the persistent shell. The release is ownership-safe
+# (--require-pipeline refuses to release a claim another pipeline owns).
+if [ -n "${N:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"
+fi
+```
 
 ```
 ## Investigation: <title>
@@ -260,6 +319,13 @@ Output an inline report. No persistent report file.
 
 If the investigation was abandoned (couldn't reproduce, couldn't find root
 cause, fix failed twice), report what was learned and what remains unknown.
+**Before stopping on any abandon path, release the issue claim** (only if
+the input was an issue number and Phase 1 acquired a claim):
+`bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"`.
+This covers the couldn't-reproduce STOP (Phase 1), the couldn't-find-root
+STOP (Phase 2/3 — when you cannot state the causal chain), and the
+two-attempt-limit STOP (Phase 4). A released claim lets the next pipeline
+pick up the issue cleanly.
 
 ## Key Rules
 

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.29+a8614b"
+  version: "2026.05.29+aa461b"
 ---
 
 # /quickfix — In-Flight Fix → PR

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.29+96de31"
+  version: "2026.05.29+a8614b"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -144,6 +144,19 @@ done
 # Trim
 DESCRIPTION="${DESCRIPTION#"${DESCRIPTION%%[![:space:]]*}"}"
 DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
+
+# Issue-number parse (claim-work-item Phase 2 / W2.4). /quickfix usually
+# works an in-flight edit, not an issue — but a description that references
+# an issue (`#N` / `closes #N` / `fix #N`) is normally REDIRECTed to
+# /fix-issues by triage (WI 1.5.4) and only proceeds here under `force`.
+# Extract the FIRST bare positive integer into ISSUE_NUM so WI 1.8 can
+# claim the issue via claim-issue.sh. When no issue number is present (the
+# common case) ISSUE_NUM stays empty and nothing is claimed. The number is
+# a bare integer (claim-issue.sh rejects non-numeric input with exit 2).
+ISSUE_NUM=""
+if [[ "$DESCRIPTION" =~ \#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[1]}"
+fi
 ```
 
 ## Phase 1 — Pre-flight
@@ -686,6 +699,26 @@ branch: $BRANCH
 date: $NOW_ISO
 MARK
 
+# Issue claim (claim-work-item Phase 2 / W2.4). Acquire here — where
+# PIPELINE_ID is established and the `started` marker is written — and
+# BEFORE branch creation (WI 1.9). Only when the description referenced an
+# issue (ISSUE_NUM non-empty, parsed in WI 1.2); skip otherwise (the common
+# /quickfix case). This stops a concurrent /fix-issues cron from
+# double-working the same issue. Released in the Phase 7 explicit-finalize
+# and the fail-finalize abandon sites (test fail, commit fail, push fail).
+if [ -n "${ISSUE_NUM:-}" ]; then
+  CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
+    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
+    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
+    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
+  esac
+fi
+
 # Explicit-finalize pattern (Plan LAND_PR_BYPASS_HARDENING Phase 2; issue
 # #241 — matches /commit pr / /do pr / /fix-issues pr). The marker
 # starts as `status: started`; each terminal path (test fail at Phase 4,
@@ -857,6 +890,11 @@ else
     fi
     # Explicit fail-finalize (issue #241).
     [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
+    # Release the issue claim (only if one was acquired at WI 1.8) — this
+    # abandon path is after the acquire and before the Phase 7 finalize.
+    if [ -n "${ISSUE_NUM:-}" ]; then
+      bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    fi
     exit 4
   fi
 fi
@@ -991,6 +1029,10 @@ if ! git commit -m "$COMMIT_BODY"; then
   fi
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
+  # Release the issue claim (only if one was acquired at WI 1.8).
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 5
 fi
 ```
@@ -1055,6 +1097,10 @@ if ! git push -u origin "$BRANCH"; then
   echo "ERROR: git push failed. Branch '$BRANCH' and its commit are intact locally; retry manually once the remote is reachable." >&2
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
+  # Release the issue claim (only if one was acquired at WI 1.8).
+  if [ -n "${ISSUE_NUM:-}" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  fi
   exit 5
 fi
 ```
@@ -1184,6 +1230,11 @@ while :; do
     # and runs correctly when called by a parent pipeline. Mirrors the
     # `[ -n "${ZSKILLS_PIPELINE_ID:-}" ]` guard at line 1310 below.
     [ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
+    # Release the issue claim (only if one was acquired at WI 1.8). This
+    # early exit bypasses the end-of-fence explicit-finalize release.
+    if [ -n "${ISSUE_NUM:-}" ]; then
+      bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    fi
     exit 5
   fi
 
@@ -1408,6 +1459,19 @@ else
   find "$MAIN_ROOT/.zskills/tracking" \
     -maxdepth 2 -type d -name 'quickfix.*' \
     -exec sh -c 'rm -f "$1"/requires.land-pr.*' _ {} \;
+fi
+
+# Release the issue claim (claim-work-item Phase 2 / W2.4) — only if one
+# was acquired at WI 1.8 (ISSUE_NUM survives in the persistent shell).
+# Release-on-resolution regardless of created vs merged vs pr-ready: the
+# /quickfix invocation is terminating either way and /quickfix is one-shot
+# (no later fire re-releases). $PIPELINE_ID = quickfix.$SLUG; reconstruct
+# from $ZSKILLS_PIPELINE_ID if it didn't survive across fences.
+if [ -n "${ISSUE_NUM:-}" ]; then
+  _RELEASE_PIPELINE="${PIPELINE_ID:-${ZSKILLS_PIPELINE_ID:-}}"
+  if [ -n "$_RELEASE_PIPELINE" ]; then
+    bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$_RELEASE_PIPELINE"
+  fi
 fi
 ```
 

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+cf90e3"
+  version: "2026.05.29+8f131b"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -589,6 +589,22 @@ the plan and our session must not double-fire `/run-plan` for it.
 `run-plan.$TRACKING_ID` pipeline_id succeeds — exit 10 here therefore means
 ONLY a truly-foreign pipeline holds the plan, which is exactly when
 "declined" is the correct verdict (D8 / #803).
+
+### Self-re-entry contract (twins: claim-plan.sh / claim-issue.sh)
+
+Both twin primitives share one ownership-aware self-re-entry decision,
+implemented by the helper `skills/create-worktree/scripts/claim-self-reentry.sh`
+(invoked as a bash subprocess on each twin's already-exists branch — NEVER
+sourced, since its exit codes would terminate a sourcing caller). The
+exit-code contract is: **acquire** — `0` = fresh-OR-self (the existing claim
+is the caller's own pipeline_id, or there was no claim and we just took it →
+proceed), `10` = foreign-OR-absent/malformed (another pipeline holds it, or
+claim.json is missing/truncated → never steal), `11` = filesystem
+infrastructure failure, `2` = usage error; **release** — `12` = ownership
+mismatch (the claim is held by a different pipeline_id; release refuses).
+There is NO TTL — a claim is released ONLY by an explicit `release` call, so
+a re-entering self always sees its own claim and proceeds (`0`), and a
+foreign holder is honored until that holder explicitly releases.
 
 ```bash
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+ca3f3d"
+  version: "2026.05.29+f08ed3"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+f08ed3"
+  version: "2026.05.29+cf90e3"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -584,6 +584,12 @@ On race-lost (exit 10) this fence terminates cleanly; the orchestrator
 reports "declined" and exits the turn — a second pipeline already owns
 the plan and our session must not double-fire `/run-plan` for it.
 
+`claim-plan.sh` is ownership-aware (self-re-entry returns 0), so a chunked
+`finish auto` re-fire re-acquiring its OWN plan claim with the stable
+`run-plan.$TRACKING_ID` pipeline_id succeeds — exit 10 here therefore means
+ONLY a truly-foreign pipeline holds the plan, which is exactly when
+"declined" is the correct verdict (D8 / #803).
+
 ```bash
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$CLAUDE_PROJECT_DIR/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
@@ -599,6 +605,67 @@ case "$rc" in
   2)  echo "claim-plan.sh acquire usage error"; exit 2 ;;
   *)  echo "claim-plan.sh acquire unexpected rc=$rc"; exit 1 ;;
 esac
+```
+
+**Issue-claim acquire (W3.1/W3.2/W3.5, #803 execution-window protection).**
+If the plan's frontmatter carries one or more `issue: N` fields, claim each
+linked `issue-<N>` for the plan's FULL lifetime — held across idle gaps
+between chunked fires (filesystem + no-TTL + self-re-entry make this
+automatic) and released ONLY at the plan's terminal release points
+(execute-phase.md terminal merge, the already-complete no-op, and the
+operator-stop sweep — NEVER per-phase). The issue claim uses run-plan's OWN
+`$PIPELINE_ID` (same as the plan claim) and `--sprint-id "$PIPELINE_ID"`.
+
+This arm is **DELIBERATELY different from the plan-claim decline arm above**:
+issue-foreign-at-start is **WARN-and-PROCEED**, never abort. #739 removed
+auto-expiry, so a possibly-stale issue claim must not block a deliberately-run
+plan — the plan owns the plan; the issue contention is a softer operator
+signal. On rc=10 we log loudly and CONTINUE, and we NEVER release the
+legitimately-won plan claim (no plan-claim leak).
+
+Parse the bare-integer issue number(s) from `$PLAN_FILE_FOR_READ`'s
+frontmatter (the PR-mode-worktree-aware read authority — NOT bare
+`$PLAN_FILE`). Strip `#` and surrounding quotes to a bare positive integer
+(`claim-issue.sh validate_issue_number` rejects non-numeric input with
+exit 2), aligning with the Close-linked-issue parser's tolerance for
+`issue: 42` and `issue: "#42"`.
+
+```bash
+# Parse issue:N field(s) from the plan frontmatter (the leading `---`
+# delimited YAML block only), normalized to bare positive integers.
+# Tolerates `issue: 42`, `issue: "#42"`, `issue: '#42'`. Multiple
+# `issue:` lines → multiple claims.
+ISSUE_NUMS=()
+while IFS= read -r raw; do
+  # strip surrounding quotes and a leading '#', keep only digits
+  n=$(printf '%s' "$raw" | tr -d '"'\''#[:space:]')
+  case "$n" in
+    ''|*[!0-9]*) continue ;;   # skip non-numeric (defensive)
+  esac
+  [ "$n" -gt 0 ] 2>/dev/null && ISSUE_NUMS+=("$n")
+done < <(awk '
+  NR==1 && $0 != "---" { exit }            # no frontmatter → nothing to do
+  NR==1 { infm=1; next }
+  infm && $0 == "---" { exit }             # end of frontmatter block
+  infm && /^[[:space:]]*issue:[[:space:]]*/ {
+    sub(/^[[:space:]]*issue:[[:space:]]*/, "", $0); print $0
+  }
+' "$PLAN_FILE_FOR_READ" 2>/dev/null)
+
+for N in "${ISSUE_NUMS[@]}"; do
+  set +e
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+    acquire "$N" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+  irc=$?
+  set -e
+  case "$irc" in
+    0)  : ;;   # acquired-fresh OR self-re-entry — proceed, issue claim held
+    10) echo "issue #$N is claimed by another pipeline; proceeding with plan execution, issue claim NOT held" >&2 ;;  # WARN-and-PROCEED (D9) — do NOT abort, do NOT release the plan claim
+    11) echo "claim-issue.sh acquire infrastructure failure for issue #$N"; exit 1 ;;   # Failure Protocol
+    2)  echo "claim-issue.sh acquire usage error for issue #$N (un-stripped #N / empty PIPELINE_ID — internal bug)"; exit 2 ;;
+    *)  echo "claim-issue.sh acquire unexpected rc=$irc for issue #$N"; exit 1 ;;
+  esac
+done
 ```
 
 1. **In-progress git operation?**

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -1203,6 +1203,29 @@ bash "$CLAUDE_PROJECT_DIR/.claude/skills/run-plan/scripts/claim-plan.sh" \
   release "$PLAN_SLUG" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
 ```
 
+**Issue-claim release (W3.3 / W3.5 — already-complete no-op).** Release any
+linked `issue-<N>` claim alongside the plan claim on this no-op exit path,
+re-parsing the bare-integer issue number(s) from `$PLAN_FILE_FOR_READ`'s
+frontmatter (same normalization as the acquire fence). Without this, the
+issue claim leaks until `/run-plan stop` or a manual release.
+```bash
+ISSUE_NUMS=()
+while IFS= read -r raw; do
+  n=$(printf '%s' "$raw" | tr -d '"'\''#[:space:]')
+  case "$n" in ''|*[!0-9]*) continue ;; esac
+  [ "$n" -gt 0 ] 2>/dev/null && ISSUE_NUMS+=("$n")
+done < <(awk '
+  NR==1 && $0 != "---" { exit }
+  NR==1 { infm=1; next }
+  infm && $0 == "---" { exit }
+  infm && /^[[:space:]]*issue:[[:space:]]*/ { sub(/^[[:space:]]*issue:[[:space:]]*/, "", $0); print $0 }
+' "$PLAN_FILE_FOR_READ" 2>/dev/null)
+for N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+    release "$N" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+done
+```
+
 Exit cleanly without re-committing. Output "Plan already complete (no-op)."
 
 ### 0b. Final-verify gate
@@ -1606,6 +1629,31 @@ if [ "$rc" -eq 12 ]; then
 elif [ "$rc" -ne 0 ]; then
   echo "Release failed (rc=$rc)" >&2; exit 1
 fi
+```
+
+**Issue-claim release (W3.3 / W3.5 — terminal merge).** Release every
+linked `issue-<N>` claim run-plan held for this plan's lifetime, alongside
+the plan claim above. Re-parse the bare-integer issue number(s) from
+`$PLAN_FILE_FOR_READ`'s frontmatter (same normalization as the acquire fence
+in SKILL.md). Exit 12 (pipeline mismatch) is tolerated per-issue — it means
+another pipeline owns that issue claim (e.g., the WARN-and-PROCEED path
+never won it) and we must not clobber it.
+```bash
+ISSUE_NUMS=()
+while IFS= read -r raw; do
+  n=$(printf '%s' "$raw" | tr -d '"'\''#[:space:]')
+  case "$n" in ''|*[!0-9]*) continue ;; esac
+  [ "$n" -gt 0 ] 2>/dev/null && ISSUE_NUMS+=("$n")
+done < <(awk '
+  NR==1 && $0 != "---" { exit }
+  NR==1 { infm=1; next }
+  infm && $0 == "---" { exit }
+  infm && /^[[:space:]]*issue:[[:space:]]*/ { sub(/^[[:space:]]*issue:[[:space:]]*/, "", $0); print $0 }
+' "$PLAN_FILE_FOR_READ" 2>/dev/null)
+for N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+    release "$N" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+done
 ```
 
 Remove the worktree's `.zskills-tracked` to avoid associating future agents with a dead pipeline:

--- a/skills/run-plan/scripts/claim-plan.sh
+++ b/skills/run-plan/scripts/claim-plan.sh
@@ -13,13 +13,25 @@
 #
 # Subcommands:
 #   acquire <slug> --pipeline-id <id>
-#     Exit 0  — acquired (claim.json atomically written).
+#     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
+#               claim — the stored pipeline_id matches --pipeline-id).
 #     Exit 2  — usage error (bad slug, missing flags).
-#     Exit 10 — EEXIST: claim already held by another pipeline.
-#     Exit 11 — non-EEXIST mkdir failure (EACCES/ENOSPC/EDQUOT/EROFS/...).
+#     Exit 10 — foreign-held by another pipeline (OR claim already exists
+#               but claim.json absent/malformed — never steal).
+#     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
+#               (EACCES/ENOSPC/EDQUOT/EROFS/...).
 #   release <slug> --require-pipeline <id>
 #     Exit 0  — released (or already absent — idempotent).
-#     Exit 12 — pipeline-id mismatch (refused; claim left intact).
+#     Exit 2  — usage error.
+#     Exit 12 — release pipeline-id mismatch (claim left intact).
+#
+# Self-re-entry: the EEXIST arm of acquire delegates to
+# create-worktree/scripts/claim-self-reentry.sh (a bash subprocess). A
+# pipeline re-acquiring its OWN claim (same pipeline_id) gets exit 0; a
+# foreign claim, an absent claim.json, or a malformed claim.json gets exit
+# 10 (never steal). This makes a chunked `finish auto` re-fire re-acquiring
+# the same plan return 0 instead of self-colliding on rc=10. No
+# TTL/heartbeat/sweep.
 #   set-phase <slug> --require-pipeline <id> --current-phase "<str>"
 #     Exit 0  — current_phase updated (atomic write).
 #     Exit 2  — claim.json missing for slug.
@@ -81,6 +93,31 @@ _locate_sanitizer() {
     candidates+=(
       "${CLAUDE_PROJECT_DIR}/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
       "${CLAUDE_PROJECT_DIR}/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+    )
+  fi
+  local c
+  for c in "${candidates[@]}"; do
+    if [ -f "$c" ]; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Locate claim-self-reentry.sh — same precedence as _locate_sanitizer,
+# reusing the _CLAIM_SCRIPT_DIR anchor. SOURCED at script load; the
+# resolved PATH is invoked as a bash subprocess from the EEXIST arm of
+# cmd_acquire.
+_locate_self_reentry() {
+  local candidates=(
+    "$_CLAIM_SCRIPT_DIR/../../create-worktree/scripts/claim-self-reentry.sh"
+    "$_CLAIM_SCRIPT_DIR/../../../skills/create-worktree/scripts/claim-self-reentry.sh"
+  )
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    candidates+=(
+      "${CLAUDE_PROJECT_DIR}/.claude/skills/create-worktree/scripts/claim-self-reentry.sh"
+      "${CLAUDE_PROJECT_DIR}/skills/create-worktree/scripts/claim-self-reentry.sh"
     )
   fi
   local c
@@ -188,6 +225,21 @@ cmd_acquire() {
   if [ "$mkdir_status" -ne 0 ]; then
     case "$mkdir_err" in
       *"File exists"*)
+        # Ownership-aware self-re-entry: delegate to the shared helper as a
+        # bash SUBPROCESS (its exit 10/0 contract would terminate a sourcing
+        # caller). Helper exit 0 → self → return 0; exit 10 → foreign →
+        # return 10. If the helper cannot be located, fail conservative
+        # (return 10, never silently steal) with a one-line WARN.
+        local sr_helper
+        if ! sr_helper=$(_locate_self_reentry); then
+          echo "run-plan claim-plan.sh acquire: cannot locate claim-self-reentry.sh (looked in create-worktree bundle); treating existing claim as foreign" >&2
+          return 10
+        fi
+        bash "$sr_helper" "$claim_dir" "$pipeline_id"
+        local sr_rc=$?
+        if [ "$sr_rc" -eq 0 ]; then
+          return 0
+        fi
         return 10
         ;;
       *)

--- a/skills/run-plan/subcommands/stop-next-status.md
+++ b/skills/run-plan/subcommands/stop-next-status.md
@@ -113,14 +113,18 @@ If `$ARGUMENTS` contains `stop` (case-insensitive):
    rm -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/in-progress-defers."*
    rm -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/cron-recovery-needed."*
    ```
-3.5. **Release all run-plan plan claims (W2a.4 site 1; Option A walk).**
-   /run-plan stop is a session-wide halt by design (step 2 above already
-   deletes ALL `Run /run-plan` crons, not just this plan's). Iterate
-   `.zskills/claims/plan-*/` and call `claim-plan.sh release <slug>
-   --require-pipeline run-plan.<slug>` for every claim whose
-   `pipeline_id` starts with `run-plan.`. Mismatched pipelines are
-   skipped (exit 12) — those claims belong to other in-flight runs and
-   must not be clobbered.
+3.5. **Release all run-plan plan AND issue claims (W2a.4 site 1 + W3.4;
+   Option A walk).** /run-plan stop is a session-wide halt by design
+   (step 2 above already deletes ALL `Run /run-plan` crons, not just this
+   plan's). Iterate `.zskills/claims/plan-*/` and call `claim-plan.sh
+   release <slug> --require-pipeline run-plan.<slug>` for every claim whose
+   `pipeline_id` starts with `run-plan.`; THEN iterate
+   `.zskills/claims/issue-*/` and call `claim-issue.sh release <N>
+   --require-pipeline run-plan.<slug>` for every issue claim whose
+   `pipeline_id` starts with `run-plan.` (the #803 execution-window
+   claims run-plan now holds). Mismatched pipelines are skipped (exit 12)
+   — those claims belong to other in-flight runs (or to /fix-issues, which
+   owns its own `issue-*/` claims) and must not be clobbered.
    ```bash
    CLAIMS_ROOT="$MAIN_ROOT/.zskills/claims"
    RELEASED=0
@@ -152,6 +156,45 @@ except Exception:
        set +e
        bash "$CLAUDE_PROJECT_DIR/.claude/skills/run-plan/scripts/claim-plan.sh" \
          release "$slug" --require-pipeline "$claim_pid"
+       rc=$?
+       set -e
+       case "$rc" in
+         0) RELEASED=$((RELEASED + 1)) ;;
+         12) SKIPPED=$((SKIPPED + 1)) ;;  # mismatched pipeline (multi-session)
+         *) SKIPPED=$((SKIPPED + 1)) ;;
+       esac
+     done
+     # ISSUE-CLAIM SWEEP (W3.4 / M2/M3): run-plan now ALSO owns issue-<N>
+     # claims (the #803 execution-window protection). The plan-* loop above
+     # is structurally blind to issue-*/ dirs, so this PARALLEL loop releases
+     # every issue-<N> whose pipeline_id starts with `run-plan.` — mirroring
+     # the plan-* guard, mismatch-skip (exit 12), and tally. /fix-issues-owned
+     # issue claims (pipeline_id `fix-issues.*`) are skipped, never clobbered.
+     for d in "$CLAIMS_ROOT"/issue-*; do
+       [ -d "$d" ] || continue
+       n=$(basename "$d" | sed 's/^issue-//')
+       [ -n "$n" ] || continue
+       claim_file="$d/claim.json"
+       if [ ! -f "$claim_file" ]; then
+         continue
+       fi
+       claim_pid=$("${ZSKILLS_PYTHON:-python3}" -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get('pipeline_id', ''))
+except Exception:
+    pass
+" "$claim_file" 2>/dev/null)
+       # Only touch run-plan-owned issue claims; never clobber /fix-issues'
+       # (or any other pipeline's) issue claim.
+       case "$claim_pid" in
+         run-plan.*) ;;
+         *) continue ;;
+       esac
+       set +e
+       bash "$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh" \
+         release "$n" --require-pipeline "$claim_pid"
        rc=$?
        set -e
        case "$rc" in

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -200,6 +200,7 @@ run_suite "test-plan-claim-handleaction-guard.sh" "tests/test-plan-claim-handlea
 run_suite "test-plan-claim-moveall-skip.sh" "tests/test-plan-claim-moveall-skip.sh"
 run_suite "test-plan-claim-fingerprint.sh" "tests/test-plan-claim-fingerprint.sh"
 run_suite "test-plan-claim-conformance.sh" "tests/test-plan-claim-conformance.sh"
+run_suite "test-claim-self-reentry.sh" "tests/test-claim-self-reentry.sh"
 run_suite "test-demo-sim.sh" "tests/test-demo-sim.sh"
 run_suite "test-plugin-manifest.sh" "tests/test-plugin-manifest.sh"
 run_suite "test-plugin-marketplace.sh" "tests/test-plugin-marketplace.sh"

--- a/tests/test-claim-self-reentry.sh
+++ b/tests/test-claim-self-reentry.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# tests/test-claim-self-reentry.sh — Phase 1 (issue #803) W1.6.
+#
+# Tests ownership-aware self-re-entry:
+#   (a) helper unit — skills/create-worktree/scripts/claim-self-reentry.sh:
+#       - claim.json ABSENT → exit 10 (never steal)
+#       - stored pipeline_id MATCHES caller → exit 0 (self)
+#       - stored pipeline_id MISMATCHES caller → exit 10 (foreign)
+#       - truncated/malformed claim.json → exit 10 (NOT a traceback / non-10)
+#       - usage error (wrong arg count) → exit 2
+#   (b) claim-issue.sh integration — acquire fresh → 0; re-acquire SAME
+#       pipeline_id → 0; DIFFERENT pipeline_id → 10; dir-without-claim.json → 10
+#   (c) claim-plan.sh integration — same four cases with a slug
+#   (d) re-acquire-from-a-worktree-cwd — create a real git worktree, cd into
+#       it, re-acquire the same id; assert exit 0 AND the claim dir is under
+#       the shared common-dir's .zskills/claims/, NOT the worktree's $PWD
+#       (proves MAIN_ROOT resolves to the shared common-dir, never $PWD).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/skills/create-worktree/scripts/claim-self-reentry.sh"
+ISSUE_SH="$REPO_ROOT/skills/fix-issues/scripts/claim-issue.sh"
+PLAN_SH="$REPO_ROOT/skills/run-plan/scripts/claim-plan.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# claim-plan.sh's _locate_sanitizer / _locate_self_reentry fall back to
+# CLAUDE_PROJECT_DIR for the helper lookup; point it at REPO_ROOT.
+export CLAUDE_PROJECT_DIR="$REPO_ROOT"
+
+PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$PYTHON" ]; then
+  echo "FATAL: no Python interpreter available" >&2
+  exit 1
+fi
+
+SCRATCH_ROOT="/tmp/test-claim-self-reentry-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then
+    echo "TEST_KEEP_SCRATCH set — leaving $SCRATCH_ROOT" >&2
+    return
+  fi
+  if [ -d "$SCRATCH_ROOT" ]; then
+    find "$SCRATCH_ROOT" -type d -exec chmod 0755 {} + 2>/dev/null || true
+    find "$SCRATCH_ROOT" -mindepth 1 -delete 2>/dev/null || true
+    rmdir "$SCRATCH_ROOT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH_ROOT"
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  (cd "$repo" && git init -q && git config user.email "t@t" && git config user.name "t" \
+    && git commit --allow-empty -q -m "init") || return 1
+}
+
+# Sanity: all three scripts present.
+for f in "$HELPER" "$ISSUE_SH" "$PLAN_SH"; do
+  if [ ! -f "$f" ]; then
+    echo "FATAL: missing $f" >&2
+    exit 1
+  fi
+done
+
+echo "=== claim-self-reentry.sh + twin self-re-entry tests ==="
+
+# ───────────────────────────────────────────────────────────────────────
+# (a) Helper unit tests.
+# ───────────────────────────────────────────────────────────────────────
+echo "--- (a) helper unit ---"
+
+# a1: claim.json absent (dir present but no claim.json) → exit 10.
+a_dir="$SCRATCH_ROOT/a-claimdir"
+mkdir -p "$a_dir"
+bash "$HELPER" "$a_dir" "pipe-X"
+rc=$?
+if [ "$rc" -eq 10 ]; then
+  pass "(a1) claim.json absent → exit 10 (never steal)"
+else
+  fail "(a1) claim.json absent → 10" "got rc=$rc"
+fi
+
+# a2: matching pipeline_id → exit 0.
+printf '{"pipeline_id": "pipe-X", "issue": 1}\n' > "$a_dir/claim.json"
+bash "$HELPER" "$a_dir" "pipe-X"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(a2) matching pipeline_id → exit 0 (self)"
+else
+  fail "(a2) matching pipeline_id → 0" "got rc=$rc"
+fi
+
+# a3: mismatching pipeline_id → exit 10.
+bash "$HELPER" "$a_dir" "pipe-OTHER"
+rc=$?
+if [ "$rc" -eq 10 ]; then
+  pass "(a3) mismatching pipeline_id → exit 10 (foreign)"
+else
+  fail "(a3) mismatching pipeline_id → 10" "got rc=$rc"
+fi
+
+# a4: truncated/malformed claim.json → exit 10 (NOT a traceback / non-10).
+trunc_dir="$SCRATCH_ROOT/a-trunc"
+mkdir -p "$trunc_dir"
+printf '{"pipeline_id": "x"' > "$trunc_dir/claim.json"  # no closing brace
+helper_out=$(bash "$HELPER" "$trunc_dir" "x" 2>&1)
+rc=$?
+# Must be a clean exit 10, and stdout/stderr must NOT contain a python
+# traceback (deterministic foreign, never steal, never crash).
+if [ "$rc" -eq 10 ] && ! printf '%s' "$helper_out" | grep -q 'Traceback'; then
+  pass "(a4) truncated/malformed claim.json → exit 10, no traceback"
+else
+  fail "(a4) truncated claim.json → 10" "got rc=$rc out=<$helper_out>"
+fi
+
+# a5: usage error (wrong arg count) → exit 2.
+bash "$HELPER" "$a_dir" 2>/dev/null  # only one arg
+rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "(a5) wrong arg count → exit 2 (usage)"
+else
+  fail "(a5) usage → 2" "got rc=$rc"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# (b) claim-issue.sh integration.
+# ───────────────────────────────────────────────────────────────────────
+echo "--- (b) claim-issue.sh integration ---"
+b_repo="$SCRATCH_ROOT/b-repo"
+make_repo "$b_repo" || { echo "FATAL repo init"; exit 1; }
+
+# b1: acquire fresh → 0.
+(cd "$b_repo" && bash "$ISSUE_SH" acquire 42 --pipeline-id "fix-issues.A" --sprint-id "fix-issues.A")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(b1) issue acquire fresh → exit 0"
+else
+  fail "(b1) issue acquire fresh → 0" "got rc=$rc"
+fi
+
+# b2: re-acquire SAME pipeline_id → 0 (self-re-entry).
+(cd "$b_repo" && bash "$ISSUE_SH" acquire 42 --pipeline-id "fix-issues.A" --sprint-id "fix-issues.A")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(b2) issue re-acquire SAME pipeline_id → exit 0 (self-re-entry)"
+else
+  fail "(b2) issue re-acquire SAME → 0" "got rc=$rc"
+fi
+
+# b3: re-acquire DIFFERENT pipeline_id → 10 (foreign).
+(cd "$b_repo" && bash "$ISSUE_SH" acquire 42 --pipeline-id "fix-issues.B" --sprint-id "fix-issues.B") 2>/dev/null
+rc=$?
+if [ "$rc" -eq 10 ]; then
+  pass "(b3) issue re-acquire DIFFERENT pipeline_id → exit 10 (foreign)"
+else
+  fail "(b3) issue re-acquire DIFFERENT → 10" "got rc=$rc"
+fi
+
+# b4: dir-without-claim.json → 10 (never steal a half-written/crashed stub).
+b_stub="$b_repo/.zskills/claims/issue-99"
+mkdir -p "$b_stub"   # claim dir exists but no claim.json
+(cd "$b_repo" && bash "$ISSUE_SH" acquire 99 --pipeline-id "fix-issues.A" --sprint-id "fix-issues.A") 2>/dev/null
+rc=$?
+if [ "$rc" -eq 10 ]; then
+  pass "(b4) issue dir-without-claim.json → exit 10 (never steal)"
+else
+  fail "(b4) issue dir-without-claim.json → 10" "got rc=$rc"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# (c) claim-plan.sh integration.
+# ───────────────────────────────────────────────────────────────────────
+echo "--- (c) claim-plan.sh integration ---"
+c_repo="$SCRATCH_ROOT/c-repo"
+make_repo "$c_repo" || { echo "FATAL repo init"; exit 1; }
+
+# c1: acquire fresh → 0.
+(cd "$c_repo" && bash "$PLAN_SH" acquire myplan --pipeline-id "run-plan.myplan")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(c1) plan acquire fresh → exit 0"
+else
+  fail "(c1) plan acquire fresh → 0" "got rc=$rc"
+fi
+
+# c2: re-acquire SAME pipeline_id → 0 (self-re-entry).
+(cd "$c_repo" && bash "$PLAN_SH" acquire myplan --pipeline-id "run-plan.myplan")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(c2) plan re-acquire SAME pipeline_id → exit 0 (self-re-entry)"
+else
+  fail "(c2) plan re-acquire SAME → 0" "got rc=$rc"
+fi
+
+# c3: re-acquire DIFFERENT pipeline_id → 10 (foreign).
+(cd "$c_repo" && bash "$PLAN_SH" acquire myplan --pipeline-id "run-plan.other") 2>/dev/null
+rc=$?
+if [ "$rc" -eq 10 ]; then
+  pass "(c3) plan re-acquire DIFFERENT pipeline_id → exit 10 (foreign)"
+else
+  fail "(c3) plan re-acquire DIFFERENT → 10" "got rc=$rc"
+fi
+
+# c4: dir-without-claim.json → 10.
+c_stub="$c_repo/.zskills/claims/plan-stub"
+mkdir -p "$c_stub"
+(cd "$c_repo" && bash "$PLAN_SH" acquire stub --pipeline-id "run-plan.myplan") 2>/dev/null
+rc=$?
+if [ "$rc" -eq 10 ]; then
+  pass "(c4) plan dir-without-claim.json → exit 10 (never steal)"
+else
+  fail "(c4) plan dir-without-claim.json → 10" "got rc=$rc"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# (d) re-acquire-from-a-worktree-cwd: claim lands under the SHARED
+# common-dir, and self-re-entry from inside the worktree returns 0.
+# ───────────────────────────────────────────────────────────────────────
+echo "--- (d) re-acquire from a worktree cwd ---"
+d_main="$SCRATCH_ROOT/d-main"
+make_repo "$d_main" || { echo "FATAL repo init"; exit 1; }
+d_wt="$SCRATCH_ROOT/d-wt"
+# Create a real linked worktree off the main repo.
+(cd "$d_main" && git worktree add -q "$d_wt" -b feat/d-branch) || { echo "FATAL worktree add"; exit 1; }
+
+# First acquire FROM the worktree cwd (issue side).
+(cd "$d_wt" && bash "$ISSUE_SH" acquire 7 --pipeline-id "do.d7" --sprint-id "do.d7")
+rc_first=$?
+# The claim dir must be under the MAIN repo's .zskills/claims/, NOT the
+# worktree's $PWD (MAIN_ROOT resolves via git-common-dir parent).
+main_claim="$d_main/.zskills/claims/issue-7/claim.json"
+wt_claim="$d_wt/.zskills/claims/issue-7/claim.json"
+if [ "$rc_first" -eq 0 ] && [ -f "$main_claim" ] && [ ! -f "$wt_claim" ]; then
+  pass "(d1) acquire from worktree cwd lands claim under shared common-dir, not \$PWD"
+else
+  fail "(d1) worktree acquire main-root anchor" "rc=$rc_first main=$([ -f "$main_claim" ] && echo yes || echo no) wt=$([ -f "$wt_claim" ] && echo yes || echo no)"
+fi
+
+# Re-acquire the SAME id from inside the worktree → self-re-entry → 0.
+(cd "$d_wt" && bash "$ISSUE_SH" acquire 7 --pipeline-id "do.d7" --sprint-id "do.d7")
+rc_re=$?
+if [ "$rc_re" -eq 0 ] && [ -f "$main_claim" ] && [ ! -f "$wt_claim" ]; then
+  pass "(d2) re-acquire SAME id from worktree cwd → exit 0; claim still under shared common-dir"
+else
+  fail "(d2) worktree self-re-entry" "rc=$rc_re main=$([ -f "$main_claim" ] && echo yes || echo no) wt=$([ -f "$wt_claim" ] && echo yes || echo no)"
+fi
+
+# Clean up the worktree before the trap (so rmdir of SCRATCH succeeds).
+(cd "$d_main" && git worktree remove --force "$d_wt") 2>/dev/null || true
+
+# ───────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (%d total)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (%d total)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-plan-claim-conformance.sh
+++ b/tests/test-plan-claim-conformance.sh
@@ -201,6 +201,61 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# I. POSITIVE (Phase 3 / #803 — issue-claim execution-window protection).
+#    These ADD to the battery; they do NOT relax assertion A above (the
+#    plan-claim acquire is untouched and still precedes ### Execution).
+#
+#    I1. SKILL.md contains a `claim-issue.sh acquire` in the same region as
+#        the plan-claim acquire (the issue-claim acquire arm, W3.2). We
+#        anchor it AFTER the plan-claim `claim-plan.sh acquire` line so the
+#        new arm sits where the plan claim is already won.
+#    I2. The operator-stop release loop (stop-next-status.md) contains an
+#        `issue-*` arm: both a `"$CLAIMS_ROOT"/issue-*` glob and a
+#        `claim-issue.sh ... release` call (W3.4). Without this run-plan's
+#        issue claim leaks on /run-plan stop.
+#    I3. The terminal-merge + no-op release sites (execute-phase.md) each
+#        release issue claims via `claim-issue.sh ... release` (W3.3) — at
+#        least 2 such release calls in execute-phase.md.
+# ───────────────────────────────────────────────────────────────────────
+# I1 — issue-claim acquire present in SKILL.md, after the plan-claim acquire.
+plan_acq_ln=$(grep -nE 'claim-plan\.sh"?[[:space:]]*\\?$|claim-plan\.sh"[[:space:]]+acquire' "$RP_SKILL" | head -1 | cut -d: -f1)
+issue_acq_ln=$(grep -nE 'claim-issue\.sh"[[:space:]]*\\?$' "$RP_SKILL" | head -1 | cut -d: -f1)
+# Fall back to a joined-continuation scan to confirm the acquire verb pairs
+# with claim-issue.sh (the verb sits on the continuation line in the source).
+issue_acq_present=$(awk '
+BEGIN{buf=""}
+{ if (substr($0,length($0))=="\\") { buf=buf substr($0,1,length($0)-1) } else { print buf $0; buf="" } }
+' "$RP_SKILL" | grep -cE 'claim-issue\.sh"[[:space:]]+acquire')
+if [ -n "$issue_acq_ln" ] && [ -n "$plan_acq_ln" ] && [ "$issue_acq_ln" -gt "$plan_acq_ln" ] && [ "${issue_acq_present:-0}" -ge 1 ]; then
+  pass "issue-claim acquire present in SKILL.md (line $issue_acq_ln, after plan-claim acquire line $plan_acq_ln) — W3.2/#803"
+else
+  fail "issue-claim acquire (W3.2)" "issue_acq_ln=$issue_acq_ln plan_acq_ln=$plan_acq_ln joined-acquire-hits=$issue_acq_present — expected a claim-issue.sh acquire arm after the plan-claim acquire"
+fi
+
+# I2 — operator-stop loop has an issue-* arm (glob + claim-issue.sh release).
+stop_issue_glob=$(grep -cE '"\$CLAIMS_ROOT"/issue-\*' "$RP_SUB")
+stop_issue_rel=$(awk '
+BEGIN{buf=""}
+{ if (substr($0,length($0))=="\\") { buf=buf substr($0,1,length($0)-1) } else { print buf $0; buf="" } }
+' "$RP_SUB" | grep -cE 'claim-issue\.sh"[[:space:]]+release')
+if [ "${stop_issue_glob:-0}" -ge 1 ] && [ "${stop_issue_rel:-0}" -ge 1 ]; then
+  pass "operator-stop issue-* sweep arm present (CLAIMS_ROOT/issue-* glob + claim-issue.sh release) — W3.4/M2/M3"
+else
+  fail "operator-stop issue-* sweep (W3.4)" "issue-* glob hits=$stop_issue_glob, claim-issue.sh release hits=$stop_issue_rel — expected a parallel issue-* release loop"
+fi
+
+# I3 — terminal-merge + no-op issue-claim release sites in execute-phase.md.
+exec_issue_rel=$(awk '
+BEGIN{buf=""}
+{ if (substr($0,length($0))=="\\") { buf=buf substr($0,1,length($0)-1) } else { print buf $0; buf="" } }
+' "$RP_EXEC" | grep -cE 'claim-issue\.sh"[[:space:]]+release')
+if [ "${exec_issue_rel:-0}" -ge 2 ]; then
+  pass "issue-claim release sites in execute-phase.md (terminal merge + no-op): $exec_issue_rel claim-issue.sh release calls — W3.3"
+else
+  fail "issue-claim release sites (W3.3)" "expected >=2 claim-issue.sh release calls in execute-phase.md, got $exec_issue_rel"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -472,6 +472,27 @@ check do "Path B Worktree"  '^### Path B'
 check do "Path C Direct"    '^### Path C'
 
 echo ""
+echo "=== /do — issue-claim wiring (claim-work-item Phase 2 / W2.2 + W2.3) ==="
+# /do parses the issue number (reachable only via --force triage override).
+# Acquire uses the $CLAIM_HELPER indirection (CLAIM_HELPER=...claim-issue.sh
+# + `bash "$CLAIM_HELPER" acquire "$ISSUE_NUM"`); release inlines the
+# literal claim-issue.sh path. The sentinels grep the EXISTING script name
+# so a future edit dropping the wiring FAILS the test. These are positive
+# assertions only.
+check_fixed do "SKILL.md parses ISSUE_NUM"        'ISSUE_NUM="${BASH_REMATCH[1]}"'
+# worktree mode: acquire after PIPELINE_ID + worktree; release in Phase 5 Report (SKILL.md).
+check_in_file do "modes/worktree.md" "worktree CLAIM_HELPER"  'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
+check_in_file do "modes/worktree.md" "worktree acquire"       'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+check_in_file do "modes/direct.md"   "direct CLAIM_HELPER"    'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
+check_in_file do "modes/direct.md"   "direct acquire"         'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+check_in_file do "modes/pr.md"       "pr CLAIM_HELPER"        'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
+check_in_file do "modes/pr.md"       "pr acquire"             'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+# Release: /do worktree/direct release in SKILL.md Phase 5 Report + error
+# handling; /do pr releases inline (early-exit) + in the finalize block.
+check_fixed do "SKILL.md releases issue claim"  'claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"'
+check_in_file do "modes/pr.md"       "pr release"        'claim-issue\.sh" release "\$ISSUE_NUM" --require-pipeline "\$PIPELINE_ID"'
+
+echo ""
 echo "=== /fix-issues — behavior contracts ==="
 check       fix-issues "stop-precedence"            'Takes precedence|takes precedence'
 check_fixed fix-issues "landing-default"            'LANDING_MODE="cherry-pick"'
@@ -629,6 +650,28 @@ echo "=== /quickfix — behavior contracts (PR_LANDING_UNIFICATION Phase 5) ==="
 check_fixed quickfix "Phase 7 dispatches /land-pr" 'land-pr'
 check_not   quickfix "no inline gh pr create"      'gh pr create'
 check_not   quickfix "no fire-and-forget literal"  'Fire-and-forget'
+
+echo ""
+echo "=== /quickfix — issue-claim wiring (claim-work-item Phase 2 / W2.4) ==="
+# /quickfix parses the issue number (proceeds only under `force` since
+# triage REDIRECTs issue refs to /fix-issues), acquires at WI 1.8 around
+# the Tracking-setup block, releases in the Phase 7 finalize + abandon
+# sites. Reuses the existing PIPELINE_ID="quickfix.$SLUG".
+check_fixed quickfix "parses ISSUE_NUM"          'ISSUE_NUM="${BASH_REMATCH[1]}"'
+check_fixed quickfix "CLAIM_HELPER assignment"   'CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"'
+check_fixed quickfix "acquires issue claim"      'bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"'
+check_fixed quickfix "releases issue claim"      'claim-issue.sh" release "$ISSUE_NUM" --require-pipeline'
+
+echo ""
+echo "=== /investigate — issue-claim wiring (claim-work-item Phase 2 / W2.1) ==="
+# /investigate synthesizes PIPELINE_ID="investigate.issue-$N" (no pipeline
+# id of its own), acquires at the #N parse (Phase 1 step 1) before any
+# reproduction work, releases on the success-path Report bash block + the
+# explicit per-STOP prose at each abandon point.
+check_fixed investigate "synthesizes PIPELINE_ID"  'sanitize-pipeline-id.sh" "investigate.issue-$N"'
+check_fixed investigate "CLAIM_HELPER assignment"  'CLAIM_HELPER="$CLAUDE_PROJECT_DIR/.claude/skills/fix-issues/scripts/claim-issue.sh"'
+check_fixed investigate "acquires issue claim"     'bash "$CLAIM_HELPER" acquire "$N" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"'
+check_fixed investigate "releases issue claim"     'claim-issue.sh" release "$N" --require-pipeline "$PIPELINE_ID"'
 
 echo ""
 echo "=== /draft-plan, /refine-plan, /draft-tests — auto flag + /land-pr dispatch (#581) ==="


### PR DESCRIPTION
## Plan: Ownership-aware work-item claims (self-re-entry in the twin claim scripts)

Closes #803.

Implements ownership-aware work-item claims: a pipeline re-acquiring its **own** claim now succeeds (exit 0) instead of colliding (exit 10), and the three issue-capable consumers + run-plan all claim before working.

<!-- run-plan:progress:start -->
**Phases completed (all 4):**
- **Phase 1** — shared `claim-self-reentry.sh` helper wired into both twin claim scripts (`claim-issue.sh`/`claim-plan.sh`) EEXIST arms; +15 tests.
- **Phase 2** — `/do`, `/quickfix`, `/investigate` wired onto `claim-issue.sh` acquire/release (C1/M1 placement, C2 inline-releases); +17 conformance sentinels.
- **Phase 3** — `/run-plan` claims its linked `issue: N` for the plan lifetime (D9 WARN-and-PROCEED on foreign) + operator-stop `issue-*` sweep + `:597` clarification; +3 assertions.
- **Phase 4** — recursive claim-discipline rule in `CLAUDE_TEMPLATE.md` + re-rendered `managed.md` + self-re-entry contract docs.
<!-- run-plan:progress:end -->

**Tests:** `6553/6553 passed, 0 failed` (post-rebase onto current main, including #822's `--force` normalization which merged cleanly with the claim wiring).

**Report:** `docs/reports/plan-claim-work-item.md`.

---
Generated by `/run-plan … finish auto` (bundled single-PR landing; see plan header note).
