### PR TITLE
do: /work-on-plans grammar parity with /fix-issues

### DIFF
--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -1,32 +1,37 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "(no args = list ready queue) | [N|all] [phase|finish] [continue] | default <phase|finish> | every SCHEDULE [phase|finish] | stop | next"
+argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next | (no args = list ready queue)"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
-  [finish] per entry, honoring each plan's queued mode. Also manages the
-  queue (add/rank/remove/default) and recurring schedules. Mirrors
-  /fix-issues for bugs.
+  [finish] per entry, honoring each plan's queued mode. N|all composes with
+  every SCHEDULE + now for the queue-worker pattern (N plans per fire). Also
+  manages the queue (add/rank/remove/default) and recurring schedules.
+  Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.05.31+582e84"
+  version: "2026.06.01+af83cd"
 ---
 
-# /work-on-plans — Batch Plan Executor
+# /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor
 
 Dispatches `/run-plan <plan> auto [finish]` per entry in the
 prioritized ready queue from the monitor dashboard. Mirrors
-`/fix-issues` for bugs but operates on plans instead.
+`/fix-issues` for bugs but operates on plans instead. The count
+(`N`/`all`) **composes** with `every SCHEDULE` + `now`: each recurring
+fire drains the captured count of plans (the queue-worker pattern —
+`/work-on-plans 1 every 1h finish now` runs one plan now and one per
+hour thereafter), exactly as `/fix-issues N every SCHEDULE now` does.
 
 **Ultrathink throughout.** Use careful, thorough reasoning at every
 step.
 
 > **Phase note.** Phases 1 and 3 are landed: read-only listing
-> (`(no args)`, `next`), execute slots (`N|all [phase|finish]
-> [continue]`), and the queue-mutation + scheduling subcommands
-> (`add`, `rank`, `remove`, `default`, `every`, `stop`). All
-> read-modify-write paths use the cross-process flock on
-> `.zskills/monitor-state.json.lock` (Shared Schemas).
+> (`(no args)`, `next`), the dispatch path (`N|all [phase|finish]
+> [every SCHEDULE] [now] [continue]`), and the queue-mutation +
+> scheduling subcommands (`add`, `rank`, `remove`, `default`,
+> `every`, `stop`). All read-modify-write paths use the cross-process
+> flock on `.zskills/monitor-state.json.lock` (Shared Schemas).
 
 ## Top-level invariant
 
@@ -48,15 +53,33 @@ verify you have access to the Agent tool (a top-level marker):
 ```
 /work-on-plans                       # list ready queue (read-only)
 /work-on-plans next                  # print active schedule (read-only)
-/work-on-plans N [phase|finish] [continue]
-/work-on-plans all [phase|finish] [continue]
+/work-on-plans N    [phase|finish] [every SCHEDULE] [now] [continue] [--force]
+/work-on-plans all  [phase|finish] [every SCHEDULE] [now] [continue] [--force]
 /work-on-plans add <slug> [pos]
 /work-on-plans rank <slug> <pos>
 /work-on-plans remove <slug>
 /work-on-plans default <phase|finish>
-/work-on-plans every SCHEDULE [phase|finish] [--force]
 /work-on-plans stop
 ```
