### PR TITLE
[draft-plan-quiz-mode] /draft-plan quiz mode — interactive requirements-elicitation before drafting

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+258cda"
+  version: "2026.06.01+ab6deb"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter

--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] [quiz] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+ab6deb"
+  version: "2026.06.01+82b352"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -113,7 +113,7 @@ fi
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] [auto] <description...>
+/draft-plan [output FILE] [rounds N] [auto] [quiz] <description...>
 ```
 
 - **output FILE** (optional) — where to write the plan. Default:
@@ -146,6 +146,15 @@ fi
   `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
   (`references/brainstorm.md`) before Phase 1. Anchored so it does NOT
   match `brainstorming`/`brainstormed`/`brainstorms`.
+- `quiz` (recognized **ONLY as a leading flag token** — in the flag
+  cluster before the description begins, like `output`/`rounds`/`auto`,
+  case-insensitive) — sets `QUIZ_FLAG=1`, which conducts an interactive
+  requirements interview before drafting by loading
+  (`references/quiz.md`). A `quiz` appearing **within the description
+  text** is part of the description, NOT the flag — unlike `auto`, `quiz`
+  is NOT detected match-anywhere, so a description like "build a quiz app"
+  or a trailing "add dark mode quiz" does NOT trigger quiz mode (see the
+  detection note below and the Examples block).
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -167,6 +176,51 @@ if [[ "$ARGUMENTS" =~ (^|[[:space:]])[bB][rR][aA][iI][nN][sS][tT][oO][rR][mM]($|
 fi
 ```
 
+**`QUIZ_FLAG` is detected by LEADING-FLAG recognition — NOT `auto`'s
+match-anywhere regex.** `quiz` fires **only** when it appears in the
+leading flag cluster, before the first description token. If a description
+word "quiz" set the flag (the way a description word "auto" trips
+`AUTO_FLAG` today — a pre-existing exposure NOT inherited here), then an
+autonomously-dispatched call from `/research-and-plan` (which passes the
+user description verbatim) or the `/run-plan` delegate
+(`/draft-plan plans/FOO.md <desc> auto`) would hang the pipeline on an
+interactive prompt with no human to answer. So the parse consumes the
+leading cluster first and only then tests for `quiz`. Tokenize the leading
+cluster: consume, **in any order**, the output-file token (either the
+literal `output <path>`, OR a bare leading `*.md` token), `rounds N`
+(consuming the numeric value token after `rounds`, so the bare `N` is not
+mis-read as the first description token), `auto`, and `quiz`. The **first
+token matching none of these** begins the description, and everything from
+there (including any later `quiz`) is description, not a flag:
+
+```bash
+QUIZ_FLAG=0
+# Leading-flag scan: walk the tokens, consuming recognized flags in any
+# order. Stop at the first token that is none of them — that begins the
+# description. A `quiz` AFTER the description start is description text,
+# never the flag. (Strip the description first; never match raw
+# $ARGUMENTS match-anywhere — that is exactly auto's false-positive.)
+expect_value=0   # 1 = the previous token was `output`/`rounds`; this one is its value
+for tok in $ARGUMENTS; do
+  if [ "$expect_value" = "1" ]; then
+    # The value token after `output` (a path) or `rounds` (a number);
+    # consume it unconditionally and keep scanning the leading cluster.
+    expect_value=0
+    continue
+  fi
+  ltok=$(printf '%s' "$tok" | tr '[:upper:]' '[:lower:]')
+  case "$ltok" in
+    output)   expect_value=1 ;;                 # output <path> — value consumed next iter
+    rounds)   expect_value=1 ;;                 # rounds N — value consumed next iter
+    auto)     ;;                                # recognized flag — consume, keep scanning
+    quiz)     QUIZ_FLAG=1 ;;                     # leading quiz flag
+    *.md)     ;;                                # bare leading *.md output token
+    */*.md)   ;;                                # path-form leading *.md output token
+    *)        break ;;                          # first description token — stop
+  esac
+done
+```
+
 Examples:
 - `/draft-plan Add dark mode to the editor`
 - `/draft-plan THERMAL_PLAN.md Implement thermal domain` → writes `$ZSKILLS_PLANS_DIR/THERMAL_PLAN.md`
@@ -174,6 +228,10 @@ Examples:
 - `/draft-plan output plans/THERMAL_PLAN.md rounds 5 Implement thermal domain`
 - `/draft-plan rounds 5 Implement thermal domain with multi-domain coupling`
 - `/draft-plan Fix the README.md formatting` → description only, no output file detected
+- `/draft-plan quiz Add dark mode to the editor` → `QUIZ_FLAG=1` (leading flag) — runs the interactive requirements interview first
+- `/draft-plan output p.md quiz rounds 5 Add dark mode` → `QUIZ_FLAG=1` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
+- `/draft-plan output p.md build a quiz app` → `QUIZ_FLAG` NOT set — "quiz" is a description word, not the leading flag (NEGATIVE example; `quiz` is leading-only, never match-anywhere like `auto`)
+- `/draft-plan add dark mode quiz` → `QUIZ_FLAG` NOT set — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable quiz mode, lead with the flag (`/draft-plan quiz add dark mode`).
 
 ## Pre-check — Existing file
 
@@ -196,6 +254,48 @@ completed dialogue — proceed straight to Phase 1 using it as the seed). If the
 exists with `status: in-progress` (a dialogue interrupted by compaction/crash), RESUME it from
 its captured state rather than restarting. If `BRAINSTORM_FLAG=0`, **ignore the reference file
 entirely** and proceed straight to Phase 1.
+
+## Quiz mode (only when the `quiz` flag is present) — research sequencing
+
+When `QUIZ_FLAG=1` **and** running interactively (the same predicate as the
+subagent-skip in "Post-research tracking" below — quiz never fires under a
+subagent caller in practice, since the research-and-* callers don't pass
+`quiz`), the conversational requirements interview runs **FIRST, before any
+research.** The order is strictly: **quiz interview → (on go-signal) the
+existing Phase-1 research fan-out, seeded → Phase 2 draft.** No research is
+split, moved, or interleaved — the fan-out is simply gated behind the quiz
+and seeded with the interview file. Concretely:
+
+1. **Defer the research fan-out** until the quiz produces its go-signal. Do
+   NOT dispatch the Phase-1 Research agents while `QUIZ_FLAG=1` and the quiz
+   has not yet exited.
+2. **Conduct the interview now.** The conditional-load directive and the
+   quiz loop are emitted at the "Post-research tracking" seam below (Work
+   Item 5's 3-way branch); when `QUIZ_FLAG=1` that seam is reached with the
+   research fan-out still deferred, the directive fires, and the interview
+   runs to its explicit go-signal.
+3. **On the go-signal, run the existing Phase-1 fan-out UNCHANGED**
+   (the same agents in "Research agents" below), with one additive behavior:
+   **seed each fan-out agent with the durable interview file**
+   `/tmp/draft-plan-quiz-$TRACKING_ID.md` as priors — "here is what the
+   interview established with the user; validate and extend it, do not
+   re-derive it." Also hand the fan-out the interview file's deferred
+   open-questions list so the Codebase / Prior-art agents resolve them. This
+   is the same seeding shape brainstorm mode uses (injecting the notes path
+   into each research prompt) — inject the **literal**
+   `/tmp/draft-plan-quiz-$TRACKING_ID.md` path into the prompts, never a
+   re-derived one.
+4. **Then Phase 2 drafts** from the seeded research.
+
+When `QUIZ_FLAG=0`, research runs **exactly as today** — the full Phase-1
+fan-out runs immediately, followed by the single-shot post-research
+checkpoint. quiz.md is never read and no `step.*.quiz` marker is written.
+
+The interview mechanics (loop state machine, question-style discipline,
+go-signal contract, persistence + recovery-read, transcript-capture
+distillation) live entirely in
+[references/quiz.md](references/quiz.md); this SKILL.md only orders
+quiz-before-fan-out and passes the interview file in.
 
 ## Phase 1 — Research (parallel agents)
 
@@ -338,6 +438,24 @@ re-prompting here is redundant; proceed directly to Phase 2. (This is an
 ADDITIVE condition; the existing "if running as a subagent, skip" branch
 below is unchanged.)
 
+This steering checkpoint is a **3-way branch.** The branch sits AFTER the
+scope-check decomposition `exit` above and BEFORE Phase 2:
+
+**(a) When `QUIZ_FLAG=1` and running interactively** (the same predicate
+as the subagent-skip in branch (c) below — interactive, not a subagent):
+emit the conditional-load directive
+
+> **Read [references/quiz.md](references/quiz.md) in full and follow its
+> procedure end-to-end. Do not proceed until you have read that file.**
+
+then conduct the quiz loop per that file, exiting to Phase 2 **only on the
+explicit go-signal**. Note: per "Quiz mode" above, this branch is reached
+with the Phase-1 research fan-out still DEFERRED — the interview runs first,
+and the (seeded) fan-out runs only after the go-signal, before Phase 2.
+
+**(b) When `QUIZ_FLAG=0`** (default), the existing single-shot checkpoint,
+verbatim and unchanged:
+
 **Present the research summary to the user.** If running interactively
 (user invoked `/draft-plan` directly), wait for input:
 > Research complete. Summary written to `/tmp/draft-plan-research-<slug>.md`.
@@ -351,10 +469,51 @@ Do not stop here. The checkpoint is a pause for steering, not the end of
 the skill. After the user responds (even if they just say "looks good" or
 "continue"), move to Phase 2 without being asked again.
 
-**If running as a subagent** (dispatched by `/research-and-plan` or
+**(c) If running as a subagent** (dispatched by `/research-and-plan` or
 `/research-and-go`), skip the user checkpoint — proceed directly to
 Phase 2. The decomposition was already approved by the user in the
-parent skill.
+parent skill. (Quiz never reaches this branch in practice since the
+research-and-* callers don't pass `quiz`, but the guard is the same
+predicate and must remain — it is load-bearing for those callers.)
+
+#### Quiz exit — transcript capture + optional step marker
+
+These steps run **only when `QUIZ_FLAG=1`** (i.e., branch (a) above ran the
+quiz to its go-signal). A normal (non-quiz) run does NONE of this.
+
+1. **Transcript-capture merge (R5).** After the quiz exits, merge the
+   distilled requirements into the existing research summary file
+   `/tmp/draft-plan-research-<slug>.md` as confirmed requirements (so each
+   seeded fan-out agent treats the interview-established intent as a given to
+   validate and extend), and — in Phase 6 — add a **"Requirements captured
+   via quiz"** subsection to the plan's `## Plan Quality` section. Follow the
+   transcript-capture distillation spec in
+   [references/quiz.md](references/quiz.md) ("Transcript capture — distill,
+   don't dump"); do NOT duplicate that spec here — distill decisions plus
+   rationale, never a raw chat dump.
+
+2. **Optional `step.*.quiz` tracking marker** (convention symmetry with the
+   research/review/finalize markers; informational only, NOT hook-gated).
+   Gated behind `QUIZ_FLAG=1` so a normal run never emits it. This clones the
+   FULL research-marker fence above — including the `MAIN_ROOT` +
+   `PIPELINE_ID` derivation and the pipeline-id sanitize call — NOT just
+   the `printf`, to avoid an empty-`PIPELINE_ID` flat-marker write:
+
+```bash
+if [ "${QUIZ_FLAG:-0}" = "1" ]; then
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+    . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  else
+    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  fi
+  MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+  PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-draft-plan.$TRACKING_ID}"
+  PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+  [ -n "$PIPELINE_ID" ] || { echo "tracking: empty PIPELINE_ID — refusing flat write" >&2; exit 1; }
+  printf 'completed: %s\n' "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
+    > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.quiz"
+fi
+```
 
 ## Phase 2 — Draft
 
@@ -624,6 +783,16 @@ After each round of review + refinement:
    | 2     | 2 issues          | 3 issues                  | 5/5      |
    | 3     | 0 issues          | 0 issues                  | Converged|
    ```
+
+   **When `QUIZ_FLAG=1`**, also add a **"Requirements captured via quiz"**
+   subsection to this Plan Quality section — a short record (a few lines)
+   noting the requirements were elicited through a quiz interview and listing
+   the key decisions/assumptions confirmed. This documents *how* the plan's
+   requirements were grounded without reproducing the conversation. Produce it
+   from the transcript-capture distillation per
+   [references/quiz.md](references/quiz.md) ("Transcript capture — distill,
+   don't dump"); distill, do NOT dump the raw chat. When `QUIZ_FLAG=0`, omit
+   this subsection entirely.
 
 2. **Write the plan file** to the output path. The user can't review what
    they can't read — plans are often too large to meaningfully summarize

--- a/.claude/skills/draft-plan/references/quiz.md
+++ b/.claude/skills/draft-plan/references/quiz.md
@@ -1,0 +1,331 @@
+# /draft-plan — Quiz mode
+
+> Loaded by `SKILL.md` **only when the `quiz` token is present** (progressive
+> disclosure). This file is the complete, self-contained interaction protocol the
+> orchestrator follows when quiz mode is active: the interview loop state machine,
+> the purely-conversational research model, the question-style discipline, the
+> running understanding summary, incremental persistence + recovery-read, the
+> readiness/termination contract, and the transcript-capture distillation. SKILL.md
+> Reads this file and runs its interview loop INLINE — the quiz dispatches no
+> sub-agents.
+
+Quiz mode inserts a collaborative, multi-turn **requirements interview** at the
+very front of `/draft-plan`, *before* any research runs. Its purpose is to let the
+agent extract the user's actual intent — goal, scope, priorities, preferences —
+through conversation, instead of guessing from a one-line description and then
+discovering the wrong assumptions late in the adversarial pipeline. The
+conversational interview runs first; when the user signals readiness with a
+whole-message go-word (`draft` / `go` / `ready` / `proceed`), the existing Phase-1
+research fan-out runs — now *seeded with the durable interview file as priors* —
+and then Phase 2 drafts the plan. Quiz mode does **no research of its own**: it is
+pure conversation against the agent's existing knowledge, and every codebase
+uncertainty is deferred to the fan-out as an open question rather than interrogated
+out of the user.
+
+---
+
+## Slug pinning — the durable interview file
+
+The quiz writes its durable state to a `/tmp` file whose slug is the deterministic
+`$TRACKING_ID` the SKILL.md preamble computes (`basename "$OUTPUT_FILE" .md | tr A-Z
+a-z | tr _ -`, at `skills/draft-plan/SKILL.md:85`). `$TRACKING_ID` is already in
+scope when this stage runs. **Use it verbatim** — do NOT recompute a slug from the
+description.
+
+- **interview file:** `/tmp/draft-plan-quiz-$TRACKING_ID.md`
+
+This mirrors how the existing skill persists its research to
+`/tmp/draft-plan-research-<slug>.md` (`SKILL.md:259-265`) and how brainstorm mode
+persists to `/tmp/draft-plan-brainstorm-$TRACKING_ID.md`. As with the research
+file, do NOT assume slug parity with the research file — the research `<slug>` is
+loose orchestrator-chosen prose; the quiz file uses `$TRACKING_ID` and the
+feed-forward passes the **literal** `/tmp/draft-plan-quiz-$TRACKING_ID.md` string
+into the fan-out prompts, never a re-derived path.
+
+---
+
+## Interview loop — state machine
+
+Quiz mode is a two-state machine:
+
+```text
+        ┌──────────────┐
+        │ INTERVIEWING │◀──────── (any non-go-signal reply: steer, answer,
+        └──────┬───────┘            clarify) loops back to INTERVIEWING
+               │
+               │  user reply normalizes to a whole-message go-word
+               │  (draft / go / ready / proceed)
+               ▼
+         ┌────────────┐
+         │  DRAFTING  │  → hand off to the existing Phase-1 fan-out (seeded
+         └────────────┘     with the interview file), then Phase 2 drafts.
+```
+
+- **INTERVIEWING** is the start state. Each round the agent (1) re-reads the
+  durable interview file if its own state is not in context (recovery-read, below),
+  (2) restates the running understanding summary, (3) surfaces any new assumption as
+  a question, (4) asks ONE question (or one tight cluster of genuinely-independent
+  questions), (5) persists the updated understanding to the durable file, and (6)
+  offers the readiness exit.
+- The **only** transition edge out of INTERVIEWING is an explicit go-signal token
+  (see the termination contract). Any other reply — an answer, a clarification, a
+  course-correction, even an enthusiastic "this is great" — keeps the machine in
+  INTERVIEWING.
+- **DRAFTING** is terminal for the quiz: control returns to SKILL.md, which runs
+  the existing research fan-out and then drafts. The quiz does not re-enter
+  INTERVIEWING once it has transitioned.
+
+---
+
+## Research model — purely conversational, all research deferred
+
+Quiz mode does **no research during the interview.** The agent conducts the whole
+conversation from its own knowledge plus whatever is already in context. There is
+NO upfront research agent and NO inline Explore dispatch mid-loop. (Because there is
+no in-loop dispatch at all, there is nothing to bound, double-count, or cap — the
+quiz is latency-free conversation.)
+
+### The ask-vs-defer rule
+
+This is the load-bearing distinction that tells the agent where every uncertainty
+goes:
+
+- **Ask the USER** about anything only the user knows: **intent, scope, priorities,
+  preferences, success criteria, constraints they care about.** These are the
+  questions the interview exists to answer. Examples: "what's actually in scope?",
+  "what does done look like?", "is backward-compat a requirement or can we break
+  the old format?", "which of these two behaviors do you want as the default?"
+- **DEFER as an open question** any *codebase fact* the agent is unsure of — the
+  shape of an existing function, whether a helper already exists, how a current hook
+  behaves, where a literal lives. Do NOT interrogate the user about code: asking the
+  user to recall the codebase is the opposite annoyance and produces unreliable
+  answers. Instead, note it in the durable file's open-questions list, phrased as a
+  research task, to be resolved by the post-`draft` fan-out.
+
+A reader of this file (or a reader of the durable interview file) can always tell
+which bucket a given uncertainty landed in: user-facing intent questions are asked
+in the conversation; codebase facts are written down as deferred open questions.
+
+### All codebase research is the existing fan-out, seeded
+
+When the user says `draft`, control returns to SKILL.md and the **existing Phase-1
+research fan-out runs unchanged** (`SKILL.md:226-265`), with one small additive
+behavior: each fan-out agent is **seeded with the durable interview file as priors**
+— "here is what the interview established with the user; validate and extend it,
+do not re-derive it." This is the same seeding shape brainstorm mode already uses
+(`SKILL.md:231-240`, injecting the brainstorm notes path into each research prompt)
+and that `/research-and-plan` uses when it hands a research file to its dispatch
+(`SKILL.md:134-135`). The fan-out is also handed the deferred open-questions list so
+the Codebase / Prior-art agents specifically resolve them.
+
+### Post-`go` surprise handling
+
+Deferring all research to after the go-signal has one real trade-off: the fan-out
+may surface a codebase fact that **contradicts a requirement the user confirmed**
+during the interview. Handle it by severity, and **only on a genuine conflict** (not
+once per finding — most findings simply extend the plan):
+
+- **Minor contradiction** (the confirmed requirement is still achievable with a
+  small adjustment, or the conflict is a detail): record it in the research summary
+  as a flagged note. It is caught and surfaced by the existing Phase-3 adversarial
+  review, and the user reviews the finished plan regardless (Phase 6).
+- **Hard contradiction** (a user-confirmed requirement is infeasible or directly
+  conflicts with a discovered fact): pause and ask the user a single one-line
+  question — "the research found X, which conflicts with your requirement Y; adjust
+  or proceed?" — then continue.
+
+This handling fires **only on genuine conflict with a confirmed requirement**, never
+as a per-finding interruption.
+
+---
+
+## Question-style discipline
+
+The interview is **prose-dominant.** Open questions — the ones that draw out intent
+and scope — are asked as plain conversation text, because plain text is what lets
+the agent also mirror its running understanding back to the user in the same turn (a
+structured prompt has no room to restate the evolving spec). Examples of prose
+questions: "What's actually in scope here — just the happy path, or do you want the
+error cases covered too?" / "What does 'done' look like to you?" / "Which of these
+matters more: speed of landing, or test coverage?"
+
+Use **AskUserQuestion only for genuinely closed forks** — a small, known set of
+mutually-exclusive options where structure genuinely helps. Example: "Landing mode —
+cherry-pick, PR, or direct?" Do NOT wrap an open intent question in a structured
+prompt.
+
+Ask **one question per turn**, or at most one tight cluster of genuinely-independent
+questions. Never present a 12-question wall — it overwhelms the user and defeats the
+conversational design.
+
+### HARD RULE — a free-text escape is always present
+
+Any AskUserQuestion the quiz issues MUST leave the user a free-text path and MUST
+NOT force a choice among pre-baked options. A closed prompt with no escape can
+anchor or rubber-stamp the user toward the agent's framing — the exact failure mode
+that motivated quiz mode. The guarantee has two layers, and **the load-bearing one
+is layer (b):**
+
+- **(b) MANDATORY — the agent authors an explicit invite-free-text cue in every
+  structured prompt.** Phrase one option, or the prompt text itself, to explicitly
+  invite a free-text answer — e.g. add a final option worded "Something else — let
+  me describe it" or end the prompt with "…or just tell me in your own words." This
+  is self-sufficient: it works regardless of any harness behavior, and the rule
+  rests entirely on it. Do NOT skip this on the assumption that the tool provides an
+  escape for you.
+- **(a) BONUS — the AskUserQuestion tool contract may also surface an "Other"
+  free-text option.** This is documented in the *tool's own schema* and is NOT
+  anchored anywhere in this repo, so treat it as a convenience that *may* exist —
+  never as the guarantee. Layer (b) is what you rely on.
+
+---
+
+## Running understanding summary
+
+After each answer, the agent restates the evolving spec back to the user before
+asking the next question. This is the single most valuable element of the interview
+— it surfaces misunderstandings immediately and is the reason the style is
+prose-dominant. The summary takes a compact, consistent shape, for example:
+
+```text
+So far —
+  Goal: <one line>
+  In scope: <A>, <B>
+  Out of scope: <C>
+  Confirmed assumptions: <…>
+  Open (for research): <D>, <E>
+```
+
+Restate it **every turn**, updated with the latest answer, so the user always sees
+the current state of the agreed-upon spec and can correct drift in one reply.
+
+---
+
+## Incremental persistence + recovery-read
+
+### Persist after every answer (do NOT defer to exit)
+
+After each answer, the agent **appends/rewrites** the durable interview file
+`/tmp/draft-plan-quiz-$TRACKING_ID.md` with:
+
+- the current running understanding summary (goal / in-scope / out-of-scope),
+- the assumptions surfaced and confirmed so far,
+- the open questions noted for the post-`draft` fan-out.
+
+This mirrors how the existing skill writes its research to
+`/tmp/draft-plan-research-<slug>.md` after each phase (`SKILL.md:259-265`). The file
+carries a `status:` field — `in-progress` while INTERVIEWING, flipped to `complete`
+at the go-signal — so a resume can tell whether the interview finished.
+
+### Recovery-read on resume / post-compaction (the write is not enough)
+
+A file written every turn but never re-read leaves the agent resuming **blind** after
+context compaction. So quiz.md REQUIRES: on resuming an in-progress quiz — after a
+context compaction, or any re-entry where the running understanding is no longer in
+context — the agent **re-reads `/tmp/draft-plan-quiz-$TRACKING_ID.md` to reconstruct
+state BEFORE issuing the next question.** Only then does it restate the summary and
+continue. This is what makes the persistence operational: it is the same pattern by
+which the research file "persists through all phases" precisely because later phases
+re-read it (`SKILL.md:265`). Write-only persistence is explicitly NOT sufficient.
+
+---
+
+## Assumption-surfacing
+
+Whenever the agent would otherwise silently guess at a requirement, it instead
+**states the assumption as a question** and waits for confirmation — "I'm assuming we
+only need to support the JSON format, not the legacy CSV — is that right?" rather than
+quietly baking the guess into the eventual plan. Confirmed assumptions move into the
+running summary's "Confirmed assumptions" line and into the durable file. This
+directly pre-empts the "wrong assumptions" findings the devil's-advocate would
+otherwise raise late in the pipeline.
+
+---
+
+## Readiness / termination contract — propose, don't self-declare
+
+The agent **proposes** readiness; it never silently decides the interview is over.
+
+### Offer the exit each round
+
+End each round with an explicit readiness offer, for example: "I think I have enough
+to draft. Reply `draft` (or `go` / `ready`) to start the adversarial review, or keep
+steering." The offer names the exact go-words so the user knows the magic tokens.
+
+### Terminate ONLY on a normalized whole-message go-signal
+
+Before testing any reply as a go-signal, **normalize it**:
+
+1. Trim leading/trailing whitespace.
+2. Strip a single trailing `.` / `!` / `?`.
+3. Case-fold.
+
+THEN test **whole-message equality** against the go-word set `draft` / `go` /
+`ready` / `proceed`.
+
+- Replies that **exit** (each normalizes to a bare go-word): `draft`, `go`,
+  `ready`, `proceed`, `draft.`, `Go!`, ` ready ` (surrounding whitespace),
+  `proceed?`.
+- Replies that do **NOT** exit: a go-word plus substantive additional words. A
+  go-word embedded inside a longer steering message is **steering, not exit** —
+  e.g. "use the **go** SDK", "the **ready** state should reset the counter",
+  "**proceed** with Postgres but I still need to discuss auth." These keep the
+  machine in INTERVIEWING.
+- If a reply is **genuinely ambiguous** as to whether it's an exit, the agent
+  **re-poses the readiness offer** rather than guessing.
+
+### Bare affirmations only answer a just-posed readiness question
+
+A bare affirmation ("yes", "yep", "looks good", "sounds good") counts as the
+go-signal **only when it directly answers the agent's just-posed readiness offer**.
+A mid-stream "looks good" — said while the agent asked something else, or
+unprompted — is steering/acknowledgement, NOT an exit. Never exit on a mid-stream
+"looks good."
+
+### Honor an unprompted go-signal
+
+If the user types a whole-message `draft` / `go` / `ready` / `proceed` (after
+normalization) at any point — even when the agent did not just offer the exit —
+honor it as an immediate early exit.
+
+### No silent timeout, no auto-proceed cap
+
+There is **no silent timeout and no round cap that auto-proceeds.** In interactive
+mode the user owns the exit; the interview continues until the user gives an explicit
+go-signal.
+
+---
+
+## Transcript capture — distill, don't dump
+
+At exit (the go-signal), the agent flips the durable file's `status:` to `complete`
+and produces a **"Requirements captured via quiz"** distillation — decisions plus
+their rationale, NOT a raw chat transcript. The durable interview file is the source
+of truth; this step distills it so it informs without bloating the plan. The
+distillation is used in two places:
+
+- **(a) Merged into the Phase-1 research summary file** as confirmed requirements,
+  so each research agent treats the interview-established intent as a given to
+  validate and extend (the seeding described in the research model above).
+- **(b) Appended to the final plan's "Plan Quality" section** as a short record —
+  a few lines noting the requirements were elicited through a quiz interview and the
+  key decisions/assumptions confirmed. This documents *how* the plan's requirements
+  were grounded without reproducing the conversation.
+
+Keep both to a distillation. The incremental durable file and this distilled capture
+are **not redundant**: the former is the live, every-turn state of truth; the latter
+is the compact, durable record that feeds research and the plan.
+
+---
+
+## What quiz mode does NOT do
+
+- It dispatches **no sub-agents** (all research is the existing post-`draft`
+  fan-out). If a future edit ever adds a dispatch here, it must use
+  `subagent_type: "general-purpose"` and never a bare `Explore` (which is
+  Haiku-pinned per `.claude/rules/zskills/managed.md`).
+- It defines **no hooks and no scripts.** quiz.md is pure consulted protocol prose;
+  it does not continue any persistent shell (that is what `modes/` files are for —
+  this is correctly a `references/` file).
+- It requires **no new frontmatter** — reference files carry none; only SKILL.md
+  carries `metadata.version`.

--- a/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+++ b/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
@@ -124,7 +124,7 @@ the Requirements appendix). Key decisions:
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — Author references/quiz.md (interaction protocol) | ⬚ | | |
+| 1 — Author references/quiz.md (interaction protocol) | ✅ Done | `520aaab` | 331-line quiz.md; version 2026.06.01+ab6deb + mirror; 6773/6773 |
 | 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | ⬚ | | |
 | 3 — Mirror, version reconcile, conformance + tests | ⬚ | | |
 

--- a/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+++ b/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
@@ -1,7 +1,8 @@
 ---
 title: /draft-plan quiz mode — interactive requirements-elicitation before drafting
 created: 2026-05-31
-status: active
+status: "complete"
+completed: "2026-06-01T06:47:24Z"
 ---
 
 # Plan: /draft-plan quiz mode

--- a/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+++ b/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
@@ -125,7 +125,7 @@ the Requirements appendix). Key decisions:
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Author references/quiz.md (interaction protocol) | ✅ Done | `520aaab` | 331-line quiz.md; version 2026.06.01+ab6deb + mirror; 6773/6773 |
-| 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | 🟡 In Progress | | |
+| 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | ✅ Done | `ff1a562` | leading-flag QUIZ_FLAG + conditional-load seam + transcript wiring + gated step.*.quiz; version 2026.06.01+82b352 + mirror; conformance sanitize-count 4→5; 6773/6773 |
 | 3 — Mirror, version reconcile, conformance + tests | ⬚ | | |
 
 ---

--- a/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+++ b/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
@@ -126,7 +126,7 @@ the Requirements appendix). Key decisions:
 |-------|--------|--------|-------|
 | 1 — Author references/quiz.md (interaction protocol) | ✅ Done | `520aaab` | 331-line quiz.md; version 2026.06.01+ab6deb + mirror; 6773/6773 |
 | 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | ✅ Done | `ff1a562` | leading-flag QUIZ_FLAG + conditional-load seam + transcript wiring + gated step.*.quiz; version 2026.06.01+82b352 + mirror; conformance sanitize-count 4→5; 6773/6773 |
-| 3 — Mirror, version reconcile, conformance + tests | ⬚ | | |
+| 3 — Mirror, version reconcile, conformance + tests | 🟡 In Progress | | |
 
 ---
 

--- a/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+++ b/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
@@ -125,7 +125,7 @@ the Requirements appendix). Key decisions:
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — Author references/quiz.md (interaction protocol) | ✅ Done | `520aaab` | 331-line quiz.md; version 2026.06.01+ab6deb + mirror; 6773/6773 |
-| 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | ⬚ | | |
+| 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | 🟡 In Progress | | |
 | 3 — Mirror, version reconcile, conformance + tests | ⬚ | | |
 
 ---

--- a/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+++ b/docs/plans/DRAFT_PLAN_QUIZ_MODE.md
@@ -126,7 +126,7 @@ the Requirements appendix). Key decisions:
 |-------|--------|--------|-------|
 | 1 — Author references/quiz.md (interaction protocol) | ✅ Done | `520aaab` | 331-line quiz.md; version 2026.06.01+ab6deb + mirror; 6773/6773 |
 | 2 — Wire SKILL.md (flag, conditional load, seam, transcript) | ✅ Done | `ff1a562` | leading-flag QUIZ_FLAG + conditional-load seam + transcript wiring + gated step.*.quiz; version 2026.06.01+82b352 + mirror; conformance sanitize-count 4→5; 6773/6773 |
-| 3 — Mirror, version reconcile, conformance + tests | 🟡 In Progress | | |
+| 3 — Mirror, version reconcile, conformance + tests | ✅ Done | `e9cb987` | required co-occurrence wiring tripwire (references/quiz.md + QUIZ_FLAG=1, fails-closed); version 82b352 + mirror parity final; 6774/6774 |
 
 ---
 

--- a/docs/reports/plan-draft-plan-quiz-mode.md
+++ b/docs/reports/plan-draft-plan-quiz-mode.md
@@ -1,5 +1,31 @@
 # Plan Report — /draft-plan quiz mode
 
+## Phase — 3 Mirror, version reconcile, conformance + tests [FINAL]
+
+**Plan:** docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+**Status:** Completed (verified) — plan complete
+**Landing:** PR mode — `feat/draft-plan-quiz-mode` (lands once, here)
+**Commits:** `924a465` (in-progress), `e9cb987` (wiring tripwire), tracker/report/complete commits
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Source version finalized (`2026.06.01+82b352`) | Done (held from Phase 2; no re-bump needed) | — |
+| 2 | Mirror byte-for-byte (`.claude/skills/draft-plan/`) | Done (held from Phase 2; `diff -rq` clean) | — |
+| 3 | Full suite passes | Done | e9cb987 |
+| 4 | Targeted conformance (deny-list, version, mirror parity) | Done | e9cb987 |
+| 5 | Required wiring tripwire (co-occurrence, fails-closed) | Done | e9cb987 |
+| 6 | No CHANGELOG/README (R10) | Done (none, by design) | — |
+
+### Verification
+- Test suite: PASSED — `Overall: 6774/6774 passed, 0 failed` (new tripwire +1 over the 6773 prior).
+- **Wiring tripwire fails-closed:** `check_in_file_near draft-plan SKILL.md … 'references/quiz.md' 'QUIZ_FLAG=1' 10` — passes only when the conditional-load directive and its `QUIZ_FLAG=1` guard co-occur within 10 lines; FAILS if the guard is stripped (degraded to unconditional read) or the reference survives only in a comment. One targeted assertion, not a sweep.
+- Version reconcile: source `2026.06.01+82b352` == fresh content hash; correctly NOT re-bumped (no skill-content change in Phase 3).
+- Mirror parity: `diff -rq skills/draft-plan .claude/skills/draft-plan` clean.
+
+### Plan outcome
+All 3 phases complete and verified. `/draft-plan` now supports an opt-in leading-flag `quiz` mode (interactive requirements interview before drafting) via the conditionally-loaded `references/quiz.md`, wired into SKILL.md with the autonomous-caller leak structurally closed by leading-flag parsing. No `issue:` linked. Landing via `/land-pr` (auto-merge).
+
 ## Phase — 2 Wire SKILL.md (flag, conditional load, seam, transcript) [UNFINALIZED]
 
 **Plan:** docs/plans/DRAFT_PLAN_QUIZ_MODE.md

--- a/docs/reports/plan-draft-plan-quiz-mode.md
+++ b/docs/reports/plan-draft-plan-quiz-mode.md
@@ -1,5 +1,36 @@
 # Plan Report — /draft-plan quiz mode
 
+## Phase — 2 Wire SKILL.md (flag, conditional load, seam, transcript) [UNFINALIZED]
+
+**Plan:** docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+**Status:** Completed (verified)
+**Landing:** PR mode — `feat/draft-plan-quiz-mode` (chunked finish-auto; lands once after Phase 3)
+**Worktree:** /tmp/zskills-pr-draft-plan-quiz-mode
+**Commits:** `2eda56b` (mark in-progress), `ff1a562` (implementation), tracker commit (this phase)
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | argument-hint + usage synopsis `[quiz]` | Done | ff1a562 |
+| 2 | recognized-pattern bullet (leading-flag, loads quiz.md) | Done | ff1a562 |
+| 3 | leading-flag `QUIZ_FLAG` detection (NOT match-anywhere) + tokenization | Done | ff1a562 |
+| 4 | conditional-load 3-way branch at post-research seam | Done | ff1a562 |
+| 5 | research-sequencing (quiz first → seeded fan-out → Phase 2) | Done | ff1a562 |
+| 6 | transcript-capture wiring (research summary + Plan Quality) | Done | ff1a562 |
+| 7 | gated `step.*.quiz` marker (full fence clone) | Done | ff1a562 |
+| 8 | negative + trailing-quiz examples | Done | ff1a562 |
+| 9 | version bump `2026.06.01+82b352` + mirror | Done | ff1a562 |
+
+### Verification
+- Test suite: PASSED — `Overall: 6773/6773 passed, 0 failed`; F==0, N>=6773 (clean Phase-1 prior).
+- **Leading-flag leak closed (behaviorally verified):** description-word `quiz` does NOT set the flag (`output p.md build a quiz app`→0, `plans/FOO.md make a quiz tool auto`→0, `add dark mode quiz`→0); leading/cluster cases →1; case-insensitive.
+- `QUIZ_FLAG=0` branch character-identical to `origin/main` (single-shot checkpoint unchanged); subagent-skip preserved.
+- **Test-change scrutiny:** `check_sanitize_count` `4→5` confirmed legitimate — 5 real `sanitize-pipeline-id` construct-sites (the 5th is the new gated `step.*.quiz` fence). Not test-weakening.
+- Mirror parity: `.claude/skills/draft-plan/SKILL.md` byte-identical.
+
+### Notes
+- Phase 3 (mirror reconcile / version finalize + required wiring tripwire + full conformance) remains; cron advances.
+
 ## Phase — 1 Author references/quiz.md (interaction protocol) [UNFINALIZED]
 
 **Plan:** docs/plans/DRAFT_PLAN_QUIZ_MODE.md

--- a/docs/reports/plan-draft-plan-quiz-mode.md
+++ b/docs/reports/plan-draft-plan-quiz-mode.md
@@ -1,0 +1,36 @@
+# Plan Report — /draft-plan quiz mode
+
+## Phase — 1 Author references/quiz.md (interaction protocol) [UNFINALIZED]
+
+**Plan:** docs/plans/DRAFT_PLAN_QUIZ_MODE.md
+**Status:** Completed (verified)
+**Landing:** PR mode — `feat/draft-plan-quiz-mode` (chunked finish-auto; lands once after final phase)
+**Worktree:** /tmp/zskills-pr-draft-plan-quiz-mode
+**Commits:** `520aaab` (implementation), `7ee3b6c` (tracker)
+
+### Work Items
+| # | Item | Status | Commit |
+|---|------|--------|--------|
+| 1 | Create `skills/draft-plan/references/quiz.md` (331 lines) | Done | 520aaab |
+| 2 | Interview loop state machine (INTERVIEWING → go-signal → DRAFTING) | Done | 520aaab |
+| 3 | Conversational research model + ask-vs-defer rule + seeded fan-out | Done | 520aaab |
+| 4 | Post-`go` surprise handling (minor→summary / hard→one-line pause) | Done | 520aaab |
+| 5 | Question-style discipline + HARD free-text-escape rule (layers a/b) | Done | 520aaab |
+| 6 | Running understanding summary (restated each turn) | Done | 520aaab |
+| 7 | Incremental persistence + recovery-read on resume | Done | 520aaab |
+| 8 | Assumption-surfacing | Done | 520aaab |
+| 9 | Termination contract (normalized whole-message go-signal) | Done | 520aaab |
+| 10 | Transcript capture (distillation → research summary + Plan Quality) | Done | 520aaab |
+| 11 | Header naming trigger + flow placement | Done | 520aaab |
+| 12 | metadata.version bump (`2026.06.01+ab6deb`) + byte-for-byte mirror | Done | 520aaab |
+
+### Verification
+- Test suite: PASSED — `Overall: 6773/6773 passed, 0 failed` (`bash tests/run-all.sh`); no regressions vs baseline (6773/6773).
+- Conformance deny-list: passed with `quiz.md` present (all example prose in narrative / `text` fences).
+- Mirror parity: `.claude/skills/draft-plan/` byte-identical to source.
+- Acceptance criteria: all met (per fresh-agent verification against verbatim phase text).
+- SKILL.md changed in `metadata.version` only — no Phase-2 wiring leaked.
+
+### Notes
+- Non-numeric plan-text drift (advisory, not auto-corrected): the Phase-1 prose says "no `references/` dir exists today / the skill's first reference file," but `references/brainstorm.md` (sibling plan, #903) already created the dir. `quiz.md` is still a valid new file; the header correctly frames it as a conditionally-loaded reference. Candidate for a `/refine-plan` prose touch-up, non-blocking.
+- Phases 2 (wire SKILL.md) and 3 (mirror reconcile + conformance tripwire + tests) remain; chunked finish-auto advances via the recurring cron.

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.05.31+258cda"
+  version: "2026.06.01+ab6deb"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] [quiz] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+ab6deb"
+  version: "2026.06.01+82b352"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -113,7 +113,7 @@ fi
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] [auto] <description...>
+/draft-plan [output FILE] [rounds N] [auto] [quiz] <description...>
 ```
 
 - **output FILE** (optional) — where to write the plan. Default:
@@ -146,6 +146,15 @@ fi
   `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
   (`references/brainstorm.md`) before Phase 1. Anchored so it does NOT
   match `brainstorming`/`brainstormed`/`brainstorms`.
+- `quiz` (recognized **ONLY as a leading flag token** — in the flag
+  cluster before the description begins, like `output`/`rounds`/`auto`,
+  case-insensitive) — sets `QUIZ_FLAG=1`, which conducts an interactive
+  requirements interview before drafting by loading
+  (`references/quiz.md`). A `quiz` appearing **within the description
+  text** is part of the description, NOT the flag — unlike `auto`, `quiz`
+  is NOT detected match-anywhere, so a description like "build a quiz app"
+  or a trailing "add dark mode quiz" does NOT trigger quiz mode (see the
+  detection note below and the Examples block).
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -167,6 +176,51 @@ if [[ "$ARGUMENTS" =~ (^|[[:space:]])[bB][rR][aA][iI][nN][sS][tT][oO][rR][mM]($|
 fi
 ```
 
+**`QUIZ_FLAG` is detected by LEADING-FLAG recognition — NOT `auto`'s
+match-anywhere regex.** `quiz` fires **only** when it appears in the
+leading flag cluster, before the first description token. If a description
+word "quiz" set the flag (the way a description word "auto" trips
+`AUTO_FLAG` today — a pre-existing exposure NOT inherited here), then an
+autonomously-dispatched call from `/research-and-plan` (which passes the
+user description verbatim) or the `/run-plan` delegate
+(`/draft-plan plans/FOO.md <desc> auto`) would hang the pipeline on an
+interactive prompt with no human to answer. So the parse consumes the
+leading cluster first and only then tests for `quiz`. Tokenize the leading
+cluster: consume, **in any order**, the output-file token (either the
+literal `output <path>`, OR a bare leading `*.md` token), `rounds N`
+(consuming the numeric value token after `rounds`, so the bare `N` is not
+mis-read as the first description token), `auto`, and `quiz`. The **first
+token matching none of these** begins the description, and everything from
+there (including any later `quiz`) is description, not a flag:
+
+```bash
+QUIZ_FLAG=0
+# Leading-flag scan: walk the tokens, consuming recognized flags in any
+# order. Stop at the first token that is none of them — that begins the
+# description. A `quiz` AFTER the description start is description text,
+# never the flag. (Strip the description first; never match raw
+# $ARGUMENTS match-anywhere — that is exactly auto's false-positive.)
+expect_value=0   # 1 = the previous token was `output`/`rounds`; this one is its value
+for tok in $ARGUMENTS; do
+  if [ "$expect_value" = "1" ]; then
+    # The value token after `output` (a path) or `rounds` (a number);
+    # consume it unconditionally and keep scanning the leading cluster.
+    expect_value=0
+    continue
+  fi
+  ltok=$(printf '%s' "$tok" | tr '[:upper:]' '[:lower:]')
+  case "$ltok" in
+    output)   expect_value=1 ;;                 # output <path> — value consumed next iter
+    rounds)   expect_value=1 ;;                 # rounds N — value consumed next iter
+    auto)     ;;                                # recognized flag — consume, keep scanning
+    quiz)     QUIZ_FLAG=1 ;;                     # leading quiz flag
+    *.md)     ;;                                # bare leading *.md output token
+    */*.md)   ;;                                # path-form leading *.md output token
+    *)        break ;;                          # first description token — stop
+  esac
+done
+```
+
 Examples:
 - `/draft-plan Add dark mode to the editor`
 - `/draft-plan THERMAL_PLAN.md Implement thermal domain` → writes `$ZSKILLS_PLANS_DIR/THERMAL_PLAN.md`
@@ -174,6 +228,10 @@ Examples:
 - `/draft-plan output plans/THERMAL_PLAN.md rounds 5 Implement thermal domain`
 - `/draft-plan rounds 5 Implement thermal domain with multi-domain coupling`
 - `/draft-plan Fix the README.md formatting` → description only, no output file detected
+- `/draft-plan quiz Add dark mode to the editor` → `QUIZ_FLAG=1` (leading flag) — runs the interactive requirements interview first
+- `/draft-plan output p.md quiz rounds 5 Add dark mode` → `QUIZ_FLAG=1` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
+- `/draft-plan output p.md build a quiz app` → `QUIZ_FLAG` NOT set — "quiz" is a description word, not the leading flag (NEGATIVE example; `quiz` is leading-only, never match-anywhere like `auto`)
+- `/draft-plan add dark mode quiz` → `QUIZ_FLAG` NOT set — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable quiz mode, lead with the flag (`/draft-plan quiz add dark mode`).
 
 ## Pre-check — Existing file
 
@@ -196,6 +254,48 @@ completed dialogue — proceed straight to Phase 1 using it as the seed). If the
 exists with `status: in-progress` (a dialogue interrupted by compaction/crash), RESUME it from
 its captured state rather than restarting. If `BRAINSTORM_FLAG=0`, **ignore the reference file
 entirely** and proceed straight to Phase 1.
+
+## Quiz mode (only when the `quiz` flag is present) — research sequencing
+
+When `QUIZ_FLAG=1` **and** running interactively (the same predicate as the
+subagent-skip in "Post-research tracking" below — quiz never fires under a
+subagent caller in practice, since the research-and-* callers don't pass
+`quiz`), the conversational requirements interview runs **FIRST, before any
+research.** The order is strictly: **quiz interview → (on go-signal) the
+existing Phase-1 research fan-out, seeded → Phase 2 draft.** No research is
+split, moved, or interleaved — the fan-out is simply gated behind the quiz
+and seeded with the interview file. Concretely:
+
+1. **Defer the research fan-out** until the quiz produces its go-signal. Do
+   NOT dispatch the Phase-1 Research agents while `QUIZ_FLAG=1` and the quiz
+   has not yet exited.
+2. **Conduct the interview now.** The conditional-load directive and the
+   quiz loop are emitted at the "Post-research tracking" seam below (Work
+   Item 5's 3-way branch); when `QUIZ_FLAG=1` that seam is reached with the
+   research fan-out still deferred, the directive fires, and the interview
+   runs to its explicit go-signal.
+3. **On the go-signal, run the existing Phase-1 fan-out UNCHANGED**
+   (the same agents in "Research agents" below), with one additive behavior:
+   **seed each fan-out agent with the durable interview file**
+   `/tmp/draft-plan-quiz-$TRACKING_ID.md` as priors — "here is what the
+   interview established with the user; validate and extend it, do not
+   re-derive it." Also hand the fan-out the interview file's deferred
+   open-questions list so the Codebase / Prior-art agents resolve them. This
+   is the same seeding shape brainstorm mode uses (injecting the notes path
+   into each research prompt) — inject the **literal**
+   `/tmp/draft-plan-quiz-$TRACKING_ID.md` path into the prompts, never a
+   re-derived one.
+4. **Then Phase 2 drafts** from the seeded research.
+
+When `QUIZ_FLAG=0`, research runs **exactly as today** — the full Phase-1
+fan-out runs immediately, followed by the single-shot post-research
+checkpoint. quiz.md is never read and no `step.*.quiz` marker is written.
+
+The interview mechanics (loop state machine, question-style discipline,
+go-signal contract, persistence + recovery-read, transcript-capture
+distillation) live entirely in
+[references/quiz.md](references/quiz.md); this SKILL.md only orders
+quiz-before-fan-out and passes the interview file in.
 
 ## Phase 1 — Research (parallel agents)
 
@@ -338,6 +438,24 @@ re-prompting here is redundant; proceed directly to Phase 2. (This is an
 ADDITIVE condition; the existing "if running as a subagent, skip" branch
 below is unchanged.)
 
+This steering checkpoint is a **3-way branch.** The branch sits AFTER the
+scope-check decomposition `exit` above and BEFORE Phase 2:
+
+**(a) When `QUIZ_FLAG=1` and running interactively** (the same predicate
+as the subagent-skip in branch (c) below — interactive, not a subagent):
+emit the conditional-load directive
+
+> **Read [references/quiz.md](references/quiz.md) in full and follow its
+> procedure end-to-end. Do not proceed until you have read that file.**
+
+then conduct the quiz loop per that file, exiting to Phase 2 **only on the
+explicit go-signal**. Note: per "Quiz mode" above, this branch is reached
+with the Phase-1 research fan-out still DEFERRED — the interview runs first,
+and the (seeded) fan-out runs only after the go-signal, before Phase 2.
+
+**(b) When `QUIZ_FLAG=0`** (default), the existing single-shot checkpoint,
+verbatim and unchanged:
+
 **Present the research summary to the user.** If running interactively
 (user invoked `/draft-plan` directly), wait for input:
 > Research complete. Summary written to `/tmp/draft-plan-research-<slug>.md`.
@@ -351,10 +469,51 @@ Do not stop here. The checkpoint is a pause for steering, not the end of
 the skill. After the user responds (even if they just say "looks good" or
 "continue"), move to Phase 2 without being asked again.
 
-**If running as a subagent** (dispatched by `/research-and-plan` or
+**(c) If running as a subagent** (dispatched by `/research-and-plan` or
 `/research-and-go`), skip the user checkpoint — proceed directly to
 Phase 2. The decomposition was already approved by the user in the
-parent skill.
+parent skill. (Quiz never reaches this branch in practice since the
+research-and-* callers don't pass `quiz`, but the guard is the same
+predicate and must remain — it is load-bearing for those callers.)
+
+#### Quiz exit — transcript capture + optional step marker
+
+These steps run **only when `QUIZ_FLAG=1`** (i.e., branch (a) above ran the
+quiz to its go-signal). A normal (non-quiz) run does NONE of this.
+
+1. **Transcript-capture merge (R5).** After the quiz exits, merge the
+   distilled requirements into the existing research summary file
+   `/tmp/draft-plan-research-<slug>.md` as confirmed requirements (so each
+   seeded fan-out agent treats the interview-established intent as a given to
+   validate and extend), and — in Phase 6 — add a **"Requirements captured
+   via quiz"** subsection to the plan's `## Plan Quality` section. Follow the
+   transcript-capture distillation spec in
+   [references/quiz.md](references/quiz.md) ("Transcript capture — distill,
+   don't dump"); do NOT duplicate that spec here — distill decisions plus
+   rationale, never a raw chat dump.
+
+2. **Optional `step.*.quiz` tracking marker** (convention symmetry with the
+   research/review/finalize markers; informational only, NOT hook-gated).
+   Gated behind `QUIZ_FLAG=1` so a normal run never emits it. This clones the
+   FULL research-marker fence above — including the `MAIN_ROOT` +
+   `PIPELINE_ID` derivation and the pipeline-id sanitize call — NOT just
+   the `printf`, to avoid an empty-`PIPELINE_ID` flat-marker write:
+
+```bash
+if [ "${QUIZ_FLAG:-0}" = "1" ]; then
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+    . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  else
+    . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+  fi
+  MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+  PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-draft-plan.$TRACKING_ID}"
+  PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+  [ -n "$PIPELINE_ID" ] || { echo "tracking: empty PIPELINE_ID — refusing flat write" >&2; exit 1; }
+  printf 'completed: %s\n' "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
+    > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.quiz"
+fi
+```
 
 ## Phase 2 — Draft
 
@@ -624,6 +783,16 @@ After each round of review + refinement:
    | 2     | 2 issues          | 3 issues                  | 5/5      |
    | 3     | 0 issues          | 0 issues                  | Converged|
    ```
+
+   **When `QUIZ_FLAG=1`**, also add a **"Requirements captured via quiz"**
+   subsection to this Plan Quality section — a short record (a few lines)
+   noting the requirements were elicited through a quiz interview and listing
+   the key decisions/assumptions confirmed. This documents *how* the plan's
+   requirements were grounded without reproducing the conversation. Produce it
+   from the transcript-capture distillation per
+   [references/quiz.md](references/quiz.md) ("Transcript capture — distill,
+   don't dump"); distill, do NOT dump the raw chat. When `QUIZ_FLAG=0`, omit
+   this subsection entirely.
 
 2. **Write the plan file** to the output path. The user can't review what
    they can't read — plans are often too large to meaningfully summarize

--- a/skills/draft-plan/references/quiz.md
+++ b/skills/draft-plan/references/quiz.md
@@ -1,0 +1,331 @@
+# /draft-plan — Quiz mode
+
+> Loaded by `SKILL.md` **only when the `quiz` token is present** (progressive
+> disclosure). This file is the complete, self-contained interaction protocol the
+> orchestrator follows when quiz mode is active: the interview loop state machine,
+> the purely-conversational research model, the question-style discipline, the
+> running understanding summary, incremental persistence + recovery-read, the
+> readiness/termination contract, and the transcript-capture distillation. SKILL.md
+> Reads this file and runs its interview loop INLINE — the quiz dispatches no
+> sub-agents.
+
+Quiz mode inserts a collaborative, multi-turn **requirements interview** at the
+very front of `/draft-plan`, *before* any research runs. Its purpose is to let the
+agent extract the user's actual intent — goal, scope, priorities, preferences —
+through conversation, instead of guessing from a one-line description and then
+discovering the wrong assumptions late in the adversarial pipeline. The
+conversational interview runs first; when the user signals readiness with a
+whole-message go-word (`draft` / `go` / `ready` / `proceed`), the existing Phase-1
+research fan-out runs — now *seeded with the durable interview file as priors* —
+and then Phase 2 drafts the plan. Quiz mode does **no research of its own**: it is
+pure conversation against the agent's existing knowledge, and every codebase
+uncertainty is deferred to the fan-out as an open question rather than interrogated
+out of the user.
+
+---
+
+## Slug pinning — the durable interview file
+
+The quiz writes its durable state to a `/tmp` file whose slug is the deterministic
+`$TRACKING_ID` the SKILL.md preamble computes (`basename "$OUTPUT_FILE" .md | tr A-Z
+a-z | tr _ -`, at `skills/draft-plan/SKILL.md:85`). `$TRACKING_ID` is already in
+scope when this stage runs. **Use it verbatim** — do NOT recompute a slug from the
+description.
+
+- **interview file:** `/tmp/draft-plan-quiz-$TRACKING_ID.md`
+
+This mirrors how the existing skill persists its research to
+`/tmp/draft-plan-research-<slug>.md` (`SKILL.md:259-265`) and how brainstorm mode
+persists to `/tmp/draft-plan-brainstorm-$TRACKING_ID.md`. As with the research
+file, do NOT assume slug parity with the research file — the research `<slug>` is
+loose orchestrator-chosen prose; the quiz file uses `$TRACKING_ID` and the
+feed-forward passes the **literal** `/tmp/draft-plan-quiz-$TRACKING_ID.md` string
+into the fan-out prompts, never a re-derived path.
+
+---
+
+## Interview loop — state machine
+
+Quiz mode is a two-state machine:
+
+```text
+        ┌──────────────┐
+        │ INTERVIEWING │◀──────── (any non-go-signal reply: steer, answer,
+        └──────┬───────┘            clarify) loops back to INTERVIEWING
+               │
+               │  user reply normalizes to a whole-message go-word
+               │  (draft / go / ready / proceed)
+               ▼
+         ┌────────────┐
+         │  DRAFTING  │  → hand off to the existing Phase-1 fan-out (seeded
+         └────────────┘     with the interview file), then Phase 2 drafts.
+```
+
+- **INTERVIEWING** is the start state. Each round the agent (1) re-reads the
+  durable interview file if its own state is not in context (recovery-read, below),
+  (2) restates the running understanding summary, (3) surfaces any new assumption as
+  a question, (4) asks ONE question (or one tight cluster of genuinely-independent
+  questions), (5) persists the updated understanding to the durable file, and (6)
+  offers the readiness exit.
+- The **only** transition edge out of INTERVIEWING is an explicit go-signal token
+  (see the termination contract). Any other reply — an answer, a clarification, a
+  course-correction, even an enthusiastic "this is great" — keeps the machine in
+  INTERVIEWING.
+- **DRAFTING** is terminal for the quiz: control returns to SKILL.md, which runs
+  the existing research fan-out and then drafts. The quiz does not re-enter
+  INTERVIEWING once it has transitioned.
+
+---
+
+## Research model — purely conversational, all research deferred
+
+Quiz mode does **no research during the interview.** The agent conducts the whole
+conversation from its own knowledge plus whatever is already in context. There is
+NO upfront research agent and NO inline Explore dispatch mid-loop. (Because there is
+no in-loop dispatch at all, there is nothing to bound, double-count, or cap — the
+quiz is latency-free conversation.)
+
+### The ask-vs-defer rule
+
+This is the load-bearing distinction that tells the agent where every uncertainty
+goes:
+
+- **Ask the USER** about anything only the user knows: **intent, scope, priorities,
+  preferences, success criteria, constraints they care about.** These are the
+  questions the interview exists to answer. Examples: "what's actually in scope?",
+  "what does done look like?", "is backward-compat a requirement or can we break
+  the old format?", "which of these two behaviors do you want as the default?"
+- **DEFER as an open question** any *codebase fact* the agent is unsure of — the
+  shape of an existing function, whether a helper already exists, how a current hook
+  behaves, where a literal lives. Do NOT interrogate the user about code: asking the
+  user to recall the codebase is the opposite annoyance and produces unreliable
+  answers. Instead, note it in the durable file's open-questions list, phrased as a
+  research task, to be resolved by the post-`draft` fan-out.
+
+A reader of this file (or a reader of the durable interview file) can always tell
+which bucket a given uncertainty landed in: user-facing intent questions are asked
+in the conversation; codebase facts are written down as deferred open questions.
+
+### All codebase research is the existing fan-out, seeded
+
+When the user says `draft`, control returns to SKILL.md and the **existing Phase-1
+research fan-out runs unchanged** (`SKILL.md:226-265`), with one small additive
+behavior: each fan-out agent is **seeded with the durable interview file as priors**
+— "here is what the interview established with the user; validate and extend it,
+do not re-derive it." This is the same seeding shape brainstorm mode already uses
+(`SKILL.md:231-240`, injecting the brainstorm notes path into each research prompt)
+and that `/research-and-plan` uses when it hands a research file to its dispatch
+(`SKILL.md:134-135`). The fan-out is also handed the deferred open-questions list so
+the Codebase / Prior-art agents specifically resolve them.
+
+### Post-`go` surprise handling
+
+Deferring all research to after the go-signal has one real trade-off: the fan-out
+may surface a codebase fact that **contradicts a requirement the user confirmed**
+during the interview. Handle it by severity, and **only on a genuine conflict** (not
+once per finding — most findings simply extend the plan):
+
+- **Minor contradiction** (the confirmed requirement is still achievable with a
+  small adjustment, or the conflict is a detail): record it in the research summary
+  as a flagged note. It is caught and surfaced by the existing Phase-3 adversarial
+  review, and the user reviews the finished plan regardless (Phase 6).
+- **Hard contradiction** (a user-confirmed requirement is infeasible or directly
+  conflicts with a discovered fact): pause and ask the user a single one-line
+  question — "the research found X, which conflicts with your requirement Y; adjust
+  or proceed?" — then continue.
+
+This handling fires **only on genuine conflict with a confirmed requirement**, never
+as a per-finding interruption.
+
+---
+
+## Question-style discipline
+
+The interview is **prose-dominant.** Open questions — the ones that draw out intent
+and scope — are asked as plain conversation text, because plain text is what lets
+the agent also mirror its running understanding back to the user in the same turn (a
+structured prompt has no room to restate the evolving spec). Examples of prose
+questions: "What's actually in scope here — just the happy path, or do you want the
+error cases covered too?" / "What does 'done' look like to you?" / "Which of these
+matters more: speed of landing, or test coverage?"
+
+Use **AskUserQuestion only for genuinely closed forks** — a small, known set of
+mutually-exclusive options where structure genuinely helps. Example: "Landing mode —
+cherry-pick, PR, or direct?" Do NOT wrap an open intent question in a structured
+prompt.
+
+Ask **one question per turn**, or at most one tight cluster of genuinely-independent
+questions. Never present a 12-question wall — it overwhelms the user and defeats the
+conversational design.
+
+### HARD RULE — a free-text escape is always present
+
+Any AskUserQuestion the quiz issues MUST leave the user a free-text path and MUST
+NOT force a choice among pre-baked options. A closed prompt with no escape can
+anchor or rubber-stamp the user toward the agent's framing — the exact failure mode
+that motivated quiz mode. The guarantee has two layers, and **the load-bearing one
+is layer (b):**
+
+- **(b) MANDATORY — the agent authors an explicit invite-free-text cue in every
+  structured prompt.** Phrase one option, or the prompt text itself, to explicitly
+  invite a free-text answer — e.g. add a final option worded "Something else — let
+  me describe it" or end the prompt with "…or just tell me in your own words." This
+  is self-sufficient: it works regardless of any harness behavior, and the rule
+  rests entirely on it. Do NOT skip this on the assumption that the tool provides an
+  escape for you.
+- **(a) BONUS — the AskUserQuestion tool contract may also surface an "Other"
+  free-text option.** This is documented in the *tool's own schema* and is NOT
+  anchored anywhere in this repo, so treat it as a convenience that *may* exist —
+  never as the guarantee. Layer (b) is what you rely on.
+
+---
+
+## Running understanding summary
+
+After each answer, the agent restates the evolving spec back to the user before
+asking the next question. This is the single most valuable element of the interview
+— it surfaces misunderstandings immediately and is the reason the style is
+prose-dominant. The summary takes a compact, consistent shape, for example:
+
+```text
+So far —
+  Goal: <one line>
+  In scope: <A>, <B>
+  Out of scope: <C>
+  Confirmed assumptions: <…>
+  Open (for research): <D>, <E>
+```
+
+Restate it **every turn**, updated with the latest answer, so the user always sees
+the current state of the agreed-upon spec and can correct drift in one reply.
+
+---
+
+## Incremental persistence + recovery-read
+
+### Persist after every answer (do NOT defer to exit)
+
+After each answer, the agent **appends/rewrites** the durable interview file
+`/tmp/draft-plan-quiz-$TRACKING_ID.md` with:
+
+- the current running understanding summary (goal / in-scope / out-of-scope),
+- the assumptions surfaced and confirmed so far,
+- the open questions noted for the post-`draft` fan-out.
+
+This mirrors how the existing skill writes its research to
+`/tmp/draft-plan-research-<slug>.md` after each phase (`SKILL.md:259-265`). The file
+carries a `status:` field — `in-progress` while INTERVIEWING, flipped to `complete`
+at the go-signal — so a resume can tell whether the interview finished.
+
+### Recovery-read on resume / post-compaction (the write is not enough)
+
+A file written every turn but never re-read leaves the agent resuming **blind** after
+context compaction. So quiz.md REQUIRES: on resuming an in-progress quiz — after a
+context compaction, or any re-entry where the running understanding is no longer in
+context — the agent **re-reads `/tmp/draft-plan-quiz-$TRACKING_ID.md` to reconstruct
+state BEFORE issuing the next question.** Only then does it restate the summary and
+continue. This is what makes the persistence operational: it is the same pattern by
+which the research file "persists through all phases" precisely because later phases
+re-read it (`SKILL.md:265`). Write-only persistence is explicitly NOT sufficient.
+
+---
+
+## Assumption-surfacing
+
+Whenever the agent would otherwise silently guess at a requirement, it instead
+**states the assumption as a question** and waits for confirmation — "I'm assuming we
+only need to support the JSON format, not the legacy CSV — is that right?" rather than
+quietly baking the guess into the eventual plan. Confirmed assumptions move into the
+running summary's "Confirmed assumptions" line and into the durable file. This
+directly pre-empts the "wrong assumptions" findings the devil's-advocate would
+otherwise raise late in the pipeline.
+
+---
+
+## Readiness / termination contract — propose, don't self-declare
+
+The agent **proposes** readiness; it never silently decides the interview is over.
+
+### Offer the exit each round
+
+End each round with an explicit readiness offer, for example: "I think I have enough
+to draft. Reply `draft` (or `go` / `ready`) to start the adversarial review, or keep
+steering." The offer names the exact go-words so the user knows the magic tokens.
+
+### Terminate ONLY on a normalized whole-message go-signal
+
+Before testing any reply as a go-signal, **normalize it**:
+
+1. Trim leading/trailing whitespace.
+2. Strip a single trailing `.` / `!` / `?`.
+3. Case-fold.
+
+THEN test **whole-message equality** against the go-word set `draft` / `go` /
+`ready` / `proceed`.
+
+- Replies that **exit** (each normalizes to a bare go-word): `draft`, `go`,
+  `ready`, `proceed`, `draft.`, `Go!`, ` ready ` (surrounding whitespace),
+  `proceed?`.
+- Replies that do **NOT** exit: a go-word plus substantive additional words. A
+  go-word embedded inside a longer steering message is **steering, not exit** —
+  e.g. "use the **go** SDK", "the **ready** state should reset the counter",
+  "**proceed** with Postgres but I still need to discuss auth." These keep the
+  machine in INTERVIEWING.
+- If a reply is **genuinely ambiguous** as to whether it's an exit, the agent
+  **re-poses the readiness offer** rather than guessing.
+
+### Bare affirmations only answer a just-posed readiness question
+
+A bare affirmation ("yes", "yep", "looks good", "sounds good") counts as the
+go-signal **only when it directly answers the agent's just-posed readiness offer**.
+A mid-stream "looks good" — said while the agent asked something else, or
+unprompted — is steering/acknowledgement, NOT an exit. Never exit on a mid-stream
+"looks good."
+
+### Honor an unprompted go-signal
+
+If the user types a whole-message `draft` / `go` / `ready` / `proceed` (after
+normalization) at any point — even when the agent did not just offer the exit —
+honor it as an immediate early exit.
+
+### No silent timeout, no auto-proceed cap
+
+There is **no silent timeout and no round cap that auto-proceeds.** In interactive
+mode the user owns the exit; the interview continues until the user gives an explicit
+go-signal.
+
+---
+
+## Transcript capture — distill, don't dump
+
+At exit (the go-signal), the agent flips the durable file's `status:` to `complete`
+and produces a **"Requirements captured via quiz"** distillation — decisions plus
+their rationale, NOT a raw chat transcript. The durable interview file is the source
+of truth; this step distills it so it informs without bloating the plan. The
+distillation is used in two places:
+
+- **(a) Merged into the Phase-1 research summary file** as confirmed requirements,
+  so each research agent treats the interview-established intent as a given to
+  validate and extend (the seeding described in the research model above).
+- **(b) Appended to the final plan's "Plan Quality" section** as a short record —
+  a few lines noting the requirements were elicited through a quiz interview and the
+  key decisions/assumptions confirmed. This documents *how* the plan's requirements
+  were grounded without reproducing the conversation.
+
+Keep both to a distillation. The incremental durable file and this distilled capture
+are **not redundant**: the former is the live, every-turn state of truth; the latter
+is the compact, durable record that feeds research and the plan.
+
+---
+
+## What quiz mode does NOT do
+
+- It dispatches **no sub-agents** (all research is the existing post-`draft`
+  fan-out). If a future edit ever adds a dispatch here, it must use
+  `subagent_type: "general-purpose"` and never a bare `Explore` (which is
+  Haiku-pinned per `.claude/rules/zskills/managed.md`).
+- It defines **no hooks and no scripts.** quiz.md is pure consulted protocol prose;
+  it does not continue any persistent shell (that is what `modes/` files are for —
+  this is correctly a `references/` file).
+- It requires **no new frontmatter** — reference files carry none; only SKILL.md
+  carries `metadata.version`.

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -772,6 +772,19 @@ check_in_file_near do          "modes/pr.md"                "impl+fix-cycle pins
 check_in_file_near quickfix    "modes/execute.md"           "agent-dispatched pins implementer" 'subagent_type: "implementer"' 'Agent' 0
 check_in_file_near quickfix    "modes/land.md"              "fix-cycle pins implementer" 'subagent_type: "implementer"' 'Agent' 0
 
+# /draft-plan — quiz-mode conditional-load wiring (DRAFT_PLAN_QUIZ_MODE Phase
+# 3, R9). The interactive quiz interview is gated behind QUIZ_FLAG=1 and its
+# procedure lives in references/quiz.md, read via a conditional-load directive.
+# There is no orphan-reference gate today, so this is the ONLY automated check
+# that exercises the new wiring. Use check_in_file_near (NOT a bare grep for
+# 'references/quiz.md') so the assertion verifies CO-OCCURRENCE: the
+# references/quiz.md reference must appear within 10 lines of a QUIZ_FLAG=1
+# conditional token. A bare substring grep would still pass if the conditional
+# guard were stripped (degraded to an unconditional read) or if the string
+# survived only in a comment elsewhere; the _near form fails closed in both
+# cases — removing the `QUIZ_FLAG=1`-guarded conditional load breaks it.
+check_in_file_near draft-plan  "SKILL.md"                   "quiz conditional-load wiring" 'references/quiz.md' 'QUIZ_FLAG=1' 10
+
 # Agent definition file exists with the expected frontmatter shape.
 if [ -f "$REPO_ROOT/.claude/agents/implementer.md" ]; then
   pass "[.claude/agents/implementer.md] exists"

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -3295,7 +3295,7 @@ check_sanitize_count "skills/run-plan/SKILL.md"                       5 "skills/
 check_sanitize_count "skills/run-plan/modes/execute-phase.md"        10 "skills/run-plan/modes/execute-phase.md"
 check_sanitize_count "skills/run-plan/subcommands/stop-next-status.md" 1 "skills/run-plan/subcommands/stop-next-status.md"
 check_sanitize_count "skills/commit/modes/pr.md"      1 "skills/commit/modes/pr.md"
-check_sanitize_count "skills/draft-plan/SKILL.md"     4 "skills/draft-plan/SKILL.md"
+check_sanitize_count "skills/draft-plan/SKILL.md"     5 "skills/draft-plan/SKILL.md"
 check_sanitize_count "skills/refine-plan/SKILL.md"    3 "skills/refine-plan/SKILL.md"
 check_sanitize_count "skills/verify-changes/SKILL.md" 4 "skills/verify-changes/SKILL.md"
 


### PR DESCRIPTION
## Plan: /draft-plan quiz mode — interactive requirements-elicitation before drafting

Adds an opt-in **leading-flag `quiz`** mode to `/draft-plan`: a Socratic interview (conditionally-loaded `references/quiz.md`) that elicits intent/scope before the existing draft → adversarial-review pipeline. The autonomous-caller leak is structurally closed by leading-flag parsing (a description word "quiz" never trips the flag).

<!-- run-plan:progress:start -->
**Phases completed (all 3):**
1 — Author references/quiz.md (interaction protocol) ✅ Done `520aaab` 331-line quiz.md; version 2026.06.01+ab6deb + mirror; 6773/6773
2 — Wire SKILL.md (flag, conditional load, seam, transcript) ✅ Done `ff1a562` leading-flag QUIZ_FLAG + conditional-load seam + transcript wiring + gated step.*.quiz; version 2026.06.01+82b352 + mirror; conformance sanitize-count 4→5; 6773/6773
3 — Mirror, version reconcile, conformance + tests ✅ Done `e9cb987` required co-occurrence wiring tripwire (references/quiz.md + QUIZ_FLAG=1, fails-closed); version 82b352 + mirror parity final; 6774/6774
<!-- run-plan:progress:end -->

- Phase 1 — `references/quiz.md` interaction protocol (state machine, ask-vs-defer, free-text-escape, normalized go-signal, incremental persistence + recovery-read, transcript capture)
- Phase 2 — SKILL.md wiring (leading-flag `QUIZ_FLAG`, conditional load, quiz-before-fan-out sequencing, transcript wiring, gated `step.*.quiz` marker)
- Phase 3 — required co-occurrence wiring tripwire (fails-closed), version/mirror finalize

Full suite green on the rebased branch: **6827/6827 passed, 0 failed**.

**Report:** see `docs/reports/plan-draft-plan-quiz-mode.md`.

---
Generated by `/run-plan` (finish auto, PR mode)
