### PR TITLE
fix(do,quickfix): retire obsolete /fix-issues triage REDIRECT + anchor ISSUE_NUM regex

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+4a50c0"
+  version: "2026.05.31+95ac63"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -228,17 +228,23 @@ AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
 fi
-# Issue-number parse (claim-work-item Phase 2 / W2.2). /do is normally
-# REDIRECTed to /fix-issues when the description references an issue
-# (Phase 0a triage); the number is only reachable here when --force
-# overrides that redirect. Extract the FIRST bare positive integer from a
-# `#N` / `closes #N` / `fix #N` reference into ISSUE_NUM so the mode files
-# can claim the issue via claim-issue.sh. When no issue number is present
-# (the common /do case) ISSUE_NUM stays empty and the mode files claim
-# nothing. The number is stripped to a bare integer (claim-issue.sh
-# rejects non-numeric input with exit 2).
+# Issue-number parse (claim-work-item Phase 2 / W2.2). When the description
+# begins with a `#N` reference (optionally preceded by a close-keyword:
+# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
+# insensitive) extract the bare integer into ISSUE_NUM so the mode files
+# can claim the issue via claim-issue.sh. The regex is ANCHORED to the
+# start of the description so a `#NNN` literal appearing later in prose
+# (e.g., a quoted example, a line reference, a follow-up "see also #N")
+# does NOT set ISSUE_NUM. An optional leading double-quote is tolerated so
+# /do's quoted-description carve-out (`/do "Fix #N ..."`) still matches.
+# When no issue reference is in scope (the common /do case) ISSUE_NUM
+# stays empty and the mode files claim nothing. claim-issue.sh rejects
+# non-numeric input with exit 2; the `[0-9]+` capture guarantees a bare
+# integer.
 ISSUE_NUM=""
-if [[ "$ARGUMENTS" =~ \#([0-9]+) ]]; then
+if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[3]}"
+elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
   ISSUE_NUM="${BASH_REMATCH[1]}"
 fi
 ROUNDS=1
@@ -288,7 +294,7 @@ the verdict. Production invocations (where the harness flag is absent and
 the entry-point unset guard at the pre-flight has already cleared the
 test vars) always run the full Agent path. Recognized stub values:
 `PROCEED`, `REDIRECT:/draft-plan:reason`, `REDIRECT:/run-plan:reason`,
-`REDIRECT:/fix-issues:reason`, `REDIRECT:ask-user:reason`.
+`REDIRECT:ask-user:reason`.
 
 The model judges `$DESCRIPTION` against this rubric — qualitative,
 observable from description text, no LOC counting. /do always works in a
@@ -303,7 +309,6 @@ needed).
 | Verbs include any of: `add feature`, `redesign`, `rewrite`, `refactor across` | REDIRECT → `/draft-plan` |
 | `and` connects unrelated areas (e.g. "fix nav and update copy") | REDIRECT → `/draft-plan` |
 | Vague verbs alone: `improve`, `fix it`, `update`, `clean up` (no concrete object) | REDIRECT → ask user |
-| References a GitHub issue number (`#N`, `closes #N`, `fix #N`) | REDIRECT → `/fix-issues` |
 | References an existing plan file under `$ZSKILLS_PLANS_DIR` | REDIRECT → `/run-plan` |
 
 **Worked examples (calibrate the model's PROCEED/REDIRECT calls):**
@@ -315,7 +320,7 @@ needed).
 | `/do Update the presentation with Phase 3 results auto` | PROCEED | concrete verb + object |
 | `/do add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/do improve` | REDIRECT → ask user | vague verb, no object |
-| `/do fix #142` | REDIRECT → /fix-issues | references issue number |
+| `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
 
 Output one of:
 
@@ -330,7 +335,6 @@ linebreak is a real newline, not the literal `\n` characters):
 |--------|--------|--------|
 | `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.` |
 | `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with --force to bypass.` |
-| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with --force to bypass.` |
 | ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /do with a concrete description (verb + object + which file/area). --force will not help — vague descriptions cannot be planned.` |
 
 The model implements these as a `printf 'line1\nline2\n' "$REASON"` so

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.31+5fad41"
+  version: "2026.05.31+d0e090"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -146,15 +146,21 @@ DESCRIPTION="${DESCRIPTION#"${DESCRIPTION%%[![:space:]]*}"}"
 DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 
 # Issue-number parse (claim-work-item Phase 2 / W2.4). /quickfix usually
-# works an in-flight edit, not an issue — but a description that references
-# an issue (`#N` / `closes #N` / `fix #N`) is normally REDIRECTed to
-# /fix-issues by triage (WI 1.5.4) and only proceeds here under `force`.
-# Extract the FIRST bare positive integer into ISSUE_NUM so WI 1.8 can
-# claim the issue via claim-issue.sh. When no issue number is present (the
-# common case) ISSUE_NUM stays empty and nothing is claimed. The number is
-# a bare integer (claim-issue.sh rejects non-numeric input with exit 2).
+# works an in-flight edit, not an issue — but when the description begins
+# with a `#N` reference (optionally preceded by a close-keyword:
+# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
+# insensitive) extract the bare integer into ISSUE_NUM so WI 1.8 can
+# claim the issue via claim-issue.sh. The regex is ANCHORED to the start
+# of the description so a `#NNN` literal appearing later in prose (e.g.,
+# a quoted example, a line reference, a follow-up "see also #N") does
+# NOT set ISSUE_NUM. When no issue reference is in scope (the common
+# case) ISSUE_NUM stays empty and nothing is claimed. claim-issue.sh
+# rejects non-numeric input with exit 2; the `[0-9]+` capture guarantees
+# a bare integer.
 ISSUE_NUM=""
