### PR TITLE
fix(#892): release stale sprint lock when dashboard poll fails mid-sprint

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+e574aa"
+  version: "2026.06.01+ddf615"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -568,6 +568,22 @@ async function pollWorkOnce() {
   if (ws) {
     lastWorkState = ws;
     applyWorkState(ws);
+  } else {
+    // Issue #892 — fail OPEN, not stuck-locked. A null fetch (network
+    // error / server restart / abort) used to leave lastWorkState stale
+    // at state==="sprint". If the sprint ended during that gap, the
+    // exec-mode chip stayed locked and the change-default-mode UI stayed
+    // blocked until the next *successful* poll. Clearing to null releases
+    // the lock: every lastWorkState consumer (renderDefaultMode,
+    // renderDefaultModeFootnote, the setDefaultMode sprint guard) already
+    // short-circuits on a falsy work-state, and null is the documented
+    // bootstrap value, so no consumer null-derefs. Only re-apply if the
+    // state actually changes (it was previously a sprint), so a transient
+    // failure during idle is a no-op.
+    if (lastWorkState) {
+      lastWorkState = null;
+      applyWorkState(null);
+    }
   }
   // Slow heartbeat while hidden (HIDDEN_POLL_INTERVAL_MS), fast when
   // visible (POLL_INTERVAL_MS). The loop is never stopped.

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+e574aa"
+  version: "2026.06.01+ddf615"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -568,6 +568,22 @@ async function pollWorkOnce() {
   if (ws) {
     lastWorkState = ws;
     applyWorkState(ws);
+  } else {
+    // Issue #892 — fail OPEN, not stuck-locked. A null fetch (network
+    // error / server restart / abort) used to leave lastWorkState stale
+    // at state==="sprint". If the sprint ended during that gap, the
+    // exec-mode chip stayed locked and the change-default-mode UI stayed
+    // blocked until the next *successful* poll. Clearing to null releases
+    // the lock: every lastWorkState consumer (renderDefaultMode,
+    // renderDefaultModeFootnote, the setDefaultMode sprint guard) already
+    // short-circuits on a falsy work-state, and null is the documented
+    // bootstrap value, so no consumer null-derefs. Only re-apply if the
+    // state actually changes (it was previously a sprint), so a transient
+    // failure during idle is a no-op.
+    if (lastWorkState) {
+      lastWorkState = null;
+      applyWorkState(null);
+    }
   }
   // Slow heartbeat while hidden (HIDDEN_POLL_INTERVAL_MS), fast when
   // visible (POLL_INTERVAL_MS). The loop is never stopped.

--- a/tests/test-mode-chip-three-state.sh
+++ b/tests/test-mode-chip-three-state.sh
@@ -394,6 +394,175 @@ if [ "$NODE_RC" != "0" ] && [ "$FAIL_COUNT" -eq 0 ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Issue #892 — exec-mode chip / change-default-mode lock must FAIL OPEN when
+# fetchWorkState() returns null mid-sprint. Pre-fix, pollWorkOnce only ever
+# reassigned lastWorkState in the success branch, so a null fetch (network
+# error / server restart / abort) while the sprint ended left lastWorkState
+# stale at state==="sprint" — the chip stayed locked and setDefaultMode()
+# stayed blocked until the next *successful* poll. This drives a stub
+# fetchWorkState() returning null mid-sprint and asserts (i) the chip
+# un-locks and (ii) the change-default-mode UI re-enables. Must FAIL against
+# pre-fix behavior.
+# ---------------------------------------------------------------------------
+if command -v node >/dev/null 2>&1; then
+  POLL_OUT=$(APP_JS_PATH="$APP_JS" node - <<'NODE'
+const fs = require("fs");
+const src = fs.readFileSync(process.env.APP_JS_PATH, "utf8");
+
+function extractBlock(text, startRe, endMarker) {
+  const m = text.match(startRe);
+  if (!m) throw new Error("start pattern not found: " + startRe);
+  const startIdx = m.index;
+  const tail = text.slice(startIdx);
+  const endIdx = tail.indexOf(endMarker);
+  if (endIdx < 0) throw new Error("end marker not found: " + endMarker);
+  return tail.slice(0, endIdx + endMarker.length);
+}
+
+// Real functions under test, lifted verbatim from app.js.
+const pollWorkOnceBlk    = extractBlock(src, /\nasync function pollWorkOnce\(\)/, "\n}\n");
+const applyWorkStateBlk  = extractBlock(src, /\nfunction applyWorkState\(ws\)/, "\n}\n");
+const renderDefModeBlk   = extractBlock(src, /\nfunction renderDefaultMode\(mode, ws\)/, "\n}\n");
+const renderFootnoteBlk  = extractBlock(src, /\nfunction renderDefaultModeFootnote\(ws\)/, "\n}\n");
+const setDefaultModeBlk  = extractBlock(src, /\nasync function setDefaultMode\(mode\)/, "\n}\n");
+
+// Minimal DOM: dm-phase / dm-finish buttons + footnote node, addressed via $().
+function makeNode(id) {
+  return {
+    id,
+    attrs: {},
+    classes: new Set(),
+    setAttribute(k, v) { this.attrs[k] = String(v); },
+    getAttribute(k) { return this.attrs[k] == null ? null : this.attrs[k]; },
+    removeAttribute(k) { delete this.attrs[k]; },
+    classList: {
+      _set: null,
+      add(c) { this._set.add(c); },
+      remove(c) { this._set.delete(c); },
+      contains(c) { return this._set.has(c); },
+    },
+  };
+}
+
+const harness = `
+let lastWorkState = null;
+let lastGoodDefaultMode = "phase";
+const lastFingerprint = { workState: null, defaultMode: null };
+let setDefaultModeCommitted = null;   // captures the mode if the setter proceeds
+
+// Leaf stubs — keep the test focused on the lock/poll wiring.
+function nextPollDelay() { return 1000; }
+function scheduleWorkPoll(_d) { /* no reschedule in test */ }
+function renderRunStatus(_ws) { /* exercised elsewhere; irrelevant here */ }
+function showToast(_m, _k) { globalThis.__toastShown = true; }
+function announce(_r, _m) {}
+function clonedQueues() { return { default_mode: lastGoodDefaultMode, plans: {}, issues: {} }; }
+async function commitQueueChange(next, _opts) {
+  // Stand in for the real POST: record that the setter actually proceeded
+  // to mutate the default mode (i.e. the lock did NOT block it).
+  setDefaultModeCommitted = next.default_mode;
+  lastGoodDefaultMode = next.default_mode;
+  return true;
+}
+
+${renderDefModeBlk}
+${renderFootnoteBlk}
+${applyWorkStateBlk}
+${pollWorkOnceBlk}
+${setDefaultModeBlk}
+
+globalThis.__pollWorkOnce = pollWorkOnce;
+globalThis.__setDefaultMode = setDefaultMode;
+globalThis.__getLastWorkState = () => lastWorkState;
+globalThis.__getCommitted = () => setDefaultModeCommitted;
+globalThis.__resetCommitted = () => { setDefaultModeCommitted = null; };
+`;
+
+// $() resolves the three real DOM ids; everything else returns null.
+const nodes = {
+  "dm-phase": makeNode("dm-phase"),
+  "dm-finish": makeNode("dm-finish"),
+  "default-mode-footnote": makeNode("default-mode-footnote"),
+};
+nodes["dm-phase"].classList._set = nodes["dm-phase"].classes;
+nodes["dm-finish"].classList._set = nodes["dm-finish"].classes;
+nodes["default-mode-footnote"].classList._set = nodes["default-mode-footnote"].classes;
+const $stub = (id) => (id in nodes ? nodes[id] : null);
+
+// Controllable fetchWorkState: returns whatever __nextFetch yields.
+globalThis.__nextFetch = null;
+async function fetchWorkState() { return globalThis.__nextFetch; }
+
+(new Function("$", "globalThis", "fetchWorkState", harness))($stub, globalThis, fetchWorkState);
+
+const pollWorkOnce = globalThis.__pollWorkOnce;
+const setDefaultMode = globalThis.__setDefaultMode;
+
+function expectTrue(actual, label) {
+  if (actual) console.log("OK " + label);
+  else { console.log("FAIL " + label + " (got falsy)"); process.exitCode = 1; }
+}
+function expectFalse(actual, label) {
+  if (!actual) console.log("OK " + label);
+  else { console.log("FAIL " + label + " (got truthy)"); process.exitCode = 1; }
+}
+
+(async () => {
+  const phase = nodes["dm-phase"];
+  const finish = nodes["dm-finish"];
+  const footnote = nodes["default-mode-footnote"];
+
+  // 1) A sprint poll lands: chip locks, footnote visible, setter blocked.
+  globalThis.__nextFetch = { state: "sprint", batch_mode: "finish" };
+  await pollWorkOnce();
+  expectTrue(phase.getAttribute("data-locked") === "true", "sprint poll: dm-phase locked");
+  expectTrue(finish.getAttribute("data-locked") === "true", "sprint poll: dm-finish locked");
+  expectTrue(footnote.classList.contains("is-visible"), "sprint poll: footnote visible");
+
+  globalThis.__resetCommitted();
+  await setDefaultMode("phase");
+  expectTrue(globalThis.__getCommitted() === null, "sprint in flight: setDefaultMode blocked (no commit)");
+
+  // 2) Next poll FAILS mid-sprint (fetchWorkState -> null) AND the sprint
+  //    has ended. Pre-fix, lastWorkState stays stale at state==="sprint"
+  //    so the chip stays locked and the setter stays blocked. Post-fix,
+  //    the null fetch clears the lock (fail OPEN).
+  globalThis.__nextFetch = null;
+  await pollWorkOnce();
+
+  expectTrue(globalThis.__getLastWorkState() === null,
+    "null fetch mid-sprint: lastWorkState cleared (no longer stale 'sprint')");
+  expectFalse(phase.getAttribute("data-locked"),
+    "null fetch mid-sprint: dm-phase UNLOCKED (chip fails open)");
+  expectFalse(finish.getAttribute("data-locked"),
+    "null fetch mid-sprint: dm-finish UNLOCKED (chip fails open)");
+  expectFalse(footnote.classList.contains("is-visible"),
+    "null fetch mid-sprint: in-flight footnote hidden");
+
+  // 3) change-default-mode UI re-enabled: setDefaultMode now proceeds.
+  globalThis.__resetCommitted();
+  await setDefaultMode("finish");
+  expectTrue(globalThis.__getCommitted() === "finish",
+    "null fetch mid-sprint: setDefaultMode re-enabled (commit proceeds)");
+})();
+NODE
+)
+  POLL_RC=$?
+  echo "$POLL_OUT"
+  while IFS= read -r line; do
+    case "$line" in
+      OK\ *) pass "${line#OK }" ;;
+      FAIL\ *) fail "${line#FAIL }" ;;
+    esac
+  done <<< "$POLL_OUT"
+  if [ "$POLL_RC" != "0" ] && [ "$FAIL_COUNT" -eq 0 ]; then
+    fail "issue #892 poll harness exited non-zero ($POLL_RC) with no per-test failures parsed"
+  fi
+else
+  skip "node not available — issue #892 poll-loop tests skipped"
+fi
+
+# ---------------------------------------------------------------------------
 # Registration check
 # ---------------------------------------------------------------------------
 if grep -q "test-mode-chip-three-state.sh" "$REPO_ROOT/tests/run-all.sh"; then


### PR DESCRIPTION
## Summary
Fixes #892. The dashboard exec-mode chip locks to the in-flight `batch_mode` while a sprint runs (keyed on `lastWorkState.state === "sprint"`). But `lastWorkState` was only reassigned in the SUCCESS branch of `pollWorkOnce` — a null `fetchWorkState()` (network blip / server restart / abort) coinciding with a sprint terminus left it stale at `"sprint"`, so the chip stayed locked and the change-default-mode UI stayed blocked until the next successful poll.

Adds an `else` branch in `pollWorkOnce`: on null fetch, reset `lastWorkState = null` (guarded by `if (lastWorkState)` so a null→null poll is a no-op) and `applyWorkState(null)` — the lock fails OPEN. Verified every consumer null-short-circuits (null is also the bootstrap value), so no new null-deref. No debouncing added (matches existing code shape).

## Test plan
- [x] `bash tests/run-all.sh` — 6782/6782 passed, 0 failed (verifier-confirmed).
- [x] Extended `test-mode-chip-three-state.sh`: drives null fetch mid-sprint, asserts chip un-locks + mode-change UI re-enables. Verified to FAIL pre-fix (5 failures), pass post-fix.
- [x] mirror-parity + conformance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
