### PR TITLE
do: sandbox backfill test to not touch live docs/plans

### DIFF
--- a/tests/test-backfill-plan-completed.sh
+++ b/tests/test-backfill-plan-completed.sh
@@ -2,8 +2,20 @@
 # Tests for backfill-plan-completed.sh
 #
 # Covers:
-#   T672.1  Script does not fail with "unbound variable" when
-#           CLAUDE_PROJECT_DIR is unset (the bug fixed in #672).
+#   T672.1                      Script does not fail with "unbound variable"
+#                               when CLAUDE_PROJECT_DIR is unset (#672).
+#   T-sandbox-no-live-mutation  Running the test does NOT mutate the LIVE
+#                               repo's docs/plans/ (the regression fixed here).
+#
+# Isolation: backfill-plan-completed.sh cd's to the git toplevel and stamps a
+# `completed:` YAML frontmatter field into EVERY plan under docs/plans/ that
+# has `status: complete` and lacks `completed:`. Running it against the LIVE
+# repo therefore DIRTIES real plan files (e.g. docs/plans/SKILL_VERIFICATION_
+# SMOKES.md), which then blocks rebases mid-pipeline. So we run the real
+# backfill end-to-end inside a throwaway local CLONE of the repo — a clone is
+# guaranteed-complete (backfill needs the full working layout + the
+# BASH_SOURCE-relative helper chain) and the EXIT trap removes it, leaving the
+# live tree untouched.
 #
 # Run from repo root: bash tests/test-backfill-plan-completed.sh
 
@@ -42,14 +54,39 @@ if [ ! -f "$REPO_ROOT/$BACKFILL_SCRIPT" ]; then
   print_summary_and_exit
 fi
 
-# ── T672.1 — no "unbound variable" crash when CLAUDE_PROJECT_DIR unset ──
+# ── Throwaway clone — backfill EDITS plans in place; never touch $REPO_ROOT ──
+#
+# A local-path clone works on BOTH a full dev checkout AND a shallow CI
+# checkout (actions/checkout@v4 fetch-depth:1). Backfill only edits files in
+# place (frontmatter-set.sh) — it never `git commit`s — so the clone needs NO
+# git identity. On a shallow clone the content-pickaxe finds no history and
+# backfill legitimately skips every plan with a WARN; that is fine and must
+# not fail the test (see T-sandbox-no-live-mutation tolerance note).
+TMP="$(mktemp -d)"
+SANDBOX="$TMP/sandbox"
+trap 'rm -rf "$TMP"' EXIT
 
-# Run the script in a subshell with CLAUDE_PROJECT_DIR explicitly unset.
-# The script should NOT crash with "unbound variable". It should either
-# succeed (exit 0) or fail gracefully for other reasons (e.g., no plans
-# to backfill), but never with exit code 1 and the specific "unbound
-# variable" error message on stderr.
-output="$(cd "$REPO_ROOT" && env -u CLAUDE_PROJECT_DIR bash "$BACKFILL_SCRIPT" 2>&1)" || true
+if ! git clone --quiet "$REPO_ROOT" "$SANDBOX"; then
+  fail "0. git clone of \$REPO_ROOT into sandbox failed"
+  print_summary_and_exit
+fi
+
+# Snapshot the LIVE repo's docs/plans/ state BEFORE the backfill run. We
+# compare BEFORE vs AFTER (delta), so a pre-existing unrelated dirty tree
+# does NOT make this test fail — only a NEW modification introduced by the
+# backfill run does.
+live_plans_before="$(git -C "$REPO_ROOT" status --porcelain -- docs/plans/)"
+
+# ── T672.1 — no "unbound variable" crash when CLAUDE_PROJECT_DIR unset ──
+#
+# Run the real backfill from INSIDE the sandbox with CLAUDE_PROJECT_DIR
+# explicitly unset (preserving the EXACT T672.1 condition), via the sandbox's
+# OWN repo-relative script path so its BASH_SOURCE-relative helper resolution
+# points at the sandbox tree (not the live repo). The script should NOT crash
+# with "unbound variable". It should either succeed (exit 0) or fail
+# gracefully for other reasons (e.g., no plans to backfill), but never with
+# the specific "unbound variable" error message on stderr.
+output="$(cd "$SANDBOX" && env -u CLAUDE_PROJECT_DIR bash "$BACKFILL_SCRIPT" 2>&1)" || true
 rc=$?
 
 if echo "$output" | grep -q "unbound variable"; then
