### PR TITLE
[brainstorm-mode-plan] Brainstorm mode for /draft-plan

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+38b6ea"
+  version: "2026.05.31+874a6f"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter

--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+874a6f"
+  version: "2026.05.31+1d4478"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -142,6 +142,10 @@ fi
 - `rounds` followed by a number — max review cycles
 - `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
   for Phase 6's `/land-pr` dispatch
+- `brainstorm` (whitespace-anchored, case-insensitive) — sets
+  `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
+  (`references/brainstorm.md`) before Phase 1. Anchored so it does NOT
+  match `brainstorming`/`brainstormed`/`brainstorms`.
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -149,6 +153,17 @@ fi
 AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
+fi
+```
+
+`BRAINSTORM_FLAG` is detected by its OWN dedicated fence (kept separate
+from the `AUTO_FLAG` fence above so the args-smoke extractor that keys on
+the `AUTO_FLAG=0 … fi` block is not perturbed):
+
+```bash
+BRAINSTORM_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[bB][rR][aA][iI][nN][sS][tT][oO][rR][mM]($|[[:space:]]) ]]; then
+  BRAINSTORM_FLAG=1
 fi
 ```
 
@@ -171,6 +186,16 @@ intent from the original was lost.
 
 This handles the common case of modernizing old-format plans:
 `/draft-plan plans/OLD_PLAN.md Modernize with progress tracker and phases`
+
+## Brainstorm mode (only when the `brainstorm` flag is present)
+
+If `BRAINSTORM_FLAG=1`, **Read [references/brainstorm.md](references/brainstorm.md)** via the
+Read tool and execute its dialogue loop now, before Phase 1 — UNLESS the notes file
+`/tmp/draft-plan-brainstorm-$TRACKING_ID.md` already exists with `status: ready` (a prior,
+completed dialogue — proceed straight to Phase 1 using it as the seed). If the notes file
+exists with `status: in-progress` (a dialogue interrupted by compaction/crash), RESUME it from
+its captured state rather than restarting. If `BRAINSTORM_FLAG=0`, **ignore the reference file
+entirely** and proceed straight to Phase 1.
 
 ## Phase 1 — Research (parallel agents)
 
@@ -202,6 +227,17 @@ printf 'skill: draft-plan\nid: %s\noutput: %s\nstatus: started\ndate: %s\n' \
 
 Dispatch multiple Explore agents in parallel to investigate the problem space.
 Each agent gets the full description and a specific research focus:
+
+**Brainstorm feed-forward.** When `BRAINSTORM_FLAG=1`, inject the literal
+path `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` into EACH research
+agent's PROMPT, with an instruction to read it as the **primary design
+seed** (the user already steered the design in the brainstorm dialogue).
+Inject the path into the prompts — NOT into the research consolidation
+file, which does not exist until after dispatch. The Codebase / Patterns /
+Prior-art agents still run to ground the design against the repo; the
+Domain agent's "what to build" work is largely pre-answered by the
+brainstorm and may be reduced to verification. When `BRAINSTORM_FLAG=0`,
+dispatch the agents normally with no notes-file injection.
 
 1. **Codebase agent** — find all relevant source files, understand current
    architecture, identify what exists and what needs to change. Map
@@ -295,6 +331,12 @@ PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeli
 printf 'completed: %s\n' "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.research"
 ```
+
+**Skip this steering checkpoint when `BRAINSTORM_FLAG=1`** — the user
+already steered the design, in depth, during the brainstorm dialogue, so
+re-prompting here is redundant; proceed directly to Phase 2. (This is an
+ADDITIVE condition; the existing "if running as a subagent, skip" branch
+below is unchanged.)
 
 **Present the research summary to the user.** If running interactively
 (user invoked `/draft-plan` directly), wait for input:

--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+1d4478"
+  version: "2026.05.31+258cda"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter

