### PR TITLE
fix(#862): unify dashboard skip-reason chip with live monitor-state + claim suppression

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.31+28a992"
+  version: "2026.05.31+ec0ddc"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/.claude/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -67,10 +67,19 @@ fi
 # triage declines an issue as plan-scale / bug-unclear-cause /
 # needs-decision / deferred, the orchestrator records it here so the next
 # fire's filter drops it BEFORE re-triage — even when the issue has no
-# tracker row (raw dashboard-drag case). The map shape is
-# `{ "<issue-num>": "<skip-code>" }`, e.g. `{"803": "plan-scale"}`. This
-# is symmetric with `issues.reconsider`: monitor-state.json is gitignored,
-# so the skip-record never lands as a tracker-row commit on main.
+# tracker row (raw dashboard-drag case). The map value is EITHER a bare
+# code string `"<skip-code>"` (legacy / no-reason) OR a dict
+# `{"code": "<skip-code>", "reason": "<free-text>"}` (#862, when a
+# free-text reason was recorded). The filter only consumes the CODE; the
+# reason flows to the dashboard chip via collect.py. This is symmetric
+# with `issues.reconsider`: monitor-state.json is gitignored, so the
+# skip-record never lands as a tracker-row commit on main.
+#
+# Effective-skip-reason precedence (#862) — MUST match
+# collect.py:_resolve_effective_skip_code precedence exactly, otherwise
+# the dashboard chip and this drop-decision split-brain again: the live
+# `issues.skipped[N]` override WINS when present; only when it is absent
+# does the tracker-row `Action now:` blurb-derived code apply.
 MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
 STATE_FILE="${MAIN_ROOT:+$MAIN_ROOT/.zskills/monitor-state.json}"
 RECONSIDER_NUMS=""
@@ -96,10 +105,18 @@ try:
     with open(sys.argv[1]) as f:
         data = json.load(f)
     skipped = data.get('issues', {}).get('skipped', {}) or {}
-    # Accept both dict and list-of-pairs shapes defensively.
+    # The map value is EITHER a bare code string (legacy / no-reason) OR a
+    # dict {'code': ..., 'reason': ...} (#862). The filter only consumes
+    # the CODE; reason is for the dashboard chip. Extract the code from
+    # whichever shape is present.
     if isinstance(skipped, dict):
         for k, v in skipped.items():
-            print(f'{k}\t{v}')
+            if isinstance(v, dict):
+                code = v.get('code')
+            else:
+                code = v
+            if code:
+                print(f'{k}\t{code}')
 except Exception:
     pass
 " "$STATE_FILE" 2>/dev/null)
@@ -195,14 +212,18 @@ for N in "$@"; do
 
   if [ "$found" -eq 1 ]; then
     RESEARCHED+=("$N")
-    if [ -n "$skip_code" ]; then
-      SKIP_TAGGED+=("$N:$skip_code")
-    elif [ -n "$monitor_skip_code" ]; then
-      # Tracker row exists but is not skip-tagged; monitor-state.json
-      # has a persisted decline (e.g. agent triaged plan-scale before
-      # the row's `Action now:` was rewritten). Honor the monitor-state
-      # decision so the issue drops from Phase 2.
+    # Effective-skip-reason precedence (#862): the live monitor-state
+    # override WINS over the tracker-row blurb-derived code. This mirrors
+    # collect.py:_resolve_effective_skip_code so the dashboard chip and
+    # this drop-decision never diverge (an orchestrator that re-triages an
+    # issue and records a new classification in monitor-state must move
+    # BOTH the chip and the filter, not just the filter). When no
+    # monitor-state override is present, fall back to the tracker-derived
+    # code.
+    if [ -n "$monitor_skip_code" ]; then
       SKIP_TAGGED+=("$N:$monitor_skip_code")
+    elif [ -n "$skip_code" ]; then
+      SKIP_TAGGED+=("$N:$skip_code")
     fi
     if [ "$is_reconsidered" -eq 1 ]; then
       # already appended above when we cleared monitor_skip_code

--- a/.claude/skills/fix-issues/scripts/record-skip.sh
+++ b/.claude/skills/fix-issues/scripts/record-skip.sh
@@ -32,17 +32,25 @@
 #   <skip-code>   One of: plan-scale | bug-unclear-cause | needs-decision
 #                 | deferred. REQUIRED. These mirror the canonical
 #                 dashboard skip-codes the filter recognizes.
-#   <reason>      Optional short string (informational; not consumed by
-#                 the filter). Currently ignored; reserved for future use.
+#   <reason>      Optional short free-text string (e.g. "needs author A/B/C
+#                 scope decision"). When present, the persisted entry becomes
+#                 the dict shape `{"code": <code>, "reason": <reason>}` and the
+#                 reason flows through to the dashboard skip chip's label
+#                 (#862). When absent, the legacy bare-string shape
+#                 `"<skip-code>"` is preserved (back-compat).
 #
 # Behavior:
 #   - Resolves `$MAIN_ROOT` from `$ZSKILLS_MAIN_ROOT` if set, else from
 #     `git rev-parse --git-common-dir`.
 #   - Creates `.zskills/monitor-state.json` with `{}` if absent.
-#   - Sets `data["issues"]["skipped"][str(N)] = "<skip-code>"`.
-#   - Idempotent: if the same code is already recorded, exits 0 silently;
-#     if a different code is recorded, overwrites (latest-classification
-#     wins — the orchestrator may re-triage and re-classify).
+#   - Sets `data["issues"]["skipped"][str(N)]` to either the bare code
+#     string (no reason given) or `{"code": <code>, "reason": <reason>}`
+#     (reason given). Both shapes are accepted by every reader
+#     (filter-unresearched-candidates.sh + collect.py).
+#   - Idempotent: if the same {code, reason} is already recorded, exits 0
+#     silently; if a different code/reason is recorded, overwrites
+#     (latest-classification wins — the orchestrator may re-triage and
+#     re-classify).
 #   - Atomic write via Python tempfile + `os.replace`.
 #
 # Exit:
@@ -59,7 +67,10 @@ fi
 
 ISSUE_NUM="$1"
 SKIP_CODE="$2"
-# reason argument reserved for future use; not consumed yet.
+# Optional free-text reason (#862). Empty when omitted; when present it is
+# persisted alongside the code as `{"code": ..., "reason": ...}` and rendered
+# in the dashboard skip chip's label.
+REASON="${3:-}"
 
 case "$ISSUE_NUM" in
   ''|*[!0-9]*)
@@ -92,10 +103,12 @@ if [ ! -f "$STATE_FILE" ]; then
   printf '{}\n' > "$STATE_FILE"
 fi
 
