### PR TITLE
do: migrate inline-prose resolver refs (#832,#833)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+9dc0b2"
+  version: "2026.05.31+4a50c0"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -783,9 +783,9 @@ Verification intensity matches the change type (from Phase 1):
 
 ### Code changes (js, css, html)
 
-- **Run `$FULL_TEST_CMD`** (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) — all suites must pass, not just unit tests.
+- **Run `$FULL_TEST_CMD`** (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) — all suites must pass, not just unit tests.
   **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
   min); default 120000ms is shorter than the suite's runtime (~3-4
   min). Do NOT recover from a Bash timeout by retrying with

--- a/.claude/skills/do/modes/direct.md
+++ b/.claude/skills/do/modes/direct.md
@@ -47,9 +47,9 @@ fi
 
 **Commit discipline (Paths B and C):**
 - **On main (Path C):** commit when the work is complete. Clean, descriptive
-  message. `$FULL_TEST_CMD` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) before committing if
+  message. `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) before committing if
   code was touched. If tests fail after two fix attempts on the same error,
   STOP — report what you tried and let the user decide.
 - **In worktree (Path B):** the verification agent commits after tests pass.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   newsletter entries (/doc newsletter). Use when the user asks to "write a
   newsletter entry", "add to the newsletter", or "update the newsletter".
 metadata:
-  version: "2026.05.15+550c1f"
+  version: "2026.05.31+b7e813"
 ---
 
 # /doc [blocks|examples|\<description>] — Documentation Audit & Fix
@@ -280,9 +280,9 @@ For each gap found:
 - Check all markdown formatting (links, images, tables)
 - Verify image references point to existing files
 - Verify model files load without errors (if dev server is up)
-- `$FULL_TEST_CMD` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) if any code files
+- `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) if any code files
   were touched (component explorer, registry file, docs-registry.js,
   examples-dropdown.js)
 
@@ -315,8 +315,8 @@ Remaining gaps:
 - **Update all cross-references** — a new example needs entries in
   component explorer, `examples/README.md`, and relevant block
   explorer entries. Don't create orphaned docs.
-- **`$FULL_TEST_CMD` before committing** (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) if code files were touched.
+- **`$FULL_TEST_CMD` before committing** (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) if code files were touched.
 - **Content-only changes skip tests** — if only markdown/images were
   changed, no test run needed.

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.31+3a529c"
+  version: "2026.05.31+68a0eb"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -339,9 +339,9 @@ Do not proceed until you have read the file.
 - **Never close GH issues, update trackers, or remove worktrees** — that's
   `/fix-report`'s job.
 - **One issue per commit** — clean git history in worktrees.
-- **`$FULL_TEST_CMD` before every commit** (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) — not just `npm test`.
+- **`$FULL_TEST_CMD` before every commit** (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) — not just `npm test`.
 - **Never weaken tests** — fix the code, not the test. Do not loosen
   tolerances, skip assertions, or remove test cases.
 - **Never defer the hard parts** — finish all phases of the plan. Do not

--- a/.claude/skills/fix-issues/modes/sprint.md
+++ b/.claude/skills/fix-issues/modes/sprint.md
@@ -1665,9 +1665,9 @@ Each agent follows this fix workflow:
 2. Reproduce the bug (unit test or manual)
 3. Implement the fix
 4. Write regression tests (unit and/or E2E as appropriate)
-5. Run `$FULL_TEST_CMD` (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if you don't already have it in your environment) — all suites must pass.
+5. Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+   references/canonical-config-prelude.md §1 if you don't already have it in
+   your environment) — all suites must pass.
    **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
    min). The default 120000ms is shorter than the suite's actual runtime
    (~3-4 min in zskills). **Do NOT recover from a timeout by retrying

