### PR TITLE
fix(do): pr-ready holds claim; only merged/terminal-failure release (#864)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+7e3abd"
+  version: "2026.05.31+12f9ca"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -503,14 +503,39 @@ esac
 sed -i "s/^status: started$/status: $FINAL/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
 rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
 
-# Release the issue claim regardless of created vs merged vs failed
-# (release-on-resolution — the /do pr invocation is terminating either way,
-# and /do is one-shot so there is no later fire to re-release). Only if an
-# issue claim was acquired in Step A5.5. $PIPELINE_ID = do.$TASK_SLUG is
-# re-resolved at the tracking-setup fence-top above and survives in this
-# fence.
+# Release the issue claim based on LAND_OUTCOME (mirrors
+# fix-issues/modes/pr.md:337-345 so the two skills evolve in lockstep).
+# Only if an issue claim was acquired in Step A5.5. $PIPELINE_ID =
+# do.$TASK_SLUG is re-resolved at the tracking-setup fence-top above and
+# survives in this fence.
+#
+# Three groups (issue #864):
+#   - merged          → RELEASE (work is durably on main).
+#   - pr-ready|created→ HOLD: the PR is OPEN on the remote awaiting human
+#                       review/merge; releasing here would let a concurrent
+#                       /fix-issues (or another /do pr) re-claim the same
+#                       issue and duplicate the fix. /do is one-shot so
+#                       there is no "later fire" to re-release — the
+#                       stalled-PR claim is cleared manually via
+#                       `claim-issue.sh release` once the human resolves
+#                       the PR (same precedent as #684 for plan claims,
+#                       and same shape as fix-issues PR mode's `created`
+#                       arm at fix-issues/modes/pr.md:342-343).
+#   - terminal-failure→ RELEASE (PR is dead-on-arrival; nothing to guard).
 if [ -n "${ISSUE_NUM:-}" ]; then
-  bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
+  case "$LAND_OUTCOME" in
+    merged)
+      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
+        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
+    pr-ready|created)
+      echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $ISSUE_NUM' if the PR never lands" >&2 ;;
+    pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
+      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
+        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
+    *)
+      echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$ISSUE_NUM; defaulting to HOLD" >&2 ;;
+  esac
 fi
 ```
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+7e3abd"
+  version: "2026.05.31+12f9ca"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -503,14 +503,39 @@ esac
 sed -i "s/^status: started$/status: $FINAL/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
 rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
 
-# Release the issue claim regardless of created vs merged vs failed
-# (release-on-resolution — the /do pr invocation is terminating either way,
-# and /do is one-shot so there is no later fire to re-release). Only if an
-# issue claim was acquired in Step A5.5. $PIPELINE_ID = do.$TASK_SLUG is
-# re-resolved at the tracking-setup fence-top above and survives in this
-# fence.
+# Release the issue claim based on LAND_OUTCOME (mirrors
+# fix-issues/modes/pr.md:337-345 so the two skills evolve in lockstep).
+# Only if an issue claim was acquired in Step A5.5. $PIPELINE_ID =
+# do.$TASK_SLUG is re-resolved at the tracking-setup fence-top above and
+# survives in this fence.
+#
+# Three groups (issue #864):
+#   - merged          → RELEASE (work is durably on main).
+#   - pr-ready|created→ HOLD: the PR is OPEN on the remote awaiting human
+#                       review/merge; releasing here would let a concurrent
+#                       /fix-issues (or another /do pr) re-claim the same
+#                       issue and duplicate the fix. /do is one-shot so
+#                       there is no "later fire" to re-release — the
+#                       stalled-PR claim is cleared manually via
+#                       `claim-issue.sh release` once the human resolves
+#                       the PR (same precedent as #684 for plan claims,
+#                       and same shape as fix-issues PR mode's `created`
+#                       arm at fix-issues/modes/pr.md:342-343).
+#   - terminal-failure→ RELEASE (PR is dead-on-arrival; nothing to guard).
 if [ -n "${ISSUE_NUM:-}" ]; then
-  bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
+  case "$LAND_OUTCOME" in
+    merged)
+      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
+        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
+    pr-ready|created)
+      echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $ISSUE_NUM' if the PR never lands" >&2 ;;
+    pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
+      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
+        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
+    *)
+      echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$ISSUE_NUM; defaulting to HOLD" >&2 ;;
+  esac
 fi
 ```
 

