### PR TITLE
fix(cron-pickup): shared session-scoped in-flight guard (#877)

### DIFF
--- a/.claude/skills/create-worktree/SKILL.md
+++ b/.claude/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.05.31+8f7116"
+  version: "2026.05.31+c3b507"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/.claude/skills/create-worktree/scripts/check-inflight-batch.sh
+++ b/.claude/skills/create-worktree/scripts/check-inflight-batch.sh
@@ -1,0 +1,527 @@
+#!/bin/bash
+# check-inflight-batch.sh — Shared session-scoped in-flight guard for
+# queue-pickup workers (/fix-issues sprint, /work-on-plans batch,
+# /qe-audit audit). Closes the cron-pickup concurrency hole documented
+# in issue #877.
+#
+# Why this is shared (not three per-skill scripts): all three workers
+# share the same shape — a recurring cron fire re-fires FRESH work
+# (a fresh sprint / batch / audit, not a continuation of a specific
+# item). The right skip-key is "my session already has an in-flight
+# run of this skill," and the two robustness traps (session-scoping +
+# staleness escape) are identical. Factor once, integrate at each
+# entry point.
+#
+# Sentinel layout:
+#   $MAIN_ROOT/.zskills/inflight/<skill>/<pipeline-id>.json
+#   {
+#     "skill":       "<skill>",
+#     "pipeline_id": "<pipeline-id>",
+#     "session_id":  "<session>",      # see resolve_session_id() below
+#     "started_at":  "<ISO-8601 UTC>"
+#   }
+#
+# Subcommands:
+#   check <skill> [--max-age-seconds N] [--session-id <id>]
+#     Returns 0 (in-flight; SKIP) iff a sentinel exists for <skill>
+#     whose session_id matches THIS session AND whose started_at age
+#     is less than max-age-seconds (default 7200 = 2h).
+#     Returns 1 (no in-flight; PROCEED) otherwise. Stale sentinels
+#     (older than max-age) are removed in-line and treated as absent
+#     (graceful escape from a dead-session sentinel).
+#
+#   write <skill> --pipeline-id <id> [--session-id <id>]
+#     Create the sentinel for this skill+pipeline. Idempotent: if a
+#     sentinel for the same pipeline_id already exists it is rewritten
+#     (refresh started_at).
+#
+#   clear <skill> --pipeline-id <id>
+#     Remove the sentinel for this skill+pipeline. Idempotent: missing
+#     sentinel returns 0. Mismatched pipeline_id sentinels (different
+#     run) are left intact.
+#
+#   list <skill>
+#     Pure read. Emits one TSV line per live sentinel:
+#       <pipeline_id>\t<session_id>\t<age_seconds>
+#
+#   resolve-session-id
+#     Print the current session_id to stdout (for callers that want to
+#     inspect or pass it through).
+#
+# Session-scoping (the FIRST robustness trap from #877):
+#   resolve_session_id() walks $$'s ancestor PID chain until it hits
+#   PID 1's first descendant — typically the Claude Code main process
+#   for the current REPL session. Combines that PID with /proc/<pid>/
+#   stat's start_time field (jiffies-since-boot of process start) to
+#   produce a stable identifier that:
+#     * is constant across turns of the same Claude Code session,
+#     * differs between sessions (different process trees),
+#     * survives the bash subshell's own restart between turns.
+#   On non-Linux or when /proc is unreadable, falls back to the
+#   $MAIN_ROOT/.zskills/session-id file (lazily stamped on first call,
+#   refreshed if older than 24h). Callers can always pass an explicit
+#   --session-id to override resolution (used by tests).
+#
+# Staleness escape (the SECOND robustness trap from #877):
+#   max-age-seconds defaults to 7200 (2 hours) — a generous bound that
+#   exceeds any plausible single sprint/batch/audit. A sentinel older
+#   than max-age is treated as orphaned (crashed run) and removed
+#   in-line; the caller proceeds. Skipping a redundant pickup at worst
+#   delays the queue one interval, so the escape is non-destructive.
+#   Override via ZSKILLS_INFLIGHT_MAX_AGE_SECONDS env var or per-call
+#   --max-age-seconds flag.
+#
+# Carve-out: this helper is invoked ONLY at the pickup-path entry of
+# each consumer skill, AFTER the subcommand router has decided this
+# fire is a real run dispatch. The subcommand carve-out (stop / next /
+# sync / add / rank / remove / default / etc. must always proceed) is
+# enforced by callers placing the check call AFTER those detections
+# but BEFORE the main run-dispatch body.
+#
+# No jq — Python stdlib json for write/read.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Python interpreter resolution.
+# ---------------------------------------------------------------------------
+_INFLIGHT_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$_INFLIGHT_PYTHON" ]; then
+  echo "check-inflight-batch.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
+  exit 127
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults.
+# ---------------------------------------------------------------------------
+_DEFAULT_MAX_AGE="${ZSKILLS_INFLIGHT_MAX_AGE_SECONDS:-7200}"
+
+# ---------------------------------------------------------------------------
+# MAIN_ROOT resolution. Same pattern as claim-issue.sh / claim-plan.sh.
+# ---------------------------------------------------------------------------
+resolve_main_root() {
+  local common_dir
+  if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+    echo "check-inflight-batch.sh: cannot resolve MAIN_ROOT (not in a git working tree); cd into a project worktree first" >&2
+    return 1
+  fi
+  if ! MAIN_ROOT=$(cd "$common_dir/.." && pwd); then
+    echo "check-inflight-batch.sh: cannot resolve MAIN_ROOT (failed to cd into git common dir parent)" >&2
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Session-id resolution.
+#
+# Strategy A (Linux /proc): walk $$ up the PPID chain until we land on
+# PID 1's first descendant — this is typically the Claude Code main
+# process. Combine that PID with /proc/<pid>/stat field 22 (start_time
+# in clock ticks since boot) to form a stable identifier. Field 2 of
+# /proc/<pid>/stat is the comm in parens, so we use awk's special
+# tokenization: skip past `)` then count from there.
+#
+# Strategy B (fallback): lazily stamp $MAIN_ROOT/.zskills/session-id
+# if absent or if older than 24h. Stale-refresh is safe because the
+# refresh window is much longer than any plausible cron-pickup cycle.
+# ---------------------------------------------------------------------------
+_session_id_from_proc() {
+  if [ ! -r /proc/$$/stat ]; then
+    return 1
+  fi
+  local pid=$$
+  local ppid
+  # Walk up; stop when ppid<=1 (we hit init's child).
+  while :; do
+    if [ ! -r "/proc/$pid/stat" ]; then
+      return 1
+    fi
+    # /proc/<pid>/stat: pid (comm) state ppid ...
+    # The comm field can contain spaces and parens; strip from first `(`
+    # to last `)` to make the rest unambiguously space-delimited.
+    ppid=$(sed -n 's/.*) [A-Z] \([0-9]*\) .*/\1/p' "/proc/$pid/stat" 2>/dev/null)
+    if [ -z "$ppid" ] || ! [ "$ppid" -ge 0 ] 2>/dev/null; then
+      return 1
+    fi
+    # Stop when ppid drops to PID 1 (init) or 0 (container/kernel root)
+    # — the current `pid` is the highest stable non-init ancestor.
+    if [ "$ppid" -le 1 ]; then
+      break
+    fi
+    pid=$ppid
+  done
+  # pid now == the first descendant of PID 1. Get its start_time
+  # (/proc/<pid>/stat field 22, counted AFTER the comm-paren strip).
+  local rest start_time
+  rest=$(sed -n 's/.*) [A-Z] //p' "/proc/$pid/stat" 2>/dev/null)
+  if [ -z "$rest" ]; then
+    return 1
+  fi
+  # Field 22 of original = position (22 - 3) = 19 after the strip
+  # (we removed pid, (comm), state — 3 fields; ppid is now field 1
+  # of `rest`, so start_time is field 19 of `rest`).
+  start_time=$(printf '%s\n' "$rest" | awk '{print $19}')
+  if [ -z "$start_time" ] || ! [ "$start_time" -ge 0 ] 2>/dev/null; then
+    return 1
+  fi
+  printf 'pid-%s.%s' "$pid" "$start_time"
+  return 0
+}
+
+_session_id_from_file() {
+  local main_root="$1"
+  local session_file="${main_root}/.zskills/session-id"
+  local now age limit=86400  # 24h
+  now=$(date -u +%s)
+  if [ -f "$session_file" ]; then
+    local mtime
+    mtime=$(stat -c %Y "$session_file" 2>/dev/null || stat -f %m "$session_file" 2>/dev/null || echo 0)
+    age=$(( now - mtime ))
+    if [ "$age" -lt "$limit" ]; then
+      cat "$session_file"
+      return 0
+    fi
+  fi
+  # Stamp a fresh session-id.
+  mkdir -p "$(dirname "$session_file")"
+  local new_id
+  new_id="file-$(date -u +%Y%m%d%H%M%S)-$$"
+  printf '%s' "$new_id" > "$session_file"
+  printf '%s' "$new_id"
+  return 0
+}
+
+resolve_session_id() {
+  local sid
+  if sid=$(_session_id_from_proc); then
+    printf '%s' "$sid"
+    return 0
+  fi
+  if [ -z "${MAIN_ROOT:-}" ]; then
+    resolve_main_root || return 1
+  fi
+  _session_id_from_file "$MAIN_ROOT"
+}
+
+# ---------------------------------------------------------------------------
+# Validate skill name — must be a simple slug (a-z0-9- only). Prevents
+# path-traversal via crafted skill arg.
+# ---------------------------------------------------------------------------
+_validate_skill() {
+  local s="${1:-}"
+  if [ -z "$s" ]; then
+    echo "check-inflight-batch.sh: skill name required" >&2
+    return 1
+  fi
+  case "$s" in
+    ''|*[!a-z0-9-]*)
+      echo "check-inflight-batch.sh: invalid skill name '$s' (must match [a-z0-9-]+)" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+_validate_pipeline_id() {
+  local p="${1:-}"
+  if [ -z "$p" ]; then
+    echo "check-inflight-batch.sh: --pipeline-id required" >&2
+    return 1
+  fi
+  # Re-sanitize defensively — pipeline_ids are already sanitized by
+  # callers via sanitize-pipeline-id.sh, but accept the same shape here.
+  case "$p" in
+    ''|*[!a-zA-Z0-9._-]*)
+      echo "check-inflight-batch.sh: invalid pipeline-id '$p' (must match [a-zA-Z0-9._-]+)" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# check <skill> [--max-age-seconds N] [--session-id <id>]
+#
+# Exit 0  — in-flight, SKIP (caller should exit 0 cleanly).
+# Exit 1  — no in-flight sentinel for this session, PROCEED.
+# Exit 2  — usage error.
+# ---------------------------------------------------------------------------
+cmd_check() {
+  local skill="" max_age="$_DEFAULT_MAX_AGE" explicit_sid=""
+  if [ "$#" -lt 1 ]; then
+    echo "Usage: check-inflight-batch.sh check <skill> [--max-age-seconds N] [--session-id <id>]" >&2
+    return 2
+  fi
+  skill="$1"; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --max-age-seconds) max_age="${2:-}"; shift 2 ;;
+      --session-id)      explicit_sid="${2:-}"; shift 2 ;;
+      *) echo "check-inflight-batch.sh check: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  _validate_skill "$skill" || return 2
+  case "$max_age" in
+    ''|*[!0-9]*) echo "check-inflight-batch.sh check: --max-age-seconds must be non-negative integer" >&2; return 2 ;;
+  esac
+  resolve_main_root || return 2
+
+  local sid
+  if [ -n "$explicit_sid" ]; then
+    sid="$explicit_sid"
+  else
+    sid=$(resolve_session_id) || { echo "check-inflight-batch.sh: cannot resolve session-id" >&2; return 2; }
+  fi
+
+  local skill_dir="${MAIN_ROOT}/.zskills/inflight/${skill}"
+  if [ ! -d "$skill_dir" ]; then
+    return 1  # proceed — no sentinels at all for this skill
+  fi
+
+  # Python pass: find any sentinel matching session_id AND not stale.
+  # Stale sentinels (age > max_age) are removed inline. Returns "match"
+  # iff a fresh same-session sentinel was found.
+  local result
+  result=$("$_INFLIGHT_PYTHON" - "$skill_dir" "$sid" "$max_age" <<'PY'
+import json, os, sys, time, datetime
+skill_dir, want_sid, max_age = sys.argv[1], sys.argv[2], int(sys.argv[3])
+now = datetime.datetime.now(datetime.timezone.utc)
+match = None
+try:
+    entries = os.listdir(skill_dir)
+except OSError:
+    print("none")
+    sys.exit(0)
+for name in entries:
+    if not name.endswith(".json"):
+        continue
+    path = os.path.join(skill_dir, name)
+    if not os.path.isfile(path):
+        continue
+    try:
+        with open(path) as fh:
+            body = json.load(fh)
+    except Exception:
+        # Malformed sentinel — treat as orphan, remove.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        continue
+    started_at = body.get("started_at", "")
+    age = None
+    if started_at:
+        try:
+            t = datetime.datetime.fromisoformat(started_at)
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=datetime.timezone.utc)
+            age = (now - t).total_seconds()
+        except Exception:
+            age = None
+    if age is None or age > max_age:
+        # Stale or unparseable timestamp — orphan; remove and continue.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        continue
+    # Fresh sentinel. Check session-id.
+    if body.get("session_id", "") == want_sid:
+        match = (body.get("pipeline_id", "?"), int(age))
+        break
+if match is None:
+    print("none")
+else:
+    print(f"match\t{match[0]}\t{match[1]}")
+PY
+)
+  case "$result" in
+    match*)
+      # Emit a short diagnostic so the caller's "skipping redundant
+      # cron pickup" message has the matching pipeline_id available.
+      local pipeline_id age
+      pipeline_id=$(printf '%s' "$result" | awk -F'\t' '{print $2}')
+      age=$(printf '%s' "$result" | awk -F'\t' '{print $3}')
+      printf 'in-flight\t%s\t%s\n' "$pipeline_id" "$age"
+      return 0
+      ;;
+    none|*)
+      return 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# write <skill> --pipeline-id <id> [--session-id <id>]
+# ---------------------------------------------------------------------------
+cmd_write() {
+  local skill="" pipeline_id="" explicit_sid=""
+  if [ "$#" -lt 1 ]; then
+    echo "Usage: check-inflight-batch.sh write <skill> --pipeline-id <id> [--session-id <id>]" >&2
+    return 2
+  fi
+  skill="$1"; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      --session-id)  explicit_sid="${2:-}"; shift 2 ;;
+      *) echo "check-inflight-batch.sh write: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  _validate_skill "$skill" || return 2
+  _validate_pipeline_id "$pipeline_id" || return 2
+  resolve_main_root || return 2
+
+  local sid
+  if [ -n "$explicit_sid" ]; then
+    sid="$explicit_sid"
+  else
+    sid=$(resolve_session_id) || { echo "check-inflight-batch.sh: cannot resolve session-id" >&2; return 2; }
+  fi
+
+  local skill_dir="${MAIN_ROOT}/.zskills/inflight/${skill}"
+  local sentinel="${skill_dir}/${pipeline_id}.json"
+  local sentinel_tmp="${sentinel}.tmp"
+
+  if ! mkdir -p "$skill_dir"; then
+    echo "check-inflight-batch.sh write: failed to create $skill_dir" >&2
+    return 11
+  fi
+
+  if ! "$_INFLIGHT_PYTHON" - "$sentinel_tmp" "$sentinel" "$skill" "$pipeline_id" "$sid" <<'PY'
+import json, os, sys, datetime
+tmp, final, skill, pipeline_id, sid = sys.argv[1:6]
+body = {
+    "schema_version": 1,
+    "skill":          skill,
+    "pipeline_id":    pipeline_id,
+    "session_id":     sid,
+    "started_at":     datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+}
+with open(tmp, "w") as f:
+    json.dump(body, f, sort_keys=True)
+    f.write("\n")
+os.replace(tmp, final)
+PY
+  then
+    rm -f "$sentinel_tmp"
+    echo "check-inflight-batch.sh write: atomic write failed for $sentinel" >&2
+    return 11
+  fi
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# clear <skill> --pipeline-id <id>
+# ---------------------------------------------------------------------------
+cmd_clear() {
+  local skill="" pipeline_id=""
+  if [ "$#" -lt 1 ]; then
+    echo "Usage: check-inflight-batch.sh clear <skill> --pipeline-id <id>" >&2
+    return 2
+  fi
+  skill="$1"; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      *) echo "check-inflight-batch.sh clear: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  _validate_skill "$skill" || return 2
+  _validate_pipeline_id "$pipeline_id" || return 2
+  resolve_main_root || return 2
+
+  local sentinel="${MAIN_ROOT}/.zskills/inflight/${skill}/${pipeline_id}.json"
+  rm -f "$sentinel"
+  rm -f "${sentinel}.tmp"
+
+  # rmdir the parent if empty (best-effort cleanup; harmless if non-empty).
+  rmdir "${MAIN_ROOT}/.zskills/inflight/${skill}" 2>/dev/null || true
+  rmdir "${MAIN_ROOT}/.zskills/inflight" 2>/dev/null || true
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# list <skill>
+# ---------------------------------------------------------------------------
+cmd_list() {
+  local skill="${1:-}"
+  _validate_skill "$skill" || return 2
+  resolve_main_root || return 2
+
+  local skill_dir="${MAIN_ROOT}/.zskills/inflight/${skill}"
+  [ -d "$skill_dir" ] || return 0
+
+  "$_INFLIGHT_PYTHON" - "$skill_dir" <<'PY'
+import json, os, sys, datetime
+skill_dir = sys.argv[1]
+now = datetime.datetime.now(datetime.timezone.utc)
+try:
+    entries = sorted(os.listdir(skill_dir))
+except OSError:
+    sys.exit(0)
+for name in entries:
+    if not name.endswith(".json"):
+        continue
+    path = os.path.join(skill_dir, name)
+    try:
+        with open(path) as fh:
+            body = json.load(fh)
+    except Exception:
+        continue
+    started_at = body.get("started_at", "")
+    age = "?"
+    if started_at:
+        try:
+            t = datetime.datetime.fromisoformat(started_at)
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=datetime.timezone.utc)
+            age = str(int((now - t).total_seconds()))
+        except Exception:
+            pass
+    print(f"{body.get('pipeline_id','?')}\t{body.get('session_id','?')}\t{age}")
+PY
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# resolve-session-id  (debug aid)
+# ---------------------------------------------------------------------------
+cmd_resolve_session_id() {
+  resolve_main_root || return 2
+  local sid
+  sid=$(resolve_session_id) || return 2
+  printf '%s\n' "$sid"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch.
+# ---------------------------------------------------------------------------
+main() {
+  local sub="${1:-}"
+  if [ -z "$sub" ]; then
+    echo "Usage: check-inflight-batch.sh {check|write|clear|list|resolve-session-id} [args...]" >&2
+    return 2
+  fi
+  shift
+  case "$sub" in
+    check)              cmd_check "$@" ;;
+    write)              cmd_write "$@" ;;
+    clear)              cmd_clear "$@" ;;
+    list)               cmd_list "$@" ;;
+    resolve-session-id) cmd_resolve_session_id "$@" ;;
+    *)
+      echo "check-inflight-batch.sh: unknown subcommand '$sub'" >&2
+      echo "Usage: check-inflight-batch.sh {check|write|clear|list|resolve-session-id} [args...]" >&2
+      return 2
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+  exit $?
+fi

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.31+ec0ddc"
+  version: "2026.05.31+3d8ae4"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/modes/sprint.md
+++ b/.claude/skills/fix-issues/modes/sprint.md
@@ -130,6 +130,34 @@ PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeli
 SPRINT_ID="${PIPELINE_ID#fix-issues.}"
 ```
 
+### Shared in-flight guard (issue #877)
+
+**Cron pickup-fires can land while a previous sprint is still running**
+(CronCreate's "fires only while idle" is turn-level idle, not task-level).
+The shared `check-inflight-batch.sh` helper detects "my session already
+has an in-flight fix-issues sprint" via session-scoped sentinels and
+exits clean when so, leaving the in-flight run to finish on its own
+turns. The check runs ONLY on sprint mode entry — subcommand routing
+(`stop` / `next` / `sync` / `plan` / `add` / `remove` / `reconsider`)
+in `SKILL.md` peels off before this file is loaded, so the carve-out
+is structural. The two robustness traps (session-scoping + staleness
+escape with `ZSKILLS_INFLIGHT_MAX_AGE_SECONDS` default 2h) live in the
+helper; this fence is just the call site.
+
+```bash
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check fix-issues > /tmp/.fix-issues-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.fix-issues-inflight.$$)
+    rm -f /tmp/.fix-issues-inflight.$$
+    INFLIGHT_PIPELINE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $2}')
+    echo "fix-issues sprint ${INFLIGHT_PIPELINE:-(unknown)} in flight; skipping redundant cron pickup" >&2
+    exit 0
+  fi
+  rm -f /tmp/.fix-issues-inflight.$$
+fi
+```
+
 ### Live worktree count check (defer-all gate)
 
 **Run this BEFORE the sprint worktree gate below.** If the host is already
@@ -253,6 +281,15 @@ if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT
   printf 'skill: fix-issues\nmode: sprint\ncount: %s\nfocus: %s\nstartedAt: %s\n' \
     "$N" "${FOCUS:-default}" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
     > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID"
+fi
+
+# Issue #877 — write the shared in-flight sentinel so subsequent cron
+# pickup-fires in this session detect this sprint as live and skip.
+# Cleared at sprint completion ("Post-land tracking" at the end of this file).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" write fix-issues --pipeline-id "$PIPELINE_ID" || \
+    echo "fix-issues: WARN — could not write in-flight sentinel (continuing)" >&2
 fi
 ```
 
