### PR TITLE
do: persist dispatch_mode on plan claim record (#874)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+05dac8"
+  version: "2026.05.31+c74b30"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -629,9 +629,19 @@ else
 fi
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+# Resolve dispatch_mode for the claim record (issue #874 — sibling to
+# #858). The chip's lock condition reads plan.claim.dispatch_mode, which
+# outlives the /work-on-plans wrapper that spawned this /run-plan. Map
+# the canonical $FINISH_MODE ("finish"|"finish-auto"|"") to the
+# claim-side enum (phase|finish|inherit).
+DISPATCH_MODE_FOR_CLAIM="phase"
+if [ "$FINISH_MODE" = "finish" ] || [ "$FINISH_MODE" = "finish-auto" ]; then
+  DISPATCH_MODE_FOR_CLAIM="finish"
+fi
 set +e
 bash "$ZSKILLS_SKILLS_ROOT/run-plan/scripts/claim-plan.sh" \
-  acquire "$PLAN_SLUG" --pipeline-id "$PIPELINE_ID"
+  acquire "$PLAN_SLUG" --pipeline-id "$PIPELINE_ID" \
+  --dispatch-mode "$DISPATCH_MODE_FOR_CLAIM"
 rc=$?
 set -e
 case "$rc" in

--- a/.claude/skills/run-plan/scripts/claim-plan.sh
+++ b/.claude/skills/run-plan/scripts/claim-plan.sh
@@ -12,14 +12,23 @@
 # points at the wrong root; DA4.1 / DA7 invariant).
 #
 # Subcommands:
-#   acquire <slug> --pipeline-id <id>
+#   acquire <slug> --pipeline-id <id> [--dispatch-mode <mode>]
 #     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
 #               claim — the stored pipeline_id matches --pipeline-id).
-#     Exit 2  — usage error (bad slug, missing flags).
+#     Exit 2  — usage error (bad slug, missing flags, invalid dispatch-mode).
 #     Exit 10 — foreign-held by another pipeline (OR claim already exists
 #               but claim.json absent/malformed — never steal).
 #     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
 #               (EACCES/ENOSPC/EDQUOT/EROFS/...).
+#
+#     --dispatch-mode <mode> (issue #874): persists the dispatch mode the
+#     plan is being driven under into claim.json as `dispatch_mode`.
+#     Permitted values: `phase`, `finish`, `inherit`. `inherit` is a
+#     no-op (field omitted from claim.json). The dashboard reads the
+#     field to render the locked finish chip across the full /run-plan
+#     lifetime — outliving the /work-on-plans wrapper that spawned it.
+#     Sibling to #858 (the wrapper-lifetime batch_mode signal); this
+#     field covers the claim's full duration.
 #   release <slug> --require-pipeline <id>
 #     Exit 0  — released (or already absent — idempotent).
 #     Exit 2  — usage error.
@@ -41,11 +50,16 @@
 #       <slug>\t<pipeline_id>\t<age_seconds>
 #
 # Schema (claim.json, D5):
-#   {schema_version, kind, slug, pipeline_id, started_at, current_phase}
+#   {schema_version, kind, slug, pipeline_id, started_at, current_phase
+#    [, dispatch_mode]}
 #   sorted-keys, schema_version=1.
 #   current_phase is initialised to "Phase 0 — acquired" at acquire and
 #   updated by the `set-phase` subcommand. age_seconds is derived from
 #   started_at.
+#   dispatch_mode is OPTIONAL (#874). When --dispatch-mode is `phase` or
+#   `finish`, the field is set verbatim. When omitted or `inherit`, the
+#   field is NOT written — pre-#874 callers and back-compat readers see
+#   the original 6-field schema.
 #
 # Atomicity:
 #   acquire: `mkdir <dir>` is the POSIX atomic primitive; then write
@@ -189,15 +203,16 @@ sanitize_and_validate_slug() {
 # acquire <slug> --pipeline-id <id>
 # ---------------------------------------------------------------------------
 cmd_acquire() {
-  local raw_slug="" pipeline_id=""
+  local raw_slug="" pipeline_id="" dispatch_mode=""
   if [ "$#" -lt 1 ]; then
-    echo "Usage: claim-plan.sh acquire <slug> --pipeline-id <id>" >&2
+    echo "Usage: claim-plan.sh acquire <slug> --pipeline-id <id> [--dispatch-mode <phase|finish|inherit>]" >&2
     return 2
   fi
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      --dispatch-mode) dispatch_mode="${2:-}"; shift 2 ;;
       *) echo "run-plan claim-plan.sh acquire: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -206,6 +221,17 @@ cmd_acquire() {
     echo "run-plan claim-plan.sh acquire: --pipeline-id is required" >&2
     return 2
   fi
+  # Validate --dispatch-mode (issue #874). Empty (flag absent) and
+  # `inherit` are both no-op signals — the field is not written. Only
+  # `phase` and `finish` are persisted verbatim. Anything else is a
+  # usage error.
+  case "$dispatch_mode" in
+    ""|inherit|phase|finish) ;;
+    *)
+      echo "run-plan claim-plan.sh acquire: --dispatch-mode must be one of phase|finish|inherit (got '$dispatch_mode')" >&2
+      return 2
+      ;;
+  esac
   resolve_main_root || return 2
 
   local claims_root="${MAIN_ROOT}/.zskills/claims"
