### PR TITLE
fix(draft-plan): anchor 'brainstorm' keyword to first token (#914)

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+82b352"
+  version: "2026.06.01+ac7967"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -142,10 +142,14 @@ fi
 - `rounds` followed by a number — max review cycles
 - `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
   for Phase 6's `/land-pr` dispatch
-- `brainstorm` (whitespace-anchored, case-insensitive) — sets
+- `brainstorm` (first token only, case-insensitive) — sets
   `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
-  (`references/brainstorm.md`) before Phase 1. Anchored so it does NOT
-  match `brainstorming`/`brainstormed`/`brainstorms`.
+  (`references/brainstorm.md`) before Phase 1. Anchored to the FIRST token
+  of `$ARGUMENTS` (mirroring the `.md` output-file detection's
+  first-position anchor) so it does NOT engage when `brainstorm` appears
+  anywhere else in the args buffer, e.g. `/draft-plan Build a brainstorm
+  app for kids` or `/draft-plan Add a brainstorm feature` (#914). Also
+  anchored so it does NOT match `brainstorming`/`brainstormed`/`brainstorms`.
 - `quiz` (recognized **ONLY as a leading flag token** — in the flag
   cluster before the description begins, like `output`/`rounds`/`auto`,
   case-insensitive) — sets `QUIZ_FLAG=1`, which conducts an interactive
@@ -171,9 +175,19 @@ the `AUTO_FLAG=0 … fi` block is not perturbed):
 
 ```bash
 BRAINSTORM_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[bB][rR][aA][iI][nN][sS][tT][oO][rR][mM]($|[[:space:]]) ]]; then
+# Anchor 'brainstorm' to the FIRST token of $ARGUMENTS (#914). Mirrors the
+# `.md` output-file first-position anchor in the args parser above. This
+# makes `/draft-plan Build a brainstorm app for kids` (and any other args
+# buffer where `brainstorm` is embedded in the description) correctly fall
+# through to Phase 1 instead of opening the 8-step brainstorm dialogue.
+# Read-array off $ARGUMENTS (word-split on whitespace, same as the args
+# parser above), lowercase the first token, compare to literal "brainstorm".
+read -r _bs_first _bs_rest <<<"$ARGUMENTS"
+_bs_lower=$(printf '%s' "$_bs_first" | tr '[:upper:]' '[:lower:]')
+if [ "$_bs_lower" = "brainstorm" ]; then
   BRAINSTORM_FLAG=1
 fi
+unset _bs_first _bs_rest _bs_lower
 ```
 
 **`QUIZ_FLAG` is detected by LEADING-FLAG recognition — NOT `auto`'s

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+82b352"
+  version: "2026.06.01+ac7967"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -142,10 +142,14 @@ fi
 - `rounds` followed by a number — max review cycles
 - `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
   for Phase 6's `/land-pr` dispatch
-- `brainstorm` (whitespace-anchored, case-insensitive) — sets
+- `brainstorm` (first token only, case-insensitive) — sets
   `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
-  (`references/brainstorm.md`) before Phase 1. Anchored so it does NOT
-  match `brainstorming`/`brainstormed`/`brainstorms`.
+  (`references/brainstorm.md`) before Phase 1. Anchored to the FIRST token
+  of `$ARGUMENTS` (mirroring the `.md` output-file detection's
+  first-position anchor) so it does NOT engage when `brainstorm` appears
+  anywhere else in the args buffer, e.g. `/draft-plan Build a brainstorm
+  app for kids` or `/draft-plan Add a brainstorm feature` (#914). Also
+  anchored so it does NOT match `brainstorming`/`brainstormed`/`brainstorms`.
 - `quiz` (recognized **ONLY as a leading flag token** — in the flag
   cluster before the description begins, like `output`/`rounds`/`auto`,
   case-insensitive) — sets `QUIZ_FLAG=1`, which conducts an interactive
@@ -171,9 +175,19 @@ the `AUTO_FLAG=0 … fi` block is not perturbed):
 
 ```bash
 BRAINSTORM_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[bB][rR][aA][iI][nN][sS][tT][oO][rR][mM]($|[[:space:]]) ]]; then
+# Anchor 'brainstorm' to the FIRST token of $ARGUMENTS (#914). Mirrors the
+# `.md` output-file first-position anchor in the args parser above. This
+# makes `/draft-plan Build a brainstorm app for kids` (and any other args
+# buffer where `brainstorm` is embedded in the description) correctly fall
+# through to Phase 1 instead of opening the 8-step brainstorm dialogue.
+# Read-array off $ARGUMENTS (word-split on whitespace, same as the args
+# parser above), lowercase the first token, compare to literal "brainstorm".
+read -r _bs_first _bs_rest <<<"$ARGUMENTS"
+_bs_lower=$(printf '%s' "$_bs_first" | tr '[:upper:]' '[:lower:]')
+if [ "$_bs_lower" = "brainstorm" ]; then
   BRAINSTORM_FLAG=1
 fi
+unset _bs_first _bs_rest _bs_lower
 ```
 
 **`QUIZ_FLAG` is detected by LEADING-FLAG recognition — NOT `auto`'s

--- a/tests/test-draft-plan-args-smoke.sh
+++ b/tests/test-draft-plan-args-smoke.sh
@@ -148,11 +148,17 @@ else
       fail "brainstorm-flag: $3" "expected $2 got $BRAINSTORM_FLAG"
     fi
   }
