### PR TITLE
do: fix #923 clear in-flight sentinel on retry-exits

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.01+0f0dba"
+  version: "2026.06.01+604a89"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -938,13 +938,45 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    - If multiple phases share the same number (e.g., 4a, 4b, 4c), treat
      each sub-phase as a separate phase
 
-4. **Check dependencies** — if a prerequisite phase isn't Done, **STOP.**
+**Recoverable-STOP sentinel hygiene (Issue #923).** Steps 4–6 below each
+have a recoverable **STOP** that deliberately leaves the `every`/`finish auto`
+cron alive to retry on a later fire (dependency-not-met, phase-in-progress
+conflict, staleness). Before taking any of those STOP-and-exit branches,
+clear the #883 in-flight sentinel — otherwise the retry fire (same
+`(session_id, pipeline_id)`) is treated as a redundant re-fire and SKIPPED
+until the 2h staleness reclaims it, defeating the intended retry. Re-derive
+`$PIPELINE_ID` / `$INFLIGHT_HELPER` at fence-top exactly as the terminal-clear
+sites in `modes/execute-phase.md` do (config-source first):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
+This is distinct from Step 0 Case 3's adaptive-backoff defer — that path is a
+genuine "phase actively in progress, keep deferring" yield and MUST keep the
+sentinel set; do NOT add the clear there.
+
+4. **Check dependencies** — if a prerequisite phase isn't Done, **STOP**
+   (clear the sentinel via the fence above first).
    Report which dependency is missing. If `every`, the cron retries later.
 
 5. **Check for conflicts** — if the target phase is "In Progress" (🟡 or
-   equivalent), another agent may be working on it. **STOP.** Do not compete.
+   equivalent), another agent may be working on it. **STOP** (clear the
+   sentinel via the fence above first). Do not compete.
 
-6. **Check for staleness.** Two independent checks:
+6. **Check for staleness.** Two independent checks. If a check forces a
+   STOP-and-exit that leaves the cron alive to retry, clear the sentinel via
+   the fence above first.
 
    **a. Textual staleness.** if the plan's Dependencies section
    contains language like "drafted before," "may need refresh," or "APIs

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -1034,10 +1034,21 @@ commits on the feature branch.
    git add <plan-file> [companion-doc]
    git commit -m "chore: mark phase <name> in progress"
    ```
-   Not ✅ Done yet — Phase 6 updates to Done after landing succeeds (in
-   cherry-pick/direct via a main commit, in PR mode via a commit on the
-   feature branch *before* push so it's captured in the squash). If
-   landing fails in either mode, tracker correctly reads In Progress.
+   Not ✅ Done yet — for a phase that lands this turn (single-phase runs, and
+   the FINAL phase of a chunked `finish`/`finish auto` run), Phase 6 updates
+   to Done after landing succeeds (in cherry-pick/direct via a main commit, in
+   PR mode via a commit on the feature branch *before* push so it's captured
+   in the squash). If landing fails in either mode, tracker correctly reads
+   In Progress.
+
+   **Chunked `finish`/`finish auto` non-final phases (Issue #191 + #923).**
+   These phases do NOT land in Phase 6 — landing happens once after the final
+   phase (`LAND_NOW=false`; see Phase 6's final-phase gating). So a non-final
+   phase must reach ✅ Done at **phase-turn-end** — after the phase verifies
+   and its work is committed to the plan-scoped feature branch, before this
+   turn's Phase-5c advancement exit — not "after landing." Flip the tracker
+   row to ✅ and commit it on the same plan-scoped branch as the phase's work
+   so the next cron-fired turn reads the phase as complete and advances.
 
 5. **(PR mode only) Sync the GitHub PR body's progress section.** The PR
    body was snapshotted at PR-open time in Phase 6 (Step 5, Create PR) and

--- a/.claude/skills/run-plan/references/failure-protocol.md
+++ b/.claude/skills/run-plan/references/failure-protocol.md
@@ -19,6 +19,27 @@ CronList → find the /run-plan job ID → CronDelete
 Do this BEFORE any cleanup or reporting. Even if you're about to fix the
 problem, kill the cron. The user can restart it after reviewing.
 
+**Also clear the #883 in-flight sentinel (Issue #923 hygiene).** The cron is
+already dead so the leftover sentinel is mostly moot, but clearing it ensures
+a manual `/run-plan` re-invoke after this fatal failure isn't blocked by a
+stale entry until the 2h staleness. Re-derive `$PIPELINE_ID` /
+`$INFLIGHT_HELPER` at fence-top exactly as the terminal-clear sites in
+`modes/execute-phase.md` do (config-source first):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
 ### 2. Restore the working tree
 
 If a cherry-pick is in a conflicted state:

--- a/.claude/skills/run-plan/references/finish-mode.md
+++ b/.claude/skills/run-plan/references/finish-mode.md
@@ -119,6 +119,35 @@ idempotent re-entry check handles redundant fires as cheap no-ops.
 #   prompt: "Run /run-plan <plan-file> finish auto"
 ```
 
