### PR TITLE
fix(#907): warn when /do references an issue mid-description without claiming it

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+065fb4"
+  version: "2026.06.01+fee8a8"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -290,6 +290,28 @@ unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _n
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+# Unclaimed-reference warning (#907). If the description contains a `#N`
+# token that the claim-position rules above did NOT capture into
+# ISSUE_NUMS, the reference is real but UN-claimed. A silent no-claim is
+# the footgun that let `/do Build … for #877` run without claiming #877:
+# a parallel /fix-issues cron then picked up the unclaimed issue and
+# duplicated the work (closed PR #888 vs landed #901). Warn per stray
+# reference (non-fatal — some /do runs legitimately mention an issue
+# without working it; the run proceeds). Claim-positioned refs are already
+# in ISSUE_NUMS and are NOT re-warned.
+_DO_WARN_REMAINING="$ARGUMENTS"
+while [[ "$_DO_WARN_REMAINING" =~ \#([0-9]+) ]]; do
+  _DO_REF="${BASH_REMATCH[1]}"
+  _DO_WARN_REMAINING="${_DO_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
+  _DO_CLAIMED=0
+  for _n in "${ISSUE_NUMS[@]:-}"; do
+    [ "$_n" = "$_DO_REF" ] && { _DO_CLAIMED=1; break; }
+  done
+  if [ "$_DO_CLAIMED" -eq 0 ]; then
+    echo "WARN: /do: description references #${_DO_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_DO_REF} …\" or \"Fix #${_DO_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work." >&2
+  fi
+done
+unset _DO_WARN_REMAINING _DO_REF _DO_CLAIMED _n
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
 # `/do fix the bug --rounds in production` would otherwise capture "in" as

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.05.31+065fb4"
+  version: "2026.06.01+fee8a8"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -290,6 +290,28 @@ unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _n
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+# Unclaimed-reference warning (#907). If the description contains a `#N`
+# token that the claim-position rules above did NOT capture into
+# ISSUE_NUMS, the reference is real but UN-claimed. A silent no-claim is
+# the footgun that let `/do Build … for #877` run without claiming #877:
+# a parallel /fix-issues cron then picked up the unclaimed issue and
+# duplicated the work (closed PR #888 vs landed #901). Warn per stray
+# reference (non-fatal — some /do runs legitimately mention an issue
+# without working it; the run proceeds). Claim-positioned refs are already
+# in ISSUE_NUMS and are NOT re-warned.
+_DO_WARN_REMAINING="$ARGUMENTS"
+while [[ "$_DO_WARN_REMAINING" =~ \#([0-9]+) ]]; do
+  _DO_REF="${BASH_REMATCH[1]}"
+  _DO_WARN_REMAINING="${_DO_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
+  _DO_CLAIMED=0
+  for _n in "${ISSUE_NUMS[@]:-}"; do
+    [ "$_n" = "$_DO_REF" ] && { _DO_CLAIMED=1; break; }
+  done
+  if [ "$_DO_CLAIMED" -eq 0 ]; then
+    echo "WARN: /do: description references #${_DO_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_DO_REF} …\" or \"Fix #${_DO_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work." >&2
+  fi
+done
+unset _DO_WARN_REMAINING _DO_REF _DO_CLAIMED _n
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
 # `/do fix the bug --rounds in production` would otherwise capture "in" as

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -696,6 +696,55 @@ test_issue_nums_do "fix #832 and #833"                   "832"         "bare #N 
 test_issue_nums_do "fix #832 and fix #832"               "832"         "dedupe: duplicate #N captured once"
 
 # ────────────────────────────────────────────────────────────────────
+# Case 18w — Unclaimed-reference WARNING (#907). When the description
+# carries a `#N` token that the claim-position rules did NOT capture into
+# ISSUE_NUMS, /do warns (non-fatal) that no claim was acquired for it —
+# the footgun that let `/do Build … for #877` run unclaimed and duplicate
+# a parallel /fix-issues sprint (closed PR #888). Replicates the SKILL.md
+# warning loop (source-of-truth is SKILL.md; anchored by 18w-src below).
+# ────────────────────────────────────────────────────────────────────
+# do_warn_unclaimed echoes "WARN #N" per unclaimed reference (the real
+# skill writes the full sentence to stderr). Assumes do_parse_issue_nums
+# already populated ISSUE_NUMS.
+do_warn_unclaimed() {
+  local input="$1" _REM="$1" _REF _CLAIMED _n out=""
+  while [[ "$_REM" =~ \#([0-9]+) ]]; do
+    _REF="${BASH_REMATCH[1]}"
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+    _CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_REF" ] && { _CLAIMED=1; break; }
+    done
+    [ "$_CLAIMED" -eq 0 ] && out+="WARN #$_REF"$'\n'
+  done
+  printf '%s' "$out"
+}
+test_do_warn() {
+  local input="$1" expected_csv="$2" label="$3"
+  do_parse_issue_nums "$input"
+  local got_csv
+  got_csv=$(do_warn_unclaimed "$input" | grep -oE '#[0-9]+' | tr -d '#' | paste -sd, -)
+  if [ "$got_csv" = "$expected_csv" ]; then
+    pass "18w warn: $label (got '${got_csv:-none}')"
+  else
+    fail "18w warn: $label (expected '$expected_csv', got '$got_csv')"
+  fi
+}
+test_do_warn "Build the guard for #877"        "877" "bare mid-prose #N → WARN (the #888 footgun)"
+test_do_warn "Fix #853 — auto-route"           ""    "claim-positioned #N → NO warn"
+test_do_warn "Closes #832 / Closes #833"       ""    "both claimed (multi) → NO warn"
+test_do_warn "Closes #832, see also #999"      "999" "claimed #832 + unclaimed #999 → warn only #999"
+test_do_warn "Just a regular description"      ""    "no #N → NO warn"
+test_do_warn "Edit collect.py:#142 line ref"   "142" "stray #N → WARN (accepted non-fatal false-positive)"
+# 18w-src — anchor the replication to the SKILL.md source so a future edit
+# that removes the warning fails closed.
+if grep -qF 'is not in claim position — NO claim was acquired' "$SKILL"; then
+  pass "18w-src SKILL.md carries the unclaimed-reference WARN (#907)"
+else
+  fail "18w-src SKILL.md missing the unclaimed-reference WARN (#907)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
 # Case 19 — Phase 0a triage rubric NO LONGER contains the
 # "References a GitHub issue number → /fix-issues" REDIRECT row.
 # After PR 825 wired ISSUE_NUM + claim-issue.sh into the mode files,


### PR DESCRIPTION
## Summary
Closes #907. `/do`'s claim parser only captures `#N` in **claim position** (start-anchored, close-keyword'd, or strong/weak-separator). A bare **mid-prose** reference — e.g. `/do Build the guard for #877` — captured nothing **and warned nothing**. That silent no-claim is exactly what let the #877 guard work run unclaimed in this session and get duplicated by a parallel `/fix-issues` sprint (closed PR #888 vs landed #901).

## Change
After the issue parse, `/do` emits a **non-fatal stderr WARN per stray `#N`** that wasn't claimed: `WARN: /do: description references #N but it is not in claim position — NO claim was acquired … prefix the description (e.g. "#N …" or "Fix #N …") to claim it`. Claim-positioned references are unaffected (already in `ISSUE_NUMS`, not re-warned). The run proceeds — some `/do` runs legitimately mention an issue without working it.

## Test plan
- [x] `tests/test-do.sh` Case 18w: WARN fires on bare mid-prose `#N` and on an unclaimed `#N` after a claimed one; stays silent on claim-positioned / no-ref; plus a source anchor (`18w-src`) so removing the WARN fails closed.
- [x] `bash tests/run-all.sh` — Overall 6780/6780 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