--- a/tests/test-do-pr-claim-release.sh
+++ b/tests/test-do-pr-claim-release.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# tests/test-do-pr-claim-release.sh — issue #864
+#
+# Asserts the /do pr explicit-finalize claim release/HOLD logic at
+# skills/do/modes/pr.md mirrors the fix-issues/modes/pr.md pattern:
+#
+#   merged                → RELEASE (work is durably on main)
+#   pr-ready | created    → HOLD (PR is OPEN; concurrent fix-issues must
+#                           not re-claim and duplicate the fix)
+#   pr-ci-failing,
+#   rebase-conflict,
+#   auto-rebase-conflict,
+#   auto-rebase-blocked,
+#   behind-thrash,
+#   *-failed              → RELEASE (PR is dead-on-arrival)
+#   <unknown>             → HOLD (default — safer than auto-release)
+#
+# Background: previously /do pr released the claim on
+# merged|created|pr-ready uniformly, dropping the claim during the
+# unbounded human-review window between PR open and merge. A concurrent
+# /fix-issues cron could re-claim and duplicate the fix.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLAIM_SH="$REPO_ROOT/skills/fix-issues/scripts/claim-issue.sh"
+DO_PR_MD="$REPO_ROOT/skills/do/modes/pr.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRATCH_ROOT="/tmp/test-do-pr-claim-release-$$"
+cleanup() {
+  if [ -d "$SCRATCH_ROOT" ]; then
+    find "$SCRATCH_ROOT" -type d -exec chmod 0755 {} + 2>/dev/null || true
+    find "$SCRATCH_ROOT" -mindepth 1 -delete 2>/dev/null || true
+    rmdir "$SCRATCH_ROOT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH_ROOT"
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  (cd "$repo" && git init -q && git config user.email "t@t" && git config user.name "t" \
+    && git commit --allow-empty -q -m "init") || return 1
+}
+
+# Render the /do pr release/HOLD case fragment as an executable script.
+# Mirrors the case-arm structure from skills/do/modes/pr.md verbatim
+# (modulo $ISSUE_NUM/$LAND_OUTCOME/$PIPELINE_ID/$CLAIM_HELPER passed in).
+render_release_fragment() {
+  cat <<'FRAGMENT'
+case "$LAND_OUTCOME" in
+  merged)
+    bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
+      || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
+  pr-ready|created)
+    echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $ISSUE_NUM' if the PR never lands" >&2 ;;
+  pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
+    bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
+      || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
+  *)
+    echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$ISSUE_NUM; defaulting to HOLD" >&2 ;;
+esac
+FRAGMENT
+}
+
+# Run one case: pre-create a claim, drive the fragment, return RELEASED or HELD.
+run_case() {
+  local outcome="$1"
+  local rootname="$2"
+  local root="$SCRATCH_ROOT/$rootname"
+  make_repo "$root" || { echo "make_repo failed for $root"; return 2; }
+  # Pre-create the claim (this pipeline holds it).
+  mkdir -p "$root/.zskills/claims/issue-42"
+  cat > "$root/.zskills/claims/issue-42/claim.json" <<JSON
+{"schema_version":1,"pipeline_id":"do.task-x","sprint_id":"do.task-x","issue":42,"started_at":"2026-05-21T00:00:00+00:00"}
+JSON
+
+  local script="$root/script.sh"
+  {
+    echo "ISSUE_NUM=42"
+    echo "PIPELINE_ID=do.task-x"
+    echo "LAND_OUTCOME=$outcome"
+    echo "CLAIM_HELPER=\"$CLAIM_SH\""
+    render_release_fragment
+  } > "$script"
+
+  local stderr_file="$root/stderr.txt"
+  (cd "$root" && bash "$script") 2> "$stderr_file" >/dev/null
+  local rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "fragment-rc=$rc (LAND_OUTCOME=$outcome)" >&2
+    return 2
+  fi
+
+  if [ -d "$root/.zskills/claims/issue-42" ]; then
+    echo "HELD"
+  else
+    echo "RELEASED"
+  fi
+  return 0
+}
+
+case_stderr_for() {
+  local rootname="$1"
+  cat "$SCRATCH_ROOT/$rootname/stderr.txt" 2>/dev/null || true
+}
+
+echo "=== /do pr LAND_OUTCOME → release/HOLD (issue #864) ==="
+
+# Required behaviors per acceptance criteria:
+declare -A EXPECTED
+# Release group:
+EXPECTED[merged]=RELEASED
+# HOLD group (issue #864 fix — the bug being closed):
+EXPECTED[pr-ready]=HELD
+EXPECTED[created]=HELD
+# Terminal-failure release group:
+EXPECTED[pr-ci-failing]=RELEASED
+EXPECTED[rebase-conflict]=RELEASED
+EXPECTED[auto-rebase-conflict]=RELEASED
+EXPECTED[auto-rebase-blocked]=RELEASED
+EXPECTED[behind-thrash]=RELEASED
+EXPECTED[rebase-failed]=RELEASED
+EXPECTED[push-failed]=RELEASED
+EXPECTED[create-failed]=RELEASED
+
+i=0
+for outcome in merged pr-ready created pr-ci-failing rebase-conflict auto-rebase-conflict auto-rebase-blocked behind-thrash rebase-failed push-failed create-failed; do
+  i=$((i+1))
+  result=$(run_case "$outcome" "case-$i-$outcome")
+  if [ "$result" = "${EXPECTED[$outcome]}" ]; then
+    pass "LAND_OUTCOME=$outcome -> ${EXPECTED[$outcome]}"
+  else
+    fail "LAND_OUTCOME=$outcome" "expected=${EXPECTED[$outcome]} got=$result"
+  fi
+done
+
+# HOLD-arm log-line shape: pr-ready and created emit an in-flight message
+# naming the manual-reap recovery command (mirrors fix-issues/modes/pr.md
+# created-arm convention).
+i=$((i+1))
+case_name="case-$i-pr-ready-log"
+_=$(run_case "pr-ready" "$case_name")
+stderr=$(case_stderr_for "$case_name")
+if echo "$stderr" | grep -q "holding claim for #42" \
+   && echo "$stderr" | grep -q "in flight" \
+   && echo "$stderr" | grep -q "claim-issue.sh release"; then
+  pass "pr-ready HOLD log line shape (in-flight + manual-reap command)"
+else
+  fail "pr-ready HOLD log line shape" "stderr=$stderr"
+fi
+
+# Unknown-LAND_OUTCOME fallback: garbage → HOLD + stderr warning
+# (matches fix-issues T2.3 — safer default than silent release).
+i=$((i+1))
+case_name="case-$i-garbage"
+result=$(run_case "garbage" "$case_name")
+warn_present=0
+case_stderr_for "$case_name" | grep -q 'unknown LAND_OUTCOME=garbage' && warn_present=1
+if [ "$result" = "HELD" ] && [ "$warn_present" -eq 1 ]; then
+  pass "unknown LAND_OUTCOME=garbage → HOLD + stderr warning"
+else
+  fail "unknown LAND_OUTCOME=garbage" "result=$result warn_present=$warn_present"
+fi
+
+# unknown-status-* glob match (the unknown-STATUS fall-through from
+# modes/pr.md:399 sets LAND_OUTCOME=unknown-status-$STATUS).
+i=$((i+1))
+case_name="case-$i-unknown-status"
+result=$(run_case "unknown-status-foo" "$case_name")
+if [ "$result" = "RELEASED" ]; then
+  pass "LAND_OUTCOME=unknown-status-foo -> RELEASED (terminal-failure glob)"
+else
+  fail "LAND_OUTCOME=unknown-status-foo" "expected=RELEASED got=$result"
+fi
+
+# Source check: the fragment under test must actually appear in the
+# shipped skill (prevents test/source drift).
+if grep -q 'pr-ready|created)' "$DO_PR_MD" \
+   && grep -q 'holding claim for #' "$DO_PR_MD" \
+   && grep -q 'merged)$' "$DO_PR_MD"; then
+  pass "skills/do/modes/pr.md contains the split case arms"
+else
+  fail "skills/do/modes/pr.md split case arms" "expected three-group case missing from source"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (%d total)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (%d total)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`skills/do/modes/pr.md` was releasing the issue claim on `merged|created|pr-ready` uniformly. But `pr-ready` means the PR is OPEN (the `monitored)` arm sets it whenever `gh pr view` returns OPEN), so the claim dropped during the entire human-review window — a concurrent `/fix-issues` cron could re-claim and duplicate. This PR splits the case-arm into three groups matching the `/fix-issues/modes/pr.md:337-345` reference pattern.