@@ -57,6 +94,26 @@ if echo "$output" | grep -q "unbound variable"; then
   echo "    stderr/stdout contained: $(echo "$output" | grep 'unbound variable')"
 else
   pass "T672.1 — no 'unbound variable' error when CLAUDE_PROJECT_DIR is unset (exit $rc)"
+fi
+
+# ── T-sandbox-no-live-mutation — the LIVE repo's docs/plans/ is delta-unchanged ──
+#
+# The whole point of running backfill inside the sandbox clone: the live
+# repo's docs/plans/ must be byte-identical before and after. We compare the
+# porcelain DELTA (before vs after) so an already-dirty live tree (for some
+# unrelated reason) does not produce a false failure — only a NEW
+# docs/plans/ modification introduced by this test does.
+live_plans_after="$(git -C "$REPO_ROOT" status --porcelain -- docs/plans/)"
+
+if [ "$live_plans_before" = "$live_plans_after" ]; then
+  pass "T-sandbox-no-live-mutation — live docs/plans/ unchanged by backfill run"
+else
+  fail "T-sandbox-no-live-mutation — backfill mutated the LIVE repo's docs/plans/"
+  echo "    NEW changes introduced by the backfill run (after minus before):"
+  # Print porcelain lines present AFTER but not BEFORE.
+  comm -13 <(printf '%s\n' "$live_plans_before" | sort) \
+           <(printf '%s\n' "$live_plans_after"  | sort) \
+    | sed 's/^/      /'
 fi
 
 print_summary_and_exit


### PR DESCRIPTION
## Summary

`tests/test-backfill-plan-completed.sh` ran the **real** backfill against the **live** repo (`cd "$REPO_ROOT" && bash backfill-plan-completed.sh`). Backfill cd's to the git toplevel and stamps a `completed:` frontmatter field into every `docs/plans/*.md` with `status: complete` and no `completed:` — so the test **dirtied real plan files** (notably `SKILL_VERIFICATION_SMOKES.md`) on every run, repeatedly blocking mid-pipeline rebases. The test's only real assertion (T672.1, "no unbound-variable crash") never needed to touch the live repo.

## Fix (test-only)

- Runs the real backfill inside a **throwaway local clone** (`mktemp -d` + EXIT-trap cleanup), mirroring the just-landed `test-plugin-d4-hook-siblings.sh` pattern — any stamping lands in the disposable clone. A clone (vs a hand-built fixture) is guaranteed-complete: backfill needs the full layout + its `BASH_SOURCE`-relative helper chain. No git identity added (backfill only edits in place, never commits).
- **T672.1 preserved verbatim** (run with `CLAUDE_PROJECT_DIR` unset; FAIL on "unbound variable").
- **New `T-sandbox-no-live-mutation`**: snapshots `git status --porcelain docs/plans/` before vs after and asserts the **delta** is empty — tolerant of a pre-existing dirty tree, fails only on a NEW modification the test introduced.
- No history-dependent positive assertion (a shallow CI clone has no history; backfill legitimately skips with a WARN).

## Test plan

- [x] Live `docs/plans/` clean before → run `tests/test-backfill-plan-completed.sh` → still clean (`SKILL_VERIFICATION_SMOKES.md` NOT stamped). Both assertions pass (2/2).
- [x] Full suite `bash tests/run-all.sh` → 6574/6574, 0 failed; `docs/plans/` clean afterward (this test was the sole culprit — no other caller dirties it).

No skill `metadata.version` bump (tests-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