@@ -258,9 +284,13 @@ cmd_acquire() {
   # "Phase 0 — acquired" so the dashboard chip renders `phase 0/M`
   # immediately on acquire (not `phase ?/M`); subsequent updates flow
   # through the `set-phase` subcommand.
-  if ! "$_CLAIM_PYTHON" - "$claim_tmp" "$claim_file" "$pipeline_id" "$SLUG" <<'PY'
+  #
+  # dispatch_mode (#874): if non-empty and not `inherit`, persist
+  # alongside the 6-field core schema. Pre-#874 readers tolerate the
+  # extra key (collect.py uses an explicit allow-list).
+  if ! "$_CLAIM_PYTHON" - "$claim_tmp" "$claim_file" "$pipeline_id" "$SLUG" "$dispatch_mode" <<'PY'
 import json, os, sys, datetime
-tmp_path, final_path, pipeline_id, slug = sys.argv[1:5]
+tmp_path, final_path, pipeline_id, slug, dispatch_mode = sys.argv[1:6]
 now = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
 body = {
     "schema_version":     1,
@@ -270,6 +300,8 @@ body = {
     "started_at":         now,
     "current_phase":      "Phase 0 — acquired",
 }
+if dispatch_mode and dispatch_mode != "inherit":
+    body["dispatch_mode"] = dispatch_mode
 with open(tmp_path, "w") as f:
     json.dump(body, f, sort_keys=True)
     f.write("\n")

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+cecde4"
+  version: "2026.05.31+e6f96a"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1813,7 +1813,10 @@ def _annotate_plans_queue(
             plan["queue"] = {"column": inferred, "index": -1, "mode": None}
         # Claim chip — explicit field allow-list (NOT **claim_dict).
         # NO `worktree_path`, NO `host_pid` — same scope discipline as
-        # the issue side (DA8 / DA2.1).
+        # the issue side (DA8 / DA2.1). `dispatch_mode` (#874) IS on the
+        # allow-list because the dashboard mode chip's lock condition
+        # reads it; the issue side intentionally does NOT mirror — it's
+        # a plan-claim concept.
         if isinstance(slug, str) and slug in plan_claim_index:
             c = plan_claim_index[slug]
             plan["claim"] = {
@@ -1822,6 +1825,7 @@ def _annotate_plans_queue(
                 "current_phase":  c.get("current_phase"),
                 "age_seconds":    c.get("age_seconds"),
                 "pipeline_short": c.get("pipeline_short"),
+                "dispatch_mode":  c.get("dispatch_mode"),
             }
 
 
@@ -2318,7 +2322,8 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
     """Read run-plan claim files under `${main_root}/.zskills/claims/plan-*/`.
 
     Returns `{slug: claim_dict}` keyed by string slug. Each dict carries:
-        pipeline_id, started_at, current_phase, age_seconds, pipeline_short
+        pipeline_id, started_at, current_phase, age_seconds,
+        pipeline_short, dispatch_mode
 
     Tolerant: malformed JSON emits a single stderr line and skips that
     claim. A claim directory present without `claim.json` surfaces a
@@ -2329,6 +2334,13 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
     `age_seconds` is computed from `started_at` (post-#684 cleanup
     removed `last_heartbeat_at` as a duplicate of `started_at`; phase
     progression is now signalled by `current_phase`, not chip age).
+
+    `dispatch_mode` (#874) is the persisted mode under which the plan
+    is being driven (`phase`, `finish`, or `None` when absent). The
+    field survives the wrapper-lifetime gap that #858 left exposed:
+    `/work-on-plans` resets to idle within seconds of dispatching, but
+    the `/run-plan` claim it spawned outlives it by hours, so the
+    dispatch mode must live on the claim, not on the wrapper state file.
     """
     out: Dict[str, Dict[str, Any]] = {}
     claims_dir = main_root / ".zskills" / "claims"
@@ -2363,6 +2375,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
                 "current_phase": None,
                 "age_seconds": None,
                 "pipeline_short": None,
+                "dispatch_mode": None,
             }
             continue
         try:
@@ -2383,6 +2396,16 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_id = body.get("pipeline_id")
         started_at = body.get("started_at")
         current_phase = body.get("current_phase")
+        # dispatch_mode (#874): persisted by claim-plan.sh acquire
+        # --dispatch-mode. Only `phase` / `finish` are valid persisted
+        # values; anything else (including absence) surfaces as None and
+        # the renderer falls back to the entry/default mode precedence.
+        raw_dispatch_mode = body.get("dispatch_mode")
+        dispatch_mode: Optional[str]
+        if isinstance(raw_dispatch_mode, str) and raw_dispatch_mode in ("phase", "finish"):
+            dispatch_mode = raw_dispatch_mode
+        else:
+            dispatch_mode = None
         # Compute age from started_at (post-#684 cleanup: last_heartbeat_at
         # was a duplicate of started_at and has been removed).
         age_seconds: Optional[float] = None
@@ -2404,6 +2427,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
             "current_phase": current_phase if isinstance(current_phase, str) else None,
             "age_seconds": age_seconds,
             "pipeline_short": pipeline_short,
+            "dispatch_mode": dispatch_mode,
         }
     return out
 

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1128,11 +1128,22 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   // We still distinguish "queued" vs "running-phase" via data-state so
   // CSS can colorize running chips (signals "this is live"), but the
   // click behavior is the same in both.
-  // Effective mode = currentEntryMode(slug) || defaultMode || "phase".
+  // Effective mode precedence (issue #874):
+  //   1. plan.claim.dispatch_mode (persisted on the /run-plan claim;
+  //      outlives the /work-on-plans wrapper that spawned it — sibling
+  //      to #858's wrapper-lifetime batch_mode signal).
+  //   2. currentEntryMode(slug) explicit override.
+  //   3. defaultMode || "phase".
+  // Pre-#874 claims lack dispatch_mode → collect.py surfaces None →
+  // step 1 falls through to step 2 + step 3 unchanged. Back-compat is
+  // structural, not flag-gated.
   if (col === "ready") {
     const entryMode = currentEntryMode(slug);
     const isOverride = entryMode === "phase" || entryMode === "finish";
-    const effectiveMode = isOverride ? entryMode : (defaultMode || "phase");
+    const claimDispatchMode =
+      (plan && plan.claim && plan.claim.dispatch_mode) || null;
+    const effectiveMode =
+      claimDispatchMode || (isOverride ? entryMode : (defaultMode || "phase"));
     const isClaimed = !!(plan && plan.claim);
     const locked = isClaimed && effectiveMode === "finish";
     let state, ariaLabel;

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+05dac8"
+  version: "2026.05.31+c74b30"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -629,9 +629,19 @@ else
 fi
 PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+# Resolve dispatch_mode for the claim record (issue #874 — sibling to
+# #858). The chip's lock condition reads plan.claim.dispatch_mode, which
+# outlives the /work-on-plans wrapper that spawned this /run-plan. Map
+# the canonical $FINISH_MODE ("finish"|"finish-auto"|"") to the
+# claim-side enum (phase|finish|inherit).
+DISPATCH_MODE_FOR_CLAIM="phase"
+if [ "$FINISH_MODE" = "finish" ] || [ "$FINISH_MODE" = "finish-auto" ]; then
+  DISPATCH_MODE_FOR_CLAIM="finish"
+fi
 set +e
 bash "$ZSKILLS_SKILLS_ROOT/run-plan/scripts/claim-plan.sh" \
-  acquire "$PLAN_SLUG" --pipeline-id "$PIPELINE_ID"
+  acquire "$PLAN_SLUG" --pipeline-id "$PIPELINE_ID" \
+  --dispatch-mode "$DISPATCH_MODE_FOR_CLAIM"
 rc=$?
 set -e
 case "$rc" in

--- a/skills/run-plan/scripts/claim-plan.sh
+++ b/skills/run-plan/scripts/claim-plan.sh
@@ -12,14 +12,23 @@
 # points at the wrong root; DA4.1 / DA7 invariant).
 #
 # Subcommands:
-#   acquire <slug> --pipeline-id <id>
+#   acquire <slug> --pipeline-id <id> [--dispatch-mode <mode>]
 #     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
 #               claim — the stored pipeline_id matches --pipeline-id).
-#     Exit 2  — usage error (bad slug, missing flags).
+#     Exit 2  — usage error (bad slug, missing flags, invalid dispatch-mode).
 #     Exit 10 — foreign-held by another pipeline (OR claim already exists
 #               but claim.json absent/malformed — never steal).
 #     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
 #               (EACCES/ENOSPC/EDQUOT/EROFS/...).
+#
+#     --dispatch-mode <mode> (issue #874): persists the dispatch mode the
+#     plan is being driven under into claim.json as `dispatch_mode`.
+#     Permitted values: `phase`, `finish`, `inherit`. `inherit` is a
+#     no-op (field omitted from claim.json). The dashboard reads the
+#     field to render the locked finish chip across the full /run-plan
+#     lifetime — outliving the /work-on-plans wrapper that spawned it.
+#     Sibling to #858 (the wrapper-lifetime batch_mode signal); this
+#     field covers the claim's full duration.
 #   release <slug> --require-pipeline <id>
 #     Exit 0  — released (or already absent — idempotent).
 #     Exit 2  — usage error.
@@ -41,11 +50,16 @@
 #       <slug>\t<pipeline_id>\t<age_seconds>
 #
 # Schema (claim.json, D5):
-#   {schema_version, kind, slug, pipeline_id, started_at, current_phase}
+#   {schema_version, kind, slug, pipeline_id, started_at, current_phase
+#    [, dispatch_mode]}
 #   sorted-keys, schema_version=1.
 #   current_phase is initialised to "Phase 0 — acquired" at acquire and
 #   updated by the `set-phase` subcommand. age_seconds is derived from
 #   started_at.
+#   dispatch_mode is OPTIONAL (#874). When --dispatch-mode is `phase` or
+#   `finish`, the field is set verbatim. When omitted or `inherit`, the
+#   field is NOT written — pre-#874 callers and back-compat readers see
+#   the original 6-field schema.
 #
 # Atomicity:
 #   acquire: `mkdir <dir>` is the POSIX atomic primitive; then write
@@ -189,15 +203,16 @@ sanitize_and_validate_slug() {
 # acquire <slug> --pipeline-id <id>
 # ---------------------------------------------------------------------------
 cmd_acquire() {
-  local raw_slug="" pipeline_id=""
+  local raw_slug="" pipeline_id="" dispatch_mode=""
   if [ "$#" -lt 1 ]; then
-    echo "Usage: claim-plan.sh acquire <slug> --pipeline-id <id>" >&2
+    echo "Usage: claim-plan.sh acquire <slug> --pipeline-id <id> [--dispatch-mode <phase|finish|inherit>]" >&2
     return 2
   fi
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      --dispatch-mode) dispatch_mode="${2:-}"; shift 2 ;;
       *) echo "run-plan claim-plan.sh acquire: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -206,6 +221,17 @@ cmd_acquire() {
     echo "run-plan claim-plan.sh acquire: --pipeline-id is required" >&2
     return 2
   fi
+  # Validate --dispatch-mode (issue #874). Empty (flag absent) and
+  # `inherit` are both no-op signals — the field is not written. Only
+  # `phase` and `finish` are persisted verbatim. Anything else is a
+  # usage error.
+  case "$dispatch_mode" in
+    ""|inherit|phase|finish) ;;
+    *)
+      echo "run-plan claim-plan.sh acquire: --dispatch-mode must be one of phase|finish|inherit (got '$dispatch_mode')" >&2
+      return 2
+      ;;
+  esac
   resolve_main_root || return 2
 
   local claims_root="${MAIN_ROOT}/.zskills/claims"
@@ -258,9 +284,13 @@ cmd_acquire() {
   # "Phase 0 — acquired" so the dashboard chip renders `phase 0/M`
   # immediately on acquire (not `phase ?/M`); subsequent updates flow
   # through the `set-phase` subcommand.
-  if ! "$_CLAIM_PYTHON" - "$claim_tmp" "$claim_file" "$pipeline_id" "$SLUG" <<'PY'
+  #
+  # dispatch_mode (#874): if non-empty and not `inherit`, persist
+  # alongside the 6-field core schema. Pre-#874 readers tolerate the
+  # extra key (collect.py uses an explicit allow-list).
+  if ! "$_CLAIM_PYTHON" - "$claim_tmp" "$claim_file" "$pipeline_id" "$SLUG" "$dispatch_mode" <<'PY'
 import json, os, sys, datetime
-tmp_path, final_path, pipeline_id, slug = sys.argv[1:5]
+tmp_path, final_path, pipeline_id, slug, dispatch_mode = sys.argv[1:6]
 now = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
 body = {
     "schema_version":     1,
@@ -270,6 +300,8 @@ body = {
     "started_at":         now,
     "current_phase":      "Phase 0 — acquired",
 }
+if dispatch_mode and dispatch_mode != "inherit":
+    body["dispatch_mode"] = dispatch_mode
 with open(tmp_path, "w") as f:
     json.dump(body, f, sort_keys=True)
     f.write("\n")

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+cecde4"
+  version: "2026.05.31+e6f96a"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1813,7 +1813,10 @@ def _annotate_plans_queue(
             plan["queue"] = {"column": inferred, "index": -1, "mode": None}
         # Claim chip — explicit field allow-list (NOT **claim_dict).
         # NO `worktree_path`, NO `host_pid` — same scope discipline as
-        # the issue side (DA8 / DA2.1).
+        # the issue side (DA8 / DA2.1). `dispatch_mode` (#874) IS on the
+        # allow-list because the dashboard mode chip's lock condition
+        # reads it; the issue side intentionally does NOT mirror — it's
+        # a plan-claim concept.
         if isinstance(slug, str) and slug in plan_claim_index:
             c = plan_claim_index[slug]
             plan["claim"] = {
@@ -1822,6 +1825,7 @@ def _annotate_plans_queue(
                 "current_phase":  c.get("current_phase"),
                 "age_seconds":    c.get("age_seconds"),
                 "pipeline_short": c.get("pipeline_short"),
+                "dispatch_mode":  c.get("dispatch_mode"),
             }
 
 
@@ -2318,7 +2322,8 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
     """Read run-plan claim files under `${main_root}/.zskills/claims/plan-*/`.
 
     Returns `{slug: claim_dict}` keyed by string slug. Each dict carries:
-        pipeline_id, started_at, current_phase, age_seconds, pipeline_short
+        pipeline_id, started_at, current_phase, age_seconds,
+        pipeline_short, dispatch_mode
 
     Tolerant: malformed JSON emits a single stderr line and skips that
     claim. A claim directory present without `claim.json` surfaces a
@@ -2329,6 +2334,13 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
     `age_seconds` is computed from `started_at` (post-#684 cleanup
     removed `last_heartbeat_at` as a duplicate of `started_at`; phase
     progression is now signalled by `current_phase`, not chip age).
+
+    `dispatch_mode` (#874) is the persisted mode under which the plan
+    is being driven (`phase`, `finish`, or `None` when absent). The
+    field survives the wrapper-lifetime gap that #858 left exposed:
+    `/work-on-plans` resets to idle within seconds of dispatching, but
+    the `/run-plan` claim it spawned outlives it by hours, so the
+    dispatch mode must live on the claim, not on the wrapper state file.
     """
     out: Dict[str, Dict[str, Any]] = {}
     claims_dir = main_root / ".zskills" / "claims"
@@ -2363,6 +2375,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
                 "current_phase": None,
                 "age_seconds": None,
                 "pipeline_short": None,
+                "dispatch_mode": None,
             }
             continue
         try:
@@ -2383,6 +2396,16 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_id = body.get("pipeline_id")
         started_at = body.get("started_at")
         current_phase = body.get("current_phase")
+        # dispatch_mode (#874): persisted by claim-plan.sh acquire
+        # --dispatch-mode. Only `phase` / `finish` are valid persisted
+        # values; anything else (including absence) surfaces as None and
+        # the renderer falls back to the entry/default mode precedence.
+        raw_dispatch_mode = body.get("dispatch_mode")
+        dispatch_mode: Optional[str]
+        if isinstance(raw_dispatch_mode, str) and raw_dispatch_mode in ("phase", "finish"):
+            dispatch_mode = raw_dispatch_mode
+        else:
+            dispatch_mode = None
         # Compute age from started_at (post-#684 cleanup: last_heartbeat_at
         # was a duplicate of started_at and has been removed).
         age_seconds: Optional[float] = None
@@ -2404,6 +2427,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
             "current_phase": current_phase if isinstance(current_phase, str) else None,
             "age_seconds": age_seconds,
             "pipeline_short": pipeline_short,
+            "dispatch_mode": dispatch_mode,
         }
     return out
 

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1128,11 +1128,22 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   // We still distinguish "queued" vs "running-phase" via data-state so
   // CSS can colorize running chips (signals "this is live"), but the
   // click behavior is the same in both.
-  // Effective mode = currentEntryMode(slug) || defaultMode || "phase".
+  // Effective mode precedence (issue #874):
+  //   1. plan.claim.dispatch_mode (persisted on the /run-plan claim;
+  //      outlives the /work-on-plans wrapper that spawned it — sibling
+  //      to #858's wrapper-lifetime batch_mode signal).
+  //   2. currentEntryMode(slug) explicit override.
+  //   3. defaultMode || "phase".
+  // Pre-#874 claims lack dispatch_mode → collect.py surfaces None →
+  // step 1 falls through to step 2 + step 3 unchanged. Back-compat is
+  // structural, not flag-gated.
   if (col === "ready") {
     const entryMode = currentEntryMode(slug);
     const isOverride = entryMode === "phase" || entryMode === "finish";
-    const effectiveMode = isOverride ? entryMode : (defaultMode || "phase");
+    const claimDispatchMode =
+      (plan && plan.claim && plan.claim.dispatch_mode) || null;
+    const effectiveMode =
+      claimDispatchMode || (isOverride ? entryMode : (defaultMode || "phase"));
     const isClaimed = !!(plan && plan.claim);
     const locked = isClaimed && effectiveMode === "finish";
     let state, ariaLabel;

--- a/tests/test-plan-claim-collector.py
+++ b/tests/test-plan-claim-collector.py
@@ -143,8 +143,56 @@ class ReadPlanClaimsTests(unittest.TestCase):
         self.assertEqual(
             set(c.keys()),
             {"pipeline_id", "started_at", "current_phase",
-             "age_seconds", "pipeline_short"},
+             "age_seconds", "pipeline_short", "dispatch_mode"},
         )
+        # dispatch_mode (#874) is on the allow-list. Absent in the
+        # source claim → surfaces as None.
+        self.assertIsNone(c["dispatch_mode"])
+
+    def test_dispatch_mode_finish_persists(self) -> None:
+        # #874: claim.json carrying dispatch_mode="finish" must surface
+        # the field verbatim so the dashboard mode chip can lock.
+        _write_plan_claim(self.claims, "dmfinish", {
+            "schema_version": 1,
+            "kind": "plan",
+            "slug": "dmfinish",
+            "pipeline_id": "run-plan.dmfinish",
+            "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "current_phase": "Phase 2",
+            "dispatch_mode": "finish",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertEqual(out["dmfinish"]["dispatch_mode"], "finish")
+
+    def test_dispatch_mode_phase_persists(self) -> None:
+        _write_plan_claim(self.claims, "dmphase", {
+            "schema_version": 1,
+            "kind": "plan",
+            "slug": "dmphase",
+            "pipeline_id": "run-plan.dmphase",
+            "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "current_phase": "Phase 2",
+            "dispatch_mode": "phase",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertEqual(out["dmphase"]["dispatch_mode"], "phase")
+
+    def test_dispatch_mode_unknown_rejected_as_none(self) -> None:
+        # An invalid string in claim.json (would only happen if a future
+        # writer drifted) must NOT propagate to the dashboard — the
+        # collector clamps to None and the chip falls through to its
+        # default precedence.
+        _write_plan_claim(self.claims, "dmbogus", {
+            "schema_version": 1,
+            "kind": "plan",
+            "slug": "dmbogus",
+            "pipeline_id": "run-plan.dmbogus",
+            "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "current_phase": "Phase 1",
+            "dispatch_mode": "bogus",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertIsNone(out["dmbogus"]["dispatch_mode"])
 
     def test_pipeline_short_derived(self) -> None:
         _write_plan_claim(self.claims, "pidcheck", {
@@ -240,6 +288,7 @@ class AnnotatePlansQueueGatingTests(unittest.TestCase):
             "current_phase": "Phase 2",
             "age_seconds": 30.0,
             "pipeline_short": "alpha",
+            "dispatch_mode": "finish",
         }
         with mock.patch.object(collect, "_read_plan_claims",
                                return_value={"alpha": fake_claim}) as mocked:
@@ -250,6 +299,11 @@ class AnnotatePlansQueueGatingTests(unittest.TestCase):
         self.assertEqual(c["pipeline_id"], "run-plan.alpha")
         self.assertEqual(c["current_phase"], "Phase 2")
         self.assertEqual(c["started_at"], "2026-05-21T01:07:31+00:00")
+        # #874: dispatch_mode threads through the allow-list onto plan["claim"]
+        # so the dashboard chip can lock LOCKED finish across the full
+        # /run-plan lifetime (outliving the /work-on-plans wrapper that
+        # spawned it — sibling to #858's wrapper-lifetime batch_mode).
+        self.assertEqual(c["dispatch_mode"], "finish")
         # Allow-list discipline.
         self.assertNotIn("host_pid", c)
         self.assertNotIn("worktree_path", c)
@@ -259,7 +313,7 @@ class AnnotatePlansQueueGatingTests(unittest.TestCase):
         self.assertEqual(
             set(c.keys()),
             {"pipeline_id", "started_at", "current_phase",
-             "age_seconds", "pipeline_short"},
+             "age_seconds", "pipeline_short", "dispatch_mode"},
         )
         # Plan beta has no claim attached.
         self.assertNotIn("claim", plans[1])

--- a/tests/test-plan-claim-render-dom.sh
+++ b/tests/test-plan-claim-render-dom.sh
@@ -398,6 +398,99 @@ function collectText(node) {
   expect(findByClass(card, "claim-chip"), null,
     "no claim-chip rendered when plan.claim absent");
 }
+
+// ------------------------------------------------------------------
+// T3.11.#874.a — Ready col + claim.dispatch_mode='finish' → mode chip
+// LOCKED, regardless of entryMode/defaultMode. This is the core
+// regression gate: post wrapper-idle, the chip MUST still read locked.
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "lockfinish", title: "Locked finish", status: "active",
+    phase_count: 5, phases_done: 2,
+    claim: {
+      pipeline_id: "run-plan.lockfinish",
+      started_at: new Date(Date.now() - 60000).toISOString(),
+      current_phase: "Phase 3",
+      age_seconds: 60,
+      pipeline_short: "lock-abc",
+      dispatch_mode: "finish",
+    },
+  };
+  // defaultMode="phase" — the precedence MUST come from the claim, not
+  // the dashboard default. This is exactly the post-wrapper-idle case.
+  const card = buildPlanCard(plan, "lockfinish", "ready", "phase");
+  const modeChip = findByClass(card, "mode-chip");
+  expectTrue(modeChip,
+    "mode-chip rendered on Ready card with claim.dispatch_mode='finish'");
+  if (modeChip) {
+    expect(modeChip.getAttribute("data-state"), "running-finish",
+      "#874: data-state='running-finish' (LOCKED) when claim.dispatch_mode='finish'");
+    expect(modeChip.getAttribute("aria-disabled"), "true",
+      "#874: aria-disabled='true' when LOCKED");
+    expect(modeChip.getAttribute("disabled"), "disabled",
+      "#874: disabled attr present when LOCKED");
+    // Critically: NO data-action — the chip is informational only when
+    // locked, never togglable.
+    expect(modeChip.getAttribute("data-action"), null,
+      "#874: no data-action='toggle-mode' when LOCKED");
+  }
+}
+
+// ------------------------------------------------------------------
+// T3.11.#874.b — Pre-#874 claim (no dispatch_mode) renders exactly as
+// before: defaultMode/entryMode precedence; defaultMode='phase' → NOT
+// locked (running-phase, togglable).
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "precompat", title: "Back-compat", status: "active",
+    phase_count: 4, phases_done: 1,
+    claim: {
+      pipeline_id: "run-plan.precompat",
+      started_at: new Date(Date.now() - 60000).toISOString(),
+      current_phase: "Phase 2",
+      age_seconds: 60,
+      pipeline_short: "pc-abc",
+      // dispatch_mode intentionally absent (or null surfaced by collector).
+    },
+  };
+  const card = buildPlanCard(plan, "precompat", "ready", "phase");
+  const modeChip = findByClass(card, "mode-chip");
+  expectTrue(modeChip, "mode-chip rendered for pre-#874 claim");
+  if (modeChip) {
+    expect(modeChip.getAttribute("data-state"), "running-phase",
+      "#874 back-compat: pre-#874 claim + defaultMode='phase' → 'running-phase' (NOT locked)");
+    expect(modeChip.getAttribute("aria-disabled"), null,
+      "#874 back-compat: no aria-disabled when not locked");
+  }
+}
+
+// ------------------------------------------------------------------
+// T3.11.#874.c — explicit dispatch_mode='phase' on a claim suppresses
+// the lock even if a future caller toggled to finish via the chip.
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "phasepin", title: "Phase-pinned", status: "active",
+    phase_count: 4, phases_done: 1,
+    claim: {
+      pipeline_id: "run-plan.phasepin",
+      started_at: new Date(Date.now() - 60000).toISOString(),
+      current_phase: "Phase 2",
+      age_seconds: 60,
+      pipeline_short: "pp-abc",
+      dispatch_mode: "phase",
+    },
+  };
+  const card = buildPlanCard(plan, "phasepin", "ready", "phase");
+  const modeChip = findByClass(card, "mode-chip");
+  expectTrue(modeChip, "mode-chip rendered for dispatch_mode='phase' claim");
+  if (modeChip) {
+    expect(modeChip.getAttribute("data-state"), "running-phase",
+      "#874: dispatch_mode='phase' on claim → 'running-phase' (NOT locked)");
+  }
+}
 NODE
 )
 NODE_RC=$?

--- a/tests/test-plan-claim-script.sh
+++ b/tests/test-plan-claim-script.sh
@@ -258,6 +258,87 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# 21. --dispatch-mode "finish" persists dispatch_mode="finish" on claim.json (#874).
+# ───────────────────────────────────────────────────────────────────────
+(
+  cd "$REPO1"
+  bash "$CLAIM_SH" acquire dmfinish --pipeline-id "run-plan.dmfinish" --dispatch-mode finish
+) 2>/dev/null
+DM_FILE="$REPO1/.zskills/claims/plan-dmfinish/claim.json"
+if [ -f "$DM_FILE" ]; then
+  DM_VAL=$("$PYTHON" -c "import json; print(json.load(open('$DM_FILE')).get('dispatch_mode','<absent>'))")
+  if [ "$DM_VAL" = "finish" ]; then
+    pass "--dispatch-mode finish persists dispatch_mode='finish' (#874)"
+  else
+    fail "--dispatch-mode finish persists" "got dispatch_mode=<$DM_VAL>"
+  fi
+else
+  fail "--dispatch-mode finish acquire" "claim.json missing"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# 22. --dispatch-mode "phase" persists dispatch_mode="phase" on claim.json.
+# ───────────────────────────────────────────────────────────────────────
+(
+  cd "$REPO1"
+  bash "$CLAIM_SH" acquire dmphase --pipeline-id "run-plan.dmphase" --dispatch-mode phase
+) 2>/dev/null
+DMP_FILE="$REPO1/.zskills/claims/plan-dmphase/claim.json"
+if [ -f "$DMP_FILE" ]; then
+  DMP_VAL=$("$PYTHON" -c "import json; print(json.load(open('$DMP_FILE')).get('dispatch_mode','<absent>'))")
+  if [ "$DMP_VAL" = "phase" ]; then
+    pass "--dispatch-mode phase persists dispatch_mode='phase'"
+  else
+    fail "--dispatch-mode phase persists" "got dispatch_mode=<$DMP_VAL>"
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# 23. --dispatch-mode "inherit" is a no-op (field omitted from claim.json).
+# ───────────────────────────────────────────────────────────────────────
+(
+  cd "$REPO1"
+  bash "$CLAIM_SH" acquire dminherit --pipeline-id "run-plan.dminherit" --dispatch-mode inherit
+) 2>/dev/null
+DMI_FILE="$REPO1/.zskills/claims/plan-dminherit/claim.json"
+if [ -f "$DMI_FILE" ]; then
+  DMI_HAS=$("$PYTHON" -c "import json; d=json.load(open('$DMI_FILE')); print('yes' if 'dispatch_mode' in d else 'no')")
+  if [ "$DMI_HAS" = "no" ]; then
+    pass "--dispatch-mode inherit omits dispatch_mode field (back-compat)"
+  else
+    fail "--dispatch-mode inherit omits" "dispatch_mode present in claim.json"
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# 24. Flag absent: dispatch_mode field omitted (pre-#874 schema).
+# ───────────────────────────────────────────────────────────────────────
+(
+  cd "$REPO1"
+  bash "$CLAIM_SH" acquire dmabsent --pipeline-id "run-plan.dmabsent"
+) 2>/dev/null
+DMA_FILE="$REPO1/.zskills/claims/plan-dmabsent/claim.json"
+if [ -f "$DMA_FILE" ]; then
+  DMA_HAS=$("$PYTHON" -c "import json; d=json.load(open('$DMA_FILE')); print('yes' if 'dispatch_mode' in d else 'no')")
+  if [ "$DMA_HAS" = "no" ]; then
+    pass "flag absent: dispatch_mode field omitted (pre-#874 schema unchanged)"
+  else
+    fail "flag absent omits" "dispatch_mode present in claim.json"
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# 25. Invalid --dispatch-mode value returns exit 2.
+# ───────────────────────────────────────────────────────────────────────
+(cd "$REPO1" && bash "$CLAIM_SH" acquire dmbogus --pipeline-id "run-plan.dmbogus" --dispatch-mode bogus) 2>/dev/null
+rc_bogus=$?
+if [ "$rc_bogus" -eq 2 ] && [ ! -d "$REPO1/.zskills/claims/plan-dmbogus" ]; then
+  pass "--dispatch-mode bogus returns exit 2 (usage error, no claim created)"
+else
+  fail "--dispatch-mode bogus exit 2" "rc=$rc_bogus dir=$([ -d "$REPO1/.zskills/claims/plan-dmbogus" ] && echo yes || echo no)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Closes #874.

Sibling to #858 (PR #878, merged): #858 fixed the wrapper-lifetime half of mode-display by writing `batch_mode` into `.zskills/work-on-plans-state.json` while `/work-on-plans` is iterating. The wrapper lives seconds; the `/run-plan` it dispatches lives hours. After the wrapper resets to idle, the dashboard chip falls back to `PHASE` (togglable) because nothing else carries the dispatched mode.

This PR threads `dispatch_mode` through the plan claim record itself (`.zskills/claims/plan-<slug>/claim.json`), which lives for the full duration of the `/run-plan` dispatch.

## Changes

**Writer:** `skills/run-plan/scripts/claim-plan.sh` — `acquire` learns `--dispatch-mode {phase|finish|inherit}`; `phase`/`finish` persist into `claim.json`, `inherit`/absent omit the field (back-compat), bogus value exits 2.

**Caller:** `skills/run-plan/SKILL.md` acquire site now maps `$FINISH_MODE` → claim-side enum and passes `--dispatch-mode`.

**Reader:** `skills/zskills-dashboard/scripts/zskills_monitor/collect.py` — `_read_plan_claims` surfaces `dispatch_mode` with defensive clamp to {phase, finish, None}; `_annotate_plans_queue` extends the explicit allow-list.

**Consumer:** `skills/zskills-dashboard/scripts/zskills_monitor/static/app.js` — `effectiveMode` precedence is now `claim.dispatch_mode → entryMode (override) → defaultMode → "phase"`; pre-#874 claims fall through unchanged.

**Tests:** `tests/test-plan-claim-script.sh` (writer, 5 cases), `tests/test-plan-claim-collector.py` (reader, 3 new + extended allow-list), `tests/test-plan-claim-render-dom.sh` (consumer, 3 sub-tests).

Commits:
- cb02ecf fix(#874): persist dispatch_mode on plan claim record (sibling to #858)

Out of scope (see #884): blocking plan-row drag / X click while the claim is held — same `isClaimed` predicate, separate fix.
