### PR TITLE
fix(cron-reentry): in-flight guard for /run-plan + /do (#883)

### DIFF
--- a/.claude/skills/create-worktree/SKILL.md
+++ b/.claude/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.05.31+c3b507"
+  version: "2026.06.01+6569d1"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/.claude/skills/create-worktree/scripts/check-inflight-batch.sh
+++ b/.claude/skills/create-worktree/scripts/check-inflight-batch.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 # check-inflight-batch.sh — Shared session-scoped in-flight guard for
 # queue-pickup workers (/fix-issues sprint, /work-on-plans batch,
-# /qe-audit audit). Closes the cron-pickup concurrency hole documented
-# in issue #877.
+# /qe-audit audit; closes the cron-pickup concurrency hole in #877)
+# AND for same-work re-entry workers (/run-plan, /do; closes the
+# cron-reentry concurrency hole in #883).
 #
-# Why this is shared (not three per-skill scripts): all three workers
-# share the same shape — a recurring cron fire re-fires FRESH work
-# (a fresh sprint / batch / audit, not a continuation of a specific
-# item). The right skip-key is "my session already has an in-flight
-# run of this skill," and the two robustness traps (session-scoping +
-# staleness escape) are identical. Factor once, integrate at each
-# entry point.
+# Why this is shared (not five per-skill scripts): all five workers
+# share the same SHAPE — a recurring cron fire that can land while a
+# previous run is still mid-flight. They differ only on the skip-key.
+# The two queue-pickup workers (#877) re-fire FRESH work (any batch
+# matters), so the skip-key is "my session already has an in-flight
+# run of this skill." The two same-work workers (#883) re-fire the
+# SAME plan/task each time, so the skip-key is "my session already
+# has an in-flight run of THIS specific pipeline_id." Both forms
+# share the same session-scoping + staleness-escape robustness traps,
+# so the helper carries one Python pass parameterised by an optional
+# --pipeline-id filter on the `check` subcommand. Without the filter
+# (the #877 shape) any same-session sentinel for the skill matches;
+# with the filter (the #883 shape) only a sentinel whose pipeline_id
+# equals the filter value matches.
 #
 # Sentinel layout:
 #   $MAIN_ROOT/.zskills/inflight/<skill>/<pipeline-id>.json
@@ -22,10 +30,15 @@
 #   }
 #
 # Subcommands:
-#   check <skill> [--max-age-seconds N] [--session-id <id>]
+#   check <skill> [--max-age-seconds N] [--session-id <id>] [--pipeline-id <id>]
 #     Returns 0 (in-flight; SKIP) iff a sentinel exists for <skill>
 #     whose session_id matches THIS session AND whose started_at age
-#     is less than max-age-seconds (default 7200 = 2h).
+#     is less than max-age-seconds (default 7200 = 2h). When
+#     --pipeline-id is also passed (issue #883), the sentinel's
+#     pipeline_id must additionally equal that value — the "same work"
+#     skip-key for /run-plan + /do where the cron re-fires the SAME
+#     plan/task. Without --pipeline-id (the #877 queue-pickup shape),
+#     any same-session sentinel counts.
 #     Returns 1 (no in-flight; PROCEED) otherwise. Stale sentinels
 #     (older than max-age) are removed in-line and treated as absent
 #     (graceful escape from a dead-session sentinel).
@@ -241,16 +254,26 @@ _validate_pipeline_id() {
 }
 
 # ---------------------------------------------------------------------------
-# check <skill> [--max-age-seconds N] [--session-id <id>]
+# check <skill> [--max-age-seconds N] [--session-id <id>] [--pipeline-id <id>]
 #
 # Exit 0  — in-flight, SKIP (caller should exit 0 cleanly).
 # Exit 1  — no in-flight sentinel for this session, PROCEED.
 # Exit 2  — usage error.
+#
+# `--pipeline-id` (issue #883): when present, only a sentinel whose
+# pipeline_id matches THIS value counts as in-flight. This is the
+# "same-work" skip-key used by /run-plan and /do, where the cron re-fires
+# the SAME plan/task and must skip iff that specific plan/task is mid-
+# flight. Two concurrent /run-plan invocations for DIFFERENT plans each
+# write sentinels under inflight/run-plan/; without the pipeline-id
+# filter the per-skill check would over-match. When `--pipeline-id` is
+# absent, behavior is unchanged from #877: any same-session sentinel
+# under the skill dir counts as in-flight (the queue-pickup skip-key).
 # ---------------------------------------------------------------------------
 cmd_check() {
-  local skill="" max_age="$_DEFAULT_MAX_AGE" explicit_sid=""
+  local skill="" max_age="$_DEFAULT_MAX_AGE" explicit_sid="" filter_pid=""
   if [ "$#" -lt 1 ]; then
-    echo "Usage: check-inflight-batch.sh check <skill> [--max-age-seconds N] [--session-id <id>]" >&2
+    echo "Usage: check-inflight-batch.sh check <skill> [--max-age-seconds N] [--session-id <id>] [--pipeline-id <id>]" >&2
     return 2
   fi
   skill="$1"; shift
@@ -258,6 +281,7 @@ cmd_check() {
     case "$1" in
       --max-age-seconds) max_age="${2:-}"; shift 2 ;;
       --session-id)      explicit_sid="${2:-}"; shift 2 ;;
+      --pipeline-id)     filter_pid="${2:-}"; shift 2 ;;
       *) echo "check-inflight-batch.sh check: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -265,6 +289,9 @@ cmd_check() {
   case "$max_age" in
     ''|*[!0-9]*) echo "check-inflight-batch.sh check: --max-age-seconds must be non-negative integer" >&2; return 2 ;;
   esac
+  if [ -n "$filter_pid" ]; then
+    _validate_pipeline_id "$filter_pid" || return 2
+  fi
   resolve_main_root || return 2
 
   local sid