+**Clear the #883 in-flight sentinel before exiting this turn (Issue #923).**
+This is the non-final Phase-5c advancement exit: the cron is *meant* to fire
+again to pick up the next phase. The plan+session-scoped sentinel written at
+`/run-plan` entry must be cleared here, otherwise the next-phase cron fire —
+same `(session_id, pipeline_id)` — is treated as a redundant re-fire and
+SKIPPED until the 2h staleness reclaims it, suppressing phase advancement.
+Re-derive `$PIPELINE_ID` / `$INFLIGHT_HELPER` at fence-top exactly as the
+terminal-clear sites in `modes/execute-phase.md` do (config-source first):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
+Then output the `Phase <N> … complete / Phase <N+1> will fire automatically`
+chunking message and exit this turn. **Do NOT** clear the sentinel during a
+genuine mid-phase yield (e.g. a backgrounded baseline capture) — that path
+keeps the sentinel so a redundant re-fire while the phase is actually still
+running is correctly skipped; the 2h staleness is the dead-turn backstop.
+
 **Cron terminates when the plan completes.** Phase 1 Step 0 Case 1
 (frontmatter `status: complete`) explicitly deletes this cron — see
 the SKILL.md main file's Phase 1 Step 0 block. That's the only

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.01+0f0dba"
+  version: "2026.06.01+604a89"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -938,13 +938,45 @@ Source: `skills/run-plan/scripts/pr-preflight.sh`. Pure bash; no `jq`.
    - If multiple phases share the same number (e.g., 4a, 4b, 4c), treat
      each sub-phase as a separate phase
 
-4. **Check dependencies** — if a prerequisite phase isn't Done, **STOP.**
+**Recoverable-STOP sentinel hygiene (Issue #923).** Steps 4–6 below each
+have a recoverable **STOP** that deliberately leaves the `every`/`finish auto`
+cron alive to retry on a later fire (dependency-not-met, phase-in-progress
+conflict, staleness). Before taking any of those STOP-and-exit branches,
+clear the #883 in-flight sentinel — otherwise the retry fire (same
+`(session_id, pipeline_id)`) is treated as a redundant re-fire and SKIPPED
+until the 2h staleness reclaims it, defeating the intended retry. Re-derive
+`$PIPELINE_ID` / `$INFLIGHT_HELPER` at fence-top exactly as the terminal-clear
+sites in `modes/execute-phase.md` do (config-source first):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
+This is distinct from Step 0 Case 3's adaptive-backoff defer — that path is a
+genuine "phase actively in progress, keep deferring" yield and MUST keep the
+sentinel set; do NOT add the clear there.
+
+4. **Check dependencies** — if a prerequisite phase isn't Done, **STOP**
+   (clear the sentinel via the fence above first).
    Report which dependency is missing. If `every`, the cron retries later.
 
 5. **Check for conflicts** — if the target phase is "In Progress" (🟡 or
-   equivalent), another agent may be working on it. **STOP.** Do not compete.
+   equivalent), another agent may be working on it. **STOP** (clear the
+   sentinel via the fence above first). Do not compete.
 