@@ -2827,6 +2864,13 @@ clean up the sentinel:
 
 ```bash
 rm -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID"
+
+# Issue #877 — clear the shared in-flight sentinel so the next cron
+# fire is free to pick up fresh work.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear fix-issues --pipeline-id "$PIPELINE_ID" || true
+fi
 ```
 
 Also remove `.zskills-tracked` from each worktree that was used.

--- a/.claude/skills/qe-audit/SKILL.md
+++ b/.claude/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.31+968ff1"
+  version: "2026.05.31+af0b4b"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -165,6 +165,57 @@ If `$ARGUMENTS` contains `every <schedule>`:
 
 If `every` is NOT present, skip this phase and proceed to the audit/bash
 (bare invocation always runs immediately).
+
+## Phase 0b — Shared in-flight guard (issue #877)
+
+**Cron pickup-fires can land while a previous audit is still running**
+(CronCreate's "fires only while idle" is turn-level idle, not task-level).
+Two concurrent `/qe-audit` audits BOTH `gh issue create` and write the
+QE tracker — surfacing duplicate GitHub issues + tracker rows that then
+feed `/fix-issues` Ready as duplicate fix work. The shared
+`check-inflight-batch.sh` helper detects "my session already has an
+in-flight qe-audit run" via session-scoped sentinels and exits clean
+when so. This check fires AFTER subcommand routing (`stop` / `next`
+exited above; `every <schedule>` without `now` exited at end of Phase 0).
+
+The audit had no prior sentinel — this phase ADDS minimal session-scoped
+in-flight bookkeeping (write here, clear at the end of the audit/bash
+run) so the shared helper has something to detect. Two robustness traps
+(session-scoping + staleness escape default 2h via
+`ZSKILLS_INFLIGHT_MAX_AGE_SECONDS`) live in the helper.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check qe-audit > /tmp/.qe-audit-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.qe-audit-inflight.$$)
+    rm -f /tmp/.qe-audit-inflight.$$
+    INFLIGHT_PIPELINE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $2}')
+    echo "qe-audit run ${INFLIGHT_PIPELINE:-(unknown)} in flight; skipping redundant cron pickup" >&2
+    exit 0
+  fi
+  rm -f /tmp/.qe-audit-inflight.$$
+fi
+
+# Construct a per-audit unique pipeline_id and write the in-flight
+# sentinel. Cleared at the end of the audit/bash run (see "Phase 9 —
+# Audit-complete cleanup" below).
+AUDIT_ID="audit-$(date -u +%Y%m%d-%H%M%S)-$$"
+PIPELINE_ID="qe-audit.${AUDIT_ID}"
+SANITIZER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh"
+if [ -x "$SANITIZER" ]; then
+  PIPELINE_ID=$(bash "$SANITIZER" "$PIPELINE_ID")
+fi
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" write qe-audit --pipeline-id "$PIPELINE_ID" || \
+    echo "qe-audit: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
+```
 
 ## Mode: Commit Audit (default)
 
@@ -470,6 +521,28 @@ Run when `bash` IS present in arguments.
    - Example models deployed and verified (if applicable)
    - Screenshots taken (if manual testing)
    - If a cron is active, include the next run time
+
+## Phase 9 — Audit-complete cleanup (issue #877)
+
+After the audit (commit-audit) or bash run finishes — whether issues
+were filed or the report was empty — clear the shared in-flight
+sentinel so the next cron fire is free to pick up fresh work:
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$INFLIGHT_HELPER" clear qe-audit --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
+If the audit aborts via the Failure Protocol or an early exit, the
+staleness escape (default 2h) ensures the sentinel does not deadlock
+the next pickup — it is removed in-line on a subsequent `check` call.
 
 ## Key Rules
 

--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   queue (add/rank/remove/default) and recurring schedules. Mirrors
   /fix-issues for bugs.
 metadata:
-  version: "2026.05.31+962c6a"
+  version: "2026.05.31+582e84"
 ---
 
 # /work-on-plans — Batch Plan Executor

--- a/.claude/skills/work-on-plans/modes/execute.md
+++ b/.claude/skills/work-on-plans/modes/execute.md
@@ -108,6 +108,39 @@ Exit 0. **No tracking marker is written for `next`** (read-only).
 For `N`/`all` invocations, build the dispatch list and write the
 sprint sentinel.
 
+### Shared in-flight guard (issue #877)
+
+**Cron pickup-fires can land while a previous batch is still running**
+(CronCreate's "fires only while idle" is turn-level idle, not task-level).
+The shared `check-inflight-batch.sh` helper detects "my session already
+has an in-flight work-on-plans batch" via session-scoped sentinels and
+exits clean when so, leaving the in-flight run to finish on its own
+turns. The check runs ONLY on `N`/`all` execute entry — read-only modes
+(`(no args)`, `next`) exit in Step 3 above, and mutating subcommands
+(`add`/`rank`/`remove`/`default`/`every`/`stop`) route to
+`subcommands/add-rank-remove.md` in `SKILL.md` Step 3. The carve-out is
+structural. Two robustness traps (session-scoping + staleness escape
+default 2h) live in the helper.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check work-on-plans > /tmp/.work-on-plans-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.work-on-plans-inflight.$$)
+    rm -f /tmp/.work-on-plans-inflight.$$
+    INFLIGHT_PIPELINE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $2}')
+    echo "work-on-plans batch ${INFLIGHT_PIPELINE:-(unknown)} in flight; skipping redundant cron pickup" >&2
+    exit 0
+  fi
+  rm -f /tmp/.work-on-plans-inflight.$$
+fi
+```
+
 ```bash
 # Dispatch list: take the first N ready entries (or all when "all").
 mapfile -t READY_LINES < <(printf '%s' "$READY_TSV" \
@@ -167,6 +200,15 @@ SPRINT_ID="${PIPELINE_ID#work-on-plans.}"
 PIPELINE_DIR="$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 mkdir -p "$PIPELINE_DIR"
 echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+
+# Issue #877 — write the shared in-flight sentinel so subsequent cron
+# pickup-fires in this session detect this batch as live and skip.
+# Cleared at Step 6 (sprint completion).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" write work-on-plans --pipeline-id "$PIPELINE_ID" || \
+    echo "work-on-plans: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
 ```
 
 The PID-derived suffix keeps concurrent invocations on the same host