--- a/.claude/skills/fix-report/SKILL.md
+++ b/.claude/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.31+cb2e7e"
+  version: "2026.05.31+112185"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -472,9 +472,9 @@ not "3 fixes in category" but one per fix.
   synthetic event limitations)
 - **Pre-existing Bugs Discovered** — bugs found during verification,
   not related to sprint fixes (Bug, Found During, Location, Severity)
-- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if not already in environment) + per-suite counts
+- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via the dual-lane
+  prelude in references/canonical-config-prelude.md §1 if you don't already
+  have it in your environment) + per-suite counts
 
 **Append, don't overwrite** — new items go at the top of each domain
 section. Already-verified items stay as `✅`. Returning from a fix

--- a/.claude/skills/qe-audit/SKILL.md
+++ b/.claude/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.30+91aef8"
+  version: "2026.05.31+968ff1"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -453,9 +453,9 @@ Run when `bash` IS present in arguments.
    - **ONLY use `todo` for bugs you just DISCOVERED during this bash
      session.** NEVER use `todo` to skip a test that was passing before
      and now fails due to your changes — that's weakening, not discovery.
-   - Run `$FULL_TEST_CMD` (resolve via
-     `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-     if you don't already have it in your environment) before committing —
+   - Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+     references/canonical-config-prelude.md §1 if you don't already have it in
+     your environment) before committing —
      all suites must pass (todo-skipped tests are acceptable)
    - Commit all tests (passing + skipped) with descriptive message
 

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+20eee1"
+  version: "2026.05.31+0794e5"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -535,9 +535,9 @@ If this phase used delegate execution, verification runs on **main**:
 1. **Verify commits landed** — check `git log --oneline -10` for the
    delegate's commits. If expected commits are missing, the delegate
    failed to land — invoke Failure Protocol.
-2. **Run `$FULL_TEST_CMD` on main** (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if not already in environment) — the delegate already tested, but
+2. **Run `$FULL_TEST_CMD` on main** (resolve via the dual-lane prelude in
+   references/canonical-config-prelude.md §1 if you don't already have it in
+   your environment) — the delegate already tested, but
    /run-plan verifies against the plan's acceptance criteria.
 3. **Check acceptance criteria** from the verbatim plan text — the delegate
    skill doesn't know the plan's criteria, only /run-plan does.

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.05.31+11266d"
+  version: "2026.05.31+9eba25"
 ---
 
 # /verify-changes [scope] — Verify, Test & Fix Changes
@@ -338,8 +338,8 @@ crashes with exactly that phrase across 2026-04-29 and 2026-04-30
 sessions. Always foreground-Bash with explicit long timeout; capture
 to file as below; read the file when the call returns.
 
-1. **Run the full test suite with output captured to a file** (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`):
+1. **Run the full test suite with output captured to a file** (resolve via the
+   dual-lane prelude in references/canonical-config-prelude.md §1):
    ```bash
    if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
      . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
@@ -561,9 +561,9 @@ If any issues were found in Phases 2-4:
 
 After fixing any issues in Phase 5:
 
-1. **Run `$FULL_TEST_CMD` again** (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if not already in environment) — all suites must pass, including new tests
+1. **Run `$FULL_TEST_CMD` again** (resolve via the dual-lane prelude in
+   references/canonical-config-prelude.md §1 if you don't already have it in
+   your environment) — all suites must pass, including new tests
 2. **Re-check manual verifications** if fixes touched UI code
 3. **If new problems are found**, go back to Phase 5
 
@@ -768,9 +768,9 @@ printf 'skill: verify-changes\nid: %s\nscope: %s\nstatus: complete\ndate: %s\n' 
 - **Fix, don't just report.** When problems are found, fix them — then re-verify.
   The goal is a clean verification, not a list of issues left for the user.
 - **Start a dev server if needed.** "No dev server" is not an excuse to
-  skip manual verification. Run `$DEV_SERVER_CMD &` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) — it takes 2 seconds.
+  skip manual verification. Run `$DEV_SERVER_CMD &` (resolve via the dual-lane
+  prelude in references/canonical-config-prelude.md §1 if you don't already
+  have it in your environment) — it takes 2 seconds.
   Only report "cannot verify" for genuinely unavailable tooling (e.g.,
   no cargo for codegen).
 - **Be thorough but honest.** If something genuinely can't be verified,

--- a/references/canonical-config-prelude.md
+++ b/references/canonical-config-prelude.md
@@ -105,6 +105,34 @@ git-tracked). The helper internally reads `$CLAUDE_PROJECT_DIR` and fails
 loudly via `${CLAUDE_PROJECT_DIR:?...}` if it's unset, rather than
 silently expanding to an empty path.
 
+### Inline-prose `resolve via` references must use the lane-portable form (#832/#833)
+
+The "permanently valid" status above applies **only inside `` ```fenced``
+bash blocks** — where the single-line form is the legacy `/update-zskills`-lane
+source, and where it ALSO appears as the `else` fallback branch of the
+dual-lane prelude in §1. It does **not** extend to **inline prose**.
+
+An inline-prose reference is the single-backtick code-span form that shows up
+in a parenthetical, e.g.
+
+> Run `$FULL_TEST_CMD` (resolve via `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"` if you don't already have it).
+
+That wording instructs the agent to source a **single-lane** path. A
+mirror-less plugin install (the primary plugin consumer — no
+`.claude/skills/` mirror) following it runs a path that does not exist and
+fails. Inline-prose `resolve via` references MUST therefore use the
+lane-portable form, pointing at the dual-lane prelude in §1 rather than
+pasting the single-line literal:
+
+> Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in references/canonical-config-prelude.md §1 if you don't already have it in your environment).
+
+This is the distinction the conformance gate `=== Inline-prose resolve-via
+uses lane-portable wording (#832/#833) ===` in `tests/test-skill-conformance.sh`
+enforces: it is fence-aware and flags the single-lane literal **only** when it
+appears in an inline code-span on a non-fenced line, leaving the fence form
+(both the legacy source and the dual-prelude fallback) untouched per
+decision D23 / finding F-DA2-4.
+
 ## 2. Fallback semantics
 
 The helper produces empty values when the field is absent, the config is

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+9dc0b2"
+  version: "2026.05.31+4a50c0"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -783,9 +783,9 @@ Verification intensity matches the change type (from Phase 1):
 
 ### Code changes (js, css, html)
 
-- **Run `$FULL_TEST_CMD`** (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) — all suites must pass, not just unit tests.
+- **Run `$FULL_TEST_CMD`** (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) — all suites must pass, not just unit tests.
   **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
   min); default 120000ms is shorter than the suite's runtime (~3-4
   min). Do NOT recover from a Bash timeout by retrying with

