### PR TITLE
fix(hook): block-fix-issue-unclaimed enforces pipeline ownership (#865)

### DIFF
--- a/.claude/hooks/block-fix-issue-unclaimed.sh
+++ b/.claude/hooks/block-fix-issue-unclaimed.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.05.31
 # block-fix-issue-unclaimed.sh — PreToolUse hook on Bash.
 #
 # Backstops the /fix-issues inline-acquire prose discipline (plans/fix-issues-claims.md
@@ -22,6 +22,18 @@
 #   - If no claim exists: emits a PreToolUse deny envelope (same JSON shape
 #     as hooks/block-main-edits.sh:175) with verbatim recovery instructions
 #     mirroring the block-stale-skill-version.sh precedent.
+#   - If a claim DOES exist (issue #865): read claim.json:pipeline_id and
+#     compare to the caller's --pipeline-id (captured from the create-worktree
+#     argv). Same pipeline_id → allow (self-re-entry, e.g. cron re-fire of
+#     the same sprint). Different pipeline_id → deny (foreign pipeline trying
+#     to materialise on an already-claimed issue). Absent or malformed
+#     claim.json → fail-OPEN with stderr WARN (hook's existing infra-error
+#     discipline; do not block on unverifiable state — only deny on a
+#     concrete mismatch). NOTE: this is INTENTIONALLY different from
+#     claim-self-reentry.sh's "absent claim.json → foreign (10)" semantics:
+#     the acquire path must never STEAL an unverifiable claim, but the hook
+#     is a backstop and must never false-deny when it cannot prove a
+#     conflict.
 #   - All other branch patterns (non-fix-issue prefixes like pr-<slug>,
 #     cp-<slug>, wt-<slug>) pass through (exit 0) immediately.
 #   - MAIN_ROOT resolution: `git rev-parse --git-common-dir` parent
@@ -94,9 +106,11 @@ esac
 #   --branch-name <v>     wins outright
 #   else --prefix <v> + positional <slug>   ->   <prefix>-<slug>
 #   else positional <slug>                  ->   wt-<slug>
-# Emits two lines to stdout:
+# Emits three lines to stdout:
 #   BRANCH=<resolved-branch-or-empty>
 #   SLUG=<positional-slug-or-empty>
+#   PIPELINE_ID=<caller-pipeline-id-or-empty>   (issue #865 — captured for
+#                                                the ownership check below)
 WALK=$("$PYTHON" - <<'PY' "$CMD"
 import shlex, sys
 cmd_str = sys.argv[1]
@@ -110,6 +124,7 @@ except ValueError:
 
 prefix = None
 branch_name = None
+pipeline_id = None  # issue #865 — captured for ownership check
 positionals = []
 
 # Walk to the script-path token (whatever ends in create-worktree.sh or
@@ -128,6 +143,15 @@ while i < n:
         continue
     if tok == "--prefix" and i + 1 < n:
         prefix = argv[i + 1]
+        i += 2
+        continue
+    if tok == "--pipeline-id" and i + 1 < n:
+        # issue #865 — capture the caller's pipeline-id so the post-existence
+        # ownership check below can compare against claim.json:pipeline_id.
+        # Mirrors --branch-name / --prefix capture shape (symmetric two-arg
+        # consume). Without this branch the generic --* fall-through silently
+        # swallowed the value, leaving the hook unable to enforce ownership.
+        pipeline_id = argv[i + 1]
         i += 2
         continue
     if tok.startswith("--"):
@@ -156,15 +180,18 @@ else:
 
 print("BRANCH=" + (branch or ""))
 print("SLUG=" + (slug or ""))
+print("PIPELINE_ID=" + (pipeline_id or ""))
 PY
 )
 
 BRANCH=""
 SLUG=""
+CALLER_PIPELINE_ID=""
 while IFS= read -r line; do
   case "$line" in
-    BRANCH=*) BRANCH="${line#BRANCH=}" ;;
-    SLUG=*)   SLUG="${line#SLUG=}" ;;
+    BRANCH=*)      BRANCH="${line#BRANCH=}" ;;
+    SLUG=*)        SLUG="${line#SLUG=}" ;;
+    PIPELINE_ID=*) CALLER_PIPELINE_ID="${line#PIPELINE_ID=}" ;;
   esac
 done <<< "$WALK"
 
