### PR TITLE
do: LC_ALL=C on claim-script mkdir for non-English locales

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.29+abab96"
+  version: "2026.05.30+3fa96f"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/scripts/claim-issue.sh
+++ b/.claude/skills/fix-issues/scripts/claim-issue.sh
@@ -176,9 +176,13 @@ cmd_acquire() {
   fi
 
   # Atomic acquire: mkdir of the claim dir itself. NO 2>/dev/null — the
-  # stderr text distinguishes EEXIST from other failures.
+  # stderr text distinguishes EEXIST from other failures. LC_ALL=C forces
+  # the English "File exists" the case arm below greps for; without it,
+  # a non-English LC_MESSAGES localizes the diagnostic and the EEXIST
+  # branch silently misses, returning rc=11 instead of routing to
+  # self-re-entry (issue #827).
   local mkdir_err
-  mkdir_err=$(mkdir "$claim_dir" 2>&1)
+  mkdir_err=$(LC_ALL=C mkdir "$claim_dir" 2>&1)
   local mkdir_status=$?
   if [ "$mkdir_status" -ne 0 ]; then
     # Map "File exists" -> self-re-entry decision (0 self / 10 foreign);

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+8f131b"
+  version: "2026.05.30+9e8919"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/scripts/claim-plan.sh
+++ b/.claude/skills/run-plan/scripts/claim-plan.sh
@@ -220,7 +220,11 @@ cmd_acquire() {
 
   # Atomic acquire: mkdir of the claim dir itself.
   local mkdir_err mkdir_status
-  mkdir_err=$(mkdir "$claim_dir" 2>&1)
+  # LC_ALL=C forces mkdir's diagnostic to the English "File exists" the
+  # case arm below greps for. Without it, a non-English LC_MESSAGES
+  # localizes the diagnostic and the EEXIST branch silently misses,
+  # returning rc=11 instead of routing to self-re-entry (issue #827).
+  mkdir_err=$(LC_ALL=C mkdir "$claim_dir" 2>&1)
   mkdir_status=$?
   if [ "$mkdir_status" -ne 0 ]; then
     case "$mkdir_err" in

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.29+abab96"
+  version: "2026.05.30+3fa96f"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/scripts/claim-issue.sh
+++ b/skills/fix-issues/scripts/claim-issue.sh
@@ -176,9 +176,13 @@ cmd_acquire() {
   fi
 
   # Atomic acquire: mkdir of the claim dir itself. NO 2>/dev/null — the
-  # stderr text distinguishes EEXIST from other failures.
+  # stderr text distinguishes EEXIST from other failures. LC_ALL=C forces
+  # the English "File exists" the case arm below greps for; without it,
+  # a non-English LC_MESSAGES localizes the diagnostic and the EEXIST
+  # branch silently misses, returning rc=11 instead of routing to
+  # self-re-entry (issue #827).
   local mkdir_err
-  mkdir_err=$(mkdir "$claim_dir" 2>&1)
+  mkdir_err=$(LC_ALL=C mkdir "$claim_dir" 2>&1)
   local mkdir_status=$?
   if [ "$mkdir_status" -ne 0 ]; then
     # Map "File exists" -> self-re-entry decision (0 self / 10 foreign);

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.29+8f131b"
+  version: "2026.05.30+9e8919"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/scripts/claim-plan.sh
+++ b/skills/run-plan/scripts/claim-plan.sh
@@ -220,7 +220,11 @@ cmd_acquire() {
 
   # Atomic acquire: mkdir of the claim dir itself.
   local mkdir_err mkdir_status
-  mkdir_err=$(mkdir "$claim_dir" 2>&1)
+  # LC_ALL=C forces mkdir's diagnostic to the English "File exists" the
+  # case arm below greps for. Without it, a non-English LC_MESSAGES
+  # localizes the diagnostic and the EEXIST branch silently misses,
+  # returning rc=11 instead of routing to self-re-entry (issue #827).
+  mkdir_err=$(LC_ALL=C mkdir "$claim_dir" 2>&1)
   mkdir_status=$?
   if [ "$mkdir_status" -ne 0 ]; then
     case "$mkdir_err" in

--- a/tests/test-claim-self-reentry.sh
+++ b/tests/test-claim-self-reentry.sh
@@ -256,6 +256,96 @@ fi
 (cd "$d_main" && git worktree remove --force "$d_wt") 2>/dev/null || true
 
 # ───────────────────────────────────────────────────────────────────────
+# (e) Locale-independence: self-re-entry must work under a non-English
+# LC_MESSAGES locale (issue #827). The twin scripts grep mkdir's stderr
+# for the literal English "File exists" to detect EEXIST. On a localized
+# locale the diagnostic translates and the case arm misses, silently
+# returning rc=11 instead of routing to self-re-entry. The fix forces
+# `LC_ALL=C` on the mkdir invocation. If a non-English locale is
+# unavailable in this environment (devcontainers commonly only ship C +
+# en_US.utf8), the test gracefully degrades and still asserts the
+# C-locale path keeps working.
+# ───────────────────────────────────────────────────────────────────────
+echo "--- (e) locale-independence ---"
+
+# Pick a non-English locale if one is installed. Prefer fr_FR.UTF-8;
+# accept any non-C/non-en locale otherwise. `locale -a` is POSIX-portable.
+pick_localized_locale() {
+  local cand
+  for cand in fr_FR.UTF-8 fr_FR.utf8 de_DE.UTF-8 de_DE.utf8 es_ES.UTF-8 es_ES.utf8 ja_JP.UTF-8 ja_JP.utf8; do
+    if locale -a 2>/dev/null | grep -Fxq "$cand"; then
+      printf '%s' "$cand"
+      return 0
+    fi
+  done
+  # Fall back to any installed locale that isn't C/POSIX/en*.
+  cand=$(locale -a 2>/dev/null | grep -viE '^(C|POSIX|en[_.])' | head -n 1)
+  if [ -n "$cand" ]; then
+    printf '%s' "$cand"
+    return 0
+  fi
+  return 1
+}
+
+e_repo="$SCRATCH_ROOT/e-repo"
+make_repo "$e_repo" || { echo "FATAL repo init"; exit 1; }
+
+# e1 (always runs): acquire under LC_ALL=C — fresh acquire → 0.
+(cd "$e_repo" && LC_ALL=C bash "$ISSUE_SH" acquire 17 --pipeline-id "fix-issues.E" --sprint-id "fix-issues.E")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(e1) acquire under LC_ALL=C fresh → exit 0"
+else
+  fail "(e1) acquire under LC_ALL=C fresh → 0" "got rc=$rc"
+fi
+
+# e2 (always runs): re-acquire SAME id under LC_ALL=C — self-re-entry → 0.
+(cd "$e_repo" && LC_ALL=C bash "$ISSUE_SH" acquire 17 --pipeline-id "fix-issues.E" --sprint-id "fix-issues.E")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "(e2) re-acquire SAME id under LC_ALL=C → exit 0 (self-re-entry)"
+else
+  fail "(e2) re-acquire SAME id under LC_ALL=C → 0" "got rc=$rc"
+fi
+
+# e3: re-acquire SAME id under a NON-ENGLISH LC_ALL — must still route to
+# self-re-entry (rc=0), NOT silently return rc=11 because the localized
+# "File exists" diagnostic missed the case arm.
+LOCALE=""
+if LOCALE=$(pick_localized_locale); then
+  (cd "$e_repo" && LC_ALL="$LOCALE" bash "$ISSUE_SH" acquire 17 --pipeline-id "fix-issues.E" --sprint-id "fix-issues.E")
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    pass "(e3) re-acquire SAME id under LC_ALL=$LOCALE → exit 0 (self-re-entry survives localized mkdir diagnostic)"
+  elif [ "$rc" -eq 11 ]; then
+    fail "(e3) re-acquire SAME id under LC_ALL=$LOCALE → 0" "got rc=11 — LC_ALL=C prefix on mkdir is missing or ineffective (issue #827 regression)"
+  else
+    fail "(e3) re-acquire SAME id under LC_ALL=$LOCALE → 0" "got rc=$rc"
+  fi
+
+  # e4: same coverage for the plan twin.
+  e_prepo="$SCRATCH_ROOT/e-prepo"
+  make_repo "$e_prepo" || { echo "FATAL repo init"; exit 1; }
+  (cd "$e_prepo" && LC_ALL=C bash "$PLAN_SH" acquire eplan --pipeline-id "run-plan.E") >/dev/null
+  (cd "$e_prepo" && LC_ALL="$LOCALE" bash "$PLAN_SH" acquire eplan --pipeline-id "run-plan.E")
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    pass "(e4) plan re-acquire SAME id under LC_ALL=$LOCALE → exit 0 (self-re-entry survives localized mkdir diagnostic)"
+  elif [ "$rc" -eq 11 ]; then
+    fail "(e4) plan re-acquire SAME id under LC_ALL=$LOCALE → 0" "got rc=11 — LC_ALL=C prefix on mkdir is missing or ineffective (issue #827 regression)"
+  else
+    fail "(e4) plan re-acquire SAME id under LC_ALL=$LOCALE → 0" "got rc=$rc"
+  fi
+else
+  echo "  NOTE: no non-English locale installed (locale -a lists only C / POSIX / en*);" >&2
+  echo "        skipping (e3,e4) localized-diagnostic assertions. The fix is" >&2
+  echo "        still in place — LC_ALL=C prefix on mkdir in both claim-plan.sh" >&2
+  echo "        and claim-issue.sh — and the C-locale path (e1,e2) covers" >&2
+  echo "        the unchanged-behavior side. Install fr_FR.UTF-8 (or any" >&2
+  echo "        non-English UTF-8 locale) to exercise the localized branch." >&2
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

`mkdir` stderr is localized — `fr_FR.UTF-8` returns `"Le fichier existe"` instead of `"File exists"`. Both claim scripts (`skills/run-plan/scripts/claim-plan.sh` and `skills/fix-issues/scripts/claim-issue.sh`) string-matched for the English text to distinguish EEXIST from other mkdir failures, so non-English-locale consumers silently fell through to rc=11 instead of the self-re-entry path that PR #825 added.

Fix: prefix the mkdir invocation with `LC_ALL=C` so the diagnostic is always the English form. One-line change per file.

Closes #827

## Test plan
- [x] `bash tests/run-all.sh` — 6555/6555 passed (0 failed); new `test-claim-self-reentry.sh` section (e) adds 4 cases:
      - e1/e2 (always run): prove `LC_ALL=C` round-trip preserves the existing path.
      - e3/e4 (conditional): re-acquire under a non-English `LC_ALL` asserts rc=0 (not rc=11). Gracefully skips with stderr NOTE when no non-English locale is available in the env.
- [x] Devcontainer has no `fr_FR.UTF-8` so e3/e4 emitted the documented skip note here; CI runners with localized glibc will exercise the localized branch automatically.
- [x] `metadata.version` bumped on `skills/run-plan/SKILL.md` (`2026.05.30+9e8919`) and `skills/fix-issues/SKILL.md` (`2026.05.30+3fa96f`) per skill-versioning rule.
- [x] Source + `.claude/skills/` mirror copies kept in sync via `scripts/mirror-skill.sh`.

## Commits

09e71b1 fix(claim): force LC_ALL=C on mkdir so EEXIST detection works in non-English locales