--- a/skills/do/modes/direct.md
+++ b/skills/do/modes/direct.md
@@ -47,9 +47,9 @@ fi
 
 **Commit discipline (Paths B and C):**
 - **On main (Path C):** commit when the work is complete. Clean, descriptive
-  message. `$FULL_TEST_CMD` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) before committing if
+  message. `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) before committing if
   code was touched. If tests fail after two fix attempts on the same error,
   STOP — report what you tried and let the user decide.
 - **In worktree (Path B):** the verification agent commits after tests pass.

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   newsletter entries (/doc newsletter). Use when the user asks to "write a
   newsletter entry", "add to the newsletter", or "update the newsletter".
 metadata:
-  version: "2026.05.15+550c1f"
+  version: "2026.05.31+b7e813"
 ---
 
 # /doc [blocks|examples|\<description>] — Documentation Audit & Fix
@@ -280,9 +280,9 @@ For each gap found:
 - Check all markdown formatting (links, images, tables)
 - Verify image references point to existing files
 - Verify model files load without errors (if dev server is up)
-- `$FULL_TEST_CMD` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) if any code files
+- `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) if any code files
   were touched (component explorer, registry file, docs-registry.js,
   examples-dropdown.js)
 
@@ -315,8 +315,8 @@ Remaining gaps:
 - **Update all cross-references** — a new example needs entries in
   component explorer, `examples/README.md`, and relevant block
   explorer entries. Don't create orphaned docs.
