### PR TITLE
do: sync docs — brainstorm + quiz modes + drift

### DIFF
--- a/PRESENTATION.html
+++ b/PRESENTATION.html
@@ -303,7 +303,7 @@
         </div>
         <div class="skill-mini" style="border-color: var(--accent);">
           <h5><code>/draft-plan</code></h5>
-          <p>Adversarial plan drafting. Multiple agents research, draft, review, play devil's advocate, refine over up to 3 rounds. Scope check escalates to <code>/research-and-plan</code> when the task is too big.</p>
+          <p>Adversarial plan drafting. Multiple agents research, draft, review, play devil's advocate, refine over up to 3 rounds. Scope check escalates to <code>/research-and-plan</code> when the task is too big. Optional <code>brainstorm</code> flag runs an interactive design dialogue first; optional <code>quiz</code> flag runs an interactive requirements interview first.</p>
         </div>
         <div class="skill-mini" style="border-color: var(--accent);">
           <h5><code>/refine-plan</code></h5>

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ by other skills — see Helpers below.
 | Skill | Purpose |
 |-------|---------|
 | `/research-and-plan` | Decompose broad goals into focused sub-plans with dependency ordering |
-| `/draft-plan` | Adversarial plan drafting: research, draft, devil's advocate review, refine until converged |
+| `/draft-plan` | Adversarial plan drafting: research, draft, devil's advocate review, refine until converged. Optional `brainstorm` flag runs an interactive design dialogue first; optional `quiz` flag runs an interactive requirements interview first |
 | `/refine-plan` | Refine in-progress plans: review remaining phases against completed work, generate Drift Log |
 | `/draft-tests` | Append a `### Tests` subsection to each pending phase of an existing plan via a senior-QE reviewer + devil's-advocate + refiner loop |
 | `/plans` | Plan dashboard: index, status tracking, priority ranking |

--- a/docs/guides/WORKFLOWS.md
+++ b/docs/guides/WORKFLOWS.md
@@ -44,7 +44,9 @@ once CI is green.
 
 - `/draft-plan` researches the goal and runs iterative adversarial review,
   emitting a plan file under `docs/plans/`. This catches design flaws before
-  they cost you commits.
+  they cost you commits. Add `brainstorm` for an interactive design dialogue
+  before research, or `quiz` for an interactive requirements interview that
+  elicits intent and scope before research.
 - `/run-plan` executes that plan. `finish` runs **all** phases (not just the
   next one) and `auto` lets it land each phase autonomously, so you can walk
   away. Drop `finish auto` to step through one phase at a time.
@@ -63,6 +65,9 @@ once CI is green.
   its phases, so each phase ships with its tests defined rather than improvised.
 - `/run-plan` then executes phases whose acceptance criteria already include
   those tests.
+- For an even more grounded plan, pre-seed `/draft-plan` with `brainstorm`
+  (design dialogue) or `quiz` (requirements interview) before `/draft-tests`
+  appends test specs.
 
 ## 3. Big goal decomposition
 

--- a/docs/skills/cleanup-merged.md
+++ b/docs/skills/cleanup-merged.md
@@ -1,6 +1,6 @@
 # /cleanup-merged
 
-> Post-PR-merge local normalization: fetch-and-prune origin, switch off merged feature branches, pull main, and delete local branches whose upstream is gone or whose PR has merged. Preview by default.
+> Post-PR-merge local normalization: fetch-and-prune origin, switch off merged feature branches, pull main, and delete local branches whose upstream is gone, whose PR has merged, or whose tip is fully contained in main (0 commits ahead). Preview by default.
 
 ## Usage
 

