### PR TITLE
fix(#869): dual-lane clear-tracking.sh path in research-and-go + run-plan recovery hints

### DIFF
--- a/.claude/skills/research-and-go/SKILL.md
+++ b/.claude/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.31+02562d"
+  version: "2026.05.31+bdce69"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -354,7 +354,7 @@ the end of Step 2.
 Under chunked finish auto, `/research-and-go` Step 2 schedules a cron and
 exits -- Step 3 never runs in-session. Cleanup happens when the user (or a
 future automation) observes the pipeline is complete. Run
-`bash .claude/skills/update-zskills/scripts/clear-tracking.sh` (interactive) to wipe tracking. Do NOT
+the clear-tracking script — on the plugin install `bash ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh`, or the legacy mirror path `bash .claude/skills/update-zskills/scripts/clear-tracking.sh` — (interactive) to wipe tracking. Do NOT
 auto-wipe -- `requires.verify-changes.final.*` and its fulfillment marker
 are pipeline-completion records that should survive until the user confirms
 the pipeline finished.

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+c74b30"
+  version: "2026.05.31+f2c567"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -1515,8 +1515,12 @@ against a leftover `requires.*` from a prior pipeline).
 
 Count remaining non-completion markers across all pipelines and surface
 a one-line reminder. Do NOT auto-clean — this skill's job is
-to run plans, not manage long-term tracking state. The user runs
-`bash .claude/skills/update-zskills/scripts/clear-tracking.sh` when they're ready.
+to run plans, not manage long-term tracking state. The user runs the
+clear-tracking script — on the plugin install
+`bash ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh`,
+or the legacy mirror path
+`bash .claude/skills/update-zskills/scripts/clear-tracking.sh` — when they're
+ready.
 
 ```bash
 # This count surfaces accumulated bookkeeping across ALL pipelines (not just
@@ -1536,8 +1540,16 @@ MARKER_COUNT=$(ls "$MAIN_ROOT/.zskills/tracking/"*/requires.* \
                     "$MAIN_ROOT/.zskills/tracking/"fulfilled.verify-changes.* 2>/dev/null \
                 | wc -l)
 if [ "$MARKER_COUNT" -ge 10 ]; then
+  # Lane-correct path: prefer the ${CLAUDE_PLUGIN_ROOT} form on the plugin
+  # install (no .claude/skills/ mirror exists there), else the legacy mirror
+  # path. Mirrors the dual-lane resolution used elsewhere in this skill (#865).
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh" ]; then
+    CLEAR_TRACKING_PATH="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh"
+  else
+    CLEAR_TRACKING_PATH=".claude/skills/update-zskills/scripts/clear-tracking.sh"
+  fi
   echo "NOTE: $MARKER_COUNT bookkeeping tracking markers on disk across completed pipelines."
-  echo "      Run: bash .claude/skills/update-zskills/scripts/clear-tracking.sh   (preserves fulfilled.run-plan.* completion records)"
+  echo "      Run: bash $CLEAR_TRACKING_PATH   (preserves fulfilled.run-plan.* completion records)"
 fi
 ```
 

--- a/skills/research-and-go/SKILL.md
+++ b/skills/research-and-go/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   adversarial review, then execute all of them autonomously via /run-plan.
   One command, walk away.
 metadata:
-  version: "2026.05.31+02562d"
+  version: "2026.05.31+bdce69"
 ---
 
 # /research-and-go \<description> — Plan and Execute Everything
@@ -354,7 +354,7 @@ the end of Step 2.
 Under chunked finish auto, `/research-and-go` Step 2 schedules a cron and
 exits -- Step 3 never runs in-session. Cleanup happens when the user (or a
 future automation) observes the pipeline is complete. Run
-`bash .claude/skills/update-zskills/scripts/clear-tracking.sh` (interactive) to wipe tracking. Do NOT
+the clear-tracking script — on the plugin install `bash ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh`, or the legacy mirror path `bash .claude/skills/update-zskills/scripts/clear-tracking.sh` — (interactive) to wipe tracking. Do NOT
 auto-wipe -- `requires.verify-changes.final.*` and its fulfillment marker
 are pipeline-completion records that should survive until the user confirms
 the pipeline finished.

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+c74b30"
+  version: "2026.05.31+f2c567"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -1515,8 +1515,12 @@ against a leftover `requires.*` from a prior pipeline).
 
 Count remaining non-completion markers across all pipelines and surface
 a one-line reminder. Do NOT auto-clean — this skill's job is