-  # Positives — whitespace-anchored, case-insensitive, any position.
-  check_brainstorm "brainstorm Add dark mode" 1 "leading 'brainstorm'"
-  check_brainstorm "Add dark mode brainstorm" 1 "trailing 'brainstorm'"
-  check_brainstorm "output X.md brainstorm rounds 3 Add dark mode" 1 "mid 'brainstorm' word-bounded"
-  check_brainstorm "BRAINSTORM Add dark mode" 1 "uppercase 'BRAINSTORM'"
+  # Positives — first token only, case-insensitive (#914).
+  check_brainstorm "brainstorm Add dark mode" 1 "first-position 'brainstorm' engages"
+  check_brainstorm "BRAINSTORM Add dark mode" 1 "first-position uppercase 'BRAINSTORM' engages"
+  check_brainstorm "Brainstorm a new editor" 1 "first-position mixed-case 'Brainstorm' engages"
+  # Negatives — 'brainstorm' anywhere but first token must NOT engage (#914).
+  check_brainstorm "Add dark mode brainstorm" 0 "trailing 'brainstorm' does NOT engage (#914)"
+  check_brainstorm "output X.md brainstorm rounds 3 Add dark mode" 0 "mid 'brainstorm' does NOT engage (#914)"
+  check_brainstorm "Build a brainstorm app for kids" 0 "'brainstorm' inside description does NOT engage (#914)"
+  check_brainstorm "Add a brainstorm feature to the editor" 0 "'brainstorm' inside description does NOT engage (#914)"
+  check_brainstorm "Document our brainstorm process" 0 "'brainstorm' inside description does NOT engage (#914)"
+  check_brainstorm "auto brainstorm Add dark mode" 0 "'brainstorm' after 'auto' does NOT engage (not first token, #914)"
   # Negatives — substring/inflection forms must NOT trip the flag (flag stays 0).
   check_brainstorm "brainstorming the design" 0 "'brainstorming' (no boundary) rejected"
   check_brainstorm "brainstormed yesterday" 0 "'brainstormed' (no boundary) rejected"


### PR DESCRIPTION
## Summary

PR #891 added brainstorm mode to `/draft-plan` but the keyword regex matched `brainstorm` anywhere in args. Descriptions like `/draft-plan Build a brainstorm app for kids` wrongly engaged the 8-step interactive dialogue. **A test at `tests/test-draft-plan-args-smoke.sh:153-154` actively LOCKED the misbehavior in** — those assertions had to be flipped.

Closes #914

## Fix
Anchored the keyword to the **literal first token** of `$ARGUMENTS` (case-insensitive `read`+lowercase compare), stricter than "first non-flag position" — required for the issue body's mandated case `"output X.md brainstorm rounds 3 Add dark mode" → 0`.

## Files (3)
- `skills/draft-plan/SKILL.md` — first-token check + Detection-prose update + version → `2026.06.01+b24bc5`
- `.claude/skills/draft-plan/SKILL.md` — mirror
- `tests/test-draft-plan-args-smoke.sh` — flipped 153-154 from `1`→`0`, updated descriptions, added 6 new cases (2 positives + 4 negatives covering "auto brainstorm" + issue-body examples)

## Test plan
- [x] `bash tests/run-all.sh` — 6831/6831 passed.
- [x] `test-draft-plan-args-smoke.sh` 34/34 including all flipped + new anchor cases.

## Commits
$(cd /tmp/zskills-do-914-draftplan-brainstorm-anchor && git log origin/main..HEAD --format='%h %s' | head -3)
