### PR TITLE
fix(do,quickfix): claim parser accepts 'Fix issue #N' (#920)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+0a315a"
+  version: "2026.06.01+f85099"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -246,6 +246,13 @@ fi
 #     "Closes #832, see also #999" from accidentally claiming #999
 #     (comma is a normal prose punctuator, so bare `#N` after it would
 #     over-capture) while still accepting "Closes #832, Closes #833".
+# After the close-keyword (in any of leading/strong/weak passes), an
+# optional `issue[s]?:?` filler token is tolerated between the keyword
+# and `#N` (#920): "Fix issue #906", "fixes issues #906", "Resolves
+# issue: #906" all parse. The token MUST be adjacent to `#N` — a word
+# between `issue` and `#N` (e.g. "Fix issue ticketing for #906") breaks
+# the adjacency and no capture occurs, preserving #863's
+# strong-vs-weak separator discipline.
 # When no issue reference is in scope (the common /do case) ISSUE_NUMS
 # stays empty and the mode files claim nothing. ISSUE_NUM is kept as a
 # back-compat scalar (= ISSUE_NUMS[0] when non-empty, else empty).
@@ -253,27 +260,33 @@ fi
 # capture guarantees a bare integer.
 ISSUE_NUMS=()
 _DO_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
-# Leading anchored match (optional close-keyword, optional leading quote).
-if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+_DO_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
+# Leading anchored match (optional close-keyword, optional leading quote,
+# optional `issue[s]?:?` filler between kw and `#N`). BASH_REMATCH groups
+# (kw branch): 1=kw outer, 2=kw inner, 3=optional filler, 4=digit capture.
+if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
 elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
-# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
-# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
-# 4=digit capture.
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK; if
+# the keyword is present, the optional `issue[s]?:?` filler is also
+# permitted between the kw and `#N`. BASH_REMATCH groups: 1=outer kw+
+# filler wrapper, 2=kw outer, 3=kw inner, 4=optional filler, 5=digit
+# capture.
 _DO_REMAINING="$ARGUMENTS"
-while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
   _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
 # close-keyword before `#N` so prose like "Closes #N, see also #M" doesn't
-# over-capture #M. BASH_REMATCH groups: 1=outer separator, 2=and/or word,
-# 3=kw outer, 4=kw inner, 5=digit capture.
+# over-capture #M. Optional `issue[s]?:?` filler is allowed between kw and
+# `#N`. BASH_REMATCH groups: 1=outer separator, 2=and/or word, 3=kw outer,
+# 4=kw inner, 5=optional filler, 6=digit capture.
 _DO_REMAINING="$ARGUMENTS"
-while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[6]}")
   _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Dedupe preserving first-seen order (acquire is order-dependent for the
@@ -285,7 +298,7 @@ for _n in "${ISSUE_NUMS[@]:-}"; do
   if [ -z "${_DO_SEEN[$_n]:-}" ]; then _DO_UNIQUE+=("$_n"); _DO_SEEN[$_n]=1; fi
 done
 ISSUE_NUMS=("${_DO_UNIQUE[@]}")
-unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _n
+unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _DO_ISSUE_FILLER _n
 # Back-compat scalar (= first claimed issue, or empty when none). Mode
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.31+993373"
+  version: "2026.06.01+88285e"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -160,6 +160,13 @@ DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 #   - WEAK separators (`,`, `;`, ` and `, ` or `) — require an explicit
 #     close-keyword between the separator and `#N`. This blocks
 #     "Closes #832, see also #999" from accidentally claiming #999.
+# After the close-keyword (in any of leading/strong/weak passes), an
+# optional `issue[s]?:?` filler token is tolerated between the keyword
+# and `#N` (#920): "Fix issue #906", "fixes issues #906", "Resolves
+# issue: #906" all parse. The token MUST be adjacent to `#N` — a word
+# between `issue` and `#N` (e.g. "Fix issue ticketing for #906") breaks
+# the adjacency and no capture occurs, preserving #863's
+# strong-vs-weak separator discipline.
 # When no issue reference is in scope (the common case) ISSUE_NUMS stays
 # empty and nothing is claimed. ISSUE_NUM is kept as a back-compat
 # scalar (= ISSUE_NUMS[0] when non-empty, else empty). claim-issue.sh
@@ -167,27 +174,33 @@ DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 # a bare integer.
 ISSUE_NUMS=()
 _QF_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+_QF_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
 # Leading anchored match (no leading-quote tolerance: /quickfix runs after
 # the quoted-head carve-out has already normalized the description).
-if [[ "$DESCRIPTION" =~ ^[[:space:]]*${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+# BASH_REMATCH groups (kw branch): 1=kw outer, 2=kw inner, 3=optional
+# filler, 4=digit capture.
+if [[ "$DESCRIPTION" =~ ^[[:space:]]*${_QF_ISSUE_KW}[[:space:]]+${_QF_ISSUE_FILLER}#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
 elif [[ "$DESCRIPTION" =~ ^[[:space:]]*#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
-# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
-# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
-# 4=digit capture.
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK; if
+# the keyword is present, the optional `issue[s]?:?` filler is also
+# permitted between the kw and `#N`. BASH_REMATCH groups: 1=outer kw+
+# filler wrapper, 2=kw outer, 3=kw inner, 4=optional filler, 5=digit
+# capture.
 _QF_REMAINING="$DESCRIPTION"
-while [[ "$_QF_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_QF_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+while [[ "$_QF_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_QF_ISSUE_KW}[[:space:]]+${_QF_ISSUE_FILLER})?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
   _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
-# close-keyword before `#N`. BASH_REMATCH groups: 1=outer separator,
-# 2=and/or word, 3=kw outer, 4=kw inner, 5=digit capture.
+# close-keyword before `#N`. Optional `issue[s]?:?` filler is allowed
+# between kw and `#N`. BASH_REMATCH groups: 1=outer separator, 2=and/or
+# word, 3=kw outer, 4=kw inner, 5=optional filler, 6=digit capture.
 _QF_REMAINING="$DESCRIPTION"
-while [[ "$_QF_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+while [[ "$_QF_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_QF_ISSUE_KW}[[:space:]]+${_QF_ISSUE_FILLER}#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[6]}")
   _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Dedupe preserving first-seen order.
@@ -198,7 +211,7 @@ for _n in "${ISSUE_NUMS[@]:-}"; do
   if [ -z "${_QF_SEEN[$_n]:-}" ]; then _QF_UNIQUE+=("$_n"); _QF_SEEN[$_n]=1; fi
 done
 ISSUE_NUMS=("${_QF_UNIQUE[@]}")
-unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _n
+unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _QF_ISSUE_FILLER _n
 # Back-compat scalar (= first claimed issue, or empty when none).
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 ```

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+0a315a"
+  version: "2026.06.01+f85099"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -246,6 +246,13 @@ fi
 #     "Closes #832, see also #999" from accidentally claiming #999
 #     (comma is a normal prose punctuator, so bare `#N` after it would
 #     over-capture) while still accepting "Closes #832, Closes #833".
+# After the close-keyword (in any of leading/strong/weak passes), an
+# optional `issue[s]?:?` filler token is tolerated between the keyword
+# and `#N` (#920): "Fix issue #906", "fixes issues #906", "Resolves
+# issue: #906" all parse. The token MUST be adjacent to `#N` — a word
+# between `issue` and `#N` (e.g. "Fix issue ticketing for #906") breaks
+# the adjacency and no capture occurs, preserving #863's
+# strong-vs-weak separator discipline.
 # When no issue reference is in scope (the common /do case) ISSUE_NUMS
 # stays empty and the mode files claim nothing. ISSUE_NUM is kept as a
 # back-compat scalar (= ISSUE_NUMS[0] when non-empty, else empty).
@@ -253,27 +260,33 @@ fi
 # capture guarantees a bare integer.
 ISSUE_NUMS=()
 _DO_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
-# Leading anchored match (optional close-keyword, optional leading quote).
-if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+_DO_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
+# Leading anchored match (optional close-keyword, optional leading quote,
+# optional `issue[s]?:?` filler between kw and `#N`). BASH_REMATCH groups
+# (kw branch): 1=kw outer, 2=kw inner, 3=optional filler, 4=digit capture.
+if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
 elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
-# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
-# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
-# 4=digit capture.
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK; if
+# the keyword is present, the optional `issue[s]?:?` filler is also
+# permitted between the kw and `#N`. BASH_REMATCH groups: 1=outer kw+
+# filler wrapper, 2=kw outer, 3=kw inner, 4=optional filler, 5=digit
+# capture.
 _DO_REMAINING="$ARGUMENTS"
-while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
   _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
 # close-keyword before `#N` so prose like "Closes #N, see also #M" doesn't
-# over-capture #M. BASH_REMATCH groups: 1=outer separator, 2=and/or word,
-# 3=kw outer, 4=kw inner, 5=digit capture.
+# over-capture #M. Optional `issue[s]?:?` filler is allowed between kw and
+# `#N`. BASH_REMATCH groups: 1=outer separator, 2=and/or word, 3=kw outer,
+# 4=kw inner, 5=optional filler, 6=digit capture.
 _DO_REMAINING="$ARGUMENTS"
-while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[6]}")
   _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Dedupe preserving first-seen order (acquire is order-dependent for the
@@ -285,7 +298,7 @@ for _n in "${ISSUE_NUMS[@]:-}"; do
   if [ -z "${_DO_SEEN[$_n]:-}" ]; then _DO_UNIQUE+=("$_n"); _DO_SEEN[$_n]=1; fi
 done
 ISSUE_NUMS=("${_DO_UNIQUE[@]}")
-unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _n
+unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _DO_ISSUE_FILLER _n
 # Back-compat scalar (= first claimed issue, or empty when none). Mode
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.05.31+993373"
+  version: "2026.06.01+88285e"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -160,6 +160,13 @@ DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 #   - WEAK separators (`,`, `;`, ` and `, ` or `) — require an explicit
 #     close-keyword between the separator and `#N`. This blocks
 #     "Closes #832, see also #999" from accidentally claiming #999.
+# After the close-keyword (in any of leading/strong/weak passes), an
+# optional `issue[s]?:?` filler token is tolerated between the keyword
+# and `#N` (#920): "Fix issue #906", "fixes issues #906", "Resolves
+# issue: #906" all parse. The token MUST be adjacent to `#N` — a word
+# between `issue` and `#N` (e.g. "Fix issue ticketing for #906") breaks
+# the adjacency and no capture occurs, preserving #863's
+# strong-vs-weak separator discipline.
 # When no issue reference is in scope (the common case) ISSUE_NUMS stays
 # empty and nothing is claimed. ISSUE_NUM is kept as a back-compat
 # scalar (= ISSUE_NUMS[0] when non-empty, else empty). claim-issue.sh
@@ -167,27 +174,33 @@ DESCRIPTION="${DESCRIPTION%"${DESCRIPTION##*[![:space:]]}"}"
 # a bare integer.
 ISSUE_NUMS=()
 _QF_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
+_QF_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
 # Leading anchored match (no leading-quote tolerance: /quickfix runs after
 # the quoted-head carve-out has already normalized the description).
-if [[ "$DESCRIPTION" =~ ^[[:space:]]*${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; then
-  ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+# BASH_REMATCH groups (kw branch): 1=kw outer, 2=kw inner, 3=optional
+# filler, 4=digit capture.
+if [[ "$DESCRIPTION" =~ ^[[:space:]]*${_QF_ISSUE_KW}[[:space:]]+${_QF_ISSUE_FILLER}#([0-9]+) ]]; then
+  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
 elif [[ "$DESCRIPTION" =~ ^[[:space:]]*#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[1]}")
 fi
-# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK.
-# BASH_REMATCH groups: 1=outer kw+space wrapper, 2=kw outer, 3=kw inner,
-# 4=digit capture.
+# Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK; if
+# the keyword is present, the optional `issue[s]?:?` filler is also
+# permitted between the kw and `#N`. BASH_REMATCH groups: 1=outer kw+
+# filler wrapper, 2=kw outer, 3=kw inner, 4=optional filler, 5=digit
+# capture.
 _QF_REMAINING="$DESCRIPTION"
-while [[ "$_QF_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_QF_ISSUE_KW}[[:space:]]+)?#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+while [[ "$_QF_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_QF_ISSUE_KW}[[:space:]]+${_QF_ISSUE_FILLER})?#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
   _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
-# close-keyword before `#N`. BASH_REMATCH groups: 1=outer separator,
-# 2=and/or word, 3=kw outer, 4=kw inner, 5=digit capture.
+# close-keyword before `#N`. Optional `issue[s]?:?` filler is allowed
+# between kw and `#N`. BASH_REMATCH groups: 1=outer separator, 2=and/or
+# word, 3=kw outer, 4=kw inner, 5=optional filler, 6=digit capture.
 _QF_REMAINING="$DESCRIPTION"
-while [[ "$_QF_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_QF_ISSUE_KW}[[:space:]]+#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+while [[ "$_QF_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_QF_ISSUE_KW}[[:space:]]+${_QF_ISSUE_FILLER}#([0-9]+) ]]; do
+  ISSUE_NUMS+=("${BASH_REMATCH[6]}")
   _QF_REMAINING="${_QF_REMAINING#*"${BASH_REMATCH[0]}"}"
 done
 # Dedupe preserving first-seen order.
@@ -198,7 +211,7 @@ for _n in "${ISSUE_NUMS[@]:-}"; do
   if [ -z "${_QF_SEEN[$_n]:-}" ]; then _QF_UNIQUE+=("$_n"); _QF_SEEN[$_n]=1; fi
 done
 ISSUE_NUMS=("${_QF_UNIQUE[@]}")
-unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _n
+unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _QF_ISSUE_FILLER _n
 # Back-compat scalar (= first claimed issue, or empty when none).
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 ```

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -592,21 +592,23 @@ do_parse_issue_nums() {
   local input="$1"
   ISSUE_NUMS=()
   local _KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
-  if [[ "$input" =~ ^[[:space:]]*\"?${_KW}[[:space:]]+#([0-9]+) ]]; then
-    ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+  # #920: optional `issue[s]?:?` filler tolerated between kw and `#N`.
+  local _FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
+  if [[ "$input" =~ ^[[:space:]]*\"?${_KW}[[:space:]]+${_FILLER}#([0-9]+) ]]; then
+    ISSUE_NUMS+=("${BASH_REMATCH[4]}")
   elif [[ "$input" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
     ISSUE_NUMS+=("${BASH_REMATCH[1]}")
   fi
-  # Strong separators: bare #N OK.
+  # Strong separators: bare #N OK; kw+filler optional.
   local _REM="$input"
-  while [[ "$_REM" =~ [[:space:]]*[/+\&][[:space:]]*(${_KW}[[:space:]]+)?#([0-9]+) ]]; do
-    ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  while [[ "$_REM" =~ [[:space:]]*[/+\&][[:space:]]*(${_KW}[[:space:]]+${_FILLER})?#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
     _REM="${_REM#*"${BASH_REMATCH[0]}"}"
   done
-  # Weak separators: close-keyword required.
+  # Weak separators: close-keyword required; filler optional.
   _REM="$input"
-  while [[ "$_REM" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_KW}[[:space:]]+#([0-9]+) ]]; do
-    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+  while [[ "$_REM" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_KW}[[:space:]]+${_FILLER}#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[6]}")
     _REM="${_REM#*"${BASH_REMATCH[0]}"}"
   done
   declare -A _SEEN=()
@@ -676,6 +678,32 @@ test_issue_num_do "address #853 work" "" "non-recognized keyword (address) → n
 test_issue_num_do "work on #853" "" "non-recognized verb (work) → no capture"
 
 # ────────────────────────────────────────────────────────────────────
+# Case 18i — #920: optional `issue[s]?:?` filler token tolerated between
+# the close-keyword and `#N`. Natural phrasings ("Fix issue #N", "fixes
+# issues #N", "Resolves issue: #N") now capture. The filler MUST be
+# adjacent to `#N` — a word between `issue` and `#N` breaks adjacency
+# and no capture occurs (preserves #863's strong-vs-weak separator
+# discipline).
+# ────────────────────────────────────────────────────────────────────
+# Positive — kw + filler + #N captures
+test_issue_num_do "Fix issue #906: bring /work-on-plans into spec" "906" "Fix issue #N (live #920 regression case)"
+test_issue_num_do "fixes issue #906" "906" "fixes issue #N"
+test_issue_num_do "Fixed issue #906" "906" "Fixed issue #N"
+test_issue_num_do "Closes issue #906" "906" "Closes issue #N"
+test_issue_num_do "closed issue #906" "906" "closed issue #N"
+test_issue_num_do "Resolves issue #906" "906" "Resolves issue #N"
+test_issue_num_do "fixes issues #906" "906" "fixes issues #N (plural)"
+test_issue_num_do "Closes issues #906" "906" "Closes issues #N (plural)"
+test_issue_num_do "Resolves issue: #906" "906" "Resolves issue: #N (colon variant)"
+test_issue_num_do "Fix issue #906 the bug" "906" "Fix issue #N followed by prose"
+test_issue_num_do "\"Fix issue #906 quoted-head\"" "906" "leading quote + Fix issue #N (quoted-head carve-out)"
+# Negative — filler word but NOT adjacent to #N → no capture
+test_issue_num_do "Fix issue ticketing for #906" "" "word between 'issue' and #N → no capture (adjacency required)"
+test_issue_num_do "Fix issue with #906" "" "'with' between 'issue' and #N → no capture"
+# Existing forms still work — keyword without filler is unchanged
+test_issue_num_do "Closes #906" "906" "Closes #N (no filler) still works"
+
+# ────────────────────────────────────────────────────────────────────
 # Case 18m — Multi-issue parser (#863). Description references multiple
 # `#N` issues separated by /, ,, ;, +, &, or " and "/" or " — all
 # captured into ISSUE_NUMS array; back-compat ISSUE_NUM stays as first.
@@ -694,6 +722,14 @@ test_issue_nums_do "Closes #832, see also #999"          "832"         "see-also
 test_issue_nums_do "Closes #832, #833"                   "832"         "bare #N after comma (weak sep) → only #832"
 test_issue_nums_do "fix #832 and #833"                   "832"         "bare #N after 'and' (weak sep) → only #832"
 test_issue_nums_do "fix #832 and fix #832"               "832"         "dedupe: duplicate #N captured once"
+# #920: filler token across separator passes
+test_issue_nums_do "Closes issue #832 / Closes issue #833"        "832,833"     "slash-separated double Closes-issue (kw+filler, strong sep)"
+test_issue_nums_do "Fixes issues #832 + #833"                     "832,833"     "Fixes issues (plural) + bare #N (strong sep, kw absent on RHS)"
+test_issue_nums_do "Fix issue #832 and Closes issue #833"         "832,833"     "and-separated kw+filler on both sides (weak sep)"
+test_issue_nums_do "Fix issue #832, Closes #833"                  "832,833"     "comma-separated: kw+filler then bare-kw (weak sep)"
+# #920 negative — filler-without-adjacency in weak-sep position
+test_issue_nums_do "Fix issue #832, see also issue #999"          "832"         "see-also after comma → only #832 even though 'issue' near #999 (no kw before #999)"
+test_issue_nums_do "fixes issues #906 and #907"                   "906"         "plural 'issues' in leading does NOT loosen weak-sep guard (no kw before #907)"
 
 # ────────────────────────────────────────────────────────────────────
 # Case 18w — Unclaimed-reference WARNING (#907). When the description

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -2055,19 +2055,21 @@ qf_parse_issue_nums() {
   local input="$1"
   ISSUE_NUMS=()
   local _KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
-  if [[ "$input" =~ ^[[:space:]]*${_KW}[[:space:]]+#([0-9]+) ]]; then
-    ISSUE_NUMS+=("${BASH_REMATCH[3]}")
+  # #920: optional `issue[s]?:?` filler tolerated between kw and `#N`.
+  local _FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
+  if [[ "$input" =~ ^[[:space:]]*${_KW}[[:space:]]+${_FILLER}#([0-9]+) ]]; then
+    ISSUE_NUMS+=("${BASH_REMATCH[4]}")
   elif [[ "$input" =~ ^[[:space:]]*#([0-9]+) ]]; then
     ISSUE_NUMS+=("${BASH_REMATCH[1]}")
   fi
   local _REM="$input"
-  while [[ "$_REM" =~ [[:space:]]*[/+\&][[:space:]]*(${_KW}[[:space:]]+)?#([0-9]+) ]]; do
-    ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  while [[ "$_REM" =~ [[:space:]]*[/+\&][[:space:]]*(${_KW}[[:space:]]+${_FILLER})?#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
     _REM="${_REM#*"${BASH_REMATCH[0]}"}"
   done
   _REM="$input"
-  while [[ "$_REM" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_KW}[[:space:]]+#([0-9]+) ]]; do
-    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+  while [[ "$_REM" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_KW}[[:space:]]+${_FILLER}#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[6]}")
     _REM="${_REM#*"${BASH_REMATCH[0]}"}"
   done
   declare -A _SEEN=()
@@ -2137,6 +2139,29 @@ test_issue_num_qf "address #853 work" "" "non-recognized keyword (address) → n
 test_issue_num_qf "work on #853" "" "non-recognized verb (work) → no capture"
 
 # ────────────────────────────────────────────────────────────────────
+# Case 71i — #920: optional `issue[s]?:?` filler token tolerated between
+# the close-keyword and `#N`. Mirrors test-do.sh Case 18i — the parser
+# shape is unified across /do and /quickfix (#863) and the #920 fix
+# extends both in lockstep.
+# ────────────────────────────────────────────────────────────────────
+# Positive — kw + filler + #N captures
+test_issue_num_qf "Fix issue #906: bring /work-on-plans into spec" "906" "Fix issue #N (live #920 regression case)"
+test_issue_num_qf "fixes issue #906" "906" "fixes issue #N"
+test_issue_num_qf "Fixed issue #906" "906" "Fixed issue #N"
+test_issue_num_qf "Closes issue #906" "906" "Closes issue #N"
+test_issue_num_qf "closed issue #906" "906" "closed issue #N"
+test_issue_num_qf "Resolves issue #906" "906" "Resolves issue #N"
+test_issue_num_qf "fixes issues #906" "906" "fixes issues #N (plural)"
+test_issue_num_qf "Closes issues #906" "906" "Closes issues #N (plural)"
+test_issue_num_qf "Resolves issue: #906" "906" "Resolves issue: #N (colon variant)"
+test_issue_num_qf "Fix issue #906 the bug" "906" "Fix issue #N followed by prose"
+# Negative — filler word but NOT adjacent to #N → no capture
+test_issue_num_qf "Fix issue ticketing for #906" "" "word between 'issue' and #N → no capture (adjacency required)"
+test_issue_num_qf "Fix issue with #906" "" "'with' between 'issue' and #N → no capture"
+# Existing forms still work
+test_issue_num_qf "Closes #906" "906" "Closes #N (no filler) still works"
+
+# ────────────────────────────────────────────────────────────────────
 # Case 71m — Multi-issue parser (#863). Description references multiple
 # `#N` issues via strong separators (`/`, `+`, `&` — bare `#N` allowed)
 # or weak separators (`,`, `;`, ` and `, ` or ` — close-keyword required).
@@ -2156,6 +2181,14 @@ test_issue_nums_qf "Closes #832, see also #999"          "832"         "see-also
 test_issue_nums_qf "Closes #832, #833"                   "832"         "bare #N after comma (weak sep) → only #832"
 test_issue_nums_qf "fix #832 and #833"                   "832"         "bare #N after 'and' (weak sep) → only #832"
 test_issue_nums_qf "fix #832 and fix #832"               "832"         "dedupe: duplicate #N captured once"
+# #920: filler token across separator passes
+test_issue_nums_qf "Closes issue #832 / Closes issue #833"        "832,833"     "slash-separated double Closes-issue (kw+filler, strong sep)"
+test_issue_nums_qf "Fixes issues #832 + #833"                     "832,833"     "Fixes issues (plural) + bare #N (strong sep, kw absent on RHS)"
+test_issue_nums_qf "Fix issue #832 and Closes issue #833"         "832,833"     "and-separated kw+filler on both sides (weak sep)"
+test_issue_nums_qf "Fix issue #832, Closes #833"                  "832,833"     "comma-separated: kw+filler then bare-kw (weak sep)"
+# #920 negative — filler-without-adjacency in weak-sep position
+test_issue_nums_qf "Fix issue #832, see also issue #999"          "832"         "see-also after comma → only #832 even though 'issue' near #999 (no kw before #999)"
+test_issue_nums_qf "fixes issues #906 and #907"                   "906"         "plural 'issues' in leading does NOT loosen weak-sep guard (no kw before #907)"
 
 # ────────────────────────────────────────────────────────────────────
 # Case 72 — Phase 0a triage rubric NO LONGER contains the

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -481,8 +481,10 @@ echo "=== /do — issue-claim wiring (claim-work-item Phase 2 / W2.2 + W2.3) ===
 # The sentinels grep the EXISTING patterns so a future edit dropping the
 # wiring FAILS the test. These are positive assertions only.
 # Multi-issue parser (#863): ISSUE_NUMS array populated from leading
-# anchored + separator-delimited subsequent matches.
-check_fixed do "SKILL.md parses ISSUE_NUMS array"     'ISSUE_NUMS+=("${BASH_REMATCH[3]}")'
+# anchored + separator-delimited subsequent matches. BASH_REMATCH index
+# is `[4]` after #920 added an optional `issue[s]?:?` filler capture group
+# between the close-keyword and `#N`.
+check_fixed do "SKILL.md parses ISSUE_NUMS array"     'ISSUE_NUMS+=("${BASH_REMATCH[4]}")'
 check_fixed do "SKILL.md back-compat ISSUE_NUM"       'ISSUE_NUM="${ISSUE_NUMS[0]:-}"'
 # worktree mode: acquire after PIPELINE_ID + worktree; release in Phase 5 Report (SKILL.md).
 check_in_file do "modes/worktree.md" "worktree CLAIM_HELPER"     'CLAIM_HELPER=.*fix-issues/scripts/claim-issue\.sh'
@@ -672,7 +674,7 @@ echo "=== /quickfix — issue-claim wiring (claim-work-item Phase 2 / W2.4) ==="
 # triage REDIRECTs issue refs to /fix-issues), acquires at WI 1.8 around
 # the Tracking-setup block, releases in the Phase 7 finalize + abandon
 # sites. Reuses the existing PIPELINE_ID="quickfix.$SLUG".
-check_fixed quickfix "parses ISSUE_NUMS array"   'ISSUE_NUMS+=("${BASH_REMATCH[3]}")'
+check_fixed quickfix "parses ISSUE_NUMS array"   'ISSUE_NUMS+=("${BASH_REMATCH[4]}")'
 check_fixed quickfix "back-compat ISSUE_NUM"     'ISSUE_NUM="${ISSUE_NUMS[0]:-}"'
 check_fixed quickfix "CLAIM_HELPER assignment"   'CLAIM_HELPER="$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh"'
 check_fixed quickfix "fan-out acquire"           'for ISSUE_NUM in "${ISSUE_NUMS[@]}"'


### PR DESCRIPTION
## Summary

`/do`'s issue-claim parser (and `/quickfix`'s sibling) required the close-keyword to be **immediately adjacent to `#N`** — `Fix #906`, `Closes #906`. The natural phrasing **"Fix issue #906"** broke the `keyword[[:space:]]+#N` adjacency, so `ISSUE_NUMS` came up empty and Step A5.5 claim-acquire silently no-op'd. Live observed this session.

Closes #920

## Fix
Added an optional `(issue[s]?:?[[:space:]]+)?` filler subpattern between the close-keyword and `#N` at all 3 regex sites (leading anchored, strong-separator loop, weak-separator loop), shared as `_DO_ISSUE_FILLER` / `_QF_ISSUE_FILLER`. The filler is regex-optional and ITSELF requires `#N` adjacency — backtracking on `"Fix issue ticketing for #906"` fails to match. BASH_REMATCH digit-capture indexes shifted by 1 at each site (conformance sentinels updated in lockstep).

## Files (7)
- `skills/do/SKILL.md` parser + comment + version → `2026.06.01+f85099`
- `skills/quickfix/SKILL.md` parser + comment + version → `2026.06.01+88285e`
- 2 mirrors
- `tests/test-do.sh` — parser replica + Case 18i positive/negative + Case 18m kw+filler multi-issue cases
- `tests/test-quickfix.sh` — parser replica + Case 71i + Case 71m kw+filler multi-issue cases
- `tests/test-skill-conformance.sh` — BASH_REMATCH index sentinels `[3]→[4]` for do + quickfix

## Test plan
- [x] `bash tests/run-all.sh` — 6871/6871 passed.
- [x] Live regression: `"Fix issue #906: ..."` → `ISSUE_NUMS=(906)` ✓
- [x] Multi-issue: `"fixes issues #906 and #907"` → `(906)` (weak-sep `and #907` lacks keyword, correctly NOT grabbed — preserves #863 semantics)
- [x] Negative: `"Fix issue ticketing for #906"` does NOT capture (regex backtracking required).

## Commits
$(cd /tmp/zskills-do-920-do-claim-keyword-issue && git log origin/main..HEAD --format='%h %s' | head -3)