Closes #864

## Behavior
- `merged)` → release claim (work durably done).
- `pr-ready|created)` → **HOLD** the claim. Stderr line: `do: holding claim for #N (LAND_OUTCOME=X — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release N' if the PR never lands`.
- Terminal failures (`pr-ci-failing`, `rebase-conflict`, `auto-rebase-conflict`, `auto-rebase-blocked`, `behind-thrash`, `rebase-failed`, `push-failed`, `create-failed`, `monitor-failed`, `merge-failed`, `unknown-status-*`) → release claim.
- Unknown `LAND_OUTCOME` → **HOLD with WARN** (failure-safe; matches `/fix-issues` discipline).

## Files (5)
- `skills/do/modes/pr.md` (+33/-10) + mirror
- `skills/do/SKILL.md` — `metadata.version` → `2026.05.31+12f9ca` + mirror
- `tests/test-do-pr-claim-release.sh` (new, +205 lines, 15 assertions covering all 10 LAND_OUTCOME values + HOLD-log-line shape + unknown-fallback + source-drift guard)

## Test plan
- [x] `bash tests/run-all.sh` → 6653/6653 passed.
- [x] New `test-do-pr-claim-release.sh` → 15/15 passed.
- [x] Source-drift guard: future edits reverting the case-split fail the test immediately.

## Commits
f1db611 fix(do): pr-ready holds the issue claim; only merged/terminal-failure release (#864)