@@ -385,6 +427,13 @@ empty-after-failure):
      "$SPRINT_ID" "$DISPATCH_COUNT" "$DONE" "${CONTINUE_ON_FAILURE:-0}" \
      "$SPRINT_FINAL_STATUS" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
      > "$PIPELINE_DIR/fulfilled.work-on-plans.$SPRINT_ID"
+
+   # Issue #877 — clear the shared in-flight sentinel so the next cron
+   # fire is free to pick up fresh work.
+   INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+   if [ -x "$INFLIGHT_HELPER" ]; then
+     bash "$INFLIGHT_HELPER" clear work-on-plans --pipeline-id "$PIPELINE_ID" || true
+   fi
    ```
 
 2. Rewrite `$WORK_STATE` to `{"state":"idle"}` (last-writer-wins):

--- a/skills/create-worktree/SKILL.md
+++ b/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.05.31+8f7116"
+  version: "2026.05.31+c3b507"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/skills/create-worktree/scripts/check-inflight-batch.sh
+++ b/skills/create-worktree/scripts/check-inflight-batch.sh
@@ -1,0 +1,527 @@
+#!/bin/bash
+# check-inflight-batch.sh — Shared session-scoped in-flight guard for
+# queue-pickup workers (/fix-issues sprint, /work-on-plans batch,
+# /qe-audit audit). Closes the cron-pickup concurrency hole documented
+# in issue #877.
+#
+# Why this is shared (not three per-skill scripts): all three workers
+# share the same shape — a recurring cron fire re-fires FRESH work
+# (a fresh sprint / batch / audit, not a continuation of a specific
+# item). The right skip-key is "my session already has an in-flight
+# run of this skill," and the two robustness traps (session-scoping +
+# staleness escape) are identical. Factor once, integrate at each
+# entry point.
+#
+# Sentinel layout:
+#   $MAIN_ROOT/.zskills/inflight/<skill>/<pipeline-id>.json
+#   {
+#     "skill":       "<skill>",
+#     "pipeline_id": "<pipeline-id>",
+#     "session_id":  "<session>",      # see resolve_session_id() below
+#     "started_at":  "<ISO-8601 UTC>"
+#   }
+#
+# Subcommands:
+#   check <skill> [--max-age-seconds N] [--session-id <id>]
+#     Returns 0 (in-flight; SKIP) iff a sentinel exists for <skill>
+#     whose session_id matches THIS session AND whose started_at age
+#     is less than max-age-seconds (default 7200 = 2h).
+#     Returns 1 (no in-flight; PROCEED) otherwise. Stale sentinels
+#     (older than max-age) are removed in-line and treated as absent
+#     (graceful escape from a dead-session sentinel).
+#
+#   write <skill> --pipeline-id <id> [--session-id <id>]
+#     Create the sentinel for this skill+pipeline. Idempotent: if a
+#     sentinel for the same pipeline_id already exists it is rewritten
+#     (refresh started_at).
+#
+#   clear <skill> --pipeline-id <id>
+#     Remove the sentinel for this skill+pipeline. Idempotent: missing
+#     sentinel returns 0. Mismatched pipeline_id sentinels (different
+#     run) are left intact.
+#
+#   list <skill>
+#     Pure read. Emits one TSV line per live sentinel:
+#       <pipeline_id>\t<session_id>\t<age_seconds>
+#
+#   resolve-session-id
+#     Print the current session_id to stdout (for callers that want to
+#     inspect or pass it through).
+#
+# Session-scoping (the FIRST robustness trap from #877):
+#   resolve_session_id() walks $$'s ancestor PID chain until it hits
+#   PID 1's first descendant — typically the Claude Code main process
+#   for the current REPL session. Combines that PID with /proc/<pid>/
+#   stat's start_time field (jiffies-since-boot of process start) to
+#   produce a stable identifier that:
+#     * is constant across turns of the same Claude Code session,
+#     * differs between sessions (different process trees),
+#     * survives the bash subshell's own restart between turns.
+#   On non-Linux or when /proc is unreadable, falls back to the
+#   $MAIN_ROOT/.zskills/session-id file (lazily stamped on first call,
+#   refreshed if older than 24h). Callers can always pass an explicit
+#   --session-id to override resolution (used by tests).
+#
+# Staleness escape (the SECOND robustness trap from #877):
+#   max-age-seconds defaults to 7200 (2 hours) — a generous bound that
+#   exceeds any plausible single sprint/batch/audit. A sentinel older
+#   than max-age is treated as orphaned (crashed run) and removed
+#   in-line; the caller proceeds. Skipping a redundant pickup at worst
+#   delays the queue one interval, so the escape is non-destructive.
+#   Override via ZSKILLS_INFLIGHT_MAX_AGE_SECONDS env var or per-call
+#   --max-age-seconds flag.
+#
+# Carve-out: this helper is invoked ONLY at the pickup-path entry of
+# each consumer skill, AFTER the subcommand router has decided this
+# fire is a real run dispatch. The subcommand carve-out (stop / next /
+# sync / add / rank / remove / default / etc. must always proceed) is
+# enforced by callers placing the check call AFTER those detections
+# but BEFORE the main run-dispatch body.
+#
+# No jq — Python stdlib json for write/read.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Python interpreter resolution.
+# ---------------------------------------------------------------------------
+_INFLIGHT_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$_INFLIGHT_PYTHON" ]; then
+  echo "check-inflight-batch.sh: install Python 3 (or set ZSKILLS_PYTHON)" >&2
+  exit 127
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults.
+# ---------------------------------------------------------------------------
+_DEFAULT_MAX_AGE="${ZSKILLS_INFLIGHT_MAX_AGE_SECONDS:-7200}"
+
+# ---------------------------------------------------------------------------
+# MAIN_ROOT resolution. Same pattern as claim-issue.sh / claim-plan.sh.
+# ---------------------------------------------------------------------------
+resolve_main_root() {
+  local common_dir
+  if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+    echo "check-inflight-batch.sh: cannot resolve MAIN_ROOT (not in a git working tree); cd into a project worktree first" >&2
+    return 1
+  fi
+  if ! MAIN_ROOT=$(cd "$common_dir/.." && pwd); then
+    echo "check-inflight-batch.sh: cannot resolve MAIN_ROOT (failed to cd into git common dir parent)" >&2
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Session-id resolution.
+#
+# Strategy A (Linux /proc): walk $$ up the PPID chain until we land on
+# PID 1's first descendant — this is typically the Claude Code main
+# process. Combine that PID with /proc/<pid>/stat field 22 (start_time
+# in clock ticks since boot) to form a stable identifier. Field 2 of
+# /proc/<pid>/stat is the comm in parens, so we use awk's special
+# tokenization: skip past `)` then count from there.
+#
+# Strategy B (fallback): lazily stamp $MAIN_ROOT/.zskills/session-id
+# if absent or if older than 24h. Stale-refresh is safe because the
+# refresh window is much longer than any plausible cron-pickup cycle.
+# ---------------------------------------------------------------------------
+_session_id_from_proc() {
+  if [ ! -r /proc/$$/stat ]; then
+    return 1
+  fi
+  local pid=$$
+  local ppid
+  # Walk up; stop when ppid<=1 (we hit init's child).
+  while :; do
+    if [ ! -r "/proc/$pid/stat" ]; then
+      return 1
+    fi
+    # /proc/<pid>/stat: pid (comm) state ppid ...
+    # The comm field can contain spaces and parens; strip from first `(`
+    # to last `)` to make the rest unambiguously space-delimited.
+    ppid=$(sed -n 's/.*) [A-Z] \([0-9]*\) .*/\1/p' "/proc/$pid/stat" 2>/dev/null)
+    if [ -z "$ppid" ] || ! [ "$ppid" -ge 0 ] 2>/dev/null; then
+      return 1
+    fi
+    # Stop when ppid drops to PID 1 (init) or 0 (container/kernel root)
+    # — the current `pid` is the highest stable non-init ancestor.
+    if [ "$ppid" -le 1 ]; then
+      break
+    fi
+    pid=$ppid
+  done
+  # pid now == the first descendant of PID 1. Get its start_time
+  # (/proc/<pid>/stat field 22, counted AFTER the comm-paren strip).
+  local rest start_time
+  rest=$(sed -n 's/.*) [A-Z] //p' "/proc/$pid/stat" 2>/dev/null)
+  if [ -z "$rest" ]; then
+    return 1
+  fi
+  # Field 22 of original = position (22 - 3) = 19 after the strip
+  # (we removed pid, (comm), state — 3 fields; ppid is now field 1
+  # of `rest`, so start_time is field 19 of `rest`).
+  start_time=$(printf '%s\n' "$rest" | awk '{print $19}')
+  if [ -z "$start_time" ] || ! [ "$start_time" -ge 0 ] 2>/dev/null; then
+    return 1
+  fi
+  printf 'pid-%s.%s' "$pid" "$start_time"
+  return 0
+}
+
+_session_id_from_file() {
+  local main_root="$1"
+  local session_file="${main_root}/.zskills/session-id"
+  local now age limit=86400  # 24h
+  now=$(date -u +%s)
+  if [ -f "$session_file" ]; then
+    local mtime
+    mtime=$(stat -c %Y "$session_file" 2>/dev/null || stat -f %m "$session_file" 2>/dev/null || echo 0)
+    age=$(( now - mtime ))
+    if [ "$age" -lt "$limit" ]; then
+      cat "$session_file"
+      return 0
+    fi
+  fi
+  # Stamp a fresh session-id.
+  mkdir -p "$(dirname "$session_file")"
+  local new_id
+  new_id="file-$(date -u +%Y%m%d%H%M%S)-$$"
+  printf '%s' "$new_id" > "$session_file"
+  printf '%s' "$new_id"
+  return 0
+}
+
+resolve_session_id() {
+  local sid
+  if sid=$(_session_id_from_proc); then
+    printf '%s' "$sid"
+    return 0
+  fi
+  if [ -z "${MAIN_ROOT:-}" ]; then
+    resolve_main_root || return 1
+  fi
+  _session_id_from_file "$MAIN_ROOT"
+}
+
+# ---------------------------------------------------------------------------
+# Validate skill name — must be a simple slug (a-z0-9- only). Prevents
+# path-traversal via crafted skill arg.
+# ---------------------------------------------------------------------------
+_validate_skill() {
+  local s="${1:-}"
+  if [ -z "$s" ]; then
+    echo "check-inflight-batch.sh: skill name required" >&2
+    return 1
+  fi
+  case "$s" in
+    ''|*[!a-z0-9-]*)
+      echo "check-inflight-batch.sh: invalid skill name '$s' (must match [a-z0-9-]+)" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+_validate_pipeline_id() {
+  local p="${1:-}"
+  if [ -z "$p" ]; then
+    echo "check-inflight-batch.sh: --pipeline-id required" >&2
+    return 1
+  fi
+  # Re-sanitize defensively — pipeline_ids are already sanitized by
+  # callers via sanitize-pipeline-id.sh, but accept the same shape here.
+  case "$p" in
+    ''|*[!a-zA-Z0-9._-]*)
+      echo "check-inflight-batch.sh: invalid pipeline-id '$p' (must match [a-zA-Z0-9._-]+)" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# check <skill> [--max-age-seconds N] [--session-id <id>]
+#
+# Exit 0  — in-flight, SKIP (caller should exit 0 cleanly).
+# Exit 1  — no in-flight sentinel for this session, PROCEED.
+# Exit 2  — usage error.
+# ---------------------------------------------------------------------------
+cmd_check() {
+  local skill="" max_age="$_DEFAULT_MAX_AGE" explicit_sid=""
+  if [ "$#" -lt 1 ]; then
+    echo "Usage: check-inflight-batch.sh check <skill> [--max-age-seconds N] [--session-id <id>]" >&2
+    return 2
+  fi
+  skill="$1"; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --max-age-seconds) max_age="${2:-}"; shift 2 ;;
+      --session-id)      explicit_sid="${2:-}"; shift 2 ;;
+      *) echo "check-inflight-batch.sh check: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  _validate_skill "$skill" || return 2
+  case "$max_age" in
+    ''|*[!0-9]*) echo "check-inflight-batch.sh check: --max-age-seconds must be non-negative integer" >&2; return 2 ;;
+  esac
+  resolve_main_root || return 2
+
+  local sid
+  if [ -n "$explicit_sid" ]; then
+    sid="$explicit_sid"
+  else
+    sid=$(resolve_session_id) || { echo "check-inflight-batch.sh: cannot resolve session-id" >&2; return 2; }
+  fi
+
+  local skill_dir="${MAIN_ROOT}/.zskills/inflight/${skill}"
+  if [ ! -d "$skill_dir" ]; then
+    return 1  # proceed — no sentinels at all for this skill
+  fi
+
+  # Python pass: find any sentinel matching session_id AND not stale.
+  # Stale sentinels (age > max_age) are removed inline. Returns "match"
+  # iff a fresh same-session sentinel was found.
+  local result
+  result=$("$_INFLIGHT_PYTHON" - "$skill_dir" "$sid" "$max_age" <<'PY'
+import json, os, sys, time, datetime
+skill_dir, want_sid, max_age = sys.argv[1], sys.argv[2], int(sys.argv[3])
+now = datetime.datetime.now(datetime.timezone.utc)
+match = None
+try:
+    entries = os.listdir(skill_dir)
+except OSError:
+    print("none")
+    sys.exit(0)
+for name in entries:
+    if not name.endswith(".json"):
+        continue
+    path = os.path.join(skill_dir, name)
+    if not os.path.isfile(path):
+        continue
+    try:
+        with open(path) as fh:
+            body = json.load(fh)
+    except Exception:
+        # Malformed sentinel — treat as orphan, remove.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        continue
+    started_at = body.get("started_at", "")
+    age = None
+    if started_at:
+        try:
+            t = datetime.datetime.fromisoformat(started_at)
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=datetime.timezone.utc)
+            age = (now - t).total_seconds()
+        except Exception:
+            age = None
+    if age is None or age > max_age:
+        # Stale or unparseable timestamp — orphan; remove and continue.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        continue
+    # Fresh sentinel. Check session-id.
+    if body.get("session_id", "") == want_sid:
+        match = (body.get("pipeline_id", "?"), int(age))
+        break
+if match is None:
+    print("none")
+else:
+    print(f"match\t{match[0]}\t{match[1]}")
+PY
+)
+  case "$result" in
+    match*)
+      # Emit a short diagnostic so the caller's "skipping redundant
+      # cron pickup" message has the matching pipeline_id available.
+      local pipeline_id age
+      pipeline_id=$(printf '%s' "$result" | awk -F'\t' '{print $2}')
+      age=$(printf '%s' "$result" | awk -F'\t' '{print $3}')
+      printf 'in-flight\t%s\t%s\n' "$pipeline_id" "$age"
+      return 0
+      ;;
+    none|*)
+      return 1
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# write <skill> --pipeline-id <id> [--session-id <id>]
+# ---------------------------------------------------------------------------
+cmd_write() {
+  local skill="" pipeline_id="" explicit_sid=""
+  if [ "$#" -lt 1 ]; then
+    echo "Usage: check-inflight-batch.sh write <skill> --pipeline-id <id> [--session-id <id>]" >&2
+    return 2
+  fi
+  skill="$1"; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      --session-id)  explicit_sid="${2:-}"; shift 2 ;;
+      *) echo "check-inflight-batch.sh write: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  _validate_skill "$skill" || return 2
+  _validate_pipeline_id "$pipeline_id" || return 2
+  resolve_main_root || return 2
+
+  local sid
+  if [ -n "$explicit_sid" ]; then
+    sid="$explicit_sid"
+  else
+    sid=$(resolve_session_id) || { echo "check-inflight-batch.sh: cannot resolve session-id" >&2; return 2; }
+  fi
+
+  local skill_dir="${MAIN_ROOT}/.zskills/inflight/${skill}"
+  local sentinel="${skill_dir}/${pipeline_id}.json"
+  local sentinel_tmp="${sentinel}.tmp"
+
+  if ! mkdir -p "$skill_dir"; then
+    echo "check-inflight-batch.sh write: failed to create $skill_dir" >&2
+    return 11
+  fi
+
+  if ! "$_INFLIGHT_PYTHON" - "$sentinel_tmp" "$sentinel" "$skill" "$pipeline_id" "$sid" <<'PY'
+import json, os, sys, datetime
+tmp, final, skill, pipeline_id, sid = sys.argv[1:6]
+body = {
+    "schema_version": 1,
+    "skill":          skill,
+    "pipeline_id":    pipeline_id,
+    "session_id":     sid,
+    "started_at":     datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+}
+with open(tmp, "w") as f:
+    json.dump(body, f, sort_keys=True)
+    f.write("\n")
+os.replace(tmp, final)
+PY
+  then
+    rm -f "$sentinel_tmp"
+    echo "check-inflight-batch.sh write: atomic write failed for $sentinel" >&2
+    return 11
+  fi
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# clear <skill> --pipeline-id <id>
+# ---------------------------------------------------------------------------
+cmd_clear() {
+  local skill="" pipeline_id=""
+  if [ "$#" -lt 1 ]; then
+    echo "Usage: check-inflight-batch.sh clear <skill> --pipeline-id <id>" >&2
+    return 2
+  fi
+  skill="$1"; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      *) echo "check-inflight-batch.sh clear: unknown arg '$1'" >&2; return 2 ;;
+    esac
+  done
+  _validate_skill "$skill" || return 2
+  _validate_pipeline_id "$pipeline_id" || return 2
+  resolve_main_root || return 2
+
+  local sentinel="${MAIN_ROOT}/.zskills/inflight/${skill}/${pipeline_id}.json"
+  rm -f "$sentinel"
+  rm -f "${sentinel}.tmp"
+
+  # rmdir the parent if empty (best-effort cleanup; harmless if non-empty).
+  rmdir "${MAIN_ROOT}/.zskills/inflight/${skill}" 2>/dev/null || true
+  rmdir "${MAIN_ROOT}/.zskills/inflight" 2>/dev/null || true
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# list <skill>
+# ---------------------------------------------------------------------------
+cmd_list() {
+  local skill="${1:-}"
+  _validate_skill "$skill" || return 2
+  resolve_main_root || return 2
+
+  local skill_dir="${MAIN_ROOT}/.zskills/inflight/${skill}"
+  [ -d "$skill_dir" ] || return 0
+
+  "$_INFLIGHT_PYTHON" - "$skill_dir" <<'PY'
+import json, os, sys, datetime
+skill_dir = sys.argv[1]
+now = datetime.datetime.now(datetime.timezone.utc)
+try:
+    entries = sorted(os.listdir(skill_dir))
+except OSError:
+    sys.exit(0)
+for name in entries:
+    if not name.endswith(".json"):
+        continue
+    path = os.path.join(skill_dir, name)
+    try:
+        with open(path) as fh:
+            body = json.load(fh)
+    except Exception:
+        continue
+    started_at = body.get("started_at", "")
+    age = "?"
+    if started_at:
+        try:
+            t = datetime.datetime.fromisoformat(started_at)
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=datetime.timezone.utc)
+            age = str(int((now - t).total_seconds()))
+        except Exception:
+            pass
+    print(f"{body.get('pipeline_id','?')}\t{body.get('session_id','?')}\t{age}")
+PY
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# resolve-session-id  (debug aid)
+# ---------------------------------------------------------------------------
+cmd_resolve_session_id() {
+  resolve_main_root || return 2
+  local sid
+  sid=$(resolve_session_id) || return 2
+  printf '%s\n' "$sid"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch.
+# ---------------------------------------------------------------------------
+main() {
+  local sub="${1:-}"
+  if [ -z "$sub" ]; then
+    echo "Usage: check-inflight-batch.sh {check|write|clear|list|resolve-session-id} [args...]" >&2
+    return 2
+  fi
+  shift
+  case "$sub" in
+    check)              cmd_check "$@" ;;
+    write)              cmd_write "$@" ;;
+    clear)              cmd_clear "$@" ;;
+    list)               cmd_list "$@" ;;
+    resolve-session-id) cmd_resolve_session_id "$@" ;;
+    *)
+      echo "check-inflight-batch.sh: unknown subcommand '$sub'" >&2
+      echo "Usage: check-inflight-batch.sh {check|write|clear|list|resolve-session-id} [args...]" >&2
+      return 2
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+  exit $?
+fi

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.05.31+ec0ddc"
+  version: "2026.05.31+3d8ae4"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/modes/sprint.md
+++ b/skills/fix-issues/modes/sprint.md
@@ -130,6 +130,34 @@ PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeli
 SPRINT_ID="${PIPELINE_ID#fix-issues.}"
 ```
 