--- a/docs/skills/draft-plan.md
+++ b/docs/skills/draft-plan.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-/draft-plan [output FILE] [rounds N] [auto] <description...>
+/draft-plan [output FILE] [rounds N] [auto] [brainstorm] [quiz] <description...>
 ```
 
 ## Arguments
@@ -13,9 +13,15 @@
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `description` | Yes | What the plan should accomplish, in natural language |
-| `output FILE` | No | Output path for the plan file (default: auto-derived from description) |
+| `output FILE` | No | Output path for the plan file (default: auto-derived from description). May appear as `output <path>` or as a bare leading `*.md` token |
 | `rounds N` | No | Maximum adversarial review rounds (default: 3) |
-| `auto` | No | After the Phase 6 worktree commit, dispatch `/land-pr` to push the branch, open a PR, monitor CI, and auto-merge. Without `auto`, the plan is committed in the worktree and the caller lands manually. |
+| `auto` | No | After the Phase 6 worktree commit, dispatch `/land-pr` to push the branch, open a PR, monitor CI, and auto-merge. Without `auto`, the plan is committed in the worktree and the caller lands manually. Whitespace-anchored, case-insensitive, match-anywhere in `$ARGUMENTS`. |
+| `brainstorm` | No | Before Phase 1, load `references/brainstorm.md` and run an 8-step interactive design dialogue that captures decisions/rationale/open questions into a durable `/tmp` notes file, then feeds the notes into the research fan-out. Whitespace-anchored, case-insensitive, match-anywhere -- but anchored so it does **not** match `brainstorming` / `brainstormed` / `brainstorms`. |
+| `quiz` | No | Before Phase 1, load `references/quiz.md` and run an interactive Socratic requirements interview that elicits intent, scope, and priorities through conversation, persisting state to a durable `/tmp` file and seeding the deferred research fan-out with the captured requirements. **Leading-flag only** -- recognized only when it appears in the flag cluster before the description begins (like `output` / `rounds`), **not** match-anywhere like `auto` / `brainstorm`. A `quiz` inside the description text is description, not the flag. |
+
+> `brainstorm` and `quiz` are progressive-disclosure references: their bodies are
+> conditionally loaded only when the corresponding flag is set, keeping the base
+> SKILL.md lean for the common case.
 
 ## Examples
 
@@ -24,17 +30,52 @@
 /draft-plan output plans/DARK_MODE.md Add dark mode support
 /draft-plan rounds 5 Redesign the solver architecture
 /draft-plan auto Implement undo/redo for the block editor
+/draft-plan brainstorm Add a settings panel             # interactive design dialogue first
+/draft-plan quiz Add dark mode support                   # interactive requirements interview first
+/draft-plan output p.md quiz rounds 5 Add dark mode      # quiz in the leading flag cluster, any order
+/draft-plan output p.md build a quiz app                 # QUIZ_FLAG NOT set -- "quiz" is description
+/draft-plan add dark mode quiz                           # QUIZ_FLAG NOT set -- trailing quiz is description
 ```
 
 > `auto` mirrors the same token in `/run-plan`, `/do`, `/fix-issues`, and
 > `/quickfix`: it triggers the post-commit `/land-pr` auto-merge dispatch. It