-- **`$FULL_TEST_CMD` before committing** (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) if code files were touched.
+- **`$FULL_TEST_CMD` before committing** (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) if code files were touched.
 - **Content-only changes skip tests** — if only markdown/images were
   changed, no test run needed.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.31+3a529c"
+  version: "2026.05.31+68a0eb"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -339,9 +339,9 @@ Do not proceed until you have read the file.
 - **Never close GH issues, update trackers, or remove worktrees** — that's
   `/fix-report`'s job.
 - **One issue per commit** — clean git history in worktrees.
-- **`$FULL_TEST_CMD` before every commit** (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) — not just `npm test`.
+- **`$FULL_TEST_CMD` before every commit** (resolve via the dual-lane prelude in
+  references/canonical-config-prelude.md §1 if you don't already have it in
+  your environment) — not just `npm test`.
 - **Never weaken tests** — fix the code, not the test. Do not loosen
   tolerances, skip assertions, or remove test cases.
 - **Never defer the hard parts** — finish all phases of the plan. Do not

--- a/skills/fix-issues/modes/sprint.md
+++ b/skills/fix-issues/modes/sprint.md
@@ -1665,9 +1665,9 @@ Each agent follows this fix workflow:
 2. Reproduce the bug (unit test or manual)
 3. Implement the fix
 4. Write regression tests (unit and/or E2E as appropriate)
-5. Run `$FULL_TEST_CMD` (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if you don't already have it in your environment) — all suites must pass.
+5. Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+   references/canonical-config-prelude.md §1 if you don't already have it in
+   your environment) — all suites must pass.
    **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
    min). The default 120000ms is shorter than the suite's actual runtime
    (~3-4 min in zskills). **Do NOT recover from a timeout by retrying

--- a/skills/fix-report/SKILL.md
+++ b/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.05.31+cb2e7e"
+  version: "2026.05.31+112185"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -472,9 +472,9 @@ not "3 fixes in category" but one per fix.
   synthetic event limitations)
 - **Pre-existing Bugs Discovered** — bugs found during verification,
   not related to sprint fixes (Bug, Found During, Location, Severity)
-- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if not already in environment) + per-suite counts
+- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via the dual-lane
+  prelude in references/canonical-config-prelude.md §1 if you don't already
+  have it in your environment) + per-suite counts
 
 **Append, don't overwrite** — new items go at the top of each domain
 section. Already-verified items stay as `✅`. Returning from a fix

--- a/skills/qe-audit/SKILL.md
+++ b/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.30+91aef8"
+  version: "2026.05.31+968ff1"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -453,9 +453,9 @@ Run when `bash` IS present in arguments.
    - **ONLY use `todo` for bugs you just DISCOVERED during this bash
      session.** NEVER use `todo` to skip a test that was passing before
      and now fails due to your changes — that's weakening, not discovery.