-python3 - "$STATE_FILE" "$ISSUE_NUM" "$SKIP_CODE" <<'PY' || exit 2
+python3 - "$STATE_FILE" "$ISSUE_NUM" "$SKIP_CODE" "$REASON" <<'PY' || exit 2
 import json, os, sys, tempfile
 
 path, num_s, code = sys.argv[1], sys.argv[2], sys.argv[3]
+reason = sys.argv[4] if len(sys.argv) > 4 else ""
+reason = reason.strip()
 
 try:
     with open(path) as f:
@@ -112,13 +125,30 @@ if not isinstance(skipped, dict):
     skipped = {}
     issues['skipped'] = skipped
 
-# Idempotent — same code recorded already, exit silently.
-if skipped.get(num_s) == code:
+
+def _norm(entry):
+    """Normalise either skip-entry shape to (code, reason) for comparison.
+
+    Accepts both the legacy bare-string shape (`"<code>"`) and the
+    dict shape (`{"code": ..., "reason": ...}`) so idempotency holds
+    across a mix of old and new writers (#862)."""
+    if isinstance(entry, dict):
+        return (entry.get('code'), entry.get('reason') or '')
+    return (entry, '')
+
+
+# When a reason is supplied, persist the dict shape so the chip can
+# render it; otherwise keep the legacy bare-string shape (back-compat).
+new_value = {'code': code, 'reason': reason} if reason else code
+
+# Idempotent — same (code, reason) recorded already, exit silently.
+prev_entry = skipped.get(num_s)
+if _norm(prev_entry) == _norm(new_value):
     print(f"/fix-issues: #{num_s} already recorded as skipped ({code}); no-op.", file=sys.stderr)
     sys.exit(0)
 
