### PR TITLE
fix(add-block): wrap dual-lane resolver preludes in bash fences (#866)

### DIFF
--- a/.claude/skills/add-block/SKILL.md
+++ b/.claude/skills/add-block/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Step-by-step guide for adding new block types. Use when the user asks to
   "add a block", "create a new block", or "implement a block".
 metadata:
-  version: "2026.05.31+c5656a"
+  version: "2026.05.31+445ceb"
 ---
 
 # Adding Block Types
@@ -569,11 +569,6 @@ Add a Rust emitter for the block in `src/codegen/block-emitter.js`.
    ```javascript
    Name: { paramName: defaultValue },
    ```
-   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
-     . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
-   else
-     . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
-   fi
 
 4. Add any codegen-only params to `CODEGEN_ONLY_PARAMS` if they shouldn't appear in the Rust `Params` struct.
 
@@ -641,11 +636,6 @@ Create a GitHub issue and add an entry to `$ZSKILLS_ISSUES_DIR/BUILD_ISSUES.md` 
 
 **Description:** {Why this block can't be emitted yet and what's needed.}
 ```
-if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
-  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
-else
-  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
-fi
 
 After deferring codegen, create the deferred marker with the GitHub issue number:
 ```bash

--- a/block-diagram/add-block/SKILL.md
+++ b/block-diagram/add-block/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Step-by-step guide for adding new block types. Use when the user asks to
   "add a block", "create a new block", or "implement a block".
 metadata:
-  version: "2026.05.31+c5656a"
+  version: "2026.05.31+445ceb"
 ---
 
 # Adding Block Types
@@ -569,11 +569,6 @@ Add a Rust emitter for the block in `src/codegen/block-emitter.js`.
    ```javascript
    Name: { paramName: defaultValue },
    ```
-   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
-     . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
-   else
-     . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
-   fi
 
 4. Add any codegen-only params to `CODEGEN_ONLY_PARAMS` if they shouldn't appear in the Rust `Params` struct.
 
@@ -641,11 +636,6 @@ Create a GitHub issue and add an entry to `$ZSKILLS_ISSUES_DIR/BUILD_ISSUES.md` 
 
 **Description:** {Why this block can't be emitted yet and what's needed.}
 ```
-if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
-  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
-else
-  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
-fi
 
 After deferring codegen, create the deferred marker with the GitHub issue number:
 ```bash


### PR DESCRIPTION
## Summary

Two dual-lane resolver preludes in `block-diagram/add-block/SKILL.md` (PR #831 migration artifacts) sat outside any executable bash fence — they rendered as markdown prose and never executed. The downstream consumer fences (`step.add-block.${BLOCK_SLUG}.codegen` and `.codegen-deferred`) ALREADY contain their own self-sourced copies of the dual-lane resolver inside their bash fences, so the leaked outer copies were pure orphaned duplicates. Cleanest fix: delete the duplicates.

Closes #866

## Files (2)
- `block-diagram/add-block/SKILL.md` — removed two leaked prelude blocks; `metadata.version` bumped to `2026.05.31+445ceb`
- `.claude/skills/add-block/SKILL.md` — mirror

## Test plan
- [x] `bash tests/run-all.sh` — 6635/6635 passed.
- [x] Verified downstream fences (`step.add-block.${BLOCK_SLUG}.codegen` at L617, `.codegen-deferred` at L651) self-source the resolver inside their own bash fences, so variable resolution path is preserved.
- [x] Skipped optional conformance gate for "resolver-prelude outside fence" — scope expansion not warranted for this PR; can be filed as a follow-up.

## Commits
35d6a9f fix(add-block): wrap dual-lane resolver preludes in bash fences (#866)