-> does **not** skip the planning review rounds.
+> does **not** skip the planning review rounds or the brainstorm/quiz dialogue.
+
+## Brainstorm mode (`brainstorm`)
+
+Loads [`references/brainstorm.md`](https://github.com/zeroskills/zskills/blob/main/skills/draft-plan/references/brainstorm.md) and runs an 8-step interactive dialogue **before Phase 1**:
+
+1. Restate the seed idea in 1-2 sentences.
+2. Optionally offer a visual companion (live HTML demo or `playwright-cli` screenshot) when the idea is visual.
+3. Ask clarifying questions one at a time -- most fundamental first.
+4. Propose 2-3 approaches with trade-offs and an explicit recommendation at each fork.
+5. Apply ruthless YAGNI and gentle pushback.
+6. Capture decisions, rationale, and rejected alternatives into `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` as they're made.
+7. Offer the transition checkpoint when open questions are exhausted.
+8. On affirmative confirm, flip the notes file status to `ready` and hand off to Phase 1.
+
+The notes file is a **resumable state machine** -- if compaction interrupts the dialogue, re-entry resumes from `status: in-progress` rather than restarting. The Phase 1 research agents are then seeded with the literal notes-file path as the primary design seed; the Codebase/Patterns/Prior-art agents still run to ground the design against the repo. Demo HTML lives under `/tmp/draft-plan-demo-$TRACKING_ID/` on an OS-assigned ephemeral port, never inside the worktree.
+
+## Quiz mode (`quiz`)
+
+Loads [`references/quiz.md`](https://github.com/zeroskills/zskills/blob/main/skills/draft-plan/references/quiz.md) and runs an interactive **requirements interview** before any research:
+
+- **No research during the interview** -- conversation runs against the agent's existing knowledge. Codebase uncertainties are deferred to the post-interview fan-out as open questions, never interrogated out of the user.
+- **Ask vs defer rule:** ask the *user* about intent, scope, priorities, preferences, and success criteria; defer any *codebase fact* the agent is unsure of to the fan-out's open-questions list.
+- **Running understanding summary** is restated every turn (goal / in-scope / out-of-scope / confirmed assumptions / open) so the user can correct drift in one reply.
+- **Persistence + recovery-read:** state is written to `/tmp/draft-plan-quiz-$TRACKING_ID.md` after every answer, and re-read on resume after compaction before issuing the next question.
+- **Termination contract:** the agent proposes readiness each round; it terminates only on an explicit, normalized, whole-message go-word (`draft` / `go` / `ready` / `proceed`). A go-word embedded in a steering sentence does **not** exit. Bare affirmations count only when they directly answer a just-posed readiness offer.
+- **On exit,** the Phase 1 research fan-out runs unchanged but seeded with the durable interview file as priors, and the deferred open questions are handed to the Codebase/Prior-art agents to resolve. Phase 6 finalize adds a "Requirements captured via quiz" subsection to the plan's `## Plan Quality` section -- a distillation, not a raw transcript.
+
+`quiz` is deliberately leading-flag-only (unlike `auto` and `brainstorm`) so that a description like "build a quiz app" or an autonomously-dispatched call from `/research-and-plan` cannot accidentally hang on an interactive prompt with no human to answer.
 
 ## Common Patterns
 
 - **Standard plan drafting:** `/draft-plan Implement physics simulation blocks` -- research, draft, review cycles until convergence
 - **Custom output:** `/draft-plan output plans/PHYSICS_BLOCKS.md Implement physics simulation blocks`
-- **More review rounds:** `/draft-plan rounds 5 Redesign the state machine` -- allow up to 5 adversarial review rounds
+- **More review rounds:** `/draft-plan rounds 5 Redesign the state machine`
+- **Interactive design exploration:** `/draft-plan brainstorm <idea>` -- pre-Phase-1 dialogue with optional visual demo
+- **Interactive requirements elicitation:** `/draft-plan quiz <idea>` -- pre-research Socratic interview, then seeded fan-out
 - **Autonomous (from /research-and-go):** `/draft-plan auto <description>` -- skip confirmation checkpoints
 
 ## Tips & Gotchas
@@ -45,3 +86,5 @@
 - Completed phases from a prior `/run-plan` execution are never modified during refinement
 - If the goal is broad enough to decompose into multiple sub-plans, consider `/research-and-plan` instead
 - Reserve `/draft-plan` for skills/workflows with non-trivial design surface (integration points, multiple commands, hook interactions) -- thin prompt changes don't need adversarial review
+- `brainstorm` and `quiz` are not mutually exclusive at the parser level, but they target different gaps -- `brainstorm` for "design surface is fuzzy and I want a co-design conversation"; `quiz` for "I know roughly what I want but the agent needs to extract precise requirements." Pick the one that matches the bottleneck; using both at once is unusual.
+- `quiz` is leading-only by design -- to enable it you must lead with the flag (`/draft-plan quiz <description>`), not append it (`/draft-plan <description> quiz`)

--- a/docs/skills/update-zskills.md
+++ b/docs/skills/update-zskills.md
@@ -5,7 +5,8 @@
 ## Usage
 
 ```
-/update-zskills [install | --rerender | --migrate-paths] [cherry-pick | locked-main-pr | direct]
+/update-zskills [install | --rerender | --migrate-paths | --switch-install-path={to-plugin|to-update-zskills}]
+                [cherry-pick | locked-main-pr | direct]
                 [--with-addons | --with-block-diagram-addons]
 ```
 
@@ -16,6 +17,7 @@
 | `install` | No | Force a full first-time setup (skip detection step) |
 | `--rerender` | No | Regenerate `.claude/rules/zskills/managed.md` from current config |
 | `--migrate-paths` | No | One-shot relocation of legacy artifacts into path-config layout |
+| `--switch-install-path={to-plugin\|to-update-zskills}` | No | Switch between the two install lanes — `to-plugin` migrates a legacy `/update-zskills`-installed project to the plugin lane, `to-update-zskills` moves the other way |
 | `cherry-pick` | No | Landing mode: cherry-pick changes |
 | `locked-main-pr` | No | Landing mode: PR when main is protected |
 | `direct` | No | Landing mode: direct to main |
@@ -39,6 +41,10 @@ Regenerate `.claude/rules/zskills/managed.md` against the current config. Simple
 ### `--migrate-paths`
 
 One-shot deterministic relocation of legacy artifacts into the path-config layout (`docs/plans/` for plan files, `.zskills/audit/` for reports, `docs/issues/` for issue trackers). Idempotent -- refuses to re-run if the migration manifest already exists.
+
+### `--switch-install-path={to-plugin|to-update-zskills}`
+
+Switch between the two install lanes. `--switch-install-path=to-plugin` migrates a project from the legacy `/update-zskills`-installed layout to the plugin lane (`.claude-plugin/`); `--switch-install-path=to-update-zskills` moves a plugin-installed project back to the `/update-zskills` lane. Used when a project wants to change how it consumes zskills without losing its config or trackers.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Third doc-sync pass after PRs #786 (initial sync, block-diagram subfolder,
WORKFLOWS.md) and #821 (`/migrate-crons` removal). Brings user-facing docs
back into agreement with current `SKILL.md` sources after the
plugin-distribution and quiz-mode landings.

## What changed (6 files)

- **`docs/skills/draft-plan.md` — full rewrite** documenting both modes
  that have landed since the prior sync:
  - **`brainstorm` (PR #891)** — match-anywhere positional token; loads
    `references/brainstorm.md` for an 8-step interactive design dialogue
    before Phase 1, captures decisions/rationale/open-questions to a
    durable `/tmp` notes file, seeds Phase 1 research with the notes.
  - **`quiz` (PR #922)** — leading-flag-only positional token (NOT
    match-anywhere); loads `references/quiz.md` for an interactive
    Socratic requirements interview that elicits intent/scope/priorities
    through conversation before any research, with persistence/recovery,
    explicit go-word termination, and post-interview seeded fan-out.
- **`docs/skills/update-zskills.md`** — added missing
  `--switch-install-path=` flag (was in source argument-hint but not the
  doc).
- **`docs/skills/cleanup-merged.md`** — blurb updated to reflect the
  "0 commits ahead" branch sweep widening.
- **`docs/guides/WORKFLOWS.md`** — recipes 1 + 2 mention `brainstorm`
  and `quiz` as pre-Phase-1 options on `/draft-plan`.
- **`README.md`** — `/draft-plan` row in the Plan catalog nods to
  brainstorm + quiz.
- **`PRESENTATION.html`** — `/draft-plan` card text updated (no
  structural HTML changes).

## Scope discipline

- **Doc-layer only.** Canonical skill counts (25 core / 23 user-facing /
  3 add-ons) preserved across CLAUDE.md, README, PRESENTATION,
  docs/skills/README, block-diagram/README, update-zskills SKILL.md, and
  `tests/test-skill-version-delta.sh`.
- **No source `skills/*/SKILL.md` edits** in this PR. One source-side
  drift item was surfaced but deferred per scope rule:
  `skills/research-and-plan/SKILL.md` argument-hint omits `auto` even
  though the body documents the token; will be filed/handled separately.
- **No structural PRESENTATION.html changes** — text-only edits in
  existing card markup.
- Audit of the remaining 23 user-facing docs + 3 addon docs against
  their current `SKILL.md` sources surfaced no other concrete drift.

## Test plan

- [x] `bash tests/run-all.sh` — **6827/6827 passed, 0 failed** locally
- [x] `git diff HEAD~1..HEAD --stat`: 6 files, +64/−10 — scope clean,
      no source SKILL.md / `.claude/skills/` mirror / count edits
- [x] `docs/skills/draft-plan.md` re-verified against current
      `skills/draft-plan/SKILL.md` + both `references/{brainstorm,quiz}.md`
- [ ] `PRESENTATION.html` blurb-only edit not browser-rendered — single
      text change inside existing card; structurally safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
