### PR TITLE
fix(work-on-plans,dashboard): dual-lane sanitize-pipeline-id.sh (#913, sibling of #868)

### DIFF
--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   manages the queue (add/rank/remove/default) and recurring schedules.
   Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.06.01+af83cd"
+  version: "2026.06.01+7a11d3"
 ---
 
 # /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor
@@ -163,8 +163,9 @@ ZSKILLS_PATHS_ROOT="$MAIN_ROOT" \
     source "$MAIN_ROOT/.claude/skills/update-zskills/scripts/zskills-paths.sh"
   fi
 export ZSKILLS_PLANS_DIR ZSKILLS_ISSUES_DIR ZSKILLS_AUDIT_DIR
-SANITIZE="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
-[ ! -x "$SANITIZE" ] && SANITIZE="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+SANITIZE="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh"
+[ -x "$SANITIZE" ] || SANITIZE="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+[ -x "$SANITIZE" ] || SANITIZE="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
 mkdir -p "$MAIN_ROOT/.zskills/tracking" "$MAIN_ROOT/.zskills" "$ZSKILLS_AUDIT_DIR"
 MONITOR_STATE="$MAIN_ROOT/.zskills/monitor-state.json"
 MONITOR_LOCK="$MAIN_ROOT/.zskills/monitor-state.json.lock"

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+ddf615"
+  version: "2026.06.01+300230"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -85,13 +85,21 @@ fi
 PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
 LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
 PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
-PORT_SCRIPT="$MAIN_ROOT/.claude/skills/update-zskills/scripts/port.sh"
-SANITIZE_SCRIPT="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
-
-# Source-tree fallback (zskills repo + tests). In normal installed use the
-# .claude/skills/... paths are canonical.
-[ -x "$PORT_SCRIPT" ] || PORT_SCRIPT="$MAIN_ROOT/skills/update-zskills/scripts/port.sh"
-[ -x "$SANITIZE_SCRIPT" ] || SANITIZE_SCRIPT="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+# Dual-lane resolution: plugin install (${CLAUDE_PLUGIN_ROOT}) first, then
+# .claude/skills/... mirror (legacy /update-zskills install lane), then
+# source-tree fallback (zskills repo + tests).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/port.sh" ]; then
+  PORT_SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/port.sh"
+else
+  PORT_SCRIPT="$MAIN_ROOT/.claude/skills/update-zskills/scripts/port.sh"
+  [ -x "$PORT_SCRIPT" ] || PORT_SCRIPT="$MAIN_ROOT/skills/update-zskills/scripts/port.sh"
+fi
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/skills/create-worktree/scripts/sanitize-pipeline-id.sh" ]; then
+  SANITIZE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+else
+  SANITIZE_SCRIPT="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+  [ -x "$SANITIZE_SCRIPT" ] || SANITIZE_SCRIPT="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+fi
 
 # Server's own scripts dir is in-skill — no install/source split.
 mkdir -p "$MAIN_ROOT/.zskills"

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   manages the queue (add/rank/remove/default) and recurring schedules.
   Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.06.01+af83cd"
+  version: "2026.06.01+7a11d3"
 ---
 
 # /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor
@@ -163,8 +163,9 @@ ZSKILLS_PATHS_ROOT="$MAIN_ROOT" \
     source "$MAIN_ROOT/.claude/skills/update-zskills/scripts/zskills-paths.sh"
   fi
 export ZSKILLS_PLANS_DIR ZSKILLS_ISSUES_DIR ZSKILLS_AUDIT_DIR
-SANITIZE="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
-[ ! -x "$SANITIZE" ] && SANITIZE="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+SANITIZE="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh"
+[ -x "$SANITIZE" ] || SANITIZE="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+[ -x "$SANITIZE" ] || SANITIZE="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
 mkdir -p "$MAIN_ROOT/.zskills/tracking" "$MAIN_ROOT/.zskills" "$ZSKILLS_AUDIT_DIR"
 MONITOR_STATE="$MAIN_ROOT/.zskills/monitor-state.json"
 MONITOR_LOCK="$MAIN_ROOT/.zskills/monitor-state.json.lock"

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+ddf615"
+  version: "2026.06.01+300230"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -85,13 +85,21 @@ fi
 PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
 LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
 PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
-PORT_SCRIPT="$MAIN_ROOT/.claude/skills/update-zskills/scripts/port.sh"
-SANITIZE_SCRIPT="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
-
-# Source-tree fallback (zskills repo + tests). In normal installed use the
-# .claude/skills/... paths are canonical.
-[ -x "$PORT_SCRIPT" ] || PORT_SCRIPT="$MAIN_ROOT/skills/update-zskills/scripts/port.sh"
-[ -x "$SANITIZE_SCRIPT" ] || SANITIZE_SCRIPT="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+# Dual-lane resolution: plugin install (${CLAUDE_PLUGIN_ROOT}) first, then
+# .claude/skills/... mirror (legacy /update-zskills install lane), then
+# source-tree fallback (zskills repo + tests).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/port.sh" ]; then
+  PORT_SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/port.sh"
+else
+  PORT_SCRIPT="$MAIN_ROOT/.claude/skills/update-zskills/scripts/port.sh"
+  [ -x "$PORT_SCRIPT" ] || PORT_SCRIPT="$MAIN_ROOT/skills/update-zskills/scripts/port.sh"
+fi
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/skills/create-worktree/scripts/sanitize-pipeline-id.sh" ]; then
+  SANITIZE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+else
+  SANITIZE_SCRIPT="$MAIN_ROOT/.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+  [ -x "$SANITIZE_SCRIPT" ] || SANITIZE_SCRIPT="$MAIN_ROOT/skills/create-worktree/scripts/sanitize-pipeline-id.sh"
+fi
 
 # Server's own scripts dir is in-skill — no install/source split.
 mkdir -p "$MAIN_ROOT/.zskills"


### PR DESCRIPTION
## Summary

Sibling miss of just-closed #868. PR #897 migrated `/quickfix`'s `sanitize-pipeline-id.sh` resolution to dual-lane; two sites with the exact same pattern were missed at `skills/work-on-plans/SKILL.md:120-121` and `skills/zskills-dashboard/SKILL.md:89,94`. Both crashed hard under plugin lane (no `${CLAUDE_PLUGIN_ROOT}` branch + post-#879 empty-PIPELINE_ID guard fails loud).

Closes #913

## Fix
- `skills/work-on-plans/SKILL.md` — used `$ZSKILLS_SKILLS_ROOT` (already exported via `zskills-paths.sh` source on the preceding lines, matching the post-#868 idiom)
- `skills/zskills-dashboard/SKILL.md` — used explicit `if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] ...` dual-lane shape because `ZSKILLS_SKILLS_ROOT` isn't in scope yet at Step 0 line 88 (the resolver source happens later, ~L174). Also migrated **PORT_SCRIPT** at the adjacent lines per the issue body's authorized scope expansion.

## Files (4)
- `skills/work-on-plans/SKILL.md` — `SANITIZE` migration; version → `2026.06.01+7a11d3`
- `skills/zskills-dashboard/SKILL.md` — `SANITIZE_SCRIPT` + `PORT_SCRIPT` migration; version → `2026.06.01+300230`
- 2 byte-identical mirrors under `.claude/skills/`

## Test plan
- [x] `bash tests/run-all.sh` — 6826/6826 passed.
- [x] PORT_SCRIPT migrated per issue body authorization.

## Commits
$(cd /tmp/zskills-do-913-sanitize-dual-lane-sibling && git log origin/main..HEAD --format='%h %s' | head -3)