--- a/.claude/skills/draft-plan/references/brainstorm.md
+++ b/.claude/skills/draft-plan/references/brainstorm.md
@@ -1,0 +1,338 @@
+# /draft-plan — Brainstorm mode
+
+> Loaded by `SKILL.md` **only when the `brainstorm` flag is present** (progressive
+> disclosure). This file is the complete, self-contained dialogue protocol the
+> orchestrator follows when brainstorm mode is active, including the throwaway-demo
+> lifecycle, the durable notes-file state machine, the feed-forward into Phase 1
+> research, and the reconciliations with zskills framework rules. SKILL.md Reads this
+> file and executes its loop INLINE — the dialogue dispatches no sub-agents.
+
+Brainstorm mode is adapted from the [superpowers](https://github.com/obra/superpowers)
+`brainstorming` skill, re-grounded for zskills. superpowers writes a committed design
+doc and hands off to `writing-plans`; here the terminal artifact is the `/draft-plan`
+plan file, so the brainstorm produces a `/tmp` **notes seed** that feeds Phase 1
+research instead of a committed spec. The dialogue runs a collaborative, multi-turn
+conversation to flesh out a rough idea *before* the existing adversarial pipeline runs:
+one focused question at a time, 2–3 approaches with trade-offs, ruthless YAGNI, and
+optional throwaway demos. It proceeds until the user explicitly confirms they're ready.
+
+---
+
+## Slug pinning — load-bearing for the notes + demo paths
+
+The brainstorm notes file and the demo directory derive their slug from the
+deterministic `$TRACKING_ID` the SKILL.md preamble computes (`basename "$OUTPUT_FILE"
+.md | tr A-Z a-z | tr _ -`, at `skills/draft-plan/SKILL.md:85`). `$TRACKING_ID` is
+already in scope at the brainstorm stage (it is set before this stage runs). **Use it
+verbatim** — do NOT recompute a slug from the description:
+
+- **notes file:** `/tmp/draft-plan-brainstorm-$TRACKING_ID.md`
+- **demo directory:** `/tmp/draft-plan-demo-$TRACKING_ID/`
+
+**Do NOT assume the existing research file shares this slug.** The research file's
+`<slug>` is loose, orchestrator-chosen prose (`SKILL.md:222-226` derives it from the
+output filename "if one was provided," else from the description), so it is NOT
+guaranteed to equal `$TRACKING_ID`. (Example: a pipeline's research file may be
+`/tmp/draft-plan-research-BRAINSTORM_MODE.md` while `$TRACKING_ID` = `brainstorm-mode-plan`.)
+The feed-forward therefore does NOT re-derive a path — it passes the **literal**
+`/tmp/draft-plan-brainstorm-$TRACKING_ID.md` string into the research-agent prompts (see
+[Feed-forward](#feed-forward-into-phase-1-research)), so it never depends on slug parity.
+
+**All `/tmp` paths are ABSOLUTE.** This is required because the brainstorm stage runs
+*after* the worktree preamble, so the current working directory is the worktree. A
+relative demo/notes path would write *into* the worktree and dirty the tree.
+
+---
+
+## The 8-step dialogue protocol
+
+Execute these steps inline as the orchestrator. The loop is conversational and
+multi-turn; there is no fixed number of turns — it ends only when the user affirmatively
+confirms at step 7/8.
+
+1. **Open: restate + light context.** Reflect the user's seed idea back in 1–2
+   sentences so they can confirm or correct your understanding. The worktree,
+   `$OUTPUT_FILE`, and `$TRACKING_ID` are already resolved by the preamble, so defer
+   heavy repo exploration to Phase 1 research — read only what's needed to ask good
+   questions, not to pre-solve the design.
+
+2. **Offer a visual companion as its OWN standalone message** (superpowers pattern) —
+   but **only** when the upcoming exploration involves visual content (UI, layout,
+   diagrams, flows). The message contains nothing but the offer plus a one-line
+   description of what would be shown, and requests consent before building anything.
+   **Skip this step entirely for non-visual ideas** (most plans). See
+   [Quick-demo lifecycle](#quick-demo-lifecycle--exact-idioms) for how to build one once
+   the user consents.
+
+3. **Ask clarifying questions ONE per message.** Most-fundamental first (problem / user
+   / success criteria), then mechanics and naming. When a question has natural choices,
+   **offer them in plain prose** — e.g. "Option A: …; Option B: …; I lean toward A
+   because …" — and **never** the `AskUserQuestion` tool (see
+   [Reconciliations](#reconciliations-with-zskills-rules)).
+
+4. **Propose 2–3 approaches with trade-offs + an explicit recommendation** at each real
+   fork in the design. Don't enumerate options neutrally — say which one you'd pick and
+   why, so the user has a concrete position to push against.
+
+5. **Apply ruthless YAGNI / gentle pushback.** Surface hidden costs and simpler
+   alternatives as questions ("Do we actually need X, or would the simpler Y cover the
+   real case?"). This is the soft, in-dialogue cousin of the Phase-3 adversarial review
+   — it does **not** replace it. The full review still runs after the transition.
+
+6. **Capture decisions as they're made** into the notes file (see
+   [Durable notes file](#durable-notes-file--resumable-state-machine)) — each decision
+   with its rationale, plus the rejected alternatives and any open questions. Update the
+   notes file after each decision, not in one batch at the end, so the state survives a
+   compaction.
+
+7. **Offer the transition checkpoint** when the open questions are exhausted:
+   > "I think we've got enough to draft a plan — start the adversarial design review, or
+   > keep exploring?"
+
+   Require an **affirmative confirm**. If the reply is ambiguous, **ask once more** — do
+   not infer readiness. **Never keyword-auto-detect "ready"**: a stray mention of the
+   word "ready" (or "done", "go", etc.) in the user's prose is NOT a confirmation. Only
+   an explicit, unambiguous affirmative to *this* checkpoint authorizes the transition.
+
+8. **On confirm:** finalize the notes file as a structured design summary, flip its
+   header to `status: ready` (the terminal marker that authorizes the transition — see
+   below), then return control to SKILL.md, which proceeds to Phase 1 research using the
+   notes file as the seed. (Phase 2 of the brainstorm plan wires the SKILL.md-side return
+   and the redundant-checkpoint skip.)
+
+---
+
+## Quick-demo lifecycle — EXACT idioms
+
+These are the worktree-safety + process-lifecycle load-bearing rules. They are specified
+literally because casual versions are factually wrong about screenshot paths and ports.
+
+**All demo files live under `/tmp/draft-plan-demo-$TRACKING_ID/`, NEVER inside the
+worktree.** Phase 6 finalize stages ONLY the plan `.md` via a `FILE_REL` guard and
+`exit 1`s if any other file is staged (`skills/draft-plan/SKILL.md:640-645`); a
+worktree-resident demo would dirty the tree and confuse `/land-pr`. Keeping demos in
+`/tmp` is what makes them safe.
+
+### Live browser visual companion (the common / default case)
+
+Write a self-contained HTML file (inline CSS/JS, no external assets) under
+`/tmp/draft-plan-demo-$TRACKING_ID/`, then serve that directory on an **OS-assigned free
+port**. Do NOT use `port.sh` — that returns the same per-worktree-deterministic port the
+dev server uses, so reusing it would collide with a running dev server; an ephemeral port
+(`port 0`) avoids all collisions. Use Python's stdlib http server (Python is a hard
+zskills dependency; this avoids any consumer-specific serve literal and the uncustomized
+`start-dev.sh` stub).
+
+Capture the chosen port AND the PID to a **pidfile**: the Bash tool does not persist
+shell state across calls, so an in-memory `$!` is lost on the next Bash invocation — a
+pidfile is mandatory so a later call can find and stop the server. Spec the idiom
+literally:
+
+```bash
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+DEMO_DIR="/tmp/draft-plan-demo-$TRACKING_ID"; mkdir -p "$DEMO_DIR"
+# Serve on an OS-assigned free port; the python prints its URL to .serve.url.
+"$PYTHON" - "$DEMO_DIR" > "$DEMO_DIR/.serve.url" 2>&1 <<'PY' &
+import http.server, socketserver, os, sys, functools
+os.chdir(sys.argv[1])
+h = functools.partial(http.server.SimpleHTTPRequestHandler)
+with socketserver.TCPServer(("127.0.0.1", 0), h) as s:
+    print(f"http://127.0.0.1:{s.server_address[1]}/", flush=True)
+    s.serve_forever()
+PY
+echo "$!" > "$DEMO_DIR/.serve.pid"          # NO trailing space — ps -p chokes on it
+# The server needs ~1-3s to bind + flush the URL; wait for it WITHOUT a foreground `sleep`
+# (harness-blocked per CLAUDE.md). A timeout-bounded busy-wait is sleep-free:
+timeout 8 bash -c 'until [ -s "$1/.serve.url" ]; do :; done' _ "$DEMO_DIR" || true
+```
+
+Give the user the URL by reading it from `$DEMO_DIR/.serve.url` **AFTER** the
+`timeout … until [ -s … ]` wait above — an immediate read returns empty because the
+server has not yet bound the port and flushed its URL. Iterate the HTML in place and tell
+the user to refresh the page to see changes.
+
+**Authoring-effort honesty note.** The inline-built HTML companion is a THROWAWAY
+visualization, not production UI. Keep mockups minimal — enough to make the idea concrete,
+not polished. Do NOT sink disproportionate effort into demo HTML mid-dialogue; the goal
+is to unblock the conversation, not to ship a pixel-perfect mockup.
+
+### Stopping the server
+
+**NEVER use `kill -9`, `killall`, `pkill`, or `fuser -k`; never `lsof -ti | xargs kill`.**
+Read the PID from `$DEMO_DIR/.serve.pid` and SIGTERM that specific PID only:
+
+```bash
+DEMO_DIR="/tmp/draft-plan-demo-$TRACKING_ID"
+PID=$(cat "$DEMO_DIR/.serve.pid")
+kill "$PID"   # SIGTERM to the one server PID — never kill -9/pkill/killall/fuser -k/lsof|xargs kill
+```
+
+Stop the server at brainstorm exit, or leave it for the user to stop. Because demos live
+in `/tmp` on an ephemeral port, a stranded server does not dirty the worktree and cannot
+block `/land-pr` (it is not on a tracked path and not on the dev-server port); still, stop
+it on a clean exit for tidiness.
+
+### Static screenshot (the "sometimes" lighter case)
+
+`playwright-cli screenshot` takes **NO URL** and requires the browser to be open first (a
+bare `playwright-cli screenshot file://…` errors "browser 'default' is not open"). The
+verified sequence is:
+
+```bash
+DEMO_DIR="/tmp/draft-plan-demo-$TRACKING_ID"
+playwright-cli open "file://$DEMO_DIR/<demo>.html"
+playwright-cli screenshot   # NO --filename, NO url
+playwright-cli close
+```
+
+Omitting `--filename` saves the image into the configured, gitignored `.playwright/output/`
+directory (which is invisible to git — `.gitignore:20` ignores `.playwright/*`; the
+screenshot lands there headless in this environment). **Do NOT move or rename the
+screenshot into the tracked worktree** — that is the actual pollution hazard; the image is
+safe only while it stays in the gitignored `.playwright/output/` dir. Show the user the
+image from `.playwright/output/`. If `playwright-cli` errors on the environment, check
+`.devcontainer/setup.sh` first before concluding the container can't do it
+(`feedback_check_devcontainer_before_bailing`).
+
+### Which demo to use
+
+**Default toward the live companion** when the user benefits from interaction (clicking,
+hovering, refreshing as the idea evolves). Use the static screenshot for fast, static
+conceptual shots where interaction adds nothing. Demos are throwaway and never committed;
+optionally clean up on brainstorm exit:
+
+```bash
+rm -rf "/tmp/draft-plan-demo-$TRACKING_ID"
+```
+
+---
+
+## Durable notes file — resumable state machine
+
+Maintain `/tmp/draft-plan-brainstorm-$TRACKING_ID.md`, updated after each decision (step
+6). This mirrors the skill's existing `/tmp/draft-plan-research-$TRACKING_ID.md`
+compaction-survival pattern (`SKILL.md:222-228`). Accumulate, as the dialogue progresses:
+
+- the refined problem statement,
+- decisions + rationale,
+- rejected alternatives,
+- open questions,
+- pointers to demo screenshots / URLs.
+
+**The notes file IS a resumable state machine.** The dialogue is multi-turn and WILL
+sometimes span a context compaction. After compaction, the in-context dialogue state and
+the `BRAINSTORM_FLAG` shell variable are gone, and nothing would otherwise re-trigger the
+loop — the orchestrator could wrongly jump to Phase 1 with a half-finished seed. Defend
+this structurally with a header status line:
+
+- The notes file carries a header `status: in-progress` from creation.
+- It is flipped to the terminal `status: ready` line **ONLY at step 8** (user confirm).
+
+The notes file therefore looks like this from the start of the dialogue:
+
+```
+---
+status: in-progress
+tracking_id: <$TRACKING_ID>
+---
+
+# Brainstorm notes: <restated idea>
+
+## Refined problem statement
+...
+
+## Decisions
+- <decision> — <rationale>
+
+## Rejected alternatives
+- <alternative> — <why rejected>
+
+## Open questions
+- <question>
+
+## Demo pointers
+- <URL or .playwright/output/ screenshot path>
+```
+
+**Resume-on-reentry semantics.** When SKILL.md (re)enters with `BRAINSTORM_FLAG=1`, it
+checks for the notes file (Phase 2 wires the SKILL.md side):
+
+- **Notes file exists with `status: ready`** → a prior dialogue already completed.
+  Proceed straight to Phase 1, using the notes file as the seed. Do NOT re-run the
+  dialogue, and do NOT re-offer the transition checkpoint.
+- **Notes file exists with `status: in-progress`** → a dialogue was interrupted by
+  compaction or crash. **RESUME** the dialogue from its captured state (re-read the notes
+  file to reconstruct decisions / open questions), rather than restarting from step 1 or
+  skipping to Phase 1.
+- **Notes file absent** → run the dialogue from step 1.
+
+Only a `status: ready` notes file authorizes the transition to Phase 1. This makes the
+dialogue crash/compaction-safe.
+
+---
+
+## Feed-forward into Phase 1 research
+
+At the transition (after `status: ready`), the notes-file path is injected into **EACH**
+Phase 1 research agent's **PROMPT**, with an instruction to read it as the primary design
+seed. (Phase 2 of the brainstorm plan wires the SKILL.md-side dispatch.)
+
+**The feed-forward is "inject the notes-file path into each research agent's prompt," NOT
+"append to the research file before dispatch."** The research file
+(`/tmp/draft-plan-research-$TRACKING_ID.md` per the loose slug) is the *post-dispatch
+CONSOLIDATION*, written AFTER the agents are dispatched (`skills/draft-plan/SKILL.md:202`),
+so notes cannot be "added to the research file" before agents read it — the file does not
+exist yet at dispatch time. The path injected into the prompts is the **literal**
+`/tmp/draft-plan-brainstorm-$TRACKING_ID.md` string (it does not depend on research-file
+slug parity — see [Slug pinning](#slug-pinning--load-bearing-for-the-notes--demo-paths)).
+
+The post-dispatch consolidation then incorporates both the agents' findings and the
+brainstorm notes. **This is hybrid — the brainstorm does NOT skip research:**
+
+- The **Codebase / Patterns / Prior-art** agents STILL run to ground the design against
+  the actual repo.
+- The **Domain** agent's "what to build" work is largely pre-answered by the brainstorm
+  and may be reduced to verification.
+
+---
+
+## Reconciliations with zskills rules
+
+Stated here so future editors don't re-litigate them.
+
+- **No `AskUserQuestion`.** Per `skills/update-zskills/SKILL.md:701`: "Do NOT use
+  AskUserQuestion. Ask in plain conversation text." superpowers "prefers multiple choice"
+  → here, options are offered in plain prose ("Option A: …; Option B: …; I lean toward
+  A because …").
+
+- **No sub-agent dispatch in the dialogue.** The loop and demo-building are INLINE
+  orchestrator work; the dialogue dispatches no agents, so it adds no `Agent`-tool
+  requirement beyond the existing Preflight and needs no `subagent_type` pin. (Forward
+  constraint: if a future revision dispatches an agent to build a demo, it MUST pin
+  `subagent_type: "implementer"` and never Haiku.)
+
+- **No forbidden literals in this file.** This IS a skill file (it lives under `skills/`),
+  so it is in the forbidden-literals deny-list scope. No `TZ=America/New_York` (use
+  `${TIMEZONE:-UTC}` via `zskills-resolve-config.sh` if a timestamp is ever needed), no
+  `npm run test:all`, `npm start`, `$TEST_OUT/.test-results.txt`, or the skill-version
+  regex inside exec fences without an `<!-- allow-hardcoded: … reason: … -->` marker. The
+  Python-http-server + ephemeral-port + `file://`-screenshot design deliberately
+  references none of the six config-resolution variables, so no positive-side fence-local
+  config-sourcing is triggered; if a future fence references one, source the helper
+  in/above it.
+
+- **Never `kill -9` / `killall` / `pkill` / `fuser -k` / `lsof -ti | xargs kill`** to stop
+  the demo server — SIGTERM the one pidfile PID (see
+  [Stopping the server](#stopping-the-server)).
+
+- **No foreground `sleep`** in the serve-URL wait — the harness blocks it; the
+  `timeout … until [ -s … ]` busy-wait is the sleep-free substitute.
+
+**Authoring constraint — script-source references use the two-lane dual-path form.** Try
+`${CLAUDE_PLUGIN_ROOT}/skills/...` first, fall back to
+`$CLAUDE_PROJECT_DIR/.claude/skills/...`. For example, when sourcing the config-resolution
+helper:
+
+```bash
+. "${CLAUDE_PLUGIN_ROOT:-$CLAUDE_PROJECT_DIR/.claude}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+```

--- a/docs/plans/BRAINSTORM_MODE_PLAN.md
+++ b/docs/plans/BRAINSTORM_MODE_PLAN.md
@@ -66,7 +66,7 @@ design surface that warrants adversarial review up front.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Author references/brainstorm.md | ⬚ | | |
+| 1 — Author references/brainstorm.md | ✅ Done | `aa6d16b` | 338-line brainstorm.md; version 2026.05.31+874a6f + mirror; issue-606 allowlist; 6575/6575 |
 | 2 — Wire brainstorm into SKILL.md | ⬚ | | |
 | 3 — Tests, version bumps, mirrors, conformance | ⬚ | | |
 

--- a/docs/plans/BRAINSTORM_MODE_PLAN.md
+++ b/docs/plans/BRAINSTORM_MODE_PLAN.md
@@ -1,7 +1,8 @@
 ---
 title: Brainstorm mode for /draft-plan
 created: 2026-05-31
-status: active
+status: "complete"
+completed: "2026-06-01T00:19:25Z"
 ---
 
 # Plan: Brainstorm mode for /draft-plan
@@ -68,7 +69,7 @@ design surface that warrants adversarial review up front.
 |-------|--------|--------|-------|
 | 1 — Author references/brainstorm.md | ✅ Done | `aa6d16b` | 338-line brainstorm.md; version 2026.05.31+874a6f + mirror; issue-606 allowlist; 6575/6575 |
 | 2 — Wire brainstorm into SKILL.md | ✅ Done | `0a296c1` | BRAINSTORM_FLAG + conditional-load/resume + feed-forward + checkpoint-skip + argument-hint; version 1d4478 + mirror; 6575/6575 |
-| 3 — Tests, version bumps, mirrors, conformance | ⬚ | | |
+| 3 — Tests, version bumps, mirrors, conformance | ✅ Done | `b0b514b` | +16 args-smoke cases; 6591/6591; conformance 726/726 |
 
 ---
 

--- a/docs/plans/BRAINSTORM_MODE_PLAN.md
+++ b/docs/plans/BRAINSTORM_MODE_PLAN.md
@@ -67,7 +67,7 @@ design surface that warrants adversarial review up front.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Author references/brainstorm.md | ✅ Done | `aa6d16b` | 338-line brainstorm.md; version 2026.05.31+874a6f + mirror; issue-606 allowlist; 6575/6575 |
-| 2 — Wire brainstorm into SKILL.md | ⬚ | | |
+| 2 — Wire brainstorm into SKILL.md | ✅ Done | `0a296c1` | BRAINSTORM_FLAG + conditional-load/resume + feed-forward + checkpoint-skip + argument-hint; version 1d4478 + mirror; 6575/6575 |
 | 3 — Tests, version bumps, mirrors, conformance | ⬚ | | |
 
 ---

--- a/docs/reports/plan-brainstorm-mode-plan.md
+++ b/docs/reports/plan-brainstorm-mode-plan.md
@@ -1,0 +1,30 @@
+# Plan Report — Brainstorm mode for /draft-plan
+
+## Phase — 1 Author references/brainstorm.md
+
+**Plan:** docs/plans/BRAINSTORM_MODE_PLAN.md (Phase 1 of 3)
+**Status:** Completed (verified)
+**Mode:** finish auto, PR landing (deferred to final phase)
+**Worktree:** /tmp/zskills-pr-brainstorm-mode-plan (branch feat/brainstorm-mode-plan)
+**Commit:** aa6d16b
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Create skills/draft-plan/references/brainstorm.md (338 lines) | Done | aa6d16b |
+| 2 | 8-step dialogue protocol documented | Done | aa6d16b |
+| 3 | Quick-demo lifecycle (ephemeral-port server + file:// screenshot) literal idioms | Done | aa6d16b |
+| 4 | Durable notes-file resumable state machine + feed-forward | Done | aa6d16b |
+| 5 | Transition signal + reconciliations (no AskUserQuestion, no kbd-auto-detect, no forbidden literals) | Done | aa6d16b |
+| 6 | Version bump 2026.05.31+874a6f + mirror parity | Done | aa6d16b |
+
+### Verification
+- Independent verifier (fresh agent): PASS on all 9 acceptance criteria.
+- Test suite: `bash tests/run-all.sh` → Overall: 6575/6575 passed, 0 failed (baseline 6575/6575; no regressions).
+- Test-file change (issue-606 allowlist entry for inherited $TRACKING_ID): independently confirmed legitimate use of the designed extension point (exact file<TAB>var match, still fails closed elsewhere, plan mandates inheritance, precedent exists). NOT a test weakening.
+- Mirror parity: diff -rq skills/draft-plan .claude/skills/draft-plan clean; content-hash 874a6f == committed metadata.version.
+- Drift tokens: none.
+
+### Notes
+- finish-auto chunked mode: Phases 2 and 3 will run on subsequent cron fires; PR landing happens once after Phase 3.
+- No UI impact (skill-doc authoring) — no user sign-off required.

--- a/docs/reports/plan-brainstorm-mode-plan.md
+++ b/docs/reports/plan-brainstorm-mode-plan.md
@@ -1,5 +1,12 @@
 # Plan Report — Brainstorm mode for /draft-plan
 
+## Phase — 3 Tests, version bumps, mirrors, conformance (FINAL)
+
+**Status:** Completed (verified) — commit b0b514b
+- +16 brainstorm cases in test-draft-plan-args-smoke.sh (flag extract-and-run ±, conditional-load + no-PIPELINE_ID guard, resume, feed-forward, checkpoint-skip, brainstorm.md idiom greps).
+- Verifier PASS; assertions confirmed non-tautological (flag test extract-and-runs the live SKILL.md fence). Full suite 6591/6591; args-smoke 29/29; conformance 726/726. No drift, test-only (no version bump).
+- Note: a redundant orchestrator baseline capture hung once on an intermittent harness/stdin transient; re-attempted with no workaround, did not recur; no code/infra change.
+
 ## Phase — 2 Wire brainstorm into SKILL.md
 
 **Plan:** docs/plans/BRAINSTORM_MODE_PLAN.md (Phase 2 of 3)

--- a/docs/reports/plan-brainstorm-mode-plan.md
+++ b/docs/reports/plan-brainstorm-mode-plan.md
@@ -1,5 +1,26 @@
 # Plan Report — Brainstorm mode for /draft-plan
 
+## Phase — 2 Wire brainstorm into SKILL.md
+
+**Plan:** docs/plans/BRAINSTORM_MODE_PLAN.md (Phase 2 of 3)
+**Status:** Completed (verified)
+**Commit:** 0a296c1
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Dedicated BRAINSTORM_FLAG detection fence (separate from AUTO_FLAG) | Done | 0a296c1 |
+| 2 | `brainstorm` added to recognized-flag prose list; preamble loop untouched | Done | 0a296c1 |
+| 3 | "Brainstorm mode" conditional-load + resume-on-reentry stage | Done | 0a296c1 |
+| 4 | Feed-forward (notes-file path into research prompts) + post-research checkpoint skip | Done | 0a296c1 |
+| 5 | argument-hint += [brainstorm] ([auto] retained) | Done | 0a296c1 |
+| 6 | Version bump 2026.05.31+1d4478 + mirror parity | Done | 0a296c1 |
+
+### Verification
+- Independent verifier: PASS on all 7 ACs + every must-not-break conformance/args-smoke pin.
+- Test suite: 6575/6575 passed, 0 failed (baseline 6575/6575; no regressions). test-draft-plan-args-smoke.sh + test-skill-conformance.sh green.
+- Scope: only the two SKILL.md files (+46/-4 symmetric). No drift tokens.
+
 ## Phase — 1 Author references/brainstorm.md
 
 **Plan:** docs/plans/BRAINSTORM_MODE_PLAN.md (Phase 1 of 3)

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+38b6ea"
+  version: "2026.05.31+874a6f"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+874a6f"
+  version: "2026.05.31+1d4478"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -142,6 +142,10 @@ fi
 - `rounds` followed by a number — max review cycles
 - `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
   for Phase 6's `/land-pr` dispatch
+- `brainstorm` (whitespace-anchored, case-insensitive) — sets
+  `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
+  (`references/brainstorm.md`) before Phase 1. Anchored so it does NOT
+  match `brainstorming`/`brainstormed`/`brainstorms`.
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -149,6 +153,17 @@ fi
 AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
+fi
+```
+
+`BRAINSTORM_FLAG` is detected by its OWN dedicated fence (kept separate
+from the `AUTO_FLAG` fence above so the args-smoke extractor that keys on
+the `AUTO_FLAG=0 … fi` block is not perturbed):
+
+```bash
+BRAINSTORM_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[bB][rR][aA][iI][nN][sS][tT][oO][rR][mM]($|[[:space:]]) ]]; then
+  BRAINSTORM_FLAG=1
 fi
 ```
 
@@ -171,6 +186,16 @@ intent from the original was lost.
 
 This handles the common case of modernizing old-format plans:
 `/draft-plan plans/OLD_PLAN.md Modernize with progress tracker and phases`
+
+## Brainstorm mode (only when the `brainstorm` flag is present)
+
+If `BRAINSTORM_FLAG=1`, **Read [references/brainstorm.md](references/brainstorm.md)** via the
+Read tool and execute its dialogue loop now, before Phase 1 — UNLESS the notes file
+`/tmp/draft-plan-brainstorm-$TRACKING_ID.md` already exists with `status: ready` (a prior,
+completed dialogue — proceed straight to Phase 1 using it as the seed). If the notes file
+exists with `status: in-progress` (a dialogue interrupted by compaction/crash), RESUME it from
+its captured state rather than restarting. If `BRAINSTORM_FLAG=0`, **ignore the reference file
+entirely** and proceed straight to Phase 1.
 
 ## Phase 1 — Research (parallel agents)
 
@@ -202,6 +227,17 @@ printf 'skill: draft-plan\nid: %s\noutput: %s\nstatus: started\ndate: %s\n' \
 
 Dispatch multiple Explore agents in parallel to investigate the problem space.
 Each agent gets the full description and a specific research focus:
+
+**Brainstorm feed-forward.** When `BRAINSTORM_FLAG=1`, inject the literal
+path `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` into EACH research
+agent's PROMPT, with an instruction to read it as the **primary design
+seed** (the user already steered the design in the brainstorm dialogue).
+Inject the path into the prompts — NOT into the research consolidation
+file, which does not exist until after dispatch. The Codebase / Patterns /
+Prior-art agents still run to ground the design against the repo; the
+Domain agent's "what to build" work is largely pre-answered by the
+brainstorm and may be reduced to verification. When `BRAINSTORM_FLAG=0`,
+dispatch the agents normally with no notes-file injection.
 
 1. **Codebase agent** — find all relevant source files, understand current
    architecture, identify what exists and what needs to change. Map
@@ -295,6 +331,12 @@ PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeli
 printf 'completed: %s\n' "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.research"
 ```
+
+**Skip this steering checkpoint when `BRAINSTORM_FLAG=1`** — the user
+already steered the design, in depth, during the brainstorm dialogue, so
+re-prompting here is redundant; proceed directly to Phase 2. (This is an
+ADDITIVE condition; the existing "if running as a subagent, skip" branch
+below is unchanged.)
 
 **Present the research summary to the user.** If running interactively
 (user invoked `/draft-plan` directly), wait for input:

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+1d4478"
+  version: "2026.05.31+258cda"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter

--- a/skills/draft-plan/references/brainstorm.md
+++ b/skills/draft-plan/references/brainstorm.md
@@ -1,0 +1,338 @@
+# /draft-plan — Brainstorm mode
+
+> Loaded by `SKILL.md` **only when the `brainstorm` flag is present** (progressive
+> disclosure). This file is the complete, self-contained dialogue protocol the
+> orchestrator follows when brainstorm mode is active, including the throwaway-demo
+> lifecycle, the durable notes-file state machine, the feed-forward into Phase 1
+> research, and the reconciliations with zskills framework rules. SKILL.md Reads this
+> file and executes its loop INLINE — the dialogue dispatches no sub-agents.
+
+Brainstorm mode is adapted from the [superpowers](https://github.com/obra/superpowers)
+`brainstorming` skill, re-grounded for zskills. superpowers writes a committed design
+doc and hands off to `writing-plans`; here the terminal artifact is the `/draft-plan`
+plan file, so the brainstorm produces a `/tmp` **notes seed** that feeds Phase 1
+research instead of a committed spec. The dialogue runs a collaborative, multi-turn
+conversation to flesh out a rough idea *before* the existing adversarial pipeline runs:
+one focused question at a time, 2–3 approaches with trade-offs, ruthless YAGNI, and
+optional throwaway demos. It proceeds until the user explicitly confirms they're ready.
+
+---
+
+## Slug pinning — load-bearing for the notes + demo paths
+
+The brainstorm notes file and the demo directory derive their slug from the
+deterministic `$TRACKING_ID` the SKILL.md preamble computes (`basename "$OUTPUT_FILE"
+.md | tr A-Z a-z | tr _ -`, at `skills/draft-plan/SKILL.md:85`). `$TRACKING_ID` is
+already in scope at the brainstorm stage (it is set before this stage runs). **Use it
+verbatim** — do NOT recompute a slug from the description:
+
+- **notes file:** `/tmp/draft-plan-brainstorm-$TRACKING_ID.md`
+- **demo directory:** `/tmp/draft-plan-demo-$TRACKING_ID/`
+
+**Do NOT assume the existing research file shares this slug.** The research file's
+`<slug>` is loose, orchestrator-chosen prose (`SKILL.md:222-226` derives it from the
+output filename "if one was provided," else from the description), so it is NOT
+guaranteed to equal `$TRACKING_ID`. (Example: a pipeline's research file may be
+`/tmp/draft-plan-research-BRAINSTORM_MODE.md` while `$TRACKING_ID` = `brainstorm-mode-plan`.)
+The feed-forward therefore does NOT re-derive a path — it passes the **literal**
+`/tmp/draft-plan-brainstorm-$TRACKING_ID.md` string into the research-agent prompts (see
+[Feed-forward](#feed-forward-into-phase-1-research)), so it never depends on slug parity.
+
+**All `/tmp` paths are ABSOLUTE.** This is required because the brainstorm stage runs
+*after* the worktree preamble, so the current working directory is the worktree. A
+relative demo/notes path would write *into* the worktree and dirty the tree.
+
+---
+
+## The 8-step dialogue protocol
+
+Execute these steps inline as the orchestrator. The loop is conversational and
+multi-turn; there is no fixed number of turns — it ends only when the user affirmatively
+confirms at step 7/8.
+
+1. **Open: restate + light context.** Reflect the user's seed idea back in 1–2
+   sentences so they can confirm or correct your understanding. The worktree,
+   `$OUTPUT_FILE`, and `$TRACKING_ID` are already resolved by the preamble, so defer
+   heavy repo exploration to Phase 1 research — read only what's needed to ask good
+   questions, not to pre-solve the design.
+
+2. **Offer a visual companion as its OWN standalone message** (superpowers pattern) —
+   but **only** when the upcoming exploration involves visual content (UI, layout,
+   diagrams, flows). The message contains nothing but the offer plus a one-line
+   description of what would be shown, and requests consent before building anything.
+   **Skip this step entirely for non-visual ideas** (most plans). See
+   [Quick-demo lifecycle](#quick-demo-lifecycle--exact-idioms) for how to build one once
+   the user consents.
+
+3. **Ask clarifying questions ONE per message.** Most-fundamental first (problem / user
+   / success criteria), then mechanics and naming. When a question has natural choices,
+   **offer them in plain prose** — e.g. "Option A: …; Option B: …; I lean toward A
+   because …" — and **never** the `AskUserQuestion` tool (see
+   [Reconciliations](#reconciliations-with-zskills-rules)).
+
+4. **Propose 2–3 approaches with trade-offs + an explicit recommendation** at each real
+   fork in the design. Don't enumerate options neutrally — say which one you'd pick and
+   why, so the user has a concrete position to push against.
+
+5. **Apply ruthless YAGNI / gentle pushback.** Surface hidden costs and simpler
+   alternatives as questions ("Do we actually need X, or would the simpler Y cover the
+   real case?"). This is the soft, in-dialogue cousin of the Phase-3 adversarial review
+   — it does **not** replace it. The full review still runs after the transition.
+
+6. **Capture decisions as they're made** into the notes file (see
+   [Durable notes file](#durable-notes-file--resumable-state-machine)) — each decision
+   with its rationale, plus the rejected alternatives and any open questions. Update the
+   notes file after each decision, not in one batch at the end, so the state survives a
+   compaction.
+
+7. **Offer the transition checkpoint** when the open questions are exhausted:
+   > "I think we've got enough to draft a plan — start the adversarial design review, or
+   > keep exploring?"
+
+   Require an **affirmative confirm**. If the reply is ambiguous, **ask once more** — do
+   not infer readiness. **Never keyword-auto-detect "ready"**: a stray mention of the
+   word "ready" (or "done", "go", etc.) in the user's prose is NOT a confirmation. Only
+   an explicit, unambiguous affirmative to *this* checkpoint authorizes the transition.
+
+8. **On confirm:** finalize the notes file as a structured design summary, flip its
+   header to `status: ready` (the terminal marker that authorizes the transition — see
+   below), then return control to SKILL.md, which proceeds to Phase 1 research using the
+   notes file as the seed. (Phase 2 of the brainstorm plan wires the SKILL.md-side return
+   and the redundant-checkpoint skip.)
+
+---
+
+## Quick-demo lifecycle — EXACT idioms
+
+These are the worktree-safety + process-lifecycle load-bearing rules. They are specified
+literally because casual versions are factually wrong about screenshot paths and ports.
+
+**All demo files live under `/tmp/draft-plan-demo-$TRACKING_ID/`, NEVER inside the
+worktree.** Phase 6 finalize stages ONLY the plan `.md` via a `FILE_REL` guard and
+`exit 1`s if any other file is staged (`skills/draft-plan/SKILL.md:640-645`); a
+worktree-resident demo would dirty the tree and confuse `/land-pr`. Keeping demos in
+`/tmp` is what makes them safe.
+
+### Live browser visual companion (the common / default case)
+
+Write a self-contained HTML file (inline CSS/JS, no external assets) under
+`/tmp/draft-plan-demo-$TRACKING_ID/`, then serve that directory on an **OS-assigned free
+port**. Do NOT use `port.sh` — that returns the same per-worktree-deterministic port the
+dev server uses, so reusing it would collide with a running dev server; an ephemeral port
+(`port 0`) avoids all collisions. Use Python's stdlib http server (Python is a hard
+zskills dependency; this avoids any consumer-specific serve literal and the uncustomized
+`start-dev.sh` stub).
+
+Capture the chosen port AND the PID to a **pidfile**: the Bash tool does not persist
+shell state across calls, so an in-memory `$!` is lost on the next Bash invocation — a
+pidfile is mandatory so a later call can find and stop the server. Spec the idiom
+literally:
+
+```bash
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+DEMO_DIR="/tmp/draft-plan-demo-$TRACKING_ID"; mkdir -p "$DEMO_DIR"
+# Serve on an OS-assigned free port; the python prints its URL to .serve.url.
+"$PYTHON" - "$DEMO_DIR" > "$DEMO_DIR/.serve.url" 2>&1 <<'PY' &
+import http.server, socketserver, os, sys, functools
+os.chdir(sys.argv[1])
+h = functools.partial(http.server.SimpleHTTPRequestHandler)
+with socketserver.TCPServer(("127.0.0.1", 0), h) as s:
+    print(f"http://127.0.0.1:{s.server_address[1]}/", flush=True)
+    s.serve_forever()
+PY
+echo "$!" > "$DEMO_DIR/.serve.pid"          # NO trailing space — ps -p chokes on it
+# The server needs ~1-3s to bind + flush the URL; wait for it WITHOUT a foreground `sleep`
+# (harness-blocked per CLAUDE.md). A timeout-bounded busy-wait is sleep-free:
+timeout 8 bash -c 'until [ -s "$1/.serve.url" ]; do :; done' _ "$DEMO_DIR" || true
+```
+
+Give the user the URL by reading it from `$DEMO_DIR/.serve.url` **AFTER** the
+`timeout … until [ -s … ]` wait above — an immediate read returns empty because the
+server has not yet bound the port and flushed its URL. Iterate the HTML in place and tell
+the user to refresh the page to see changes.
+
+**Authoring-effort honesty note.** The inline-built HTML companion is a THROWAWAY
+visualization, not production UI. Keep mockups minimal — enough to make the idea concrete,
+not polished. Do NOT sink disproportionate effort into demo HTML mid-dialogue; the goal
+is to unblock the conversation, not to ship a pixel-perfect mockup.
+
+### Stopping the server
+
+**NEVER use `kill -9`, `killall`, `pkill`, or `fuser -k`; never `lsof -ti | xargs kill`.**
+Read the PID from `$DEMO_DIR/.serve.pid` and SIGTERM that specific PID only:
+
+```bash
+DEMO_DIR="/tmp/draft-plan-demo-$TRACKING_ID"
+PID=$(cat "$DEMO_DIR/.serve.pid")
+kill "$PID"   # SIGTERM to the one server PID — never kill -9/pkill/killall/fuser -k/lsof|xargs kill
+```
+
+Stop the server at brainstorm exit, or leave it for the user to stop. Because demos live
+in `/tmp` on an ephemeral port, a stranded server does not dirty the worktree and cannot
+block `/land-pr` (it is not on a tracked path and not on the dev-server port); still, stop
+it on a clean exit for tidiness.
+
+### Static screenshot (the "sometimes" lighter case)
+
+`playwright-cli screenshot` takes **NO URL** and requires the browser to be open first (a
+bare `playwright-cli screenshot file://…` errors "browser 'default' is not open"). The
+verified sequence is:
+
+```bash
+DEMO_DIR="/tmp/draft-plan-demo-$TRACKING_ID"
+playwright-cli open "file://$DEMO_DIR/<demo>.html"
+playwright-cli screenshot   # NO --filename, NO url
+playwright-cli close
+```
+
+Omitting `--filename` saves the image into the configured, gitignored `.playwright/output/`
+directory (which is invisible to git — `.gitignore:20` ignores `.playwright/*`; the
+screenshot lands there headless in this environment). **Do NOT move or rename the
+screenshot into the tracked worktree** — that is the actual pollution hazard; the image is
+safe only while it stays in the gitignored `.playwright/output/` dir. Show the user the
+image from `.playwright/output/`. If `playwright-cli` errors on the environment, check
+`.devcontainer/setup.sh` first before concluding the container can't do it
+(`feedback_check_devcontainer_before_bailing`).
+
+### Which demo to use
+
+**Default toward the live companion** when the user benefits from interaction (clicking,
+hovering, refreshing as the idea evolves). Use the static screenshot for fast, static
+conceptual shots where interaction adds nothing. Demos are throwaway and never committed;
+optionally clean up on brainstorm exit:
+
+```bash
+rm -rf "/tmp/draft-plan-demo-$TRACKING_ID"
+```
+
+---
+
+## Durable notes file — resumable state machine
+
+Maintain `/tmp/draft-plan-brainstorm-$TRACKING_ID.md`, updated after each decision (step
+6). This mirrors the skill's existing `/tmp/draft-plan-research-$TRACKING_ID.md`
+compaction-survival pattern (`SKILL.md:222-228`). Accumulate, as the dialogue progresses:
+
+- the refined problem statement,
+- decisions + rationale,
+- rejected alternatives,
+- open questions,
+- pointers to demo screenshots / URLs.
+
+**The notes file IS a resumable state machine.** The dialogue is multi-turn and WILL
+sometimes span a context compaction. After compaction, the in-context dialogue state and
+the `BRAINSTORM_FLAG` shell variable are gone, and nothing would otherwise re-trigger the
+loop — the orchestrator could wrongly jump to Phase 1 with a half-finished seed. Defend
+this structurally with a header status line:
+
+- The notes file carries a header `status: in-progress` from creation.
+- It is flipped to the terminal `status: ready` line **ONLY at step 8** (user confirm).
+
+The notes file therefore looks like this from the start of the dialogue:
+
+```
+---
+status: in-progress
+tracking_id: <$TRACKING_ID>
+---
+
+# Brainstorm notes: <restated idea>
+
+## Refined problem statement
+...
+
+## Decisions
+- <decision> — <rationale>
+
+## Rejected alternatives
+- <alternative> — <why rejected>
+
+## Open questions
+- <question>
+
+## Demo pointers
+- <URL or .playwright/output/ screenshot path>
+```
+
+**Resume-on-reentry semantics.** When SKILL.md (re)enters with `BRAINSTORM_FLAG=1`, it
+checks for the notes file (Phase 2 wires the SKILL.md side):
+
+- **Notes file exists with `status: ready`** → a prior dialogue already completed.
+  Proceed straight to Phase 1, using the notes file as the seed. Do NOT re-run the
+  dialogue, and do NOT re-offer the transition checkpoint.
+- **Notes file exists with `status: in-progress`** → a dialogue was interrupted by
+  compaction or crash. **RESUME** the dialogue from its captured state (re-read the notes
+  file to reconstruct decisions / open questions), rather than restarting from step 1 or
+  skipping to Phase 1.
+- **Notes file absent** → run the dialogue from step 1.
+
+Only a `status: ready` notes file authorizes the transition to Phase 1. This makes the
+dialogue crash/compaction-safe.
+
+---
+
+## Feed-forward into Phase 1 research
+
+At the transition (after `status: ready`), the notes-file path is injected into **EACH**
+Phase 1 research agent's **PROMPT**, with an instruction to read it as the primary design
+seed. (Phase 2 of the brainstorm plan wires the SKILL.md-side dispatch.)
+
+**The feed-forward is "inject the notes-file path into each research agent's prompt," NOT
+"append to the research file before dispatch."** The research file
+(`/tmp/draft-plan-research-$TRACKING_ID.md` per the loose slug) is the *post-dispatch
+CONSOLIDATION*, written AFTER the agents are dispatched (`skills/draft-plan/SKILL.md:202`),
+so notes cannot be "added to the research file" before agents read it — the file does not
+exist yet at dispatch time. The path injected into the prompts is the **literal**
+`/tmp/draft-plan-brainstorm-$TRACKING_ID.md` string (it does not depend on research-file
+slug parity — see [Slug pinning](#slug-pinning--load-bearing-for-the-notes--demo-paths)).
+
+The post-dispatch consolidation then incorporates both the agents' findings and the
+brainstorm notes. **This is hybrid — the brainstorm does NOT skip research:**
+
+- The **Codebase / Patterns / Prior-art** agents STILL run to ground the design against
+  the actual repo.
+- The **Domain** agent's "what to build" work is largely pre-answered by the brainstorm
+  and may be reduced to verification.
+
+---
+
+## Reconciliations with zskills rules
+
+Stated here so future editors don't re-litigate them.
+
+- **No `AskUserQuestion`.** Per `skills/update-zskills/SKILL.md:701`: "Do NOT use
+  AskUserQuestion. Ask in plain conversation text." superpowers "prefers multiple choice"
+  → here, options are offered in plain prose ("Option A: …; Option B: …; I lean toward
+  A because …").
+
+- **No sub-agent dispatch in the dialogue.** The loop and demo-building are INLINE
+  orchestrator work; the dialogue dispatches no agents, so it adds no `Agent`-tool
+  requirement beyond the existing Preflight and needs no `subagent_type` pin. (Forward
+  constraint: if a future revision dispatches an agent to build a demo, it MUST pin
+  `subagent_type: "implementer"` and never Haiku.)
+
+- **No forbidden literals in this file.** This IS a skill file (it lives under `skills/`),
+  so it is in the forbidden-literals deny-list scope. No `TZ=America/New_York` (use
+  `${TIMEZONE:-UTC}` via `zskills-resolve-config.sh` if a timestamp is ever needed), no
+  `npm run test:all`, `npm start`, `$TEST_OUT/.test-results.txt`, or the skill-version
+  regex inside exec fences without an `<!-- allow-hardcoded: … reason: … -->` marker. The
+  Python-http-server + ephemeral-port + `file://`-screenshot design deliberately
+  references none of the six config-resolution variables, so no positive-side fence-local
+  config-sourcing is triggered; if a future fence references one, source the helper
+  in/above it.
+
+- **Never `kill -9` / `killall` / `pkill` / `fuser -k` / `lsof -ti | xargs kill`** to stop
+  the demo server — SIGTERM the one pidfile PID (see
+  [Stopping the server](#stopping-the-server)).
+
+- **No foreground `sleep`** in the serve-URL wait — the harness blocks it; the
+  `timeout … until [ -s … ]` busy-wait is the sleep-free substitute.
+
+**Authoring constraint — script-source references use the two-lane dual-path form.** Try
+`${CLAUDE_PLUGIN_ROOT}/skills/...` first, fall back to
+`$CLAUDE_PROJECT_DIR/.claude/skills/...`. For example, when sourcing the config-resolution
+helper:
+
+```bash
+. "${CLAUDE_PLUGIN_ROOT:-$CLAUDE_PROJECT_DIR/.claude}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+```

--- a/tests/test-draft-plan-args-smoke.sh
+++ b/tests/test-draft-plan-args-smoke.sh
@@ -124,6 +124,128 @@ else
   check_auto "use auto-land mode" 0 "'auto-land' (no whitespace boundary) rejected"
 fi
 
+# ── Surface 3: BRAINSTORM_FLAG regex (extract-and-run) ───────────────
+# The BRAINSTORM_FLAG fence is self-contained (pure `[[ =~ ]]`) and lives
+# in its OWN block (kept separate from AUTO_FLAG so the AUTO extractor that
+# stops at the first `^fi$` is not perturbed). Extract it verbatim and run.
+BRAINSTORM_BLOCK=$(awk '
+  /^BRAINSTORM_FLAG=0$/{capture=1}
+  capture {print}
+  capture && /^fi$/{exit}
+' "$SKILL")
+
+if [ -z "$BRAINSTORM_BLOCK" ]; then
+  fail "brainstorm-flag: could not extract BRAINSTORM_FLAG fence" "awk extract empty"
+else
+  pass "brainstorm-flag: BRAINSTORM_FLAG fence extracted from SKILL.md"
+  check_brainstorm() { # $1=ARGUMENTS $2=expected(0/1) $3=label
+    local ARGUMENTS="$1"
+    local BRAINSTORM_FLAG
+    eval "$BRAINSTORM_BLOCK"
+    if [ "$BRAINSTORM_FLAG" = "$2" ]; then
+      pass "brainstorm-flag: $3 -> BRAINSTORM_FLAG=$2"
+    else
+      fail "brainstorm-flag: $3" "expected $2 got $BRAINSTORM_FLAG"
+    fi
+  }
+  # Positives — whitespace-anchored, case-insensitive, any position.
+  check_brainstorm "brainstorm Add dark mode" 1 "leading 'brainstorm'"
+  check_brainstorm "Add dark mode brainstorm" 1 "trailing 'brainstorm'"
+  check_brainstorm "output X.md brainstorm rounds 3 Add dark mode" 1 "mid 'brainstorm' word-bounded"
+  check_brainstorm "BRAINSTORM Add dark mode" 1 "uppercase 'BRAINSTORM'"
+  # Negatives — substring/inflection forms must NOT trip the flag (flag stays 0).
+  check_brainstorm "brainstorming the design" 0 "'brainstorming' (no boundary) rejected"
+  check_brainstorm "brainstormed yesterday" 0 "'brainstormed' (no boundary) rejected"
+  check_brainstorm "brainstorms" 0 "'brainstorms' (no boundary) rejected"
+fi
+
+# ── Surface 4: brainstorm-mode wiring parity greps (externally-sourced) ──
+# These fences are NOT self-contained (they live in prose / depend on the
+# Read-tool dispatch and $TRACKING_ID), so assert by fingerprint grep that
+# the wiring stays present, mirroring the Surface-1 `grep -qF` parity style.
+
+# Conditional-load parity: references/brainstorm.md is gated on BRAINSTORM_FLAG,
+# i.e. the Read is NOT unconditional. The "## Brainstorm mode" section opens
+# with the `If BRAINSTORM_FLAG=1, **Read [references/brainstorm.md]...` gate.
+if grep -qF 'If `BRAINSTORM_FLAG=1`, **Read [references/brainstorm.md](references/brainstorm.md)**' "$SKILL"; then
+  pass "conditional-load: brainstorm.md Read is gated on BRAINSTORM_FLAG=1"
+else
+  fail "conditional-load: brainstorm.md gate drifted" "missing BRAINSTORM_FLAG=1 Read gate"
+fi
+# Regression guard: the gate must NOT re-introduce the inert ZSKILLS_PIPELINE_ID
+# check. Scope the assertion to the "## Brainstorm mode" section so unrelated
+# PIPELINE_ID uses elsewhere in SKILL.md (tracking fences) don't false-positive.
+BRAINSTORM_SECTION=$(awk '
+  /^## Brainstorm mode/{capture=1; next}
+  /^## /{if (capture) exit}
+  capture {print}
+' "$SKILL")
+if printf '%s' "$BRAINSTORM_SECTION" | grep -qF 'ZSKILLS_PIPELINE_ID'; then
+  fail "conditional-load: brainstorm gate references ZSKILLS_PIPELINE_ID" "inert check re-added"
+else
+  pass "conditional-load: brainstorm gate does NOT reference ZSKILLS_PIPELINE_ID"
+fi
+
+# Resume-contract: the brainstorm-mode prose wires the resume state machine
+# on the notes-file status markers (status: ready / status: in-progress).
+if printf '%s' "$BRAINSTORM_SECTION" | grep -qF 'status: ready' \
+   && printf '%s' "$BRAINSTORM_SECTION" | grep -qF 'status: in-progress'; then
+  pass "resume-contract: brainstorm prose references status: ready / status: in-progress"
+else
+  fail "resume-contract: brainstorm resume states drifted" "missing status: ready / status: in-progress"
+fi
+
+# Feed-forward: the brainstorm-mode research dispatch injects the notes-file
+# path /tmp/draft-plan-brainstorm-<id>.md into each research agent prompt.
+if grep -qF '/tmp/draft-plan-brainstorm-' "$SKILL"; then
+  pass "feed-forward: research dispatch references /tmp/draft-plan-brainstorm- notes path"
+else
+  fail "feed-forward: notes-file path drifted" "missing /tmp/draft-plan-brainstorm-"
+fi
+
+# Checkpoint-skip: the post-research steering checkpoint is gated on
+# BRAINSTORM_FLAG=1 (skipped because the user already steered in dialogue).
+if grep -qF 'Skip this steering checkpoint when `BRAINSTORM_FLAG=1`' "$SKILL"; then
+  pass "checkpoint-skip: post-research checkpoint gated on BRAINSTORM_FLAG=1"
+else
+  fail "checkpoint-skip: checkpoint gate drifted" "missing 'Skip this steering checkpoint when BRAINSTORM_FLAG=1'"
+fi
+
+# ── Surface 5: references/brainstorm.md idiom parity greps ───────────
+# Round-2 regression guards: the verified playwright / serve-wait idioms in
+# references/brainstorm.md must not regress to the buggy forms.
+BRAINSTORM_REF="$REPO_ROOT/skills/draft-plan/references/brainstorm.md"
+if [ ! -f "$BRAINSTORM_REF" ]; then
+  fail "brainstorm.md idioms: reference file missing" "$BRAINSTORM_REF not found"
+else
+  # playwright-cli open MUST precede screenshot (bare screenshot file://… errors
+  # "browser 'default' is not open"). Anchor on the FENCED command lines (start
+  # of line, no leading backtick) so inline prose like `playwright-cli screenshot`
+  # — which legitimately appears earlier when documenting the gotcha — is ignored.
+  OPEN_LINE=$(grep -nE '^playwright-cli open' "$BRAINSTORM_REF" | head -1 | cut -d: -f1)
+  SHOT_LINE=$(grep -nE '^playwright-cli screenshot' "$BRAINSTORM_REF" | head -1 | cut -d: -f1)
+  if [ -n "$OPEN_LINE" ] && [ -n "$SHOT_LINE" ] && [ "$OPEN_LINE" -lt "$SHOT_LINE" ]; then
+    pass "brainstorm.md idioms: 'playwright-cli open' precedes 'screenshot'"
+  else
+    fail "brainstorm.md idioms: open/screenshot order" "open=$OPEN_LINE screenshot=$SHOT_LINE (open must precede)"
+  fi
+  # Pidfile write must have NO trailing space after the redirect target
+  # (`echo "$!" > "$DEMO_DIR/.serve.pid"` — a trailing space breaks `ps -p`).
+  if grep -qF 'echo "$!" > "$DEMO_DIR/.serve.pid"' "$BRAINSTORM_REF"; then
+    pass "brainstorm.md idioms: pidfile write has no trailing space"
+  else
+    fail "brainstorm.md idioms: pidfile write drifted" "missing exact 'echo \"\$!\" > \"\$DEMO_DIR/.serve.pid\"'"
+  fi
+  # The serve-wait must contain NO bare foreground `sleep` (harness-blocked);
+  # the timeout-bounded busy-wait is the sleep-free substitute. Assert no
+  # fenced bash line invokes `sleep` as a command.
+  if grep -nE '(^|[^[:alnum:]_])sleep[[:space:]]+[0-9]' "$BRAINSTORM_REF" | grep -vq '`sleep`'; then
+    fail "brainstorm.md idioms: bare 'sleep' present in serve-wait" "$(grep -nE '(^|[^[:alnum:]_])sleep[[:space:]]+[0-9]' "$BRAINSTORM_REF" | grep -v '`sleep`')"
+  else
+    pass "brainstorm.md idioms: no bare foreground 'sleep' in serve-wait"
+  fi
+fi
+
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
 [ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -158,6 +158,13 @@ ISSUE_606_ALLOWLIST=(
   "skills/draft-tests/modes/draft.md	PLAN_FILE"
   "skills/draft-tests/modes/backfill.md	PLAN_FILE"
   "skills/draft-tests/modes/land.md	TRACKING_ID"
+  # draft-plan's brainstorm-mode reference file inherits $TRACKING_ID from
+  # the main SKILL.md's preamble (computed at skills/draft-plan/SKILL.md:85,
+  # in scope before the brainstorm stage runs). It is conditionally Read by
+  # SKILL.md only when the `brainstorm` flag is set and is not an entrypoint,
+  # so it documents but does not own the resolver — same pattern as
+  # run-plan/modes/pr.md TRACKING_ID above.
+  "skills/draft-plan/references/brainstorm.md	TRACKING_ID"
 )
 FAMILY_VARS_RE='^(TRACKING_ID|PLAN_FILE|OUTPUT_FILE|META_PLAN_PATH|GOAL|CHANGE_SUMMARY|SPRINT_ID|ROUND)$'
 FAMILY_FAIL=""


### PR DESCRIPTION
## Plan: Brainstorm mode for /draft-plan

Adds an opt-in `brainstorm` mode to `/draft-plan` — a collaborative pre-pipeline dialogue (one question at a time, 2-3 approaches with trade-offs, YAGNI pushback, optional throwaway demos) whose output seeds the existing research → finalize pipeline. Progressive-disclosure: the behavior lives in a new `references/brainstorm.md` read only when the `brainstorm` flag is present.

<!-- run-plan:progress:start -->
**Phases completed (3/3):**

<!-- run-plan:progress:end -->

- **Phase 1** — `skills/draft-plan/references/brainstorm.md` (338 lines): 8-step dialogue protocol, demo lifecycle (ephemeral-port server + file:// screenshot), resumable notes-file state machine, research feed-forward.
- **Phase 2** — wired into `SKILL.md`: `BRAINSTORM_FLAG` detection, conditional-load + resume stage, feed-forward injection, post-research checkpoint skip, `[brainstorm]` in argument-hint. All `auto`/`land-pr` conformance pins + args-smoke fingerprints preserved.
- **Phase 3** — +16 `test-draft-plan-args-smoke.sh` cases (flag ±, conditional-load, resume, feed-forward, checkpoint-skip, brainstorm.md idiom guards). Full suite 6591/6591; conformance 726/726.

Each phase verified by an independent verifier agent. No UI impact.

**Report:** `docs/reports/plan-brainstorm-mode-plan.md`

---
Generated by `/run-plan` (finish auto, PR landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
