### PR TITLE
do: center mode-chip text within full-width chip

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+70c1d4"
+  version: "2026.05.31+594158"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1276,12 +1276,8 @@ button svg { display: inline-block; vertical-align: middle; }
   font-family: inherit;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
-  /* In a flex-column card the default align-items: stretch was making
-     the chip span full card width with text anchored at the left
-     (#814 follow-up). Pin to start so the chip stays a content-sized
-     pill, restoring the centered-looking text people expect. */
-  align-self: flex-start;
 }
 
 /* Queued + inherit (issue #814): subtle filled button, not the old

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+70c1d4"
+  version: "2026.05.31+594158"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -1276,12 +1276,8 @@ button svg { display: inline-block; vertical-align: middle; }
   font-family: inherit;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
-  /* In a flex-column card the default align-items: stretch was making
-     the chip span full card width with text anchored at the left
-     (#814 follow-up). Pin to start so the chip stays a content-sized
-     pill, restoring the centered-looking text people expect. */
-  align-self: flex-start;
 }
 
 /* Queued + inherit (issue #814): subtle filled button, not the old


### PR DESCRIPTION
## Summary
The #817 follow-up commit's "fix" added `align-self: flex-start` to `.mode-chip` and collapsed it to a content-sized pill — the wrong layout. The chip is meant to occupy the full width of its own row in the card; the left-anchored-text symptom that motivated the regression was the default `justify-content: flex-start`, not the chip stretching.

Drop the `align-self: flex-start` override (and its now-stale block comment) and add `justify-content: center` so the chip stretches as designed and its content (text, or lock icon + text in running-finish) is horizontally centered.

## Test plan
- [x] Full suite green — `Overall: 6581/6581 passed, 0 failed`
- [x] Real-browser verified via playwright-cli on the static demo: all three chip states (queued / running-phase / running-finish) measure `chipW=390` of `cardW=416` with 13px symmetric padding and `justify-content: center` — text horizontally centered within the full-width chip
