### PR TITLE
fix(hook): extract_cd_target finds cd target through shell preambles (#924)

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.0
 # block-stale-skill-version.sh — PreToolUse Bash hook.
 #
 # Denies `git commit` when a staged skill's content hash no longer matches
@@ -167,15 +167,77 @@ extract_cd_target() {
     fi
     break
   done
-  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-    local target="${BASH_REMATCH[1]}"
-    # Remove surrounding quotes if present
-    target="${target%\"}"
-    target="${target#\"}"
-    if [ -d "$target" ]; then
-      echo "$target"
-    fi
-  fi
+  # Segment-walk: split $cmd on statement separators (`;`, `&&`, `||`, `|`,
+  # newline) and look for the first `cd <target>` whose preamble in the
+  # segment is purely env-mutating / inert shell statements. Issue #924:
+  # the previous `^cd[[:space:]]+` regex against the whole command missed
+  # `set -e; cd /tmp/wt && …`, `export X=Y; cd …`, `. resolver.sh && cd …`,
+  # `VAR=val cd …`, all common in orchestrator-side worktree bookkeeping.
+  # Segment separators we split on are exactly those that terminate the
+  # previous statement in bash; they cannot appear inside `cd`'s target
+  # token (it's stop-classed on the same chars).
+  local SEG_IFS=$'\n'
+  # Replace each `&&`, `||`, `|`, `;` with a newline so we can read -a.
+  local segs="${cmd//&&/$'\n'}"
+  segs="${segs//||/$'\n'}"
+  segs="${segs//|/$'\n'}"
+  segs="${segs//;/$'\n'}"
+  local IFS_OLD="$IFS"
+  IFS="$SEG_IFS"
+  local -a SEGMENTS
+  # shellcheck disable=SC2206
+  SEGMENTS=( $segs )
+  IFS="$IFS_OLD"
+  local seg
+  for seg in "${SEGMENTS[@]}"; do
+    # Trim leading/trailing whitespace.
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+    seg="${seg%"${seg##*[![:space:]]}"}"
+    [ -z "$seg" ] && continue
+    local -a STOKENS
+    # shellcheck disable=SC2206
+    read -ra STOKENS <<< "$seg"
+    local si=0 sn=${#STOKENS[@]}
+    # Skip env-var assignment prefixes (KEY=val ...).
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    # Skip `env` wrapper (and its KEY=val args).
+    [[ $si -lt $sn && "${STOKENS[$si]}" == "env" ]] && ((si++))
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    local stok="${STOKENS[$si]:-}"
+    case "$stok" in
+      */*) stok="${stok##*/}" ;;
+    esac
+    case "$stok" in
+      set|export|unset|source|.|:|true|false|alias|unalias|shopt|declare|local|readonly|typeset)
+        # Inert / env-mutating preamble statement — skip this segment.
+        continue
+        ;;
+      cd)
+        local stgt="${STOKENS[$((si+1))]:-}"
+        [ -z "$stgt" ] && continue
+        # Strip surrounding quotes if present.
+        stgt="${stgt%\"}"; stgt="${stgt#\"}"
+        stgt="${stgt%\'}"; stgt="${stgt#\'}"
+        if [ -d "$stgt" ]; then
+          echo "$stgt"
+          return 0
+        fi
+        # cd target didn't resolve — stop walking; downstream segments
+        # operate on a different cwd we can't reason about.
+        return 0
+        ;;
+      *)
+        # First "real" statement is not a cd — no preamble-cd in this
+        # command. Stop walking; per design, only a leading preamble of
+        # env-mutating statements is allowed before the cd.
+        return 0
+        ;;
+    esac
+  done
 }
 
 # Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -459,15 +459,77 @@ extract_cd_target() {
     fi
     break
   done