-6. **Check for staleness.** Two independent checks:
+6. **Check for staleness.** Two independent checks. If a check forces a
+   STOP-and-exit that leaves the cron alive to retry, clear the sentinel via
+   the fence above first.
 
    **a. Textual staleness.** if the plan's Dependencies section
    contains language like "drafted before," "may need refresh," or "APIs

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -1034,10 +1034,21 @@ commits on the feature branch.
    git add <plan-file> [companion-doc]
    git commit -m "chore: mark phase <name> in progress"
    ```
-   Not ✅ Done yet — Phase 6 updates to Done after landing succeeds (in
-   cherry-pick/direct via a main commit, in PR mode via a commit on the
-   feature branch *before* push so it's captured in the squash). If
-   landing fails in either mode, tracker correctly reads In Progress.
+   Not ✅ Done yet — for a phase that lands this turn (single-phase runs, and
+   the FINAL phase of a chunked `finish`/`finish auto` run), Phase 6 updates
+   to Done after landing succeeds (in cherry-pick/direct via a main commit, in
+   PR mode via a commit on the feature branch *before* push so it's captured
+   in the squash). If landing fails in either mode, tracker correctly reads
+   In Progress.
+
+   **Chunked `finish`/`finish auto` non-final phases (Issue #191 + #923).**
+   These phases do NOT land in Phase 6 — landing happens once after the final
+   phase (`LAND_NOW=false`; see Phase 6's final-phase gating). So a non-final
+   phase must reach ✅ Done at **phase-turn-end** — after the phase verifies
+   and its work is committed to the plan-scoped feature branch, before this
+   turn's Phase-5c advancement exit — not "after landing." Flip the tracker
+   row to ✅ and commit it on the same plan-scoped branch as the phase's work
+   so the next cron-fired turn reads the phase as complete and advances.
 
 5. **(PR mode only) Sync the GitHub PR body's progress section.** The PR
    body was snapshotted at PR-open time in Phase 6 (Step 5, Create PR) and

--- a/skills/run-plan/references/failure-protocol.md
+++ b/skills/run-plan/references/failure-protocol.md
@@ -19,6 +19,27 @@ CronList → find the /run-plan job ID → CronDelete
 Do this BEFORE any cleanup or reporting. Even if you're about to fix the
 problem, kill the cron. The user can restart it after reviewing.
 
+**Also clear the #883 in-flight sentinel (Issue #923 hygiene).** The cron is
+already dead so the leftover sentinel is mostly moot, but clearing it ensures
+a manual `/run-plan` re-invoke after this fatal failure isn't blocked by a
+stale entry until the 2h staleness. Re-derive `$PIPELINE_ID` /
+`$INFLIGHT_HELPER` at fence-top exactly as the terminal-clear sites in
+`modes/execute-phase.md` do (config-source first):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
 ### 2. Restore the working tree
 
 If a cherry-pick is in a conflicted state:

--- a/skills/run-plan/references/finish-mode.md
+++ b/skills/run-plan/references/finish-mode.md
@@ -119,6 +119,35 @@ idempotent re-entry check handles redundant fires as cheap no-ops.
 #   prompt: "Run /run-plan <plan-file> finish auto"
 ```
 
