### PR TITLE
sprint-report: sprint-20260531-153707-sprint (dashboard sprint — #839, #836)

### DIFF
--- a/docs/reports/SPRINT_REPORT.md
+++ b/docs/reports/SPRINT_REPORT.md
@@ -49,3 +49,31 @@ The implementer noted that `tests/test-plans-render-index.sh` mutates `docs/plan
 - Sprint worktree: /tmp/zskills-fix-issues-sprint-20260531-143854-docstidy
 - Issue claim for #842 acquired and released cleanly.
 - Cron: `36 */2 * * *` — next fire ~2h.
+
+## Sprint — 2026-05-31 12:39 [UNFINALIZED]
+
+**Mode:** auto | **Focus:** dashboard (Ready queue) | **Landing:** PR (auto-merge) | **N:** 2 | **Pipeline:** fix-issues.sprint-20260531-153707-sprint
+
+### Fixed
+| # | Title | Worktree | Commit | Tests | Agent Verify | User Verify |
+|---|-------|----------|--------|-------|-------------|-------------|
+| #839 | /session-report handoff mode (durable hand-off, progressive disclosure) | /tmp/zskills-fix-issue-839 (fix/issue-839) | 086ba5b | full suite 6573/6573, 0 failed | PASS (fresh verifier re-ran full suite; mirror byte-identical; version bdd065 matches) | N/A (skill prose only) |
+| #836 | /quickfix: extract phases into modes/ + references/ | /tmp/zskills-fix-issue-836 (fix/issue-836) | 7ec9c18 | full suite 6574/6574, 0 failed (test-quickfix 30/30, conformance 726/726, invariants 112/112) | PASS (fresh verifier: verbatim move confirmed, cross-refs repointed, no assertion weakened) | N/A (skill prose only) |
+
+### Skipped — Already Classified (Phase 2 SKIP_TAGGED, dropped before triage)
+| # | Title | Why |
+|---|-------|-----|
+| #833 | test-skill-conformance.sh check_not for legacy resolver source | Action now: /draft-plan — plan-scale, author scope decision pending (tagged prior fire) |
+| #832 | skills/doc/SKILL.md single-lane resolver source | Action now: /draft-plan — plan-scale, author scope decision pending (tagged prior fire) |
+
+### Not Reached (queued for next fire)
+| # | Title | Why |
+|---|-------|-----|
+| #835 | /draft-tests: extract phases/references into mode/reference files | N=2 satisfied by #839 + #836; #835 is next in dashboard drag order |
+
+### Notes
+- Dashboard Ready queue (drag order) this fire: #839, #836, #835, #833, #832. Pool: 5 candidates considered (Ready ∩ open).
+- Both fixes are skill-file changes: skill-version bumps applied (session-report 2026.05.31+bdd065; quickfix 5fad41 + edited commit 4f1129, do 9dc0b2) and mirrored byte-identically to .claude/skills/.
+- #836 cross-refs repointed: skills/commit/modes/pr.md + skills/do/modes/pr.md quickfix/SKILL.md:634 → :672 (+ mirrors).
+- Stray test side-effect docs/plans/SKILL_VERIFICATION_SMOKES.md was correctly excluded from both per-issue commits.
+- Cron: `6,36 * * * *` (every 30m, ID 2b96cd74) — next fire ~16:06 ET.


### PR DESCRIPTION
## Summary
`/fix-issues` dashboard sprint sprint-20260531-153707-sprint — landed #839 (PR #848) and #836 (PR #849). This PR ships the sprint report.

## Test plan
- [x] Sprint-report content only (no code changes); per-issue PRs carried their own full-suite CI.