-prev = skipped.get(num_s)
-skipped[num_s] = code
+prev_code = _norm(prev_entry)[0] if prev_entry is not None else None
+skipped[num_s] = new_value
 
 tmp = tempfile.NamedTemporaryFile('w', delete=False,
     dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
@@ -127,8 +157,9 @@ tmp.write('\n')
 tmp.close()
 os.replace(tmp.name, path)
 
-if prev:
-    print(f"/fix-issues: #{num_s} skip-state updated ({prev} -> {code}).", file=sys.stderr)
+suffix = f" — {reason}" if reason else ""
+if prev_code:
+    print(f"/fix-issues: #{num_s} skip-state updated ({prev_code} -> {code}{suffix}).", file=sys.stderr)
 else:
-    print(f"/fix-issues: #{num_s} recorded as skipped ({code}).", file=sys.stderr)
+    print(f"/fix-issues: #{num_s} recorded as skipped ({code}{suffix}).", file=sys.stderr)
 PY

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+e6f96a"
+  version: "2026.05.31+1c6775"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1871,9 +1871,17 @@ def _annotate_issues_queue(
                 continue  # closed — route via inference to completed/triage
             pos[n] = (col, i)
 
+    # Live monitor-state skip override map (#862). Read from `state` (not
+    # the filesystem) so it is available even in the 2-arg fixture branch,
+    # and so it is the SAME source `filter-unresearched-candidates.sh`
+    # consumes from `monitor-state.json`. The unified precedence
+    # (override wins, else blurb) is applied per-issue below via
+    # `_resolve_effective_skip_reason`.
+    monitor_skipped: Dict[int, Dict[str, str]] = _read_monitor_skipped(state)
+
     # Build skip-reason index once per snapshot (avoids re-parsing the
     # tracker per Ready issue). Only populated when main_root is given.
-    skip_index: Dict[int, Dict[str, str]] = {}
+    skip_index: Dict[int, Optional[Dict[str, str]]] = {}
     issues_plan_path: Optional[pathlib.Path] = None
     # Claim index — parallel to skip_index; gated on main_root for the
     # same reason (R2.6: fixture branch passes 2-arg, no real filesystem).
@@ -1925,10 +1933,15 @@ def _annotate_issues_queue(
         if isinstance(num, int) and num in pos:
             col, i = pos[num]
             issue["queue"] = {"column": col, "index": i}
-            if num in skip_index:
-                reason = skip_index[num]
-                if reason is not None:
-                    issue["skip_reason"] = reason
+            # Effective skip-reason (#862): live monitor-state override
+            # wins over the blurb-derived reason. Identical precedence to
+            # filter-unresearched-candidates.sh so the chip and the
+            # drop-decision never split-brain.
+            reason = _resolve_effective_skip_reason(
+                num, monitor_skipped, skip_index,
+            )
+            if reason is not None:
+                issue["skip_reason"] = reason
         else:
             # W1.2b — issue default-column inference. Closed-within-window
             # issues land in `completed`; everything else falls through
@@ -2174,6 +2187,112 @@ def _build_skip_reason_index(
     for num in issue_numbers:
         out[num] = _parse_action_now(num, text)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Effective skip-reason resolution (issue #862)
+# ---------------------------------------------------------------------------
+#
+# Split-brain fix: the dashboard skip chip and the /fix-issues drop-decision
+# were sourced from two different, non-unified places — the chip from the
+# committed `Action now:` blurb (`_parse_action_now`), the drop from
+# `monitor-state.json:issues.skipped` (read by
+# `filter-unresearched-candidates.sh`). An orchestrator that re-triaged an
+# issue and recorded a new classification moved the FILTER but not the CHIP.
+#
+# The fix unifies both behind ONE precedence, implemented identically in
+# this module (chip path) and in `filter-unresearched-candidates.sh`
+# (drop path) — the two languages can't literally share a function, so the
+# precedence is mirrored and locked by a cross-path agreement test
+# (tests/test-fix-issues-skip-effective-reason.sh):
+#
+#   1. LIVE OVERRIDE — `monitor-state.json:issues.skipped[N]` wins when
+#      present. The value is EITHER a bare code string (legacy / no-reason)
+#      OR a dict `{"code": ..., "reason": ...}` (#862 free-text reason).
+#   2. BLURB FALLBACK — else the `Action now:` blurb-derived reason
+#      (`_parse_action_now` via `_build_skip_reason_index`).
+#
+# `reconsider <N>` clears `issues.skipped[N]` (the filter's one-shot dual),
+# which naturally resets the chip to the blurb baseline — no separate
+# clear-path is needed here.
+
+# Canonical dashboard skip-code → chip label map, mirroring
+# `_parse_action_now`'s per-code default labels. Used to synthesise a chip
+# `skip_reason` dict for a monitor-state override that has no committed
+# tracker blurb to source a label from.
+_SKIP_CODE_DEFAULT_LABELS: Dict[str, str] = {
+    "plan-scale": "plan-scale",
+    "bug-unclear-cause": "unclear cause",
+    "needs-decision": "author decision needed",
+    "deferred": "deferred",
+    "unresearched": "not yet researched",
+}
+
+
+def _read_monitor_skipped(state: Dict[str, Any]) -> Dict[int, Dict[str, str]]:
+    """Read `state["issues"]["skipped"]` into `{issue_num: {code, reason}}`.
+
+    `state` is the live monitor-state dict (the same dict
+    `filter-unresearched-candidates.sh` reads from
+    `monitor-state.json`), so this is the SINGLE source the override side
+    of the precedence consults — no separate filesystem read, and it works
+    in the 2-arg fixture branch too.
+
+    Accepts BOTH persisted shapes per entry (#862):
+      - bare code string `"<code>"`  (legacy / no-reason)
+      - dict `{"code": ..., "reason": ...}`  (free-text reason recorded)
+
+    Malformed / empty entries are skipped. `reason` is normalised to a
+    (possibly empty) string.
+    """
+    out: Dict[int, Dict[str, str]] = {}
+    issues_section = state.get("issues", {})
+    if not isinstance(issues_section, dict):
+        return out
+    skipped = issues_section.get("skipped", {})
+    if not isinstance(skipped, dict):
+        return out
+    for k, v in skipped.items():
+        try:
+            num = int(k)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(v, dict):
+            code = v.get("code")
+            reason = v.get("reason") or ""
+        else:
+            code = v
+            reason = ""
+        if not isinstance(code, str) or not code:
+            continue
+        out[num] = {"code": code, "reason": str(reason)}
+    return out
+
+
+def _resolve_effective_skip_reason(
+    issue_number: int,
+    monitor_skipped: Dict[int, Dict[str, str]],
+    blurb_index: Dict[int, Optional[Dict[str, str]]],
+) -> Optional[Dict[str, str]]:
+    """Return the effective `skip_reason` dict for one issue, or None.
+
+    Implements the unified precedence (#862):
+      1. live `monitor-state.json:issues.skipped[N]` override wins;
+      2. else the blurb-derived reason.
+
+    On a live override, the chip `skip_reason` carries the override code
+    plus a label sourced from the recorded free-text reason when present,
+    otherwise the canonical per-code default label. `source` is annotated
+    so the chip tooltip discloses the override origin.
+    """
+    override = monitor_skipped.get(issue_number)
+    if override is not None:
+        code = override["code"]
+        reason = override.get("reason") or ""
+        label = reason if reason else _SKIP_CODE_DEFAULT_LABELS.get(code, code)
+        source = "monitor-state override" + (f": {reason}" if reason else "")
+        return {"code": code, "label": label, "source": source}
+    return blurb_index.get(issue_number)
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1818,7 +1818,16 @@ function buildIssueCard(issue, num, col) {
   // "N untracked" badge) can consume it. Tooltip carries the verbatim
   // Action-now / Verdict source line. Non-interactive — card remains
   // drag-and-droppable.
-  if (issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
+  //
+  // Mutual exclusion (#862): an issue with a live in-flight claim is NOT
+  // also a skipped issue — the claim chip (rendered below) is the
+  // authoritative live state, and showing BOTH an in-flight chip AND a
+  // `skip:` chip is the split-brain this fix closes. A claimed card on a
+  // non-completed column suppresses the skip chip entirely. (Completed
+  // cards never carry a live claim, so an explicitly-skipped completed
+  // item — rare — keeps its skip chip.)
+  var hasLiveClaim = !!(issue && issue.claim && !isCompleted);
+  if (!hasLiveClaim && issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
     const sr = issue.skip_reason;
     const code = String(sr.code || "");
     const label = String(sr.label || code || "");

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.31+28a992"
+  version: "2026.05.31+ec0ddc"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/scripts/filter-unresearched-candidates.sh
+++ b/skills/fix-issues/scripts/filter-unresearched-candidates.sh
@@ -67,10 +67,19 @@ fi
 # triage declines an issue as plan-scale / bug-unclear-cause /
 # needs-decision / deferred, the orchestrator records it here so the next
 # fire's filter drops it BEFORE re-triage — even when the issue has no
-# tracker row (raw dashboard-drag case). The map shape is
-# `{ "<issue-num>": "<skip-code>" }`, e.g. `{"803": "plan-scale"}`. This
-# is symmetric with `issues.reconsider`: monitor-state.json is gitignored,
-# so the skip-record never lands as a tracker-row commit on main.
+# tracker row (raw dashboard-drag case). The map value is EITHER a bare
+# code string `"<skip-code>"` (legacy / no-reason) OR a dict
+# `{"code": "<skip-code>", "reason": "<free-text>"}` (#862, when a
+# free-text reason was recorded). The filter only consumes the CODE; the
+# reason flows to the dashboard chip via collect.py. This is symmetric
+# with `issues.reconsider`: monitor-state.json is gitignored, so the
+# skip-record never lands as a tracker-row commit on main.
+#
+# Effective-skip-reason precedence (#862) — MUST match
+# collect.py:_resolve_effective_skip_code precedence exactly, otherwise
+# the dashboard chip and this drop-decision split-brain again: the live
+# `issues.skipped[N]` override WINS when present; only when it is absent
+# does the tracker-row `Action now:` blurb-derived code apply.
 MAIN_ROOT="${ZSKILLS_MAIN_ROOT:-$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)}"
 STATE_FILE="${MAIN_ROOT:+$MAIN_ROOT/.zskills/monitor-state.json}"
 RECONSIDER_NUMS=""
@@ -96,10 +105,18 @@ try:
     with open(sys.argv[1]) as f:
         data = json.load(f)
     skipped = data.get('issues', {}).get('skipped', {}) or {}
-    # Accept both dict and list-of-pairs shapes defensively.
+    # The map value is EITHER a bare code string (legacy / no-reason) OR a
+    # dict {'code': ..., 'reason': ...} (#862). The filter only consumes
+    # the CODE; reason is for the dashboard chip. Extract the code from
+    # whichever shape is present.
     if isinstance(skipped, dict):
         for k, v in skipped.items():
-            print(f'{k}\t{v}')
+            if isinstance(v, dict):
+                code = v.get('code')
+            else:
+                code = v
+            if code:
+                print(f'{k}\t{code}')
 except Exception:
     pass
 " "$STATE_FILE" 2>/dev/null)
@@ -195,14 +212,18 @@ for N in "$@"; do
 
   if [ "$found" -eq 1 ]; then
     RESEARCHED+=("$N")
-    if [ -n "$skip_code" ]; then
-      SKIP_TAGGED+=("$N:$skip_code")
-    elif [ -n "$monitor_skip_code" ]; then
-      # Tracker row exists but is not skip-tagged; monitor-state.json
-      # has a persisted decline (e.g. agent triaged plan-scale before
-      # the row's `Action now:` was rewritten). Honor the monitor-state
-      # decision so the issue drops from Phase 2.
+    # Effective-skip-reason precedence (#862): the live monitor-state
+    # override WINS over the tracker-row blurb-derived code. This mirrors
+    # collect.py:_resolve_effective_skip_code so the dashboard chip and
+    # this drop-decision never diverge (an orchestrator that re-triages an
+    # issue and records a new classification in monitor-state must move
+    # BOTH the chip and the filter, not just the filter). When no
+    # monitor-state override is present, fall back to the tracker-derived
+    # code.
+    if [ -n "$monitor_skip_code" ]; then
       SKIP_TAGGED+=("$N:$monitor_skip_code")
+    elif [ -n "$skip_code" ]; then
+      SKIP_TAGGED+=("$N:$skip_code")
     fi
     if [ "$is_reconsidered" -eq 1 ]; then
       # already appended above when we cleared monitor_skip_code

--- a/skills/fix-issues/scripts/record-skip.sh
+++ b/skills/fix-issues/scripts/record-skip.sh
@@ -32,17 +32,25 @@
 #   <skip-code>   One of: plan-scale | bug-unclear-cause | needs-decision
 #                 | deferred. REQUIRED. These mirror the canonical
 #                 dashboard skip-codes the filter recognizes.
-#   <reason>      Optional short string (informational; not consumed by
-#                 the filter). Currently ignored; reserved for future use.
+#   <reason>      Optional short free-text string (e.g. "needs author A/B/C
+#                 scope decision"). When present, the persisted entry becomes
+#                 the dict shape `{"code": <code>, "reason": <reason>}` and the
+#                 reason flows through to the dashboard skip chip's label
+#                 (#862). When absent, the legacy bare-string shape
+#                 `"<skip-code>"` is preserved (back-compat).
 #
 # Behavior:
 #   - Resolves `$MAIN_ROOT` from `$ZSKILLS_MAIN_ROOT` if set, else from
 #     `git rev-parse --git-common-dir`.
 #   - Creates `.zskills/monitor-state.json` with `{}` if absent.
-#   - Sets `data["issues"]["skipped"][str(N)] = "<skip-code>"`.
-#   - Idempotent: if the same code is already recorded, exits 0 silently;
-#     if a different code is recorded, overwrites (latest-classification
-#     wins — the orchestrator may re-triage and re-classify).
+#   - Sets `data["issues"]["skipped"][str(N)]` to either the bare code
+#     string (no reason given) or `{"code": <code>, "reason": <reason>}`
+#     (reason given). Both shapes are accepted by every reader
+#     (filter-unresearched-candidates.sh + collect.py).
+#   - Idempotent: if the same {code, reason} is already recorded, exits 0
+#     silently; if a different code/reason is recorded, overwrites
+#     (latest-classification wins — the orchestrator may re-triage and
+#     re-classify).
 #   - Atomic write via Python tempfile + `os.replace`.
 #
 # Exit:
@@ -59,7 +67,10 @@ fi
 
 ISSUE_NUM="$1"
 SKIP_CODE="$2"
-# reason argument reserved for future use; not consumed yet.
+# Optional free-text reason (#862). Empty when omitted; when present it is
+# persisted alongside the code as `{"code": ..., "reason": ...}` and rendered
+# in the dashboard skip chip's label.
+REASON="${3:-}"
 
 case "$ISSUE_NUM" in
   ''|*[!0-9]*)
@@ -92,10 +103,12 @@ if [ ! -f "$STATE_FILE" ]; then
   printf '{}\n' > "$STATE_FILE"
 fi
 
-python3 - "$STATE_FILE" "$ISSUE_NUM" "$SKIP_CODE" <<'PY' || exit 2
+python3 - "$STATE_FILE" "$ISSUE_NUM" "$SKIP_CODE" "$REASON" <<'PY' || exit 2
 import json, os, sys, tempfile
 
 path, num_s, code = sys.argv[1], sys.argv[2], sys.argv[3]
+reason = sys.argv[4] if len(sys.argv) > 4 else ""
+reason = reason.strip()
 
 try:
     with open(path) as f:
@@ -112,13 +125,30 @@ if not isinstance(skipped, dict):
     skipped = {}
     issues['skipped'] = skipped
 
-# Idempotent — same code recorded already, exit silently.
-if skipped.get(num_s) == code:
+
+def _norm(entry):
+    """Normalise either skip-entry shape to (code, reason) for comparison.
+
+    Accepts both the legacy bare-string shape (`"<code>"`) and the
+    dict shape (`{"code": ..., "reason": ...}`) so idempotency holds
+    across a mix of old and new writers (#862)."""
+    if isinstance(entry, dict):
+        return (entry.get('code'), entry.get('reason') or '')
+    return (entry, '')
+
+
+# When a reason is supplied, persist the dict shape so the chip can
+# render it; otherwise keep the legacy bare-string shape (back-compat).
+new_value = {'code': code, 'reason': reason} if reason else code
+
+# Idempotent — same (code, reason) recorded already, exit silently.
+prev_entry = skipped.get(num_s)
+if _norm(prev_entry) == _norm(new_value):
     print(f"/fix-issues: #{num_s} already recorded as skipped ({code}); no-op.", file=sys.stderr)
     sys.exit(0)
 
-prev = skipped.get(num_s)
-skipped[num_s] = code
+prev_code = _norm(prev_entry)[0] if prev_entry is not None else None
+skipped[num_s] = new_value
 
 tmp = tempfile.NamedTemporaryFile('w', delete=False,
     dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
@@ -127,8 +157,9 @@ tmp.write('\n')
 tmp.close()
 os.replace(tmp.name, path)
 
-if prev:
-    print(f"/fix-issues: #{num_s} skip-state updated ({prev} -> {code}).", file=sys.stderr)
+suffix = f" — {reason}" if reason else ""
+if prev_code:
+    print(f"/fix-issues: #{num_s} skip-state updated ({prev_code} -> {code}{suffix}).", file=sys.stderr)
 else:
-    print(f"/fix-issues: #{num_s} recorded as skipped ({code}).", file=sys.stderr)
+    print(f"/fix-issues: #{num_s} recorded as skipped ({code}{suffix}).", file=sys.stderr)
 PY

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+e6f96a"
+  version: "2026.05.31+1c6775"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1871,9 +1871,17 @@ def _annotate_issues_queue(
                 continue  # closed — route via inference to completed/triage
             pos[n] = (col, i)
 
+    # Live monitor-state skip override map (#862). Read from `state` (not
+    # the filesystem) so it is available even in the 2-arg fixture branch,
+    # and so it is the SAME source `filter-unresearched-candidates.sh`
+    # consumes from `monitor-state.json`. The unified precedence
+    # (override wins, else blurb) is applied per-issue below via
+    # `_resolve_effective_skip_reason`.
+    monitor_skipped: Dict[int, Dict[str, str]] = _read_monitor_skipped(state)
+
     # Build skip-reason index once per snapshot (avoids re-parsing the
     # tracker per Ready issue). Only populated when main_root is given.
-    skip_index: Dict[int, Dict[str, str]] = {}
+    skip_index: Dict[int, Optional[Dict[str, str]]] = {}
     issues_plan_path: Optional[pathlib.Path] = None
     # Claim index — parallel to skip_index; gated on main_root for the
     # same reason (R2.6: fixture branch passes 2-arg, no real filesystem).
@@ -1925,10 +1933,15 @@ def _annotate_issues_queue(
         if isinstance(num, int) and num in pos:
             col, i = pos[num]
             issue["queue"] = {"column": col, "index": i}
-            if num in skip_index:
-                reason = skip_index[num]
-                if reason is not None:
-                    issue["skip_reason"] = reason
+            # Effective skip-reason (#862): live monitor-state override
+            # wins over the blurb-derived reason. Identical precedence to
+            # filter-unresearched-candidates.sh so the chip and the
+            # drop-decision never split-brain.
+            reason = _resolve_effective_skip_reason(
+                num, monitor_skipped, skip_index,
+            )
+            if reason is not None:
+                issue["skip_reason"] = reason
         else:
             # W1.2b — issue default-column inference. Closed-within-window
             # issues land in `completed`; everything else falls through
@@ -2174,6 +2187,112 @@ def _build_skip_reason_index(
     for num in issue_numbers:
         out[num] = _parse_action_now(num, text)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Effective skip-reason resolution (issue #862)
+# ---------------------------------------------------------------------------
+#
+# Split-brain fix: the dashboard skip chip and the /fix-issues drop-decision
+# were sourced from two different, non-unified places — the chip from the
+# committed `Action now:` blurb (`_parse_action_now`), the drop from
+# `monitor-state.json:issues.skipped` (read by
+# `filter-unresearched-candidates.sh`). An orchestrator that re-triaged an
+# issue and recorded a new classification moved the FILTER but not the CHIP.
+#
+# The fix unifies both behind ONE precedence, implemented identically in
+# this module (chip path) and in `filter-unresearched-candidates.sh`
+# (drop path) — the two languages can't literally share a function, so the
+# precedence is mirrored and locked by a cross-path agreement test
+# (tests/test-fix-issues-skip-effective-reason.sh):
+#
+#   1. LIVE OVERRIDE — `monitor-state.json:issues.skipped[N]` wins when
+#      present. The value is EITHER a bare code string (legacy / no-reason)
+#      OR a dict `{"code": ..., "reason": ...}` (#862 free-text reason).
+#   2. BLURB FALLBACK — else the `Action now:` blurb-derived reason
+#      (`_parse_action_now` via `_build_skip_reason_index`).
+#
+# `reconsider <N>` clears `issues.skipped[N]` (the filter's one-shot dual),
+# which naturally resets the chip to the blurb baseline — no separate
+# clear-path is needed here.
+
+# Canonical dashboard skip-code → chip label map, mirroring
+# `_parse_action_now`'s per-code default labels. Used to synthesise a chip
+# `skip_reason` dict for a monitor-state override that has no committed
+# tracker blurb to source a label from.
+_SKIP_CODE_DEFAULT_LABELS: Dict[str, str] = {
+    "plan-scale": "plan-scale",
+    "bug-unclear-cause": "unclear cause",
+    "needs-decision": "author decision needed",
+    "deferred": "deferred",
+    "unresearched": "not yet researched",
+}
+
+
+def _read_monitor_skipped(state: Dict[str, Any]) -> Dict[int, Dict[str, str]]:
+    """Read `state["issues"]["skipped"]` into `{issue_num: {code, reason}}`.
+
+    `state` is the live monitor-state dict (the same dict
+    `filter-unresearched-candidates.sh` reads from
+    `monitor-state.json`), so this is the SINGLE source the override side
+    of the precedence consults — no separate filesystem read, and it works
+    in the 2-arg fixture branch too.
+
+    Accepts BOTH persisted shapes per entry (#862):
+      - bare code string `"<code>"`  (legacy / no-reason)
+      - dict `{"code": ..., "reason": ...}`  (free-text reason recorded)
+
+    Malformed / empty entries are skipped. `reason` is normalised to a
+    (possibly empty) string.
+    """
+    out: Dict[int, Dict[str, str]] = {}
+    issues_section = state.get("issues", {})
+    if not isinstance(issues_section, dict):
+        return out
+    skipped = issues_section.get("skipped", {})
+    if not isinstance(skipped, dict):
+        return out
+    for k, v in skipped.items():
+        try:
+            num = int(k)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(v, dict):
+            code = v.get("code")
+            reason = v.get("reason") or ""
+        else:
+            code = v
+            reason = ""
+        if not isinstance(code, str) or not code:
+            continue
+        out[num] = {"code": code, "reason": str(reason)}
+    return out
+
+
+def _resolve_effective_skip_reason(
+    issue_number: int,
+    monitor_skipped: Dict[int, Dict[str, str]],
+    blurb_index: Dict[int, Optional[Dict[str, str]]],
+) -> Optional[Dict[str, str]]:
+    """Return the effective `skip_reason` dict for one issue, or None.
+
+    Implements the unified precedence (#862):
+      1. live `monitor-state.json:issues.skipped[N]` override wins;
+      2. else the blurb-derived reason.
+
+    On a live override, the chip `skip_reason` carries the override code
+    plus a label sourced from the recorded free-text reason when present,
+    otherwise the canonical per-code default label. `source` is annotated
+    so the chip tooltip discloses the override origin.
+    """
+    override = monitor_skipped.get(issue_number)
+    if override is not None:
+        code = override["code"]
+        reason = override.get("reason") or ""
+        label = reason if reason else _SKIP_CODE_DEFAULT_LABELS.get(code, code)
+        source = "monitor-state override" + (f": {reason}" if reason else "")
+        return {"code": code, "label": label, "source": source}
+    return blurb_index.get(issue_number)
 
 
 # ---------------------------------------------------------------------------

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1818,7 +1818,16 @@ function buildIssueCard(issue, num, col) {
   // "N untracked" badge) can consume it. Tooltip carries the verbatim
   // Action-now / Verdict source line. Non-interactive — card remains
   // drag-and-droppable.
-  if (issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
+  //
+  // Mutual exclusion (#862): an issue with a live in-flight claim is NOT
+  // also a skipped issue — the claim chip (rendered below) is the
+  // authoritative live state, and showing BOTH an in-flight chip AND a
+  // `skip:` chip is the split-brain this fix closes. A claimed card on a
+  // non-completed column suppresses the skip chip entirely. (Completed
+  // cards never carry a live claim, so an explicitly-skipped completed
+  // item — rare — keeps its skip chip.)
+  var hasLiveClaim = !!(issue && issue.claim && !isCompleted);
+  if (!hasLiveClaim && issue && issue.skip_reason && issue.skip_reason.code && issue.skip_reason.code !== "unresearched") {
     const sr = issue.skip_reason;
     const code = String(sr.code || "");
     const label = String(sr.label || code || "");

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -106,6 +106,7 @@ run_suite "test-fix-issues-sprint-worktree-gate.sh" "tests/test-fix-issues-sprin
 run_suite "test-fix-issues-sprint-land-pr.sh" "tests/test-fix-issues-sprint-land-pr.sh"
 run_suite "test-fix-issues-phase2-source-filter.sh" "tests/test-fix-issues-phase2-source-filter.sh"
 run_suite "test-fix-issues-skip-persistence.sh" "tests/test-fix-issues-skip-persistence.sh"
+run_suite "test-fix-issues-skip-effective-reason.sh" "tests/test-fix-issues-skip-effective-reason.sh"
 run_suite "test-do.sh" "tests/test-do.sh"
 run_suite "test-commit.sh" "tests/test-commit.sh"
 run_suite "test-fix-report-smoke.sh" "tests/test-fix-report-smoke.sh"

--- a/tests/test-fix-issues-claim-collector.py
+++ b/tests/test-fix-issues-claim-collector.py
@@ -257,6 +257,96 @@ class AnnotateIssuesQueueGatingTests(unittest.TestCase):
         self.assertNotIn("claim", issues[1])
 
 
+class EffectiveSkipReasonTests(unittest.TestCase):
+    """Issue #862 — the dashboard skip chip and the /fix-issues
+    drop-decision are unified behind ONE precedence: a live
+    `monitor-state.json:issues.skipped[N]` override wins over the
+    committed `Action now:` blurb-derived reason.
+
+    These tests drive the Python (chip) side: `_read_monitor_skipped`,
+    `_resolve_effective_skip_reason`, and `_annotate_issues_queue`'s
+    wiring of the two. The bash (filter) side is asserted to agree on the
+    same inputs by tests/test-fix-issues-skip-effective-reason.sh.
+    """
+
+    def test_read_monitor_skipped_both_shapes(self) -> None:
+        # Accept bare-string (legacy) AND dict (#862 reason) entries.
+        state = {
+            "issues": {
+                "skipped": {
+                    "100": "plan-scale",
+                    "200": {"code": "needs-decision", "reason": "author A/B/C scope decision"},
+                    "300": {"code": "deferred"},  # dict without reason
+                    "bad": "plan-scale",          # non-int key skipped
+                    "400": {"no": "code"},        # malformed — skipped
+                    "500": "",                    # empty code — skipped
+                },
+            },
+        }
+        out = collect._read_monitor_skipped(state)
+        self.assertEqual(out.get(100), {"code": "plan-scale", "reason": ""})
+        self.assertEqual(
+            out.get(200),
+            {"code": "needs-decision", "reason": "author A/B/C scope decision"},
+        )
+        self.assertEqual(out.get(300), {"code": "deferred", "reason": ""})
+        self.assertNotIn(400, out)
+        self.assertNotIn(500, out)
+        # non-int key never lands.
+        self.assertNotIn("bad", out)
+
+    def test_override_beats_stale_blurb(self) -> None:
+        # (a) a live issues.skipped[N] override beats a stale blurb-derived
+        # reason in the chip. Blurb says plan-scale; override says
+        # needs-decision (the #832/#833 re-triage case).
+        monitor = {832: {"code": "needs-decision", "reason": "author decision pending"}}
+        blurb = {832: {"code": "plan-scale", "label": "plan-scale", "source": "**Action now:** /draft-plan"}}
+        eff = collect._resolve_effective_skip_reason(832, monitor, blurb)
+        self.assertEqual(eff["code"], "needs-decision")
+        self.assertEqual(eff["label"], "author decision pending")  # reason -> label
+        self.assertIn("monitor-state override", eff["source"])
+
+    def test_override_without_reason_uses_default_label(self) -> None:
+        monitor = {7: {"code": "plan-scale", "reason": ""}}
+        eff = collect._resolve_effective_skip_reason(7, monitor, {})
+        self.assertEqual(eff["code"], "plan-scale")
+        self.assertEqual(eff["label"], "plan-scale")  # canonical default
+
+    def test_blurb_fallback_when_no_override(self) -> None:
+        # No override -> blurb-derived reason flows through unchanged.
+        blurb = {9: {"code": "deferred", "label": "leave open", "source": "src"}}
+        eff = collect._resolve_effective_skip_reason(9, {}, blurb)
+        self.assertEqual(eff, {"code": "deferred", "label": "leave open", "source": "src"})
+        # And None when neither side has anything.
+        self.assertIsNone(collect._resolve_effective_skip_reason(9, {}, {}))
+
+    def test_annotate_applies_override_in_fixture_branch(self) -> None:
+        # _annotate_issues_queue reads the override from `state` even in
+        # the 2-arg fixture branch (no main_root, no blurb index). The
+        # chip gets the override reason.
+        issues = [{"number": 50, "title": "re-triaged"}]
+        state = {
+            "issues": {
+                "triage": [], "ready": [50], "in-progress": [], "done": [],
+                "skipped": {"50": {"code": "needs-decision", "reason": "needs author X/Y"}},
+            },
+        }
+        collect._annotate_issues_queue(issues, state)
+        sr = issues[0].get("skip_reason")
+        self.assertIsNotNone(sr)
+        self.assertEqual(sr["code"], "needs-decision")
+        self.assertEqual(sr["label"], "needs author X/Y")
+
+    def test_reconsider_resets_to_blurb_baseline_semantics(self) -> None:
+        # When issues.skipped[N] is absent (reconsider cleared it), the
+        # chip falls back to the blurb baseline — no separate clear-path.
+        # Here we simulate the post-reconsider state: no override entry,
+        # so _resolve_effective_skip_reason returns the blurb reason.
+        blurb = {77: {"code": "plan-scale", "label": "plan-scale", "source": "src"}}
+        eff = collect._resolve_effective_skip_reason(77, {}, blurb)
+        self.assertEqual(eff["code"], "plan-scale")
+
+
 class ReadClaimsLatencyBenchmark(unittest.TestCase):
     """T3.3 — issue #514 latency budget. <10ms wall-clock p95 for 50
     simulated claims. NOT skip-not-fail. If this regresses, memoize

--- a/tests/test-fix-issues-claim-render-dom.sh
+++ b/tests/test-fix-issues-claim-render-dom.sh
@@ -436,6 +436,56 @@ function findByClass(root, cls) {
 }
 
 // ------------------------------------------------------------------
+// #862 — mutual exclusion: a live claim SUPPRESSES the skip chip.
+// An actively-claimed issue must NOT also render a `skip:` chip
+// (the split-brain symptom #862 closes — observed an issue with a
+// live in-flight claim showing BOTH an in-flight chip AND a
+// skip:plan-scale chip). The claim chip is authoritative.
+// ------------------------------------------------------------------
+{
+  const issue = {
+    number: 862,
+    title: "Claimed AND carries a skip_reason",
+    labels: [],
+    skip_reason: { code: "plan-scale", label: "plan-scale", source: "**Action now:** /draft-plan" },
+    claim: {
+      pipeline_id: "fix-issues.sprint-20260601-010731-foo",
+      sprint_id: "sprint-20260601-010731-foo",
+      age_seconds: 30,
+      started_at: new Date(Date.now() - 30000).toISOString(),
+      pipeline_short: "010731-foo",
+    },
+  };
+  const card = buildIssueCard(issue, 862, "ready");
+  expect(findByClass(card, "skip-chip"), null,
+    "live claim suppresses skip chip (#862 mutual exclusion — no skip-chip rendered)");
+  expectTrue(findByClass(card, "claim-chip"),
+    "live claim still renders the in-flight claim chip");
+}
+
+// ------------------------------------------------------------------
+// #862 — negative control: a skip_reason WITHOUT a claim still renders
+// the skip chip (mutual exclusion only fires on a live claim).
+// ------------------------------------------------------------------
+{
+  const issue = {
+    number: 863,
+    title: "Skip reason, no claim",
+    labels: [],
+    skip_reason: { code: "needs-decision", label: "author A/B/C scope decision", source: "monitor-state override: author A/B/C scope decision" },
+  };
+  const card = buildIssueCard(issue, 863, "ready");
+  const chip = findByClass(card, "skip-chip");
+  expectTrue(chip, "skip chip renders when no claim present (#862 negative control)");
+  if (chip) {
+    expectTrue(chip.textContent.indexOf("author A/B/C scope decision") >= 0,
+      "skip chip label surfaces the monitor-state override reason (#862)");
+  }
+  expect(findByClass(card, "claim-chip"), null,
+    "no claim chip when issue.claim absent (#862 negative control)");
+}
+
+// ------------------------------------------------------------------
 // T3.2.b — handleAction guards block move/remove on claimed cards
 // ------------------------------------------------------------------
 {

--- a/tests/test-fix-issues-skip-effective-reason.sh
+++ b/tests/test-fix-issues-skip-effective-reason.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# test-fix-issues-skip-effective-reason.sh — cross-path agreement coverage
+# for issue #862 (split-brain between the dashboard skip chip and the
+# /fix-issues drop-decision).
+#
+# Root cause (#862): the dashboard skip-reason chip was sourced ONLY from
+# the committed `Action now:` blurb (collect.py:_parse_action_now), while
+# `monitor-state.json:issues.skipped[N]` was read ONLY by the filter
+# (filter-unresearched-candidates.sh). An orchestrator that re-triaged an
+# issue and recorded a new classification moved the FILTER but not the
+# CHIP — so the chip showed a stale `skip:plan-scale` while the issue had
+# actually been re-classified to needs-decision.
+#
+# Fix: ONE precedence, mirrored in both languages (they can't share a
+# function): the live `issues.skipped[N]` override WINS over the
+# blurb-derived reason; absent an override, the blurb applies. This test
+# LOCKS the agreement — for the same monitor-state + tracker input, the
+# Python chip path and the bash filter path must resolve the SAME
+# effective skip-code. If a future edit drifts one side's precedence, the
+# split-brain returns and this test fails.
+#
+# Cases:
+#   (a) override beats a stale blurb: tracker says plan-scale, monitor-state
+#       says needs-decision -> BOTH resolve needs-decision.
+#   (b) record-skip.sh-persisted free-text reason flows to the chip label.
+#   (c) no override: chip + filter both fall back to the blurb code.
+#   (d) record-skip.sh writes the {code, reason} dict shape when a reason
+#       arg is supplied (and bare-string when omitted).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FILTER="$REPO_ROOT/skills/fix-issues/scripts/filter-unresearched-candidates.sh"
+RECORD="$REPO_ROOT/skills/fix-issues/scripts/record-skip.sh"
+PKG_PARENT="$REPO_ROOT/skills/zskills-dashboard/scripts"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not available — skipping"
+  exit 0
+fi
+
+SCRATCH="$(mktemp -d)"
+cleanup() { rm -rf "$SCRATCH"; }
+trap cleanup EXIT INT TERM
+
+echo "=== /fix-issues skip effective-reason cross-path agreement (#862) ==="
+
+make_main_root() {
+  local d="$1"
+  mkdir -p "$d"
+  ( cd "$d" && git init -q && git config user.email t@t && git config user.name t \
+      && git commit --allow-empty -q -m init ) >/dev/null
+}
+
+# Resolve the bash filter's effective skip-code for issue N (the code in
+# the `N:<code>` SKIP_TAGGED token, or empty).
+filter_effective_code() {
+  local issues_dir="$1" main_root="$2" n="$3"
+  local out tagged
+  out=$(ZSKILLS_ISSUES_DIR="$issues_dir" ZSKILLS_MAIN_ROOT="$main_root" bash "$FILTER" "$n")
+  tagged=$(echo "$out" | grep '^SKIP_TAGGED=' | sed -e 's/^SKIP_TAGGED=//' -e 's/^"//' -e 's/"$//')
+  # Extract the code for this issue from `N:code` tokens.
+  for tok in $tagged; do
+    case "$tok" in
+      "$n":*) echo "${tok#*:}"; return ;;
+    esac
+  done
+  echo ""
+}
+
+# Resolve the Python chip's effective skip-code for issue N, given a
+# monitor-state file + tracker dir. Prints `code|label` (code empty when
+# None).
+chip_effective() {
+  local state_file="$1" tracker_path="$2" n="$3"
+  PYTHONPATH="$PKG_PARENT" python3 - "$state_file" "$tracker_path" "$n" <<'PY'
+import json, sys, pathlib
+from zskills_monitor.collect import (
+    _read_monitor_skipped,
+    _build_skip_reason_index,
+    _resolve_effective_skip_reason,
+)
+state_file, tracker_path, n_s = sys.argv[1], sys.argv[2], sys.argv[3]
+n = int(n_s)
+try:
+    with open(state_file) as f:
+        state = json.load(f)
+except Exception:
+    state = {}
+monitor = _read_monitor_skipped(state)
+blurb = _build_skip_reason_index(pathlib.Path(tracker_path), [n])
+eff = _resolve_effective_skip_reason(n, monitor, blurb)
+if eff is None:
+    print("|")
+else:
+    print(f"{eff.get('code','')}|{eff.get('label','')}")
+PY
+}
+
+# --- (a) override beats stale blurb (BOTH paths agree) -------------------
+test_override_beats_blurb_agreement() {
+  local issues_dir="$SCRATCH/a/issues" main_root="$SCRATCH/a/main"
+  mkdir -p "$issues_dir"; make_main_root "$main_root"
+  # Tracker blurb says plan-scale...
+  cat > "$issues_dir/ISSUES_PLAN.md" <<'EOF'
+### #832 — stale blurb
+**Action now:** /draft-plan — plan-scale design surface.
+EOF
+  # ...but the orchestrator re-triaged to needs-decision (with a reason).
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 832 needs-decision "needs author A/B/C scope decision" >/dev/null 2>&1
+
+  local fcode chip ccode
+  fcode=$(filter_effective_code "$issues_dir" "$main_root" 832)
+  chip=$(chip_effective "$main_root/.zskills/monitor-state.json" "$issues_dir/ISSUES_PLAN.md" 832)
+  ccode="${chip%%|*}"
+
+  if [ "$fcode" = "needs-decision" ] && [ "$ccode" = "needs-decision" ]; then
+    pass "override beats stale blurb AND chip+filter agree (both needs-decision)"
+  else
+    fail "override beats stale blurb / agreement" "filter=[$fcode] chip=[$ccode]"
+  fi
+}
+
+# --- (b) persisted reason flows to the chip label ------------------------
+test_reason_flows_to_chip_label() {
+  local issues_dir="$SCRATCH/b/issues" main_root="$SCRATCH/b/main"
+  mkdir -p "$issues_dir"; make_main_root "$main_root"
+  : > "$issues_dir/ISSUES_PLAN.md"
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 900 needs-decision "needs author A/B/C scope decision" >/dev/null 2>&1
+  local chip label
+  chip=$(chip_effective "$main_root/.zskills/monitor-state.json" "$issues_dir/ISSUES_PLAN.md" 900)
+  label="${chip#*|}"
+  if [ "$label" = "needs author A/B/C scope decision" ]; then
+    pass "record-skip.sh-persisted reason flows through to chip label"
+  else
+    fail "reason flows to chip label" "got label [$label] (full=[$chip])"
+  fi
+}
+
+# --- (c) no override: both paths fall back to blurb code -----------------
+test_no_override_blurb_fallback_agreement() {
+  local issues_dir="$SCRATCH/c/issues" main_root="$SCRATCH/c/main"
+  mkdir -p "$issues_dir"; make_main_root "$main_root"
+  cat > "$issues_dir/ISSUES_PLAN.md" <<'EOF'
+### #701 — plan-scale rowed
+**Action now:** /draft-plan — needs design review.
+EOF
+  # No record-skip — monitor-state has no entry.
+  printf '{}\n' > "$main_root/.zskills/monitor-state.json" 2>/dev/null || {
+    mkdir -p "$main_root/.zskills"; printf '{}\n' > "$main_root/.zskills/monitor-state.json"; }
+  local fcode chip ccode
+  fcode=$(filter_effective_code "$issues_dir" "$main_root" 701)
+  chip=$(chip_effective "$main_root/.zskills/monitor-state.json" "$issues_dir/ISSUES_PLAN.md" 701)
+  ccode="${chip%%|*}"
+  if [ "$fcode" = "plan-scale" ] && [ "$ccode" = "plan-scale" ]; then
+    pass "no override: chip+filter both fall back to blurb code (plan-scale)"
+  else
+    fail "no-override blurb fallback agreement" "filter=[$fcode] chip=[$ccode]"
+  fi
+}
+
+# --- (d) record-skip writes dict shape with reason, bare without ---------
+test_record_skip_dict_shape() {
+  local main_root="$SCRATCH/d/main"
+  make_main_root "$main_root"
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 11 needs-decision "scope decision" >/dev/null 2>&1
+  ZSKILLS_MAIN_ROOT="$main_root" bash "$RECORD" 12 plan-scale >/dev/null 2>&1
+  local shapes
+  shapes=$(python3 - "$main_root/.zskills/monitor-state.json" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+sk = data.get('issues', {}).get('skipped', {})
+e11 = sk.get('11'); e12 = sk.get('12')
+ok11 = isinstance(e11, dict) and e11.get('code') == 'needs-decision' and e11.get('reason') == 'scope decision'
+ok12 = (e12 == 'plan-scale')  # bare string when no reason
+print('ok' if (ok11 and ok12) else f'BAD e11={e11!r} e12={e12!r}')
+PY
+)
+  if [ "$shapes" = "ok" ]; then
+    pass "record-skip writes {code,reason} dict with reason, bare string without"
+  else
+    fail "record-skip dict/bare shape" "$shapes"
+  fi
+}
+
+test_override_beats_blurb_agreement
+test_reason_flows_to_chip_label
+test_no_override_blurb_fallback_agreement
+test_record_skip_dict_shape
+
+echo ""
+echo "---"
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$TOTAL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #862. The dashboard skip-reason chip and the `/fix-issues` Phase-2
drop decision were sourced from two disjoint paths, producing a split-brain
whenever they disagreed:

- The **chip** (`collect.py:_annotate_issues_queue` → `_build_skip_reason_index`)
  read ONLY the committed `Action now:` blurb in `ISSUES_PLAN.md`.
- The **filter** (`filter-unresearched-candidates.sh`) read the live
  `monitor-state.json:issues.skipped[N]` override.

So a re-triaged issue (e.g. #832/#833 → needs-decision) updated filter
behavior but kept showing the stale `skip:plan-scale` chip; and an
actively-claimed issue rendered both an in-flight chip AND a skip chip.

## Fix

- **Unified precedence** on both paths: live `monitor-state.json:issues.skipped[N]`
  override wins; else fall back to the `Action now:` blurb-derived reason.
  `collect.py` now reads `issues.skipped` (mirroring the existing
  `claim_index` read) and consults it before the blurb; the filter's emit
  order was flipped so the override wins. A cross-path test locks the two
  to agree.
- `record-skip.sh` now persists `{code, reason}` (the previously-dropped
  third arg) and surfaces `reason` through the chip label.
- `app.js`: a live (non-completed) `issue.claim` suppresses the skip-chip
  block — an in-flight issue is not also a skipped issue.
- `reconsider <N>` already clears the override → naturally resets the chip
  to the blurb baseline (verified; no new clear-path).

## Test plan
- [x] `bash tests/run-all.sh` — 6723/6723 passed, 0 failed (verifier-confirmed).
- [x] New `test-fix-issues-skip-effective-reason.sh` (4/4): override-beats-blurb, cross-path agreement, persisted-reason→label, record-skip dict shape.
- [x] `EffectiveSkipReasonTests` in collector.py (6 cases) + claim-suppresses-skip DOM test.
- [x] test-skills-mirror-parity 57/57; test-skill-conformance 754/754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