@@ -211,7 +238,48 @@ fi
 # ── Claim-presence check ─────────────────────────────────────────────────
 CLAIM_DIR="${MAIN_ROOT}/.zskills/claims/issue-${NNN}"
 if [ -d "$CLAIM_DIR" ]; then
-  exit 0
+  # ── Ownership check (issue #865) ─────────────────────────────────────
+  # Existence alone is insufficient: a foreign pipeline holding the claim
+  # would otherwise let any other pipeline materialise on top of it. Read
+  # claim.json:pipeline_id and compare to the caller's --pipeline-id.
+  #
+  # Fail-open discipline mirrors the rest of this hook (see header §
+  # "fail-open on its own infrastructure errors"): we only DENY on a
+  # concrete mismatch. Absent claim.json, malformed JSON, missing caller
+  # pipeline-id, or absent Python all WARN-and-allow — never false-deny
+  # on unverifiable state. Contrast claim-self-reentry.sh which returns
+  # 10 (foreign) on the same conditions; that path is enforcing
+  # never-steal at acquire time, this path is enforcing never-false-deny
+  # at backstop time.
+  CLAIM_FILE="${CLAIM_DIR}/claim.json"
+  if [ ! -f "$CLAIM_FILE" ]; then
+    echo "block-fix-issue-unclaimed.sh: WARN claim.json missing under $CLAIM_DIR; cannot verify ownership — allowing" >&2
+    exit 0
+  fi
+  if [ -z "$CALLER_PIPELINE_ID" ]; then
+    echo "block-fix-issue-unclaimed.sh: WARN caller did not pass --pipeline-id; cannot verify ownership of issue-${NNN} claim — allowing" >&2
+    exit 0
+  fi
+  STORED_PIPELINE_ID=$("$PYTHON" - "$CLAIM_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+  if [ -z "$STORED_PIPELINE_ID" ]; then
+    echo "block-fix-issue-unclaimed.sh: WARN claim.json at $CLAIM_FILE is malformed or missing pipeline_id; cannot verify ownership — allowing" >&2
+    exit 0
+  fi
+  if [ "$STORED_PIPELINE_ID" = "$CALLER_PIPELINE_ID" ]; then
+    # Self-re-entry — caller already owns this claim.
+    exit 0
+  fi
+  # Concrete mismatch — foreign pipeline interference. Emit the
+  # ownership-mismatch deny envelope (separate STOP_MSG below).
+  OWNERSHIP_DENY=1
 fi
 
 # ── Deny envelope (plan DA4.4 — locked text) ─────────────────────────────
@@ -224,7 +292,25 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/fix-is
 else
   CLAIM_ISSUE_PATH="${MAIN_ROOT}/.claude/skills/fix-issues/scripts/claim-issue.sh"
 fi
-STOP_MSG=$(cat <<EOF
+if [ "${OWNERSHIP_DENY:-0}" = "1" ]; then
+  # Ownership-mismatch deny (issue #865): claim dir exists and
+  # claim.json's pipeline_id differs from the caller's --pipeline-id.
+  # Treat as race-lost (exit 10 semantics in claim-issue.sh acquire) —
+  # the caller pipeline should SKIP this issue and proceed to the next.
+  STOP_MSG=$(cat <<EOF
+STOP: create-worktree.sh for fix-issue-${NNN} denied — issue is held by a foreign pipeline.
+
+Claim at ${MAIN_ROOT}/.zskills/claims/issue-${NNN}/claim.json:
+  stored pipeline_id: ${STORED_PIPELINE_ID}
+  caller pipeline_id: ${CALLER_PIPELINE_ID}
+
+This is the same outcome as ${CLAIM_ISSUE_PATH} acquire returning exit 10 (race lost). The caller pipeline should SKIP issue ${NNN} and proceed to the next. Do NOT remove the claim dir or steal the claim — the holding pipeline will release it on land-or-abandon.
+
+If you believe this is wrong (e.g., a stale claim from a crashed pipeline), inspect claim.json's started_at, sprint_id, and pipeline_id, then escalate to the operator. The hook is a backstop and intentionally fails closed only on a concrete pipeline_id mismatch.
+EOF
+)
+else
+  STOP_MSG=$(cat <<EOF
 STOP: create-worktree.sh for fix-issue-${NNN} denied — no claim found at ${MAIN_ROOT}/.zskills/claims/issue-${NNN}/.
 
 The per-issue dispatch fence in fix-issues modes/sprint.md (the "Worktree setup (cherry-pick and direct modes)" section, and the "PR mode (Phase 3)" section) MUST call:
@@ -236,6 +322,7 @@ immediately above the create-worktree.sh invocation. If this hook fired during a
 If acquire returns exit 10 (race lost — issue held by a concurrent pipeline), skip and proceed to the next issue. If exit 11 (filesystem error), abort the sprint.
 EOF
 )
+fi
 
 # Emit deny envelope. Escape for JSON: backslashes first, then quotes, then
 # newlines. Mirrors block-unsafe-project.sh / block-main-edits.sh.

--- a/hooks/block-fix-issue-unclaimed.sh
+++ b/hooks/block-fix-issue-unclaimed.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.05.31
 # block-fix-issue-unclaimed.sh — PreToolUse hook on Bash.
 #
 # Backstops the /fix-issues inline-acquire prose discipline (plans/fix-issues-claims.md
@@ -22,6 +22,18 @@
 #   - If no claim exists: emits a PreToolUse deny envelope (same JSON shape
 #     as hooks/block-main-edits.sh:175) with verbatim recovery instructions
 #     mirroring the block-stale-skill-version.sh precedent.
+#   - If a claim DOES exist (issue #865): read claim.json:pipeline_id and
+#     compare to the caller's --pipeline-id (captured from the create-worktree
+#     argv). Same pipeline_id → allow (self-re-entry, e.g. cron re-fire of
+#     the same sprint). Different pipeline_id → deny (foreign pipeline trying
+#     to materialise on an already-claimed issue). Absent or malformed
+#     claim.json → fail-OPEN with stderr WARN (hook's existing infra-error
+#     discipline; do not block on unverifiable state — only deny on a
+#     concrete mismatch). NOTE: this is INTENTIONALLY different from
+#     claim-self-reentry.sh's "absent claim.json → foreign (10)" semantics:
+#     the acquire path must never STEAL an unverifiable claim, but the hook
+#     is a backstop and must never false-deny when it cannot prove a
+#     conflict.
 #   - All other branch patterns (non-fix-issue prefixes like pr-<slug>,
 #     cp-<slug>, wt-<slug>) pass through (exit 0) immediately.
 #   - MAIN_ROOT resolution: `git rev-parse --git-common-dir` parent
@@ -94,9 +106,11 @@ esac
 #   --branch-name <v>     wins outright
 #   else --prefix <v> + positional <slug>   ->   <prefix>-<slug>
 #   else positional <slug>                  ->   wt-<slug>
-# Emits two lines to stdout:
+# Emits three lines to stdout:
 #   BRANCH=<resolved-branch-or-empty>
 #   SLUG=<positional-slug-or-empty>
+#   PIPELINE_ID=<caller-pipeline-id-or-empty>   (issue #865 — captured for
+#                                                the ownership check below)
 WALK=$("$PYTHON" - <<'PY' "$CMD"
 import shlex, sys
 cmd_str = sys.argv[1]
@@ -110,6 +124,7 @@ except ValueError:
 
 prefix = None
 branch_name = None
+pipeline_id = None  # issue #865 — captured for ownership check
 positionals = []
 
 # Walk to the script-path token (whatever ends in create-worktree.sh or
@@ -128,6 +143,15 @@ while i < n:
         continue
     if tok == "--prefix" and i + 1 < n:
         prefix = argv[i + 1]
+        i += 2
+        continue
+    if tok == "--pipeline-id" and i + 1 < n:
+        # issue #865 — capture the caller's pipeline-id so the post-existence
+        # ownership check below can compare against claim.json:pipeline_id.
+        # Mirrors --branch-name / --prefix capture shape (symmetric two-arg
+        # consume). Without this branch the generic --* fall-through silently
+        # swallowed the value, leaving the hook unable to enforce ownership.
+        pipeline_id = argv[i + 1]
         i += 2
         continue
     if tok.startswith("--"):
@@ -156,15 +180,18 @@ else:
 
 print("BRANCH=" + (branch or ""))
 print("SLUG=" + (slug or ""))
+print("PIPELINE_ID=" + (pipeline_id or ""))
 PY
 )
 
 BRANCH=""
 SLUG=""
+CALLER_PIPELINE_ID=""
 while IFS= read -r line; do
   case "$line" in
-    BRANCH=*) BRANCH="${line#BRANCH=}" ;;
-    SLUG=*)   SLUG="${line#SLUG=}" ;;
+    BRANCH=*)      BRANCH="${line#BRANCH=}" ;;
+    SLUG=*)        SLUG="${line#SLUG=}" ;;
+    PIPELINE_ID=*) CALLER_PIPELINE_ID="${line#PIPELINE_ID=}" ;;
   esac
 done <<< "$WALK"
 