-  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-    local target="${BASH_REMATCH[1]}"
-    # Remove surrounding quotes if present
-    target="${target%\"}"
-    target="${target#\"}"
-    if [ -d "$target" ]; then
-      echo "$target"
-    fi
-  fi
+  # Segment-walk: split $cmd on statement separators (`;`, `&&`, `||`, `|`,
+  # newline) and look for the first `cd <target>` whose preamble in the
+  # segment is purely env-mutating / inert shell statements. Issue #924:
+  # the previous `^cd[[:space:]]+` regex against the whole command missed
+  # `set -e; cd /tmp/wt && …`, `export X=Y; cd …`, `. resolver.sh && cd …`,
+  # `VAR=val cd …`, all common in orchestrator-side worktree bookkeeping.
+  # Segment separators we split on are exactly those that terminate the
+  # previous statement in bash; they cannot appear inside `cd`'s target
+  # token (it's stop-classed on the same chars).
+  local SEG_IFS=$'\n'
+  # Replace each `&&`, `||`, `|`, `;` with a newline so we can read -a.
+  local segs="${cmd//&&/$'\n'}"
+  segs="${segs//||/$'\n'}"
+  segs="${segs//|/$'\n'}"
+  segs="${segs//;/$'\n'}"
+  local IFS_OLD="$IFS"
+  IFS="$SEG_IFS"
+  local -a SEGMENTS
+  # shellcheck disable=SC2206
+  SEGMENTS=( $segs )
+  IFS="$IFS_OLD"
+  local seg
+  for seg in "${SEGMENTS[@]}"; do
+    # Trim leading/trailing whitespace.
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+    seg="${seg%"${seg##*[![:space:]]}"}"
+    [ -z "$seg" ] && continue
+    local -a STOKENS
+    # shellcheck disable=SC2206
+    read -ra STOKENS <<< "$seg"
+    local si=0 sn=${#STOKENS[@]}
+    # Skip env-var assignment prefixes (KEY=val ...).
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    # Skip `env` wrapper (and its KEY=val args).
+    [[ $si -lt $sn && "${STOKENS[$si]}" == "env" ]] && ((si++))
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    local stok="${STOKENS[$si]:-}"
+    case "$stok" in
+      */*) stok="${stok##*/}" ;;
+    esac
+    case "$stok" in
+      set|export|unset|source|.|:|true|false|alias|unalias|shopt|declare|local|readonly|typeset)
+        # Inert / env-mutating preamble statement — skip this segment.
+        continue
+        ;;
+      cd)
+        local stgt="${STOKENS[$((si+1))]:-}"
+        [ -z "$stgt" ] && continue
+        # Strip surrounding quotes if present.
+        stgt="${stgt%\"}"; stgt="${stgt#\"}"
+        stgt="${stgt%\'}"; stgt="${stgt#\'}"
+        if [ -d "$stgt" ]; then
+          echo "$stgt"
+          return 0
+        fi
+        # cd target didn't resolve — stop walking; downstream segments
+        # operate on a different cwd we can't reason about.
+        return 0
+        ;;
+      *)
+        # First "real" statement is not a cd — no preamble-cd in this
+        # command. Stop walking; per design, only a leading preamble of
+        # env-mutating statements is allowed before the cd.
+        return 0
+        ;;
+    esac
+  done
 }
 
 # Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).

--- a/hooks/_lib/resolve-effective-worktree-root.sh
+++ b/hooks/_lib/resolve-effective-worktree-root.sh
@@ -32,10 +32,18 @@ set -u
 # Extract the cd target from $INPUT (the PreToolUse JSON wire envelope).
 # Returns:
 #   - The cd target (echoed to stdout) iff:
-#       (a) $INPUT's "command" field begins with `cd <target>`
-#           (env-var prefixes are NOT skipped — KEY=VAL cd /tmp/wt is not
-#           recognized as a worktree-cd; this is intentional, agents do
-#           not prefix `cd` with env-vars in practice)
+#       (a) $INPUT's "command" field contains a `cd <target>` statement
+#           after a possibly-empty preamble of inert / env-mutating shell
+#           statements. Segment-walks over `;`, `&&`, `||`, `|`, and
+#           newline separators and skips segments whose first token is
+#           one of: env-var assignment (`KEY=val`), `set …`, `export …`,
+#           `unset …`, `source …`/`. …`, the `:` builtin, the `env`
+#           wrapper preamble. The first `cd <target>` segment encountered
+#           wins. Issue #924: a preamble like
+#           `set -e; export X=Y; . resolver.sh && cd $WT && git commit`
+#           previously failed to extract because the regex required a
+#           leading `cd`; agents commonly emit such preambles for
+#           orchestrator-side worktree bookkeeping.
 #       (b) <target> resolves to an existing directory on disk
 #   - Empty stdout otherwise.
 #
@@ -134,15 +142,77 @@ extract_cd_target() {
     fi
     break
   done
-  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-    local target="${BASH_REMATCH[1]}"
-    # Remove surrounding quotes if present
-    target="${target%\"}"
-    target="${target#\"}"
-    if [ -d "$target" ]; then
-      echo "$target"
-    fi
-  fi
+  # Segment-walk: split $cmd on statement separators (`;`, `&&`, `||`, `|`,
+  # newline) and look for the first `cd <target>` whose preamble in the
+  # segment is purely env-mutating / inert shell statements. Issue #924:
+  # the previous `^cd[[:space:]]+` regex against the whole command missed
+  # `set -e; cd /tmp/wt && …`, `export X=Y; cd …`, `. resolver.sh && cd …`,
+  # `VAR=val cd …`, all common in orchestrator-side worktree bookkeeping.
+  # Segment separators we split on are exactly those that terminate the
+  # previous statement in bash; they cannot appear inside `cd`'s target
+  # token (it's stop-classed on the same chars).
+  local SEG_IFS=$'\n'
+  # Replace each `&&`, `||`, `|`, `;` with a newline so we can read -a.
+  local segs="${cmd//&&/$'\n'}"
+  segs="${segs//||/$'\n'}"
+  segs="${segs//|/$'\n'}"
+  segs="${segs//;/$'\n'}"
+  local IFS_OLD="$IFS"
+  IFS="$SEG_IFS"
+  local -a SEGMENTS
+  # shellcheck disable=SC2206
+  SEGMENTS=( $segs )
+  IFS="$IFS_OLD"
+  local seg
+  for seg in "${SEGMENTS[@]}"; do
+    # Trim leading/trailing whitespace.
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+    seg="${seg%"${seg##*[![:space:]]}"}"
+    [ -z "$seg" ] && continue
+    local -a STOKENS
+    # shellcheck disable=SC2206
+    read -ra STOKENS <<< "$seg"
+    local si=0 sn=${#STOKENS[@]}
+    # Skip env-var assignment prefixes (KEY=val ...).
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    # Skip `env` wrapper (and its KEY=val args).
+    [[ $si -lt $sn && "${STOKENS[$si]}" == "env" ]] && ((si++))
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    local stok="${STOKENS[$si]:-}"
+    case "$stok" in
+      */*) stok="${stok##*/}" ;;
+    esac
+    case "$stok" in
+      set|export|unset|source|.|:|true|false|alias|unalias|shopt|declare|local|readonly|typeset)
+        # Inert / env-mutating preamble statement — skip this segment.
+        continue
+        ;;
+      cd)
+        local stgt="${STOKENS[$((si+1))]:-}"
+        [ -z "$stgt" ] && continue
+        # Strip surrounding quotes if present.
+        stgt="${stgt%\"}"; stgt="${stgt#\"}"
+        stgt="${stgt%\'}"; stgt="${stgt#\'}"
+        if [ -d "$stgt" ]; then
+          echo "$stgt"
+          return 0
+        fi
+        # cd target didn't resolve — stop walking; downstream segments
+        # operate on a different cwd we can't reason about.
+        return 0
+        ;;
+      *)
+        # First "real" statement is not a cd — no preamble-cd in this
+        # command. Stop walking; per design, only a leading preamble of
+        # env-mutating statements is allowed before the cd.
+        return 0
+        ;;
+    esac
+  done
 }
 
 # Resolve the effective worktree root via 3-way fallback. The caller passes

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.0
 # block-stale-skill-version.sh — PreToolUse Bash hook.
 #
 # Denies `git commit` when a staged skill's content hash no longer matches
