### PR TITLE
do: complete-render override + drag-to-Completed (#905)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+100432"
+  version: "2026.06.01+e574aa"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -72,12 +72,18 @@ TRIGGER_CMD_RE = re.compile(r"^/work-on-plans(\s|$)")
 
 # State-file column shapes.
 # NOTE: `completed` is intentionally NOT in either tuple — Completed is
-# read-only on the API surface, derived per-snapshot from plan frontmatter
-# `completed:` field (plans) / GitHub issue state (issues). The POST
-# validator explicitly rejects `plans.completed` / `issues.completed`
-# bodies with a specific error containing "completed column is read-only"
-# (see _validate_queue_body); the generic unknown-column path is a
-# secondary backstop.
+# DERIVED per-snapshot from plan frontmatter `completed:` field (plans) /
+# GitHub issue state (issues), not from monitor-state.json's queue arrays.
+#
+# Issue #905 — drag-to-Completed safety hatch (server-side half of #853):
+# plans.completed is conditionally writable. The POST validator accepts
+# the plans.completed shape (same {slug, mode?} as writable columns);
+# `_handle_queue_post` then runs `_validate_completed_plan_slugs` as a
+# per-slug status gate (only status: complete|landed plans pass). The
+# generic unknown-column path remains as a secondary backstop for any
+# other unexpected column name. Issues.completed remains hard-rejected
+# in _validate_queue_body — there is no analogous hatch for issues
+# (closed-ness is owned by GitHub).
 PLAN_COLUMNS = ("drafted", "reviewed", "ready", "backlog", "discarded")
 ISSUE_COLUMNS = ("triage", "ready", "backlog")
 DEFAULT_MODE_VALUES = ("phase", "finish")
@@ -456,20 +462,23 @@ def _validate_queue_body(body: Any) -> Optional[str]:
     plans = body.get("plans")
     if not isinstance(plans, dict):
         return "plans must be an object"
-    # Explicit reject for `completed` — read-only API surface (derived
-    # per-snapshot from plan frontmatter `completed:`). Placed BEFORE the
-    # generic unknown-column loop so the error message is specific and
-    # diagnosable without server logs (DA6: hard-cut migration boundary).
-    if "completed" in plans:
-        return (
-            "completed column is read-only on the API; cannot accept POSTs "
-            "(derived per-snapshot from plan frontmatter completed: field)"
-        )
+    # Issue #905 — Drag-to-Completed safety hatch (server-side half of
+    # #853): `plans.completed` is normally read-only (derived per-snapshot
+    # from plan frontmatter `completed:` — see collect.py:1785-1805). The
+    # POST validator no longer hard-rejects `plans.completed` shape-wise
+    # — it accepts the same {slug, mode?} entry shape as the writable
+    # columns. The per-slug status gate ("is the plan ACTUALLY complete
+    # or landed per its frontmatter?") is enforced in
+    # `_handle_queue_post.validate_completed_plan_slugs`, which reads
+    # the plan file directly (defense in depth: never trust the client's
+    # assertion that a plan is complete). Issues.completed remains hard-
+    # rejected — there is no drag-to-Completed hatch for issues.
     for col in plans.keys():
-        if col not in PLAN_COLUMNS:
+        if col not in PLAN_COLUMNS and col != "completed":
             return f"unexpected plans column: {col}"
     seen_slugs = set()
-    for col in PLAN_COLUMNS:
+    plan_cols_with_completed = list(PLAN_COLUMNS) + ["completed"]
+    for col in plan_cols_with_completed:
         entries = plans.get(col, [])
         if not isinstance(entries, list):
             return f"plans.{col} must be a list"
@@ -514,6 +523,89 @@ def _validate_queue_body(body: Any) -> Optional[str]:
             if n in seen_issues:
                 return f"duplicate issue across issue columns: {n}"
             seen_issues.add(n)
+    return None
+
+
+def _read_plan_status(plans_dir: pathlib.Path, slug: str) -> Optional[str]:
+    """Read the `status:` frontmatter field for `<slug>` from any *.md
+    under `plans_dir`. Returns the lowercased status string, or None if
+    the plan file cannot be located / read.
+
+    Mirrors collect.py's frontmatter discipline: scan the first 40 lines
+    for `---` fences and `^key:\\s*value` pairs (no PyYAML). The slug→
+    filename mapping uses collect.py's same convention — slugify(stem) ==
+    slug — so we iterate *.md and slugify each stem until we hit a match.
+    """
+    if not plans_dir.is_dir():
+        return None
+    # Lightweight slugify mirror of collect.py's: lowercase, replace
+    # non-alphanumeric runs with '-', strip leading/trailing dashes.
+    def _slugify(stem: str) -> str:
+        s = re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")
+        return s
+    target = None
+    for md in plans_dir.glob("*.md"):
+        if _slugify(md.stem) == slug:
+            target = md
+            break
+    if target is None:
+        return None
+    try:
+        content = target.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    lines = content.split("\n")[:40]
+    in_fm = False
+    fm_ended = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "---" and not in_fm and not fm_ended:
+            in_fm = True
+            continue
+        if stripped == "---" and in_fm:
+            fm_ended = True
+            in_fm = False
+            continue
+        if in_fm:
+            m = re.match(r"^(\w+):\s*(.+)", stripped)
+            if m and m.group(1).lower() == "status":
+                return m.group(2).strip().strip('"').strip("'").lower()
+    return None
+
+
+def _validate_completed_plan_slugs(
+    plans_dir: pathlib.Path,
+    completed_entries: List[Any],
+) -> Optional[str]:
+    """Issue #905 — Defense-in-depth for the drag-to-Completed safety
+    hatch (server-side half of #853). For each slug in `plans.completed`,
+    read the plan-file frontmatter and reject the whole request when ANY
+    slug has a status that is not `complete` / `landed`. Returns None on
+    accept, an error string on reject (caller surfaces as 400). Missing
+    plan files (slug→file lookup fails) are treated as a reject — the
+    client claims a plan is complete but we cannot confirm it; refuse
+    rather than persist an unverifiable claim. This mirrors the W1.3/D2
+    narrowness of the client-side render override: the Completed column
+    is source-of-truth from the plan file, not the dashboard.
+    """
+    if not isinstance(completed_entries, list) or not completed_entries:
+        return None
+    for entry in completed_entries:
+        if not isinstance(entry, dict):
+            # Shape errors are caught upstream by _validate_queue_body.
+            continue
+        slug = entry.get("slug", "")
+        if not isinstance(slug, str) or not slug:
+            continue
+        status = _read_plan_status(plans_dir, slug)
+        if status not in ("complete", "landed"):
+            shown = status if status is not None else "<plan-file-not-found>"
+            return (
+                f"plans.completed entry rejected: slug {slug!r} has "
+                f"status={shown!r} (only status: complete|landed plans "
+                "may be dragged to Completed; the column is otherwise "
+                "derived from plan frontmatter — see #853 / #905)"
+            )
     return None
 
 
@@ -959,13 +1051,38 @@ class MonitorHandler(BaseHTTPRequestHandler):
             return
         ctx = self._ctx()
         main_root: pathlib.Path = ctx["main_root"]
+        # Issue #905 — server-side per-slug status gate for plans.completed.
+        # The shape validator above accepts plans.completed entries; this
+        # gate reads each slug's plan-file frontmatter and rejects the
+        # whole request when any entry is non-complete/landed. Defense in
+        # depth on top of the client-side isCompletedDropAllowed guard —
+        # a malicious or buggy client cannot persist a false completion
+        # claim. Skipped when plans.completed is absent / empty.
+        completed_payload = payload.get("plans", {}).get("completed")
+        if completed_payload:
+            plans_dir = _resolve_paths(main_root)["plans_dir"]
+            completed_err = _validate_completed_plan_slugs(
+                plans_dir, completed_payload,
+            )
+            if completed_err is not None:
+                self._send_json(400, {"error": completed_err})
+                return
         with _state_lock(main_root):
             existing = _read_monitor_state(main_root)
             existing_dm = existing.get("default_mode", "phase")
+            # Persist plans.completed alongside the writable columns when
+            # the per-slug status gate accepted it. Empty completed array
+            # is preserved as `[]` so a subsequent POST omitting completed
+            # cleanly resets it. Issue #905 / #853.
+            plans_out: Dict[str, Any] = {
+                c: payload["plans"].get(c, []) for c in PLAN_COLUMNS
+            }
+            if "completed" in payload["plans"]:
+                plans_out["completed"] = payload["plans"]["completed"]
             new_doc = {
                 "version": "1.2",
                 "default_mode": payload.get("default_mode", existing_dm),
-                "plans": {c: payload["plans"].get(c, []) for c in PLAN_COLUMNS},
+                "plans": plans_out,
                 "issues": {c: payload["issues"].get(c, []) for c in ISSUE_COLUMNS},
                 "updated_at": _now_iso(),
             }

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -39,13 +39,21 @@ const POST_RECONCILE_SUPPRESS_MS = 1500;
 // Full tuples used for rendering (active row + below-panel band),
 // deepCloneQueues allocation, fingerprintPlans/Issues membership, and
 // findPlan/findIssue / movePlan / moveIssue navigation. Includes the
-// Phase-3-added `backlog` (writable) and `completed` (read-only) columns.
+// Phase-3-added `backlog` (writable) and `completed` (mostly read-only)
+// columns.
 //
-// Server contract: `completed` is read-only on /api/queue — collect.py
-// derives it per-snapshot from plan frontmatter `completed:` (plans) and
-// GH issue state (issues). postQueue() MUST strip `completed` before
-// sending so the server's validator does not 400 on an otherwise-valid
-// drag commit. See server.py:459-467 / 494-502 for the explicit reject.
+// Server contract: `completed` is derived per-snapshot from plan
+// frontmatter `completed:` (plans) and GH issue state (issues), and is
+// the source of truth for routing. postQueue() strips `completed` by
+// default to keep the writable→derived flow clean.
+//
+// Issue #905 — drag-to-Completed safety hatch (client-side half of
+// #853): a plan whose frontmatter status is `complete` or `landed` MAY
+// be dragged onto Completed; postQueue passes plans.completed through
+// when opts.includeCompletedPlans is set (movePlan threads this when
+// targetCol === "completed"). Server-side _validate_completed_plan_slugs
+// re-checks each slug's status before persisting. Issues retain the
+// unconditional strip (no analogous hatch — closed-ness is owned by GH).
 const PLAN_COLUMNS = ["drafted", "reviewed", "ready", "backlog", "discarded", "completed"];
 const ISSUE_COLUMNS = ["triage", "ready", "backlog", "completed"];
 // Sub-tuples used by renderPlans/renderIssues to draw the active
@@ -739,6 +747,12 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
   for (const c of PLAN_COLUMNS) out.plans[c] = [];
   for (const c of ISSUE_COLUMNS) out.issues[c] = [];
 
+  // Build slug→plan lookup BEFORE the state-pin loop so the completion
+  // override (#853 / #905) can consult `p.queue.column` per slug. Used
+  // later by the completed-window filter as well.
+  const slugToPlanClone = {};
+  for (const p of plans) slugToPlanClone[p.slug] = p;
+
   // Pre-populate from queues (preserves order).
   const seenSlugs = new Set();
   for (const c of PLAN_COLUMNS) {
@@ -746,6 +760,25 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
     for (const e of arr) {
       const entry = (typeof e === "string") ? { slug: e } : (e || {});
       if (!entry.slug || seenSlugs.has(entry.slug)) continue;
+      // Completion override (#905 — client-side half of #853): the ONE
+      // exception to W1.3/D2 rule (i), mirroring the server-side
+      // completion override at collect.py:1785-1805. The state file
+      // owns ordering for ACTIVE plans; for plans the server has
+      // already routed to `completed` via the source-of-truth
+      // override (status: complete|landed + parseable `completed:`),
+      // the stale pin in `queues.plans.<col>` would otherwise lock the
+      // card into its old column before the second loop's inferred
+      // routing could relocate it. Skip the pin here and let the
+      // second loop deposit the slug into out.plans.completed via
+      // `p.queue.column`. Non-complete plans pinned to ANY column
+      // still honor their pin — rule (i) only relaxes for
+      // queue.column === "completed".
+      const planForOverride = slugToPlanClone[entry.slug];
+      if (planForOverride
+          && planForOverride.queue
+          && planForOverride.queue.column === "completed") {
+        continue;
+      }
       seenSlugs.add(entry.slug);
       const obj = { slug: entry.slug };
       if (c === "ready" && entry.mode != null) obj.mode = entry.mode;
@@ -763,9 +796,6 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
   // on the user's completed-window preference from localStorage.
   const planWindow = getCompletedWindow("plan");
   const planCutoff = (planWindow === "all") ? null : Date.now() - planWindow * 86400000;
-  // Build slug→plan lookup for timestamp access during filtering.
-  const slugToPlanClone = {};
-  for (const p of plans) slugToPlanClone[p.slug] = p;
 
   for (const p of plans) {
     if (seenSlugs.has(p.slug)) continue;
@@ -2494,6 +2524,19 @@ async function postQueue(queues, opts) {
   // state, never from monitor-state.json's queue arrays. Sending an
   // EMPTY `completed: []` would still trip the validator's explicit
   // reject, so we remove the key entirely (Phase 3 / D5).
+  //
+  // Issue #905 — Drag-to-Completed safety hatch (client-side half of
+  // #853): the caller may set `opts.includeCompletedPlans = true` when
+  // the originating action was a drag onto Completed for a plan whose
+  // frontmatter status is `complete` / `landed` (gated on the UI side
+  // by isCompletedDropAllowed in onDragOver/onDragEnter/onDrop). When
+  // set, plans.completed passes through unstripped; the server-side
+  // validator at server._validate_queue_body re-checks each slug's
+  // resolved status from the plan file and rejects mismatched entries
+  // (defense in depth — never trust the client's status assertion).
+  // Issues remain unconditionally stripped — there is no drag-to-
+  // Completed hatch for issues.
+  const allowPlansCompleted = !!(opts && opts.includeCompletedPlans);
   const stripCompleted = (obj) => {
     const out = {};
     for (const k of Object.keys(obj || {})) {
@@ -2502,9 +2545,12 @@ async function postQueue(queues, opts) {
     }
     return out;
   };
+  const plansForPayload = allowPlansCompleted
+    ? Object.assign({}, queues.plans)  // pass `completed` through
+    : stripCompleted(queues.plans);
   const payload = {
     default_mode: queues.default_mode || "phase",
-    plans: stripCompleted(queues.plans),
+    plans: plansForPayload,
     issues: stripCompleted(queues.issues),
   };
   let res;
@@ -2653,7 +2699,16 @@ async function movePlan(slug, dCol, dIdxAdjust) {
     targetIdx = (dCol.idx == null) ? next.plans[targetCol].length : dCol.idx;
   }
   next.plans[targetCol].splice(targetIdx, 0, entry);
-  const ok = await commitQueueChange(next, { action: "Move plan" });
+  // Issue #905 — Drag-to-Completed safety hatch. When the user has
+  // landed a card in the Completed column (gated upstream on
+  // status: complete|landed by isCompletedDropAllowed), thread the
+  // `includeCompletedPlans` opt through commitQueueChange→postQueue so
+  // the normal `stripCompleted` defense doesn't drop the entry on the
+  // floor. Server-side _validate_queue_body independently re-verifies
+  // each slug's frontmatter status.
+  const opts = { action: "Move plan" };
+  if (targetCol === "completed") opts.includeCompletedPlans = true;
+  const ok = await commitQueueChange(next, opts);
   if (ok) {
     announce("plans-live", "Moved plan " + slug + " to " + PLAN_COLUMN_LABELS[targetCol] + " position " + (targetIdx + 1));
   }
@@ -2865,7 +2920,28 @@ function onDragStart(ev) {
   // Capture the source column for postQueue (used elsewhere to strip
   // `completed` defensively, and for column-aware drag affordances).
   const sourceColumn = card.getAttribute("data-column");
-  dragState = { kind, slug, num, sourceColumn };
+  // Issue #905 — Drag-to-Completed safety hatch (client-side half of
+  // #853). Capture the plan's effective status (lowercased) so the
+  // drop-zone guards (onDragEnter / onDragOver / onDrop) can selectively
+  // allow a drop onto the Completed column when — and only when — the
+  // plan's frontmatter declares `status: complete` or `status: landed`.
+  // For any other status (active, conflict, null, unknown) the Completed
+  // drop zone refuses to highlight and the drop is hard-rejected, exactly
+  // as today. `status` lookup is best-effort via the in-memory snapshot;
+  // null when the slug is not in lastSnapshot.plans (defensive — caller
+  // is the live DOM, so it should be present).
+  let planStatus = null;
+  if (kind === "plan" && slug) {
+    const snap = (typeof lastSnapshot !== "undefined") ? lastSnapshot : null;
+    const planList = (snap && snap.plans) || [];
+    for (const p of planList) {
+      if (p && p.slug === slug) {
+        planStatus = (p.status || "").toLowerCase() || null;
+        break;
+      }
+    }
+  }
+  dragState = { kind, slug, num, sourceColumn, planStatus };
   if (ev.dataTransfer) {
     try {
       ev.dataTransfer.setData("text/plain", JSON.stringify(dragState));
@@ -2884,12 +2960,33 @@ function onDragEnd(ev) {
   removeInsertIndicator();
 }
 
+// Issue #905 — Drag-to-Completed safety hatch (client-side half of #853).
+// Returns true when the in-flight drag is allowed to land on the Completed
+// drop zone: kind must be "plan" AND the dragged plan's frontmatter status
+// must be "complete" or "landed". Non-complete plans (active, conflict,
+// unknown, null) are blocked here so the drop zone never highlights and
+// onDrop's existing hard-reject path stays the terminal guard. The
+// server-side validator in server._validate_queue_body re-checks the
+// plan's frontmatter status independently — this client guard is UI
+// affordance, not the source of truth.
+function isCompletedDropAllowed(dragState) {
+  if (!dragState) return false;
+  if (dragState.kind !== "plan") return false;
+  const s = dragState.planStatus || "";
+  return s === "complete" || s === "landed";
+}
+
 function onDragOver(ev) {
   const dz = ev.target.closest && ev.target.closest("ul.dropzone");
   if (!dz) return;
   if (!dragState) return;
   // Kind must match dropzone kind.
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  // Issue #905 — Completed drop zone is conditionally writable. Block
+  // dragover for non-complete plans so the browser shows the no-drop
+  // cursor and the existing onDrop reject path holds.
+  if (dz.getAttribute("data-column") === "completed"
+      && !isCompletedDropAllowed(dragState)) return;
   ev.preventDefault();
   if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
   // Visible insertion-point feedback: blue line at the computed index.
@@ -2902,6 +2999,11 @@ function onDragEnter(ev) {
   if (!dz) return;
   if (!dragState) return;
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  // Issue #905 — Completed drop zone refuses to highlight for non-complete
+  // plans. Symmetric with the onDragOver guard above so the user never
+  // sees the drop-target affordance on a drop they can't make.
+  if (dz.getAttribute("data-column") === "completed"
+      && !isCompletedDropAllowed(dragState)) return;
   dz.classList.add("drop-target");
 }
 
@@ -2963,14 +3065,24 @@ async function onDrop(ev) {
   let targetCol = dz.getAttribute("data-column");
   let targetIdx = computeInsertIndex(dz, ev.clientY);
   removeInsertIndicator();
-  // Phase 4 / W4.2 — Reject drops onto Completed. Completed is read-only
-  // (terminal state derived from GH closedAt / plan frontmatter — D1).
-  // Per D5 the column still renders as a <ul> for visual consistency,
-  // but the handler hard-rejects with a no-op + warn (no POST).
-  if (targetCol === "completed") {
+  // Phase 4 / W4.2 — Completed is normally read-only (terminal state
+  // derived from GH closedAt / plan frontmatter — D1). Per D5 the column
+  // still renders as a <ul> for visual consistency.
+  //
+  // Issue #905 — drag-to-Completed safety hatch (client-side half of
+  // #853): a plan whose frontmatter status is `complete` or `landed` MAY
+  // be dropped onto Completed (e.g. to manually unstick a card the
+  // server-side override missed). For ANY other status the hard-reject
+  // path below stays the terminal guard — symmetric with the highlight
+  // guards in onDragOver / onDragEnter so a non-complete plan can't reach
+  // here through normal UI. (Defense in depth: server.py's
+  // _validate_queue_body independently re-checks the plan frontmatter
+  // and rejects mismatched POSTs.)
+  if (targetCol === "completed" && !isCompletedDropAllowed(dragState)) {
     console.warn(
-      "Drop rejected: completed column is read-only (kind=" + dragState.kind +
-      ", id=" + (dragState.slug || dragState.num) + ")"
+      "Drop rejected: completed column is read-only for non-complete plans (kind=" +
+      dragState.kind + ", id=" + (dragState.slug || dragState.num) +
+      ", status=" + (dragState.planStatus || "<none>") + ")"
     );
     dragState = null;
     return;

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.05.31+100432"
+  version: "2026.06.01+e574aa"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -72,12 +72,18 @@ TRIGGER_CMD_RE = re.compile(r"^/work-on-plans(\s|$)")
 
 # State-file column shapes.
 # NOTE: `completed` is intentionally NOT in either tuple — Completed is
-# read-only on the API surface, derived per-snapshot from plan frontmatter
-# `completed:` field (plans) / GitHub issue state (issues). The POST
-# validator explicitly rejects `plans.completed` / `issues.completed`
-# bodies with a specific error containing "completed column is read-only"
-# (see _validate_queue_body); the generic unknown-column path is a
-# secondary backstop.
+# DERIVED per-snapshot from plan frontmatter `completed:` field (plans) /
+# GitHub issue state (issues), not from monitor-state.json's queue arrays.
+#
+# Issue #905 — drag-to-Completed safety hatch (server-side half of #853):
+# plans.completed is conditionally writable. The POST validator accepts
+# the plans.completed shape (same {slug, mode?} as writable columns);
+# `_handle_queue_post` then runs `_validate_completed_plan_slugs` as a
+# per-slug status gate (only status: complete|landed plans pass). The
+# generic unknown-column path remains as a secondary backstop for any
+# other unexpected column name. Issues.completed remains hard-rejected
+# in _validate_queue_body — there is no analogous hatch for issues
+# (closed-ness is owned by GitHub).
 PLAN_COLUMNS = ("drafted", "reviewed", "ready", "backlog", "discarded")
 ISSUE_COLUMNS = ("triage", "ready", "backlog")
 DEFAULT_MODE_VALUES = ("phase", "finish")
@@ -456,20 +462,23 @@ def _validate_queue_body(body: Any) -> Optional[str]:
     plans = body.get("plans")
     if not isinstance(plans, dict):
         return "plans must be an object"
-    # Explicit reject for `completed` — read-only API surface (derived
-    # per-snapshot from plan frontmatter `completed:`). Placed BEFORE the
-    # generic unknown-column loop so the error message is specific and
-    # diagnosable without server logs (DA6: hard-cut migration boundary).
-    if "completed" in plans:
-        return (
-            "completed column is read-only on the API; cannot accept POSTs "
-            "(derived per-snapshot from plan frontmatter completed: field)"
-        )
+    # Issue #905 — Drag-to-Completed safety hatch (server-side half of
+    # #853): `plans.completed` is normally read-only (derived per-snapshot
+    # from plan frontmatter `completed:` — see collect.py:1785-1805). The
+    # POST validator no longer hard-rejects `plans.completed` shape-wise
+    # — it accepts the same {slug, mode?} entry shape as the writable
+    # columns. The per-slug status gate ("is the plan ACTUALLY complete
+    # or landed per its frontmatter?") is enforced in
+    # `_handle_queue_post.validate_completed_plan_slugs`, which reads
+    # the plan file directly (defense in depth: never trust the client's
+    # assertion that a plan is complete). Issues.completed remains hard-
+    # rejected — there is no drag-to-Completed hatch for issues.
     for col in plans.keys():
-        if col not in PLAN_COLUMNS:
+        if col not in PLAN_COLUMNS and col != "completed":
             return f"unexpected plans column: {col}"
     seen_slugs = set()
-    for col in PLAN_COLUMNS:
+    plan_cols_with_completed = list(PLAN_COLUMNS) + ["completed"]
+    for col in plan_cols_with_completed:
         entries = plans.get(col, [])
         if not isinstance(entries, list):
             return f"plans.{col} must be a list"
@@ -514,6 +523,89 @@ def _validate_queue_body(body: Any) -> Optional[str]:
             if n in seen_issues:
                 return f"duplicate issue across issue columns: {n}"
             seen_issues.add(n)
+    return None
+
+
+def _read_plan_status(plans_dir: pathlib.Path, slug: str) -> Optional[str]:
+    """Read the `status:` frontmatter field for `<slug>` from any *.md
+    under `plans_dir`. Returns the lowercased status string, or None if
+    the plan file cannot be located / read.
+
+    Mirrors collect.py's frontmatter discipline: scan the first 40 lines
+    for `---` fences and `^key:\\s*value` pairs (no PyYAML). The slug→
+    filename mapping uses collect.py's same convention — slugify(stem) ==
+    slug — so we iterate *.md and slugify each stem until we hit a match.
+    """
+    if not plans_dir.is_dir():
+        return None
+    # Lightweight slugify mirror of collect.py's: lowercase, replace
+    # non-alphanumeric runs with '-', strip leading/trailing dashes.
+    def _slugify(stem: str) -> str:
+        s = re.sub(r"[^a-z0-9]+", "-", stem.lower()).strip("-")
+        return s
+    target = None
+    for md in plans_dir.glob("*.md"):
+        if _slugify(md.stem) == slug:
+            target = md
+            break
+    if target is None:
+        return None
+    try:
+        content = target.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    lines = content.split("\n")[:40]
+    in_fm = False
+    fm_ended = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "---" and not in_fm and not fm_ended:
+            in_fm = True
+            continue
+        if stripped == "---" and in_fm:
+            fm_ended = True
+            in_fm = False
+            continue
+        if in_fm:
+            m = re.match(r"^(\w+):\s*(.+)", stripped)
+            if m and m.group(1).lower() == "status":
+                return m.group(2).strip().strip('"').strip("'").lower()
+    return None
+
+
+def _validate_completed_plan_slugs(
+    plans_dir: pathlib.Path,
+    completed_entries: List[Any],
+) -> Optional[str]:
+    """Issue #905 — Defense-in-depth for the drag-to-Completed safety
+    hatch (server-side half of #853). For each slug in `plans.completed`,
+    read the plan-file frontmatter and reject the whole request when ANY
+    slug has a status that is not `complete` / `landed`. Returns None on
+    accept, an error string on reject (caller surfaces as 400). Missing
+    plan files (slug→file lookup fails) are treated as a reject — the
+    client claims a plan is complete but we cannot confirm it; refuse
+    rather than persist an unverifiable claim. This mirrors the W1.3/D2
+    narrowness of the client-side render override: the Completed column
+    is source-of-truth from the plan file, not the dashboard.
+    """
+    if not isinstance(completed_entries, list) or not completed_entries:
+        return None
+    for entry in completed_entries:
+        if not isinstance(entry, dict):
+            # Shape errors are caught upstream by _validate_queue_body.
+            continue
+        slug = entry.get("slug", "")
+        if not isinstance(slug, str) or not slug:
+            continue
+        status = _read_plan_status(plans_dir, slug)
+        if status not in ("complete", "landed"):
+            shown = status if status is not None else "<plan-file-not-found>"
+            return (
+                f"plans.completed entry rejected: slug {slug!r} has "
+                f"status={shown!r} (only status: complete|landed plans "
+                "may be dragged to Completed; the column is otherwise "
+                "derived from plan frontmatter — see #853 / #905)"
+            )
     return None
 
 
@@ -959,13 +1051,38 @@ class MonitorHandler(BaseHTTPRequestHandler):
             return
         ctx = self._ctx()
         main_root: pathlib.Path = ctx["main_root"]
+        # Issue #905 — server-side per-slug status gate for plans.completed.
+        # The shape validator above accepts plans.completed entries; this
+        # gate reads each slug's plan-file frontmatter and rejects the
+        # whole request when any entry is non-complete/landed. Defense in
+        # depth on top of the client-side isCompletedDropAllowed guard —
+        # a malicious or buggy client cannot persist a false completion
+        # claim. Skipped when plans.completed is absent / empty.
+        completed_payload = payload.get("plans", {}).get("completed")
+        if completed_payload:
+            plans_dir = _resolve_paths(main_root)["plans_dir"]
+            completed_err = _validate_completed_plan_slugs(
+                plans_dir, completed_payload,
+            )
+            if completed_err is not None:
+                self._send_json(400, {"error": completed_err})
+                return
         with _state_lock(main_root):
             existing = _read_monitor_state(main_root)
             existing_dm = existing.get("default_mode", "phase")
+            # Persist plans.completed alongside the writable columns when
+            # the per-slug status gate accepted it. Empty completed array
+            # is preserved as `[]` so a subsequent POST omitting completed
+            # cleanly resets it. Issue #905 / #853.
+            plans_out: Dict[str, Any] = {
+                c: payload["plans"].get(c, []) for c in PLAN_COLUMNS
+            }
+            if "completed" in payload["plans"]:
+                plans_out["completed"] = payload["plans"]["completed"]
             new_doc = {
                 "version": "1.2",
                 "default_mode": payload.get("default_mode", existing_dm),
-                "plans": {c: payload["plans"].get(c, []) for c in PLAN_COLUMNS},
+                "plans": plans_out,
                 "issues": {c: payload["issues"].get(c, []) for c in ISSUE_COLUMNS},
                 "updated_at": _now_iso(),
             }

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -39,13 +39,21 @@ const POST_RECONCILE_SUPPRESS_MS = 1500;
 // Full tuples used for rendering (active row + below-panel band),
 // deepCloneQueues allocation, fingerprintPlans/Issues membership, and
 // findPlan/findIssue / movePlan / moveIssue navigation. Includes the
-// Phase-3-added `backlog` (writable) and `completed` (read-only) columns.
+// Phase-3-added `backlog` (writable) and `completed` (mostly read-only)
+// columns.
 //
-// Server contract: `completed` is read-only on /api/queue — collect.py
-// derives it per-snapshot from plan frontmatter `completed:` (plans) and
-// GH issue state (issues). postQueue() MUST strip `completed` before
-// sending so the server's validator does not 400 on an otherwise-valid
-// drag commit. See server.py:459-467 / 494-502 for the explicit reject.
+// Server contract: `completed` is derived per-snapshot from plan
+// frontmatter `completed:` (plans) and GH issue state (issues), and is
+// the source of truth for routing. postQueue() strips `completed` by
+// default to keep the writable→derived flow clean.
+//
+// Issue #905 — drag-to-Completed safety hatch (client-side half of
+// #853): a plan whose frontmatter status is `complete` or `landed` MAY
+// be dragged onto Completed; postQueue passes plans.completed through
+// when opts.includeCompletedPlans is set (movePlan threads this when
+// targetCol === "completed"). Server-side _validate_completed_plan_slugs
+// re-checks each slug's status before persisting. Issues retain the
+// unconditional strip (no analogous hatch — closed-ness is owned by GH).
 const PLAN_COLUMNS = ["drafted", "reviewed", "ready", "backlog", "discarded", "completed"];
 const ISSUE_COLUMNS = ["triage", "ready", "backlog", "completed"];
 // Sub-tuples used by renderPlans/renderIssues to draw the active
@@ -739,6 +747,12 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
   for (const c of PLAN_COLUMNS) out.plans[c] = [];
   for (const c of ISSUE_COLUMNS) out.issues[c] = [];
 
+  // Build slug→plan lookup BEFORE the state-pin loop so the completion
+  // override (#853 / #905) can consult `p.queue.column` per slug. Used
+  // later by the completed-window filter as well.
+  const slugToPlanClone = {};
+  for (const p of plans) slugToPlanClone[p.slug] = p;
+
   // Pre-populate from queues (preserves order).
   const seenSlugs = new Set();
   for (const c of PLAN_COLUMNS) {
@@ -746,6 +760,25 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
     for (const e of arr) {
       const entry = (typeof e === "string") ? { slug: e } : (e || {});
       if (!entry.slug || seenSlugs.has(entry.slug)) continue;
+      // Completion override (#905 — client-side half of #853): the ONE
+      // exception to W1.3/D2 rule (i), mirroring the server-side
+      // completion override at collect.py:1785-1805. The state file
+      // owns ordering for ACTIVE plans; for plans the server has
+      // already routed to `completed` via the source-of-truth
+      // override (status: complete|landed + parseable `completed:`),
+      // the stale pin in `queues.plans.<col>` would otherwise lock the
+      // card into its old column before the second loop's inferred
+      // routing could relocate it. Skip the pin here and let the
+      // second loop deposit the slug into out.plans.completed via
+      // `p.queue.column`. Non-complete plans pinned to ANY column
+      // still honor their pin — rule (i) only relaxes for
+      // queue.column === "completed".
+      const planForOverride = slugToPlanClone[entry.slug];
+      if (planForOverride
+          && planForOverride.queue
+          && planForOverride.queue.column === "completed") {
+        continue;
+      }
       seenSlugs.add(entry.slug);
       const obj = { slug: entry.slug };
       if (c === "ready" && entry.mode != null) obj.mode = entry.mode;
@@ -763,9 +796,6 @@ function deepCloneQueues(queues, plans, issues, issuesFetchOk) {
   // on the user's completed-window preference from localStorage.
   const planWindow = getCompletedWindow("plan");
   const planCutoff = (planWindow === "all") ? null : Date.now() - planWindow * 86400000;
-  // Build slug→plan lookup for timestamp access during filtering.
-  const slugToPlanClone = {};
-  for (const p of plans) slugToPlanClone[p.slug] = p;
 
   for (const p of plans) {
     if (seenSlugs.has(p.slug)) continue;
@@ -2494,6 +2524,19 @@ async function postQueue(queues, opts) {
   // state, never from monitor-state.json's queue arrays. Sending an
   // EMPTY `completed: []` would still trip the validator's explicit
   // reject, so we remove the key entirely (Phase 3 / D5).
+  //
+  // Issue #905 — Drag-to-Completed safety hatch (client-side half of
+  // #853): the caller may set `opts.includeCompletedPlans = true` when
+  // the originating action was a drag onto Completed for a plan whose
+  // frontmatter status is `complete` / `landed` (gated on the UI side
+  // by isCompletedDropAllowed in onDragOver/onDragEnter/onDrop). When
+  // set, plans.completed passes through unstripped; the server-side
+  // validator at server._validate_queue_body re-checks each slug's
+  // resolved status from the plan file and rejects mismatched entries
+  // (defense in depth — never trust the client's status assertion).
+  // Issues remain unconditionally stripped — there is no drag-to-
+  // Completed hatch for issues.
+  const allowPlansCompleted = !!(opts && opts.includeCompletedPlans);
   const stripCompleted = (obj) => {
     const out = {};
     for (const k of Object.keys(obj || {})) {
@@ -2502,9 +2545,12 @@ async function postQueue(queues, opts) {
     }
     return out;
   };
+  const plansForPayload = allowPlansCompleted
+    ? Object.assign({}, queues.plans)  // pass `completed` through
+    : stripCompleted(queues.plans);
   const payload = {
     default_mode: queues.default_mode || "phase",
-    plans: stripCompleted(queues.plans),
+    plans: plansForPayload,
     issues: stripCompleted(queues.issues),
   };
   let res;
@@ -2653,7 +2699,16 @@ async function movePlan(slug, dCol, dIdxAdjust) {
     targetIdx = (dCol.idx == null) ? next.plans[targetCol].length : dCol.idx;
   }
   next.plans[targetCol].splice(targetIdx, 0, entry);
-  const ok = await commitQueueChange(next, { action: "Move plan" });
+  // Issue #905 — Drag-to-Completed safety hatch. When the user has
+  // landed a card in the Completed column (gated upstream on
+  // status: complete|landed by isCompletedDropAllowed), thread the
+  // `includeCompletedPlans` opt through commitQueueChange→postQueue so
+  // the normal `stripCompleted` defense doesn't drop the entry on the
+  // floor. Server-side _validate_queue_body independently re-verifies
+  // each slug's frontmatter status.
+  const opts = { action: "Move plan" };
+  if (targetCol === "completed") opts.includeCompletedPlans = true;
+  const ok = await commitQueueChange(next, opts);
   if (ok) {
     announce("plans-live", "Moved plan " + slug + " to " + PLAN_COLUMN_LABELS[targetCol] + " position " + (targetIdx + 1));
   }
@@ -2865,7 +2920,28 @@ function onDragStart(ev) {
   // Capture the source column for postQueue (used elsewhere to strip
   // `completed` defensively, and for column-aware drag affordances).
   const sourceColumn = card.getAttribute("data-column");
-  dragState = { kind, slug, num, sourceColumn };
+  // Issue #905 — Drag-to-Completed safety hatch (client-side half of
+  // #853). Capture the plan's effective status (lowercased) so the
+  // drop-zone guards (onDragEnter / onDragOver / onDrop) can selectively
+  // allow a drop onto the Completed column when — and only when — the
+  // plan's frontmatter declares `status: complete` or `status: landed`.
+  // For any other status (active, conflict, null, unknown) the Completed
+  // drop zone refuses to highlight and the drop is hard-rejected, exactly
+  // as today. `status` lookup is best-effort via the in-memory snapshot;
+  // null when the slug is not in lastSnapshot.plans (defensive — caller
+  // is the live DOM, so it should be present).
+  let planStatus = null;
+  if (kind === "plan" && slug) {
+    const snap = (typeof lastSnapshot !== "undefined") ? lastSnapshot : null;
+    const planList = (snap && snap.plans) || [];
+    for (const p of planList) {
+      if (p && p.slug === slug) {
+        planStatus = (p.status || "").toLowerCase() || null;
+        break;
+      }
+    }
+  }
+  dragState = { kind, slug, num, sourceColumn, planStatus };
   if (ev.dataTransfer) {
     try {
       ev.dataTransfer.setData("text/plain", JSON.stringify(dragState));
@@ -2884,12 +2960,33 @@ function onDragEnd(ev) {
   removeInsertIndicator();
 }
 
+// Issue #905 — Drag-to-Completed safety hatch (client-side half of #853).
+// Returns true when the in-flight drag is allowed to land on the Completed
+// drop zone: kind must be "plan" AND the dragged plan's frontmatter status
+// must be "complete" or "landed". Non-complete plans (active, conflict,
+// unknown, null) are blocked here so the drop zone never highlights and
+// onDrop's existing hard-reject path stays the terminal guard. The
+// server-side validator in server._validate_queue_body re-checks the
+// plan's frontmatter status independently — this client guard is UI
+// affordance, not the source of truth.
+function isCompletedDropAllowed(dragState) {
+  if (!dragState) return false;
+  if (dragState.kind !== "plan") return false;
+  const s = dragState.planStatus || "";
+  return s === "complete" || s === "landed";
+}
+
 function onDragOver(ev) {
   const dz = ev.target.closest && ev.target.closest("ul.dropzone");
   if (!dz) return;
   if (!dragState) return;
   // Kind must match dropzone kind.
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  // Issue #905 — Completed drop zone is conditionally writable. Block
+  // dragover for non-complete plans so the browser shows the no-drop
+  // cursor and the existing onDrop reject path holds.
+  if (dz.getAttribute("data-column") === "completed"
+      && !isCompletedDropAllowed(dragState)) return;
   ev.preventDefault();
   if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
   // Visible insertion-point feedback: blue line at the computed index.
@@ -2902,6 +2999,11 @@ function onDragEnter(ev) {
   if (!dz) return;
   if (!dragState) return;
   if (dz.getAttribute("data-kind") !== dragState.kind) return;
+  // Issue #905 — Completed drop zone refuses to highlight for non-complete
+  // plans. Symmetric with the onDragOver guard above so the user never
+  // sees the drop-target affordance on a drop they can't make.
+  if (dz.getAttribute("data-column") === "completed"
+      && !isCompletedDropAllowed(dragState)) return;
   dz.classList.add("drop-target");
 }
 
@@ -2963,14 +3065,24 @@ async function onDrop(ev) {
   let targetCol = dz.getAttribute("data-column");
   let targetIdx = computeInsertIndex(dz, ev.clientY);
   removeInsertIndicator();
-  // Phase 4 / W4.2 — Reject drops onto Completed. Completed is read-only
-  // (terminal state derived from GH closedAt / plan frontmatter — D1).
-  // Per D5 the column still renders as a <ul> for visual consistency,
-  // but the handler hard-rejects with a no-op + warn (no POST).
-  if (targetCol === "completed") {
+  // Phase 4 / W4.2 — Completed is normally read-only (terminal state
+  // derived from GH closedAt / plan frontmatter — D1). Per D5 the column
+  // still renders as a <ul> for visual consistency.
+  //
+  // Issue #905 — drag-to-Completed safety hatch (client-side half of
+  // #853): a plan whose frontmatter status is `complete` or `landed` MAY
+  // be dropped onto Completed (e.g. to manually unstick a card the
+  // server-side override missed). For ANY other status the hard-reject
+  // path below stays the terminal guard — symmetric with the highlight
+  // guards in onDragOver / onDragEnter so a non-complete plan can't reach
+  // here through normal UI. (Defense in depth: server.py's
+  // _validate_queue_body independently re-checks the plan frontmatter
+  // and rejects mismatched POSTs.)
+  if (targetCol === "completed" && !isCompletedDropAllowed(dragState)) {
     console.warn(
-      "Drop rejected: completed column is read-only (kind=" + dragState.kind +
-      ", id=" + (dragState.slug || dragState.num) + ")"
+      "Drop rejected: completed column is read-only for non-complete plans (kind=" +
+      dragState.kind + ", id=" + (dragState.slug || dragState.num) +
+      ", status=" + (dragState.planStatus || "<none>") + ")"
     );
     dragState = null;
     return;

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -175,6 +175,7 @@ run_suite "test-fix-issues-claim-release-direct.sh" "tests/test-fix-issues-claim
 run_suite "test-fix-issues-claim-collector.sh" "tests/test-fix-issues-claim-collector.sh"
 run_suite "test-fix-issues-claim-render-dom.sh" "tests/test-fix-issues-claim-render-dom.sh"
 run_suite "test-dashboard-completed-readonly.sh" "tests/test-dashboard-completed-readonly.sh"
+run_suite "test-dashboard-complete-render-drag.sh" "tests/test-dashboard-complete-render-drag.sh"
 run_suite "test-dashboard-backlog-bidir.sh" "tests/test-dashboard-backlog-bidir.sh"
 run_suite "test-backfill-plan-completed.sh" "tests/test-backfill-plan-completed.sh"
 run_suite "test-fix-issues-claim-race-e2e.sh" "tests/test-fix-issues-claim-race-e2e.sh"

--- a/tests/test-dashboard-backlog-bidir.sh
+++ b/tests/test-dashboard-backlog-bidir.sh
@@ -130,6 +130,9 @@ const onDragStartBlock = extractBlock(src, /\nfunction onDragStart\(/, "\n}\n");
 const onDropBlock = extractBlock(src, /\nasync function onDrop\(/, "\n}\n");
 const computeIdxBlock = extractBlock(src, /\nfunction computeInsertIndex\(/, "\n}\n");
 const removeIndicatorBlock = extractBlock(src, /\nfunction removeInsertIndicator\(/, "\n}\n");
+// #905 — onDrop now consults isCompletedDropAllowed for the targetCol
+// === "completed" branch. Extract it so the harness can call into it.
+const isAllowedBlock = extractBlock(src, /\nfunction isCompletedDropAllowed\(/, "\n}\n");
 
 const harness = `
 let dragState = null;
@@ -151,6 +154,7 @@ function applyCollapseStateToColumn(_d, _k, _c) {}
 
 ${computeIdxBlock}
 ${removeIndicatorBlock}
+${isAllowedBlock}
 ${onDragStartBlock}
 ${onDropBlock}
 

--- a/tests/test-dashboard-complete-render-drag.sh
+++ b/tests/test-dashboard-complete-render-drag.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+# Tests for Issue #905 — Dashboard: client-side half of #853.
+#
+# Two coupled fixes covered here:
+#
+#   Gap 1 — Render override in deepCloneQueues. A plan whose server-
+#           annotated queue.column is "completed" must render under
+#           Completed even when the state file pins it elsewhere. A
+#           plan whose server queue.column is anything else (and
+#           especially when status: active is pinned to backlog) must
+#           continue to honor its pin (rule (i) narrowness).
+#
+#   Gap 2 — Drag-to-Completed safety hatch in onDragEnter / onDragOver
+#           / onDrop. Allow drops onto Completed ONLY when the dragged
+#           plan's status is "complete" or "landed". Reject other
+#           statuses with no highlight + no POST (existing read-only
+#           guard remains terminal for them).
+#
+# Run from repo root: bash tests/test-dashboard-complete-render-drag.sh
+#
+# Server-side per-slug status gate is covered in
+# tests/test_zskills_monitor_server.sh (#905 plans.completed ... cases).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATIC_DIR="$REPO_ROOT/skills/zskills-dashboard/scripts/zskills_monitor/static"
+APP_JS="$STATIC_DIR/app.js"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+skip() { printf '\033[33m  SKIP\033[0m %s\n' "$1"; SKIP_COUNT=$((SKIP_COUNT + 1)); }
+
+print_summary_and_exit() {
+  echo ""
+  echo "---"
+  local total=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+  if [ "$FAIL_COUNT" -eq 0 ]; then
+    printf '\033[32mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$total"
+    exit 0
+  else
+    printf '\033[31mResults: %d passed, %d failed, %d skipped (of %d)\033[0m\n' \
+      "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$total"
+    exit 1
+  fi
+}
+
+if [ ! -f "$APP_JS" ]; then
+  fail "static/app.js exists at expected path"
+  print_summary_and_exit
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  skip "node not available — DOM tests skipped"
+  print_summary_and_exit
+fi
+
+NODE_OUT=$(APP_JS_PATH="$APP_JS" node - <<'NODE'
+const fs = require("fs");
+const src = fs.readFileSync(process.env.APP_JS_PATH, "utf8");
+
+// Extract the functions we exercise.
+function extractBlock(text, startRe, endMarker) {
+  const m = text.match(startRe);
+  if (!m) throw new Error("start pattern not found: " + startRe);
+  const startIdx = m.index;
+  const tail = text.slice(startIdx);
+  const endIdx = tail.indexOf(endMarker);
+  if (endIdx < 0) throw new Error("end marker not found: " + endMarker);
+  return tail.slice(0, endIdx + endMarker.length);
+}
+
+const deepCloneBlock = extractBlock(src, /\nfunction deepCloneQueues\(/, "\n  return out;\n}\n");
+const isAllowedBlock = extractBlock(src, /\nfunction isCompletedDropAllowed\(/, "\n}\n");
+
+// Constants the function depends on.
+const PLAN_COLUMNS = ["drafted", "reviewed", "ready", "backlog", "discarded", "completed"];
+const ISSUE_COLUMNS = ["triage", "ready", "backlog", "completed"];
+
+const harness = `
+const PLAN_COLUMNS = ${JSON.stringify(PLAN_COLUMNS)};
+const ISSUE_COLUMNS = ${JSON.stringify(ISSUE_COLUMNS)};
+// Stub getCompletedWindow to disable the completed-window filter
+// (return "all"); the override should function independently of the
+// filter window.
+function getCompletedWindow(_kind) { return "all"; }
+
+${deepCloneBlock}
+${isAllowedBlock}
+
+globalThis.__deepCloneQueues = deepCloneQueues;
+globalThis.__isCompletedDropAllowed = isCompletedDropAllowed;
+`;
+
+(new Function("globalThis", harness))(globalThis);
+
+const deepCloneQueues = globalThis.__deepCloneQueues;
+const isCompletedDropAllowed = globalThis.__isCompletedDropAllowed;
+
+function expect(actual, expected, label) {
+  const aStr = JSON.stringify(actual);
+  const eStr = JSON.stringify(expected);
+  if (aStr !== eStr) {
+    console.log("FAIL " + label + " (got " + aStr + ", expected " + eStr + ")");
+    process.exitCode = 1;
+  } else {
+    console.log("OK " + label);
+  }
+}
+function expectTrue(actual, label) {
+  if (actual) console.log("OK " + label);
+  else {
+    console.log("FAIL " + label + " (got falsy " + JSON.stringify(actual) + ")");
+    process.exitCode = 1;
+  }
+}
+function expectFalse(actual, label) {
+  if (!actual) console.log("OK " + label);
+  else {
+    console.log("FAIL " + label + " (got truthy " + JSON.stringify(actual) + ")");
+    process.exitCode = 1;
+  }
+}
+
+// ------------------------------------------------------------------
+// Gap 1 — Render override.
+// A plan pinned in state.plans.ready whose server queue.column is
+// "completed" must end up in out.plans.completed (NOT out.plans.ready),
+// AND must NOT appear twice. Reproduces the live #905 bug with
+// brainstorm-mode-plan.
+// ------------------------------------------------------------------
+{
+  const queues = {
+    plans: {
+      drafted: [],
+      reviewed: [],
+      ready: [{ slug: "stuck-completed" }],
+      backlog: [],
+      discarded: [],
+      completed: [],
+    },
+    issues: { triage: [], ready: [], backlog: [], completed: [] },
+  };
+  const plans = [
+    {
+      slug: "stuck-completed",
+      status: "complete",
+      completed: "2026-06-01T00:00:00Z",
+      queue: { column: "completed", index: -1, mode: null },
+    },
+  ];
+  const out = deepCloneQueues(queues, plans, [], true);
+  expect(out.plans.ready, [],
+    "Gap 1 — pinned-in-ready slug with server completed override is NOT in out.plans.ready");
+  expect(out.plans.completed.length, 1,
+    "Gap 1 — completed-override slug appears in out.plans.completed");
+  expect(out.plans.completed[0].slug, "stuck-completed",
+    "Gap 1 — completed slug routed to Completed by inference");
+  // Negative duplication check.
+  let appearances = 0;
+  for (const c of PLAN_COLUMNS) {
+    for (const e of out.plans[c]) {
+      if ((typeof e === "string" ? e : e.slug) === "stuck-completed") appearances++;
+    }
+  }
+  expect(appearances, 1, "Gap 1 — completed slug appears EXACTLY once across all columns");
+}
+
+// ------------------------------------------------------------------
+// Gap 1 negative — narrowness invariant (rule (i) intact for non-complete).
+// A status:active plan pinned to backlog must STAY in backlog. The
+// override only relaxes for queue.column === "completed".
+// ------------------------------------------------------------------
+{
+  const queues = {
+    plans: {
+      drafted: [],
+      reviewed: [],
+      ready: [],
+      backlog: [{ slug: "active-in-backlog" }],
+      discarded: [],
+      completed: [],
+    },
+    issues: { triage: [], ready: [], backlog: [], completed: [] },
+  };
+  const plans = [
+    {
+      slug: "active-in-backlog",
+      status: "active",
+      // Server respects the pin → queue.column = "backlog".
+      queue: { column: "backlog", index: 0, mode: null },
+    },
+  ];
+  const out = deepCloneQueues(queues, plans, [], true);
+  expect(out.plans.backlog.length, 1,
+    "Gap 1 narrowness — active plan pinned to backlog stays in backlog");
+  expect(out.plans.backlog[0].slug, "active-in-backlog",
+    "Gap 1 narrowness — pinned slug preserved in backlog");
+  expect(out.plans.completed, [],
+    "Gap 1 narrowness — non-complete plan NOT in completed");
+}
+
+// ------------------------------------------------------------------
+// Gap 1 mixed — completed override + writable pin coexist.
+// One status:active plan pinned to ready stays in ready; one
+// status:complete plan pinned to ready (e.g. stale historical pin)
+// moves to completed via the override.
+// ------------------------------------------------------------------
+{
+  const queues = {
+    plans: {
+      drafted: [],
+      reviewed: [],
+      ready: [{ slug: "active-keep" }, { slug: "complete-move" }],
+      backlog: [],
+      discarded: [],
+      completed: [],
+    },
+    issues: { triage: [], ready: [], backlog: [], completed: [] },
+  };
+  const plans = [
+    {
+      slug: "active-keep",
+      status: "active",
+      queue: { column: "ready", index: 0, mode: null },
+    },
+    {
+      slug: "complete-move",
+      status: "complete",
+      completed: "2026-06-01T00:00:00Z",
+      queue: { column: "completed", index: -1, mode: null },
+    },
+  ];
+  const out = deepCloneQueues(queues, plans, [], true);
+  expect(out.plans.ready.length, 1,
+    "Gap 1 mixed — only the active plan remains in ready");
+  expect(out.plans.ready[0].slug, "active-keep",
+    "Gap 1 mixed — active-keep stays in ready");
+  expect(out.plans.completed.length, 1,
+    "Gap 1 mixed — complete plan moved to completed");
+  expect(out.plans.completed[0].slug, "complete-move",
+    "Gap 1 mixed — complete-move surfaces in completed");
+}
+
+// ------------------------------------------------------------------
+// Gap 2 — isCompletedDropAllowed gate.
+// Plan kind + status:complete → true; status:landed → true; any other
+// status / kind → false.
+// ------------------------------------------------------------------
+expectTrue(isCompletedDropAllowed({ kind: "plan", slug: "x", planStatus: "complete" }),
+  "Gap 2 — plan w/ status:complete allowed");
+expectTrue(isCompletedDropAllowed({ kind: "plan", slug: "x", planStatus: "landed" }),
+  "Gap 2 — plan w/ status:landed allowed");
+expectFalse(isCompletedDropAllowed({ kind: "plan", slug: "x", planStatus: "active" }),
+  "Gap 2 — plan w/ status:active rejected");
+expectFalse(isCompletedDropAllowed({ kind: "plan", slug: "x", planStatus: null }),
+  "Gap 2 — plan w/ null status rejected");
+expectFalse(isCompletedDropAllowed({ kind: "plan", slug: "x", planStatus: "" }),
+  "Gap 2 — plan w/ empty status rejected");
+expectFalse(isCompletedDropAllowed({ kind: "issue", num: "1", planStatus: "complete" }),
+  "Gap 2 — issue kind rejected even with planStatus:complete (no analogous hatch)");
+expectFalse(isCompletedDropAllowed(null),
+  "Gap 2 — null dragState rejected");
+
+NODE
+)
+NODE_RC=$?
+
+echo "$NODE_OUT"
+
+while IFS= read -r line; do
+  case "$line" in
+    OK\ *) pass "${line#OK }" ;;
+    FAIL\ *) fail "${line#FAIL }" ;;
+  esac
+done <<< "$NODE_OUT"
+
+if [ "$NODE_RC" != "0" ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  fail "node harness exited non-zero ($NODE_RC) with no per-test failures parsed"
+fi
+
+# ------------------------------------------------------------------
+# Source-level invariants — the override comment must cite #853 / #905
+# so a future refactor doesn't silently regress the override without
+# updating the rationale block.
+# ------------------------------------------------------------------
+if grep -q "Completion override (#905" "$APP_JS"; then
+  pass "app.js carries the #905 completion-override rationale comment"
+else
+  fail "app.js missing the #905 completion-override rationale comment"
+fi
+
+if grep -q "isCompletedDropAllowed" "$APP_JS"; then
+  pass "app.js defines isCompletedDropAllowed gate"
+else
+  fail "app.js missing isCompletedDropAllowed gate"
+fi
+
+# postQueue must consult opts.includeCompletedPlans (don't unconditionally strip).
+if grep -q "includeCompletedPlans" "$APP_JS"; then
+  pass "postQueue honors includeCompletedPlans opt"
+else
+  fail "postQueue still unconditionally strips plans.completed"
+fi
+
+# Registration check.
+if grep -q "test-dashboard-complete-render-drag.sh" "$REPO_ROOT/tests/run-all.sh"; then
+  pass "tests/run-all.sh references test-dashboard-complete-render-drag.sh"
+else
+  fail "tests/run-all.sh missing test-dashboard-complete-render-drag.sh registration"
+fi
+
+print_summary_and_exit

--- a/tests/test_zskills_monitor_server.sh
+++ b/tests/test_zskills_monitor_server.sh
@@ -578,27 +578,37 @@ print(f"ok={ok} ua={bool(has_ua)} sua={bool(has_sua)} eq={eq}")
     fail "validate_queue_body_rejects_issues_discarded_in_post: issues.discarded → $CODE_DI (expected 400)"
   fi
 
-  # W2.7 — validate_queue_body_rejects_completed_in_post (plans.completed)
+  # W2.7 / #905 — plans.completed for a non-complete plan must be rejected
+  # by the per-slug status gate (server-side half of the drag-to-Completed
+  # safety hatch). The fixture `sample-plan` has status: active per the
+  # MR5 setup, so a POST claiming it is completed must 400 with a clear
+  # message naming the status mismatch.
   RESP=$(curl -s -X POST \
     -H "Origin: http://127.0.0.1:$PORT_D" \
     -H 'Content-Type: application/json' \
-    -d '{"plans":{"drafted":[],"reviewed":[],"ready":[],"completed":[{"slug":"x"}]},"issues":{"triage":[],"ready":[]}}' \
+    -d '{"plans":{"drafted":[],"reviewed":[],"ready":[],"completed":[{"slug":"sample-plan"}]},"issues":{"triage":[],"ready":[]}}' \
     -w '\n%{http_code}' \
     "http://127.0.0.1:$PORT_D/api/queue")
   CODE=$(printf '%s\n' "$RESP" | tail -n1)
   BODY=$(printf '%s\n' "$RESP" | sed '$d')
   if [ "$CODE" = "400" ]; then
-    pass "validate_queue_body_rejects_completed_in_post: plans.completed → 400"
+    pass "#905 plans.completed non-complete slug → 400"
   else
-    fail "validate_queue_body_rejects_completed_in_post: plans.completed → $CODE"
+    fail "#905 plans.completed non-complete slug → $CODE"
   fi
-  if printf '%s' "$BODY" | grep -q "completed column is read-only"; then
-    pass "validate_queue_body_rejects_completed_in_post: plans error contains read-only message"
+  if printf '%s' "$BODY" | grep -q "plans.completed entry rejected"; then
+    pass "#905 plans.completed rejection message names the gate"
   else
-    fail "validate_queue_body_rejects_completed_in_post: plans error missing read-only message: $BODY"
+    fail "#905 plans.completed rejection message missing the gate: $BODY"
+  fi
+  if printf '%s' "$BODY" | grep -q "status='active'"; then
+    pass "#905 plans.completed rejection surfaces the actual status"
+  else
+    fail "#905 plans.completed rejection missing actual status in message: $BODY"
   fi
 
-  # W2.7 — analogous case for issues.completed
+  # #905 — issues.completed remains hard-rejected. No drag-to-Completed
+  # safety hatch for issues (closed-ness is owned by GitHub).
   RESP=$(curl -s -X POST \
     -H "Origin: http://127.0.0.1:$PORT_D" \
     -H 'Content-Type: application/json' \
@@ -618,12 +628,74 @@ print(f"ok={ok} ua={bool(has_ua)} sua={bool(has_sua)} eq={eq}")
     fail "validate_queue_body_rejects_completed_in_post: issues error missing read-only message: $BODY"
   fi
 
-  # Clarifying assertion: the read-only message must NOT collide with the
-  # generic "unexpected ... column" path (W2.2 specificity contract).
+  # Clarifying assertion: the issues.completed read-only message must NOT
+  # collide with the generic "unexpected ... column" path (W2.2 specificity
+  # contract). plans.completed no longer hits this path (#905).
   if printf '%s' "$BODY" | grep -q "unexpected issues column"; then
     fail "validate_queue_body_rejects_completed_in_post: completed error collides with generic unknown-column path"
   else
     pass "validate_queue_body_rejects_completed_in_post: completed error is distinct from generic unknown-column"
+  fi
+
+  # #905 — Positive case: plans.completed with a slug whose plan file
+  # declares status: complete must return 200 and persist into the state
+  # file. Set up a fresh fixture plan whose frontmatter status is
+  # complete; POST a body with that slug under plans.completed and
+  # assert (a) 200 OK, (b) the state file's plans.completed contains it.
+  cat >"$MR5/plans/COMPLETE_FIXTURE.md" <<'EOF'
+---
+title: Complete Fixture
+status: complete
+completed: 2026-05-31T10:00:00Z
+---
+## Overview
+Drag-to-Completed positive-case fixture.
+
+## Phase 1 — Trivial
+EOF
+  RESP=$(curl -s -X POST \
+    -H "Origin: http://127.0.0.1:$PORT_D" \
+    -H 'Content-Type: application/json' \
+    -d '{"plans":{"drafted":[],"reviewed":[],"ready":[],"completed":[{"slug":"complete-fixture"}]},"issues":{"triage":[],"ready":[]}}' \
+    -w '\n%{http_code}' \
+    "http://127.0.0.1:$PORT_D/api/queue")
+  CODE=$(printf '%s\n' "$RESP" | tail -n1)
+  if [ "$CODE" = "200" ]; then
+    pass "#905 plans.completed status:complete slug → 200"
+  else
+    BODY=$(printf '%s\n' "$RESP" | sed '$d')
+    fail "#905 plans.completed status:complete slug → $CODE (body: $BODY)"
+  fi
+  if grep -q '"complete-fixture"' "$MR5/.zskills/monitor-state.json"; then
+    pass "#905 plans.completed status:complete slug persisted to state file"
+  else
+    fail "#905 plans.completed status:complete slug missing from state file"
+  fi
+
+  # #905 — status: landed is equivalently accepted (both treated as
+  # complete by collect.py:1801 and _read_plan_status downstream).
+  cat >"$MR5/plans/LANDED_FIXTURE.md" <<'EOF'
+---
+title: Landed Fixture
+status: landed
+completed: 2026-05-31T11:00:00Z
+---
+## Overview
+Drag-to-Completed status:landed positive-case fixture.
+
+## Phase 1 — Trivial
+EOF
+  RESP=$(curl -s -X POST \
+    -H "Origin: http://127.0.0.1:$PORT_D" \
+    -H 'Content-Type: application/json' \
+    -d '{"plans":{"drafted":[],"reviewed":[],"ready":[],"completed":[{"slug":"landed-fixture"}]},"issues":{"triage":[],"ready":[]}}' \
+    -w '\n%{http_code}' \
+    "http://127.0.0.1:$PORT_D/api/queue")
+  CODE=$(printf '%s\n' "$RESP" | tail -n1)
+  if [ "$CODE" = "200" ]; then
+    pass "#905 plans.completed status:landed slug → 200"
+  else
+    fail "#905 plans.completed status:landed slug → $CODE"
   fi
 
   # W2.8 — queue_post_roundtrip_backlog: POST a backlog entry, GET


### PR DESCRIPTION
Closes #905.

#853 was filed against two related symptoms: completed plans staying pinned in their old column, and no UI affordance to drag a stuck plan into Completed. PR #876 landed only the primary's server-side half — `collect.py:1785-1805` correctly sets `plan.queue.column = "completed"` for completed plans — but the live dashboard still renders them in their stale-pinned columns, and the original spec's secondary drag-to-Completed safety hatch was dropped. This PR closes both gaps client-side.

## Changes

**Gap 1 — Render override** (`static/app.js` `deepCloneQueues`): hoist the `slugToPlanClone` lookup ahead of the state-pin loop; the first loop now skips a pinned slug when the server has annotated `p.queue.column === "completed"`, leaving the slug out of `seenSlugs` so the second loop's existing inference deposits it in Completed. Mirrors `collect.py:1785-1805`. Narrowness preserved: rule (i) only relaxes for `queue.column === "completed"`, which the server already gates on `status in ("complete","landed")` + parseable `completed:`.

**Gap 2 — Drag-to-Completed safety hatch.**
- Client (`app.js`): `onDragStart` captures the plan's lowercased status onto `dragState.planStatus`. New `isCompletedDropAllowed` gate (kind === plan && status in {complete,landed}) controls `dragenter`/`dragover` highlight + `preventDefault`. `postQueue` honors `opts.includeCompletedPlans`; `movePlan` threads it when `targetCol === "completed"`.
- Server (`server.py`): `_validate_completed_plan_slugs` reads each slug's plan-file frontmatter via the existing `_parse_frontmatter` discipline and rejects the whole 400 when any entry isn't complete/landed (slug not found → reject — claim unverifiable). `_handle_queue_post` gates before the state-lock+write. `issues.completed` remains hard-rejected.

**Tests** (6799/6799 local pass): new `test-dashboard-complete-render-drag.sh` (22 cases — Gap 1 override positive + narrowness + mixed-source; Gap 2 gate matrix; source-level invariants); `test_zskills_monitor_server.sh` +6 #905 cases (status:active → 400 with status-naming; status:complete/landed → 200 + persistence; updated W2.7 plans.completed wording); `test-dashboard-backlog-bidir.sh` updated to import the extracted `isCompletedDropAllowed` for its `onDrop` harness.

Commits:
- f9f3c70 fix(#905): complete-render override + drag-to-Completed safety hatch (client-side half of #853)