+### Shared in-flight guard (issue #877)
+
+**Cron pickup-fires can land while a previous sprint is still running**
+(CronCreate's "fires only while idle" is turn-level idle, not task-level).
+The shared `check-inflight-batch.sh` helper detects "my session already
+has an in-flight fix-issues sprint" via session-scoped sentinels and
+exits clean when so, leaving the in-flight run to finish on its own
+turns. The check runs ONLY on sprint mode entry — subcommand routing
+(`stop` / `next` / `sync` / `plan` / `add` / `remove` / `reconsider`)
+in `SKILL.md` peels off before this file is loaded, so the carve-out
+is structural. The two robustness traps (session-scoping + staleness
+escape with `ZSKILLS_INFLIGHT_MAX_AGE_SECONDS` default 2h) live in the
+helper; this fence is just the call site.
+
+```bash
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check fix-issues > /tmp/.fix-issues-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.fix-issues-inflight.$$)
+    rm -f /tmp/.fix-issues-inflight.$$
+    INFLIGHT_PIPELINE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $2}')
+    echo "fix-issues sprint ${INFLIGHT_PIPELINE:-(unknown)} in flight; skipping redundant cron pickup" >&2
+    exit 0
+  fi
+  rm -f /tmp/.fix-issues-inflight.$$
+fi
+```
+
 ### Live worktree count check (defer-all gate)
 
 **Run this BEFORE the sprint worktree gate below.** If the host is already
@@ -253,6 +281,15 @@ if [ ! -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT
   printf 'skill: fix-issues\nmode: sprint\ncount: %s\nfocus: %s\nstartedAt: %s\n' \
     "$N" "${FOCUS:-default}" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
     > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID"
+fi
+
+# Issue #877 — write the shared in-flight sentinel so subsequent cron
+# pickup-fires in this session detect this sprint as live and skip.
+# Cleared at sprint completion ("Post-land tracking" at the end of this file).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" write fix-issues --pipeline-id "$PIPELINE_ID" || \
+    echo "fix-issues: WARN — could not write in-flight sentinel (continuing)" >&2
 fi
 ```
 
@@ -2827,6 +2864,13 @@ clean up the sentinel:
 
 ```bash
 rm -f "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/pipeline.fix-issues.$SPRINT_ID"
+
+# Issue #877 — clear the shared in-flight sentinel so the next cron
+# fire is free to pick up fresh work.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear fix-issues --pipeline-id "$PIPELINE_ID" || true
+fi
 ```
 
 Also remove `.zskills-tracked` from each worktree that was used.

--- a/skills/qe-audit/SKILL.md
+++ b/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.05.31+968ff1"
+  version: "2026.05.31+af0b4b"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -165,6 +165,57 @@ If `$ARGUMENTS` contains `every <schedule>`:
 
 If `every` is NOT present, skip this phase and proceed to the audit/bash
 (bare invocation always runs immediately).
+
+## Phase 0b — Shared in-flight guard (issue #877)
+
+**Cron pickup-fires can land while a previous audit is still running**
+(CronCreate's "fires only while idle" is turn-level idle, not task-level).
+Two concurrent `/qe-audit` audits BOTH `gh issue create` and write the
+QE tracker — surfacing duplicate GitHub issues + tracker rows that then
+feed `/fix-issues` Ready as duplicate fix work. The shared
+`check-inflight-batch.sh` helper detects "my session already has an
+in-flight qe-audit run" via session-scoped sentinels and exits clean
+when so. This check fires AFTER subcommand routing (`stop` / `next`
+exited above; `every <schedule>` without `now` exited at end of Phase 0).
+
+The audit had no prior sentinel — this phase ADDS minimal session-scoped
+in-flight bookkeeping (write here, clear at the end of the audit/bash
+run) so the shared helper has something to detect. Two robustness traps
+(session-scoping + staleness escape default 2h via
+`ZSKILLS_INFLIGHT_MAX_AGE_SECONDS`) live in the helper.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check qe-audit > /tmp/.qe-audit-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.qe-audit-inflight.$$)
+    rm -f /tmp/.qe-audit-inflight.$$
+    INFLIGHT_PIPELINE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $2}')
+    echo "qe-audit run ${INFLIGHT_PIPELINE:-(unknown)} in flight; skipping redundant cron pickup" >&2
+    exit 0
+  fi
+  rm -f /tmp/.qe-audit-inflight.$$
+fi
+
+# Construct a per-audit unique pipeline_id and write the in-flight
+# sentinel. Cleared at the end of the audit/bash run (see "Phase 9 —
+# Audit-complete cleanup" below).
+AUDIT_ID="audit-$(date -u +%Y%m%d-%H%M%S)-$$"
+PIPELINE_ID="qe-audit.${AUDIT_ID}"
+SANITIZER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh"
+if [ -x "$SANITIZER" ]; then
+  PIPELINE_ID=$(bash "$SANITIZER" "$PIPELINE_ID")
+fi
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" write qe-audit --pipeline-id "$PIPELINE_ID" || \
+    echo "qe-audit: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
+```
 
 ## Mode: Commit Audit (default)
 
@@ -470,6 +521,28 @@ Run when `bash` IS present in arguments.
    - Example models deployed and verified (if applicable)
    - Screenshots taken (if manual testing)
    - If a cron is active, include the next run time
+
+## Phase 9 — Audit-complete cleanup (issue #877)
+
+After the audit (commit-audit) or bash run finishes — whether issues
+were filed or the report was empty — clear the shared in-flight
+sentinel so the next cron fire is free to pick up fresh work:
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$INFLIGHT_HELPER" clear qe-audit --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
+If the audit aborts via the Failure Protocol or an early exit, the
+staleness escape (default 2h) ensures the sentinel does not deadlock
+the next pickup — it is removed in-line on a subsequent `check` call.
 
 ## Key Rules
 

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   queue (add/rank/remove/default) and recurring schedules. Mirrors
   /fix-issues for bugs.
 metadata:
-  version: "2026.05.31+962c6a"
+  version: "2026.05.31+582e84"
 ---
 
 # /work-on-plans — Batch Plan Executor

--- a/skills/work-on-plans/modes/execute.md
+++ b/skills/work-on-plans/modes/execute.md
@@ -108,6 +108,39 @@ Exit 0. **No tracking marker is written for `next`** (read-only).
 For `N`/`all` invocations, build the dispatch list and write the
 sprint sentinel.
 
+### Shared in-flight guard (issue #877)
+
+**Cron pickup-fires can land while a previous batch is still running**
+(CronCreate's "fires only while idle" is turn-level idle, not task-level).
+The shared `check-inflight-batch.sh` helper detects "my session already
+has an in-flight work-on-plans batch" via session-scoped sentinels and
+exits clean when so, leaving the in-flight run to finish on its own
+turns. The check runs ONLY on `N`/`all` execute entry — read-only modes
+(`(no args)`, `next`) exit in Step 3 above, and mutating subcommands
+(`add`/`rank`/`remove`/`default`/`every`/`stop`) route to
+`subcommands/add-rank-remove.md` in `SKILL.md` Step 3. The carve-out is
+structural. Two robustness traps (session-scoping + staleness escape
+default 2h) live in the helper.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check work-on-plans > /tmp/.work-on-plans-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.work-on-plans-inflight.$$)
+    rm -f /tmp/.work-on-plans-inflight.$$
+    INFLIGHT_PIPELINE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $2}')
+    echo "work-on-plans batch ${INFLIGHT_PIPELINE:-(unknown)} in flight; skipping redundant cron pickup" >&2
+    exit 0
+  fi
+  rm -f /tmp/.work-on-plans-inflight.$$
+fi
+```
+
 ```bash
 # Dispatch list: take the first N ready entries (or all when "all").
 mapfile -t READY_LINES < <(printf '%s' "$READY_TSV" \
@@ -167,6 +200,15 @@ SPRINT_ID="${PIPELINE_ID#work-on-plans.}"
 PIPELINE_DIR="$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID"
 mkdir -p "$PIPELINE_DIR"
 echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
+
+# Issue #877 — write the shared in-flight sentinel so subsequent cron
+# pickup-fires in this session detect this batch as live and skip.
+# Cleared at Step 6 (sprint completion).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" write work-on-plans --pipeline-id "$PIPELINE_ID" || \
+    echo "work-on-plans: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
 ```
 
 The PID-derived suffix keeps concurrent invocations on the same host
@@ -385,6 +427,13 @@ empty-after-failure):
      "$SPRINT_ID" "$DISPATCH_COUNT" "$DONE" "${CONTINUE_ON_FAILURE:-0}" \
      "$SPRINT_FINAL_STATUS" "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
      > "$PIPELINE_DIR/fulfilled.work-on-plans.$SPRINT_ID"
+
+   # Issue #877 — clear the shared in-flight sentinel so the next cron
+   # fire is free to pick up fresh work.
+   INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+   if [ -x "$INFLIGHT_HELPER" ]; then
+     bash "$INFLIGHT_HELPER" clear work-on-plans --pipeline-id "$PIPELINE_ID" || true
+   fi
    ```
 
 2. Rewrite `$WORK_STATE` to `{"state":"idle"}` (last-writer-wins):

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -203,6 +203,7 @@ run_suite "test-plan-claim-moveall-skip.sh" "tests/test-plan-claim-moveall-skip.
 run_suite "test-plan-claim-fingerprint.sh" "tests/test-plan-claim-fingerprint.sh"
 run_suite "test-plan-claim-conformance.sh" "tests/test-plan-claim-conformance.sh"
 run_suite "test-claim-self-reentry.sh" "tests/test-claim-self-reentry.sh"
+run_suite "test-inflight-batch-guard.sh" "tests/test-inflight-batch-guard.sh"
 run_suite "test-demo-sim.sh" "tests/test-demo-sim.sh"
 run_suite "test-plugin-manifest.sh" "tests/test-plugin-manifest.sh"
 run_suite "test-plugin-marketplace.sh" "tests/test-plugin-marketplace.sh"

--- a/tests/test-inflight-batch-guard.sh
+++ b/tests/test-inflight-batch-guard.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# test-inflight-batch-guard.sh — issue #877.
+#
+# Tests the shared session-scoped in-flight guard helper
+# (skills/create-worktree/scripts/check-inflight-batch.sh) and the
+# three call-site wirings (sprint.md, execute.md, qe-audit SKILL.md).
+#
+# Helper unit tests:
+#   - resolve-session-id returns a non-empty stable value
+#   - write + check (same session) → exit 0 (in-flight)
+#   - write + check (different session) → exit 1 (proceed)
+#   - write + check with max-age-seconds=0 → stale escape → exit 1
+#   - clear removes the sentinel
+#   - list emits TSV for live sentinels
+#
+# Wiring assertions (one per skill):
+#   - skills/fix-issues/modes/sprint.md sources the helper at pickup entry
+#   - skills/work-on-plans/modes/execute.md ditto at Step 4
+#   - skills/qe-audit/SKILL.md ditto at Phase 0b
+#   AND each writes + clears the sentinel via the helper.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/skills/create-worktree/scripts/check-inflight-batch.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+SCRATCH="/tmp/test-inflight-batch-guard-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then return; fi
+  [ -d "$SCRATCH" ] && rm -rf "$SCRATCH"
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH"
+
+# Fixture: real git repo so MAIN_ROOT resolves.
+FIXTURE="$SCRATCH/fixture"
+mkdir -p "$FIXTURE"
+(
+  cd "$FIXTURE"
+  git init -q
+  git config user.email "t@t"
+  git config user.name "t"
+  git commit --allow-empty -q -m init
+) || { fail "fixture init" "git init failed"; echo "Results: $PASS passed, $((FAIL+1)) failed"; exit 1; }
+
+echo "=== helper presence + executability ==="
+if [ -x "$HELPER" ]; then
+  pass "helper exists and is executable"
+else
+  fail "helper exists and is executable" "missing or non-executable at $HELPER"
+  echo "Results: $PASS passed, $((FAIL)) failed"; exit 1
+fi
+
+echo ""
+echo "=== resolve-session-id ==="
+SID=$(cd "$FIXTURE" && bash "$HELPER" resolve-session-id)
+if [ -n "$SID" ]; then
+  pass "resolve-session-id returns non-empty value ($SID)"
+else
+  fail "resolve-session-id returns non-empty value" "got empty"
+fi
+
+# Stability across calls in the same shell.
+SID2=$(cd "$FIXTURE" && bash "$HELPER" resolve-session-id)
+if [ "$SID" = "$SID2" ]; then
+  pass "resolve-session-id is stable across calls in same shell"
+else
+  fail "resolve-session-id is stable across calls in same shell" \
+       "first=$SID second=$SID2"
+fi
+
+echo ""
+echo "=== check (no sentinel) → proceed ==="
+(cd "$FIXTURE" && bash "$HELPER" check fix-issues --session-id "TEST-SID-1" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "check returns rc=1 when no sentinel"
+else
+  fail "check returns rc=1 when no sentinel" "got rc=$rc"
+fi
+
+echo ""
+echo "=== write + check (same session) → in-flight ==="
+(cd "$FIXTURE" && bash "$HELPER" write fix-issues --pipeline-id "fix-issues.test-A" --session-id "TEST-SID-1") || \
+  fail "write" "exit non-zero"
+out=$(cd "$FIXTURE" && bash "$HELPER" check fix-issues --session-id "TEST-SID-1" 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "check returns rc=0 (in-flight) when matching sentinel exists"
+else
+  fail "check returns rc=0 (in-flight) when matching sentinel exists" "got rc=$rc"
+fi
+if printf '%s' "$out" | grep -q "fix-issues.test-A"; then
+  pass "check stdout includes the matching pipeline-id"
+else
+  fail "check stdout includes the matching pipeline-id" "stdout='$out'"
+fi
+
+echo ""
+echo "=== check (different session) → proceed ==="
+(cd "$FIXTURE" && bash "$HELPER" check fix-issues --session-id "TEST-SID-2" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "check returns rc=1 when sentinel exists for a different session"
+else
+  fail "check returns rc=1 when sentinel exists for a different session" "got rc=$rc"
+fi
+
+echo ""
+echo "=== staleness escape (max-age=0) ==="
+(cd "$FIXTURE" && bash "$HELPER" check fix-issues --session-id "TEST-SID-1" --max-age-seconds 0 >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "stale sentinel (max-age=0) → escape (rc=1)"
+else
+  fail "stale sentinel (max-age=0) → escape (rc=1)" "got rc=$rc"
+fi
+# After stale escape, sentinel must be removed.
+remaining=$(cd "$FIXTURE" && bash "$HELPER" list fix-issues 2>/dev/null)
+if [ -z "$remaining" ]; then
+  pass "stale escape removes the orphan sentinel"
+else
+  fail "stale escape removes the orphan sentinel" "list still emits: $remaining"
+fi
+
+echo ""
+echo "=== write + clear ==="
+(cd "$FIXTURE" && bash "$HELPER" write fix-issues --pipeline-id "fix-issues.test-B" --session-id "TEST-SID-1") \
+  || fail "write" "exit non-zero"
+(cd "$FIXTURE" && bash "$HELPER" clear fix-issues --pipeline-id "fix-issues.test-B")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "clear returns rc=0"
+else
+  fail "clear returns rc=0" "got rc=$rc"
+fi
+remaining=$(cd "$FIXTURE" && bash "$HELPER" list fix-issues 2>/dev/null)
+if [ -z "$remaining" ]; then
+  pass "clear removes the sentinel"
+else
+  fail "clear removes the sentinel" "list still emits: $remaining"
+fi
+# Idempotent: clear an already-cleared sentinel.
+(cd "$FIXTURE" && bash "$HELPER" clear fix-issues --pipeline-id "fix-issues.test-B")
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "clear is idempotent (re-clear returns rc=0)"
+else
+  fail "clear is idempotent" "got rc=$rc"
+fi
+
+echo ""
+echo "=== multi-skill isolation ==="
+(cd "$FIXTURE" && bash "$HELPER" write fix-issues --pipeline-id "fix-issues.iso" --session-id "TEST-SID-1")
+(cd "$FIXTURE" && bash "$HELPER" check work-on-plans --session-id "TEST-SID-1" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "fix-issues sentinel does not gate work-on-plans"
+else
+  fail "fix-issues sentinel does not gate work-on-plans" "got rc=$rc"
+fi
+(cd "$FIXTURE" && bash "$HELPER" check qe-audit --session-id "TEST-SID-1" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "fix-issues sentinel does not gate qe-audit"
+else
+  fail "fix-issues sentinel does not gate qe-audit" "got rc=$rc"
+fi
+(cd "$FIXTURE" && bash "$HELPER" clear fix-issues --pipeline-id "fix-issues.iso") >/dev/null 2>&1
+
+echo ""
+echo "=== input-validation ==="
+# Bad skill name (contains uppercase / slash).
+(cd "$FIXTURE" && bash "$HELPER" check 'BadSkill' >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+  pass "invalid skill name rejected (usage error rc=$rc)"
+else
+  fail "invalid skill name rejected" "got rc=$rc"
+fi
+(cd "$FIXTURE" && bash "$HELPER" write fix-issues --pipeline-id '../escape' --session-id 'X' >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  pass "invalid pipeline-id rejected (rc=$rc)"
+else
+  fail "invalid pipeline-id rejected" "got rc=0"
+fi
+
+echo ""
+echo "=== call-site wiring assertions ==="
+
+assert_wired() {
+  local label="$1"; local file="$2"; local fragment="$3"
+  if grep -q "$fragment" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "fragment '$fragment' not found in $file"
+  fi
+}
+
+# /fix-issues sprint mode — check + write + clear all present.
+SPRINT="$REPO_ROOT/skills/fix-issues/modes/sprint.md"
+assert_wired "fix-issues sprint: check call" "$SPRINT" '"\$INFLIGHT_HELPER" check fix-issues'
+assert_wired "fix-issues sprint: write call" "$SPRINT" '"\$INFLIGHT_HELPER" write fix-issues'
+assert_wired "fix-issues sprint: clear call" "$SPRINT" '"\$INFLIGHT_HELPER" clear fix-issues'
+# Skip skipping message anchored as the spec wording.
+assert_wired "fix-issues sprint: skip message" "$SPRINT" 'skipping redundant cron pickup'
+
+# /work-on-plans execute mode.
+EXECUTE="$REPO_ROOT/skills/work-on-plans/modes/execute.md"
+assert_wired "work-on-plans execute: check call" "$EXECUTE" '"\$INFLIGHT_HELPER" check work-on-plans'
+assert_wired "work-on-plans execute: write call" "$EXECUTE" '"\$INFLIGHT_HELPER" write work-on-plans'
+assert_wired "work-on-plans execute: clear call" "$EXECUTE" '"\$INFLIGHT_HELPER" clear work-on-plans'
+assert_wired "work-on-plans execute: skip message" "$EXECUTE" 'skipping redundant cron pickup'
+
+# /qe-audit.
+QE="$REPO_ROOT/skills/qe-audit/SKILL.md"
+assert_wired "qe-audit: check call" "$QE" '"\$INFLIGHT_HELPER" check qe-audit'
+assert_wired "qe-audit: write call" "$QE" '"\$INFLIGHT_HELPER" write qe-audit'
+assert_wired "qe-audit: clear call" "$QE" '"\$INFLIGHT_HELPER" clear qe-audit'
+assert_wired "qe-audit: skip message" "$QE" 'skipping redundant cron pickup'
+
+# Mirror parity: each .claude/skills/<skill>/ has the same wiring.
+for pair in "fix-issues/modes/sprint.md" "work-on-plans/modes/execute.md" "qe-audit/SKILL.md"; do
+  SRC="$REPO_ROOT/skills/$pair"
+  DST="$REPO_ROOT/.claude/skills/$pair"
+  if diff -q "$SRC" "$DST" >/dev/null 2>&1; then
+    pass "mirror parity: $pair"
+  else
+    fail "mirror parity: $pair" "src and .claude/skills mirror differ"
+  fi
+done
+
+# Helper itself mirrored too.
+SRC_HELPER="$REPO_ROOT/skills/create-worktree/scripts/check-inflight-batch.sh"
+DST_HELPER="$REPO_ROOT/.claude/skills/create-worktree/scripts/check-inflight-batch.sh"
+if diff -q "$SRC_HELPER" "$DST_HELPER" >/dev/null 2>&1; then
+  pass "mirror parity: helper script"
+else
+  fail "mirror parity: helper script" "src and .claude/skills mirror differ"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Cron pickup-fires (`Run /fix-issues N every 30m now`, `Run /work-on-plans N every ... now`, `Run /qe-audit every ... now`) can land while a previous run is still going — CronCreate's "fires only while idle" is turn-level, not task-level. Per-issue/plan claims catch item-level duplication but not batch-level; `/qe-audit` had no claim at all and was double-filing GitHub issues that then fed `/fix-issues` as duplicate fix work.

Closes #877

## Design

**Shared helper** `skills/create-worktree/scripts/check-inflight-batch.sh` (~527 lines) — subcommands `check / write / clear / list / resolve-session-id`. Sentinels live under new `.zskills/inflight/<skill>/<pipeline-id>.json` namespace (NOT under `.zskills/tracking/...` because the inflight sentinel is session-scoped and skill-keyed, not pipeline-scoped).

**Session-scoping mechanism:** walks `$$`'s PPID chain on Linux until landing on the first descendant of PID 1 (init), forms session-id as `pid-<pid>.<start_time>` using `/proc/<pid>/stat` field 22 (start in clock-ticks-since-boot). Constant across all turns of one Claude Code REPL session (the harness/CLI persists across turns) and differs across sessions (different PIDs + start_times). Falls back to a lazily-stamped `.zskills/session-id` file (24h refresh) on non-Linux. **Critical:** this preserves LEGITIMATE parallel pipelines (different sessions can each run their own sprint concurrently — they have different session-ids).

**Two robustness traps closed:**
- **Session-scoping** — a fire is in-session per CronCreate; a dead/other session's sentinel never gates this one.
- **Staleness escape** — 7200s (2h) default, configurable via `ZSKILLS_INFLIGHT_MAX_AGE_SECONDS` / `--max-age-seconds`. Generous enough that any plausible run fits inside, not so long that crashed runs deadlock the cron forever.

**Subcommand carve-out:** structural, not flag-based. The router peels off `stop`/`next`/`sync`/`add`/`rank`/`remove`/`reconsider`/`default` BEFORE `sprint.md` / `execute.md` is read; placing the guard inside those mode files means the carve-out is enforced by the existing routing. For `/qe-audit` the Phase 0b guard comes after the existing `stop`/`next`/`every`-only-without-`now` exits in the SKILL.md prose.

## Files (16)
- `skills/create-worktree/scripts/check-inflight-batch.sh` — NEW (~527 lines)
- `skills/create-worktree/SKILL.md` — `metadata.version` bump
- `skills/fix-issues/modes/sprint.md` — check-gate + sentinel-write + sentinel-clear
- `skills/fix-issues/SKILL.md` — `metadata.version` bump
- `skills/work-on-plans/modes/execute.md` — check-gate at Step 4 + sentinel-write + sentinel-clear at Step 6
- `skills/work-on-plans/SKILL.md` — `metadata.version` bump
- `skills/qe-audit/SKILL.md` — NEW Phase 0b (check + write) + Phase 9 (clear); `metadata.version` bump
- 7 mirror files under `.claude/skills/`
- `tests/test-inflight-batch-guard.sh` — NEW 32-assertion suite
- `tests/run-all.sh` — register new test

## Test plan
- [x] `bash tests/run-all.sh` — **6759/6759 passed** (+50 new tests from this PR).
- [x] Helper tests confirm session-id stability across calls + isolation across `--session-id` overrides.
- [x] Idempotent helpers: `clear` rc=0 on missing sentinel, `write` overwrites same-pipeline, `check` sweeps stale/malformed in-line.

## Out of scope (filed as follow-up considerations in the implementer report)
- **Dashboard chip** showing live in-flight sentinels — UX enhancement, not correctness gap.
- **#883** (`/run-plan` + `/do` re-entry guard) — same helper, different skip-key. Separate PR.
- **Session-id fallback refresh window** (24h) — only matters on non-Linux; revisit if zskills ships outside Linux containers.

## Commits
$(cd /tmp/zskills-do-877-shared-inflight-guard && git log origin/main..HEAD --format='%h %s' | head -3)