-   - Run `$FULL_TEST_CMD` (resolve via
-     `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-     if you don't already have it in your environment) before committing —
+   - Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
+     references/canonical-config-prelude.md §1 if you don't already have it in
+     your environment) before committing —
      all suites must pass (todo-skipped tests are acceptable)
    - Commit all tests (passing + skipped) with descriptive message
 

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+20eee1"
+  version: "2026.05.31+0794e5"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -535,9 +535,9 @@ If this phase used delegate execution, verification runs on **main**:
 1. **Verify commits landed** — check `git log --oneline -10` for the
    delegate's commits. If expected commits are missing, the delegate
    failed to land — invoke Failure Protocol.
-2. **Run `$FULL_TEST_CMD` on main** (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if not already in environment) — the delegate already tested, but
+2. **Run `$FULL_TEST_CMD` on main** (resolve via the dual-lane prelude in
+   references/canonical-config-prelude.md §1 if you don't already have it in
+   your environment) — the delegate already tested, but
    /run-plan verifies against the plan's acceptance criteria.
 3. **Check acceptance criteria** from the verbatim plan text — the delegate
    skill doesn't know the plan's criteria, only /run-plan does.

--- a/skills/verify-changes/SKILL.md
+++ b/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.05.31+11266d"
+  version: "2026.05.31+9eba25"
 ---
 
 # /verify-changes [scope] — Verify, Test & Fix Changes
@@ -338,8 +338,8 @@ crashes with exactly that phrase across 2026-04-29 and 2026-04-30
 sessions. Always foreground-Bash with explicit long timeout; capture
 to file as below; read the file when the call returns.
 
-1. **Run the full test suite with output captured to a file** (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`):
+1. **Run the full test suite with output captured to a file** (resolve via the
+   dual-lane prelude in references/canonical-config-prelude.md §1):
    ```bash
    if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
      . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
@@ -561,9 +561,9 @@ If any issues were found in Phases 2-4:
 
 After fixing any issues in Phase 5:
 
-1. **Run `$FULL_TEST_CMD` again** (resolve via
-   `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-   if not already in environment) — all suites must pass, including new tests
+1. **Run `$FULL_TEST_CMD` again** (resolve via the dual-lane prelude in
+   references/canonical-config-prelude.md §1 if you don't already have it in
+   your environment) — all suites must pass, including new tests
 2. **Re-check manual verifications** if fixes touched UI code
 3. **If new problems are found**, go back to Phase 5
 
@@ -768,9 +768,9 @@ printf 'skill: verify-changes\nid: %s\nscope: %s\nstatus: complete\ndate: %s\n' 
 - **Fix, don't just report.** When problems are found, fix them — then re-verify.
   The goal is a clean verification, not a list of issues left for the user.
 - **Start a dev server if needed.** "No dev server" is not an excuse to
