### PR TITLE
Fix #853: route completed+pinned plans to Completed column

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+594158"
+  version: "2026.05.31+6b2c0a"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1732,8 +1732,19 @@ def _annotate_plans_queue(
 
     Precedence (W1.3 / D2 rule (i)): state-file explicit-position WINS
     over inference — a plan present in the state file's `backlog` (or
-    `drafted`, etc.) stays there even if `status: complete` would
-    otherwise infer `completed`. Tested by W1.20.
+    `drafted`, etc.) stays there even if inference would route it
+    elsewhere. Tested by W1.20.
+
+    Completion override (#853): the ONE exception to rule (i). A plan
+    whose frontmatter declares `status: complete|landed` AND carries a
+    parseable `completed:` timestamp bypasses any pin and routes to
+    `completed` via inference. The Completed column is derived (not a
+    drop target, not in PLAN_COLUMNS), so a stale pin would otherwise
+    strand a completed card in its old column with no UI affordance to
+    unstick it. The plan file is source of truth for completion; once it
+    transitions, the dashboard column follows on the next poll. Non-
+    complete pinned plans are unaffected — their pin still beats
+    inference.
 
     `now_utc` defaults to current wall-clock UTC. `window_days` controls
     the `completed:` recency window (D1, configurable via
@@ -1771,7 +1782,28 @@ def _annotate_plans_queue(
 
     for plan in plans:
         slug = plan["slug"]
-        if slug in pos:
+        # Completion override (#853): a plan whose frontmatter declares
+        # `status: complete|landed` AND carries a parseable `completed:`
+        # timestamp is COMPLETE per the plan-file-is-source-of-truth rule.
+        # The Completed column is derived (not a drop target / not in
+        # PLAN_COLUMNS), so a stale pin in the state file (manual drag,
+        # programmatic write, or initial seeding) would otherwise strand
+        # the card in its old column forever. Bypass the pos pin here and
+        # route via inference (→ "completed"), auto-healing stuck plans on
+        # the next poll. This is a NARROW exception to W1.3/D2 rule (i):
+        # non-complete pinned plans still honor their pin below.
+        status = (plan.get("status") or "").strip().lower()
+        completed_raw = plan.get("completed") or ""
+        completed_dt = (
+            _parse_iso_utc(completed_raw)
+            if isinstance(completed_raw, str) else None
+        )
+        if status in ("complete", "landed") and completed_dt is not None:
+            inferred = _infer_default_column(
+                plan, now_utc=now_utc, window_days=window_days,
+            )
+            plan["queue"] = {"column": inferred, "index": -1, "mode": None}
+        elif slug in pos:
             col, i, mode = pos[slug]
             plan["queue"] = {"column": col, "index": i, "mode": mode}
         else:

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+594158"
+  version: "2026.05.31+6b2c0a"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1732,8 +1732,19 @@ def _annotate_plans_queue(
 
     Precedence (W1.3 / D2 rule (i)): state-file explicit-position WINS
     over inference — a plan present in the state file's `backlog` (or
-    `drafted`, etc.) stays there even if `status: complete` would
-    otherwise infer `completed`. Tested by W1.20.
+    `drafted`, etc.) stays there even if inference would route it
+    elsewhere. Tested by W1.20.
+
+    Completion override (#853): the ONE exception to rule (i). A plan
+    whose frontmatter declares `status: complete|landed` AND carries a
+    parseable `completed:` timestamp bypasses any pin and routes to
+    `completed` via inference. The Completed column is derived (not a
+    drop target, not in PLAN_COLUMNS), so a stale pin would otherwise
+    strand a completed card in its old column with no UI affordance to
+    unstick it. The plan file is source of truth for completion; once it
+    transitions, the dashboard column follows on the next poll. Non-
+    complete pinned plans are unaffected — their pin still beats
+    inference.
 
     `now_utc` defaults to current wall-clock UTC. `window_days` controls
     the `completed:` recency window (D1, configurable via
@@ -1771,7 +1782,28 @@ def _annotate_plans_queue(
 
     for plan in plans:
         slug = plan["slug"]
-        if slug in pos:
+        # Completion override (#853): a plan whose frontmatter declares
+        # `status: complete|landed` AND carries a parseable `completed:`
+        # timestamp is COMPLETE per the plan-file-is-source-of-truth rule.
+        # The Completed column is derived (not a drop target / not in
+        # PLAN_COLUMNS), so a stale pin in the state file (manual drag,
+        # programmatic write, or initial seeding) would otherwise strand
+        # the card in its old column forever. Bypass the pos pin here and
+        # route via inference (→ "completed"), auto-healing stuck plans on
+        # the next poll. This is a NARROW exception to W1.3/D2 rule (i):
+        # non-complete pinned plans still honor their pin below.
+        status = (plan.get("status") or "").strip().lower()
+        completed_raw = plan.get("completed") or ""
+        completed_dt = (
+            _parse_iso_utc(completed_raw)
+            if isinstance(completed_raw, str) else None
+        )
+        if status in ("complete", "landed") and completed_dt is not None:
+            inferred = _infer_default_column(
+                plan, now_utc=now_utc, window_days=window_days,
+            )
+            plan["queue"] = {"column": inferred, "index": -1, "mode": None}
+        elif slug in pos:
             col, i, mode = pos[slug]
             plan["queue"] = {"column": col, "index": i, "mode": mode}
         else:

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -1475,10 +1475,13 @@ else
   fail "W1.19: got '$W119'"
 fi
 
-# W1.20 — annotate_plans_queue_prefers_completed_on_dual_membership:
-# WRONG — actually per D2 state-file explicit-position WINS over
-# inference. A plan in state-file's `drafted` column with status:complete
-# stays in `drafted`, NOT in `completed`.
+# W1.20 — annotate_plans_queue_completion_overrides_pin (#853):
+# A plan with status:complete AND a parseable completed: timestamp routes
+# to `completed` EVEN WHEN pinned in state-file's `drafted` column. The
+# completion override (#853) is the ONE exception to D2 rule (i): the
+# Completed column is derived (not a drop target), so a stale pin would
+# otherwise strand a completed card with no UI affordance to unstick it.
+# Inverts the prior W1.20 assertion (was `col=drafted`).
 W120=$(PYTHONPATH="$PKG_PARENT" python3 -c '
 import sys
 sys.path.insert(0, "'"$PKG_PARENT"'")
@@ -1501,10 +1504,43 @@ plans = [
 c._annotate_plans_queue(plans, state, now_utc=now, window_days=14)
 print("col=" + plans[0]["queue"]["column"])
 ' 2>&1)
-if printf '%s\n' "$W120" | grep -q "^col=drafted$"; then
-  pass "W1.20: annotate_plans_queue_prefers_state_explicit_over_completed (D2)"
+if printf '%s\n' "$W120" | grep -q "^col=completed$"; then
+  pass "W1.20: annotate_plans_queue_completion_overrides_pin (#853)"
 else
   fail "W1.20: got '$W120'"
+fi
+
+# W1.20b — completion override is NARROW: a non-complete pinned plan still
+# honors its pin (D2 rule (i) intact). status:active pinned in `drafted`
+# stays `drafted`; status:complete WITHOUT parseable completed: also stays
+# pinned (no override without a valid timestamp).
+W120B=$(PYTHONPATH="$PKG_PARENT" python3 -c '
+import sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+from datetime import datetime, timezone, timedelta
+
+now = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+state = {
+    "plans": {
+        "backlog": [{"slug": "active-plan", "mode": None},
+                    {"slug": "complete-no-date", "mode": None}],
+    },
+    "issues": {"backlog": []},
+}
+plans = [
+    {"slug": "active-plan", "status": "active", "phases_done": 0},
+    {"slug": "complete-no-date", "status": "complete", "completed": "", "phases_done": 1},
+]
+c._annotate_plans_queue(plans, state, now_utc=now, window_days=14)
+print("active=" + plans[0]["queue"]["column"])
+print("nodate=" + plans[1]["queue"]["column"])
+' 2>&1)
+if printf '%s\n' "$W120B" | grep -q "^active=backlog$" \
+    && printf '%s\n' "$W120B" | grep -q "^nodate=backlog$"; then
+  pass "W1.20b: completion_override_narrow_pin_preserved (#853)"
+else
+  fail "W1.20b: got '$W120B'"
 fi
 
 # W1.21 — annotate_issues_queue_drops_closed_from_explicit_positions:


### PR DESCRIPTION
Closes #853

## Summary
Dashboard `collect.py:_annotate_plans_queue` now routes a plan to **Completed** when its frontmatter is `status: complete|landed` + a parseable `completed:`, **bypassing a stale state-file pin** — fixes plans (e.g. `claim-work-item.md`) stuck in DRAFTED despite being complete. Non-complete pinned plans still honor the pin (W1.3/D2 rule (i) preserved).

## Test plan
- [x] `test_zskills_monitor_collect.sh` 72/72 (W1.20 inverted to assert the fix; W1.20b proves the override is narrow)
- [x] Full suite green on rebased tree (6577/6577); mirror byte-identical; version bumped