@@ -280,12 +307,15 @@ cmd_check() {
   fi
 
   # Python pass: find any sentinel matching session_id AND not stale.
-  # Stale sentinels (age > max_age) are removed inline. Returns "match"
-  # iff a fresh same-session sentinel was found.
+  # Stale sentinels (age > max_age) are removed inline. When filter_pid
+  # is non-empty (issue #883), additionally require the sentinel's
+  # pipeline_id to equal filter_pid — this is the "same work in flight"
+  # skip-key used by /run-plan and /do. When filter_pid is empty, any
+  # same-session sentinel counts (the #877 queue-pickup skip-key).
   local result
-  result=$("$_INFLIGHT_PYTHON" - "$skill_dir" "$sid" "$max_age" <<'PY'
+  result=$("$_INFLIGHT_PYTHON" - "$skill_dir" "$sid" "$max_age" "$filter_pid" <<'PY'
 import json, os, sys, time, datetime
-skill_dir, want_sid, max_age = sys.argv[1], sys.argv[2], int(sys.argv[3])
+skill_dir, want_sid, max_age, want_pid = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
 now = datetime.datetime.now(datetime.timezone.utc)
 match = None
 try:
@@ -327,9 +357,13 @@ for name in entries:
             pass
         continue
     # Fresh sentinel. Check session-id.
-    if body.get("session_id", "") == want_sid:
-        match = (body.get("pipeline_id", "?"), int(age))
-        break
+    if body.get("session_id", "") != want_sid:
+        continue
+    # Optional per-work-identity filter (issue #883).
+    if want_pid and body.get("pipeline_id", "") != want_pid:
+        continue
+    match = (body.get("pipeline_id", "?"), int(age))
+    break
 if match is None:
     print("none")
 else:

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+fee8a8"
+  version: "2026.06.01+5deb35"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -974,6 +974,18 @@ if [ "${#ISSUE_NUMS[@]}" -gt 0 ] && [ -n "${PIPELINE_ID:-}" ]; then
     bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
   done
   unset _ISSUE_N
+fi
+
+# Issue #883 — clear the in-flight sentinel for worktree/direct modes
+# (PR mode handles its own clear inside modes/pr.md's explicit-finalize
+# block, before exiting and skipping this Phase 5). $PIPELINE_ID was
+# set by the mode file (worktree.md: do.${TASK_SLUG} unsuffixed;
+# direct.md: do.${ISSUE_NUMS[0]}); both modes match the WRITE key
+# exactly, so a single clear works for both. Skip entirely when
+# $PIPELINE_ID never got set (the no-issue direct-mode path).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$INFLIGHT_HELPER" clear do --pipeline-id "$PIPELINE_ID" || true
 fi
 ```
 

--- a/.claude/skills/do/modes/direct.md
+++ b/.claude/skills/do/modes/direct.md
@@ -31,6 +31,26 @@ else
 fi
 if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "do.${ISSUE_NUMS[0]}")
+
+  # Issue #883 — same-task in-flight guard. Direct mode without an
+  # issue number has no stable identity (no TASK_SLUG), so the guard
+  # only attaches when an issue number anchors the pipeline_id. A
+  # cron re-fire of `Run /do Fix #N ... every ... now` would otherwise
+  # double-fire on top of the in-flight turn. Write the sentinel right
+  # after the check passes; clear it in /do Phase 5 Report (universal
+  # terminal for worktree/direct modes).
+  INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+  if [ -x "$INFLIGHT_HELPER" ]; then
+    if bash "$INFLIGHT_HELPER" check do --pipeline-id "$PIPELINE_ID" > /tmp/.do-inflight.$$ 2>/dev/null; then
+      rm -f /tmp/.do-inflight.$$
+      echo "/do task $PIPELINE_ID in flight; skipping redundant cron re-fire" >&2
+      exit 0
+    fi
+    rm -f /tmp/.do-inflight.$$
+    bash "$INFLIGHT_HELPER" write do --pipeline-id "$PIPELINE_ID" || \
+      echo "do: WARN — could not write in-flight sentinel (continuing)" >&2
+  fi
+
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
   _ACQUIRED=()
   for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -26,7 +26,45 @@ if ! [[ "$TASK_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#TASK_SLUG} -gt 30 ];
 fi
 ```
 
-**Step A2 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
+**Step A2 — Same-task in-flight guard (issue #883, BEFORE collision check).**
+Cron re-fires of `Run /do <task-description> ... every N now` would
+otherwise re-run the SAME task while a previous turn is still mid-
+flight. The shared `check-inflight-batch.sh` helper, called with the
+per-work-identity `--pipeline-id "do.<unsuffixed-TASK_SLUG>"` filter,
+detects the same-session same-task sentinel and exits clean — leaving
+the in-flight turn to finish. This MUST run BEFORE the Step A2.5
+collision check below: the collision check would suffix `TASK_SLUG`
+when a worktree already exists, masking the very same-task signal we
+want to detect. Crashed-turn worktrees ARE escaped by the helper's
+staleness logic (2h max-age sentinel reclaim) — when the sentinel
+ages out, the next fire proceeds AND the collision check still
+suffixes around the stale worktree on disk.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+INFLIGHT_KEY="do.${TASK_SLUG}"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check do --pipeline-id "$INFLIGHT_KEY" > /tmp/.do-inflight.$$ 2>/dev/null; then
+    rm -f /tmp/.do-inflight.$$
+    echo "/do task $INFLIGHT_KEY in flight; skipping redundant cron re-fire" >&2
+    exit 0
+  fi
+  rm -f /tmp/.do-inflight.$$
+  # Write the sentinel immediately so a same-session re-fire arriving
+  # within the helper-call window also skips. The check + write must
+  # both use the UNSUFFIXED key so a future re-fire (which re-derives
+  # the same unsuffixed TASK_SLUG from the same description) finds it.
+  bash "$INFLIGHT_HELPER" write do --pipeline-id "$INFLIGHT_KEY" || \
+    echo "do: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
+```
+
+**Step A2.5 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
 ```bash
 PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel)")
 if [ -d "/tmp/${PROJECT_NAME}-do-${TASK_SLUG}" ]; then
@@ -566,6 +604,19 @@ if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
     esac
   done
   unset _ISSUE_N
+fi
+
+# Issue #883 — clear the in-flight sentinel on every LAND_OUTCOME
+# (terminal point for /do pr; Phase 5 in SKILL.md is bypassed by the
+# `exit` at the end of this caller-loop). Use $INFLIGHT_KEY (the
+# unsuffixed form set in Step A2) — it persists in the same shell
+# session because /do pr's fences run inline. Falling back to
+# $PIPELINE_ID when INFLIGHT_KEY is unset defends against any future
+# refactor that drops Step A2's variable set without dropping the
+# write.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear do --pipeline-id "${INFLIGHT_KEY:-$PIPELINE_ID}" || true
 fi
 ```
 

--- a/.claude/skills/do/modes/worktree.md
+++ b/.claude/skills/do/modes/worktree.md
@@ -33,6 +33,27 @@ fi
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 ATTEMPT_SLUG="${TASK_SLUG}"
 PIPELINE_ID="do.${TASK_SLUG}"
+
+# Issue #883 — same-task in-flight guard. Run BEFORE the worktree
+# create-with-retry below: the rc=2 retry suffixes ATTEMPT_SLUG when a
+# directory already exists, which would mask a legitimate same-task re-
+# fire (the second cron fire's TASK_SLUG would be re-derived from the
+# same description and naively match the pre-existing worktree, then
+# fall into the timestamp-suffix branch and create a second worktree
+# alongside the first). The shared sentinel uses the UNSUFFIXED key
+# (`do.${TASK_SLUG}`) so the check and the writer agree. Cleared at
+# /do Phase 5 Report (universal terminal for worktree mode).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check do --pipeline-id "$PIPELINE_ID" > /tmp/.do-inflight.$$ 2>/dev/null; then
+    rm -f /tmp/.do-inflight.$$
+    echo "/do task $PIPELINE_ID in flight; skipping redundant cron re-fire" >&2
+    exit 0
+  fi
+  rm -f /tmp/.do-inflight.$$
+  bash "$INFLIGHT_HELPER" write do --pipeline-id "$PIPELINE_ID" || \
+    echo "do: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
 # rc=0 BEFORE the first invocation is MANDATORY (R-M2 regression guard:
 # without it, a stale rc=2 from an earlier shell scope would falsely
 # trigger the retry block even when the first invocation succeeded).

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+bd3dd9"
+  version: "2026.06.01+0f0dba"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -651,6 +651,54 @@ case "$rc" in
   2)  echo "claim-plan.sh acquire usage error"; exit 2 ;;
   *)  echo "claim-plan.sh acquire unexpected rc=$rc"; exit 1 ;;
 esac
+```
+
+### Same-plan in-flight guard (issue #883)
+
+**Cron re-fires can land while the previous turn of THIS SAME plan is
+still mid-flight** (chunked `finish auto` re-fires `/run-plan $PLAN_FILE`
+every interval, and CronCreate's "fires only while idle" is turn-level
+idle, not task-level). `claim-plan.sh` does NOT close this: its self-
+re-entry returns rc=0 (proceed) for any same-pipeline re-acquire (#825),
+so two same-session same-plan turns both pass the claim gate. The
+shared `check-inflight-batch.sh` helper, called with the per-work-
+identity `--pipeline-id` filter, distinguishes "same plan re-fire mid-
+flight" (skip) from "different plan in-flight" (proceed):
+
+- Two `/run-plan` invocations for DIFFERENT plans → each writes its own
+  `inflight/run-plan/run-plan.<plan-a>.json` / `<plan-b>.json` sentinel;
+  the `--pipeline-id` filter ensures cross-plan fires don't collide.
+- Two cron fires of `/run-plan $PLAN_A` while phase-N is still running →
+  the second fire sees the same-pipeline sentinel and exits clean,
+  leaving the in-flight turn to finish on its own.
+
+The sentinel is cleared at all `/run-plan` terminal exit points (Phase
+5b's already-complete no-op release + Phase 6's terminal-merge release;
+both in `modes/execute-phase.md`). Stale escape lives in the helper
+(2h max-age) — a crashed turn's sentinel is reclaimed automatically.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check run-plan --pipeline-id "$PIPELINE_ID" > /tmp/.run-plan-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.run-plan-inflight.$$)
+    rm -f /tmp/.run-plan-inflight.$$
+    INFLIGHT_AGE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $3}')
+    echo "run-plan $PIPELINE_ID in flight (sentinel age ${INFLIGHT_AGE:-?}s); skipping redundant cron re-fire" >&2
+    exit 0
+  fi
+  rm -f /tmp/.run-plan-inflight.$$
+  # Fresh fire — write our sentinel so subsequent same-session same-plan
+  # re-fires see it and skip. Cleared in modes/execute-phase.md at the
+  # already-complete no-op (Phase 5b) and the terminal-merge (Phase 6).
+  bash "$INFLIGHT_HELPER" write run-plan --pipeline-id "$PIPELINE_ID" || \
+    echo "run-plan: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
 ```
 
 **Issue-claim acquire (W3.1/W3.2/W3.5, #803 execution-window protection).**

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -1225,6 +1225,14 @@ PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
 bash "$ZSKILLS_SKILLS_ROOT/run-plan/scripts/claim-plan.sh" \
   release "$PLAN_SLUG" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+
+# Issue #883 — clear the shared in-flight sentinel on the already-complete
+# no-op exit path so the next cron fire (if scheduling has not stopped
+# yet) is free to no-op cleanly without seeing a stale sentinel.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
 ```
 
 **Issue-claim release (W3.3 / W3.5 — already-complete no-op).** Release any
@@ -1695,6 +1703,16 @@ if [ "$rc" -eq 12 ]; then
   exit 1
 elif [ "$rc" -ne 0 ]; then
   echo "Release failed (rc=$rc)" >&2; exit 1
+fi
+
+# Issue #883 — clear the shared in-flight sentinel at the terminal merge.
+# This is the canonical "we are truly done with this plan" point, so any
+# stragglers re-firing on the same cron schedule before the schedule is
+# torn down will see the sentinel gone and run cleanly through the
+# already-complete no-op.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
 fi
 ```
 

--- a/skills/create-worktree/SKILL.md
+++ b/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.05.31+c3b507"
+  version: "2026.06.01+6569d1"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/skills/create-worktree/scripts/check-inflight-batch.sh
+++ b/skills/create-worktree/scripts/check-inflight-batch.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 # check-inflight-batch.sh — Shared session-scoped in-flight guard for
 # queue-pickup workers (/fix-issues sprint, /work-on-plans batch,
-# /qe-audit audit). Closes the cron-pickup concurrency hole documented
-# in issue #877.
+# /qe-audit audit; closes the cron-pickup concurrency hole in #877)
+# AND for same-work re-entry workers (/run-plan, /do; closes the
+# cron-reentry concurrency hole in #883).
 #
-# Why this is shared (not three per-skill scripts): all three workers
-# share the same shape — a recurring cron fire re-fires FRESH work
-# (a fresh sprint / batch / audit, not a continuation of a specific
-# item). The right skip-key is "my session already has an in-flight
-# run of this skill," and the two robustness traps (session-scoping +
-# staleness escape) are identical. Factor once, integrate at each
-# entry point.
+# Why this is shared (not five per-skill scripts): all five workers
+# share the same SHAPE — a recurring cron fire that can land while a
+# previous run is still mid-flight. They differ only on the skip-key.
+# The two queue-pickup workers (#877) re-fire FRESH work (any batch
+# matters), so the skip-key is "my session already has an in-flight
+# run of this skill." The two same-work workers (#883) re-fire the
+# SAME plan/task each time, so the skip-key is "my session already
+# has an in-flight run of THIS specific pipeline_id." Both forms
+# share the same session-scoping + staleness-escape robustness traps,
+# so the helper carries one Python pass parameterised by an optional
+# --pipeline-id filter on the `check` subcommand. Without the filter
+# (the #877 shape) any same-session sentinel for the skill matches;
+# with the filter (the #883 shape) only a sentinel whose pipeline_id
+# equals the filter value matches.
 #
 # Sentinel layout:
 #   $MAIN_ROOT/.zskills/inflight/<skill>/<pipeline-id>.json
@@ -22,10 +30,15 @@
 #   }
 #
 # Subcommands:
-#   check <skill> [--max-age-seconds N] [--session-id <id>]
+#   check <skill> [--max-age-seconds N] [--session-id <id>] [--pipeline-id <id>]
 #     Returns 0 (in-flight; SKIP) iff a sentinel exists for <skill>
 #     whose session_id matches THIS session AND whose started_at age
-#     is less than max-age-seconds (default 7200 = 2h).
+#     is less than max-age-seconds (default 7200 = 2h). When
+#     --pipeline-id is also passed (issue #883), the sentinel's
+#     pipeline_id must additionally equal that value — the "same work"
+#     skip-key for /run-plan + /do where the cron re-fires the SAME
+#     plan/task. Without --pipeline-id (the #877 queue-pickup shape),
+#     any same-session sentinel counts.
 #     Returns 1 (no in-flight; PROCEED) otherwise. Stale sentinels
 #     (older than max-age) are removed in-line and treated as absent
 #     (graceful escape from a dead-session sentinel).
@@ -241,16 +254,26 @@ _validate_pipeline_id() {
 }
 
 # ---------------------------------------------------------------------------
-# check <skill> [--max-age-seconds N] [--session-id <id>]
+# check <skill> [--max-age-seconds N] [--session-id <id>] [--pipeline-id <id>]
 #
 # Exit 0  — in-flight, SKIP (caller should exit 0 cleanly).
 # Exit 1  — no in-flight sentinel for this session, PROCEED.
 # Exit 2  — usage error.
+#
+# `--pipeline-id` (issue #883): when present, only a sentinel whose
+# pipeline_id matches THIS value counts as in-flight. This is the
+# "same-work" skip-key used by /run-plan and /do, where the cron re-fires
+# the SAME plan/task and must skip iff that specific plan/task is mid-
+# flight. Two concurrent /run-plan invocations for DIFFERENT plans each
+# write sentinels under inflight/run-plan/; without the pipeline-id
+# filter the per-skill check would over-match. When `--pipeline-id` is
+# absent, behavior is unchanged from #877: any same-session sentinel
+# under the skill dir counts as in-flight (the queue-pickup skip-key).
 # ---------------------------------------------------------------------------
 cmd_check() {
-  local skill="" max_age="$_DEFAULT_MAX_AGE" explicit_sid=""
+  local skill="" max_age="$_DEFAULT_MAX_AGE" explicit_sid="" filter_pid=""
   if [ "$#" -lt 1 ]; then
-    echo "Usage: check-inflight-batch.sh check <skill> [--max-age-seconds N] [--session-id <id>]" >&2
+    echo "Usage: check-inflight-batch.sh check <skill> [--max-age-seconds N] [--session-id <id>] [--pipeline-id <id>]" >&2
     return 2
   fi
   skill="$1"; shift
@@ -258,6 +281,7 @@ cmd_check() {
     case "$1" in
       --max-age-seconds) max_age="${2:-}"; shift 2 ;;
       --session-id)      explicit_sid="${2:-}"; shift 2 ;;
+      --pipeline-id)     filter_pid="${2:-}"; shift 2 ;;
       *) echo "check-inflight-batch.sh check: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -265,6 +289,9 @@ cmd_check() {
   case "$max_age" in
     ''|*[!0-9]*) echo "check-inflight-batch.sh check: --max-age-seconds must be non-negative integer" >&2; return 2 ;;
   esac
+  if [ -n "$filter_pid" ]; then
+    _validate_pipeline_id "$filter_pid" || return 2
+  fi
   resolve_main_root || return 2
 
   local sid
@@ -280,12 +307,15 @@ cmd_check() {
   fi
 
   # Python pass: find any sentinel matching session_id AND not stale.
-  # Stale sentinels (age > max_age) are removed inline. Returns "match"
-  # iff a fresh same-session sentinel was found.
+  # Stale sentinels (age > max_age) are removed inline. When filter_pid
+  # is non-empty (issue #883), additionally require the sentinel's
+  # pipeline_id to equal filter_pid — this is the "same work in flight"
+  # skip-key used by /run-plan and /do. When filter_pid is empty, any
+  # same-session sentinel counts (the #877 queue-pickup skip-key).
   local result
-  result=$("$_INFLIGHT_PYTHON" - "$skill_dir" "$sid" "$max_age" <<'PY'
+  result=$("$_INFLIGHT_PYTHON" - "$skill_dir" "$sid" "$max_age" "$filter_pid" <<'PY'
 import json, os, sys, time, datetime
-skill_dir, want_sid, max_age = sys.argv[1], sys.argv[2], int(sys.argv[3])
+skill_dir, want_sid, max_age, want_pid = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
 now = datetime.datetime.now(datetime.timezone.utc)
 match = None
 try:
@@ -327,9 +357,13 @@ for name in entries:
             pass
         continue
     # Fresh sentinel. Check session-id.
-    if body.get("session_id", "") == want_sid:
-        match = (body.get("pipeline_id", "?"), int(age))
-        break
+    if body.get("session_id", "") != want_sid:
+        continue
+    # Optional per-work-identity filter (issue #883).
+    if want_pid and body.get("pipeline_id", "") != want_pid:
+        continue
+    match = (body.get("pipeline_id", "?"), int(age))
+    break
 if match is None:
     print("none")
 else:

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+fee8a8"
+  version: "2026.06.01+5deb35"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -974,6 +974,18 @@ if [ "${#ISSUE_NUMS[@]}" -gt 0 ] && [ -n "${PIPELINE_ID:-}" ]; then
     bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
   done
   unset _ISSUE_N
+fi
+
+# Issue #883 — clear the in-flight sentinel for worktree/direct modes
+# (PR mode handles its own clear inside modes/pr.md's explicit-finalize
+# block, before exiting and skipping this Phase 5). $PIPELINE_ID was
+# set by the mode file (worktree.md: do.${TASK_SLUG} unsuffixed;
+# direct.md: do.${ISSUE_NUMS[0]}); both modes match the WRITE key
+# exactly, so a single clear works for both. Skip entirely when
+# $PIPELINE_ID never got set (the no-issue direct-mode path).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ] && [ -n "${PIPELINE_ID:-}" ]; then
+  bash "$INFLIGHT_HELPER" clear do --pipeline-id "$PIPELINE_ID" || true
 fi
 ```
 

--- a/skills/do/modes/direct.md
+++ b/skills/do/modes/direct.md
@@ -31,6 +31,26 @@ else
 fi
 if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
   PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "do.${ISSUE_NUMS[0]}")
+
+  # Issue #883 — same-task in-flight guard. Direct mode without an
+  # issue number has no stable identity (no TASK_SLUG), so the guard
+  # only attaches when an issue number anchors the pipeline_id. A
+  # cron re-fire of `Run /do Fix #N ... every ... now` would otherwise
+  # double-fire on top of the in-flight turn. Write the sentinel right
+  # after the check passes; clear it in /do Phase 5 Report (universal
+  # terminal for worktree/direct modes).
+  INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+  if [ -x "$INFLIGHT_HELPER" ]; then
+    if bash "$INFLIGHT_HELPER" check do --pipeline-id "$PIPELINE_ID" > /tmp/.do-inflight.$$ 2>/dev/null; then
+      rm -f /tmp/.do-inflight.$$
+      echo "/do task $PIPELINE_ID in flight; skipping redundant cron re-fire" >&2
+      exit 0
+    fi
+    rm -f /tmp/.do-inflight.$$
+    bash "$INFLIGHT_HELPER" write do --pipeline-id "$PIPELINE_ID" || \
+      echo "do: WARN — could not write in-flight sentinel (continuing)" >&2
+  fi
+
   CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"
   _ACQUIRED=()
   for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -26,7 +26,45 @@ if ! [[ "$TASK_SLUG" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] || [ ${#TASK_SLUG} -gt 30 ];
 fi
 ```
 
-**Step A2 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
+**Step A2 — Same-task in-flight guard (issue #883, BEFORE collision check).**
+Cron re-fires of `Run /do <task-description> ... every N now` would
+otherwise re-run the SAME task while a previous turn is still mid-
+flight. The shared `check-inflight-batch.sh` helper, called with the
+per-work-identity `--pipeline-id "do.<unsuffixed-TASK_SLUG>"` filter,
+detects the same-session same-task sentinel and exits clean — leaving
+the in-flight turn to finish. This MUST run BEFORE the Step A2.5
+collision check below: the collision check would suffix `TASK_SLUG`
+when a worktree already exists, masking the very same-task signal we
+want to detect. Crashed-turn worktrees ARE escaped by the helper's
+staleness logic (2h max-age sentinel reclaim) — when the sentinel
+ages out, the next fire proceeds AND the collision check still
+suffixes around the stale worktree on disk.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+INFLIGHT_KEY="do.${TASK_SLUG}"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check do --pipeline-id "$INFLIGHT_KEY" > /tmp/.do-inflight.$$ 2>/dev/null; then
+    rm -f /tmp/.do-inflight.$$
+    echo "/do task $INFLIGHT_KEY in flight; skipping redundant cron re-fire" >&2
+    exit 0
+  fi
+  rm -f /tmp/.do-inflight.$$
+  # Write the sentinel immediately so a same-session re-fire arriving
+  # within the helper-call window also skips. The check + write must
+  # both use the UNSUFFIXED key so a future re-fire (which re-derives
+  # the same unsuffixed TASK_SLUG from the same description) finds it.
+  bash "$INFLIGHT_HELPER" write do --pipeline-id "$INFLIGHT_KEY" || \
+    echo "do: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
+```
+
+**Step A2.5 — Collision check (BEFORE deriving BRANCH_NAME or WORKTREE_PATH):**
 ```bash
 PROJECT_NAME=$(basename "$(git rev-parse --show-toplevel)")
 if [ -d "/tmp/${PROJECT_NAME}-do-${TASK_SLUG}" ]; then
@@ -566,6 +604,19 @@ if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
     esac
   done
   unset _ISSUE_N
+fi
+
+# Issue #883 — clear the in-flight sentinel on every LAND_OUTCOME
+# (terminal point for /do pr; Phase 5 in SKILL.md is bypassed by the
+# `exit` at the end of this caller-loop). Use $INFLIGHT_KEY (the
+# unsuffixed form set in Step A2) — it persists in the same shell
+# session because /do pr's fences run inline. Falling back to
+# $PIPELINE_ID when INFLIGHT_KEY is unset defends against any future
+# refactor that drops Step A2's variable set without dropping the
+# write.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear do --pipeline-id "${INFLIGHT_KEY:-$PIPELINE_ID}" || true
 fi
 ```
 

--- a/skills/do/modes/worktree.md
+++ b/skills/do/modes/worktree.md
@@ -33,6 +33,27 @@ fi
 MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 ATTEMPT_SLUG="${TASK_SLUG}"
 PIPELINE_ID="do.${TASK_SLUG}"
+
+# Issue #883 — same-task in-flight guard. Run BEFORE the worktree
+# create-with-retry below: the rc=2 retry suffixes ATTEMPT_SLUG when a
+# directory already exists, which would mask a legitimate same-task re-
+# fire (the second cron fire's TASK_SLUG would be re-derived from the
+# same description and naively match the pre-existing worktree, then
+# fall into the timestamp-suffix branch and create a second worktree
+# alongside the first). The shared sentinel uses the UNSUFFIXED key
+# (`do.${TASK_SLUG}`) so the check and the writer agree. Cleared at
+# /do Phase 5 Report (universal terminal for worktree mode).
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check do --pipeline-id "$PIPELINE_ID" > /tmp/.do-inflight.$$ 2>/dev/null; then
+    rm -f /tmp/.do-inflight.$$
+    echo "/do task $PIPELINE_ID in flight; skipping redundant cron re-fire" >&2
+    exit 0
+  fi
+  rm -f /tmp/.do-inflight.$$
+  bash "$INFLIGHT_HELPER" write do --pipeline-id "$PIPELINE_ID" || \
+    echo "do: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
 # rc=0 BEFORE the first invocation is MANDATORY (R-M2 regression guard:
 # without it, a stale rc=2 from an earlier shell scope would falsely
 # trigger the retry block even when the first invocation succeeded).

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.05.31+bd3dd9"
+  version: "2026.06.01+0f0dba"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -651,6 +651,54 @@ case "$rc" in
   2)  echo "claim-plan.sh acquire usage error"; exit 2 ;;
   *)  echo "claim-plan.sh acquire unexpected rc=$rc"; exit 1 ;;
 esac
+```
+
+### Same-plan in-flight guard (issue #883)
+
+**Cron re-fires can land while the previous turn of THIS SAME plan is
+still mid-flight** (chunked `finish auto` re-fires `/run-plan $PLAN_FILE`
+every interval, and CronCreate's "fires only while idle" is turn-level
+idle, not task-level). `claim-plan.sh` does NOT close this: its self-
+re-entry returns rc=0 (proceed) for any same-pipeline re-acquire (#825),
+so two same-session same-plan turns both pass the claim gate. The
+shared `check-inflight-batch.sh` helper, called with the per-work-
+identity `--pipeline-id` filter, distinguishes "same plan re-fire mid-
+flight" (skip) from "different plan in-flight" (proceed):
+
+- Two `/run-plan` invocations for DIFFERENT plans → each writes its own
+  `inflight/run-plan/run-plan.<plan-a>.json` / `<plan-b>.json` sentinel;
+  the `--pipeline-id` filter ensures cross-plan fires don't collide.
+- Two cron fires of `/run-plan $PLAN_A` while phase-N is still running →
+  the second fire sees the same-pipeline sentinel and exits clean,
+  leaving the in-flight turn to finish on its own.
+
+The sentinel is cleared at all `/run-plan` terminal exit points (Phase
+5b's already-complete no-op release + Phase 6's terminal-merge release;
+both in `modes/execute-phase.md`). Stale escape lives in the helper
+(2h max-age) — a crashed turn's sentinel is reclaimed automatically.
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  if bash "$INFLIGHT_HELPER" check run-plan --pipeline-id "$PIPELINE_ID" > /tmp/.run-plan-inflight.$$ 2>/dev/null; then
+    INFLIGHT_LINE=$(cat /tmp/.run-plan-inflight.$$)
+    rm -f /tmp/.run-plan-inflight.$$
+    INFLIGHT_AGE=$(printf '%s' "$INFLIGHT_LINE" | awk -F'\t' '{print $3}')
+    echo "run-plan $PIPELINE_ID in flight (sentinel age ${INFLIGHT_AGE:-?}s); skipping redundant cron re-fire" >&2
+    exit 0
+  fi
+  rm -f /tmp/.run-plan-inflight.$$
+  # Fresh fire — write our sentinel so subsequent same-session same-plan
+  # re-fires see it and skip. Cleared in modes/execute-phase.md at the
+  # already-complete no-op (Phase 5b) and the terminal-merge (Phase 6).
+  bash "$INFLIGHT_HELPER" write run-plan --pipeline-id "$PIPELINE_ID" || \
+    echo "run-plan: WARN — could not write in-flight sentinel (continuing)" >&2
+fi
 ```
 
 **Issue-claim acquire (W3.1/W3.2/W3.5, #803 execution-window protection).**

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -1225,6 +1225,14 @@ PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
 PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
 bash "$ZSKILLS_SKILLS_ROOT/run-plan/scripts/claim-plan.sh" \
   release "$PLAN_SLUG" --require-pipeline "$PIPELINE_ID" 2>/dev/null || true
+
+# Issue #883 — clear the shared in-flight sentinel on the already-complete
+# no-op exit path so the next cron fire (if scheduling has not stopped
+# yet) is free to no-op cleanly without seeing a stale sentinel.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
 ```
 
 **Issue-claim release (W3.3 / W3.5 — already-complete no-op).** Release any
@@ -1695,6 +1703,16 @@ if [ "$rc" -eq 12 ]; then
   exit 1
 elif [ "$rc" -ne 0 ]; then
   echo "Release failed (rc=$rc)" >&2; exit 1
+fi
+
+# Issue #883 — clear the shared in-flight sentinel at the terminal merge.
+# This is the canonical "we are truly done with this plan" point, so any
+# stragglers re-firing on the same cron schedule before the schedule is
+# torn down will see the sentinel gone and run cleanly through the
+# already-complete no-op.
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
 fi
 ```
 

--- a/tests/test-inflight-reentry-guard.sh
+++ b/tests/test-inflight-reentry-guard.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+# test-inflight-reentry-guard.sh — issue #883.
+#
+# Tests the per-work-identity in-flight guard wired into /run-plan and
+# /do. Builds on the shared session-scoped helper from #877; #883 added
+# an optional `--pipeline-id` filter to `check` so the skip-key matches
+# THIS plan / THIS task in flight, not "any same-skill run."
+#
+# Helper-level unit tests (the #883 additions):
+#   - check with --pipeline-id filter matches only the named pipeline_id
+#   - check with --pipeline-id filter ignores other-pipeline same-session sentinels
+#   - two different pipeline_ids under the same skill+session both proceed
+#     when filtered; both skip when unfiltered (back-compat with #877)
+#   - input validation: bad --pipeline-id rejected at check time
+#
+# Wiring assertions:
+#   - skills/run-plan/SKILL.md sources the helper at the same-plan guard
+#     fence (check + write with --pipeline-id)
+#   - skills/run-plan/modes/execute-phase.md clears the sentinel at the
+#     Phase 5b no-op AND Phase 6 terminal-merge release points
+#   - skills/do/modes/{pr,worktree,direct}.md source the helper at the
+#     entry guard
+#   - skills/do/SKILL.md Phase 5 Report clears the sentinel (worktree
+#     and direct modes; pr clears inline in modes/pr.md's finalize)
+#   - mirror parity for the modified files
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/skills/create-worktree/scripts/check-inflight-batch.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+SCRATCH="/tmp/test-inflight-reentry-guard-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then return; fi
+  [ -d "$SCRATCH" ] && rm -rf "$SCRATCH"
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH"
+
+# Fixture: real git repo so MAIN_ROOT resolves.
+FIXTURE="$SCRATCH/fixture"
+mkdir -p "$FIXTURE"
+(
+  cd "$FIXTURE"
+  git init -q
+  git config user.email "t@t"
+  git config user.name "t"
+  git commit --allow-empty -q -m init
+) || { fail "fixture init" "git init failed"; echo "Results: $PASS passed, $((FAIL+1)) failed"; exit 1; }
+
+echo "=== helper presence ==="
+if [ -x "$HELPER" ]; then
+  pass "helper exists and is executable"
+else
+  fail "helper exists and is executable" "missing or non-executable at $HELPER"
+  echo "Results: $PASS passed, $FAIL failed"; exit 1
+fi
+
+echo ""
+echo "=== check --pipeline-id (same work in flight, same session) ==="
+(cd "$FIXTURE" && bash "$HELPER" write run-plan --pipeline-id "run-plan.plan-a" --session-id "TEST-SID-1")
+out=$(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-1" --pipeline-id "run-plan.plan-a" 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "check rc=0 (in-flight) when filter matches existing pipeline_id"
+else
+  fail "check rc=0 (in-flight) when filter matches existing pipeline_id" "got rc=$rc"
+fi
+if printf '%s' "$out" | grep -q "run-plan.plan-a"; then
+  pass "check stdout names the matching pipeline_id"
+else
+  fail "check stdout names the matching pipeline_id" "stdout='$out'"
+fi
+
+echo ""
+echo "=== check --pipeline-id filter ignores other-pipeline sentinels ==="
+(cd "$FIXTURE" && bash "$HELPER" write run-plan --pipeline-id "run-plan.plan-b" --session-id "TEST-SID-1")
+# Now two sentinels exist for run-plan: plan-a and plan-b (same session).
+# Filtering on plan-c should still PROCEED (no plan-c sentinel exists).
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-1" --pipeline-id "run-plan.plan-c" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "filter on non-existent pipeline_id → proceed (rc=1)"
+else
+  fail "filter on non-existent pipeline_id → proceed (rc=1)" "got rc=$rc"
+fi
+# But filter on plan-b still matches.
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-1" --pipeline-id "run-plan.plan-b" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "filter on plan-b still matches its own sentinel (rc=0)"
+else
+  fail "filter on plan-b still matches its own sentinel (rc=0)" "got rc=$rc"
+fi
+
+echo ""
+echo "=== two different plans in same session → both proceed when filtered ==="
+# Imagine /run-plan invocations for plan-x and plan-y both starting fresh
+# in the same session. Each should see no in-flight sentinel for its own
+# pipeline_id, even though the other plan's sentinel exists.
+(cd "$FIXTURE" && bash "$HELPER" write run-plan --pipeline-id "run-plan.plan-x" --session-id "TEST-SID-2")
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-2" --pipeline-id "run-plan.plan-y" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "different plan in same session → proceeds (rc=1) when filtered"
+else
+  fail "different plan in same session → proceeds (rc=1) when filtered" "got rc=$rc"
+fi
+# Sanity: unfiltered check (the #877 shape) still reports in-flight for
+# the same skill+session — back-compat.
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-2" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "unfiltered check (no --pipeline-id) still reports in-flight (back-compat with #877)"
+else
+  fail "unfiltered check still reports in-flight (back-compat)" "got rc=$rc"
+fi
+
+echo ""
+echo "=== stale-escape applies under --pipeline-id filter ==="
+# Same-pipeline match with max-age=0 should still escape (stale-reclaim
+# robustness trap from #877 stays in force under the new filter).
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-2" --pipeline-id "run-plan.plan-x" --max-age-seconds 0 >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "stale escape applies even with --pipeline-id match (rc=1)"
+else
+  fail "stale escape applies even with --pipeline-id match (rc=1)" "got rc=$rc"
+fi
+# After stale escape, the sentinel must be removed (orphan reclaim).
+remaining=$(cd "$FIXTURE" && bash "$HELPER" list run-plan 2>/dev/null | grep "run-plan.plan-x" || true)
+if [ -z "$remaining" ]; then
+  pass "stale escape removed the run-plan.plan-x sentinel"
+else
+  fail "stale escape removed the run-plan.plan-x sentinel" "list still has: $remaining"
+fi
+
+# Clean up remaining sentinels from earlier tests.
+(cd "$FIXTURE" && bash "$HELPER" clear run-plan --pipeline-id "run-plan.plan-a") >/dev/null 2>&1
+(cd "$FIXTURE" && bash "$HELPER" clear run-plan --pipeline-id "run-plan.plan-b") >/dev/null 2>&1
+
+echo ""
+echo "=== input validation: bad --pipeline-id rejected at check ==="
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "X" --pipeline-id '../escape' >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "check rejects path-traversal in --pipeline-id (rc=2)"
+else
+  fail "check rejects path-traversal in --pipeline-id (rc=2)" "got rc=$rc"
+fi
+
+echo ""
+echo "=== /do same-task re-fire skip ==="
+# Simulate /do composing the same TASK_SLUG twice (cron re-fire). First
+# fire writes do.fix-readme sentinel; second fire's check should skip.
+(cd "$FIXTURE" && bash "$HELPER" write do --pipeline-id "do.fix-readme" --session-id "TEST-SID-DO")
+(cd "$FIXTURE" && bash "$HELPER" check do --session-id "TEST-SID-DO" --pipeline-id "do.fix-readme" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "/do same-task re-fire detects sentinel and skips (rc=0)"
+else
+  fail "/do same-task re-fire detects sentinel and skips (rc=0)" "got rc=$rc"
+fi
+
+echo ""
+echo "=== /do different-task in same session → proceeds ==="
+(cd "$FIXTURE" && bash "$HELPER" check do --session-id "TEST-SID-DO" --pipeline-id "do.different-task" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "/do different-task proceeds even while another /do is in flight"
+else
+  fail "/do different-task proceeds" "got rc=$rc"
+fi
+(cd "$FIXTURE" && bash "$HELPER" clear do --pipeline-id "do.fix-readme") >/dev/null 2>&1
+
+echo ""
+echo "=== call-site wiring assertions ==="
+
+assert_wired() {
+  local label="$1"; local file="$2"; local fragment="$3"
+  if grep -q "$fragment" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "fragment '$fragment' not found in $file"
+  fi
+}
+
+# /run-plan SKILL.md — same-plan guard fence (check + write with
+# --pipeline-id).
+RP_SKILL="$REPO_ROOT/skills/run-plan/SKILL.md"
+assert_wired "run-plan SKILL.md: check call w/ --pipeline-id" "$RP_SKILL" \
+  '"\$INFLIGHT_HELPER" check run-plan --pipeline-id "\$PIPELINE_ID"'
+assert_wired "run-plan SKILL.md: write call w/ --pipeline-id" "$RP_SKILL" \
+  '"\$INFLIGHT_HELPER" write run-plan --pipeline-id "\$PIPELINE_ID"'
+assert_wired "run-plan SKILL.md: skip message" "$RP_SKILL" \
+  'skipping redundant cron re-fire'
+assert_wired "run-plan SKILL.md: same-plan guard heading" "$RP_SKILL" \
+  'Same-plan in-flight guard (issue #883)'
+
+# /run-plan modes/execute-phase.md — two clear sites (5b no-op + 6 terminal merge).
+RP_EXEC="$REPO_ROOT/skills/run-plan/modes/execute-phase.md"
+clear_count=$(grep -c '"\$INFLIGHT_HELPER" clear run-plan' "$RP_EXEC" || true)
+if [ "$clear_count" -ge 2 ]; then
+  pass "run-plan execute-phase.md: at least 2 clear sites (got $clear_count)"
+else
+  fail "run-plan execute-phase.md: at least 2 clear sites" "got $clear_count"
+fi
+assert_wired "run-plan execute-phase.md: clear w/ --pipeline-id" "$RP_EXEC" \
+  '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
+
+# /do mode files — entry-guard wiring.
+DO_PR="$REPO_ROOT/skills/do/modes/pr.md"
+DO_WT="$REPO_ROOT/skills/do/modes/worktree.md"
+DO_DIR="$REPO_ROOT/skills/do/modes/direct.md"
+DO_SKILL="$REPO_ROOT/skills/do/SKILL.md"
+
+assert_wired "do pr.md: check call w/ --pipeline-id" "$DO_PR" \
+  '"\$INFLIGHT_HELPER" check do --pipeline-id'
+assert_wired "do pr.md: write call w/ --pipeline-id" "$DO_PR" \
+  '"\$INFLIGHT_HELPER" write do --pipeline-id'
+assert_wired "do pr.md: clear call (in modes/pr.md finalize)" "$DO_PR" \
+  '"\$INFLIGHT_HELPER" clear do --pipeline-id'
+assert_wired "do pr.md: skip message" "$DO_PR" \
+  'skipping redundant cron re-fire'
+
+assert_wired "do worktree.md: check call w/ --pipeline-id" "$DO_WT" \
+  '"\$INFLIGHT_HELPER" check do --pipeline-id "\$PIPELINE_ID"'
+assert_wired "do worktree.md: write call w/ --pipeline-id" "$DO_WT" \
+  '"\$INFLIGHT_HELPER" write do --pipeline-id "\$PIPELINE_ID"'
+
+assert_wired "do direct.md: check call w/ --pipeline-id" "$DO_DIR" \
+  '"\$INFLIGHT_HELPER" check do --pipeline-id "\$PIPELINE_ID"'
+assert_wired "do direct.md: write call w/ --pipeline-id" "$DO_DIR" \
+  '"\$INFLIGHT_HELPER" write do --pipeline-id "\$PIPELINE_ID"'
+
+assert_wired "do SKILL.md Phase 5: clear call (worktree/direct terminal)" "$DO_SKILL" \
+  '"\$INFLIGHT_HELPER" clear do --pipeline-id'
+assert_wired "do SKILL.md Phase 5: issue #883 annotation" "$DO_SKILL" \
+  'Issue #883'
+
+echo ""
+echo "=== mirror parity (.claude/skills) ==="
+for pair in \
+  "create-worktree/scripts/check-inflight-batch.sh" \
+  "run-plan/SKILL.md" \
+  "run-plan/modes/execute-phase.md" \
+  "do/SKILL.md" \
+  "do/modes/pr.md" \
+  "do/modes/worktree.md" \
+  "do/modes/direct.md"; do
+  SRC="$REPO_ROOT/skills/$pair"
+  DST="$REPO_ROOT/.claude/skills/$pair"
+  if diff -q "$SRC" "$DST" >/dev/null 2>&1; then
+    pass "mirror parity: $pair"
+  else
+    fail "mirror parity: $pair" "src and .claude/skills mirror differ"
+  fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Same-work cron re-entry was unguarded: `/run-plan $PLAN every ... now` and `/do <task> every ... now` self-register crons that re-fire the SAME work, not fresh queue pickups. CronCreate's turn-level idle can land a fire while that plan's phase / task is mid-execution → conflicting commits, double landings. `claim-plan` already returns rc=0 on self-re-entry (per #825), so it doesn't close this. This PR adds a per-work-id in-flight guard at the relevant entry points.

Closes #883

## Design

**Reuses #877's `check-inflight-batch.sh` helper**, with one additive (backward-compatible) change: `check` accepts an optional `--pipeline-id <id>` flag for per-work-id filtering. Necessary because #877's per-skill skip-key over-matches here: two concurrent `/run-plan` for DIFFERENT plans both write sentinels under `inflight/run-plan/`, and the unfiltered `check run-plan` would see any sibling sentinel. The new filter is opt-in — every #877 call site keeps exact prior behavior.

**Skip-keys** (chosen carefully per skill mode):
- **`/run-plan`** → `$PIPELINE_ID = run-plan.$TRACKING_ID` (TRACKING_ID derived from plan-file basename). Same plan → same key → second fire skips. Different plans → different keys → both proceed.
- **`/do` PR mode** → `do.${TASK_SLUG}` captured at Step A2 **before** the Step A2.5 collision suffix would mutate it. The unsuffixed form is critical because a future cron re-fire re-composes the same unsuffixed `TASK_SLUG` from the same description and must find the original sentinel. Stored in `INFLIGHT_KEY` and reused at finalize-clear.
- **`/do` worktree mode** → `do.${TASK_SLUG}`. `PIPELINE_ID` is set once with no suffix mutation in this mode, so `$PIPELINE_ID` and `INFLIGHT_KEY` stay identical throughout.
- **`/do` direct mode** → `do.${ISSUE_NUMS[0]}` (sanitized; same identity used by issue-claim acquire). Only attaches when an issue number anchors the pipeline (no-issue direct-mode invocations have no stable identity, so the guard cleanly no-ops).

## /research-and-go assessment

**Not guarded — and that is correct.** `/research-and-go` is a one-shot kickoff: Step 0 stamps the pipeline, Step 1 dispatches `/research-and-plan`, Step 2 invokes `/run-plan $META_PLAN_PATH finish auto`, and exits. The chunked-finish-auto self-perpetuation that the issue body mentions lives entirely in `/run-plan` Phase 5c — each completed phase schedules the next turn via cron, firing `Run /run-plan $META_PLAN_PATH finish auto`. `/research-and-go` itself does NOT register a recurring cron and is never the cron's target — so `/run-plan`'s new guard (in this PR) protects the downstream. Existing Step 0 "Re-run Handling" already covers user-typed double-invocation idempotently. No additional guard needed; no follow-up filed.

## Files (17)
- `skills/create-worktree/scripts/check-inflight-batch.sh` (+76/-26) — new optional `--pipeline-id` filter on `check`
- `skills/run-plan/SKILL.md` (+49/-1) — in-flight guard fence + version bump
- `skills/run-plan/modes/execute-phase.md` (+18) — clear at Phase 5b no-op + Phase 6 terminal merge
- `skills/do/SKILL.md` (+13/-1) — clear at Phase 5 Report (worktree/direct terminal) + version bump
- `skills/do/modes/pr.md` (+52/-1) — check+write at Step A2 (pre-collision-suffix) + clear in finalize
- `skills/do/modes/worktree.md` (+21) — check+write after PIPELINE_ID composition
- `skills/do/modes/direct.md` (+20) — check+write after PIPELINE_ID composition (issue-anchored only)
- `skills/create-worktree/SKILL.md` — version bump
- 8 mirror files under `.claude/skills/`
- `tests/test-inflight-reentry-guard.sh` (+268, new) — 35 tests covering helper filter semantics + wiring + mirror parity

## Test plan
- [x] `bash tests/run-all.sh` — **6759/6759 passed**.
- [x] New suite `test-inflight-reentry-guard.sh` — 35/35.
- [x] Existing `test-inflight-batch-guard.sh` from #877 — 32/32 (back-compat preserved with unfiltered `check`).

## Commits
$(cd /tmp/zskills-do-883-reentry-guard-runplan-do && git log origin/main..HEAD --format='%h %s' | head -3)
