### PR TITLE
fix(#893): use $CLAIM_HELPER in /do pr HOLD-arm stderr (dual-lane path)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+5deb35"
+  version: "2026.06.01+0a315a"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -595,7 +595,7 @@ if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
         bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
           || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;
       pr-ready|created)
-        echo "do: holding claim for #$_ISSUE_N (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $_ISSUE_N' if the PR never lands" >&2 ;;
+        echo "do: holding claim for #$_ISSUE_N (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash $CLAIM_HELPER release $_ISSUE_N' if the PR never lands" >&2 ;;
       pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
         bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
           || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+5deb35"
+  version: "2026.06.01+0a315a"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -595,7 +595,7 @@ if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
         bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
           || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;
       pr-ready|created)
-        echo "do: holding claim for #$_ISSUE_N (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $_ISSUE_N' if the PR never lands" >&2 ;;
+        echo "do: holding claim for #$_ISSUE_N (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash $CLAIM_HELPER release $_ISSUE_N' if the PR never lands" >&2 ;;
       pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
         bash "$CLAIM_HELPER" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID" \
           || echo "do: claim release for #$_ISSUE_N returned non-zero (continuing)" >&2 ;;

--- a/tests/test-do-pr-claim-release.sh
+++ b/tests/test-do-pr-claim-release.sh
@@ -60,7 +60,7 @@ case "$LAND_OUTCOME" in
     bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
       || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
   pr-ready|created)
-    echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash skills/fix-issues/scripts/claim-issue.sh release $ISSUE_NUM' if the PR never lands" >&2 ;;
+    echo "do: holding claim for #$ISSUE_NUM (LAND_OUTCOME=$LAND_OUTCOME — PR is in flight awaiting human review/merge); /do is one-shot so the claim is reaped manually via 'bash $CLAIM_HELPER release $ISSUE_NUM' if the PR never lands" >&2 ;;
   pr-ci-failing|rebase-conflict|auto-rebase-conflict|auto-rebase-blocked|behind-thrash|rebase-failed|push-failed|create-failed|monitor-failed|merge-failed|unknown-status-*)
     bash "$CLAIM_HELPER" release "$ISSUE_NUM" --require-pipeline "$PIPELINE_ID" \
       || echo "do: claim release for #$ISSUE_NUM returned non-zero (continuing)" >&2 ;;
@@ -189,6 +189,17 @@ if grep -q 'pr-ready|created)' "$DO_PR_MD" \
   pass "skills/do/modes/pr.md contains the split case arms"
 else
   fail "skills/do/modes/pr.md split case arms" "expected three-group case missing from source"
+fi
+
+# Dual-lane path discipline (issue #893): the HOLD-arm stderr manual-reap
+# instruction must reference the resolved $CLAIM_HELPER, never the legacy
+# single-lane literal `skills/fix-issues/scripts/claim-issue.sh` (which does
+# not exist on the plugin lane). Same defect class as #832, in stderr prose.
+if grep -q "reaped manually via 'bash \$CLAIM_HELPER release" "$DO_PR_MD" \
+   && ! grep -q 'skills/fix-issues/scripts/claim-issue.sh' "$DO_PR_MD"; then
+  pass "skills/do/modes/pr.md HOLD-arm stderr uses \$CLAIM_HELPER (no hardcoded single-lane path, #893)"
+else
+  fail "skills/do/modes/pr.md HOLD-arm dual-lane path" "expected \$CLAIM_HELPER in HOLD-arm stderr and no hardcoded skills/fix-issues/scripts/claim-issue.sh literal"
 fi
 
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes #893. `/do`'s `pr-ready|created` HOLD-arm in `skills/do/modes/pr.md` printed a manual-reap stderr instruction hardcoding the legacy single-lane path `bash skills/fix-issues/scripts/claim-issue.sh release ...` — which doesn't exist on the plugin lane (the script lives under `${CLAUDE_PLUGIN_ROOT}/skills/...` there). Same defect class as closed #832, but in stderr prose. The very next case already used the resolved `$CLAIM_HELPER` variable — this line just didn't.

Swaps the literal for `bash $CLAIM_HELPER release $_ISSUE_N` (the helper is assigned earlier in the same block, in scope at the echo). Mirror synced; `skills/do` version bumped. Extends `tests/test-do-pr-claim-release.sh` with an assertion that the HOLD-arm stderr uses `$CLAIM_HELPER` and carries no hardcoded single-lane path.

## Test plan
- [x] `bash tests/run-all.sh` — 6773/6773 passed, 0 failed (verifier-confirmed).
- [x] New assertion fails pre-fix (line had the hardcoded path), passes post-fix.
- [x] mirror-parity + conformance pass.

Note: `tests/test-do-pr-claim-release.sh` is not registered in `run-all.sh` (orphaned since #864) — tracking separately; the assertion was run directly (16/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
