### PR TITLE
fix(#908): prefer CLAUDE_CODE_SESSION_ID in check-inflight-batch.sh

### DIFF
--- a/.claude/skills/create-worktree/SKILL.md
+++ b/.claude/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.06.01+6569d1"
+  version: "2026.06.01+e7b84c"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/.claude/skills/create-worktree/scripts/check-inflight-batch.sh
+++ b/.claude/skills/create-worktree/scripts/check-inflight-batch.sh
@@ -207,6 +207,19 @@ _session_id_from_file() {
 
 resolve_session_id() {
   local sid
+  # Strategy 0 (#908): prefer the harness-provided CLAUDE_CODE_SESSION_ID —
+  # the canonical session identity. It is stable across context compaction
+  # and is re-derived from the persisted session on `--resume`, so it does
+  # not suffer the reboot-staleness of Strategy B's stamped file (which
+  # persists for up to 24h and could make a resumed session read a stale
+  # stamp). Strategies A/B remain as fallbacks for older harnesses or
+  # non-Claude-Code contexts where the env var is absent. The `cc-` prefix
+  # records provenance; write and read both route through this function, so
+  # the namespace stays internally consistent.
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    printf 'cc-%s' "$CLAUDE_CODE_SESSION_ID"
+    return 0
+  fi
   if sid=$(_session_id_from_proc); then
     printf '%s' "$sid"
     return 0

--- a/skills/create-worktree/SKILL.md
+++ b/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills-tracked / .worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.06.01+6569d1"
+  version: "2026.06.01+e7b84c"
 ---
 
 # /create-worktree — Unified Worktree Creation

--- a/skills/create-worktree/scripts/check-inflight-batch.sh
+++ b/skills/create-worktree/scripts/check-inflight-batch.sh
@@ -207,6 +207,19 @@ _session_id_from_file() {
 
 resolve_session_id() {
   local sid
+  # Strategy 0 (#908): prefer the harness-provided CLAUDE_CODE_SESSION_ID —
+  # the canonical session identity. It is stable across context compaction
+  # and is re-derived from the persisted session on `--resume`, so it does
+  # not suffer the reboot-staleness of Strategy B's stamped file (which
+  # persists for up to 24h and could make a resumed session read a stale
+  # stamp). Strategies A/B remain as fallbacks for older harnesses or
+  # non-Claude-Code contexts where the env var is absent. The `cc-` prefix
+  # records provenance; write and read both route through this function, so
+  # the namespace stays internally consistent.
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    printf 'cc-%s' "$CLAUDE_CODE_SESSION_ID"
+    return 0
+  fi
   if sid=$(_session_id_from_proc); then
     printf '%s' "$sid"
     return 0

--- a/tests/test-inflight-batch-guard.sh
+++ b/tests/test-inflight-batch-guard.sh
@@ -193,6 +193,33 @@ else
 fi
 
 echo ""
+echo "=== #908 — prefer CLAUDE_CODE_SESSION_ID for session resolution ==="
+# resolve-session-id prefers the harness-provided env var (cc- prefix).
+SID_ENV=$(cd "$FIXTURE" && CLAUDE_CODE_SESSION_ID="UUID-ABC-123" bash "$HELPER" resolve-session-id)
+if [ "$SID_ENV" = "cc-UUID-ABC-123" ]; then
+  pass "resolve-session-id prefers CLAUDE_CODE_SESSION_ID (#908)"
+else
+  fail "resolve-session-id prefers CLAUDE_CODE_SESSION_ID (#908)" "got '$SID_ENV'"
+fi
+# Falls back to proc/file resolution (non-cc) when the env var is absent.
+SID_FB=$(cd "$FIXTURE" && env -u CLAUDE_CODE_SESSION_ID bash "$HELPER" resolve-session-id)
+if [ -n "$SID_FB" ] && [ "${SID_FB#cc-}" = "$SID_FB" ]; then
+  pass "resolve-session-id falls back (non-cc) when env var unset (#908)"
+else
+  fail "resolve-session-id falls back when env var unset (#908)" "got '$SID_FB'"
+fi
+# End-to-end: the env-var session scopes the guard (same id → in-flight;
+# different id → proceed) even with no --session-id override.
+(cd "$FIXTURE" && CLAUDE_CODE_SESSION_ID="UUID-ENV-1" bash "$HELPER" write fix-issues --pipeline-id "fix-issues.env1" >/dev/null 2>&1)
+(cd "$FIXTURE" && CLAUDE_CODE_SESSION_ID="UUID-ENV-1" bash "$HELPER" check fix-issues >/dev/null 2>&1); rc_same=$?
+(cd "$FIXTURE" && CLAUDE_CODE_SESSION_ID="UUID-ENV-2" bash "$HELPER" check fix-issues >/dev/null 2>&1); rc_diff=$?
+if [ "$rc_same" -eq 0 ] && [ "$rc_diff" -eq 1 ]; then
+  pass "env-var session scoping: same id in-flight, different proceeds (#908)"
+else
+  fail "env-var session scoping (#908)" "same=$rc_same(want 0) diff=$rc_diff(want 1)"
+fi
+
+echo ""
 echo "=== call-site wiring assertions ==="
 
 assert_wired() {


### PR DESCRIPTION
## Summary
Closes #908. Hardens the `#877` in-flight guard helper (`check-inflight-batch.sh`, landed via #901) to **prefer `CLAUDE_CODE_SESSION_ID`** for session identity, falling back to the existing PID-walk + stamped-file strategies only when the env var is absent.

## Why
The landed helper resolved session identity via a PID-ancestor-walk (Strategy A) and a `.zskills/session-id` file (Strategy B) that persists across reboot (refreshed only >24h). `CLAUDE_CODE_SESSION_ID` is the harness's canonical session id — stable across context compaction and re-derived from the persisted session on `--resume` — so it sidesteps Strategy B's reboot-staleness (where a resumed session could read a stale stamp and false-skip) and is strictly more discriminating than the proc-walk (which can collapse two sessions sharing an ancestor PID). Raised during review of the closed duplicate PR #888.

## Change
`resolve_session_id()` gains a Strategy 0: if `CLAUDE_CODE_SESSION_ID` is set, return `cc-<value>` and stop; otherwise the unchanged A→B fallback runs. Write and check both route through `resolve_session_id`, so the namespace stays internally consistent. A mid-deploy mix (old `pid-`/`file-` sentinel checked by new `cc-` form) is fail-open (proceed) — never a deadlock or a gated parallel pipeline.

## Test plan
- [x] `tests/test-inflight-batch-guard.sh` (#908 cases): env-var preferred → `cc-` prefix; fallback → non-cc when unset; end-to-end same-id in-flight / different-id proceeds. (35/35)
- [x] `bash tests/run-all.sh` — full suite green.
- [x] Independent verifier — CLEAN (write/check consistency, `--session-id` override unaffected, fallback intact, fail-open mid-deploy, reduces cross-session false-positive risk).

## Related
#883 (same-work re-entry guard) will add a per-work key to this same helper — coordinate to avoid re-churning `resolve_session_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