@@ -211,7 +238,48 @@ fi
 # ── Claim-presence check ─────────────────────────────────────────────────
 CLAIM_DIR="${MAIN_ROOT}/.zskills/claims/issue-${NNN}"
 if [ -d "$CLAIM_DIR" ]; then
-  exit 0
+  # ── Ownership check (issue #865) ─────────────────────────────────────
+  # Existence alone is insufficient: a foreign pipeline holding the claim
+  # would otherwise let any other pipeline materialise on top of it. Read
+  # claim.json:pipeline_id and compare to the caller's --pipeline-id.
+  #
+  # Fail-open discipline mirrors the rest of this hook (see header §
+  # "fail-open on its own infrastructure errors"): we only DENY on a
+  # concrete mismatch. Absent claim.json, malformed JSON, missing caller
+  # pipeline-id, or absent Python all WARN-and-allow — never false-deny
+  # on unverifiable state. Contrast claim-self-reentry.sh which returns
+  # 10 (foreign) on the same conditions; that path is enforcing
+  # never-steal at acquire time, this path is enforcing never-false-deny
+  # at backstop time.
+  CLAIM_FILE="${CLAIM_DIR}/claim.json"
+  if [ ! -f "$CLAIM_FILE" ]; then
+    echo "block-fix-issue-unclaimed.sh: WARN claim.json missing under $CLAIM_DIR; cannot verify ownership — allowing" >&2
+    exit 0
+  fi
+  if [ -z "$CALLER_PIPELINE_ID" ]; then
+    echo "block-fix-issue-unclaimed.sh: WARN caller did not pass --pipeline-id; cannot verify ownership of issue-${NNN} claim — allowing" >&2
+    exit 0
+  fi
+  STORED_PIPELINE_ID=$("$PYTHON" - "$CLAIM_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+  if [ -z "$STORED_PIPELINE_ID" ]; then
+    echo "block-fix-issue-unclaimed.sh: WARN claim.json at $CLAIM_FILE is malformed or missing pipeline_id; cannot verify ownership — allowing" >&2
+    exit 0
+  fi
+  if [ "$STORED_PIPELINE_ID" = "$CALLER_PIPELINE_ID" ]; then
+    # Self-re-entry — caller already owns this claim.
+    exit 0
+  fi
+  # Concrete mismatch — foreign pipeline interference. Emit the
+  # ownership-mismatch deny envelope (separate STOP_MSG below).
+  OWNERSHIP_DENY=1
 fi
 
 # ── Deny envelope (plan DA4.4 — locked text) ─────────────────────────────
@@ -224,7 +292,25 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/fix-is
 else
   CLAIM_ISSUE_PATH="${MAIN_ROOT}/.claude/skills/fix-issues/scripts/claim-issue.sh"
 fi
-STOP_MSG=$(cat <<EOF
+if [ "${OWNERSHIP_DENY:-0}" = "1" ]; then
+  # Ownership-mismatch deny (issue #865): claim dir exists and
+  # claim.json's pipeline_id differs from the caller's --pipeline-id.
+  # Treat as race-lost (exit 10 semantics in claim-issue.sh acquire) —
+  # the caller pipeline should SKIP this issue and proceed to the next.
+  STOP_MSG=$(cat <<EOF
+STOP: create-worktree.sh for fix-issue-${NNN} denied — issue is held by a foreign pipeline.
+
+Claim at ${MAIN_ROOT}/.zskills/claims/issue-${NNN}/claim.json:
+  stored pipeline_id: ${STORED_PIPELINE_ID}
+  caller pipeline_id: ${CALLER_PIPELINE_ID}
+
+This is the same outcome as ${CLAIM_ISSUE_PATH} acquire returning exit 10 (race lost). The caller pipeline should SKIP issue ${NNN} and proceed to the next. Do NOT remove the claim dir or steal the claim — the holding pipeline will release it on land-or-abandon.
+
+If you believe this is wrong (e.g., a stale claim from a crashed pipeline), inspect claim.json's started_at, sprint_id, and pipeline_id, then escalate to the operator. The hook is a backstop and intentionally fails closed only on a concrete pipeline_id mismatch.
+EOF
+)
+else
+  STOP_MSG=$(cat <<EOF
 STOP: create-worktree.sh for fix-issue-${NNN} denied — no claim found at ${MAIN_ROOT}/.zskills/claims/issue-${NNN}/.
 
 The per-issue dispatch fence in fix-issues modes/sprint.md (the "Worktree setup (cherry-pick and direct modes)" section, and the "PR mode (Phase 3)" section) MUST call:
@@ -236,6 +322,7 @@ immediately above the create-worktree.sh invocation. If this hook fired during a
 If acquire returns exit 10 (race lost — issue held by a concurrent pipeline), skip and proceed to the next issue. If exit 11 (filesystem error), abort the sprint.
 EOF
 )
+fi
 
 # Emit deny envelope. Escape for JSON: backslashes first, then quotes, then
 # newlines. Mirrors block-unsafe-project.sh / block-main-edits.sh.

--- a/tests/test-block-fix-issue-unclaimed-ownership.sh
+++ b/tests/test-block-fix-issue-unclaimed-ownership.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# tests/test-block-fix-issue-unclaimed-ownership.sh — issue #865.
+#
+# Covers the pipeline-ownership check added on top of the bare existence
+# check in hooks/block-fix-issue-unclaimed.sh. Existing baseline behaviour
+# (deny on no claim, allow on present claim for the SAME pipeline) is
+# covered by tests/test-fix-issues-claim-regression-single.sh; this file
+# adds the ownership-mismatch and infra-failure-fail-open arms.
+#
+# Cases:
+#   1. Self-re-entry pass — claim.json.pipeline_id == caller --pipeline-id
+#      → hook exits 0 with no deny envelope.
+#   2. Foreign-pipeline deny — claim.json.pipeline_id != caller
+#      --pipeline-id → hook emits a deny envelope citing both ids.
+#   3. Fail-open on absent claim.json — claim dir exists but claim.json is
+#      missing (e.g. mid-acquire crash window) → hook exits 0 with WARN to
+#      stderr; no deny.
+#   4. Fail-open on malformed claim.json — claim dir + claim.json with
+#      invalid JSON → hook exits 0 with WARN; no deny.
+#   5. Fail-open when caller omits --pipeline-id — claim dir + valid
+#      claim.json but the create-worktree command line has no
+#      --pipeline-id flag → hook exits 0 with WARN; no deny. (Cannot
+#      false-deny on unverifiable state.)
+#   6. Baseline no-claim deny still fires — sanity backstop confirming
+#      the ownership extension didn't break the existence-only path.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/block-fix-issue-unclaimed.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRATCH_ROOT="/tmp/test-block-fix-issue-unclaimed-ownership-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then
+    echo "TEST_KEEP_SCRATCH set — leaving $SCRATCH_ROOT" >&2
+    return
+  fi
+  if [ -d "$SCRATCH_ROOT" ]; then
+    find "$SCRATCH_ROOT" -mindepth 1 -delete || true
+    rmdir "$SCRATCH_ROOT" || true
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH_ROOT"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FATAL: $HOOK missing" >&2; exit 1
+fi
+
+echo "=== block-fix-issue-unclaimed.sh ownership check (#865) ==="
+
+# Per-case fixture initialised on demand. Each test cd's into a fresh git
+# working tree so MAIN_ROOT resolution (git rev-parse --git-common-dir
+# parent) lands on a known root, and stages its own .zskills/claims/issue-N
+# state.
+init_fixture() {
+  local dir="$1"
+  mkdir -p "$dir"
+  ( cd "$dir" && git init -q && git config user.email "t@t" && git config user.name "t" \
+    && git commit --allow-empty -q -m "init" )
+}
+
+write_claim() {
+  # write_claim <fixture_dir> <issue> <pipeline_id>
+  local fixture="$1" n="$2" pid="$3"
+  local claim_dir="$fixture/.zskills/claims/issue-$n"
+  mkdir -p "$claim_dir"
+  python3 -c "
+import json, sys
+body = {
+    'schema_version': 1,
+    'pipeline_id': sys.argv[1],
+    'sprint_id': 'sprint-test',
+    'issue': int(sys.argv[2]),
+    'started_at': '2026-05-31T00:00:00+00:00',
+}
+with open(sys.argv[3], 'w') as f:
+    json.dump(body, f, sort_keys=True)
+    f.write('\n')
+" "$pid" "$n" "$claim_dir/claim.json"
+}
+
+write_malformed_claim() {
+  # write_malformed_claim <fixture_dir> <issue>
+  local fixture="$1" n="$2"
+  local claim_dir="$fixture/.zskills/claims/issue-$n"
+  mkdir -p "$claim_dir"
+  printf '{not valid json' > "$claim_dir/claim.json"
+}
+
+write_empty_claim_dir() {
+  # write_empty_claim_dir <fixture_dir> <issue>  (no claim.json — simulates
+  # mid-acquire crash window)
+  local fixture="$1" n="$2"
+  mkdir -p "$fixture/.zskills/claims/issue-$n"
+}
+
+build_payload() {
+  # build_payload <issue> <pipeline_id_arg_or_empty>
+  # When pipeline_id_arg is empty, the resulting command omits
+  # --pipeline-id entirely (used by case 5).
+  local n="$1" pid="$2"
+  local cmd
+  if [ -n "$pid" ]; then
+    cmd="bash $REPO_ROOT/skills/create-worktree/scripts/create-worktree.sh --prefix fix-issue --purpose \"fix-issues; issue=$n\" --pipeline-id $pid $n"
+  else
+    cmd="bash $REPO_ROOT/skills/create-worktree/scripts/create-worktree.sh --prefix fix-issue --purpose \"fix-issues; issue=$n\" $n"
+  fi
+  python3 -c "
+import json, sys
+print(json.dumps({
+    'tool_name': 'Bash',
+    'tool_input': { 'command': sys.argv[1] },
+}))
+" "$cmd"
+}
+
+run_hook() {
+  # run_hook <fixture_dir> <payload>
+  # Returns the captured rc; stdout in $LAST_STDOUT, stderr in $LAST_STDERR.
+  local fixture="$1" payload="$2"
+  local out_file="$SCRATCH_ROOT/_out.$$"
+  local err_file="$SCRATCH_ROOT/_err.$$"
+  (
+    cd "$fixture" || exit 1
+    echo "$payload" | bash "$HOOK"
+  ) >"$out_file" 2>"$err_file"
+  LAST_RC=$?
+  LAST_STDOUT=$(cat "$out_file")
+  LAST_STDERR=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+}
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 1: self-re-entry pass.
+# ───────────────────────────────────────────────────────────────────────
+F1="$SCRATCH_ROOT/f1"
+init_fixture "$F1" || { fail "test 1" "fixture init"; }
+write_claim "$F1" 10 "pipe-self"
+PAYLOAD=$(build_payload 10 "pipe-self")
+run_hook "$F1" "$PAYLOAD"
+if [ "$LAST_RC" -ne 0 ]; then
+  fail "self-re-entry pass" "hook exited $LAST_RC, expected 0; stdout=$LAST_STDOUT stderr=$LAST_STDERR"
+elif echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"'; then
+  fail "self-re-entry pass" "hook emitted deny envelope despite matching pipeline_id: $LAST_STDOUT"
+else
+  pass "self-re-entry — caller pipeline_id matches claim.json:pipeline_id; hook allows"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 2: foreign-pipeline deny.
+# ───────────────────────────────────────────────────────────────────────
+F2="$SCRATCH_ROOT/f2"
+init_fixture "$F2"
+write_claim "$F2" 11 "pipe-A-holder"
+PAYLOAD=$(build_payload 11 "pipe-B-intruder")
+run_hook "$F2" "$PAYLOAD"
+if [ "$LAST_RC" -ne 0 ]; then
+  fail "foreign-pipeline deny" "hook exited $LAST_RC, expected 0 (deny envelope on stdout); stderr=$LAST_STDERR"
+elif ! echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"'; then
+  fail "foreign-pipeline deny" "hook did NOT emit deny envelope on pipeline mismatch; stdout=$LAST_STDOUT"
+elif ! echo "$LAST_STDOUT" | grep -q 'pipe-A-holder'; then
+  fail "foreign-pipeline deny" "deny envelope omitted the stored pipeline_id; stdout=$LAST_STDOUT"
+elif ! echo "$LAST_STDOUT" | grep -q 'pipe-B-intruder'; then
+  fail "foreign-pipeline deny" "deny envelope omitted the caller pipeline_id; stdout=$LAST_STDOUT"
+elif ! echo "$LAST_STDOUT" | grep -q 'fix-issue-11'; then
+  fail "foreign-pipeline deny" "deny envelope omitted the issue number; stdout=$LAST_STDOUT"
+else
+  pass "foreign-pipeline deny — claim.json.pipeline_id != caller --pipeline-id; hook denies with both ids cited"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 3: fail-open on absent claim.json (mid-acquire crash window).
+# ───────────────────────────────────────────────────────────────────────
+F3="$SCRATCH_ROOT/f3"
+init_fixture "$F3"
+write_empty_claim_dir "$F3" 12
+PAYLOAD=$(build_payload 12 "pipe-any")
+run_hook "$F3" "$PAYLOAD"
+if [ "$LAST_RC" -ne 0 ]; then
+  fail "fail-open on absent claim.json" "hook exited $LAST_RC, expected 0 (allow); stdout=$LAST_STDOUT stderr=$LAST_STDERR"
+elif echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"'; then
+  fail "fail-open on absent claim.json" "hook false-denied on unverifiable state: $LAST_STDOUT"
+elif ! echo "$LAST_STDERR" | grep -q 'WARN.*claim.json missing'; then
+  fail "fail-open on absent claim.json" "hook did not emit WARN to stderr; stderr=$LAST_STDERR"
+else
+  pass "fail-open on absent claim.json — hook allows + WARN to stderr (mid-acquire crash window not false-denied)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 4: fail-open on malformed claim.json.
+# ───────────────────────────────────────────────────────────────────────
+F4="$SCRATCH_ROOT/f4"
+init_fixture "$F4"
+write_malformed_claim "$F4" 13
+PAYLOAD=$(build_payload 13 "pipe-any")
+run_hook "$F4" "$PAYLOAD"
+if [ "$LAST_RC" -ne 0 ]; then
+  fail "fail-open on malformed claim.json" "hook exited $LAST_RC, expected 0 (allow); stdout=$LAST_STDOUT stderr=$LAST_STDERR"
+elif echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"'; then
+  fail "fail-open on malformed claim.json" "hook false-denied on unverifiable state: $LAST_STDOUT"
+elif ! echo "$LAST_STDERR" | grep -q 'WARN.*malformed'; then
+  fail "fail-open on malformed claim.json" "hook did not emit malformed WARN to stderr; stderr=$LAST_STDERR"
+else
+  pass "fail-open on malformed claim.json — hook allows + WARN to stderr"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 5: fail-open when caller omits --pipeline-id.
+# ───────────────────────────────────────────────────────────────────────
+F5="$SCRATCH_ROOT/f5"
+init_fixture "$F5"
+write_claim "$F5" 14 "pipe-holder"
+PAYLOAD=$(build_payload 14 "")  # no --pipeline-id arg on the command line
+run_hook "$F5" "$PAYLOAD"
+if [ "$LAST_RC" -ne 0 ]; then
+  fail "fail-open on missing caller --pipeline-id" "hook exited $LAST_RC, expected 0 (allow); stdout=$LAST_STDOUT stderr=$LAST_STDERR"
+elif echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"'; then
+  fail "fail-open on missing caller --pipeline-id" "hook false-denied on unverifiable caller id: $LAST_STDOUT"
+elif ! echo "$LAST_STDERR" | grep -q 'WARN.*caller did not pass --pipeline-id'; then
+  fail "fail-open on missing caller --pipeline-id" "hook did not emit caller-pipeline-id WARN; stderr=$LAST_STDERR"
+else
+  pass "fail-open when caller omits --pipeline-id — hook allows + WARN (cannot false-deny on unverifiable input)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Test 6: baseline no-claim deny still fires.
+# ───────────────────────────────────────────────────────────────────────
+F6="$SCRATCH_ROOT/f6"
+init_fixture "$F6"
+# Intentionally NO write_claim call — the claim dir does not exist.
+PAYLOAD=$(build_payload 15 "pipe-any")
+run_hook "$F6" "$PAYLOAD"
+if [ "$LAST_RC" -ne 0 ]; then
+  fail "baseline no-claim deny" "hook exited $LAST_RC, expected 0 (deny envelope on stdout); stderr=$LAST_STDERR"
+elif ! echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"'; then
+  fail "baseline no-claim deny" "existence check regressed — no deny on missing claim; stdout=$LAST_STDOUT"
+elif ! echo "$LAST_STDOUT" | grep -q 'no claim found'; then
+  fail "baseline no-claim deny" "deny envelope no longer cites 'no claim found'; stdout=$LAST_STDOUT"
+else
+  pass "baseline no-claim deny — existence-check path still fires (ownership extension is additive)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (%d total)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (%d total)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`hooks/block-fix-issue-unclaimed.sh` was an existence-only gate (`if [ -d "$CLAIM_DIR" ]; then exit 0; fi`). Pipeline B's `create-worktree.sh --prefix fix-issue NNN --pipeline-id <B>` passed the hook even though pipeline A held `claim.json:pipeline_id=A`. This PR extends the hook to read `claim.json` via Python json and deny on concrete pipeline mismatch.

Closes #865

## Changes
1. Line-2 `# zskills-hook-version:` stamp bumped `2026.05.0` → `2026.05.31`.
2. shlex walk extended to capture `--pipeline-id <v>` symmetrically with `--branch-name` / `--prefix` (previously swallowed by the generic `--*` two-arg skip).
3. Post-existence ownership check: reads `claim.json:pipeline_id`, compares to caller's `--pipeline-id`. Self-re-entry → exit 0. Mismatch → deny envelope citing both IDs + recovery guidance.
4. Fail-OPEN with WARN on absent/malformed `claim.json` or missing caller `--pipeline-id` (backstop discipline; `claim-self-reentry.sh` is the canonical never-steal gate).

## Files (3)
- `hooks/block-fix-issue-unclaimed.sh` (+99/-12)
- `.claude/hooks/block-fix-issue-unclaimed.sh` (+99/-12, byte-identical mirror)
- `tests/test-block-fix-issue-unclaimed-ownership.sh` (+262 new, 6 cases)

## Test plan
- [x] `bash tests/run-all.sh` — 6635/6635 passed.
- [x] New `test-block-fix-issue-unclaimed-ownership.sh` — 6/6: self-re-entry pass, foreign deny, absent claim.json fail-open, malformed JSON fail-open, missing caller --pipeline-id fail-open, baseline no-claim deny still fires.
- [x] **Gate-fires sanity check** — constructed claim with `pipeline_id=holder-pipe`, fed hook `--pipeline-id intruder-pipe 99`. Hook emitted informative deny envelope citing both IDs + race-lost semantics reference to `claim-issue.sh acquire exit 10` + anti-steal guidance.

## Commits
9eb2539 fix(hook): block-fix-issue-unclaimed.sh enforces pipeline ownership (#865)