@@ -167,15 +167,77 @@ extract_cd_target() {
     fi
     break
   done
-  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-    local target="${BASH_REMATCH[1]}"
-    # Remove surrounding quotes if present
-    target="${target%\"}"
-    target="${target#\"}"
-    if [ -d "$target" ]; then
-      echo "$target"
-    fi
-  fi
+  # Segment-walk: split $cmd on statement separators (`;`, `&&`, `||`, `|`,
+  # newline) and look for the first `cd <target>` whose preamble in the
+  # segment is purely env-mutating / inert shell statements. Issue #924:
+  # the previous `^cd[[:space:]]+` regex against the whole command missed
+  # `set -e; cd /tmp/wt && …`, `export X=Y; cd …`, `. resolver.sh && cd …`,
+  # `VAR=val cd …`, all common in orchestrator-side worktree bookkeeping.
+  # Segment separators we split on are exactly those that terminate the
+  # previous statement in bash; they cannot appear inside `cd`'s target
+  # token (it's stop-classed on the same chars).
+  local SEG_IFS=$'\n'
+  # Replace each `&&`, `||`, `|`, `;` with a newline so we can read -a.
+  local segs="${cmd//&&/$'\n'}"
+  segs="${segs//||/$'\n'}"
+  segs="${segs//|/$'\n'}"
+  segs="${segs//;/$'\n'}"
+  local IFS_OLD="$IFS"
+  IFS="$SEG_IFS"
+  local -a SEGMENTS
+  # shellcheck disable=SC2206
+  SEGMENTS=( $segs )
+  IFS="$IFS_OLD"
+  local seg
+  for seg in "${SEGMENTS[@]}"; do
+    # Trim leading/trailing whitespace.
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+    seg="${seg%"${seg##*[![:space:]]}"}"
+    [ -z "$seg" ] && continue
+    local -a STOKENS
+    # shellcheck disable=SC2206
+    read -ra STOKENS <<< "$seg"
+    local si=0 sn=${#STOKENS[@]}
+    # Skip env-var assignment prefixes (KEY=val ...).
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    # Skip `env` wrapper (and its KEY=val args).
+    [[ $si -lt $sn && "${STOKENS[$si]}" == "env" ]] && ((si++))
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    local stok="${STOKENS[$si]:-}"
+    case "$stok" in
+      */*) stok="${stok##*/}" ;;
+    esac
+    case "$stok" in
+      set|export|unset|source|.|:|true|false|alias|unalias|shopt|declare|local|readonly|typeset)
+        # Inert / env-mutating preamble statement — skip this segment.
+        continue
+        ;;
+      cd)
+        local stgt="${STOKENS[$((si+1))]:-}"
+        [ -z "$stgt" ] && continue
+        # Strip surrounding quotes if present.
+        stgt="${stgt%\"}"; stgt="${stgt#\"}"
+        stgt="${stgt%\'}"; stgt="${stgt#\'}"
+        if [ -d "$stgt" ]; then
+          echo "$stgt"
+          return 0
+        fi
+        # cd target didn't resolve — stop walking; downstream segments
+        # operate on a different cwd we can't reason about.
+        return 0
+        ;;
+      *)
+        # First "real" statement is not a cd — no preamble-cd in this
+        # command. Stop walking; per design, only a leading preamble of
+        # env-mutating statements is allowed before the cd.
+        return 0
+        ;;
+    esac
+  done
 }
 
 # Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -459,15 +459,77 @@ extract_cd_target() {
     fi
     break
   done
