### PR TITLE
fix(do,quickfix): parse all #N + fan-out claim acquire/release (#863)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+12f9ca"
+  version: "2026.05.31+065fb4"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -228,25 +228,68 @@ AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
 fi
-# Issue-number parse (claim-work-item Phase 2 / W2.2). When the description
-# begins with a `#N` reference (optionally preceded by a close-keyword:
-# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
-# insensitive) extract the bare integer into ISSUE_NUM so the mode files
-# can claim the issue via claim-issue.sh. The regex is ANCHORED to the
-# start of the description so a `#NNN` literal appearing later in prose
-# (e.g., a quoted example, a line reference, a follow-up "see also #N")
-# does NOT set ISSUE_NUM. An optional leading double-quote is tolerated so
-# /do's quoted-description carve-out (`/do "Fix #N ..."`) still matches.
-# When no issue reference is in scope (the common /do case) ISSUE_NUM
-# stays empty and the mode files claim nothing. claim-issue.sh rejects
-# non-numeric input with exit 2; the `[0-9]+` capture guarantees a bare
-# integer.
-ISSUE_NUM=""
-if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[3]}"
+# Issue-number parse (claim-work-item Phase 2 / W2.2). Collect ALL `#N`
+# references in the description into the ISSUE_NUMS array so the mode
+# files can fan-out the claim acquire across every closed issue. The
+# leading match is ANCHORED to the start of the description (optionally
+# preceded by a close-keyword: close/closes/closed/fix/fixes/fixed/
+# resolve/resolves/resolved, case-insensitive; an optional leading
+# double-quote is tolerated for /do's quoted-description carve-out
+# `/do "Fix #N ..."`). Subsequent matches recognize TWO boundary
+# classes:
+#   - STRONG separators (`/`, `+`, `&`) — bare `#N` allowed because
+#     these don't naturally appear in English prose before a `#`
+#     reference. Canonical patterns: "fix #N + #M", "Closes #N / Closes
+#     #M", "fix #N & #M".
+#   - WEAK separators (`,`, `;`, ` and `, ` or `) — require an explicit
+#     close-keyword between the separator and `#N`. This is what blocks
+#     "Closes #832, see also #999" from accidentally claiming #999
+#     (comma is a normal prose punctuator, so bare `#N` after it would
+#     over-capture) while still accepting "Closes #832, Closes #833".
+# When no issue reference is in scope (the common /do case) ISSUE_NUMS
+# stays empty and the mode files claim nothing. ISSUE_NUM is kept as a
+# back-compat scalar (= ISSUE_NUMS[0] when non-empty, else empty).
+# claim-issue.sh rejects non-numeric input with exit 2; the `[0-9]+`
+# capture guarantees a bare integer.
+ISSUE_NUMS=()
+_DO_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+# Leading anchored match (optional close-keyword, optional leading quote).
+if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
 elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
+# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
+# 4=digit capture.
+_DO_REMAINING="$ARGUMENTS"
+while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
+# close-keyword before `#N` so prose like "Closes #N, see also #M" doesn't
+# over-capture #M. BASH_REMATCH groups: 1=outer separator, 2=and/or word,
+# 3=kw outer, 4=kw inner, 5=digit capture.
+_DO_REMAINING="$ARGUMENTS"
+while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+  _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Dedupe preserving first-seen order (acquire is order-dependent for the
+# partial-rollback contract; releases are idempotent per claim-issue.sh).
+declare -A _DO_SEEN=()
+_DO_UNIQUE=()
+for _n in "${ISSUE_NUMS[@]:-}"; do
+  [ -z "$_n" ] && continue
+  if [ -z "${_DO_SEEN[$_n]:-}" ]; then _DO_UNIQUE+=("$_n"); _DO_SEEN[$_n]=1; fi
+done
+ISSUE_NUMS=("${_DO_UNIQUE[@]}")
+unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _n
+# Back-compat scalar (= first claimed issue, or empty when none). Mode
+# files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
+# iterates "${ISSUE_NUMS[@]}".
+ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
 # `/do fix the bug --rounds in production` would otherwise capture "in" as
@@ -320,7 +363,7 @@ needed).
 | `/do Update the presentation with Phase 3 results auto` | PROCEED | concrete verb + object |
 | `/do add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/do improve` | REDIRECT → ask user | vague verb, no object |
-| `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
+| `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue(s) via ISSUE_NUMS and proceed |
 
 Output one of:
 
@@ -741,12 +784,14 @@ procedure end-to-end**. Do not proceed until you have read the file.
 | `worktree`     | B    | [modes/worktree.md](modes/worktree.md) |
 | `direct`       | C    | [modes/direct.md](modes/direct.md) |
 
-**`$ISSUE_NUM` propagates into the mode files** (set in the Pre-flight
-pre-parse). When non-empty, the mode file claims the issue via
-`claim-issue.sh` AFTER it constructs its `PIPELINE_ID` (the C1/M1 rule —
-never acquire before a non-empty PIPELINE_ID exists). The acquire is NEVER
-placed here in SKILL.md before mode dispatch: PIPELINE_ID is empty at this
-point, so `--pipeline-id ""` would fail usage-error exit 2.
+**`$ISSUE_NUMS` propagates into the mode files** (array set in the
+Pre-flight pre-parse; `$ISSUE_NUM` is kept as a back-compat scalar = the
+first element). When `${#ISSUE_NUMS[@]} -gt 0`, the mode file fans out
+the `claim-issue.sh` acquire across every element AFTER it constructs
+its `PIPELINE_ID` (the C1/M1 rule — never acquire before a non-empty
+PIPELINE_ID exists). The acquire is NEVER placed here in SKILL.md before
+mode dispatch: PIPELINE_ID is empty at this point, so `--pipeline-id ""`
+would fail usage-error exit 2.
 
 ## Phase 3 — Verify
 
@@ -882,14 +927,14 @@ Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invoca
 
 ## Phase 5 — Report
 
-**Release the issue claim (worktree/direct modes).** Phase 5 is the
+**Release the issue claim(s) (worktree/direct modes).** Phase 5 is the
 universal terminal reached on BOTH the `auto` and non-`auto` exits of
-worktree and direct modes — so the issue claim (acquired by the mode file
-when `$ISSUE_NUM` was non-empty) is released HERE, not in Phase 4 Land
-(which is `AUTO_FLAG=1`-gated and would leak the claim on the dominant
-non-auto path). PR mode (Path A) handles its own release inside
+worktree and direct modes — so the issue claims (acquired by the mode
+file when `${#ISSUE_NUMS[@]} -gt 0`) are released HERE, not in Phase 4
+Land (which is `AUTO_FLAG=1`-gated and would leak the claims on the
+dominant non-auto path). PR mode (Path A) handles its own release inside
 `modes/pr.md`'s finalize block and exits before reaching this section.