+**Clear the #883 in-flight sentinel before exiting this turn (Issue #923).**
+This is the non-final Phase-5c advancement exit: the cron is *meant* to fire
+again to pick up the next phase. The plan+session-scoped sentinel written at
+`/run-plan` entry must be cleared here, otherwise the next-phase cron fire —
+same `(session_id, pipeline_id)` — is treated as a redundant re-fire and
+SKIPPED until the 2h staleness reclaims it, suppressing phase advancement.
+Re-derive `$PIPELINE_ID` / `$INFLIGHT_HELPER` at fence-top exactly as the
+terminal-clear sites in `modes/execute-phase.md` do (config-source first):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+if [ -x "$INFLIGHT_HELPER" ]; then
+  bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+fi
+```
+
+Then output the `Phase <N> … complete / Phase <N+1> will fire automatically`
+chunking message and exit this turn. **Do NOT** clear the sentinel during a
+genuine mid-phase yield (e.g. a backgrounded baseline capture) — that path
+keeps the sentinel so a redundant re-fire while the phase is actually still
+running is correctly skipped; the 2h staleness is the dead-turn backstop.
+
 **Cron terminates when the plan completes.** Phase 1 Step 0 Case 1
 (frontmatter `status: complete`) explicitly deletes this cron — see
 the SKILL.md main file's Phase 1 Step 0 block. That's the only

--- a/tests/test-inflight-reentry-guard.sh
+++ b/tests/test-inflight-reentry-guard.sh
@@ -180,6 +180,39 @@ fi
 (cd "$FIXTURE" && bash "$HELPER" clear do --pipeline-id "do.fix-readme") >/dev/null 2>&1
 
 echo ""
+echo "=== #923: phase advancement NOT suppressed after a turn clears on exit ==="
+# Models the chunked finish-auto fix: phase N's turn writes the sentinel at
+# entry, then clears it on its non-terminal Phase-5c advancement exit. The
+# next cron fire (same session+pipeline) for phase N+1 must PROCEED, not be
+# treated as a redundant re-fire. Before #923 the sentinel survived the
+# advancement exit, so this check returned rc=0 (skip) and suppressed
+# advancement until the 2h staleness.
+(cd "$FIXTURE" && bash "$HELPER" write run-plan --pipeline-id "run-plan.plan-adv" --session-id "TEST-SID-ADV")
+# Phase N's turn completes and clears its sentinel on the advancement exit.
+# `clear` is keyed on skill+pipeline-id only (no --session-id arg) — exactly
+# the `clear run-plan --pipeline-id "$PIPELINE_ID"` call the fix adds.
+(cd "$FIXTURE" && bash "$HELPER" clear run-plan --pipeline-id "run-plan.plan-adv") >/dev/null 2>&1
+# Phase N+1's cron fire (SAME session+pipeline) re-enters the guard.
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-ADV" --pipeline-id "run-plan.plan-adv" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "next phase proceeds (rc=1) after prior turn cleared its sentinel on exit"
+else
+  fail "next phase proceeds (rc=1) after prior turn cleared its sentinel on exit" "got rc=$rc (advancement suppressed)"
+fi
+# Control: WITHOUT the clear, the same next-phase check still skips (rc=0) —
+# confirms the assertion above is driven by the clear, not a vacant sentinel.
+(cd "$FIXTURE" && bash "$HELPER" write run-plan --pipeline-id "run-plan.plan-adv2" --session-id "TEST-SID-ADV")
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "TEST-SID-ADV" --pipeline-id "run-plan.plan-adv2" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "control: without the on-exit clear, next-phase check still skips (rc=0)"
+else
+  fail "control: without the on-exit clear, next-phase check still skips (rc=0)" "got rc=$rc"
+fi
+(cd "$FIXTURE" && bash "$HELPER" clear run-plan --pipeline-id "run-plan.plan-adv2") >/dev/null 2>&1
+
+echo ""
 echo "=== call-site wiring assertions ==="
 
 assert_wired() {
@@ -212,6 +245,18 @@ else
   fail "run-plan execute-phase.md: at least 2 clear sites" "got $clear_count"
 fi
 assert_wired "run-plan execute-phase.md: clear w/ --pipeline-id" "$RP_EXEC" \
+  '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
+
+# #923: clear-on-retry-exit sites added to finish-mode.md (non-final Phase-5c
+# advancement), SKILL.md (recoverable Parse-plan STOPs), and
+# failure-protocol.md (§1 hygiene). The fix is incomplete if any is missing.
+RP_FINISH="$REPO_ROOT/skills/run-plan/references/finish-mode.md"
+RP_FAIL="$REPO_ROOT/skills/run-plan/references/failure-protocol.md"
+assert_wired "run-plan finish-mode.md (#923): clear on Phase-5c advancement exit" "$RP_FINISH" \
+  '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
+assert_wired "run-plan SKILL.md (#923): clear before recoverable Parse-plan STOPs" "$RP_SKILL" \
+  '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
+assert_wired "run-plan failure-protocol.md (#923): clear in §1 hygiene" "$RP_FAIL" \
   '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
 
 # /do mode files — entry-guard wiring.
@@ -250,6 +295,8 @@ for pair in \
   "create-worktree/scripts/check-inflight-batch.sh" \
   "run-plan/SKILL.md" \
   "run-plan/modes/execute-phase.md" \
+  "run-plan/references/finish-mode.md" \
+  "run-plan/references/failure-protocol.md" \
   "do/SKILL.md" \
   "do/modes/pr.md" \
   "do/modes/worktree.md" \

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -3306,7 +3306,7 @@ check_sanitize_count() {
     fail "$label: found $actual sanitize wraps, expected exactly $expected" "$expected sanitize-pipeline-id.sh wraps in $skill_path"
   fi
 }
-check_sanitize_count "skills/run-plan/SKILL.md"                       5 "skills/run-plan/SKILL.md"
+check_sanitize_count "skills/run-plan/SKILL.md"                       6 "skills/run-plan/SKILL.md"
 check_sanitize_count "skills/run-plan/modes/execute-phase.md"        10 "skills/run-plan/modes/execute-phase.md"
 check_sanitize_count "skills/run-plan/subcommands/stop-next-status.md" 1 "skills/run-plan/subcommands/stop-next-status.md"
 check_sanitize_count "skills/commit/modes/pr.md"      1 "skills/commit/modes/pr.md"

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -142,6 +142,12 @@ ISSUE_606_ALLOWLIST=(
   # so they don't need their own resolver. Filed: separate issue
   # (post-#606 follow-up) if the family-pattern test fails on them.
   "skills/run-plan/references/failure-protocol.md	PLAN_FILE"
+  # failure-protocol.md's #923 §1 sentinel-clear fence reads $TRACKING_ID via
+  # PIPELINE_ID's default (run-plan.$TRACKING_ID), inheriting it from the main
+  # SKILL.md preamble in scope when the Failure Protocol runs — same inherit
+  # pattern as the PLAN_FILE entry directly above; documents but does not own
+  # the resolver.
+  "skills/run-plan/references/failure-protocol.md	TRACKING_ID"
   # After #725 extraction, PLAN_FILE is assigned in subcommands/stop-next-status.md
   # (Status mode's resolver) and modes/execute-phase.md (Phase 2 example); the
   # router SKILL.md reads it from the orchestrator's parsed $ARGUMENTS context.
@@ -150,6 +156,13 @@ ISSUE_606_ALLOWLIST=(
   "skills/run-plan/modes/execute-phase.md	TRACKING_ID"
   "skills/run-plan/modes/pr.md	PLAN_FILE"
   "skills/run-plan/modes/pr.md	TRACKING_ID"
+  # finish-mode.md is a reference file Read by Phase 5c (execute-phase.md);
+  # its #923 sentinel-clear fence reads $TRACKING_ID via PIPELINE_ID's default
+  # (run-plan.$TRACKING_ID), inheriting it from the main SKILL.md / Phase 1
+  # preamble in scope when Phase 5c runs — same inherit pattern as
+  # modes/pr.md and execute-phase.md above; it documents but does not own
+  # the resolver.
+  "skills/run-plan/references/finish-mode.md	TRACKING_ID"
   "skills/commit/modes/pr.md	TRACKING_ID"
   "skills/fix-issues/modes/pr.md	SPRINT_ID"
   # After #835 split, draft-tests mode files inherit PLAN_FILE/TRACKING_ID


### PR DESCRIPTION
Task: Fix #923 — clear the #883 in-flight sentinel on non-terminal /run-plan exits where the cron is meant to fire again, so chunked finish-auto phase advancement isn't suppressed until 2h staleness.

Closes #923.

#883's plan+session-scoped in-flight sentinel was cleared only at the two terminal /run-plan exits, so in chunked `finish auto` the next-phase cron fire was treated as a redundant re-fire and skipped — advancement stalled until 2h staleness; recoverable dependency-not-met STOPs were likewise blocked. This adds the existing `check-inflight-batch.sh clear run-plan` call at the Phase-5c advancement exit, the recoverable STOP paths, and Failure-Protocol hygiene; the sentinel is left set only during a genuine mid-phase yield. Also clarifies the 🟡→✅ tracker transition for non-final chunked phases. Extends test-inflight-reentry-guard.sh (write→clear→check proceeds rc=1).

Worktree: /tmp/zskills-do-runplan-inflight-clear-923
Commits: b24a797 fix(#923): clear #883 in-flight sentinel on non-terminal /run-plan retry-exits