-  if [[ "$cmd" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-    local target="${BASH_REMATCH[1]}"
-    # Remove surrounding quotes if present
-    target="${target%\"}"
-    target="${target#\"}"
-    if [ -d "$target" ]; then
-      echo "$target"
-    fi
-  fi
+  # Segment-walk: split $cmd on statement separators (`;`, `&&`, `||`, `|`,
+  # newline) and look for the first `cd <target>` whose preamble in the
+  # segment is purely env-mutating / inert shell statements. Issue #924:
+  # the previous `^cd[[:space:]]+` regex against the whole command missed
+  # `set -e; cd /tmp/wt && …`, `export X=Y; cd …`, `. resolver.sh && cd …`,
+  # `VAR=val cd …`, all common in orchestrator-side worktree bookkeeping.
+  # Segment separators we split on are exactly those that terminate the
+  # previous statement in bash; they cannot appear inside `cd`'s target
+  # token (it's stop-classed on the same chars).
+  local SEG_IFS=$'\n'
+  # Replace each `&&`, `||`, `|`, `;` with a newline so we can read -a.
+  local segs="${cmd//&&/$'\n'}"
+  segs="${segs//||/$'\n'}"
+  segs="${segs//|/$'\n'}"
+  segs="${segs//;/$'\n'}"
+  local IFS_OLD="$IFS"
+  IFS="$SEG_IFS"
+  local -a SEGMENTS
+  # shellcheck disable=SC2206
+  SEGMENTS=( $segs )
+  IFS="$IFS_OLD"
+  local seg
+  for seg in "${SEGMENTS[@]}"; do
+    # Trim leading/trailing whitespace.
+    seg="${seg#"${seg%%[![:space:]]*}"}"
+    seg="${seg%"${seg##*[![:space:]]}"}"
+    [ -z "$seg" ] && continue
+    local -a STOKENS
+    # shellcheck disable=SC2206
+    read -ra STOKENS <<< "$seg"
+    local si=0 sn=${#STOKENS[@]}
+    # Skip env-var assignment prefixes (KEY=val ...).
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    # Skip `env` wrapper (and its KEY=val args).
+    [[ $si -lt $sn && "${STOKENS[$si]}" == "env" ]] && ((si++))
+    while [[ $si -lt $sn && "${STOKENS[$si]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((si++))
+    done
+    local stok="${STOKENS[$si]:-}"
+    case "$stok" in
+      */*) stok="${stok##*/}" ;;
+    esac
+    case "$stok" in
+      set|export|unset|source|.|:|true|false|alias|unalias|shopt|declare|local|readonly|typeset)
+        # Inert / env-mutating preamble statement — skip this segment.
+        continue
+        ;;
+      cd)
+        local stgt="${STOKENS[$((si+1))]:-}"
+        [ -z "$stgt" ] && continue
+        # Strip surrounding quotes if present.
+        stgt="${stgt%\"}"; stgt="${stgt#\"}"
+        stgt="${stgt%\'}"; stgt="${stgt#\'}"
+        if [ -d "$stgt" ]; then
+          echo "$stgt"
+          return 0
+        fi
+        # cd target didn't resolve — stop walking; downstream segments
+        # operate on a different cwd we can't reason about.
+        return 0
+        ;;
+      *)
+        # First "real" statement is not a cd — no preamble-cd in this
+        # command. Stop walking; per design, only a leading preamble of
+        # env-mutating statements is allowed before the cd.
+        return 0
+        ;;
+    esac
+  done
 }
 
 # Inlined from hooks/_lib/resolve-effective-worktree-root.sh (source-of-truth, #401).

--- a/tests/test-resolve-effective-worktree-root.sh
+++ b/tests/test-resolve-effective-worktree-root.sh
@@ -10,8 +10,11 @@
 #       * quoted target path (single/double quotes stripped)
 #       * non-existent target (returns empty)
 #       * no leading `cd` (returns empty)
-#       * env-var-prefixed `KEY=val cd ...` (NOT recognized — intentional,
-#         documented carve-out)
+#       * env-var-prefixed `KEY=val cd ...` (recognized — #924)
+#       * shell preamble before cd: `set -e; cd …`, `export X=Y; cd …`,
+#         `. resolver.sh && cd …`, mixed-preamble (#924)
+#       * preamble of inert statements that does NOT contain a cd → empty
+#         (e.g., `set -e; git commit -m foo`)
 #   - resolve_effective_worktree_root:
 #       * env_override takes precedence over cd_target AND fallback
 #       * cd_target takes precedence over fallback when env_override empty
@@ -87,13 +90,14 @@ else
   fail "CE5 expected empty, got [$got]"
 fi
 
-# CE6 — env-var prefix BEFORE cd is NOT recognized (intentional carve-out).
+# CE6 — env-var prefix BEFORE cd is recognized (#924: orchestrator-side
+# `VAR=val cd /tmp/wt && git commit` is a real shape we see in practice).
 INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"FOO=bar cd $TMPDIR_REAL && git commit\"}}"
 got=$(extract_cd_target)
-if [ -z "$got" ]; then
-  pass "CE6 env-var-prefixed cd → empty (intentional carve-out)"
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE6 env-var-prefixed cd (#924) → echoes target"
 else
-  fail "CE6 expected empty (env-prefix not recognized), got [$got]"
+  fail "CE6 expected [$TMPDIR_REAL] got [$got]"
 fi
 
 # CE7 — semicolon separator (cd /tmp/x; git commit).
@@ -103,6 +107,91 @@ if [ "$got" = "$TMPDIR_REAL" ]; then
   pass "CE7 cd <dir>; <cmd> (semicolon separator) → echoes target"
 else
   fail "CE7 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# ─── #924 preamble shapes ───
+# Orchestrator-side worktree bookkeeping commits routinely emit commands
+# with a shell preamble before the cd: `set -e`, `export FOO=bar`,
+# `source <resolver>` / `. <resolver>`, `VAR=val cd …`. Pre-#924 the
+# extract regex required `^cd …`, falling back to the ambient main-repo
+# cwd and triggering false-positive "main is protected" blocks.
+
+# CE8 — `set -e` preamble.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"set -e; cd $TMPDIR_REAL && git commit -m foo\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE8 #924: set -e; cd <dir> → echoes target"
+else
+  fail "CE8 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE9 — `export VAR=val` preamble.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"export FOO=bar; cd $TMPDIR_REAL && git commit\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE9 #924: export VAR=val; cd <dir> → echoes target"
+else
+  fail "CE9 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE10 — `. <file>` (source) preamble joined with &&.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\". /tmp/resolver.sh && cd $TMPDIR_REAL && git commit\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE10 #924: . <file> && cd <dir> → echoes target"
+else
+  fail "CE10 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE11 — `source <file>` preamble joined with &&.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"source /tmp/resolver.sh && cd $TMPDIR_REAL && git commit\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE11 #924: source <file> && cd <dir> → echoes target"
+else
+  fail "CE11 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE12 — mixed preamble (set -e + export + cd).
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"set -e; export FOO=bar; cd $TMPDIR_REAL && git commit -m foo\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE12 #924: set -e; export X=Y; cd <dir> → echoes target"
+else
+  fail "CE12 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE13 — preamble that does NOT lead to a cd → empty (no false-positive
+# extraction from an inert-statement prefix).
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"set -e; export FOO=bar; git commit -m foo\"}}"
+got=$(extract_cd_target)
+if [ -z "$got" ]; then
+  pass "CE13 #924: preamble without cd → empty"
+else
+  fail "CE13 expected empty, got [$got]"
+fi
+
+# CE14 — newline-separated preamble (multi-line bash command).
+# Wire-format double-escape: agent JSON encodes a real newline as `\n`,
+# and we already test `\n` decoding in CE3. Here use the same wire form.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"set -e\\nexport FOO=bar\\ncd $TMPDIR_REAL\\ngit commit\"}}"
+got=$(extract_cd_target)
+if [ "$got" = "$TMPDIR_REAL" ]; then
+  pass "CE14 #924: multi-line preamble + cd → echoes target"
+else
+  fail "CE14 expected [$TMPDIR_REAL] got [$got]"
+fi
+
+# CE15 — non-preamble first statement (e.g., `git status`) before a cd
+# should NOT silently extract the later cd. Pre-#924 the regex would not
+# have matched either; post-#924 we explicitly stop at the first non-inert
+# statement to preserve "first effective cwd" semantics.
+INPUT="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status; cd $TMPDIR_REAL && git commit\"}}"
+got=$(extract_cd_target)
+if [ -z "$got" ]; then
+  pass "CE15 #924: non-inert prefix before cd → empty (stop on first real statement)"
+else
+  fail "CE15 expected empty, got [$got]"
 fi
 
 # ─── resolve_effective_worktree_root tests ───


### PR DESCRIPTION
## Summary

`block-unsafe-project.sh`'s `extract_cd_target` only matched `cd` at command position 0. Commands with shell preamble (`set -e`, `export X=Y`, `. resolver.sh`, `VAR=val cd …`) fell through to ambient cwd → wrongly resolved as main → legitimate worktree commits blocked as "main protected." The fix uses a segment-walking shape that classifies preamble tokens as inert and continues to the first effective `cd`.

Closes #924

## Approach: segment-walking loop (chosen over regex extension)

Splits the command on bash statement separators (`&&`, `||`, `|`, `;`, newline) into segments. Per-segment: skip env-var assignments + optional `env`, then check the first non-env token against an inert-statement whitelist (`set`, `export`, `unset`, `source`, `.`, `:`, `true`, `false`, `alias`, `unalias`, `shopt`, `declare`, `local`, `readonly`, `typeset`). Inert segments skip; a `cd` segment extracts and returns; ANY OTHER "real" statement (e.g. `git status`, `git commit`) stops the walk and returns empty — preserves "first effective cwd wins."

Why segment-walking over regex: regex alternative would fail on multi-segment preambles like `set -e; export X=Y; cd …` because a single anchored regex can't enforce "every preceding segment is inert."

## Files (5)
- `hooks/_lib/resolve-effective-worktree-root.sh` — source-of-truth helper body rewritten; doc-comment updated
- `hooks/block-unsafe-project.sh.template` — inlined helper re-synced byte-identical; line-2 stamp `2026.05.0` → `2026.06.0`
- `hooks/block-stale-skill-version.sh` — inlined helper re-synced byte-identical; stamp bumped
- 2 `.claude/hooks/` mirrors
- `tests/test-resolve-effective-worktree-root.sh` — 8 new cases (CE8-CE15): `set -e`, `export VAR=val`, `. <file>`, `source <file>`, mixed preamble, preamble-without-cd (negative), multi-line wire-newline preamble, non-inert-prefix-before-cd (negative — stops at first real statement). CE6 reversed: `VAR=val cd …` now extracts. Quote-stripping handles BOTH single AND double quotes.

## Test plan
- [x] `bash tests/run-all.sh` — 6840/6840 passed.
- [x] Targeted `test-resolve-effective-worktree-root.sh` — 24/24 (16 prior + 8 new).
- [x] `test-hook-helper-drift.sh` — verified inlined helpers stay byte-identical across all 3 sites.
- [x] Wrapper-unwrap loop (`bash -c '...'`, etc.) preserved unchanged.

## Commits
$(cd /tmp/zskills-do-924-extract-cd-prefix-skip && git log origin/main..HEAD --format='%h %s' | head -3)