-Skip when no issue claim was acquired (the common /do case — `$ISSUE_NUM`
+Skip when no issue claim was acquired (the common /do case — `ISSUE_NUMS`
 empty):
 
 ```bash
@@ -898,11 +943,15 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-# $ISSUE_NUM (Pre-flight pre-parse) and $PIPELINE_ID (set in the mode file:
-# do.${TASK_SLUG}) survive in the persistent shell. The release is
-# ownership-safe via --require-pipeline.
-if [ -n "${ISSUE_NUM:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
-  bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+# $ISSUE_NUMS (Pre-flight pre-parse) and $PIPELINE_ID (set in the mode file:
+# do.${TASK_SLUG}) survive in the persistent shell. Release each claim in
+# order — releases are idempotent per claim-issue.sh, and ownership-safe via
+# --require-pipeline. Skip entirely when no issues were claimed.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ] && [ -n "${PIPELINE_ID:-}" ]; then
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+  done
+  unset _ISSUE_N
 fi
 ```
 
@@ -972,13 +1021,17 @@ Status: pr-ready | pr-ci-failing | landed
   `.landed` with `status: conflict` and exit with an error message.
 - **If stuck on anything:** report the state and ask the user for
   guidance. Do not retry the same approach in a loop.
-- **Release the issue claim on every abandon path (worktree/direct modes).**
-  When `$ISSUE_NUM` was non-empty and the mode file acquired a
-  `claim-issue.sh` claim, any error exit above (test failure, content
-  issue, cherry-pick conflict, push failure, task-too-big) MUST release it
-  before stopping so the next pipeline can pick the issue up:
-  `bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"`
-  (only if an issue claim was acquired — skip when `$ISSUE_NUM` is empty).
+- **Release the issue claim(s) on every abandon path (worktree/direct modes).**
+  When `${#ISSUE_NUMS[@]} -gt 0` and the mode file acquired
+  `claim-issue.sh` claims, any error exit above (test failure, content
+  issue, cherry-pick conflict, push failure, task-too-big) MUST release
+  each one before stopping so the next pipeline can pick the issue(s) up:
+  ```bash
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+  done
+  ```
+  (only if any claim was acquired — skip when `ISSUE_NUMS` is empty).
   PR mode's abandon-path releases live inside `modes/pr.md`.
 
 ## Key Rules

--- a/.claude/skills/do/modes/direct.md
+++ b/.claude/skills/do/modes/direct.md
@@ -7,16 +7,21 @@ Selected when the user passes `direct` explicitly, when `execution.landing`
 in `.claude/zskills-config.json` is `"direct"`, or as the fallback when
 no config is present. Work directly on main.
 
-**Claim the issue (when `$ISSUE_NUM` is non-empty).** Direct mode
+**Claim the issue(s) (when `${#ISSUE_NUMS[@]} -gt 0`).** Direct mode
 constructs no `TASK_SLUG`/`PIPELINE_ID` of its own, so synthesize a minimal
-`PIPELINE_ID="do.<bare-issue>"` (routed through the shared sanitizer)
-BEFORE acquiring the `claim-issue.sh` claim. This stops a concurrent
-`/fix-issues` cron from double-working the same issue. `$ISSUE_NUM` is
-propagated from `/do`'s Pre-flight pre-parse (set only when the description
-referenced an issue and `--force` overrode the `/fix-issues` redirect).
-Skip entirely when `$ISSUE_NUM` is empty (the common /do direct case —
-direct mode is rarely issue-driven). The claim is released in `/do` Phase 5
-Report.
+`PIPELINE_ID="do.<first-issue>"` (routed through the shared sanitizer)
+BEFORE acquiring the `claim-issue.sh` claims. This stops a concurrent
+`/fix-issues` cron from double-working the same issue(s). `ISSUE_NUMS` is
+propagated from `/do`'s Pre-flight pre-parse (populated only when the
+description referenced one or more issues and `--force` overrode the
+`/fix-issues` redirect). Skip entirely when `ISSUE_NUMS` is empty (the
+common /do direct case — direct mode is rarely issue-driven). The claims
+are released in `/do` Phase 5 Report. **Partial-acquire rollback:** if
+any acquire returns rc=10 (foreign-held) on issue K, the loop releases
+issues 1..K-1 (which this pipeline successfully acquired earlier in the
+loop) before exiting — the foreign holder keeps its claim, and this
+pipeline leaves no orphaned claims on the issues it had already grabbed.
+Same rollback applies on rc=11/2/* failures.
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -24,18 +29,29 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-if [ -n "${ISSUE_NUM:-}" ]; then
-  PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "do.$ISSUE_NUM")
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+  PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "do.${ISSUE_NUMS[0]}")
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 ```
 

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -96,17 +96,21 @@ fi
 ```
 Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` as shell output in the main session — the `.zskills-tracked` file in the worktree is the single source of truth.
 
-**Step A5.5 — Claim the issue (when `$ISSUE_NUM` is non-empty).** Now that
-`PIPELINE_ID="do.${TASK_SLUG}"` is set (A4) and the worktree exists (A5),
-acquire the `claim-issue.sh` claim BEFORE dispatching the implementation
-agent (A6). This stops a concurrent `/fix-issues` cron from double-working
-the same issue. `$ISSUE_NUM` is propagated from `/do`'s Pre-flight
-pre-parse (set only when the description referenced an issue and `--force`
-overrode the `/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is
-empty (the common /do pr case). The A1 slug guards and A5's `exit "$RC"`
-are PRE-acquire, so they need no release. The claim is released in the
-explicit-finalize block at the end of the caller loop (Step A8), and
-inline before every post-acquire-pre-finalize early exit.
+**Step A5.5 — Claim the issue(s) (when `${#ISSUE_NUMS[@]} -gt 0`).** Now
+that `PIPELINE_ID="do.${TASK_SLUG}"` is set (A4) and the worktree exists
+(A5), fan out the `claim-issue.sh` acquire across every element of
+`ISSUE_NUMS` BEFORE dispatching the implementation agent (A6). This stops
+a concurrent `/fix-issues` cron from double-working any of the same
+issues. `ISSUE_NUMS` is propagated from `/do`'s Pre-flight pre-parse
+(populated only when the description referenced one or more issues and
+`--force` overrode the `/fix-issues` redirect). Skip entirely when
+`ISSUE_NUMS` is empty (the common /do pr case). The A1 slug guards and
+A5's `exit "$RC"` are PRE-acquire, so they need no release. The claims are
+released in the explicit-finalize block at the end of the caller loop
+(Step A8), and inline before every post-acquire-pre-finalize early exit.
+**Partial-acquire rollback:** if any acquire returns rc=10 (foreign-held)
+on issue K, release issues 1..K-1 (acquired earlier in this loop) before
+declining. Same rollback applies on rc=11/2/* failures.
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -114,17 +118,28 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-if [ -n "${ISSUE_NUM:-}" ]; then
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 ```
 
@@ -202,17 +217,23 @@ cd "$WORKTREE_PATH"
 if [ -z "${PR_TITLE:-}" ]; then
   echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
   # C2 inline-release: this exit is AFTER the Step A5.5 acquire and BEFORE
-  # the explicit-finalize block, so release the issue claim (only if one
-  # was acquired) before bailing or it leaks.
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  # the explicit-finalize block, so release the issue claim(s) (only if any
+  # were acquired) before bailing or they leak.
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 5
 fi
 if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 60 ] || [[ "$PR_TITLE" != do:\ * ]]; then
   echo "ERROR: PR_TITLE must be a single line ≤60 chars starting with 'do: ' (got '$PR_TITLE')." >&2
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 2
 fi
@@ -333,9 +354,12 @@ while :; do
     rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
     sed -i "s/^status: started$/status: failed/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
     # C2 inline-release: post-acquire, pre-finalize early exit — release
-    # the issue claim (only if one was acquired) or it leaks.
-    if [ -n "${ISSUE_NUM:-}" ]; then
-      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    # the issue claim(s) (only if any were acquired) or they leak.
+    if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+      for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+        bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+      done
+      unset _ISSUE_N
     fi
     exit 1
   fi
@@ -503,13 +527,13 @@ esac
 sed -i "s/^status: started$/status: $FINAL/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
 rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
 
-# Release the issue claim based on LAND_OUTCOME (mirrors
+# Release the issue claim(s) based on LAND_OUTCOME (mirrors
 # fix-issues/modes/pr.md:337-345 so the two skills evolve in lockstep).
-# Only if an issue claim was acquired in Step A5.5. $PIPELINE_ID =
+# Only if issue claims were acquired in Step A5.5. $PIPELINE_ID =
 # do.$TASK_SLUG is re-resolved at the tracking-setup fence-top above and
 # survives in this fence.
 #
-# Three groups (issue #864):
+# Three groups (issue #864) × ISSUE_NUMS fan-out (issue #863):
 #   - merged          → RELEASE (work is durably on main).
 #   - pr-ready|created→ HOLD: the PR is OPEN on the remote awaiting human
 #                       review/merge; releasing here would let a concurrent
@@ -522,20 +546,26 @@ rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
 #                       and same shape as fix-issues PR mode's `created`
 #                       arm at fix-issues/modes/pr.md:342-343).
 #   - terminal-failure→ RELEASE (PR is dead-on-arrival; nothing to guard).
-if [ -n "${ISSUE_NUM:-}" ]; then
+#
+# Releases are idempotent per claim-issue.sh, so any claim already
+# released by an inline-release early-exit upstream no-ops here.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  case "$LAND_OUTCOME" in
-    merged)
-      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
-        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
-    pr-ready|created)
-      echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $ISSUE_NUM' if the PR never lands" >&2 ;;
-    pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
-      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
-        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
-    *)
-      echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$ISSUE_NUM; defaulting to HOLD" >&2 ;;
-  esac
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    case "$LAND_OUTCOME" in
+      merged)
+        bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
+          || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;
+      pr-ready|created)
+        echo "do: holding claim for #$_ISSUE_N (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $_ISSUE_N' if the PR never lands" >&2 ;;
+      pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
+        bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
+          || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;
+      *)
+        echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$_ISSUE_N; defaulting to HOLD" >&2 ;;
+    esac
+  done
+  unset _ISSUE_N
 fi
 ```
 

--- a/.claude/skills/do/modes/worktree.md
+++ b/.claude/skills/do/modes/worktree.md
@@ -61,15 +61,20 @@ if [ "${rc:-0}" = "2" ]; then
 fi
 ```
 
-**Claim the issue (when `$ISSUE_NUM` is non-empty).** After the worktree
-exists and `PIPELINE_ID="do.${TASK_SLUG}"` is set, acquire the
-`claim-issue.sh` claim BEFORE dispatching the implementation agent — this
-stops a concurrent `/fix-issues` cron from double-working the same issue.
-`$ISSUE_NUM` is propagated from `/do`'s Pre-flight pre-parse (set only when
-the description referenced an issue and `--force` overrode the
-`/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is empty (the
-common /do case). The claim is released in `/do` Phase 5 Report (the
-universal terminal for both auto and non-auto exits).
+**Claim the issue(s) (when `${#ISSUE_NUMS[@]} -gt 0`).** After the
+worktree exists and `PIPELINE_ID="do.${TASK_SLUG}"` is set, fan out the
+`claim-issue.sh` acquire across every element of `ISSUE_NUMS` BEFORE
+dispatching the implementation agent — this stops a concurrent
+`/fix-issues` cron from double-working any of the same issues.
+`ISSUE_NUMS` is propagated from `/do`'s Pre-flight pre-parse (populated
+only when the description referenced one or more issues and `--force`
+overrode the `/fix-issues` redirect). Skip entirely when `ISSUE_NUMS` is
+empty (the common /do case). The claims are released in `/do` Phase 5
+Report (the universal terminal for both auto and non-auto exits).
+**Partial-acquire rollback:** if any acquire returns rc=10 (foreign-held)
+on issue K, release issues 1..K-1 (acquired earlier in this loop) before
+declining. Same rollback applies on rc=11/2/* failures so we never leave
+orphaned partial claims.
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -77,17 +82,28 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-if [ -n "${ISSUE_NUM:-}" ]; then
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 ```
 

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.31+9063b5"
+  version: "2026.05.31+c444a9"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -146,23 +146,61 @@ DESCRIPTION="${DESCRIPTION#"${DESCRIPTION%%[![:space:]]*}"}"
 DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 
 # Issue-number parse (claim-work-item Phase 2 / W2.4). /quickfix usually
-# works an in-flight edit, not an issue — but when the description begins
-# with a `#N` reference (optionally preceded by a close-keyword:
-# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
-# insensitive) extract the bare integer into ISSUE_NUM so WI 1.8 can
-# claim the issue via claim-issue.sh. The regex is ANCHORED to the start
-# of the description so a `#NNN` literal appearing later in prose (e.g.,
-# a quoted example, a line reference, a follow-up "see also #N") does
-# NOT set ISSUE_NUM. When no issue reference is in scope (the common
-# case) ISSUE_NUM stays empty and nothing is claimed. claim-issue.sh
+# works an in-flight edit, not an issue — but when the description
+# references one or more `#N` issues, collect them all into ISSUE_NUMS so
+# WI 1.8 can fan-out the claim acquire across every closed issue. The
+# leading match is ANCHORED to the start of the description (optionally
+# preceded by a close-keyword: close/closes/closed/fix/fixes/fixed/
+# resolve/resolves/resolved, case-insensitive). Subsequent matches
+# recognize TWO boundary classes:
+#   - STRONG separators (`/`, `+`, `&`) — bare `#N` allowed because
+#     these don't naturally appear in English prose before a `#`
+#     reference. Canonical patterns: "fix #N + #M", "Closes #N / Closes
+#     #M", "fix #N & #M".
+#   - WEAK separators (`,`, `;`, ` and `, ` or `) — require an explicit
+#     close-keyword between the separator and `#N`. This blocks
+#     "Closes #832, see also #999" from accidentally claiming #999.
+# When no issue reference is in scope (the common case) ISSUE_NUMS stays
+# empty and nothing is claimed. ISSUE_NUM is kept as a back-compat
+# scalar (= ISSUE_NUMS[0] when non-empty, else empty). claim-issue.sh
 # rejects non-numeric input with exit 2; the `[0-9]+` capture guarantees
 # a bare integer.
-ISSUE_NUM=""
-if [[ "$DESCRIPTION" =~ ^[[:space:]]*([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[3]}"
+ISSUE_NUMS=()
+_QF_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+# Leading anchored match (no leading-quote tolerance: /quickfix runs after
+# the quoted-head carve-out has already normalized the description).
+if [[ "$DESCRIPTION" =~ ^[[:space:]]*${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
 elif [[ "$DESCRIPTION" =~ ^[[:space:]]*#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
+# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
+# 4=digit capture.
+_QF_REMAINING="$DESCRIPTION"
+while [[ "$_QF_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_QF_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
+# close-keyword before `#N`. BASH_REMATCH groups: 1=outer separator,
+# 2=and/or word, 3=kw outer, 4=kw inner, 5=digit capture.
+_QF_REMAINING="$DESCRIPTION"
+while [[ "$_QF_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+  _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Dedupe preserving first-seen order.
+declare -A _QF_SEEN=()
+_QF_UNIQUE=()
+for _n in "${ISSUE_NUMS[@]:-}"; do
+  [ -z "$_n" ] && continue
+  if [ -z "${_QF_SEEN[$_n]:-}" ]; then _QF_UNIQUE+=("$_n"); _QF_SEEN[$_n]=1; fi
+done
+ISSUE_NUMS=("${_QF_UNIQUE[@]}")
+unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _n
+# Back-compat scalar (= first claimed issue, or empty when none).
+ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 ```
 
 ## Phase 1 — Pre-flight
@@ -378,7 +416,7 @@ text and dirty-tree shape, no LOC counting:
 | `/quickfix update CHANGELOG with v0.5 release notes` | PROCEED | concrete verb + object + file |
 | `/quickfix add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/quickfix improve` | REDIRECT → ask user | vague verb, no object |
-| `/quickfix Fix #853 typo` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
+| `/quickfix Fix #853 typo` | PROCEED | issue-numbered descriptions claim the issue(s) via ISSUE_NUMS and proceed |
 
 Output one of:
 
@@ -704,24 +742,38 @@ branch: $BRANCH
 date: $NOW_ISO
 MARK
 
-# Issue claim (claim-work-item Phase 2 / W2.4). Acquire here — where
+# Issue claim(s) (claim-work-item Phase 2 / W2.4). Acquire here — where
 # PIPELINE_ID is established and the `started` marker is written — and
-# BEFORE branch creation (WI 1.9). Only when the description referenced an
-# issue (ISSUE_NUM non-empty, parsed in WI 1.2); skip otherwise (the common
-# /quickfix case). This stops a concurrent /fix-issues cron from
-# double-working the same issue. Released in the Phase 7 explicit-finalize
-# and the fail-finalize abandon sites (test fail, commit fail, push fail).
-if [ -n "${ISSUE_NUM:-}" ]; then
+# BEFORE branch creation (WI 1.9). Only when the description referenced
+# one or more issues (ISSUE_NUMS non-empty, parsed in WI 1.2); skip
+# otherwise (the common /quickfix case). This stops a concurrent
+# /fix-issues cron from double-working any of the same issues. Released in
+# the Phase 7 explicit-finalize and the fail-finalize abandon sites (test
+# fail, commit fail, push fail). Partial-acquire rollback: if any acquire
+# returns rc=10/11/2/* on issue K, release issues 1..K-1 acquired earlier
+# in this loop before declining/stopping.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 
 # Explicit-finalize pattern (Plan LAND_PR_BYPASS_HARDENING Phase 2; issue
@@ -791,13 +843,13 @@ context cost of the entire lifecycle up front:
    `modes/execute.md`** for Phases 3–6 (make the change → test gate →
    commit → verify → push). The shared shell variables established above
    (`$MODE`, `$SLUG`, `$BRANCH`, `$BASE_BRANCH`, `$MARKER`, `$PIPELINE_ID`,
-   `$ZSKILLS_PIPELINE_ID`, `$ISSUE_NUM`, `$CHANGED_FILES`, `$DELS`,
-   `$COMMIT_SUBJECT`) all survive into those phases via the persistent
-   shell.
+   `$ZSKILLS_PIPELINE_ID`, `$ISSUE_NUMS` (+ back-compat `$ISSUE_NUM`),
+   `$CHANGED_FILES`, `$DELS`, `$COMMIT_SUBJECT`) all survive into those
+   phases via the persistent shell.
 2. **Then read `modes/land.md`** for Phase 7 (PR creation, CI poll, and
    the fix-cycle dispatched via `/land-pr`), which consumes
    `$PR_TITLE`, `$BRANCH`, `$BASE_BRANCH`, `$MARKER`, `$SLUG`,
-   `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUM`.
+   `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUMS`.
 3. **Exit codes and Key Rules** live in `references/exit-codes-and-rules.md`.
 
 Read these in order; do not skip ahead. Phases 3–7 are a single

--- a/.claude/skills/quickfix/modes/execute.md
+++ b/.claude/skills/quickfix/modes/execute.md
@@ -3,7 +3,8 @@
 > Execution modes for `/quickfix`, loaded after Phase 2 mode detection +
 > branch creation in `SKILL.md`. The persistent shell carries `$MODE`,
 > `$SLUG`, `$BRANCH`, `$BASE_BRANCH`, `$MARKER`, `$PIPELINE_ID`,
-> `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUM` from Phase 2 into these phases.
+> `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUMS` (+ back-compat `$ISSUE_NUM`)
+> from Phase 2 into these phases.
 > After Phase 6 (push), read `modes/land.md` for Phase 7.
 
 ## Phase 3 — Make the change
@@ -124,10 +125,13 @@ else
     fi
     # Explicit fail-finalize (issue #241).
     [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-    # Release the issue claim (only if one was acquired at WI 1.8) — this
-    # abandon path is after the acquire and before the Phase 7 finalize.
-    if [ -n "${ISSUE_NUM:-}" ]; then
-      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    # Release the issue claim(s) (only if any were acquired at WI 1.8) —
+    # this abandon path is after the acquire and before the Phase 7 finalize.
+    if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+      for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+        bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+      done
+      unset _ISSUE_N
     fi
     exit 4
   fi
@@ -263,9 +267,12 @@ if ! git commit -m "$COMMIT_BODY"; then
   fi
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-  # Release the issue claim (only if one was acquired at WI 1.8).
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  # Release the issue claim(s) (only if any were acquired at WI 1.8).
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 5
 fi
@@ -336,9 +343,12 @@ if ! git push -u origin "$BRANCH"; then
   echo "ERROR: git push failed. Branch '$BRANCH' and its commit are intact locally; retry manually once the remote is reachable." >&2
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-  # Release the issue claim (only if one was acquired at WI 1.8).
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  # Release the issue claim(s) (only if any were acquired at WI 1.8).
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 5
 fi

--- a/.claude/skills/quickfix/modes/land.md
+++ b/.claude/skills/quickfix/modes/land.md
@@ -3,8 +3,9 @@
 > Final phase of the `/quickfix` lifecycle, loaded after `modes/execute.md`
 > pushes the branch (Phase 6). The persistent shell carries `$PR_TITLE`
 > (composed model-layer below), `$BRANCH`, `$BASE_BRANCH`, `$MARKER`,
-> `$SLUG`, `$PIPELINE_ID`, `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUM` from
-> the earlier phases. Exit codes + Key Rules live in
+> `$SLUG`, `$PIPELINE_ID`, `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUMS` (+
+> back-compat `$ISSUE_NUM`) from the earlier phases. Exit codes + Key
+> Rules live in
 > `references/exit-codes-and-rules.md`.
 
 ## Phase 7 — PR creation, CI poll, fix-cycle (WI 1.15) — dispatch `/land-pr`
@@ -132,10 +133,13 @@ while :; do
     # and runs correctly when called by a parent pipeline. Mirrors the
     # `[ -n "${ZSKILLS_PIPELINE_ID:-}" ]` guard at line 1310 below.
     [ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
-    # Release the issue claim (only if one was acquired at WI 1.8). This
-    # early exit bypasses the end-of-fence explicit-finalize release.
-    if [ -n "${ISSUE_NUM:-}" ]; then
-      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    # Release the issue claim(s) (only if any were acquired at WI 1.8).
+    # This early exit bypasses the end-of-fence explicit-finalize release.
+    if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+      for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+        bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+      done
+      unset _ISSUE_N
     fi
     exit 5
   fi
@@ -363,16 +367,21 @@ else
     -exec sh -c 'rm -f "$1"/requires.land-pr.*' _ {} \;
 fi
 
-# Release the issue claim (claim-work-item Phase 2 / W2.4) — only if one
-# was acquired at WI 1.8 (ISSUE_NUM survives in the persistent shell).
-# Release-on-resolution regardless of created vs merged vs pr-ready: the
-# /quickfix invocation is terminating either way and /quickfix is one-shot
-# (no later fire re-releases). $PIPELINE_ID = quickfix.$SLUG; reconstruct
-# from $ZSKILLS_PIPELINE_ID if it didn't survive across fences.
-if [ -n "${ISSUE_NUM:-}" ]; then
+# Release the issue claim(s) (claim-work-item Phase 2 / W2.4) — only if
+# any were acquired at WI 1.8 (ISSUE_NUMS survives in the persistent
+# shell). Release-on-resolution regardless of created vs merged vs
+# pr-ready: the /quickfix invocation is terminating either way and
+# /quickfix is one-shot (no later fire re-releases). $PIPELINE_ID =
+# quickfix.$SLUG; reconstruct from $ZSKILLS_PIPELINE_ID if it didn't
+# survive across fences. Releases are idempotent per claim-issue.sh, so
+# any claim already released by an upstream inline-release no-ops here.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   _RELEASE_PIPELINE="${PIPELINE_ID:-${ZSKILLS_PIPELINE_ID:-}}"
   if [ -n "$_RELEASE_PIPELINE" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$_RELEASE_PIPELINE"
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$_RELEASE_PIPELINE"
+    done
+    unset _ISSUE_N
   fi
 fi
 ```

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+12f9ca"
+  version: "2026.05.31+065fb4"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -228,25 +228,68 @@ AUTO_FLAG=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
   AUTO_FLAG=1
 fi
-# Issue-number parse (claim-work-item Phase 2 / W2.2). When the description
-# begins with a `#N` reference (optionally preceded by a close-keyword:
-# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
-# insensitive) extract the bare integer into ISSUE_NUM so the mode files
-# can claim the issue via claim-issue.sh. The regex is ANCHORED to the
-# start of the description so a `#NNN` literal appearing later in prose
-# (e.g., a quoted example, a line reference, a follow-up "see also #N")
-# does NOT set ISSUE_NUM. An optional leading double-quote is tolerated so
-# /do's quoted-description carve-out (`/do "Fix #N ..."`) still matches.
-# When no issue reference is in scope (the common /do case) ISSUE_NUM
-# stays empty and the mode files claim nothing. claim-issue.sh rejects
-# non-numeric input with exit 2; the `[0-9]+` capture guarantees a bare
-# integer.
-ISSUE_NUM=""
-if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[3]}"
+# Issue-number parse (claim-work-item Phase 2 / W2.2). Collect ALL `#N`
+# references in the description into the ISSUE_NUMS array so the mode
+# files can fan-out the claim acquire across every closed issue. The
+# leading match is ANCHORED to the start of the description (optionally
+# preceded by a close-keyword: close/closes/closed/fix/fixes/fixed/
+# resolve/resolves/resolved, case-insensitive; an optional leading
+# double-quote is tolerated for /do's quoted-description carve-out
+# `/do "Fix #N ..."`). Subsequent matches recognize TWO boundary
+# classes:
+#   - STRONG separators (`/`, `+`, `&`) — bare `#N` allowed because
+#     these don't naturally appear in English prose before a `#`
+#     reference. Canonical patterns: "fix #N + #M", "Closes #N / Closes
+#     #M", "fix #N & #M".
+#   - WEAK separators (`,`, `;`, ` and `, ` or `) — require an explicit
+#     close-keyword between the separator and `#N`. This is what blocks
+#     "Closes #832, see also #999" from accidentally claiming #999
+#     (comma is a normal prose punctuator, so bare `#N` after it would
+#     over-capture) while still accepting "Closes #832, Closes #833".
+# When no issue reference is in scope (the common /do case) ISSUE_NUMS
+# stays empty and the mode files claim nothing. ISSUE_NUM is kept as a
+# back-compat scalar (= ISSUE_NUMS[0] when non-empty, else empty).
+# claim-issue.sh rejects non-numeric input with exit 2; the `[0-9]+`
+# capture guarantees a bare integer.
+ISSUE_NUMS=()
+_DO_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+# Leading anchored match (optional close-keyword, optional leading quote).
+if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
 elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
+# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
+# 4=digit capture.
+_DO_REMAINING="$ARGUMENTS"
+while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
+# close-keyword before `#N` so prose like "Closes #N, see also #M" doesn't
+# over-capture #M. BASH_REMATCH groups: 1=outer separator, 2=and/or word,
+# 3=kw outer, 4=kw inner, 5=digit capture.
+_DO_REMAINING="$ARGUMENTS"
+while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+  _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Dedupe preserving first-seen order (acquire is order-dependent for the
+# partial-rollback contract; releases are idempotent per claim-issue.sh).
+declare -A _DO_SEEN=()
+_DO_UNIQUE=()
+for _n in "${ISSUE_NUMS[@]:-}"; do
+  [ -z "$_n" ] && continue
+  if [ -z "${_DO_SEEN[$_n]:-}" ]; then _DO_UNIQUE+=("$_n"); _DO_SEEN[$_n]=1; fi
+done
+ISSUE_NUMS=("${_DO_UNIQUE[@]}")
+unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _n
+# Back-compat scalar (= first claimed issue, or empty when none). Mode
+# files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
+# iterates "${ISSUE_NUMS[@]}".
+ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
 # `/do fix the bug --rounds in production` would otherwise capture "in" as
@@ -320,7 +363,7 @@ needed).
 | `/do Update the presentation with Phase 3 results auto` | PROCEED | concrete verb + object |
 | `/do add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/do improve` | REDIRECT → ask user | vague verb, no object |
-| `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
+| `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue(s) via ISSUE_NUMS and proceed |
 
 Output one of:
 
@@ -741,12 +784,14 @@ procedure end-to-end**. Do not proceed until you have read the file.
 | `worktree`     | B    | [modes/worktree.md](modes/worktree.md) |
 | `direct`       | C    | [modes/direct.md](modes/direct.md) |
 
-**`$ISSUE_NUM` propagates into the mode files** (set in the Pre-flight
-pre-parse). When non-empty, the mode file claims the issue via
-`claim-issue.sh` AFTER it constructs its `PIPELINE_ID` (the C1/M1 rule —
-never acquire before a non-empty PIPELINE_ID exists). The acquire is NEVER
-placed here in SKILL.md before mode dispatch: PIPELINE_ID is empty at this
-point, so `--pipeline-id ""` would fail usage-error exit 2.
+**`$ISSUE_NUMS` propagates into the mode files** (array set in the
+Pre-flight pre-parse; `$ISSUE_NUM` is kept as a back-compat scalar = the
+first element). When `${#ISSUE_NUMS[@]} -gt 0`, the mode file fans out
+the `claim-issue.sh` acquire across every element AFTER it constructs
+its `PIPELINE_ID` (the C1/M1 rule — never acquire before a non-empty
+PIPELINE_ID exists). The acquire is NEVER placed here in SKILL.md before
+mode dispatch: PIPELINE_ID is empty at this point, so `--pipeline-id ""`
+would fail usage-error exit 2.
 
 ## Phase 3 — Verify
 
@@ -882,14 +927,14 @@ Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invoca
 
 ## Phase 5 — Report
 
-**Release the issue claim (worktree/direct modes).** Phase 5 is the
+**Release the issue claim(s) (worktree/direct modes).** Phase 5 is the
 universal terminal reached on BOTH the `auto` and non-`auto` exits of
-worktree and direct modes — so the issue claim (acquired by the mode file
-when `$ISSUE_NUM` was non-empty) is released HERE, not in Phase 4 Land
-(which is `AUTO_FLAG=1`-gated and would leak the claim on the dominant
-non-auto path). PR mode (Path A) handles its own release inside
+worktree and direct modes — so the issue claims (acquired by the mode
+file when `${#ISSUE_NUMS[@]} -gt 0`) are released HERE, not in Phase 4
+Land (which is `AUTO_FLAG=1`-gated and would leak the claims on the
+dominant non-auto path). PR mode (Path A) handles its own release inside
 `modes/pr.md`'s finalize block and exits before reaching this section.
-Skip when no issue claim was acquired (the common /do case — `$ISSUE_NUM`
+Skip when no issue claim was acquired (the common /do case — `ISSUE_NUMS`
 empty):
 
 ```bash
@@ -898,11 +943,15 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-# $ISSUE_NUM (Pre-flight pre-parse) and $PIPELINE_ID (set in the mode file:
-# do.${TASK_SLUG}) survive in the persistent shell. The release is
-# ownership-safe via --require-pipeline.
-if [ -n "${ISSUE_NUM:-}" ] && [ -n "${PIPELINE_ID:-}" ]; then
-  bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+# $ISSUE_NUMS (Pre-flight pre-parse) and $PIPELINE_ID (set in the mode file:
+# do.${TASK_SLUG}) survive in the persistent shell. Release each claim in
+# order — releases are idempotent per claim-issue.sh, and ownership-safe via
+# --require-pipeline. Skip entirely when no issues were claimed.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ] && [ -n "${PIPELINE_ID:-}" ]; then
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+  done
+  unset _ISSUE_N
 fi
 ```
 
@@ -972,13 +1021,17 @@ Status: pr-ready | pr-ci-failing | landed
   `.landed` with `status: conflict` and exit with an error message.
 - **If stuck on anything:** report the state and ask the user for
   guidance. Do not retry the same approach in a loop.
-- **Release the issue claim on every abandon path (worktree/direct modes).**
-  When `$ISSUE_NUM` was non-empty and the mode file acquired a
-  `claim-issue.sh` claim, any error exit above (test failure, content
-  issue, cherry-pick conflict, push failure, task-too-big) MUST release it
-  before stopping so the next pipeline can pick the issue up:
-  `bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"`
-  (only if an issue claim was acquired — skip when `$ISSUE_NUM` is empty).
+- **Release the issue claim(s) on every abandon path (worktree/direct modes).**
+  When `${#ISSUE_NUMS[@]} -gt 0` and the mode file acquired
+  `claim-issue.sh` claims, any error exit above (test failure, content
+  issue, cherry-pick conflict, push failure, task-too-big) MUST release
+  each one before stopping so the next pipeline can pick the issue(s) up:
+  ```bash
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+  done
+  ```
+  (only if any claim was acquired — skip when `ISSUE_NUMS` is empty).
   PR mode's abandon-path releases live inside `modes/pr.md`.
 
 ## Key Rules

--- a/skills/do/modes/direct.md
+++ b/skills/do/modes/direct.md
@@ -7,16 +7,21 @@ Selected when the user passes `direct` explicitly, when `execution.landing`
 in `.claude/zskills-config.json` is `"direct"`, or as the fallback when
 no config is present. Work directly on main.
 
-**Claim the issue (when `$ISSUE_NUM` is non-empty).** Direct mode
+**Claim the issue(s) (when `${#ISSUE_NUMS[@]} -gt 0`).** Direct mode
 constructs no `TASK_SLUG`/`PIPELINE_ID` of its own, so synthesize a minimal
-`PIPELINE_ID="do.<bare-issue>"` (routed through the shared sanitizer)
-BEFORE acquiring the `claim-issue.sh` claim. This stops a concurrent
-`/fix-issues` cron from double-working the same issue. `$ISSUE_NUM` is
-propagated from `/do`'s Pre-flight pre-parse (set only when the description
-referenced an issue and `--force` overrode the `/fix-issues` redirect).
-Skip entirely when `$ISSUE_NUM` is empty (the common /do direct case —
-direct mode is rarely issue-driven). The claim is released in `/do` Phase 5
-Report.
+`PIPELINE_ID="do.<first-issue>"` (routed through the shared sanitizer)
+BEFORE acquiring the `claim-issue.sh` claims. This stops a concurrent
+`/fix-issues` cron from double-working the same issue(s). `ISSUE_NUMS` is
+propagated from `/do`'s Pre-flight pre-parse (populated only when the
+description referenced one or more issues and `--force` overrode the
+`/fix-issues` redirect). Skip entirely when `ISSUE_NUMS` is empty (the
+common /do direct case — direct mode is rarely issue-driven). The claims
+are released in `/do` Phase 5 Report. **Partial-acquire rollback:** if
+any acquire returns rc=10 (foreign-held) on issue K, the loop releases
+issues 1..K-1 (which this pipeline successfully acquired earlier in the
+loop) before exiting — the foreign holder keeps its claim, and this
+pipeline leaves no orphaned claims on the issues it had already grabbed.
+Same rollback applies on rc=11/2/* failures.
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -24,18 +29,29 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-if [ -n "${ISSUE_NUM:-}" ]; then
-  PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "do.$ISSUE_NUM")
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+  PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "do.${ISSUE_NUMS[0]}")
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 ```
 

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -96,17 +96,21 @@ fi
 ```
 Do NOT echo `ZSKILLS_PIPELINE_ID=do.${TASK_SLUG}` as shell output in the main session — the `.zskills-tracked` file in the worktree is the single source of truth.
 
-**Step A5.5 — Claim the issue (when `$ISSUE_NUM` is non-empty).** Now that
-`PIPELINE_ID="do.${TASK_SLUG}"` is set (A4) and the worktree exists (A5),
-acquire the `claim-issue.sh` claim BEFORE dispatching the implementation
-agent (A6). This stops a concurrent `/fix-issues` cron from double-working
-the same issue. `$ISSUE_NUM` is propagated from `/do`'s Pre-flight
-pre-parse (set only when the description referenced an issue and `--force`
-overrode the `/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is
-empty (the common /do pr case). The A1 slug guards and A5's `exit "$RC"`
-are PRE-acquire, so they need no release. The claim is released in the
-explicit-finalize block at the end of the caller loop (Step A8), and
-inline before every post-acquire-pre-finalize early exit.
+**Step A5.5 — Claim the issue(s) (when `${#ISSUE_NUMS[@]} -gt 0`).** Now
+that `PIPELINE_ID="do.${TASK_SLUG}"` is set (A4) and the worktree exists
+(A5), fan out the `claim-issue.sh` acquire across every element of
+`ISSUE_NUMS` BEFORE dispatching the implementation agent (A6). This stops
+a concurrent `/fix-issues` cron from double-working any of the same
+issues. `ISSUE_NUMS` is propagated from `/do`'s Pre-flight pre-parse
+(populated only when the description referenced one or more issues and
+`--force` overrode the `/fix-issues` redirect). Skip entirely when
+`ISSUE_NUMS` is empty (the common /do pr case). The A1 slug guards and
+A5's `exit "$RC"` are PRE-acquire, so they need no release. The claims are
+released in the explicit-finalize block at the end of the caller loop
+(Step A8), and inline before every post-acquire-pre-finalize early exit.
+**Partial-acquire rollback:** if any acquire returns rc=10 (foreign-held)
+on issue K, release issues 1..K-1 (acquired earlier in this loop) before
+declining. Same rollback applies on rc=11/2/* failures.
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -114,17 +118,28 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-if [ -n "${ISSUE_NUM:-}" ]; then
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 ```
 
@@ -202,17 +217,23 @@ cd "$WORKTREE_PATH"
 if [ -z "${PR_TITLE:-}" ]; then
   echo "ERROR: PR_TITLE not set — model-layer composition step skipped." >&2
   # C2 inline-release: this exit is AFTER the Step A5.5 acquire and BEFORE
-  # the explicit-finalize block, so release the issue claim (only if one
-  # was acquired) before bailing or it leaks.
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  # the explicit-finalize block, so release the issue claim(s) (only if any
+  # were acquired) before bailing or they leak.
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 5
 fi
 if [[ "$PR_TITLE" == *$'\n'* ]] || [ ${#PR_TITLE} -gt 60 ] || [[ "$PR_TITLE" != do:\ * ]]; then
   echo "ERROR: PR_TITLE must be a single line ≤60 chars starting with 'do: ' (got '$PR_TITLE')." >&2
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 2
 fi
@@ -333,9 +354,12 @@ while :; do
     rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
     sed -i "s/^status: started$/status: failed/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
     # C2 inline-release: post-acquire, pre-finalize early exit — release
-    # the issue claim (only if one was acquired) or it leaks.
-    if [ -n "${ISSUE_NUM:-}" ]; then
-      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    # the issue claim(s) (only if any were acquired) or they leak.
+    if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+      for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+        bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+      done
+      unset _ISSUE_N
     fi
     exit 1
   fi
@@ -503,13 +527,13 @@ esac
 sed -i "s/^status: started$/status: $FINAL/" "$TRACK_DIR/fulfilled.do.$TASK_SLUG"
 rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
 
-# Release the issue claim based on LAND_OUTCOME (mirrors
+# Release the issue claim(s) based on LAND_OUTCOME (mirrors
 # fix-issues/modes/pr.md:337-345 so the two skills evolve in lockstep).
-# Only if an issue claim was acquired in Step A5.5. $PIPELINE_ID =
+# Only if issue claims were acquired in Step A5.5. $PIPELINE_ID =
 # do.$TASK_SLUG is re-resolved at the tracking-setup fence-top above and
 # survives in this fence.
 #
-# Three groups (issue #864):
+# Three groups (issue #864) × ISSUE_NUMS fan-out (issue #863):
 #   - merged          → RELEASE (work is durably on main).
 #   - pr-ready|created→ HOLD: the PR is OPEN on the remote awaiting human
 #                       review/merge; releasing here would let a concurrent
@@ -522,20 +546,26 @@ rm -f "$TRACK_DIR/requires.land-pr.$TASK_SLUG"
 #                       and same shape as fix-issues PR mode's `created`
 #                       arm at fix-issues/modes/pr.md:342-343).
 #   - terminal-failure→ RELEASE (PR is dead-on-arrival; nothing to guard).
-if [ -n "${ISSUE_NUM:-}" ]; then
+#
+# Releases are idempotent per claim-issue.sh, so any claim already
+# released by an inline-release early-exit upstream no-ops here.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  case "$LAND_OUTCOME" in
-    merged)
-      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
-        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
-    pr-ready|created)
-      echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $ISSUE_NUM' if the PR never lands" >&2 ;;
-    pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
-      bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
-        || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
-    *)
-      echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$ISSUE_NUM; defaulting to HOLD" >&2 ;;
-  esac
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    case "$LAND_OUTCOME" in
+      merged)
+        bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
+          || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;
+      pr-ready|created)
+        echo "do: holding claim for #$_ISSUE_N (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $_ISSUE_N' if the PR never lands" >&2 ;;
+      pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
+        bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
+          || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;
+      *)
+        echo "do: unknown LAND_OUTCOME=$LAND_OUTCOME for #$_ISSUE_N; defaulting to HOLD" >&2 ;;
+    esac
+  done
+  unset _ISSUE_N
 fi
 ```
 

--- a/skills/do/modes/worktree.md
+++ b/skills/do/modes/worktree.md
@@ -61,15 +61,20 @@ if [ "${rc:-0}" = "2" ]; then
 fi
 ```
 
-**Claim the issue (when `$ISSUE_NUM` is non-empty).** After the worktree
-exists and `PIPELINE_ID="do.${TASK_SLUG}"` is set, acquire the
-`claim-issue.sh` claim BEFORE dispatching the implementation agent — this
-stops a concurrent `/fix-issues` cron from double-working the same issue.
-`$ISSUE_NUM` is propagated from `/do`'s Pre-flight pre-parse (set only when
-the description referenced an issue and `--force` overrode the
-`/fix-issues` redirect). Skip entirely when `$ISSUE_NUM` is empty (the
-common /do case). The claim is released in `/do` Phase 5 Report (the
-universal terminal for both auto and non-auto exits).
+**Claim the issue(s) (when `${#ISSUE_NUMS[@]} -gt 0`).** After the
+worktree exists and `PIPELINE_ID="do.${TASK_SLUG}"` is set, fan out the
+`claim-issue.sh` acquire across every element of `ISSUE_NUMS` BEFORE
+dispatching the implementation agent — this stops a concurrent
+`/fix-issues` cron from double-working any of the same issues.
+`ISSUE_NUMS` is propagated from `/do`'s Pre-flight pre-parse (populated
+only when the description referenced one or more issues and `--force`
+overrode the `/fix-issues` redirect). Skip entirely when `ISSUE_NUMS` is
+empty (the common /do case). The claims are released in `/do` Phase 5
+Report (the universal terminal for both auto and non-auto exits).
+**Partial-acquire rollback:** if any acquire returns rc=10 (foreign-held)
+on issue K, release issues 1..K-1 (acquired earlier in this loop) before
+declining. Same rollback applies on rc=11/2/* failures so we never leave
+orphaned partial claims.
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -77,17 +82,28 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update
 else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-if [ -n "${ISSUE_NUM:-}" ]; then
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 ```
 

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.31+9063b5"
+  version: "2026.05.31+c444a9"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -146,23 +146,61 @@ DESCRIPTION="${DESCRIPTION#"${DESCRIPTION%%[![:space:]]*}"}"
 DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 
 # Issue-number parse (claim-work-item Phase 2 / W2.4). /quickfix usually
-# works an in-flight edit, not an issue — but when the description begins
-# with a `#N` reference (optionally preceded by a close-keyword:
-# close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved, case-
-# insensitive) extract the bare integer into ISSUE_NUM so WI 1.8 can
-# claim the issue via claim-issue.sh. The regex is ANCHORED to the start
-# of the description so a `#NNN` literal appearing later in prose (e.g.,
-# a quoted example, a line reference, a follow-up "see also #N") does
-# NOT set ISSUE_NUM. When no issue reference is in scope (the common
-# case) ISSUE_NUM stays empty and nothing is claimed. claim-issue.sh
+# works an in-flight edit, not an issue — but when the description
+# references one or more `#N` issues, collect them all into ISSUE_NUMS so
+# WI 1.8 can fan-out the claim acquire across every closed issue. The
+# leading match is ANCHORED to the start of the description (optionally
+# preceded by a close-keyword: close/closes/closed/fix/fixes/fixed/
+# resolve/resolves/resolved, case-insensitive). Subsequent matches
+# recognize TWO boundary classes:
+#   - STRONG separators (`/`, `+`, `&`) — bare `#N` allowed because
+#     these don't naturally appear in English prose before a `#`
+#     reference. Canonical patterns: "fix #N + #M", "Closes #N / Closes
+#     #M", "fix #N & #M".
+#   - WEAK separators (`,`, `;`, ` and `, ` or `) — require an explicit
+#     close-keyword between the separator and `#N`. This blocks
+#     "Closes #832, see also #999" from accidentally claiming #999.
+# When no issue reference is in scope (the common case) ISSUE_NUMS stays
+# empty and nothing is claimed. ISSUE_NUM is kept as a back-compat
+# scalar (= ISSUE_NUMS[0] when non-empty, else empty). claim-issue.sh
 # rejects non-numeric input with exit 2; the `[0-9]+` capture guarantees
 # a bare integer.
-ISSUE_NUM=""
-if [[ "$DESCRIPTION" =~ ^[[:space:]]*([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[3]}"
+ISSUE_NUMS=()
+_QF_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+# Leading anchored match (no leading-quote tolerance: /quickfix runs after
+# the quoted-head carve-out has already normalized the description).
+if [[ "$DESCRIPTION" =~ ^[[:space:]]*${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
 elif [[ "$DESCRIPTION" =~ ^[[:space:]]*#([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[1]}"
+  ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
+# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
+# 4=digit capture.
+_QF_REMAINING="$DESCRIPTION"
+while [[ "$_QF_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_QF_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
+# close-keyword before `#N`. BASH_REMATCH groups: 1=outer separator,
+# 2=and/or word, 3=kw outer, 4=kw inner, 5=digit capture.
+_QF_REMAINING="$DESCRIPTION"
+while [[ "$_QF_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+  _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
+done
+# Dedupe preserving first-seen order.
+declare -A _QF_SEEN=()
+_QF_UNIQUE=()
+for _n in "${ISSUE_NUMS[@]:-}"; do
+  [ -z "$_n" ] && continue
+  if [ -z "${_QF_SEEN[$_n]:-}" ]; then _QF_UNIQUE+=("$_n"); _QF_SEEN[$_n]=1; fi
+done
+ISSUE_NUMS=("${_QF_UNIQUE[@]}")
+unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _n
+# Back-compat scalar (= first claimed issue, or empty when none).
+ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 ```
 
 ## Phase 1 — Pre-flight
@@ -378,7 +416,7 @@ text and dirty-tree shape, no LOC counting:
 | `/quickfix update CHANGELOG with v0.5 release notes` | PROCEED | concrete verb + object + file |
 | `/quickfix add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/quickfix improve` | REDIRECT → ask user | vague verb, no object |
-| `/quickfix Fix #853 typo` | PROCEED | issue-numbered descriptions claim the issue via ISSUE_NUM and proceed |
+| `/quickfix Fix #853 typo` | PROCEED | issue-numbered descriptions claim the issue(s) via ISSUE_NUMS and proceed |
 
 Output one of:
 
@@ -704,24 +742,38 @@ branch: $BRANCH
 date: $NOW_ISO
 MARK
 
-# Issue claim (claim-work-item Phase 2 / W2.4). Acquire here — where
+# Issue claim(s) (claim-work-item Phase 2 / W2.4). Acquire here — where
 # PIPELINE_ID is established and the `started` marker is written — and
-# BEFORE branch creation (WI 1.9). Only when the description referenced an
-# issue (ISSUE_NUM non-empty, parsed in WI 1.2); skip otherwise (the common
-# /quickfix case). This stops a concurrent /fix-issues cron from
-# double-working the same issue. Released in the Phase 7 explicit-finalize
-# and the fail-finalize abandon sites (test fail, commit fail, push fail).
-if [ -n "${ISSUE_NUM:-}" ]; then
+# BEFORE branch creation (WI 1.9). Only when the description referenced
+# one or more issues (ISSUE_NUMS non-empty, parsed in WI 1.2); skip
+# otherwise (the common /quickfix case). This stops a concurrent
+# /fix-issues cron from double-working any of the same issues. Released in
+# the Phase 7 explicit-finalize and the fail-finalize abandon sites (test
+# fail, commit fail, push fail). Partial-acquire rollback: if any acquire
+# returns rc=10/11/2/* on issue K, release issues 1..K-1 acquired earlier
+# in this loop before declining/stopping.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
-  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
-  ACQ_RC=$?
-  case "$ACQ_RC" in
-    0)  : ;;  # acquired (fresh or self-re-entry) — proceed
-    10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining." >&2; exit 0 ;;
-    11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-    2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM) — internal bug; stopping." >&2; exit 1 ;;
-    *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM; stopping." >&2; exit 1 ;;
-  esac
+  _ACQUIRED=()
+  for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+    bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"
+    ACQ_RC=$?
+    case "$ACQ_RC" in
+      0)  _ACQUIRED+=("$ISSUE_NUM") ;;  # acquired (fresh or self-re-entry) — proceed
+      10|11|2|*)
+        # Partial-acquire rollback: release everything this pipeline grabbed earlier in this loop.
+        for _RB in "${_ACQUIRED[@]}"; do
+          bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID"
+        done
+        case "$ACQ_RC" in
+          10) echo "issue #$ISSUE_NUM is being worked by another pipeline; declining (released ${#_ACQUIRED[@]} prior claim(s))." >&2; exit 0 ;;
+          11) echo "claim-issue.sh: filesystem error acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+          2)  echo "claim-issue.sh: usage error (empty PIPELINE_ID or non-numeric ISSUE_NUM=$ISSUE_NUM; released ${#_ACQUIRED[@]} prior claim(s)) — internal bug; stopping." >&2; exit 1 ;;
+          *)  echo "claim-issue.sh: unexpected exit $ACQ_RC acquiring issue #$ISSUE_NUM (released ${#_ACQUIRED[@]} prior claim(s)); stopping." >&2; exit 1 ;;
+        esac ;;
+    esac
+  done
+  unset _ACQUIRED _RB
 fi
 
 # Explicit-finalize pattern (Plan LAND_PR_BYPASS_HARDENING Phase 2; issue
@@ -791,13 +843,13 @@ context cost of the entire lifecycle up front:
    `modes/execute.md`** for Phases 3–6 (make the change → test gate →
    commit → verify → push). The shared shell variables established above
    (`$MODE`, `$SLUG`, `$BRANCH`, `$BASE_BRANCH`, `$MARKER`, `$PIPELINE_ID`,
-   `$ZSKILLS_PIPELINE_ID`, `$ISSUE_NUM`, `$CHANGED_FILES`, `$DELS`,
-   `$COMMIT_SUBJECT`) all survive into those phases via the persistent
-   shell.
+   `$ZSKILLS_PIPELINE_ID`, `$ISSUE_NUMS` (+ back-compat `$ISSUE_NUM`),
+   `$CHANGED_FILES`, `$DELS`, `$COMMIT_SUBJECT`) all survive into those
+   phases via the persistent shell.
 2. **Then read `modes/land.md`** for Phase 7 (PR creation, CI poll, and
    the fix-cycle dispatched via `/land-pr`), which consumes
    `$PR_TITLE`, `$BRANCH`, `$BASE_BRANCH`, `$MARKER`, `$SLUG`,
-   `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUM`.
+   `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUMS`.
 3. **Exit codes and Key Rules** live in `references/exit-codes-and-rules.md`.
 
 Read these in order; do not skip ahead. Phases 3–7 are a single

--- a/skills/quickfix/modes/execute.md
+++ b/skills/quickfix/modes/execute.md
@@ -3,7 +3,8 @@
 > Execution modes for `/quickfix`, loaded after Phase 2 mode detection +
 > branch creation in `SKILL.md`. The persistent shell carries `$MODE`,
 > `$SLUG`, `$BRANCH`, `$BASE_BRANCH`, `$MARKER`, `$PIPELINE_ID`,
-> `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUM` from Phase 2 into these phases.
+> `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUMS` (+ back-compat `$ISSUE_NUM`)
+> from Phase 2 into these phases.
 > After Phase 6 (push), read `modes/land.md` for Phase 7.
 
 ## Phase 3 — Make the change
@@ -124,10 +125,13 @@ else
     fi
     # Explicit fail-finalize (issue #241).
     [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-    # Release the issue claim (only if one was acquired at WI 1.8) — this
-    # abandon path is after the acquire and before the Phase 7 finalize.
-    if [ -n "${ISSUE_NUM:-}" ]; then
-      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    # Release the issue claim(s) (only if any were acquired at WI 1.8) —
+    # this abandon path is after the acquire and before the Phase 7 finalize.
+    if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+      for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+        bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+      done
+      unset _ISSUE_N
     fi
     exit 4
   fi
@@ -263,9 +267,12 @@ if ! git commit -m "$COMMIT_BODY"; then
   fi
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-  # Release the issue claim (only if one was acquired at WI 1.8).
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  # Release the issue claim(s) (only if any were acquired at WI 1.8).
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 5
 fi
@@ -336,9 +343,12 @@ if ! git push -u origin "$BRANCH"; then
   echo "ERROR: git push failed. Branch '$BRANCH' and its commit are intact locally; retry manually once the remote is reachable." >&2
   # Explicit fail-finalize (issue #241).
   [ -f "$MARKER" ] && sed -i "s/^status: started$/status: failed/" "$MARKER"
-  # Release the issue claim (only if one was acquired at WI 1.8).
-  if [ -n "${ISSUE_NUM:-}" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+  # Release the issue claim(s) (only if any were acquired at WI 1.8).
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+    done
+    unset _ISSUE_N
   fi
   exit 5
 fi

--- a/skills/quickfix/modes/land.md
+++ b/skills/quickfix/modes/land.md
@@ -3,8 +3,9 @@
 > Final phase of the `/quickfix` lifecycle, loaded after `modes/execute.md`
 > pushes the branch (Phase 6). The persistent shell carries `$PR_TITLE`
 > (composed model-layer below), `$BRANCH`, `$BASE_BRANCH`, `$MARKER`,
-> `$SLUG`, `$PIPELINE_ID`, `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUM` from
-> the earlier phases. Exit codes + Key Rules live in
+> `$SLUG`, `$PIPELINE_ID`, `$ZSKILLS_PIPELINE_ID`, and `$ISSUE_NUMS` (+
+> back-compat `$ISSUE_NUM`) from the earlier phases. Exit codes + Key
+> Rules live in
 > `references/exit-codes-and-rules.md`.
 
 ## Phase 7 — PR creation, CI poll, fix-cycle (WI 1.15) — dispatch `/land-pr`
@@ -132,10 +133,13 @@ while :; do
     # and runs correctly when called by a parent pipeline. Mirrors the
     # `[ -n "${ZSKILLS_PIPELINE_ID:-}" ]` guard at line 1310 below.
     [ -n "${ZSKILLS_PIPELINE_ID:-}" ] && rm -f "$MAIN_ROOT/.zskills/tracking/$ZSKILLS_PIPELINE_ID/requires.land-pr.$SLUG" 2>/dev/null
-    # Release the issue claim (only if one was acquired at WI 1.8). This
-    # early exit bypasses the end-of-fence explicit-finalize release.
-    if [ -n "${ISSUE_NUM:-}" ]; then
-      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"
+    # Release the issue claim(s) (only if any were acquired at WI 1.8).
+    # This early exit bypasses the end-of-fence explicit-finalize release.
+    if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+      for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+        bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+      done
+      unset _ISSUE_N
     fi
     exit 5
   fi
@@ -363,16 +367,21 @@ else
     -exec sh -c 'rm -f "$1"/requires.land-pr.*' _ {} \;
 fi
 
-# Release the issue claim (claim-work-item Phase 2 / W2.4) — only if one
-# was acquired at WI 1.8 (ISSUE_NUM survives in the persistent shell).
-# Release-on-resolution regardless of created vs merged vs pr-ready: the
-# /quickfix invocation is terminating either way and /quickfix is one-shot
-# (no later fire re-releases). $PIPELINE_ID = quickfix.$SLUG; reconstruct
-# from $ZSKILLS_PIPELINE_ID if it didn't survive across fences.
-if [ -n "${ISSUE_NUM:-}" ]; then
+# Release the issue claim(s) (claim-work-item Phase 2 / W2.4) — only if
+# any were acquired at WI 1.8 (ISSUE_NUMS survives in the persistent
+# shell). Release-on-resolution regardless of created vs merged vs
+# pr-ready: the /quickfix invocation is terminating either way and
+# /quickfix is one-shot (no later fire re-releases). $PIPELINE_ID =
+# quickfix.$SLUG; reconstruct from $ZSKILLS_PIPELINE_ID if it didn't
+# survive across fences. Releases are idempotent per claim-issue.sh, so
+# any claim already released by an upstream inline-release no-ops here.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   _RELEASE_PIPELINE="${PIPELINE_ID:-${ZSKILLS_PIPELINE_ID:-}}"
   if [ -n "$_RELEASE_PIPELINE" ]; then
-    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$_RELEASE_PIPELINE"
+    for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+      bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$_RELEASE_PIPELINE"
+    done
+    unset _ISSUE_N
   fi
 fi
 ```

--- a/tests/test-do-quickfix-multi-issue-fanout.sh
+++ b/tests/test-do-quickfix-multi-issue-fanout.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# Tests for the multi-issue claim acquire/release fan-out introduced in
+# PR #863 (skills/do, skills/quickfix). Exercises:
+#
+#   1. Multi-issue acquire fans out N independent claim acquires via
+#      claim-issue.sh — each issue gets its own claim dir.
+#   2. Partial-acquire rollback: when the K-th acquire returns rc=10
+#      (foreign-held), the loop releases issues 1..K-1 acquired earlier
+#      so this pipeline leaves no orphaned partial claims.
+#   3. Multi-issue release fans out N independent releases, each
+#      idempotent (re-running release on an already-released claim is a
+#      no-op per claim-issue.sh).
+#
+# These tests drive claim-issue.sh directly rather than running the full
+# /do or /quickfix lifecycle — the loop semantics under test are pure
+# bash that the SKILL.md fences inline verbatim.
+#
+# Run from repo root: bash tests/test-do-quickfix-multi-issue-fanout.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLAIM_HELPER="$REPO_ROOT/skills/fix-issues/scripts/claim-issue.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# Each test runs in an isolated temp git repo so claim-issue.sh's
+# MAIN_ROOT resolution (via git rev-parse --git-common-dir) lands somewhere
+# we can clean up.
+make_repo() {
+  local d
+  d=$(mktemp -d -t "zskills-multi-issue-fanout-XXXXXX")
+  (
+    cd "$d" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+  )
+  printf '%s' "$d"
+}
+
+cleanup_dirs=()
+trap 'for d in "${cleanup_dirs[@]:-}"; do [ -d "$d" ] && rm -rf "$d"; done' EXIT
+
+echo "=== Multi-issue acquire fan-out ==="
+
+REPO_A=$(make_repo)
+cleanup_dirs+=("$REPO_A")
+cd "$REPO_A" || exit 1
+
+ISSUE_NUMS=(832 833 834)
+PIPELINE_ID="do.test-multi-832"
+_ACQUIRED=()
+ACQ_RC=0
+for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID" 2>/dev/null
+  ACQ_RC=$?
+  if [ "$ACQ_RC" -eq 0 ]; then
+    _ACQUIRED+=("$ISSUE_NUM")
+  else
+    break
+  fi
+done
+
+if [ "${#_ACQUIRED[@]}" -eq 3 ]; then
+  pass "1a fan-out acquire: all 3 issues acquired"
+else
+  fail "1a fan-out acquire: expected 3 acquired, got ${#_ACQUIRED[@]}"
+fi
+
+# Verify each claim dir exists.
+expected_count=0
+for N in 832 833 834; do
+  if [ -d "$REPO_A/.zskills/claims/issue-$N" ] && [ -f "$REPO_A/.zskills/claims/issue-$N/claim.json" ]; then
+    expected_count=$((expected_count + 1))
+  fi
+done
+if [ "$expected_count" -eq 3 ]; then
+  pass "1b fan-out acquire: 3 claim dirs+claim.json created on disk"
+else
+  fail "1b fan-out acquire: expected 3 claim files, got $expected_count"
+fi
+
+echo ""
+echo "=== Partial-acquire rollback on rc=10 (foreign-held) ==="
+
+REPO_B=$(make_repo)
+cleanup_dirs+=("$REPO_B")
+cd "$REPO_B" || exit 1
+
+# Foreign pipeline holds issue 901.
+bash "$CLAIM_HELPER" acquire 901 --pipeline-id "foreign.pipeline" --sprint-id "foreign.pipeline" 2>/dev/null
+foreign_rc=$?
+if [ "$foreign_rc" -ne 0 ]; then
+  fail "2pre foreign holder setup: expected rc=0 on fresh acquire, got $foreign_rc"
+fi
+
+# Our pipeline tries to claim 900, 901, 902 — 901 is foreign-held so we
+# should acquire 900, fail on 901 with rc=10, then roll back 900.
+ISSUE_NUMS=(900 901 902)
+PIPELINE_ID="do.test-rollback"
+_ACQUIRED=()
+ACQ_RC=0
+FAILED_AT=""
+for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID" 2>/dev/null
+  ACQ_RC=$?
+  case "$ACQ_RC" in
+    0) _ACQUIRED+=("$ISSUE_NUM") ;;
+    *)
+      FAILED_AT="$ISSUE_NUM"
+      # Rollback: release everything this pipeline grabbed earlier.
+      for _RB in "${_ACQUIRED[@]}"; do
+        bash "$CLAIM_HELPER" release "$_RB" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+      done
+      break ;;
+  esac
+done
+
+if [ "$ACQ_RC" -eq 10 ] && [ "$FAILED_AT" = "901" ]; then
+  pass "2a rollback: hit rc=10 on foreign-held issue 901 (as expected)"
+else
+  fail "2a rollback: expected rc=10 on #901, got rc=$ACQ_RC failed_at='$FAILED_AT'"
+fi
+
+# Verify 900 was acquired then rolled back (no claim dir remains for our
+# pipeline). Foreign 901 still intact.
+if [ -d "$REPO_B/.zskills/claims/issue-900" ]; then
+  fail "2b rollback: issue-900 claim dir still exists — rollback didn't release"
+else
+  pass "2b rollback: issue-900 claim released (no leak)"
+fi
+
+if [ -d "$REPO_B/.zskills/claims/issue-901" ]; then
+  pass "2c rollback: foreign issue-901 claim intact (not stolen)"
+else
+  fail "2c rollback: foreign issue-901 claim missing — rollback overreached"
+fi
+
+# Verify our pipeline-id is not stamped on 901's claim.json.
+if grep -q '"pipeline_id": "foreign.pipeline"' "$REPO_B/.zskills/claims/issue-901/claim.json" 2>/dev/null; then
+  pass "2d rollback: issue-901 claim.json still owned by foreign pipeline"
+else
+  fail "2d rollback: issue-901 claim.json missing or pipeline_id wrong"
+fi
+
+# Issue 902 was never attempted (loop broke at 901).
+if [ -d "$REPO_B/.zskills/claims/issue-902" ]; then
+  fail "2e rollback: issue-902 claim dir exists — loop did not break at 901"
+else
+  pass "2e rollback: issue-902 never acquired (loop broke at 901)"
+fi
+
+echo ""
+echo "=== Multi-issue release fan-out (idempotent) ==="
+
+REPO_C=$(make_repo)
+cleanup_dirs+=("$REPO_C")
+cd "$REPO_C" || exit 1
+
+ISSUE_NUMS=(700 701 702)
+PIPELINE_ID="quickfix.test-release"
+# Acquire all three.
+for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID" 2>/dev/null
+done
+
+# Release fan-out (1st pass).
+release_failures=0
+for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" 2>/dev/null
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    release_failures=$((release_failures + 1))
+  fi
+done
+
+if [ "$release_failures" -eq 0 ]; then
+  pass "3a release fan-out: all 3 releases succeeded (rc=0)"
+else
+  fail "3a release fan-out: $release_failures release(s) failed on 1st pass"
+fi
+
+# Verify all claim dirs are gone.
+for N in 700 701 702; do
+  if [ -d "$REPO_C/.zskills/claims/issue-$N" ]; then
+    fail "3b release fan-out: issue-$N claim dir still exists after release"
+  else
+    pass "3b release fan-out: issue-$N claim dir removed"
+  fi
+done
+
+# Release fan-out (2nd pass) — should be idempotent no-ops.
+release_failures=0
+for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" 2>/dev/null
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    release_failures=$((release_failures + 1))
+  fi
+done
+
+if [ "$release_failures" -eq 0 ]; then
+  pass "3c release fan-out: 2nd pass (already-released) idempotent rc=0"
+else
+  fail "3c release fan-out: $release_failures release(s) failed on 2nd pass (not idempotent)"
+fi
+
+echo ""
+echo "=== Single-issue case still works through the fan-out loop ==="
+
+REPO_D=$(make_repo)
+cleanup_dirs+=("$REPO_D")
+cd "$REPO_D" || exit 1
+
+ISSUE_NUMS=(500)
+PIPELINE_ID="do.test-single"
+_ACQUIRED=()
+for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID" 2>/dev/null
+  if [ "$?" -eq 0 ]; then _ACQUIRED+=("$ISSUE_NUM"); fi
+done
+
+if [ "${#_ACQUIRED[@]}" -eq 1 ] && [ "${_ACQUIRED[0]}" = "500" ]; then
+  pass "4a single-issue: fan-out loop with N=1 acquires issue 500"
+else
+  fail "4a single-issue: expected [500], got [${_ACQUIRED[*]:-}]"
+fi
+
+for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+  bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" 2>/dev/null
+done
+
+if [ -d "$REPO_D/.zskills/claims/issue-500" ]; then
+  fail "4b single-issue: claim dir survived release"
+else
+  pass "4b single-issue: claim released cleanly"
+fi
+
+echo ""
+echo "=== Empty array → skip fan-out ==="
+
+REPO_E=$(make_repo)
+cleanup_dirs+=("$REPO_E")
+cd "$REPO_E" || exit 1
+
+ISSUE_NUMS=()
+PIPELINE_ID="do.test-empty"
+guard_fired=0
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+  guard_fired=1
+fi
+if [ "$guard_fired" -eq 0 ]; then
+  pass "5a empty array: guard skips fan-out (no claim attempt)"
+else
+  fail "5a empty array: guard fired (would have attempted claims)"
+fi
+
+if [ ! -d "$REPO_E/.zskills/claims" ]; then
+  pass "5b empty array: no .zskills/claims dir created"
+else
+  fail "5b empty array: .zskills/claims dir exists (claims were attempted)"
+fi
+
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo "=============================="
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, %d failed, 0 skipped (of %d)\033[0m\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed, 0 skipped (of %d)\033[0m\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -584,23 +584,75 @@ fi
 # re-implements it as a behavioral fixture so a future edit that breaks
 # one of these cases fails closed.
 # ────────────────────────────────────────────────────────────────────
+# do_parse_issue_nums replicates the SKILL.md parser. Sets the
+# ISSUE_NUMS array (and back-compat ISSUE_NUM = first) for the caller.
+# Strong separators (`/`, `+`, `&`) accept bare `#N`; weak separators
+# (`,`, `;`, ` and `, ` or `) require a close-keyword before `#N`.
+do_parse_issue_nums() {
+  local input="$1"
+  ISSUE_NUMS=()
+  local _KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+  if [[ "$input" =~ ^[[:space:]]*\"?${_KW}[[:space:]]+#([0-9]+) ]]; then
+    ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+  elif [[ "$input" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
+    ISSUE_NUMS+=("${BASH_REMATCH[1]}")
+  fi
+  # Strong separators: bare #N OK.
+  local _REM="$input"
+  while [[ "$_REM" =~ [[:space:]]*[/+\&][[:space:]]*(${_KW}[[:space:]]+)?#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+  done
+  # Weak separators: close-keyword required.
+  _REM="$input"
+  while [[ "$_REM" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_KW}[[:space:]]+#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+  done
+  declare -A _SEEN=()
+  local _UNIQUE=()
+  local _n
+  for _n in "${ISSUE_NUMS[@]:-}"; do
+    [ -z "$_n" ] && continue
+    if [ -z "${_SEEN[$_n]:-}" ]; then _UNIQUE+=("$_n"); _SEEN[$_n]=1; fi
+  done
+  ISSUE_NUMS=("${_UNIQUE[@]}")
+  ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+}
+
+# test_issue_num_do — back-compat scalar (= ISSUE_NUMS[0]) check.
 test_issue_num_do() {
   local input="$1"
   local expected="$2"
   local label="$3"
-  local ISSUE_NUM=""
-  if [[ "$input" =~ ^[[:space:]]*\"?([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
-    ISSUE_NUM="${BASH_REMATCH[3]}"
-  elif [[ "$input" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
-    ISSUE_NUM="${BASH_REMATCH[1]}"
-  fi
-  if [ "$ISSUE_NUM" = "$expected" ]; then
-    pass "18 ISSUE_NUM: $label (got '$ISSUE_NUM')"
+  do_parse_issue_nums "$input"
+  if [ "${ISSUE_NUM:-}" = "$expected" ]; then
+    pass "18 ISSUE_NUM: $label (got '${ISSUE_NUM:-}')"
   else
-    fail "18 ISSUE_NUM: $label (expected '$expected', got '$ISSUE_NUM')"
+    fail "18 ISSUE_NUM: $label (expected '$expected', got '${ISSUE_NUM:-}')"
   fi
 }
-# Positive — should capture issue number
+
+# test_issue_nums_do — multi-issue array check. `expected_csv` is the
+# comma-joined expected array (e.g., "832,833"); empty string asserts the
+# array is empty.
+test_issue_nums_do() {
+  local input="$1"
+  local expected_csv="$2"
+  local label="$3"
+  do_parse_issue_nums "$input"
+  local got_csv=""
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    got_csv=$(IFS=','; echo "${ISSUE_NUMS[*]}")
+  fi
+  if [ "$got_csv" = "$expected_csv" ]; then
+    pass "18m ISSUE_NUMS: $label (got '$got_csv')"
+  else
+    fail "18m ISSUE_NUMS: $label (expected '$expected_csv', got '$got_csv')"
+  fi
+}
+
+# Positive — should capture issue number(s)
 test_issue_num_do "Fix #853 — auto-route completed plans" "853" "Fix #N at start (capital F)"
 test_issue_num_do "fix #853 — lowercase" "853" "fix #N at start (lowercase)"
 test_issue_num_do "Fixes #853 typo" "853" "Fixes #N at start"
@@ -622,6 +674,26 @@ test_issue_num_do "Just a regular description" "" "no # at all → no capture"
 test_issue_num_do "Description mentioning #N letter" "" "#N where N is a letter → no capture"
 test_issue_num_do "address #853 work" "" "non-recognized keyword (address) → no capture"
 test_issue_num_do "work on #853" "" "non-recognized verb (work) → no capture"
+
+# ────────────────────────────────────────────────────────────────────
+# Case 18m — Multi-issue parser (#863). Description references multiple
+# `#N` issues separated by /, ,, ;, +, &, or " and "/" or " — all
+# captured into ISSUE_NUMS array; back-compat ISSUE_NUM stays as first.
+# ────────────────────────────────────────────────────────────────────
+test_issue_nums_do "Closes #832 / Closes #833"           "832,833"     "slash-separated double Closes (the canonical multi-issue pattern)"
+test_issue_nums_do "fix #832 + #833"                     "832,833"     "plus-separated bare #N (strong sep)"
+test_issue_nums_do "Closes #832 & #833"                  "832,833"     "ampersand-separated bare #N (strong sep)"
+test_issue_nums_do "fix #832 and fix #833"               "832,833"     "and-separated keyword + #N (weak sep + kw OK)"
+test_issue_nums_do "Closes #832; Resolves #833"          "832,833"     "semicolon-separated different keywords (weak sep + kw OK)"
+test_issue_nums_do "Fix #832, Closes #833"               "832,833"     "comma-separated keyword + #N (weak sep + kw OK)"
+test_issue_nums_do "Closes #832 / Closes #833 + #834"    "832,833,834" "triple-fanout slash + plus (mixed strong seps)"
+test_issue_nums_do "Fix #853"                            "853"         "single-issue case still works"
+test_issue_nums_do "Just a regular description"          ""            "zero-issue case → empty array"
+# Weak separators without a close-keyword don't fan out (over-capture guard):
+test_issue_nums_do "Closes #832, see also #999"          "832"         "see-also after comma → only #832 (weak sep, no kw before #999)"
+test_issue_nums_do "Closes #832, #833"                   "832"         "bare #N after comma (weak sep) → only #832"
+test_issue_nums_do "fix #832 and #833"                   "832"         "bare #N after 'and' (weak sep) → only #832"
+test_issue_nums_do "fix #832 and fix #832"               "832"         "dedupe: duplicate #N captured once"
 
 # ────────────────────────────────────────────────────────────────────
 # Case 19 — Phase 0a triage rubric NO LONGER contains the

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -2023,20 +2023,68 @@ fi
 # test re-implements it as a behavioral fixture so a future edit that
 # breaks one of these cases fails closed.
 # ────────────────────────────────────────────────────────────────────
+# qf_parse_issue_nums replicates the SKILL.md parser. Sets the
+# ISSUE_NUMS array (and back-compat ISSUE_NUM = first) for the caller.
+# Strong separators (`/`, `+`, `&`) accept bare `#N`; weak separators
+# (`,`, `;`, ` and `, ` or `) require a close-keyword before `#N`.
+qf_parse_issue_nums() {
+  local input="$1"
+  ISSUE_NUMS=()
+  local _KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+  if [[ "$input" =~ ^[[:space:]]*${_KW}[[:space:]]+#([0-9]+) ]]; then
+    ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+  elif [[ "$input" =~ ^[[:space:]]*#([0-9]+) ]]; then
+    ISSUE_NUMS+=("${BASH_REMATCH[1]}")
+  fi
+  local _REM="$input"
+  while [[ "$_REM" =~ [[:space:]]*[/+\&][[:space:]]*(${_KW}[[:space:]]+)?#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+  done
+  _REM="$input"
+  while [[ "$_REM" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_KW}[[:space:]]+#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+  done
+  declare -A _SEEN=()
+  local _UNIQUE=()
+  local _n
+  for _n in "${ISSUE_NUMS[@]:-}"; do
+    [ -z "$_n" ] && continue
+    if [ -z "${_SEEN[$_n]:-}" ]; then _UNIQUE+=("$_n"); _SEEN[$_n]=1; fi
+  done
+  ISSUE_NUMS=("${_UNIQUE[@]}")
+  ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+}
+
+# test_issue_num_qf — back-compat scalar (= ISSUE_NUMS[0]) check.
 test_issue_num_qf() {
   local input="$1"
   local expected="$2"
   local label="$3"
-  local ISSUE_NUM=""
-  if [[ "$input" =~ ^[[:space:]]*([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)[[:space:]]+#([0-9]+) ]]; then
-    ISSUE_NUM="${BASH_REMATCH[3]}"
-  elif [[ "$input" =~ ^[[:space:]]*#([0-9]+) ]]; then
-    ISSUE_NUM="${BASH_REMATCH[1]}"
-  fi
-  if [ "$ISSUE_NUM" = "$expected" ]; then
-    pass "71 ISSUE_NUM: $label (got '$ISSUE_NUM')"
+  qf_parse_issue_nums "$input"
+  if [ "${ISSUE_NUM:-}" = "$expected" ]; then
+    pass "71 ISSUE_NUM: $label (got '${ISSUE_NUM:-}')"
   else
-    fail "71 ISSUE_NUM: $label (expected '$expected', got '$ISSUE_NUM')"
+    fail "71 ISSUE_NUM: $label (expected '$expected', got '${ISSUE_NUM:-}')"
+  fi
+}
+
+# test_issue_nums_qf — multi-issue array check; expected_csv is the
+# comma-joined expected array (empty string asserts empty).
+test_issue_nums_qf() {
+  local input="$1"
+  local expected_csv="$2"
+  local label="$3"
+  qf_parse_issue_nums "$input"
+  local got_csv=""
+  if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+    got_csv=$(IFS=','; echo "${ISSUE_NUMS[*]}")
+  fi
+  if [ "$got_csv" = "$expected_csv" ]; then
+    pass "71m ISSUE_NUMS: $label (got '$got_csv')"
+  else
+    fail "71m ISSUE_NUMS: $label (expected '$expected_csv', got '$got_csv')"
   fi
 }
 # Positive — should capture issue number
@@ -2063,6 +2111,27 @@ test_issue_num_qf "Just a regular description" "" "no # at all → no capture"
 test_issue_num_qf "Description mentioning #N letter" "" "#N where N is a letter → no capture"
 test_issue_num_qf "address #853 work" "" "non-recognized keyword (address) → no capture"
 test_issue_num_qf "work on #853" "" "non-recognized verb (work) → no capture"
+
+# ────────────────────────────────────────────────────────────────────
+# Case 71m — Multi-issue parser (#863). Description references multiple
+# `#N` issues via strong separators (`/`, `+`, `&` — bare `#N` allowed)
+# or weak separators (`,`, `;`, ` and `, ` or ` — close-keyword required).
+# All captured into ISSUE_NUMS array; back-compat ISSUE_NUM stays as
+# first element.
+# ────────────────────────────────────────────────────────────────────
+test_issue_nums_qf "Closes #832 / Closes #833"           "832,833"     "slash-separated double Closes (canonical multi-issue pattern)"
+test_issue_nums_qf "fix #832 + #833"                     "832,833"     "plus-separated bare #N (strong sep)"
+test_issue_nums_qf "Closes #832 & #833"                  "832,833"     "ampersand-separated bare #N (strong sep)"
+test_issue_nums_qf "fix #832 and fix #833"               "832,833"     "and-separated keyword + #N (weak sep + kw OK)"
+test_issue_nums_qf "Closes #832; Resolves #833"          "832,833"     "semicolon-separated different keywords (weak sep + kw OK)"
+test_issue_nums_qf "Fix #832, Closes #833"               "832,833"     "comma-separated keyword + #N (weak sep + kw OK)"
+test_issue_nums_qf "Closes #832 / Closes #833 + #834"    "832,833,834" "triple-fanout slash + plus (mixed strong seps)"
+test_issue_nums_qf "Fix #853"                            "853"         "single-issue case still works"
+test_issue_nums_qf "Just a regular description"          ""            "zero-issue case → empty array"
+test_issue_nums_qf "Closes #832, see also #999"          "832"         "see-also after comma → only #832 (weak sep, no kw before #999)"
+test_issue_nums_qf "Closes #832, #833"                   "832"         "bare #N after comma (weak sep) → only #832"
+test_issue_nums_qf "fix #832 and #833"                   "832"         "bare #N after 'and' (weak sep) → only #832"
+test_issue_nums_qf "fix #832 and fix #832"               "832"         "dedupe: duplicate #N captured once"
 
 # ────────────────────────────────────────────────────────────────────
 # Case 72 — Phase 0a triage rubric NO LONGER contains the

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -473,24 +473,39 @@ check do "Path C Direct"    '^### Path C'
 
 echo ""
 echo "=== /do — issue-claim wiring (claim-work-item Phase 2 / W2.2 + W2.3) ==="
-# /do parses the issue number (reachable only via --force triage override).
-# Acquire uses the $CLAIM_HELPER indirection (CLAIM_HELPER=...claim-issue.sh
-# + `bash "$CLAIM_HELPER" acquire "$ISSUE_NUM"`); release inlines the
-# literal claim-issue.sh path. The sentinels grep the EXISTING script name
-# so a future edit dropping the wiring FAILS the test. These are positive
-# assertions only.
-check_fixed do "SKILL.md parses ISSUE_NUM"        'ISSUE_NUM="${BASH_REMATCH[1]}"'
+# /do parses the issue number(s) into ISSUE_NUMS (reachable only via
+# --force triage override). Acquire uses the $CLAIM_HELPER indirection
+# (CLAIM_HELPER=...claim-issue.sh + per-issue `bash "$CLAIM_HELPER"
+# acquire "$ISSUE_NUM"` inside a fan-out loop over `"${ISSUE_NUMS[@]}"`);
+# release iterates the array and inlines the literal claim-issue.sh path.
+# The sentinels grep the EXISTING patterns so a future edit dropping the
+# wiring FAILS the test. These are positive assertions only.
+# Multi-issue parser (#863): ISSUE_NUMS array populated from leading
+# anchored + separator-delimited subsequent matches.
+check_fixed do "SKILL.md parses ISSUE_NUMS array"     'ISSUE_NUMS+=("${BASH_REMATCH[3]}")'
+check_fixed do "SKILL.md back-compat ISSUE_NUM"       'ISSUE_NUM="${ISSUE_NUMS[0]:-}"'
 # worktree mode: acquire after PIPELINE_ID + worktree; release in Phase 5 Report (SKILL.md).
-check_in_file do "modes/worktree.md" "worktree CLAIM_HELPER"  'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
-check_in_file do "modes/worktree.md" "worktree acquire"       'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
-check_in_file do "modes/direct.md"   "direct CLAIM_HELPER"    'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
-check_in_file do "modes/direct.md"   "direct acquire"         'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
-check_in_file do "modes/pr.md"       "pr CLAIM_HELPER"        'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
-check_in_file do "modes/pr.md"       "pr acquire"             'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+check_in_file do "modes/worktree.md" "worktree CLAIM_HELPER"     'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
+check_in_file do "modes/worktree.md" "worktree fan-out acquire"  'for ISSUE_NUM in "\${ISSUE_NUMS\[@\]}"'
+check_in_file do "modes/worktree.md" "worktree acquire call"     'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+check_in_file do "modes/direct.md"   "direct CLAIM_HELPER"       'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
+check_in_file do "modes/direct.md"   "direct fan-out acquire"    'for ISSUE_NUM in "\${ISSUE_NUMS\[@\]}"'
+check_in_file do "modes/direct.md"   "direct acquire call"       'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+check_in_file do "modes/pr.md"       "pr CLAIM_HELPER"           'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
+check_in_file do "modes/pr.md"       "pr fan-out acquire"        'for ISSUE_NUM in "\${ISSUE_NUMS\[@\]}"'
+check_in_file do "modes/pr.md"       "pr acquire call"           'bash "\$CLAIM_HELPER" acquire "\$ISSUE_NUM"'
+# Partial-acquire rollback: each acquire site releases prior claims on
+# rc=10/11/2/* (issue #863).
+check_in_file do "modes/worktree.md" "worktree rollback"  'for _RB in "\${_ACQUIRED\[@\]}"'
+check_in_file do "modes/direct.md"   "direct rollback"    'for _RB in "\${_ACQUIRED\[@\]}"'
+check_in_file do "modes/pr.md"       "pr rollback"        'for _RB in "\${_ACQUIRED\[@\]}"'
 # Release: /do worktree/direct release in SKILL.md Phase 5 Report + error
 # handling; /do pr releases inline (early-exit) + in the finalize block.
-check_fixed do "SKILL.md releases issue claim"  'claim-issue.sh" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID"'
-check_in_file do "modes/pr.md"       "pr release"        'claim-issue\.sh" release "\$ISSUE_NUM" --require-pipeline "\$PIPELINE_ID"'
+# Release iterates ISSUE_NUMS via `for _ISSUE_N in "${ISSUE_NUMS[@]}"`.
+check_fixed do "SKILL.md release fan-out"        'for _ISSUE_N in "${ISSUE_NUMS[@]}"'
+check_fixed do "SKILL.md release call"           'claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"'
+check_in_file do "modes/pr.md"       "pr release fan-out"  'for _ISSUE_N in "\${ISSUE_NUMS\[@\]}"'
+check_in_file do "modes/pr.md"       "pr release call"     'claim-issue\.sh" release "\$_ISSUE_N" --require-pipeline "\$PIPELINE_ID"'
 
 echo ""
 echo "=== /fix-issues — behavior contracts ==="
@@ -657,10 +672,14 @@ echo "=== /quickfix — issue-claim wiring (claim-work-item Phase 2 / W2.4) ==="
 # triage REDIRECTs issue refs to /fix-issues), acquires at WI 1.8 around
 # the Tracking-setup block, releases in the Phase 7 finalize + abandon
 # sites. Reuses the existing PIPELINE_ID="quickfix.$SLUG".
-check_fixed quickfix "parses ISSUE_NUM"          'ISSUE_NUM="${BASH_REMATCH[1]}"'
+check_fixed quickfix "parses ISSUE_NUMS array"   'ISSUE_NUMS+=("${BASH_REMATCH[3]}")'
+check_fixed quickfix "back-compat ISSUE_NUM"     'ISSUE_NUM="${ISSUE_NUMS[0]:-}"'
 check_fixed quickfix "CLAIM_HELPER assignment"   'CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"'
+check_fixed quickfix "fan-out acquire"           'for ISSUE_NUM in "${ISSUE_NUMS[@]}"'
 check_fixed quickfix "acquires issue claim"      'bash "$CLAIM_HELPER" acquire "$ISSUE_NUM" --pipeline-id "$PIPELINE_ID" --sprint-id "$PIPELINE_ID"'
-check_fixed quickfix "releases issue claim"      'claim-issue.sh" release "$ISSUE_NUM" --require-pipeline'
+check_fixed quickfix "partial-acquire rollback"  'for _RB in "${_ACQUIRED[@]}"'
+check_fixed quickfix "release fan-out"           'for _ISSUE_N in "${ISSUE_NUMS[@]}"'
+check_fixed quickfix "releases issue claim"      'claim-issue.sh" release "$_ISSUE_N" --require-pipeline'
 
 echo ""
 echo "=== /investigate — issue-claim wiring (claim-work-item Phase 2 / W2.1) ==="


### PR DESCRIPTION
## Summary

Parser at `skills/do/SKILL.md` and `skills/quickfix/SKILL.md` previously used `\#([0-9]+)` BASH_REMATCH single-capture — only the FIRST `#N` was captured. Multi-issue descriptions (`"Closes #832 / Closes #833"`) left N-1 issues unclaimed. This PR converts `ISSUE_NUM` scalar → `ISSUE_NUMS` array, fans out acquire (with partial-rollback) and release across all sites.

Closes #863

## Design highlights
- **Strong vs weak separator semantics** to avoid over-capture: `/`, `+`, `&` accept bare `#N` (clean multi-issue idioms); `,`, `;`, ` and `, ` or ` require explicit close-keyword (prevents `"Closes #832, see also #999"` from grabbing #999).
- **Partial-acquire rollback** — if acquire returns rc=10 on issue K of N, releases issues 1..K-1 then exits 0 (declining) — matching the existing single-issue rc=10 behavior. Critical for `/do` which is one-shot (no later fire would clean up).
- **Back-compat scalar `$ISSUE_NUM` preserved** as `${ISSUE_NUMS[0]:-}` so existing prose references keep working.
- **Release fan-out is idempotent** (`claim-issue.sh release` already no-ops on absent claims).
- **No tracking-marker changes needed** — markers key off `TASK_SLUG`/`PIPELINE_ID`, not `ISSUE_NUM`.

## Files (18)
- `skills/do/{SKILL.md, modes/direct.md, modes/worktree.md, modes/pr.md}` + mirrors — parser + fan-out acquire (rollback on rc=10) + 4 release sites (PR_TITLE-empty, PR_TITLE-invalid, no-result-file, finalize); version → `2026.05.31+fda0cc`
- `skills/quickfix/{SKILL.md, modes/execute.md, modes/land.md}` + mirrors — parser + WI 1.8 fan-out acquire with rollback + 5 release sites; version → `2026.05.31+c444a9`
- `tests/test-do-quickfix-multi-issue-fanout.sh` (NEW, 16 cases): acquire-all, rc=10 rollback (verifies foreign holder intact + prior claims released), release fan-out (1st + 2nd-pass idempotence), single-issue degenerate, empty-array guard
- `tests/test-do.sh`, `tests/test-quickfix.sh` — refactored cases 18 + 71; added cases 18m + 71m (13 multi-issue parse assertions each)
- `tests/test-skill-conformance.sh` — sentinels updated for array semantics

## Test plan
- [x] `bash tests/run-all.sh` → **6692/6692 passed, 0 failed**. Conformance: 754/754.
- [x] New fan-out test suite 16/16; new multi-issue parse cases 13/13 ×2.
- [x] Single-issue degenerate path unchanged (back-compat verified).

## Commits
0a75400 fix(do,quickfix): parse all #N issues + fan-out claim acquire/release (#863)
