### PR TITLE
test(conformance): pin /draft-tests split file existence (#861)

### DIFF
--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1756,6 +1756,37 @@ check_fixed research-and-go   "preflight: Agent-tool-required heading (issue #14
   '## Preflight — top-level dispatch required'
 
 echo ""
+echo "=== /draft-tests — structural existence pins (issue #861) ==="
+# PR #855 split /draft-tests's SKILL.md into 5 files (3 modes + 2 references).
+# This block mirrors the post-#849 /quickfix pin pattern: assert every split
+# file exists on BOTH the source tree (skills/draft-tests/) AND the install
+# mirror (.claude/skills/draft-tests/), failing closed if any vanishes. The
+# /draft-tests row in docs/issues/ISSUES_PLAN.md noted that prior coverage
+# (test-skill-conformance.sh:936 /land-pr caller array + variable-family
+# allowlist in test-skill-invariants.sh) is sideways — it gates downstream
+# behavior but never asserts the files themselves. This block closes that
+# gap symmetrically with /quickfix.
+DT_REQ_FILES=(
+  "skills/draft-tests/modes/draft.md"
+  "skills/draft-tests/modes/backfill.md"
+  "skills/draft-tests/modes/land.md"
+  "skills/draft-tests/references/test-spec-format.md"
+  "skills/draft-tests/references/design-constraints.md"
+  ".claude/skills/draft-tests/modes/draft.md"
+  ".claude/skills/draft-tests/modes/backfill.md"
+  ".claude/skills/draft-tests/modes/land.md"
+  ".claude/skills/draft-tests/references/test-spec-format.md"
+  ".claude/skills/draft-tests/references/design-constraints.md"
+)
+for dt_path in "${DT_REQ_FILES[@]}"; do
+  if [ -f "$REPO_ROOT/$dt_path" ]; then
+    pass "[draft-tests-presence] $dt_path exists"
+  else
+    fail "[draft-tests-presence] $dt_path exists" "$dt_path"
+  fi
+done
+
+echo ""
 echo "=== /draft-tests — behavior contracts (WI 6.3) ==="
 # Anchor: tests/test-skill-conformance.sh draft-tests block — one check
 # per WI 6.3 sub-bullet of plans/DRAFT_TESTS_SKILL_PLAN.md (current count:


### PR DESCRIPTION
## Summary

PR #855 split `/draft-tests/SKILL.md` into 5 files (3 modes + 2 references) but added no structural-existence assertions in conformance. `grep -rn 'draft-tests/references' tests/` returned zero hits. This PR adds a 10-path existence-pin block (5 split files × 2 lanes) in `tests/test-skill-conformance.sh`, mirroring the materialiser-presence loop pattern at lines 240-253.

Closes #861

## Files (1)
- `tests/test-skill-conformance.sh` (+31 lines) — adds a `DT_REQ_FILES` array + per-path `for dt_path` loop placed at line 1758, immediately above the `=== /draft-tests — behavior contracts (WI 6.3) ===` block so all /draft-tests checks cluster together. Excludes `skills/draft-tests/SKILL.md` (already gated by the AC-6.6 jq-absence check at line 1833).

## Test plan
- [x] `bash tests/run-all.sh` — 6634/6634 passed locally (was 6604 pre-change; +10 new `[draft-tests-presence]` PASS lines).
- [x] **Gate-fires sanity check.** Moved `skills/draft-tests/modes/backfill.md` → `/tmp/backfill.md.bak`, re-ran conformance — got the expected `FAIL [draft-tests-presence] skills/draft-tests/modes/backfill.md exists — pattern not found`. Restored immediately. Gate verifiably catches missing files.
- [x] CI-only change — no production code touched; no `metadata.version` bumps needed (no SKILL.md edits).

## Commits

7aa2056 test(conformance): pin structural existence of /draft-tests split files