-to run plans, not manage long-term tracking state. The user runs
-`bash .claude/skills/update-zskills/scripts/clear-tracking.sh` when they're ready.
+to run plans, not manage long-term tracking state. The user runs the
+clear-tracking script — on the plugin install
+`bash ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh`,
+or the legacy mirror path
+`bash .claude/skills/update-zskills/scripts/clear-tracking.sh` — when they're
+ready.
 
 ```bash
 # This count surfaces accumulated bookkeeping across ALL pipelines (not just
@@ -1536,8 +1540,16 @@ MARKER_COUNT=$(ls "$MAIN_ROOT/.zskills/tracking/"*/requires.* \
                     "$MAIN_ROOT/.zskills/tracking/"fulfilled.verify-changes.* 2>/dev/null \
                 | wc -l)
 if [ "$MARKER_COUNT" -ge 10 ]; then
+  # Lane-correct path: prefer the ${CLAUDE_PLUGIN_ROOT} form on the plugin
+  # install (no .claude/skills/ mirror exists there), else the legacy mirror
+  # path. Mirrors the dual-lane resolution used elsewhere in this skill (#865).
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh" ]; then
+    CLEAR_TRACKING_PATH="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh"
+  else
+    CLEAR_TRACKING_PATH=".claude/skills/update-zskills/scripts/clear-tracking.sh"
+  fi
   echo "NOTE: $MARKER_COUNT bookkeeping tracking markers on disk across completed pipelines."
-  echo "      Run: bash .claude/skills/update-zskills/scripts/clear-tracking.sh   (preserves fulfilled.run-plan.* completion records)"
+  echo "      Run: bash $CLEAR_TRACKING_PATH   (preserves fulfilled.run-plan.* completion records)"
 fi
 ```
 

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2010,6 +2010,41 @@ check_fixed block-diagram/add-example "ensure-worktree invocation" 'bash "$HELPE
 check_fixed fix-issues                "ensure-worktree invocation" 'bash "$HELPER"'
 
 echo ""
+echo "=== clear-tracking recovery hint — dual-lane path (#865) ==="
+# User-facing tracking-cleanup recovery hints must NOT print a bare
+# mirror-only clear-tracking.sh path as the SOLE hint: on the plugin lane
+# there is no .claude/skills/ mirror, so the legacy path does not exist.
+# Each site that mentions clear-tracking.sh MUST also carry the
+# ${CLAUDE_PLUGIN_ROOT}-resolved form. A future edit that drops the
+# plugin-lane path (regressing to bare mirror-only) fails closed here.
+CLEAR_TRACKING_HINT_SITES=(
+  "skills/research-and-go/SKILL.md"
+  "skills/run-plan/modes/execute-phase.md"
+  "skills/run-plan/SKILL.md"
+)
+CT_HINT_CHECKED=0
+for rel in "${CLEAR_TRACKING_HINT_SITES[@]}"; do
+  f="$REPO_ROOT/$rel"
+  [ -f "$f" ] || continue
+  # Only enforce on files that actually reference clear-tracking.sh.
+  if grep -q 'clear-tracking\.sh' "$f"; then
+    CT_HINT_CHECKED=$((CT_HINT_CHECKED + 1))
+    if grep -qF '${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh' "$f"; then
+      pass "[$rel] clear-tracking.sh hint carries \${CLAUDE_PLUGIN_ROOT} (plugin-lane) path"
+    else
+      fail "[$rel] clear-tracking.sh hint missing plugin-lane path" '${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/clear-tracking.sh (bare mirror-only path is wrong on the plugin lane — #865)'
+    fi
+  fi
+done
+# Guard against the site list silently going stale (files renamed away or
+# clear-tracking.sh dropped everywhere) making the assertion vacuous.
+if [ "$CT_HINT_CHECKED" -lt 2 ]; then
+  fail "[clear-tracking dual-lane] too few sites scanned ($CT_HINT_CHECKED < 2)" "clear-tracking.sh recovery-hint sites moved/removed — update CLEAR_TRACKING_HINT_SITES (#865)"
+else
+  pass "clear-tracking.sh recovery-hint dual-lane scan covered $CT_HINT_CHECKED sites"
+fi
+
+echo ""
 echo "=== ensure-worktree.sh caller contract ==="
 # Companion to the create-worktree.sh caller-contract scan above.
 # Every multi-line `bash "$HELPER" \` invocation in skills/ AND


### PR DESCRIPTION
## Summary

Fixes #869. Two user-facing tracking-cleanup recovery hints hardcoded the
**mirror-only** path `.claude/skills/update-zskills/scripts/clear-tracking.sh`,
which does not exist on the plugin install lane (no `.claude/skills/` mirror
there) — telling plugin-lane users to run a script that isn't present.

The fix prints a **lane-correct** path, preferring the
`${CLAUDE_PLUGIN_ROOT}`-resolved form and falling back to the legacy mirror
path, matching the established dual-lane idiom used elsewhere in these skills.

### Changes
- `skills/research-and-go/SKILL.md` — Pipeline Cleanup recovery prose now shows both lanes' paths.
- `skills/run-plan/modes/execute-phase.md` — prose hint + a runtime `CLEAR_TRACKING_PATH` resolver so the echoed path is lane-correct at runtime.
- `tests/test-skill-conformance.sh` — new conformance section asserting the dual-lane form is present at each site (fails closed if a bare mirror-only hint is reintroduced; includes a vacuity guard).
- `.claude/skills/` mirrors re-synced; `metadata.version` bumped on research-and-go + run-plan.

## Test plan
- [x] `bash tests/run-all.sh` — 6656/6656 passed, 0 failed (verifier-confirmed).
- [x] test-skill-conformance.sh 744/744 (incl. new clear-tracking dual-lane checks).
- [x] test-skills-mirror-parity.sh 57/57 (source↔mirror parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
