### PR TITLE
fix(#912): tag stale plan-claims and unlock dashboard card for recovery

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+300230"
+  version: "2026.06.01+992395"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1826,6 +1826,9 @@ def _annotate_plans_queue(
                 "age_seconds":    c.get("age_seconds"),
                 "pipeline_short": c.get("pipeline_short"),
                 "dispatch_mode":  c.get("dispatch_mode"),
+                # stale (#912): drives the client's in-UI release
+                # affordance for dead-pipeline claims.
+                "stale":          bool(c.get("stale")),
             }
 
 
@@ -2312,6 +2315,18 @@ def _resolve_effective_skip_reason(
 _CLAIM_DIR_RE = re.compile(r"^issue-(\d+)$")
 _PLAN_CLAIM_DIR_RE = re.compile(r"^plan-(.+)$")
 
+# Staleness threshold for plan claims (#912). A `/run-plan` pipeline that
+# died mid-flight (kill -9, OOM, container restart) leaves claim.json on
+# disk indefinitely, which the dashboard renders as a permanently
+# claim-locked card with no in-UI recovery. A claim older than this is
+# tagged `stale: true` so the renderer can offer a release affordance
+# (it is NOT filtered out — the card must still render so the user sees
+# and can dismiss it). 6h is comfortably longer than any healthy phase or
+# inter-phase idle gap. Fail toward NOT stale: a claim whose age cannot be
+# computed (missing/malformed started_at) is never tagged stale, so a live
+# claim is never wrongly offered for release.
+PLAN_CLAIM_STALE_SECONDS = 21600  # 6h
+
 
 def _derive_pipeline_short(pipeline_id: str, maxlen: int = 28) -> str:
     """Derive a short, human-meaningful label from a pipeline id.
@@ -2442,7 +2457,16 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
 
     Returns `{slug: claim_dict}` keyed by string slug. Each dict carries:
         pipeline_id, started_at, current_phase, age_seconds,
-        pipeline_short, dispatch_mode
+        pipeline_short, dispatch_mode, stale
+
+    `stale` (#912) is `True` when `age_seconds` exceeds
+    `PLAN_CLAIM_STALE_SECONDS` (6h) — the signal that the owning pipeline
+    almost certainly died mid-flight and left an orphaned claim. The
+    renderer uses it to offer an in-UI release affordance instead of the
+    hard claim-lock. It is computed fail-toward-not-stale: if `age_seconds`
+    is `None` (missing/malformed/unparseable `started_at`, or the
+    null-metadata sweep-race entry) the claim is NEVER marked stale, so a
+    live claim is never wrongly surfaced as releasable.
 
     Tolerant: malformed JSON emits a single stderr line and skips that
     claim. A claim directory present without `claim.json` surfaces a
@@ -2495,6 +2519,9 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
                 "age_seconds": None,
                 "pipeline_short": None,
                 "dispatch_mode": None,
+                # Null-metadata sweep-race entry has no age → fail toward
+                # not-stale (#912).
+                "stale": False,
             }
             continue
         try:
@@ -2540,6 +2567,12 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_short: Optional[str] = None
         if isinstance(pipeline_id, str) and pipeline_id:
             pipeline_short = _derive_pipeline_short(pipeline_id)
+        # Staleness (#912): fail toward NOT stale — only a successfully
+        # computed age that exceeds the threshold marks the claim stale.
+        # A None age (missing/malformed/unparseable started_at) leaves a
+        # live claim hard-locked rather than wrongly offering it for
+        # release.
+        stale = isinstance(age_seconds, (int, float)) and age_seconds > PLAN_CLAIM_STALE_SECONDS
         out[slug] = {
             "pipeline_id": pipeline_id if isinstance(pipeline_id, str) else None,
             "started_at": started_at if isinstance(started_at, str) else None,
@@ -2547,6 +2580,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
             "age_seconds": age_seconds,
             "pipeline_short": pipeline_short,
             "dispatch_mode": dispatch_mode,
+            "stale": bool(stale),
         }
     return out
 

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -453,6 +453,18 @@ code, pre, .mono {
   vertical-align: middle;
 }
 
+/* Issue #912 — stale claim chip. A /run-plan pipeline that died mid-flight
+   leaves an orphaned claim.json; collect.py tags it stale (age >6h). The
+   card is NOT hard-locked (the X is re-enabled so the user can clear it);
+   the chip recolours from the live green to a muted amber to read as
+   "dead, recoverable" rather than "actively working". */
+.claim-chip--stale {
+  background: rgba(210, 153, 34, 0.14);
+  border-color: var(--yellow, #d29922);
+  color: var(--yellow, #d29922);
+  cursor: help;
+}
+
 /* Closure-reason chip (#687) — muted pill for "not planned" / "closed"
    on Completed-column issue cards. Matches claim-chip--in-flight's pill
    aesthetic but uses neutral grey to read as informational, not active. */

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1068,11 +1068,29 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   // `plan && plan.claim`. When set we (1) drop draggable + add a
   // claim-lock tooltip naming the in-flight pipeline short id, and
   // (2) render the X disabled + dimmed with the same tooltip (below).
-  const isClaimLocked = !!(plan && plan.claim);
+  // Issue #912 — stale-claim recovery. A claim whose owning /run-plan
+  // pipeline died mid-flight (kill -9, OOM, crash) leaves claim.json on
+  // disk indefinitely. collect.py tags such claims `stale: true` (age >
+  // 6h). A stale claim must NOT hard-lock the card: the user needs an
+  // in-UI path to dismiss the dead card from their queue (the X they'd
+  // click is itself disabled by the lock — a UI trap with zero recovery).
+  // So `isClaimLocked` excludes stale claims: a stale claim leaves the
+  // card draggable + the X enabled (its existing `plan-discard` action
+  // fires, moving the card to Discarded). A non-stale (live) claim keeps
+  // the #884/#904 hard-lock unchanged. The on-disk claim.json persists
+  // until shell cleanup — the dashboard is read-only collectors + thin JS
+  // with no server endpoint to delete claim files (same constraint as
+  // #884) — but the card leaves the user's active queue immediately.
+  const isClaimStale = !!(plan && plan.claim && plan.claim.stale);
+  const isClaimLocked = !!(plan && plan.claim) && !isClaimStale;
   const claimLockPidShort =
-    isClaimLocked ? ((plan.claim.pipeline_short) || "?") : null;
+    (plan && plan.claim) ? ((plan.claim.pipeline_short) || "?") : null;
   const claimLockTip = isClaimLocked
     ? "Locked while plan is being worked (pipeline " + claimLockPidShort + ")."
+    : null;
+  const claimStaleTip = isClaimStale
+    ? "Pipeline appears dead (claim >6h old, pipeline " + claimLockPidShort +
+      ") — click to release."
     : null;
   const card = el("li", { cls: "card", attrs: cardAttrs });
   const head = el("div", { cls: "card-row" });
@@ -1155,28 +1173,47 @@ function buildPlanCard(plan, slug, col, defaultMode) {
       const m = cp.match(/Phase\s+(\d+)/i);
       phaseFragment = m ? "working on phase " + m[1] : "working on " + cp;
     }
-    const tip = c.pipeline_id
-      ? "claim pipeline=" + c.pipeline_id +
-        " started=" + (c.started_at || "?") +
-        " current_phase=" + (c.current_phase || "?")
-      : "claim metadata pending";
+    // Issue #912 — stale claims read as "stale (dead pipeline)" rather
+    // than the live "working on phase N" framing, and carry the release
+    // hint as their chip tooltip.
+    const tip = isClaimStale
+      ? claimStaleTip
+      : (c.pipeline_id
+        ? "claim pipeline=" + c.pipeline_id +
+          " started=" + (c.started_at || "?") +
+          " current_phase=" + (c.current_phase || "?")
+        : "claim metadata pending");
+    const chipText = isClaimStale
+      ? "stale (dead pipeline) · " + pidShort + " · " + ageStr
+      : phaseFragment + " · " + pidShort + " · " + ageStr;
     const row = el("div", { cls: "card-sub" });
     row.appendChild(el("span", {
-      cls: "claim-chip claim-chip--in-flight",
+      cls: "claim-chip claim-chip--in-flight" +
+        (isClaimStale ? " claim-chip--stale" : ""),
       attrs: { title: tip },
-      text: phaseFragment + " · " + pidShort + " · " + ageStr,
+      text: chipText,
     }));
     card.appendChild(row);
-    card.setAttribute("aria-disabled", "true");
-    card.removeAttribute("draggable");
-    // Issue #884 — gate (a): the card is already non-draggable (no
-    // draggable attr → onDragStart's `li.card[draggable='true']` match
-    // fails, so no drag starts and no recolumn drop is possible). Add the
-    // claim-lock affordance: a `claim-locked` class for CSS pointer-event
-    // suppression on the drag surface + a tooltip naming the in-flight
-    // pipeline short id (same string used on the disabled X below).
-    card.className = (card.className ? card.className + " " : "") + "claim-locked";
-    if (claimLockTip) card.setAttribute("title", claimLockTip);
+    if (isClaimStale) {
+      // Issue #912 — a stale claim's owning pipeline is dead. Do NOT
+      // hard-lock: leave the card draggable and aria-enabled so the
+      // runtime handleAction guard (which keys on aria-disabled="true")
+      // passes through to the existing plan-discard / move actions,
+      // giving the user a path to clear the dead card. No claim-locked
+      // class, no aria-disabled, no draggable removal.
+      if (claimStaleTip) card.setAttribute("title", claimStaleTip);
+    } else {
+      card.setAttribute("aria-disabled", "true");
+      card.removeAttribute("draggable");
+      // Issue #884 — gate (a): the card is already non-draggable (no
+      // draggable attr → onDragStart's `li.card[draggable='true']` match
+      // fails, so no drag starts and no recolumn drop is possible). Add the
+      // claim-lock affordance: a `claim-locked` class for CSS pointer-event
+      // suppression on the drag surface + a tooltip naming the in-flight
+      // pipeline short id (same string used on the disabled X below).
+      card.className = (card.className ? card.className + " " : "") + "claim-locked";
+      if (claimLockTip) card.setAttribute("title", claimLockTip);
+    }
   }
 
   // Per-row mode chip on Ready cards (issue #814 + follow-up).

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+300230"
+  version: "2026.06.01+992395"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1826,6 +1826,9 @@ def _annotate_plans_queue(
                 "age_seconds":    c.get("age_seconds"),
                 "pipeline_short": c.get("pipeline_short"),
                 "dispatch_mode":  c.get("dispatch_mode"),
+                # stale (#912): drives the client's in-UI release
+                # affordance for dead-pipeline claims.
+                "stale":          bool(c.get("stale")),
             }
 
 
@@ -2312,6 +2315,18 @@ def _resolve_effective_skip_reason(
 _CLAIM_DIR_RE = re.compile(r"^issue-(\d+)$")
 _PLAN_CLAIM_DIR_RE = re.compile(r"^plan-(.+)$")
 
+# Staleness threshold for plan claims (#912). A `/run-plan` pipeline that
+# died mid-flight (kill -9, OOM, container restart) leaves claim.json on
+# disk indefinitely, which the dashboard renders as a permanently
+# claim-locked card with no in-UI recovery. A claim older than this is
+# tagged `stale: true` so the renderer can offer a release affordance
+# (it is NOT filtered out — the card must still render so the user sees
+# and can dismiss it). 6h is comfortably longer than any healthy phase or
+# inter-phase idle gap. Fail toward NOT stale: a claim whose age cannot be
+# computed (missing/malformed started_at) is never tagged stale, so a live
+# claim is never wrongly offered for release.
+PLAN_CLAIM_STALE_SECONDS = 21600  # 6h
+
 
 def _derive_pipeline_short(pipeline_id: str, maxlen: int = 28) -> str:
     """Derive a short, human-meaningful label from a pipeline id.
@@ -2442,7 +2457,16 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
 
     Returns `{slug: claim_dict}` keyed by string slug. Each dict carries:
         pipeline_id, started_at, current_phase, age_seconds,
-        pipeline_short, dispatch_mode
+        pipeline_short, dispatch_mode, stale
+
+    `stale` (#912) is `True` when `age_seconds` exceeds
+    `PLAN_CLAIM_STALE_SECONDS` (6h) — the signal that the owning pipeline
+    almost certainly died mid-flight and left an orphaned claim. The
+    renderer uses it to offer an in-UI release affordance instead of the
+    hard claim-lock. It is computed fail-toward-not-stale: if `age_seconds`
+    is `None` (missing/malformed/unparseable `started_at`, or the
+    null-metadata sweep-race entry) the claim is NEVER marked stale, so a
+    live claim is never wrongly surfaced as releasable.
 
     Tolerant: malformed JSON emits a single stderr line and skips that
     claim. A claim directory present without `claim.json` surfaces a
@@ -2495,6 +2519,9 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
                 "age_seconds": None,
                 "pipeline_short": None,
                 "dispatch_mode": None,
+                # Null-metadata sweep-race entry has no age → fail toward
+                # not-stale (#912).
+                "stale": False,
             }
             continue
         try:
@@ -2540,6 +2567,12 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_short: Optional[str] = None
         if isinstance(pipeline_id, str) and pipeline_id:
             pipeline_short = _derive_pipeline_short(pipeline_id)
+        # Staleness (#912): fail toward NOT stale — only a successfully
+        # computed age that exceeds the threshold marks the claim stale.
+        # A None age (missing/malformed/unparseable started_at) leaves a
+        # live claim hard-locked rather than wrongly offering it for
+        # release.
+        stale = isinstance(age_seconds, (int, float)) and age_seconds > PLAN_CLAIM_STALE_SECONDS
         out[slug] = {
             "pipeline_id": pipeline_id if isinstance(pipeline_id, str) else None,
             "started_at": started_at if isinstance(started_at, str) else None,
@@ -2547,6 +2580,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
             "age_seconds": age_seconds,
             "pipeline_short": pipeline_short,
             "dispatch_mode": dispatch_mode,
+            "stale": bool(stale),
         }
     return out
 

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -453,6 +453,18 @@ code, pre, .mono {
   vertical-align: middle;
 }
 
+/* Issue #912 — stale claim chip. A /run-plan pipeline that died mid-flight
+   leaves an orphaned claim.json; collect.py tags it stale (age >6h). The
+   card is NOT hard-locked (the X is re-enabled so the user can clear it);
+   the chip recolours from the live green to a muted amber to read as
+   "dead, recoverable" rather than "actively working". */
+.claim-chip--stale {
+  background: rgba(210, 153, 34, 0.14);
+  border-color: var(--yellow, #d29922);
+  color: var(--yellow, #d29922);
+  cursor: help;
+}
+
 /* Closure-reason chip (#687) — muted pill for "not planned" / "closed"
    on Completed-column issue cards. Matches claim-chip--in-flight's pill
    aesthetic but uses neutral grey to read as informational, not active. */

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -1068,11 +1068,29 @@ function buildPlanCard(plan, slug, col, defaultMode) {
   // `plan && plan.claim`. When set we (1) drop draggable + add a
   // claim-lock tooltip naming the in-flight pipeline short id, and
   // (2) render the X disabled + dimmed with the same tooltip (below).
-  const isClaimLocked = !!(plan && plan.claim);
+  // Issue #912 — stale-claim recovery. A claim whose owning /run-plan
+  // pipeline died mid-flight (kill -9, OOM, crash) leaves claim.json on
+  // disk indefinitely. collect.py tags such claims `stale: true` (age >
+  // 6h). A stale claim must NOT hard-lock the card: the user needs an
+  // in-UI path to dismiss the dead card from their queue (the X they'd
+  // click is itself disabled by the lock — a UI trap with zero recovery).
+  // So `isClaimLocked` excludes stale claims: a stale claim leaves the
+  // card draggable + the X enabled (its existing `plan-discard` action
+  // fires, moving the card to Discarded). A non-stale (live) claim keeps
+  // the #884/#904 hard-lock unchanged. The on-disk claim.json persists
+  // until shell cleanup — the dashboard is read-only collectors + thin JS
+  // with no server endpoint to delete claim files (same constraint as
+  // #884) — but the card leaves the user's active queue immediately.
+  const isClaimStale = !!(plan && plan.claim && plan.claim.stale);
+  const isClaimLocked = !!(plan && plan.claim) && !isClaimStale;
   const claimLockPidShort =
-    isClaimLocked ? ((plan.claim.pipeline_short) || "?") : null;
+    (plan && plan.claim) ? ((plan.claim.pipeline_short) || "?") : null;
   const claimLockTip = isClaimLocked
     ? "Locked while plan is being worked (pipeline " + claimLockPidShort + ")."
+    : null;
+  const claimStaleTip = isClaimStale
+    ? "Pipeline appears dead (claim >6h old, pipeline " + claimLockPidShort +
+      ") — click to release."
     : null;
   const card = el("li", { cls: "card", attrs: cardAttrs });
   const head = el("div", { cls: "card-row" });
@@ -1155,28 +1173,47 @@ function buildPlanCard(plan, slug, col, defaultMode) {
       const m = cp.match(/Phase\s+(\d+)/i);
       phaseFragment = m ? "working on phase " + m[1] : "working on " + cp;
     }
-    const tip = c.pipeline_id
-      ? "claim pipeline=" + c.pipeline_id +
-        " started=" + (c.started_at || "?") +
-        " current_phase=" + (c.current_phase || "?")
-      : "claim metadata pending";
+    // Issue #912 — stale claims read as "stale (dead pipeline)" rather
+    // than the live "working on phase N" framing, and carry the release
+    // hint as their chip tooltip.
+    const tip = isClaimStale
+      ? claimStaleTip
+      : (c.pipeline_id
+        ? "claim pipeline=" + c.pipeline_id +
+          " started=" + (c.started_at || "?") +
+          " current_phase=" + (c.current_phase || "?")
+        : "claim metadata pending");
+    const chipText = isClaimStale
+      ? "stale (dead pipeline) · " + pidShort + " · " + ageStr
+      : phaseFragment + " · " + pidShort + " · " + ageStr;
     const row = el("div", { cls: "card-sub" });
     row.appendChild(el("span", {
-      cls: "claim-chip claim-chip--in-flight",
+      cls: "claim-chip claim-chip--in-flight" +
+        (isClaimStale ? " claim-chip--stale" : ""),
       attrs: { title: tip },
-      text: phaseFragment + " · " + pidShort + " · " + ageStr,
+      text: chipText,
     }));
     card.appendChild(row);
-    card.setAttribute("aria-disabled", "true");
-    card.removeAttribute("draggable");
-    // Issue #884 — gate (a): the card is already non-draggable (no
-    // draggable attr → onDragStart's `li.card[draggable='true']` match
-    // fails, so no drag starts and no recolumn drop is possible). Add the
-    // claim-lock affordance: a `claim-locked` class for CSS pointer-event
-    // suppression on the drag surface + a tooltip naming the in-flight
-    // pipeline short id (same string used on the disabled X below).
-    card.className = (card.className ? card.className + " " : "") + "claim-locked";
-    if (claimLockTip) card.setAttribute("title", claimLockTip);
+    if (isClaimStale) {
+      // Issue #912 — a stale claim's owning pipeline is dead. Do NOT
+      // hard-lock: leave the card draggable and aria-enabled so the
+      // runtime handleAction guard (which keys on aria-disabled="true")
+      // passes through to the existing plan-discard / move actions,
+      // giving the user a path to clear the dead card. No claim-locked
+      // class, no aria-disabled, no draggable removal.
+      if (claimStaleTip) card.setAttribute("title", claimStaleTip);
+    } else {
+      card.setAttribute("aria-disabled", "true");
+      card.removeAttribute("draggable");
+      // Issue #884 — gate (a): the card is already non-draggable (no
+      // draggable attr → onDragStart's `li.card[draggable='true']` match
+      // fails, so no drag starts and no recolumn drop is possible). Add the
+      // claim-lock affordance: a `claim-locked` class for CSS pointer-event
+      // suppression on the drag surface + a tooltip naming the in-flight
+      // pipeline short id (same string used on the disabled X below).
+      card.className = (card.className ? card.className + " " : "") + "claim-locked";
+      if (claimLockTip) card.setAttribute("title", claimLockTip);
+    }
   }
 
   // Per-row mode chip on Ready cards (issue #814 + follow-up).

--- a/tests/test-plan-claim-collector.py
+++ b/tests/test-plan-claim-collector.py
@@ -143,11 +143,13 @@ class ReadPlanClaimsTests(unittest.TestCase):
         self.assertEqual(
             set(c.keys()),
             {"pipeline_id", "started_at", "current_phase",
-             "age_seconds", "pipeline_short", "dispatch_mode"},
+             "age_seconds", "pipeline_short", "dispatch_mode", "stale"},
         )
         # dispatch_mode (#874) is on the allow-list. Absent in the
         # source claim → surfaces as None.
         self.assertIsNone(c["dispatch_mode"])
+        # stale (#912) is on the allow-list. A fresh claim → not stale.
+        self.assertFalse(c["stale"])
 
     def test_dispatch_mode_finish_persists(self) -> None:
         # #874: claim.json carrying dispatch_mode="finish" must surface
@@ -252,6 +254,101 @@ class ReadPlanClaimsTests(unittest.TestCase):
         # age_seconds=None (renderer falls back to '?').
         self.assertIsNone(out["bad-started"]["age_seconds"])
 
+    # ------------------------------------------------------------------
+    # Staleness gate (#912) — dead-pipeline claim recovery.
+    # ------------------------------------------------------------------
+
+    def test_stale_claim_tagged_when_old(self) -> None:
+        # A claim whose owning /run-plan pipeline died mid-flight leaves
+        # claim.json on disk indefinitely. age > PLAN_CLAIM_STALE_SECONDS
+        # (6h) → stale: True so the renderer offers an in-UI release path
+        # instead of the permanent hard-lock. ~24h ago is well past 6h.
+        now = datetime.now(timezone.utc)
+        old_started = now - timedelta(hours=24)
+        _write_plan_claim(self.claims, "dead-pipeline", {
+            "schema_version": 1,
+            "kind": "run-plan",
+            "slug": "dead-pipeline",
+            "pipeline_id": "run-plan.dead-pipeline",
+            "started_at": old_started.isoformat(timespec="seconds"),
+            "current_phase": "Phase 3",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        c = out["dead-pipeline"]
+        self.assertTrue(c["stale"])
+        # The card must still render (NOT filtered out) so the user can
+        # dismiss it.
+        self.assertIsNotNone(c["age_seconds"])
+        self.assertGreater(c["age_seconds"], collect.PLAN_CLAIM_STALE_SECONDS)
+
+    def test_fresh_claim_not_stale(self) -> None:
+        # A just-started claim (started_at=now) is a LIVE pipeline; it must
+        # keep the #884/#904 hard-lock (stale: False).
+        now = datetime.now(timezone.utc)
+        _write_plan_claim(self.claims, "live-pipeline", {
+            "schema_version": 1,
+            "kind": "run-plan",
+            "slug": "live-pipeline",
+            "pipeline_id": "run-plan.live-pipeline",
+            "started_at": now.isoformat(timespec="seconds"),
+            "current_phase": "Phase 1",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertFalse(out["live-pipeline"]["stale"])
+
+    def test_claim_just_under_threshold_not_stale(self) -> None:
+        # Boundary: a claim a few minutes under 6h is still live.
+        now = datetime.now(timezone.utc)
+        started = now - timedelta(
+            seconds=collect.PLAN_CLAIM_STALE_SECONDS - 300)
+        _write_plan_claim(self.claims, "near-threshold", {
+            "schema_version": 1,
+            "kind": "run-plan",
+            "slug": "near-threshold",
+            "pipeline_id": "run-plan.near-threshold",
+            "started_at": started.isoformat(timespec="seconds"),
+            "current_phase": "Phase 5",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertFalse(out["near-threshold"]["stale"])
+
+    def test_unparseable_started_at_fails_toward_not_stale(self) -> None:
+        # Fail-toward-not-stale: an unparseable started_at yields
+        # age_seconds=None, which must NOT be treated as stale — otherwise
+        # a live claim with a transiently-malformed timestamp would be
+        # wrongly offered for release.
+        _write_plan_claim(self.claims, "bad-age", {
+            "schema_version": 1,
+            "kind": "run-plan",
+            "slug": "bad-age",
+            "pipeline_id": "run-plan.bad-age",
+            "started_at": "garbage-not-iso",
+            "current_phase": "Phase 1",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertIsNone(out["bad-age"]["age_seconds"])
+        self.assertFalse(out["bad-age"]["stale"])
+
+    def test_missing_started_at_fails_toward_not_stale(self) -> None:
+        # A claim with no started_at at all → age None → not stale.
+        _write_plan_claim(self.claims, "no-started", {
+            "schema_version": 1,
+            "kind": "run-plan",
+            "slug": "no-started",
+            "pipeline_id": "run-plan.no-started",
+            "current_phase": "Phase 1",
+        })
+        out = collect._read_plan_claims(self.tmp)
+        self.assertIsNone(out["no-started"]["age_seconds"])
+        self.assertFalse(out["no-started"]["stale"])
+
+    def test_null_metadata_entry_not_stale(self) -> None:
+        # Sweep-while-flush race (dir present, claim.json absent) → null
+        # metadata entry with stale: False (no age to judge).
+        _mkdir_no_claim(self.claims, "pending")
+        out = collect._read_plan_claims(self.tmp)
+        self.assertFalse(out["pending"]["stale"])
+
 
 class AnnotatePlansQueueGatingTests(unittest.TestCase):
     """R2.6 mirror — the 2-arg fixture branch MUST NOT call _read_plan_claims."""
@@ -313,8 +410,10 @@ class AnnotatePlansQueueGatingTests(unittest.TestCase):
         self.assertEqual(
             set(c.keys()),
             {"pipeline_id", "started_at", "current_phase",
-             "age_seconds", "pipeline_short", "dispatch_mode"},
+             "age_seconds", "pipeline_short", "dispatch_mode", "stale"},
         )
+        # stale (#912) threads through onto plan["claim"] from the collector.
+        self.assertIn("stale", c)
         # Plan beta has no claim attached.
         self.assertNotIn("claim", plans[1])
 

--- a/tests/test-plan-claim-render-dom.sh
+++ b/tests/test-plan-claim-render-dom.sh
@@ -480,6 +480,92 @@ function collectText(node) {
 }
 
 // ------------------------------------------------------------------
+// T3.11.#912.a — STALE claim (claim.stale=true): card is NOT hard-locked.
+// The owning pipeline is dead (claim >6h old). The card must stay
+// draggable + aria-enabled, the X must be re-enabled with its existing
+// plan-discard action, and the chip must carry the claim-chip--stale
+// modifier + a "click to release" tooltip. This is the #912 recovery
+// affordance — the user can finally dismiss the dead card.
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "deadpipe", title: "Dead pipeline", status: "active",
+    phase_count: 5, phases_done: 2,
+    claim: {
+      pipeline_id: "run-plan.deadpipe",
+      started_at: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
+      current_phase: "Phase 3",
+      age_seconds: 24 * 3600,
+      pipeline_short: "dp-abc",
+      stale: true,
+    },
+  };
+  const card = buildPlanCard(plan, "deadpipe", "ready", "phase");
+  // Card NOT hard-locked: aria-enabled, still draggable, no claim-locked.
+  expect(card.getAttribute("aria-disabled"), null,
+    "#912: stale claim card is NOT aria-disabled (recovery enabled)");
+  expect(card.getAttribute("draggable"), "true",
+    "#912: stale claim card retains draggable='true'");
+  expectTrue(!/(^|\s)claim-locked(\s|$)/.test(card.className),
+    "#912: stale claim card has NO claim-locked class");
+  // Chip still rendered, with the stale modifier + release tooltip.
+  const chip = findByClass(card, "claim-chip");
+  expectTrue(chip, "#912: claim chip still rendered for stale claim");
+  expectTrue(chip && /claim-chip--stale/.test(chip.className),
+    "#912: stale chip carries claim-chip--stale modifier");
+  expectTrue(chip && chip.textContent.indexOf("stale") >= 0,
+    "#912: stale chip text reads as stale (dead pipeline)");
+  expectTrue(chip && /click to release/.test(chip.getAttribute("title") || ""),
+    "#912: stale chip tooltip offers 'click to release'");
+  // X is re-enabled with the existing plan-discard action.
+  const rmBtn = findByClass(card, "remove-btn");
+  expectTrue(rmBtn, "#912: X (remove-btn) rendered on stale claim card");
+  if (rmBtn) {
+    expect(rmBtn.getAttribute("disabled"), null,
+      "#912: stale claim X is ENABLED (no disabled attr)");
+    expect(rmBtn.getAttribute("aria-disabled"), null,
+      "#912: stale claim X has no aria-disabled");
+    expect(rmBtn.getAttribute("data-action"), "plan-discard",
+      "#912: stale claim X retains data-action='plan-discard' (release path)");
+    expectTrue(!/(^|\s)claim-locked(\s|$)/.test(rmBtn.className),
+      "#912: stale claim X has no claim-locked class");
+  }
+}
+
+// ------------------------------------------------------------------
+// T3.11.#912.b — FRESH claim (claim.stale=false): the #884/#904 hard-lock
+// is UNCHANGED. X disabled, card aria-disabled + claim-locked. This is the
+// regression guard ensuring the stale branch doesn't loosen live claims.
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "livepipe", title: "Live pipeline", status: "active",
+    phase_count: 5, phases_done: 2,
+    claim: {
+      pipeline_id: "run-plan.livepipe",
+      started_at: new Date(Date.now() - 60000).toISOString(),
+      current_phase: "Phase 3",
+      age_seconds: 60,
+      pipeline_short: "lv-abc",
+      stale: false,
+    },
+  };
+  const card = buildPlanCard(plan, "livepipe", "ready", "phase");
+  expect(card.getAttribute("aria-disabled"), "true",
+    "#912: fresh (non-stale) claim card stays aria-disabled (hard-locked)");
+  expectTrue(/(^|\s)claim-locked(\s|$)/.test(card.className),
+    "#912: fresh claim card retains claim-locked class");
+  const rmBtn = findByClass(card, "remove-btn");
+  expectTrue(rmBtn, "#912: X rendered on fresh claim card");
+  if (rmBtn) {
+    expect(rmBtn.getAttribute("disabled"), "disabled",
+      "#912: fresh claim X stays disabled (hard-lock unchanged)");
+    expect(rmBtn.getAttribute("data-action"), null,
+      "#912: fresh claim X has NO data-action (hard-lock unchanged)");
+  }
+}
+
+// ------------------------------------------------------------------
 // T3.11.#874.a — Ready col + claim.dispatch_mode='finish' → mode chip
 // LOCKED, regardless of entryMode/defaultMode. This is the core
 // regression gate: post wrapper-idle, the chip MUST still read locked.


### PR DESCRIPTION
## Summary
Fixes #912. A `/run-plan` plan-claim left behind by a dead pipeline (kill -9/OOM/crash) left the dashboard plan card permanently `claim-locked` (#904: not draggable, X disabled) — zero in-UI recovery, since the X to discard it was itself disabled by the held claim. `collect.py:_read_plan_claims` surfaced every `claim.json` as live with no staleness gate.

Adds a staleness gate + UI recovery:
- **Server (`collect.py`):** claims older than 6h (21600s, computed from the already-present `age_seconds`) are tagged `stale: true` — still rendered (so the user sees the card), not filtered. Fail-toward-not-stale: a missing/unparseable `started_at` (age None) is never marked stale, so a live claim is never wrongly offered for release.
- **Client (`app.js`/`app.css`):** a stale claim no longer hard-locks the card — the X (existing `plan-discard`) is re-enabled and the chip shows an amber "click to release" affordance naming the dead pipeline. A LIVE (non-stale) claim keeps the #884/#904 hard-lock byte-for-byte unchanged.

UI-discard removes the card from the active queue; the on-disk claim.json persists until shell cleanup (dashboard is read-only collectors + thin JS — same constraint as #884; no new server endpoint).

## Test plan
- [x] `bash tests/run-all.sh` — 6850/6850 passed, 0 failed (verifier-confirmed).
- [x] Collector: stale-24h tagged, fresh not, just-under-threshold not, unparseable/missing/null-metadata not stale.
- [x] DOM: stale→X-enabled+draggable+no-lock; fresh→X-disabled+locked (hard-lock unchanged).
- [x] mirror-parity + conformance pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