-if [[ "$DESCRIPTION" =~ \#([0-9]+) ]]; then
+if [[ "$DESCRIPTION" =~ ^[[:space:]]*([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[3]}"
+elif [[ "$DESCRIPTION" =~ ^[[:space:]]*#([0-9]+) ]]; then
   ISSUE_NUM="${BASH_REMATCH[1]}"
 fi
 ```
@@ -347,7 +353,7 @@ the verdict. Production invocations (where the harness flag is absent
 and the entry-point unset guard at WI 1.2 has already cleared the test
 vars) always run the full Agent path. Recognized stub values:
 `PROCEED`, `REDIRECT:/draft-plan:reason`, `REDIRECT:/run-plan:reason`,
-`REDIRECT:/fix-issues:reason`, `REDIRECT:ask-user:reason`.
+`REDIRECT:ask-user:reason`.
 
 The model judges `$DESCRIPTION` (and, in user-edited mode, the dirty-tree
 shape) against this rubric — qualitative, observable from description
@@ -360,7 +366,6 @@ text and dirty-tree shape, no LOC counting:
 | Verbs include any of: `add feature`, `redesign`, `rewrite`, `refactor across` | REDIRECT → `/draft-plan` | both |
 | `and` connects unrelated areas (e.g. "fix nav and update copy") | REDIRECT → `/draft-plan` | both |
 | Vague verbs alone: `improve`, `fix it`, `update`, `clean up` (no concrete object) | REDIRECT → ask user | both |
-| References a GitHub issue number (`#N`, `closes #N`, `fix #N`) | REDIRECT → `/fix-issues` | both |
 | References an existing plan file under `$ZSKILLS_PLANS_DIR` | REDIRECT → `/run-plan` | both |
 | Dirty tree (user-edited mode) spans heterogeneous subsystems (model judgment) | REDIRECT → `/draft-plan` | user-edited only |
 
@@ -373,7 +378,7 @@ text and dirty-tree shape, no LOC counting:
 | `/quickfix update CHANGELOG with v0.5 release notes` | PROCEED | concrete verb + object + file |
 | `/quickfix add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/quickfix improve` | REDIRECT → ask user | vague verb, no object |
-| `/quickfix fix #142` | REDIRECT → /fix-issues | references issue number |
+| `/quickfix Fix #853 typo` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
 
 Output one of:
 
@@ -388,7 +393,6 @@ linebreak is a real newline, not the literal `\n` characters):
 |--------|--------|--------|
 | `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.` |
 | `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with --force to bypass.` |
-| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with --force to bypass.` |
 | ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /quickfix with a concrete description (verb + object + which file/area). --force will not help — vague descriptions cannot be planned.` |
 
 The model implements these as a `printf 'line1\nline2\n' "$REASON"` so

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+4a50c0"
+  version: "2026.05.31+95ac63"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -228,17 +228,23 @@ AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
 fi
-# Issue-number parse (claim-work-item Phase 2 / W2.2). /do is normally
-# REDIRECTed to /fix-issues when the description references an issue
-# (Phase 0a triage); the number is only reachable here when --force
-# overrides that redirect. Extract the FIRST bare positive integer from a
-# `#N` / `closes #N` / `fix #N` reference into ISSUE_NUM so the mode files
-# can claim the issue via claim-issue.sh. When no issue number is present
-# (the common /do case) ISSUE_NUM stays empty and the mode files claim
-# nothing. The number is stripped to a bare integer (claim-issue.sh
-# rejects non-numeric input with exit 2).
+# Issue-number parse (claim-work-item Phase 2 / W2.2). When the description
+# begins with a `#N` reference (optionally preceded by a close-keyword:
+# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
+# insensitive) extract the bare integer into ISSUE_NUM so the mode files
+# can claim the issue via claim-issue.sh. The regex is ANCHORED to the
+# start of the description so a `#NNN` literal appearing later in prose
+# (e.g., a quoted example, a line reference, a follow-up "see also #N")
+# does NOT set ISSUE_NUM. An optional leading double-quote is tolerated so
+# /do's quoted-description carve-out (`/do "Fix #N ..."`) still matches.
+# When no issue reference is in scope (the common /do case) ISSUE_NUM
+# stays empty and the mode files claim nothing. claim-issue.sh rejects
+# non-numeric input with exit 2; the `[0-9]+` capture guarantees a bare
+# integer.
 ISSUE_NUM=""
-if [[ "$ARGUMENTS" =~ \#([0-9]+) ]]; then
+if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[3]}"
+elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
   ISSUE_NUM="${BASH_REMATCH[1]}"
 fi
 ROUNDS=1
@@ -288,7 +294,7 @@ the verdict. Production invocations (where the harness flag is absent and
 the entry-point unset guard at the pre-flight has already cleared the
 test vars) always run the full Agent path. Recognized stub values:
 `PROCEED`, `REDIRECT:/draft-plan:reason`, `REDIRECT:/run-plan:reason`,
-`REDIRECT:/fix-issues:reason`, `REDIRECT:ask-user:reason`.
+`REDIRECT:ask-user:reason`.
 
 The model judges `$DESCRIPTION` against this rubric — qualitative,
 observable from description text, no LOC counting. /do always works in a
@@ -303,7 +309,6 @@ needed).
 | Verbs include any of: `add feature`, `redesign`, `rewrite`, `refactor across` | REDIRECT → `/draft-plan` |
 | `and` connects unrelated areas (e.g. "fix nav and update copy") | REDIRECT → `/draft-plan` |
 | Vague verbs alone: `improve`, `fix it`, `update`, `clean up` (no concrete object) | REDIRECT → ask user |
-| References a GitHub issue number (`#N`, `closes #N`, `fix #N`) | REDIRECT → `/fix-issues` |
 | References an existing plan file under `$ZSKILLS_PLANS_DIR` | REDIRECT → `/run-plan` |
 
 **Worked examples (calibrate the model's PROCEED/REDIRECT calls):**
@@ -315,7 +320,7 @@ needed).
 | `/do Update the presentation with Phase 3 results auto` | PROCEED | concrete verb + object |
 | `/do add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/do improve` | REDIRECT → ask user | vague verb, no object |
-| `/do fix #142` | REDIRECT → /fix-issues | references issue number |
+| `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
 
 Output one of:
 
@@ -330,7 +335,6 @@ linebreak is a real newline, not the literal `\n` characters):
 |--------|--------|--------|
 | `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.` |
 | `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with --force to bypass.` |
-| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with --force to bypass.` |
 | ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /do with a concrete description (verb + object + which file/area). --force will not help — vague descriptions cannot be planned.` |
 
 The model implements these as a `printf 'line1\nline2\n' "$REASON"` so

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.31+5fad41"
+  version: "2026.05.31+d0e090"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -146,15 +146,21 @@ DESCRIPTION="${DESCRIPTION#"${DESCRIPTION%%[![:space:]]*}"}"
 DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 
 # Issue-number parse (claim-work-item Phase 2 / W2.4). /quickfix usually
-# works an in-flight edit, not an issue — but a description that references
-# an issue (`#N` / `closes #N` / `fix #N`) is normally REDIRECTed to
-# /fix-issues by triage (WI 1.5.4) and only proceeds here under `force`.
-# Extract the FIRST bare positive integer into ISSUE_NUM so WI 1.8 can
-# claim the issue via claim-issue.sh. When no issue number is present (the
-# common case) ISSUE_NUM stays empty and nothing is claimed. The number is
-# a bare integer (claim-issue.sh rejects non-numeric input with exit 2).
+# works an in-flight edit, not an issue — but when the description begins
+# with a `#N` reference (optionally preceded by a close-keyword:
+# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
+# insensitive) extract the bare integer into ISSUE_NUM so WI 1.8 can
+# claim the issue via claim-issue.sh. The regex is ANCHORED to the start
+# of the description so a `#NNN` literal appearing later in prose (e.g.,
+# a quoted example, a line reference, a follow-up "see also #N") does
+# NOT set ISSUE_NUM. When no issue reference is in scope (the common
+# case) ISSUE_NUM stays empty and nothing is claimed. claim-issue.sh
+# rejects non-numeric input with exit 2; the `[0-9]+` capture guarantees
+# a bare integer.
 ISSUE_NUM=""
-if [[ "$DESCRIPTION" =~ \#([0-9]+) ]]; then
+if [[ "$DESCRIPTION" =~ ^[[:space:]]*([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[3]}"
+elif [[ "$DESCRIPTION" =~ ^[[:space:]]*#([0-9]+) ]]; then
   ISSUE_NUM="${BASH_REMATCH[1]}"
 fi
 ```
@@ -347,7 +353,7 @@ the verdict. Production invocations (where the harness flag is absent
 and the entry-point unset guard at WI 1.2 has already cleared the test
 vars) always run the full Agent path. Recognized stub values:
 `PROCEED`, `REDIRECT:/draft-plan:reason`, `REDIRECT:/run-plan:reason`,
-`REDIRECT:/fix-issues:reason`, `REDIRECT:ask-user:reason`.
+`REDIRECT:ask-user:reason`.
 
 The model judges `$DESCRIPTION` (and, in user-edited mode, the dirty-tree
 shape) against this rubric — qualitative, observable from description
@@ -360,7 +366,6 @@ text and dirty-tree shape, no LOC counting:
 | Verbs include any of: `add feature`, `redesign`, `rewrite`, `refactor across` | REDIRECT → `/draft-plan` | both |
 | `and` connects unrelated areas (e.g. "fix nav and update copy") | REDIRECT → `/draft-plan` | both |
 | Vague verbs alone: `improve`, `fix it`, `update`, `clean up` (no concrete object) | REDIRECT → ask user | both |
-| References a GitHub issue number (`#N`, `closes #N`, `fix #N`) | REDIRECT → `/fix-issues` | both |
 | References an existing plan file under `$ZSKILLS_PLANS_DIR` | REDIRECT → `/run-plan` | both |
 | Dirty tree (user-edited mode) spans heterogeneous subsystems (model judgment) | REDIRECT → `/draft-plan` | user-edited only |
 
@@ -373,7 +378,7 @@ text and dirty-tree shape, no LOC counting:
 | `/quickfix update CHANGELOG with v0.5 release notes` | PROCEED | concrete verb + object + file |
 | `/quickfix add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/quickfix improve` | REDIRECT → ask user | vague verb, no object |
-| `/quickfix fix #142` | REDIRECT → /fix-issues | references issue number |
+| `/quickfix Fix #853 typo` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
 
 Output one of:
 
@@ -388,7 +393,6 @@ linebreak is a real newline, not the literal `\n` characters):
 |--------|--------|--------|
 | `/draft-plan` | `Triage: redirecting to /draft-plan. Reason: <reason>` | `This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.` |
 | `/run-plan` | `Triage: redirecting to /run-plan. Reason: <reason>` | `This task references an existing plan file. Run \`/run-plan <plan-path>\` to execute it, or re-invoke with --force to bypass.` |
-| `/fix-issues` | `Triage: redirecting to /fix-issues. Reason: <reason>` | `This task references a GitHub issue. Run \`/fix-issues <issue-number>\` instead, or re-invoke with --force to bypass.` |
 | ask-user | `Triage: cannot proceed — description is too vague to act on. Reason: <reason>` | `Re-invoke /quickfix with a concrete description (verb + object + which file/area). --force will not help — vague descriptions cannot be planned.` |
 
 The model implements these as a `printf 'line1\nline2\n' "$REASON"` so

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -572,6 +572,87 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
+# Case 18 — Pre-flight ISSUE_NUM regex is anchored to start-of-description
+# (with optional close-keyword + optional leading double-quote, case-
+# insensitive). A `#NNN` literal appearing later in prose — quoted
+# example, line ref, follow-up "see also #N" — must NOT capture an
+# issue number, otherwise the mode file's claim-issue.sh acquire claims
+# an unrelated issue.
+#
+# Replicates the regex from skills/do/SKILL.md Pre-flight and exercises
+# it directly. The regex source-of-truth is the SKILL.md; this test
+# re-implements it as a behavioral fixture so a future edit that breaks
+# one of these cases fails closed.
+# ────────────────────────────────────────────────────────────────────
+test_issue_num_do() {
+  local input="$1"
+  local expected="$2"
+  local label="$3"
+  local ISSUE_NUM=""
+  if [[ "$input" =~ ^[[:space:]]*\"?([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
+    ISSUE_NUM="${BASH_REMATCH[3]}"
+  elif [[ "$input" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
+    ISSUE_NUM="${BASH_REMATCH[1]}"
+  fi
+  if [ "$ISSUE_NUM" = "$expected" ]; then
+    pass "18 ISSUE_NUM: $label (got '$ISSUE_NUM')"
+  else
+    fail "18 ISSUE_NUM: $label (expected '$expected', got '$ISSUE_NUM')"
+  fi
+}
+# Positive — should capture issue number
+test_issue_num_do "Fix #853 — auto-route completed plans" "853" "Fix #N at start (capital F)"
+test_issue_num_do "fix #853 — lowercase" "853" "fix #N at start (lowercase)"
+test_issue_num_do "Fixes #853 typo" "853" "Fixes #N at start"
+test_issue_num_do "Fixed #853" "853" "Fixed #N at start"
+test_issue_num_do "Closes #853 follow-up work" "853" "Closes #N at start"
+test_issue_num_do "closed #853" "853" "closed #N at start"
+test_issue_num_do "Resolves #853" "853" "Resolves #N at start"
+test_issue_num_do "#853 work item" "853" "bare #N at start"
+test_issue_num_do "   Fix #853 leading whitespace" "853" "leading whitespace + Fix #N"
+test_issue_num_do "\"Fix #853 quoted-head\"" "853" "leading quote + Fix #N (quoted-head carve-out)"
+test_issue_num_do "\"#853 bare-quoted\"" "853" "leading quote + bare #N"
+
+# Negative — should NOT capture
+test_issue_num_do "Remove the example 'fix #142' from prose" "" "fix #N in mid-prose quote → no capture"
+test_issue_num_do "Update file X, see also #853 for context" "" "#N after see-also → no capture"
+test_issue_num_do "Edit collect.py:#142 line reference" "" "#N as path/line reference → no capture"
+test_issue_num_do "Some text fix #142 mid prose" "" "fix #N in middle of prose → no capture"
+test_issue_num_do "Just a regular description" "" "no # at all → no capture"
+test_issue_num_do "Description mentioning #N letter" "" "#N where N is a letter → no capture"
+test_issue_num_do "address #853 work" "" "non-recognized keyword (address) → no capture"
+test_issue_num_do "work on #853" "" "non-recognized verb (work) → no capture"
+
+# ────────────────────────────────────────────────────────────────────
+# Case 19 — Phase 0a triage rubric NO LONGER contains the
+# "References a GitHub issue number → /fix-issues" REDIRECT row.
+# After PR 825 wired ISSUE_NUM + claim-issue.sh into the mode files,
+# the redirect made the claim machinery unreachable on the default
+# path. The row, its worked example, the per-target message template
+# row, and the test-stub-verdict entry are all expected to be absent.
+# ────────────────────────────────────────────────────────────────────
+if grep -qE 'References a GitHub issue number.*REDIRECT.*/fix-issues' "$SKILL"; then
+  fail "19a Phase 0a rubric still contains the issue-number REDIRECT row"
+else
+  pass "19a Phase 0a rubric: issue-number REDIRECT row removed"
+fi
+if grep -qE '/do fix #142.*REDIRECT.*/fix-issues' "$SKILL"; then
+  fail "19b Worked-example row '/do fix #142 → REDIRECT → /fix-issues' still present"
+else
+  pass "19b Worked-example row removed"
+fi
+if grep -qE '^\| `/fix-issues` \| `Triage: redirecting to /fix-issues' "$SKILL"; then
+  fail "19c Per-target redirect-message-template row for /fix-issues still present"
+else
+  pass "19c /fix-issues message-template row removed"
+fi
+if grep -qE 'REDIRECT:/fix-issues:reason' "$SKILL"; then
+  fail "19d Recognized test-stub verdict list still includes REDIRECT:/fix-issues:reason"
+else
+  pass "19d Test-stub verdict list pruned"
+fi
+
+# ────────────────────────────────────────────────────────────────────
 # Suite summary
 # ────────────────────────────────────────────────────────────────────
 TOTAL=$((PASS_COUNT + FAIL_COUNT))

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -1432,12 +1432,6 @@ case "$VERDICT" in
     printf 'This task references an existing plan file. Run `/run-plan <plan-path>` to execute it, or re-invoke with --force to bypass.\n'
     exit 0
     ;;
-  REDIRECT:/fix-issues:*)
-    REASON="${VERDICT#REDIRECT:/fix-issues:}"
-    printf 'Triage: redirecting to /fix-issues. Reason: %s\n' "$REASON"
-    printf 'This task references a GitHub issue. Run `/fix-issues <issue-number>` instead, or re-invoke with --force to bypass.\n'
-    exit 0
-    ;;
   PROCEED|*)
     echo "PROCEED"
     exit 0
@@ -1601,20 +1595,23 @@ fi
 #   (2) Strengthened structural assertion (replaces the weak
 #       `! grep -F 'Reason: <reason>\nThis task'`): extract the
 #       redirect-message markdown table from WI 1.5.4, then for EACH of
-#       the 4 documented targets (`/draft-plan`, `/run-plan`,
-#       `/fix-issues`, `ask-user`), assert (a) the row exists, (b) the
-#       Line 2 column starts with the documented opener. Also assert
-#       the table has exactly 4 data rows.
+#       the 3 documented targets (`/draft-plan`, `/run-plan`,
+#       `ask-user`), assert (a) the row exists, (b) the Line 2 column
+#       starts with the documented opener. Also assert the table has
+#       exactly 3 data rows.
+#
+# The `/fix-issues` redirect was retired once /quickfix's mode files
+# gained their own claim-issue.sh acquire/release machinery — issue-
+# numbered descriptions now claim and proceed instead of being kicked
+# to /fix-issues. The table dropped from 4 rows to 3.
 # ────────────────────────────────────────────────────────────────────
 # Part 1: per-target line-grep.
 if grep -q 'Triage: redirecting to /draft-plan' "$SKILL" \
    && grep -q 'This task spans more than one concept' "$SKILL" \
    && grep -q 'Triage: redirecting to /run-plan' "$SKILL" \
    && grep -q 'This task references an existing plan file' "$SKILL" \
-   && grep -q 'Triage: redirecting to /fix-issues' "$SKILL" \
-   && grep -q 'This task references a GitHub issue' "$SKILL" \
    && grep -q 'Re-invoke /quickfix with a concrete description' "$SKILL"; then
-  pass "51a redirect lines: line 1 + line 2 present per target (/draft-plan, /run-plan, /fix-issues, ask-user)"
+  pass "51a redirect lines: line 1 + line 2 present per target (/draft-plan, /run-plan, ask-user)"
 else
   fail "51a redirect lines: at least one per-target line missing in skill source"
 fi
@@ -1631,11 +1628,11 @@ TABLE=$(awk '
   in_table                        { print }
 ' "$SKILL")
 
-# 4 rows expected: /draft-plan, /run-plan, /fix-issues, ask-user.
+# 3 rows expected: /draft-plan, /run-plan, ask-user. The /fix-issues row
+# was retired (see Part 1 header comment above).
 ROW_COUNT=$(echo "$TABLE" | grep -c '^|')
 ROW_DRAFT=$(echo "$TABLE" | grep -c '^| `/draft-plan` ')
 ROW_RUNPLAN=$(echo "$TABLE" | grep -c '^| `/run-plan` ')
-ROW_FIX=$(echo "$TABLE" | grep -c '^| `/fix-issues` ')
 ROW_ASK=$(echo "$TABLE" | grep -c '^| ask-user ')
 
 # Check Line 2 opener for each row by extracting the third pipe column.
@@ -1663,28 +1660,28 @@ opener_for() {
 # verbatim including the wrapping backticks.
 DRAFT_OPENER=$(opener_for '`/draft-plan`')
 RUNPLAN_OPENER=$(opener_for '`/run-plan`')
-FIX_OPENER=$(opener_for '`/fix-issues`')
 ASK_OPENER=$(opener_for 'ask-user')
 
 OPENER_OK=1
 case "$DRAFT_OPENER"   in 'This task spans more than one concept'*) ;; *) OPENER_OK=0;; esac
 case "$RUNPLAN_OPENER" in 'This task references an existing plan file'*) ;; *) OPENER_OK=0;; esac
-case "$FIX_OPENER"     in 'This task references a GitHub issue'*) ;; *) OPENER_OK=0;; esac
 case "$ASK_OPENER"     in 'Re-invoke /quickfix with a concrete description'*) ;; *) OPENER_OK=0;; esac
 
-if [ "$ROW_COUNT" -eq 4 ] \
+# Defensive: assert the retired /fix-issues row is NOT present.
+ROW_FIX=$(echo "$TABLE" | grep -c '^| `/fix-issues` ')
+
+if [ "$ROW_COUNT" -eq 3 ] \
    && [ "$ROW_DRAFT" -eq 1 ] \
    && [ "$ROW_RUNPLAN" -eq 1 ] \
-   && [ "$ROW_FIX" -eq 1 ] \
+   && [ "$ROW_FIX" -eq 0 ] \
    && [ "$ROW_ASK" -eq 1 ] \
    && [ "$OPENER_OK" -eq 1 ]; then
-  pass "51b redirect-table structure: 4 rows (draft/run/fix/ask), each Line 2 starts with documented opener"
+  pass "51b redirect-table structure: 3 rows (draft/run/ask), /fix-issues row absent, each Line 2 starts with documented opener"
 else
   fail "51b redirect-table structure: rows=$ROW_COUNT draft=$ROW_DRAFT run=$ROW_RUNPLAN fix=$ROW_FIX ask=$ROW_ASK opener-ok=$OPENER_OK"
   echo "  --- table ---"; echo "$TABLE" | sed 's/^/    /'
   echo "  draft-opener='$DRAFT_OPENER'"
   echo "  runplan-opener='$RUNPLAN_OPENER'"
-  echo "  fix-opener='$FIX_OPENER'"
   echo "  ask-opener='$ASK_OPENER'"
 fi
 
@@ -2012,6 +2009,89 @@ if [ -n "$BEGIN_LINE" ] && [ -n "$CLOSE_LINE" ]; then
   fi
 else
   fail "59 end-of-Phase-7 explicit-finalize: BEGIN/CLOSE anchors not located (BEGIN_LINE=$BEGIN_LINE CLOSE_LINE=$CLOSE_LINE)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 71 — Pre-flight ISSUE_NUM regex is anchored to start-of-description
+# (with optional close-keyword + leading whitespace, case-insensitive).
+# A `#NNN` literal appearing later in prose — quoted example, line ref,
+# follow-up "see also #N" — must NOT capture an issue number, otherwise
+# the claim-issue.sh acquire in WI 1.8 claims an unrelated issue.
+#
+# Replicates the regex from skills/quickfix/SKILL.md Pre-flight and
+# exercises it directly. The regex source-of-truth is the SKILL.md; this
+# test re-implements it as a behavioral fixture so a future edit that
+# breaks one of these cases fails closed.
+# ────────────────────────────────────────────────────────────────────
+test_issue_num_qf() {
+  local input="$1"
+  local expected="$2"
+  local label="$3"
+  local ISSUE_NUM=""
+  if [[ "$input" =~ ^[[:space:]]*([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
+    ISSUE_NUM="${BASH_REMATCH[3]}"
+  elif [[ "$input" =~ ^[[:space:]]*#([0-9]+) ]]; then
+    ISSUE_NUM="${BASH_REMATCH[1]}"
+  fi
+  if [ "$ISSUE_NUM" = "$expected" ]; then
+    pass "71 ISSUE_NUM: $label (got '$ISSUE_NUM')"
+  else
+    fail "71 ISSUE_NUM: $label (expected '$expected', got '$ISSUE_NUM')"
+  fi
+}
+# Positive — should capture issue number
+test_issue_num_qf "Fix #853 — auto-route completed plans" "853" "Fix #N at start (capital F)"
+test_issue_num_qf "fix #853 — lowercase" "853" "fix #N at start (lowercase)"
+test_issue_num_qf "Fixes #853 typo" "853" "Fixes #N at start"
+test_issue_num_qf "Fixed #853" "853" "Fixed #N at start"
+test_issue_num_qf "Closes #853 follow-up work" "853" "Closes #N at start"
+test_issue_num_qf "closed #853" "853" "closed #N at start"
+test_issue_num_qf "Resolves #853" "853" "Resolves #N at start"
+test_issue_num_qf "#853 work item" "853" "bare #N at start"
+test_issue_num_qf "   Fix #853 leading whitespace" "853" "leading whitespace + Fix #N"
+# Quickfix Pre-flight runs after the quoted-head carve-out is normalized,
+# so it does not need to tolerate a leading literal `"`. (/do's regex
+# does tolerate it for its different invocation shape.) The quickfix
+# regex deliberately omits `\"?`.
+
+# Negative — should NOT capture
+test_issue_num_qf "Remove the example 'fix #142' from prose" "" "fix #N in mid-prose quote → no capture"
+test_issue_num_qf "Update file X, see also #853 for context" "" "#N after see-also → no capture"
+test_issue_num_qf "Edit collect.py:#142 line reference" "" "#N as path/line reference → no capture"
+test_issue_num_qf "Some text fix #142 mid prose" "" "fix #N in middle of prose → no capture"
+test_issue_num_qf "Just a regular description" "" "no # at all → no capture"
+test_issue_num_qf "Description mentioning #N letter" "" "#N where N is a letter → no capture"
+test_issue_num_qf "address #853 work" "" "non-recognized keyword (address) → no capture"
+test_issue_num_qf "work on #853" "" "non-recognized verb (work) → no capture"
+
+# ────────────────────────────────────────────────────────────────────
+# Case 72 — Phase 0a triage rubric NO LONGER contains the
+# "References a GitHub issue number → /fix-issues" REDIRECT row.
+# After PR 825 wired ISSUE_NUM + claim-issue.sh into the mode files,
+# the redirect made the claim machinery unreachable on the default
+# path. The row, its worked example, the per-target message template
+# row, and the test-stub-verdict entry are all expected to be absent.
+# ────────────────────────────────────────────────────────────────────
+SKILL="$REPO_ROOT/skills/quickfix/SKILL.md"
+if grep -qE 'References a GitHub issue number.*REDIRECT.*/fix-issues' "$SKILL"; then
+  fail "72a Phase 0a rubric still contains the issue-number REDIRECT row"
+else
+  pass "72a Phase 0a rubric: issue-number REDIRECT row removed"
+fi
+if grep -qE '/quickfix fix #142.*REDIRECT.*/fix-issues' "$SKILL"; then
+  fail "72b Worked-example row '/quickfix fix #142 → REDIRECT → /fix-issues' still present"
+else
+  pass "72b Worked-example row removed"
+fi
+if grep -qE '^\| `/fix-issues` \| `Triage: redirecting to /fix-issues' "$SKILL"; then
+  fail "72c Per-target redirect-message-template row for /fix-issues still present"
+else
+  pass "72c /fix-issues message-template row removed"
+fi
+if grep -qE 'REDIRECT:/fix-issues:reason' "$SKILL"; then
+  fail "72d Recognized test-stub verdict list still includes REDIRECT:/fix-issues:reason"
+else
+  pass "72d Test-stub verdict list pruned"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Retire the obsolete `References a GitHub issue number → REDIRECT to /fix-issues` triage gate in `/do` and `/quickfix`, and tighten the `ISSUE_NUM` regex so prose-embedded `#NNN` literals don't claim unrelated issues.

**Bug 1: the gate predates its own machinery.** PRs #151 / #153 (`quickfix-do-triage-plan`) added the rubric REDIRECT row back when neither skill knew how to claim an issue. PR #825 (`claim-work-item`) later wired full `claim-issue.sh` acquire/release plumbing into `/do`'s and `/quickfix`'s mode files, but left the redirect gate intact — making the new claim machinery unreachable on the default path. Net effect: a user invoking `/do Fix #853 ...` saw a "Triage: redirecting to /fix-issues" refusal that the same skill was, structurally, fully equipped to handle. The plan body itself (`docs/plans/claim-work-item.md` ~L543) acknowledged the inconsistency and chose to leave the gate as a follow-up; this is that follow-up.

**Bug 2: the `ISSUE_NUM` regex was over-broad.** The previous `\#([0-9]+)` captured the FIRST `#NNN` from anywhere in the description. With the redirect gate gone, that's now the only signal that drives `claim-issue.sh` — and incidental `#NNN` mentions in prose (quoted examples, line refs, "see also #N" follow-ups) would silently claim unrelated issues. Concrete case: a description quoting `'fix #142'` as the worked-example row being deleted would `claim-issue.sh acquire 142` even though #142 is a long-merged PR. The regex is now **anchored to start-of-description**, optionally preceded by whitespace and a leading double-quote (for `/do`'s quoted-description carve-out), optionally preceded by a GitHub close-keyword (`close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved`, case-insensitive). Bare `#N` at the start also captures. Anywhere else in the prose: no capture.

**Out of scope.** `/run-plan` and `/investigate` were already correct (no redirect gate, and `/investigate` takes `#N` as primary input). The `claim-issue.sh` wiring in `/do`'s and `/quickfix`'s mode files is unchanged — it just becomes reachable on the default path. No other triage rules are touched.

## Files changed

- `skills/do/SKILL.md`, `.claude/skills/do/SKILL.md` — drop the issue-number rubric row, worked-example row, message-template row, test-stub list entry; rewrite the Pre-flight comment; replace the regex with the anchored form; bump `metadata.version`.
- `skills/quickfix/SKILL.md`, `.claude/skills/quickfix/SKILL.md` — same five surfaces, same regex tightening (without the leading-quote tolerance — `/quickfix` parses against `$DESCRIPTION`, which is the post-trim form).
- `tests/test-do.sh` — new Case 18 (ISSUE_NUM regex: 11 positive + 8 negative fixtures) and Case 19 (rubric/example/template/stub-list absence assertions).
- `tests/test-quickfix.sh` — new Case 71 (ISSUE_NUM regex: 9 positive + 8 negative) and Case 72 (absence assertions); pre-existing Case 51b retargeted from 4 rows to 3 with a defensive ROW_FIX=0 check; dead `REDIRECT:/fix-issues:*)` case dropped from the Case 47 triage-simulator.

## Test plan

- [x] `bash tests/run-all.sh` passes locally (full suite, 6619 tests; all green after the post-fix re-run).
- [x] `tests/test-do.sh` — 41 tests pass (was 17 before; new Cases 18 + 19 cover the regex + absence assertions).
- [x] `tests/test-quickfix.sh` — 105 tests pass (was 70 before; new Cases 71 + 72 cover the regex + absence assertions, and Case 51b retargeted cleanly).
- [x] `tests/test-skill-conformance.sh` — 726 tests pass.
- [x] `tests/test-skills-mirror-parity.sh` — 57 tests pass (after `bash scripts/mirror-skill.sh do && bash scripts/mirror-skill.sh quickfix`).
- [ ] Post-merge dogfood: re-invoke `/do <description-with-#853> pr auto` — expect Phase 0a to PROCEED, ISSUE_NUM to populate from `Fix #853 ...`, and the mode-file `claim-issue.sh` acquire to fire on default path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