+
+`N`/`all` **compose** with `every SCHEDULE` + `now` — they are no
+longer mutually exclusive (this is the parity fix with `/fix-issues`,
+issue #906):
+
+- **No `every`** → one-shot dispatch of the count, exactly as before.
+- **`every SCHEDULE` without `now`** → register the recurring cron
+  only; do NOT dispatch this invocation.
+- **`every SCHEDULE` with `now`** → register the recurring cron AND
+  dispatch the count immediately.
+
+The recurring cron prompt **carries the count**:
+`Run /work-on-plans $N <mode> every $SCHEDULE now` (mirrors
+`/fix-issues`'s `sprint.md` count-carrying cron). Each fire drains the
+captured `N` plans — NOT unconditional `all` — so "1 plan per hour"
+(`/work-on-plans 1 every 1h finish now`) is now expressible. (Bare
+`every SCHEDULE` with no leading count still registers a recurring
+schedule; absent an explicit count it drains `all` per fire, as
+before.)
 
 **Parsing rules.** Treat `$ARGUMENTS` as whitespace-separated tokens.
 Trim and lowercase each (slugs come pre-lowercased per Shared Schemas).
@@ -70,30 +93,39 @@ Trim and lowercase each (slugs come pre-lowercased per Shared Schemas).
 3. **First token is `stop` → cancel any active `/work-on-plans`
    cron** (see Step 7 — `stop`).
 
-4. **First token matches `^[0-9]+$` → execute mode (N).** Set `N` to
+4. **First token matches `^[0-9]+$` → dispatch path (N).** Set `N` to
    that integer.
 
-5. **First token is `all` → execute mode (all).** Set `N` to the count
-   of `plans.ready` after sync (resolved at dispatch time).
+5. **First token is `all` → dispatch path (all).** Set `ALL_MODE=1`;
+   `N` resolves to the count of `plans.ready` after sync (at dispatch
+   time, in `modes/execute.md`).
 
 6. **First token is one of `add`, `rank`, `remove`, `default`,
    `every`** → mutating subcommand (see Step 7 — Mutating
    subcommands). Subcommand keywords match slot 1 literally. A slot-1
-   value matching `^[0-9]+$` or `^all$` continues to route to execute
-   mode (rules 4–5).
+   value matching `^[0-9]+$` or `^all$` routes to the dispatch path
+   (rules 4–5). Bare `every` as the first token (no leading count) is
+   still the recurring-schedule subcommand and drains `all` per fire.
 
 7. **First token is anything else → usage error.** Print:
 
-   > Usage: /work-on-plans (no args) | next | stop | N [phase|finish] [continue] | all [phase|finish] [continue] | add <slug> [pos] | rank <slug> <pos> | remove <slug> | default <phase|finish> | every SCHEDULE [phase|finish] [--force]
+   > Usage: /work-on-plans (no args) | next | stop | N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | add <slug> [pos] | rank <slug> <pos> | remove <slug> | default <phase|finish>
 
    Exit 2.
 
-In execute mode, the remaining tokens are recognised by name (order
-insensitive, no positional meaning):
+On the dispatch path (rules 4–5), the remaining tokens are recognised
+by name (order insensitive, no positional meaning):
 
 - `phase` → `MODE_OVERRIDE=phase` (mutex with `finish`)
 - `finish` → `MODE_OVERRIDE=finish` (mutex with `phase`)
 - `continue` → `CONTINUE_ON_FAILURE=1`
+- `every` followed by a SCHEDULE expression → `SCHEDULE` captured;
+  register a recurring cron (see Step 7 — `every`). **Composes with
+  `N`/`all`** — the count is carried into the cron prompt.
+- `now` → `RUN_NOW=1`. With `every`, dispatch this invocation AND
+  schedule. Without `every`, `now` is a no-op (the default is to run).
+- `--force` → `FORCE=1` (take over a foreign live schedule; relevant
+  only with `every`).
 - anything else → usage error (same message as above)
 
 If both `phase` and `finish` appear, error:
@@ -101,6 +133,20 @@ If both `phase` and `finish` appear, error:
 > Usage: /work-on-plans … : `phase` and `finish` are mutually exclusive.
 
 Order-insensitive: `N finish continue` ≡ `N continue finish`.
+
+**Composed-form routing.** When `every` is present on the dispatch
+path, route as follows (mirrors `/fix-issues` Phase 0):
+
+1. **Register the recurring cron FIRST** — follow Step 7's `every`
+   procedure (`subcommands/add-rank-remove.md`), passing the captured
+   `N`/`ALL_MODE` so the cron prompt carries the count
+   (`Run /work-on-plans $N <mode> every $SCHEDULE now`). When
+   `ALL_MODE=1`, the cron prompt carries `all` instead of an integer.
+2. **Then decide whether to dispatch this invocation:**
+   - `now` present → fall through to the dispatch path
+     (`modes/execute.md`) and drain the count immediately.
+   - `now` absent → **exit after registration.** Do NOT dispatch now;
+     the cron fires on schedule.
 
 **The mode override is per-batch only.** It does NOT mutate the saved
 `mode` on individual ready-queue entries or the top-level
@@ -407,9 +453,10 @@ end-to-end**. Do not proceed until you have read the file.
 
 | Condition | Reference file |
 |-----------|----------------|
-| No args, or `next` | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + execute loop + sprint completion) |
-| Integer `N` or `all` (execute mode) | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + execute loop + sprint completion) |
-| `add`, `rank`, `remove`, `default`, `every`, `stop` | [subcommands/add-rank-remove.md](subcommands/add-rank-remove.md) — Step 7 (mutating subcommands) |
+| No args, or `next` | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + dispatch loop + sprint completion) |
+| Integer `N` or `all`, **with `every`** | [subcommands/add-rank-remove.md](subcommands/add-rank-remove.md) — Step 7 `every` (register the count-carrying cron) FIRST, then [modes/execute.md](modes/execute.md) Steps 3-6 only if `now` is present |
+| Integer `N` or `all`, no `every` (one-shot dispatch) | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + dispatch loop + sprint completion) |
+| Bare `add`, `rank`, `remove`, `default`, `every`, `stop` | [subcommands/add-rank-remove.md](subcommands/add-rank-remove.md) — Step 7 (mutating subcommands) |
 
 Both reference files assume all variables from Steps 0-2 are already
 set (`$MAIN_ROOT`, `$MONITOR_STATE`, `$MONITOR_LOCK`, `$WORK_STATE`,
@@ -461,6 +508,18 @@ set (`$MAIN_ROOT`, `$MONITOR_STATE`, `$MONITOR_LOCK`, `$WORK_STATE`,
   `work-on-plans-state.json`. Each cron fire dispatches with the
   captured mode, NOT live `default_mode`. To change mode, `stop`
   and re-register.
+- **Count-carrying cron (issue #906).** When `every` composes with a
+  leading `N`/`all`, the count is persisted as `schedule_count` in
+  `work-on-plans-state.json` and baked into the cron prompt
+  (`Run /work-on-plans $N <mode> every $SCHEDULE now`), mirroring
+  `/fix-issues`'s `sprint.md:53`. Each fire drains that many plans —
+  NOT unconditional `all`. Bare `every` (no leading count) carries
+  `all` per fire, as before.
+- **Prune on completion (issue #906).** When a dispatched `/run-plan`
+  reports `status: complete` for a plan, remove that slug from
+  `plans.ready` in `monitor-state.json` — through `with_monitor_lock`
+  + atomic `os.replace`, the same locked read-modify-write path the
+  mutating subcommands use (a merged plan must not linger in `ready`).
 - **Finish-mode SCHEDULE ≥ 1h.** `/work-on-plans every <s> finish`
   refuses sub-hour intervals. Phase mode has no minimum.
 - **Same-session re-registration is idempotent.** `every` from the

--- a/.claude/skills/work-on-plans/modes/execute.md
+++ b/.claude/skills/work-on-plans/modes/execute.md
@@ -1,11 +1,19 @@
-# Execute mode + read-only listing
+# Dispatch path + read-only listing
+
+> **Terminology (issue #906).** This file implements the **dispatch
+> path** (the `N`/`all` queue-draining loop). The word "execute" is
+> deliberately avoided as a label here because it collides with the
+> CLAUDE.md "Execution Modes" concept (cherry-pick / pr / direct
+> landing), which is unrelated. The file is still named `execute.md`
+> for path-stability, but the procedure is "dispatch", not a mode.
 
 > **Loaded by the router.** Variables `$MAIN_ROOT`, `$MONITOR_STATE`,
 > `$MONITOR_LOCK`, `$WORK_STATE`, `$PLAN_INDEX`, `$SANITIZE`,
 > `$READY_TSV`, `$DEFAULT_MODE`, `$WORK_STATE_VALUE`, `$N`,
 > `$ALL_MODE`, `$MODE_OVERRIDE`, `$CONTINUE_ON_FAILURE` are set by
-> Steps 0-2 in `SKILL.md` before this file is read. All bash fences
-> below reference those variables directly.
+> Steps 0-2 in `SKILL.md` before this file is read, and the
+> `ensure_lockfile` / `with_monitor_lock` helpers from Step 0 are
+> also defined. All bash fences below reference those directly.
 
 ## Step 3 — Read-only modes (no args, `next`)
 
@@ -103,7 +111,7 @@ PY
 
 Exit 0. **No tracking marker is written for `next`** (read-only).
 
-## Step 4 — Execute mode setup
+## Step 4 — Dispatch-path setup
 
 For `N`/`all` invocations, build the dispatch list and write the
 sprint sentinel.
@@ -115,7 +123,7 @@ sprint sentinel.
 The shared `check-inflight-batch.sh` helper detects "my session already
 has an in-flight work-on-plans batch" via session-scoped sentinels and
 exits clean when so, leaving the in-flight run to finish on its own
-turns. The check runs ONLY on `N`/`all` execute entry — read-only modes
+turns. The check runs ONLY on `N`/`all` dispatch-path entry — read-only modes
 (`(no args)`, `next`) exit in Step 3 above, and mutating subcommands
 (`add`/`rank`/`remove`/`default`/`every`/`stop`) route to
 `subcommands/add-rank-remove.md` in `SKILL.md` Step 3. The carve-out is
@@ -396,6 +404,58 @@ For each ready entry in `plans.ready[0:N]`:
      ```
 
    - Heartbeat `$WORK_STATE` (`progress.done++`, `updated_at = now`).
+
+   - **Prune the completed plan from `plans.ready` (issue #906).**
+     `/run-plan` sets the plan's frontmatter `status: complete` when
+     it lands; a completed plan must not linger in the ready queue
+     (observed bug: a merged plan stayed in `ready` slot 1, ahead of
+     runnable plans, so subsequent `N`/`all` targeted a no-op stale
+     entry). Drop the just-completed `$SLUG` from `plans.ready` via
+     the **locked** read-modify-write path — `with_monitor_lock` so
+     the prune serializes against the Phase 5 HTTP server, and
+     `os.replace` for the atomic write (same pattern the mutating
+     subcommands use). The prune is conditional on the plan file's
+     `status: complete` so a per-batch run that did NOT land (phase
+     mode that stopped mid-plan) does not strip a still-runnable
+     entry:
+
+     <!-- allow-hardcoded: 2a.10-AC-non-using-sites reason: Python embed operates on $MONITOR_STATE state file in $MAIN_ROOT/.zskills/; no path-config preamble needed -->
+     ```bash
+     prune_completed() {
+       # Drop $SLUG from plans.ready iff its plan file is status:complete.
+       python3 - "$MONITOR_STATE" "$SLUG" "${SLUG_TO_FILE[$SLUG]:-}" <<'PY'
+     import json, os, re, sys, tempfile
+     path, slug, plan_file = sys.argv[1], sys.argv[2], sys.argv[3]
+     # Only prune when the plan landed (frontmatter status: complete).
+     status = ''
+     if plan_file and os.path.exists(plan_file):
+         text = open(plan_file, encoding='utf-8', errors='replace').read()
+         if text.startswith('---'):
+             end = text.find('\n---', 3)
+             if end >= 0:
+                 m = re.search(r'^status:\s*([^\n]+)', text[3:end], re.MULTILINE)
+                 if m:
+                     status = m.group(1).strip().strip('"').strip("'").lower()
+     if status != 'complete':
+         sys.exit(0)  # not landed yet — leave it in ready
+     doc = json.load(open(path))
+     ready = doc.get('plans', {}).get('ready', [])
+     new_ready = [e for e in ready
+                  if not ((isinstance(e, dict) and e.get('slug') == slug) or e == slug)]
+     if len(new_ready) == len(ready):
+         sys.exit(0)  # already gone — no-op
+     doc.setdefault('plans', {})['ready'] = new_ready
+     import datetime
+     doc['updated_at'] = datetime.datetime.now().astimezone().isoformat(timespec='seconds')
+     tmp = tempfile.NamedTemporaryFile('w', delete=False,
+         dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+     json.dump(doc, tmp, indent=2); tmp.write('\n'); tmp.close()
+     os.replace(tmp.name, path)
+     print(f"/work-on-plans: pruned completed plan '{slug}' from ready queue.")
+     PY
+     }
+     with_monitor_lock prune_completed
+     ```
 
    - Note: `/run-plan` writes its OWN
      `fulfilled.run-plan.<child-slug>` under

--- a/.claude/skills/work-on-plans/subcommands/add-rank-remove.md
+++ b/.claude/skills/work-on-plans/subcommands/add-rank-remove.md
@@ -328,8 +328,25 @@ PY
 ### `every SCHEDULE [phase|finish] [--force]`
 
 Register an in-session recurring cron via `CronCreate`. The cron
-fires on schedule and re-runs `/work-on-plans all <schedule_mode>`
-(self-perpetuating: the cron itself dies with the session).
+fires on schedule and re-runs `/work-on-plans <count> <schedule_mode>
+every <SCHEDULE> now` (self-perpetuating: the cron itself dies with
+the session).
+
+**Count capture (issue #906 — parity with `/fix-issues`).** `every`
+is reached two ways:
+
+- **Composed with a leading `N`/`all`** on the dispatch path (router
+  Step 3 composed-form routing): `$N` (or `ALL_MODE=1`) is already
+  set. Capture it as the **`schedule_count`** — the cron prompt
+  carries that count so each fire drains exactly `N` plans (or `all`
+  when `ALL_MODE=1`), NOT unconditional `all`.
+- **Bare `every SCHEDULE`** (no leading count, first-token
+  subcommand): `schedule_count` is the literal `all` — drain the
+  whole ready queue per fire, the pre-#906 behavior.
+
+`COUNT_TOKEN` below is `$N` when an integer count was given, else
+`all`. It is both persisted (`schedule_count` in `$WORK_STATE`) and
+baked into the cron prompt.
 
 **Mode capture.** At registration, resolve the captured `schedule_mode`
 once and persist it: CLI flag (`phase` or `finish` token after
@@ -391,7 +408,9 @@ current_session_id`:
 If `state == "scheduled"` AND `session_id == current_session_id`:
 treat as idempotent take-over — `CronDelete` the existing
 `/work-on-plans` cron (matched by `prompt` starting with
-`Run /work-on-plans every`), then proceed with the new registration.
+`Run /work-on-plans ` — the prompt now carries a count/`all` token
+between the skill name and `every`, so match the broad prefix, the
+same prefix `stop` uses), then proceed with the new registration.
 `--force` is NOT required in the same-session case.
 
 **`CronCreate` failure.** Exit 1 with:
@@ -411,6 +430,7 @@ Do NOT write `$WORK_STATE` on `CronCreate` failure.
   "session_id": "<host>:<pid>:<invocation_start_time>",
   "schedule": "every <SCHEDULE>",
   "schedule_mode": "phase|finish",
+  "schedule_count": "<COUNT_TOKEN>",
   "session_started_at": "<iso>",
   "last_fire_at": "<iso == session_started_at>",
   "next_fire_at": "<iso>",
@@ -419,16 +439,33 @@ Do NOT write `$WORK_STATE` on `CronCreate` failure.
 ```
 
 `last_fire_at = session_started_at` so staleness computes from the
-schedule's birth, not epoch (Shared Schemas).
+schedule's birth, not epoch (Shared Schemas). `schedule_count` is the
+captured count (`$N` or `all`) so the schedule's identity survives a
+session-end-then-`next` query.
 
 The `every` skill body uses the **`CronCreate`/`CronDelete`/`CronList`
-tools** (not bash). The cron prompt is reconstructed verbatim:
+tools** (not bash). The cron prompt is reconstructed with the captured
+count and mode, and **always includes `now`** so each fire runs
+immediately and re-registers itself (self-perpetuating — mirrors
+`/fix-issues`'s `sprint.md:53` `CRON_PROMPT`):
 
 ```
-Run /work-on-plans all <schedule_mode>
+Run /work-on-plans <COUNT_TOKEN> <schedule_mode> every <SCHEDULE> now
 ```
 
-(Captured mode wins, regardless of `default_mode` at fire time.)
+Examples:
+- `/work-on-plans 1 every 1h finish now` →
+  `Run /work-on-plans 1 finish every 1h now` (one plan per hour).
+- `/work-on-plans all every 4h phase now` →
+  `Run /work-on-plans all phase every 4h now`.
+- bare `/work-on-plans every 2h` →
+  `Run /work-on-plans all phase every 2h now`.
+
+(Captured count + mode win, regardless of `default_mode` /
+queue size at fire time. The `now` in the cron prompt is for the
+CRON's own re-invocation; whether THIS invocation runs immediately is
+controlled by the user's own `now` flag per the router's composed-form
+routing.)
 
 For schedule expression conversion (interval → cron) and `CronCreate`
 mechanics, mirror the `/fix-issues` Phase 0 implementation

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -1,32 +1,37 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "(no args = list ready queue) | [N|all] [phase|finish] [continue] | default <phase|finish> | every SCHEDULE [phase|finish] | stop | next"
+argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next | (no args = list ready queue)"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
-  [finish] per entry, honoring each plan's queued mode. Also manages the
-  queue (add/rank/remove/default) and recurring schedules. Mirrors
-  /fix-issues for bugs.
+  [finish] per entry, honoring each plan's queued mode. N|all composes with
+  every SCHEDULE + now for the queue-worker pattern (N plans per fire). Also
+  manages the queue (add/rank/remove/default) and recurring schedules.
+  Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.05.31+582e84"
+  version: "2026.06.01+af83cd"
 ---
 
-# /work-on-plans — Batch Plan Executor
+# /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor
 
 Dispatches `/run-plan <plan> auto [finish]` per entry in the
 prioritized ready queue from the monitor dashboard. Mirrors
-`/fix-issues` for bugs but operates on plans instead.
+`/fix-issues` for bugs but operates on plans instead. The count
+(`N`/`all`) **composes** with `every SCHEDULE` + `now`: each recurring
+fire drains the captured count of plans (the queue-worker pattern —
+`/work-on-plans 1 every 1h finish now` runs one plan now and one per
+hour thereafter), exactly as `/fix-issues N every SCHEDULE now` does.
 
 **Ultrathink throughout.** Use careful, thorough reasoning at every
 step.
 
 > **Phase note.** Phases 1 and 3 are landed: read-only listing
-> (`(no args)`, `next`), execute slots (`N|all [phase|finish]
-> [continue]`), and the queue-mutation + scheduling subcommands
-> (`add`, `rank`, `remove`, `default`, `every`, `stop`). All
-> read-modify-write paths use the cross-process flock on
-> `.zskills/monitor-state.json.lock` (Shared Schemas).
+> (`(no args)`, `next`), the dispatch path (`N|all [phase|finish]
+> [every SCHEDULE] [now] [continue]`), and the queue-mutation +
+> scheduling subcommands (`add`, `rank`, `remove`, `default`,
+> `every`, `stop`). All read-modify-write paths use the cross-process
+> flock on `.zskills/monitor-state.json.lock` (Shared Schemas).
 
 ## Top-level invariant
 
@@ -48,15 +53,33 @@ verify you have access to the Agent tool (a top-level marker):
 ```
 /work-on-plans                       # list ready queue (read-only)
 /work-on-plans next                  # print active schedule (read-only)
-/work-on-plans N [phase|finish] [continue]
-/work-on-plans all [phase|finish] [continue]
+/work-on-plans N    [phase|finish] [every SCHEDULE] [now] [continue] [--force]
+/work-on-plans all  [phase|finish] [every SCHEDULE] [now] [continue] [--force]
 /work-on-plans add <slug> [pos]
 /work-on-plans rank <slug> <pos>
 /work-on-plans remove <slug>
 /work-on-plans default <phase|finish>
-/work-on-plans every SCHEDULE [phase|finish] [--force]
 /work-on-plans stop
 ```
+
+`N`/`all` **compose** with `every SCHEDULE` + `now` — they are no
+longer mutually exclusive (this is the parity fix with `/fix-issues`,
+issue #906):
+
+- **No `every`** → one-shot dispatch of the count, exactly as before.
+- **`every SCHEDULE` without `now`** → register the recurring cron
+  only; do NOT dispatch this invocation.
+- **`every SCHEDULE` with `now`** → register the recurring cron AND
+  dispatch the count immediately.
+
+The recurring cron prompt **carries the count**:
+`Run /work-on-plans $N <mode> every $SCHEDULE now` (mirrors
+`/fix-issues`'s `sprint.md` count-carrying cron). Each fire drains the
+captured `N` plans — NOT unconditional `all` — so "1 plan per hour"
+(`/work-on-plans 1 every 1h finish now`) is now expressible. (Bare
+`every SCHEDULE` with no leading count still registers a recurring
+schedule; absent an explicit count it drains `all` per fire, as
+before.)
 
 **Parsing rules.** Treat `$ARGUMENTS` as whitespace-separated tokens.
 Trim and lowercase each (slugs come pre-lowercased per Shared Schemas).
@@ -70,30 +93,39 @@ Trim and lowercase each (slugs come pre-lowercased per Shared Schemas).
 3. **First token is `stop` → cancel any active `/work-on-plans`
    cron** (see Step 7 — `stop`).
 
-4. **First token matches `^[0-9]+$` → execute mode (N).** Set `N` to
+4. **First token matches `^[0-9]+$` → dispatch path (N).** Set `N` to
    that integer.
 
-5. **First token is `all` → execute mode (all).** Set `N` to the count
-   of `plans.ready` after sync (resolved at dispatch time).
+5. **First token is `all` → dispatch path (all).** Set `ALL_MODE=1`;
+   `N` resolves to the count of `plans.ready` after sync (at dispatch
+   time, in `modes/execute.md`).
 
 6. **First token is one of `add`, `rank`, `remove`, `default`,
    `every`** → mutating subcommand (see Step 7 — Mutating
    subcommands). Subcommand keywords match slot 1 literally. A slot-1
-   value matching `^[0-9]+$` or `^all$` continues to route to execute
-   mode (rules 4–5).
+   value matching `^[0-9]+$` or `^all$` routes to the dispatch path
+   (rules 4–5). Bare `every` as the first token (no leading count) is
+   still the recurring-schedule subcommand and drains `all` per fire.
 
 7. **First token is anything else → usage error.** Print:
 
-   > Usage: /work-on-plans (no args) | next | stop | N [phase|finish] [continue] | all [phase|finish] [continue] | add <slug> [pos] | rank <slug> <pos> | remove <slug> | default <phase|finish> | every SCHEDULE [phase|finish] [--force]
+   > Usage: /work-on-plans (no args) | next | stop | N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | add <slug> [pos] | rank <slug> <pos> | remove <slug> | default <phase|finish>
 
    Exit 2.
 
-In execute mode, the remaining tokens are recognised by name (order
-insensitive, no positional meaning):
+On the dispatch path (rules 4–5), the remaining tokens are recognised
+by name (order insensitive, no positional meaning):
 
 - `phase` → `MODE_OVERRIDE=phase` (mutex with `finish`)
 - `finish` → `MODE_OVERRIDE=finish` (mutex with `phase`)
 - `continue` → `CONTINUE_ON_FAILURE=1`
+- `every` followed by a SCHEDULE expression → `SCHEDULE` captured;
+  register a recurring cron (see Step 7 — `every`). **Composes with
+  `N`/`all`** — the count is carried into the cron prompt.
+- `now` → `RUN_NOW=1`. With `every`, dispatch this invocation AND
+  schedule. Without `every`, `now` is a no-op (the default is to run).
+- `--force` → `FORCE=1` (take over a foreign live schedule; relevant
+  only with `every`).
 - anything else → usage error (same message as above)
 
 If both `phase` and `finish` appear, error:
@@ -101,6 +133,20 @@ If both `phase` and `finish` appear, error:
 > Usage: /work-on-plans … : `phase` and `finish` are mutually exclusive.
 
 Order-insensitive: `N finish continue` ≡ `N continue finish`.
+
+**Composed-form routing.** When `every` is present on the dispatch
+path, route as follows (mirrors `/fix-issues` Phase 0):
+
+1. **Register the recurring cron FIRST** — follow Step 7's `every`
+   procedure (`subcommands/add-rank-remove.md`), passing the captured
+   `N`/`ALL_MODE` so the cron prompt carries the count
+   (`Run /work-on-plans $N <mode> every $SCHEDULE now`). When
+   `ALL_MODE=1`, the cron prompt carries `all` instead of an integer.
+2. **Then decide whether to dispatch this invocation:**
+   - `now` present → fall through to the dispatch path
+     (`modes/execute.md`) and drain the count immediately.
+   - `now` absent → **exit after registration.** Do NOT dispatch now;
+     the cron fires on schedule.
 
 **The mode override is per-batch only.** It does NOT mutate the saved
 `mode` on individual ready-queue entries or the top-level
@@ -407,9 +453,10 @@ end-to-end**. Do not proceed until you have read the file.
 
 | Condition | Reference file |
 |-----------|----------------|
-| No args, or `next` | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + execute loop + sprint completion) |
-| Integer `N` or `all` (execute mode) | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + execute loop + sprint completion) |
-| `add`, `rank`, `remove`, `default`, `every`, `stop` | [subcommands/add-rank-remove.md](subcommands/add-rank-remove.md) — Step 7 (mutating subcommands) |
+| No args, or `next` | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + dispatch loop + sprint completion) |
+| Integer `N` or `all`, **with `every`** | [subcommands/add-rank-remove.md](subcommands/add-rank-remove.md) — Step 7 `every` (register the count-carrying cron) FIRST, then [modes/execute.md](modes/execute.md) Steps 3-6 only if `now` is present |
+| Integer `N` or `all`, no `every` (one-shot dispatch) | [modes/execute.md](modes/execute.md) — Steps 3-6 (read-only listing + dispatch loop + sprint completion) |
+| Bare `add`, `rank`, `remove`, `default`, `every`, `stop` | [subcommands/add-rank-remove.md](subcommands/add-rank-remove.md) — Step 7 (mutating subcommands) |
 
 Both reference files assume all variables from Steps 0-2 are already
 set (`$MAIN_ROOT`, `$MONITOR_STATE`, `$MONITOR_LOCK`, `$WORK_STATE`,
@@ -461,6 +508,18 @@ set (`$MAIN_ROOT`, `$MONITOR_STATE`, `$MONITOR_LOCK`, `$WORK_STATE`,
   `work-on-plans-state.json`. Each cron fire dispatches with the
   captured mode, NOT live `default_mode`. To change mode, `stop`
   and re-register.
+- **Count-carrying cron (issue #906).** When `every` composes with a
+  leading `N`/`all`, the count is persisted as `schedule_count` in
+  `work-on-plans-state.json` and baked into the cron prompt
+  (`Run /work-on-plans $N <mode> every $SCHEDULE now`), mirroring
+  `/fix-issues`'s `sprint.md:53`. Each fire drains that many plans —
+  NOT unconditional `all`. Bare `every` (no leading count) carries
+  `all` per fire, as before.
+- **Prune on completion (issue #906).** When a dispatched `/run-plan`
+  reports `status: complete` for a plan, remove that slug from
+  `plans.ready` in `monitor-state.json` — through `with_monitor_lock`
+  + atomic `os.replace`, the same locked read-modify-write path the
+  mutating subcommands use (a merged plan must not linger in `ready`).
 - **Finish-mode SCHEDULE ≥ 1h.** `/work-on-plans every <s> finish`
   refuses sub-hour intervals. Phase mode has no minimum.
 - **Same-session re-registration is idempotent.** `every` from the

--- a/skills/work-on-plans/modes/execute.md
+++ b/skills/work-on-plans/modes/execute.md
@@ -1,11 +1,19 @@
-# Execute mode + read-only listing
+# Dispatch path + read-only listing
+
+> **Terminology (issue #906).** This file implements the **dispatch
+> path** (the `N`/`all` queue-draining loop). The word "execute" is
+> deliberately avoided as a label here because it collides with the
+> CLAUDE.md "Execution Modes" concept (cherry-pick / pr / direct
+> landing), which is unrelated. The file is still named `execute.md`
+> for path-stability, but the procedure is "dispatch", not a mode.
 
 > **Loaded by the router.** Variables `$MAIN_ROOT`, `$MONITOR_STATE`,
 > `$MONITOR_LOCK`, `$WORK_STATE`, `$PLAN_INDEX`, `$SANITIZE`,
 > `$READY_TSV`, `$DEFAULT_MODE`, `$WORK_STATE_VALUE`, `$N`,
 > `$ALL_MODE`, `$MODE_OVERRIDE`, `$CONTINUE_ON_FAILURE` are set by
-> Steps 0-2 in `SKILL.md` before this file is read. All bash fences
-> below reference those variables directly.
+> Steps 0-2 in `SKILL.md` before this file is read, and the
+> `ensure_lockfile` / `with_monitor_lock` helpers from Step 0 are
+> also defined. All bash fences below reference those directly.
 
 ## Step 3 — Read-only modes (no args, `next`)
 
@@ -103,7 +111,7 @@ PY
 
 Exit 0. **No tracking marker is written for `next`** (read-only).
 
-## Step 4 — Execute mode setup
+## Step 4 — Dispatch-path setup
 
 For `N`/`all` invocations, build the dispatch list and write the
 sprint sentinel.
@@ -115,7 +123,7 @@ sprint sentinel.
 The shared `check-inflight-batch.sh` helper detects "my session already
 has an in-flight work-on-plans batch" via session-scoped sentinels and
 exits clean when so, leaving the in-flight run to finish on its own
-turns. The check runs ONLY on `N`/`all` execute entry — read-only modes
+turns. The check runs ONLY on `N`/`all` dispatch-path entry — read-only modes
 (`(no args)`, `next`) exit in Step 3 above, and mutating subcommands
 (`add`/`rank`/`remove`/`default`/`every`/`stop`) route to
 `subcommands/add-rank-remove.md` in `SKILL.md` Step 3. The carve-out is
@@ -396,6 +404,58 @@ For each ready entry in `plans.ready[0:N]`:
      ```
 
    - Heartbeat `$WORK_STATE` (`progress.done++`, `updated_at = now`).
+
+   - **Prune the completed plan from `plans.ready` (issue #906).**
+     `/run-plan` sets the plan's frontmatter `status: complete` when
+     it lands; a completed plan must not linger in the ready queue
+     (observed bug: a merged plan stayed in `ready` slot 1, ahead of
+     runnable plans, so subsequent `N`/`all` targeted a no-op stale
+     entry). Drop the just-completed `$SLUG` from `plans.ready` via
+     the **locked** read-modify-write path — `with_monitor_lock` so
+     the prune serializes against the Phase 5 HTTP server, and
+     `os.replace` for the atomic write (same pattern the mutating
+     subcommands use). The prune is conditional on the plan file's
+     `status: complete` so a per-batch run that did NOT land (phase
+     mode that stopped mid-plan) does not strip a still-runnable
+     entry:
+
+     <!-- allow-hardcoded: 2a.10-AC-non-using-sites reason: Python embed operates on $MONITOR_STATE state file in $MAIN_ROOT/.zskills/; no path-config preamble needed -->
+     ```bash
+     prune_completed() {
+       # Drop $SLUG from plans.ready iff its plan file is status:complete.
+       python3 - "$MONITOR_STATE" "$SLUG" "${SLUG_TO_FILE[$SLUG]:-}" <<'PY'
+     import json, os, re, sys, tempfile
+     path, slug, plan_file = sys.argv[1], sys.argv[2], sys.argv[3]
+     # Only prune when the plan landed (frontmatter status: complete).
+     status = ''
+     if plan_file and os.path.exists(plan_file):
+         text = open(plan_file, encoding='utf-8', errors='replace').read()
+         if text.startswith('---'):
+             end = text.find('\n---', 3)
+             if end >= 0:
+                 m = re.search(r'^status:\s*([^\n]+)', text[3:end], re.MULTILINE)
+                 if m:
+                     status = m.group(1).strip().strip('"').strip("'").lower()
+     if status != 'complete':
+         sys.exit(0)  # not landed yet — leave it in ready
+     doc = json.load(open(path))
+     ready = doc.get('plans', {}).get('ready', [])
+     new_ready = [e for e in ready
+                  if not ((isinstance(e, dict) and e.get('slug') == slug) or e == slug)]
+     if len(new_ready) == len(ready):
+         sys.exit(0)  # already gone — no-op
+     doc.setdefault('plans', {})['ready'] = new_ready
+     import datetime
+     doc['updated_at'] = datetime.datetime.now().astimezone().isoformat(timespec='seconds')
+     tmp = tempfile.NamedTemporaryFile('w', delete=False,
+         dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+     json.dump(doc, tmp, indent=2); tmp.write('\n'); tmp.close()
+     os.replace(tmp.name, path)
+     print(f"/work-on-plans: pruned completed plan '{slug}' from ready queue.")
+     PY
+     }
+     with_monitor_lock prune_completed
+     ```
 
    - Note: `/run-plan` writes its OWN
      `fulfilled.run-plan.<child-slug>` under

--- a/skills/work-on-plans/subcommands/add-rank-remove.md
+++ b/skills/work-on-plans/subcommands/add-rank-remove.md
@@ -328,8 +328,25 @@ PY
 ### `every SCHEDULE [phase|finish] [--force]`
 
 Register an in-session recurring cron via `CronCreate`. The cron
-fires on schedule and re-runs `/work-on-plans all <schedule_mode>`
-(self-perpetuating: the cron itself dies with the session).
+fires on schedule and re-runs `/work-on-plans <count> <schedule_mode>
+every <SCHEDULE> now` (self-perpetuating: the cron itself dies with
+the session).
+
+**Count capture (issue #906 — parity with `/fix-issues`).** `every`
+is reached two ways:
+
+- **Composed with a leading `N`/`all`** on the dispatch path (router
+  Step 3 composed-form routing): `$N` (or `ALL_MODE=1`) is already
+  set. Capture it as the **`schedule_count`** — the cron prompt
+  carries that count so each fire drains exactly `N` plans (or `all`
+  when `ALL_MODE=1`), NOT unconditional `all`.
+- **Bare `every SCHEDULE`** (no leading count, first-token
+  subcommand): `schedule_count` is the literal `all` — drain the
+  whole ready queue per fire, the pre-#906 behavior.
+
+`COUNT_TOKEN` below is `$N` when an integer count was given, else
+`all`. It is both persisted (`schedule_count` in `$WORK_STATE`) and
+baked into the cron prompt.
 
 **Mode capture.** At registration, resolve the captured `schedule_mode`
 once and persist it: CLI flag (`phase` or `finish` token after
@@ -391,7 +408,9 @@ current_session_id`:
 If `state == "scheduled"` AND `session_id == current_session_id`:
 treat as idempotent take-over — `CronDelete` the existing
 `/work-on-plans` cron (matched by `prompt` starting with
-`Run /work-on-plans every`), then proceed with the new registration.
+`Run /work-on-plans ` — the prompt now carries a count/`all` token
+between the skill name and `every`, so match the broad prefix, the
+same prefix `stop` uses), then proceed with the new registration.
 `--force` is NOT required in the same-session case.
 
 **`CronCreate` failure.** Exit 1 with:
@@ -411,6 +430,7 @@ Do NOT write `$WORK_STATE` on `CronCreate` failure.
   "session_id": "<host>:<pid>:<invocation_start_time>",
   "schedule": "every <SCHEDULE>",
   "schedule_mode": "phase|finish",
+  "schedule_count": "<COUNT_TOKEN>",
   "session_started_at": "<iso>",
   "last_fire_at": "<iso == session_started_at>",
   "next_fire_at": "<iso>",
@@ -419,16 +439,33 @@ Do NOT write `$WORK_STATE` on `CronCreate` failure.
 ```
 
 `last_fire_at = session_started_at` so staleness computes from the
-schedule's birth, not epoch (Shared Schemas).
+schedule's birth, not epoch (Shared Schemas). `schedule_count` is the
+captured count (`$N` or `all`) so the schedule's identity survives a
+session-end-then-`next` query.
 
 The `every` skill body uses the **`CronCreate`/`CronDelete`/`CronList`
-tools** (not bash). The cron prompt is reconstructed verbatim:
+tools** (not bash). The cron prompt is reconstructed with the captured
+count and mode, and **always includes `now`** so each fire runs
+immediately and re-registers itself (self-perpetuating — mirrors
+`/fix-issues`'s `sprint.md:53` `CRON_PROMPT`):
 
 ```
-Run /work-on-plans all <schedule_mode>
+Run /work-on-plans <COUNT_TOKEN> <schedule_mode> every <SCHEDULE> now
 ```
 
-(Captured mode wins, regardless of `default_mode` at fire time.)
+Examples:
+- `/work-on-plans 1 every 1h finish now` →
+  `Run /work-on-plans 1 finish every 1h now` (one plan per hour).
+- `/work-on-plans all every 4h phase now` →
+  `Run /work-on-plans all phase every 4h now`.
+- bare `/work-on-plans every 2h` →
+  `Run /work-on-plans all phase every 2h now`.
+
+(Captured count + mode win, regardless of `default_mode` /
+queue size at fire time. The `now` in the cron prompt is for the
+CRON's own re-invocation; whether THIS invocation runs immediately is
+controlled by the user's own `now` flag per the router's composed-form
+routing.)
 
 For schedule expression conversion (interval → cron) and `CronCreate`
 mechanics, mirror the `/fix-issues` Phase 0 implementation

--- a/tests/test-work-on-plans.sh
+++ b/tests/test-work-on-plans.sh
@@ -251,9 +251,14 @@ fi
 # --- Test 4: argument-hint frontmatter advertises core surface ----------
 # Queue-mutation subcommands (add/rank/remove) were moved to the detail
 # docs page to shorten the hint under 120 chars. The hint still covers
-# the execution, default, schedule, and control subcommands.
-if grep -q 'argument-hint:.*default.*every SCHEDULE.*stop' "$SKILL"; then
-  pass "argument-hint advertises core surface (default/every/stop)"
+# the dispatch, schedule, default, and control subcommands. Post-#906
+# `every SCHEDULE` composes with the leading N|all count (it is no
+# longer a standalone subcommand listed beside default), so the order
+# is `... every SCHEDULE ... default ... stop`.
+if grep -q 'argument-hint:.*every SCHEDULE' "$SKILL" \
+   && grep -q 'argument-hint:.*default' "$SKILL" \
+   && grep -q 'argument-hint:.*stop' "$SKILL"; then
+  pass "argument-hint advertises core surface (every SCHEDULE/default/stop)"
 else
   fail "argument-hint missing one or more core subcommands"
 fi
@@ -560,6 +565,135 @@ if [ "$ec" -eq 2 ]; then
   pass "add rejects invalid slug (uppercase/punctuation)"
 else
   fail "add invalid slug (ec=$ec out=$out)"
+fi
+
+# --- Test 24: #906 combined N+every+now grammar documented -------------
+# The skill dir must show N|all composing with every+now (no longer
+# mutually exclusive), and the parser must recognise `now` + `every`
+# on the dispatch path.
+if grep -rq 'N|all .*\[every SCHEDULE\] \[now\]' "$SKILL_DIR" \
+   && grep -rq 'now. → .RUN_NOW=1' "$SKILL_DIR" \
+   && grep -rq 'Composes with' "$SKILL_DIR" \
+   && grep -rq 'compose' "$SKILL_DIR"; then
+  pass "#906 skill dir documents N|all composing with every SCHEDULE + now"
+else
+  fail "#906 combined-grammar documentation missing"
+fi
+
+# --- Test 25: #906 count-carrying recurring cron prompt shape ----------
+# The cron prompt must carry the count and `now` (mirrors
+# fix-issues/modes/sprint.md:53 CRON_PROMPT). Must NOT be the old
+# count-less `Run /work-on-plans all <mode>` form.
+if grep -rq 'Run /work-on-plans <COUNT_TOKEN> <schedule_mode> every <SCHEDULE> now' "$SKILL_DIR" \
+   && grep -rq 'Run /work-on-plans 1 finish every 1h now' "$SKILL_DIR" \
+   && grep -rq 'schedule_count' "$SKILL_DIR"; then
+  pass "#906 cron prompt carries count + now (queue-worker parity)"
+else
+  fail "#906 count-carrying cron prompt shape missing"
+fi
+# Negative: the old count-less cron prompt must be gone.
+if grep -rq '^Run /work-on-plans all <schedule_mode>$' "$SKILL_DIR"; then
+  fail "#906 stale count-less cron prompt 'Run /work-on-plans all <schedule_mode>' still present"
+else
+  pass "#906 old count-less cron prompt removed"
+fi
+
+# --- Test 26: #906 de-collided 'execute mode' terminology --------------
+# No internal use of "execute mode" / "execution mode" as the dispatch
+# path LABEL (collides with CLAUDE.md Execution Modes = landing modes).
+# The single explanatory cross-reference to CLAUDE.md "Execution Modes"
+# (the de-collision rationale itself) is exempt — it names the colliding
+# concept to explain WHY the label was renamed, it does not use it as a
+# label. Filter those rationale lines (they mention CLAUDE.md) out.
+offending=$(grep -rni 'execut\(e\|ion\) mode' "$SKILL_DIR" \
+  | grep -vi 'CLAUDE.md' || true)
+if [ -n "$offending" ]; then
+  fail "#906 'execute/execution mode' label still present: $offending"
+else
+  pass "#906 dispatch-path label de-collided from 'Execution Modes'"
+fi
+
+# --- Test 27: #906 prune-on-complete logic (functional) ----------------
+# Mirror the prune_completed embed from modes/execute.md: a slug is
+# dropped from plans.ready ONLY when its plan file frontmatter is
+# status: complete. Drive it directly against a fixture.
+prune_completed_test() {
+  local state="$1" slug="$2" plan_file="$3"
+  python3 - "$state" "$slug" "$plan_file" <<'PY'
+import json, os, re, sys, tempfile, datetime
+path, slug, plan_file = sys.argv[1], sys.argv[2], sys.argv[3]
+status = ''
+if plan_file and os.path.exists(plan_file):
+    text = open(plan_file, encoding='utf-8', errors='replace').read()
+    if text.startswith('---'):
+        end = text.find('\n---', 3)
+        if end >= 0:
+            m = re.search(r'^status:\s*([^\n]+)', text[3:end], re.MULTILINE)
+            if m:
+                status = m.group(1).strip().strip('"').strip("'").lower()
+if status != 'complete':
+    sys.exit(0)
+doc = json.load(open(path))
+ready = doc.get('plans', {}).get('ready', [])
+new_ready = [e for e in ready
+             if not ((isinstance(e, dict) and e.get('slug') == slug) or e == slug)]
+if len(new_ready) == len(ready):
+    sys.exit(0)
+doc.setdefault('plans', {})['ready'] = new_ready
+doc['updated_at'] = datetime.datetime.now().astimezone().isoformat(timespec='seconds')
+tmp = tempfile.NamedTemporaryFile('w', delete=False,
+    dir=os.path.dirname(path), prefix='.monitor-state.', suffix='.tmp')
+json.dump(doc, tmp, indent=2); tmp.write('\n'); tmp.close()
+os.replace(tmp.name, path)
+print(f"/work-on-plans: pruned completed plan '{slug}' from ready queue.")
+PY
+}
+
+F=$(make_fixture t27)
+seed_empty "$F/.zskills/monitor-state.json"
+skill_add "$F/.zskills/monitor-state.json" done-plan >/dev/null
+skill_add "$F/.zskills/monitor-state.json" todo-plan >/dev/null
+# done-plan landed (status: complete); todo-plan still active.
+printf -- '---\nstatus: complete\n---\n# done\n' > "$F/plans/done-plan.md"
+printf -- '---\nstatus: ready\n---\n# todo\n' > "$F/plans/todo-plan.md"
+# Prune the completed one through the locked path.
+out=$(with_lock "$F/.zskills/monitor-state.json.lock" \
+  prune_completed_test "$F/.zskills/monitor-state.json" done-plan "$F/plans/done-plan.md" 2>&1)
+ready=$(readq "$F/.zskills/monitor-state.json")
+if [ "$ready" = "todo-plan" ] && echo "$out" | grep -q "pruned completed plan 'done-plan'"; then
+  pass "#906 prune-on-complete drops a status:complete plan from ready (locked)"
+else
+  fail "#906 prune-on-complete (ready=$ready out=$out)"
+fi
+
+# --- Test 28: #906 prune is a no-op for a NOT-complete plan ------------
+out=$(with_lock "$F/.zskills/monitor-state.json.lock" \
+  prune_completed_test "$F/.zskills/monitor-state.json" todo-plan "$F/plans/todo-plan.md" 2>&1)
+ec=$?
+ready=$(readq "$F/.zskills/monitor-state.json")
+if [ "$ec" -eq 0 ] && [ "$ready" = "todo-plan" ] && [ -z "$out" ]; then
+  pass "#906 prune-on-complete leaves a non-complete plan in ready"
+else
+  fail "#906 prune no-op for active plan (ec=$ec ready=$ready out=$out)"
+fi
+
+# --- Test 29: #906 prune embed uses with_monitor_lock + os.replace -----
+# Watch-item (b): the prune write MUST go through the flock helper and
+# the atomic os.replace, same as the mutating subcommands.
+EXEC_MD="$SKILL_DIR/modes/execute.md"
+if grep -q 'with_monitor_lock prune_completed' "$EXEC_MD" \
+   && grep -q 'os.replace(tmp.name, path)' "$EXEC_MD" \
+   && grep -q 'def prune_completed\|prune_completed()' "$EXEC_MD"; then
+  pass "#906 prune embed wraps in with_monitor_lock + atomic os.replace"
+else
+  fail "#906 prune embed missing lock/atomic-write guards"
+fi
+
+# --- Test 30: #906 argument-hint advertises the composed form ----------
+if grep -q 'argument-hint:.*N|all .*\[every SCHEDULE\] \[now\]' "$SKILL"; then
+  pass "#906 argument-hint advertises N|all [every SCHEDULE] [now] composition"
+else
+  fail "#906 argument-hint missing composed-form surface"
 fi
 
 echo ""


### PR DESCRIPTION
Task: Bring /work-on-plans's queue-worker grammar to parity with /fix-issues — compose `N|all [phase|finish] [every SCHEDULE] [now]`, count-carrying recurring cron (`Run /work-on-plans $N <mode> every <SCHEDULE> now`), `now` = run-immediately-and-schedule, prune `status: complete` plans from `plans.ready` (locked), and de-collide the internal "execute mode"/"dispatch path" term from CLAUDE.md "Execution Modes". Ports the shipped /fix-issues pattern; no new modes/config. Deep /run-plan↔/work-on-plans coupling left out of scope.

Full suite 6781/6781; test-work-on-plans.sh 41/41; conformance green. Version bump + mirror parity.

Closes #906

Worktree: /tmp/zskills-do-work-on-plans-parity
Commits: 4234fc8 fix(#906): /work-on-plans queue-worker grammar parity with /fix-issues