-  skip manual verification. Run `$DEV_SERVER_CMD &` (resolve via
-  `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-  if you don't already have it in your environment) — it takes 2 seconds.
+  skip manual verification. Run `$DEV_SERVER_CMD &` (resolve via the dual-lane
+  prelude in references/canonical-config-prelude.md §1 if you don't already
+  have it in your environment) — it takes 2 seconds.
   Only report "cannot verify" for genuinely unavailable tooling (e.g.,
   no cargo for codegen).
 - **Be thorough but honest.** If something genuinely can't be verified,

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2177,6 +2177,76 @@ else
 fi
 
 echo ""
+echo "=== Inline-prose resolve-via uses lane-portable wording (#832/#833) ==="
+# Fence-aware gate: the legacy single-lane literal
+#   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+# is PERMANENTLY valid inside ```fenced``` bash blocks (decision D23 /
+# finding F-DA2-4 — it is the legacy /update-zskills-lane source form and the
+# `else` fallback branch of the dual-lane prelude). What is NOT valid is an
+# INLINE-PROSE reference to it — a single-backtick code-span on a non-fenced
+# line, typically a `(resolve via `...`)` parenthetical. A mirror-less plugin
+# consumer (the primary plugin install — no `.claude/skills/` mirror) that
+# follows that prose runs a path that does not exist. Such prose MUST instead
+# point at the lane-portable dual-lane prelude in
+# references/canonical-config-prelude.md §1.
+#
+# Fence-awareness is implemented in PYTHON (repo convention — no jq): walk each
+# skills/**/*.md + block-diagram/**/*.md, toggle fenced-block state on ```/~~~
+# fence-openers, and flag the literal ONLY when it appears inside an inline
+# code-span (`...`) on a NON-fenced line. The `else` fallback line inside the
+# dual-lane prelude lives in a bash fence and is therefore NEVER flagged. An
+# <!-- allow-hardcoded: ... reason: ... --> marker on the line immediately
+# above the prose line exempts that line (same marker convention as the
+# deny-list scan above).
+PROSE_RESOLVE_FAIL=0
+PROSE_RESOLVE_HITS="$(ZS_REPO_ROOT="$REPO_ROOT" "${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}" <<'PYEOF'
+import os, sys
+repo = os.environ["ZS_REPO_ROOT"]
+LIT = '. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"'
+INLINE = "`" + LIT + "`"          # the literal wrapped in a single-backtick code-span
+MARKER_FRAG = "allow-hardcoded:"  # an allow-hardcoded marker (verbatim or naming this literal) exempts the next prose line
+roots = [os.path.join(repo, "skills"), os.path.join(repo, "block-diagram")]
+files = []
+for root in roots:
+    for dirpath, _dirs, fns in os.walk(root):
+        for fn in fns:
+            if fn.endswith(".md"):
+                files.append(os.path.join(dirpath, fn))
+hits = []
+for f in sorted(files):
+    in_fence = False
+    prev = ""
+    with open(f, encoding="utf-8") as fh:
+        for i, line in enumerate(fh, 1):
+            stripped = line.lstrip()
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                in_fence = not in_fence
+                prev = line
+                continue
+            if not in_fence and INLINE in line:
+                if MARKER_FRAG not in prev:
+                    rel = os.path.relpath(f, repo)
+                    hits.append("%s:%d: inline-prose `resolve via ...zskills-resolve-config.sh` code-span "
+                                "is single-lane only — replace with a reference to the dual-lane prelude in "
+                                "references/canonical-config-prelude.md \xc2\xa71 (or add an allow-hardcoded "
+                                "marker on the line above)." % (rel, i))
+            prev = line
+for h in hits:
+    print(h)
+sys.exit(0)
+PYEOF
+)"
+if [ -n "$PROSE_RESOLVE_HITS" ]; then
+  PROSE_RESOLVE_FAIL=1
+  fail "inline-prose resolve-via uses single-lane literal (#832/#833)" "$(printf '%s' "$PROSE_RESOLVE_HITS" | grep -c .) hit(s)"
+  printf '%s\n' "$PROSE_RESOLVE_HITS" | while IFS= read -r h; do
+    [ -n "$h" ] && printf '    %s\n' "$h" >&2
+  done
+else
+  pass "no inline-prose single-lane resolve-via references (lane-portable wording per #832/#833)"
+fi
+
+echo ""
 echo "=== No skill-file drift hardcodes (extended scope: hooks/, scripts/, *.py) ==="
 # Sibling deny-list scan over non-markdown sources that the existing
 # skills/**/*.md scanner above doesn't see:


### PR DESCRIPTION
Closes #832
Closes #833

## Summary
Migrate inline-prose `(resolve via ...)` config-resolution references from the legacy single-lane path to a lane-portable wording (point at `references/canonical-config-prelude.md` §1) across 7 skills, so a **mirror-less plugin install** (the primary plugin consumer) no longer follows prose into a non-existent path. Adds a fence-aware regression gate (#833) that flags the legacy literal in **inline prose only** — never in executable fences, which D23/F-DA2-4 keep permanently valid on the /update-zskills lane.

## Changes
- Fix #832/#833: migrate inline-prose resolve-via refs to lane-portable wording + add #833 regression gate

## Test plan
- [x] Full suite green on rebased tree (6576/6576, 0 failed; new gate PASS)
- [x] 12 inline-prose sites migrated (do, doc, fix-issues, fix-report, qe-audit, verify-changes + run-plan mode file); .claude/skills mirrors byte-identical; metadata.version bumped on 7 dirs
- [x] Gate fence-aware (does not flag dual-prelude fallback lines); verified 0 false-positives
- [ ] Reviewer confirms the lane-portable prose reads well
