### PR TITLE
fix(#936): make /draft-plan brainstorm+quiz mutually exclusive, end silent order-dependence

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+ac7967"
+  version: "2026.06.01+9a3294"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -158,7 +158,10 @@ fi
   text** is part of the description, NOT the flag — unlike `auto`, `quiz`
   is NOT detected match-anywhere, so a description like "build a quiz app"
   or a trailing "add dark mode quiz" does NOT trigger quiz mode (see the
-  detection note below and the Examples block).
+  detection note below and the Examples block). `brainstorm` and `quiz` are
+  **mutually exclusive** — both are pre-draft interactive interviews
+  occupying the same steering seam, so requesting both (`/draft-plan
+  brainstorm quiz …`) is a fail-loud error, not a silent mode drop (#936).
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -227,12 +230,36 @@ for tok in $ARGUMENTS; do
     output)   expect_value=1 ;;                 # output <path> — value consumed next iter
     rounds)   expect_value=1 ;;                 # rounds N — value consumed next iter
     auto)     ;;                                # recognized flag — consume, keep scanning
+    brainstorm) ;;                              # leading brainstorm flag — consume, keep scanning (#936)
     quiz)     QUIZ_FLAG=1 ;;                     # leading quiz flag
     *.md)     ;;                                # bare leading *.md output token
     */*.md)   ;;                                # path-form leading *.md output token
     *)        break ;;                          # first description token — stop
   esac
 done
+```
+
+**`brainstorm` and `quiz` are mutually exclusive.** Both are pre-draft
+interactive interviews that occupy the SAME steering seam — `brainstorm`
+makes the post-research steering checkpoint skip ("user already steered in
+the dialogue"), and `quiz` REPLACES that same checkpoint with its interview
+loop (branch (a) of the 3-way steering checkpoint below). Running both at
+once is contradictory (two competing interviews, two separate
+`/tmp/draft-plan-{brainstorm,quiz}-$TRACKING_ID.md` notes files both
+claiming to be the pre-draft steering), so the parse FAILS LOUD rather than
+silently picking one. This guard also makes the result **order-independent**:
+`/draft-plan brainstorm quiz X` and `/draft-plan quiz brainstorm X` both
+error identically (#936 — before this guard, the leading-cluster tokenizer
+recognized `quiz` but broke at `brainstorm`, so token order silently decided
+which mode survived). The guard is detection-only — it does not touch the
+`brainstorm` first-token anchor (#914) or the `quiz` leading-flag scan, so
+neither mode's positive/negative behavior regresses:
+
+```bash
+if [ "${BRAINSTORM_FLAG:-0}" = "1" ] && [ "${QUIZ_FLAG:-0}" = "1" ]; then
+  echo "ERROR: brainstorm and quiz modes are mutually exclusive" >&2
+  exit 2
+fi
 ```
 
 Examples:
@@ -246,6 +273,8 @@ Examples:
 - `/draft-plan output p.md quiz rounds 5 Add dark mode` → `QUIZ_FLAG=1` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
 - `/draft-plan output p.md build a quiz app` → `QUIZ_FLAG` NOT set — "quiz" is a description word, not the leading flag (NEGATIVE example; `quiz` is leading-only, never match-anywhere like `auto`)
 - `/draft-plan add dark mode quiz` → `QUIZ_FLAG` NOT set — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable quiz mode, lead with the flag (`/draft-plan quiz add dark mode`).
+- `/draft-plan brainstorm quiz Add dark mode` → **ERROR (exit 2)** — `brainstorm` (first-token flag, #914) and `quiz` (leading-cluster flag) BOTH engage, and the two modes are mutually exclusive (#936). This is the only way to request both modes in one invocation, and it fails loud instead of silently dropping one.
+- `/draft-plan quiz brainstorm Add dark mode` → `QUIZ_FLAG=1`, `BRAINSTORM_FLAG=0` — quiz mode with description "brainstorm Add dark mode". Per #914, `brainstorm` is a flag ONLY as the first token; here it is at position 2, so it is description text, not the brainstorm flag. NOT a both-modes case, so no error. (The `brainstorm) ;;` tokenizer arm above only lets the quiz scan *walk past* a leading `brainstorm`; it never sets `BRAINSTORM_FLAG`, which remains first-token-anchored.)
 
 ## Pre-check — Existing file
 

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+ac7967"
+  version: "2026.06.01+9a3294"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -158,7 +158,10 @@ fi
   text** is part of the description, NOT the flag — unlike `auto`, `quiz`
   is NOT detected match-anywhere, so a description like "build a quiz app"
   or a trailing "add dark mode quiz" does NOT trigger quiz mode (see the
-  detection note below and the Examples block).
+  detection note below and the Examples block). `brainstorm` and `quiz` are
+  **mutually exclusive** — both are pre-draft interactive interviews
+  occupying the same steering seam, so requesting both (`/draft-plan
+  brainstorm quiz …`) is a fail-loud error, not a silent mode drop (#936).
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -227,12 +230,36 @@ for tok in $ARGUMENTS; do
     output)   expect_value=1 ;;                 # output <path> — value consumed next iter
     rounds)   expect_value=1 ;;                 # rounds N — value consumed next iter
     auto)     ;;                                # recognized flag — consume, keep scanning
+    brainstorm) ;;                              # leading brainstorm flag — consume, keep scanning (#936)
     quiz)     QUIZ_FLAG=1 ;;                     # leading quiz flag
     *.md)     ;;                                # bare leading *.md output token
     */*.md)   ;;                                # path-form leading *.md output token
     *)        break ;;                          # first description token — stop
   esac
 done
+```
+
+**`brainstorm` and `quiz` are mutually exclusive.** Both are pre-draft
+interactive interviews that occupy the SAME steering seam — `brainstorm`
+makes the post-research steering checkpoint skip ("user already steered in
+the dialogue"), and `quiz` REPLACES that same checkpoint with its interview
+loop (branch (a) of the 3-way steering checkpoint below). Running both at
+once is contradictory (two competing interviews, two separate
+`/tmp/draft-plan-{brainstorm,quiz}-$TRACKING_ID.md` notes files both
+claiming to be the pre-draft steering), so the parse FAILS LOUD rather than
+silently picking one. This guard also makes the result **order-independent**:
+`/draft-plan brainstorm quiz X` and `/draft-plan quiz brainstorm X` both
+error identically (#936 — before this guard, the leading-cluster tokenizer
+recognized `quiz` but broke at `brainstorm`, so token order silently decided
+which mode survived). The guard is detection-only — it does not touch the
+`brainstorm` first-token anchor (#914) or the `quiz` leading-flag scan, so
+neither mode's positive/negative behavior regresses:
+
+```bash
+if [ "${BRAINSTORM_FLAG:-0}" = "1" ] && [ "${QUIZ_FLAG:-0}" = "1" ]; then
+  echo "ERROR: brainstorm and quiz modes are mutually exclusive" >&2
+  exit 2
+fi
 ```
 
 Examples:
@@ -246,6 +273,8 @@ Examples:
 - `/draft-plan output p.md quiz rounds 5 Add dark mode` → `QUIZ_FLAG=1` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
 - `/draft-plan output p.md build a quiz app` → `QUIZ_FLAG` NOT set — "quiz" is a description word, not the leading flag (NEGATIVE example; `quiz` is leading-only, never match-anywhere like `auto`)
 - `/draft-plan add dark mode quiz` → `QUIZ_FLAG` NOT set — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable quiz mode, lead with the flag (`/draft-plan quiz add dark mode`).
+- `/draft-plan brainstorm quiz Add dark mode` → **ERROR (exit 2)** — `brainstorm` (first-token flag, #914) and `quiz` (leading-cluster flag) BOTH engage, and the two modes are mutually exclusive (#936). This is the only way to request both modes in one invocation, and it fails loud instead of silently dropping one.
+- `/draft-plan quiz brainstorm Add dark mode` → `QUIZ_FLAG=1`, `BRAINSTORM_FLAG=0` — quiz mode with description "brainstorm Add dark mode". Per #914, `brainstorm` is a flag ONLY as the first token; here it is at position 2, so it is description text, not the brainstorm flag. NOT a both-modes case, so no error. (The `brainstorm) ;;` tokenizer arm above only lets the quiz scan *walk past* a leading `brainstorm`; it never sets `BRAINSTORM_FLAG`, which remains first-token-anchored.)
 
 ## Pre-check — Existing file
 

--- a/tests/test-draft-plan-args-smoke.sh
+++ b/tests/test-draft-plan-args-smoke.sh
@@ -252,6 +252,95 @@ else
   fi
 fi
 
+# ── Surface 6: QUIZ_FLAG leading-cluster scan + brainstorm/quiz mutual
+#    exclusion (extract-and-run) ───────────────────────────────────────
+# #936: the leading-cluster tokenizer must recognize `brainstorm` (walk
+# past it) so a leading `brainstorm` does not break the scan before `quiz`
+# is reached. Combined with the first-token-anchored BRAINSTORM_FLAG fence,
+# this makes `brainstorm quiz X` set BOTH flags, which the mutual-exclusion
+# guard converts into a fail-loud exit 2 instead of a silent mode drop.
+# The guard must NOT regress #914 (brainstorm is still first-token-only for
+# BRAINSTORM_FLAG; the tokenizer arm only lets the quiz scan walk past it).
+
+# Extract the QUIZ_FLAG leading-scan fence (QUIZ_FLAG=0 … done — a for-loop,
+# not an `if … fi`, so stop at the first standalone `done`).
+QUIZ_BLOCK=$(awk '
+  /^QUIZ_FLAG=0$/{capture=1}
+  capture {print}
+  capture && /^done$/{exit}
+' "$SKILL")
+
+# Extract the mutual-exclusion guard fence (the `if [ "${BRAINSTORM_FLAG...`
+# block that emits the error and `exit 2`). Stop at its closing `fi`.
+MUTEX_BLOCK=$(awk '
+  /^if \[ "\$\{BRAINSTORM_FLAG/{capture=1}
+  capture {print}
+  capture && /^fi$/{exit}
+' "$SKILL")
+
+if [ -z "$QUIZ_BLOCK" ]; then
+  fail "quiz-flag: could not extract QUIZ_FLAG fence" "awk extract empty"
+elif [ -z "$MUTEX_BLOCK" ]; then
+  fail "mutex: could not extract brainstorm/quiz mutual-exclusion fence" "awk extract empty"
+else
+  pass "quiz-flag: QUIZ_FLAG leading-scan fence extracted from SKILL.md"
+  pass "mutex: brainstorm/quiz mutual-exclusion fence extracted from SKILL.md"
+
+  # Tokenizer-arm parity: the brainstorm) ;; arm must be present (#936).
+  if grep -qF 'brainstorm) ;;' "$SKILL"; then
+    pass "mutex: leading-cluster tokenizer has 'brainstorm) ;;' arm (#936)"
+  else
+    fail "mutex: 'brainstorm) ;;' tokenizer arm missing" "leading scan would break at brainstorm"
+  fi
+
+  # Run BOTH the BRAINSTORM_FLAG and QUIZ_FLAG fences against $ARGUMENTS,
+  # then run the mutual-exclusion guard in a subshell so its `exit 2` is
+  # captured as a subshell exit code rather than killing the test. Echo the
+  # resolved flags so we can also assert the flag values directly.
+  # Run the real fences in a subshell. The flag values are written to a
+  # dedicated file (NOT stderr) so the guard's own stderr error message does
+  # not contaminate the capture; the guard's `exit 2` becomes the subshell rc.
+  flags_for() { # $1=ARGUMENTS $2=flagfile  -> exit code = guard rc
+    (
+      ARGUMENTS="$1"
+      BRAINSTORM_FLAG=
+      QUIZ_FLAG=
+      eval "$BRAINSTORM_BLOCK"
+      eval "$QUIZ_BLOCK"
+      printf 'B=%s Q=%s\n' "$BRAINSTORM_FLAG" "$QUIZ_FLAG" > "$2"
+      eval "$MUTEX_BLOCK"
+    ) 2>/dev/null
+  }
+  check_combo() { # $1=ARGUMENTS $2=expected_B $3=expected_Q $4=expected_rc $5=label
+    local rc fl ff="/tmp/.draftplan-mutex-flags-$$"
+    flags_for "$1" "$ff"; rc=$?
+    fl=$(cat "$ff" 2>/dev/null); rm -f "$ff"
+    if [ "$fl" = "B=$2 Q=$3" ] && [ "$rc" = "$4" ]; then
+      pass "mutex: $5 -> $fl, exit $rc"
+    else
+      fail "mutex: $5" "expected B=$2 Q=$3 exit $4, got '$fl' exit $rc"
+    fi
+  }
+
+  # The core #936 assertion: requesting BOTH modes (brainstorm first, quiz in
+  # the leading cluster) sets both flags and fails loud (exit 2) — NOT a
+  # silent drop of whichever mode wasn't first.
+  check_combo "brainstorm quiz Add dark mode" 1 1 2 "'brainstorm quiz X' -> both flags, mutual-exclusion error"
+  # Reverse order: per #914, a non-first 'brainstorm' is DESCRIPTION text, not
+  # the flag. So this is unambiguously single-mode quiz (no silent drop, no
+  # error). Order is no longer SILENTLY ambiguous: 'brainstorm quiz' errors
+  # loud; 'quiz brainstorm' is the defined #914 single-mode case.
+  check_combo "quiz brainstorm Add dark mode" 0 1 0 "'quiz brainstorm X' -> quiz-only (brainstorm is description per #914), no error"
+  # Single-mode cases must NOT error.
+  check_combo "brainstorm Add dark mode" 1 0 0 "'brainstorm X' -> brainstorm-only, no error"
+  check_combo "quiz Add dark mode" 0 1 0 "'quiz X' -> quiz-only, no error"
+  # #914 non-regression: 'auto brainstorm' must NOT set BRAINSTORM_FLAG, and
+  # the brainstorm) ;; tokenizer arm must not turn it into a both-modes case.
+  check_combo "auto brainstorm Add dark mode" 0 0 0 "'auto brainstorm X' -> neither flag (#914 preserved), no error"
+  # #914 non-regression: brainstorm embedded in description stays inert.
+  check_combo "Build a brainstorm app for kids" 0 0 0 "'Build a brainstorm app' -> neither flag (#914 preserved), no error"
+fi
+
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
 [ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
Fixes #936 (sibling of #914). `/draft-plan`'s leading-cluster argument tokenizer recognized `quiz` (walk + set QUIZ_FLAG) but not `brainstorm` — so `brainstorm` was handled only by a separate first-token-anchored fence (the #914 fix). Result: `/draft-plan brainstorm quiz X` and `/draft-plan quiz brainstorm X` silently produced DIFFERENT mode results based on token order — whichever mode wasn't first got dropped with no warning.

brainstorm and quiz are both pre-draft interview modes occupying the same post-research steering seam (brainstorm skips the checkpoint; quiz replaces it) — combining them is contradictory. So the fix makes them **mutually exclusive, failing loud**:
1. Added `brainstorm) ;;` to the leading-cluster tokenizer case (scan-only — walks past a leading `brainstorm` so quiz is still detected; never sets BRAINSTORM_FLAG, preserving #914's first-token anchoring).
2. Added a mutual-exclusion guard: if both flags resolve, `ERROR: brainstorm and quiz modes are mutually exclusive` + exit 2.

Now neither order silently drops a mode: `brainstorm quiz X` → loud error; `quiz brainstorm X` → quiz mode with brainstorm-as-description (well-defined per #914).

## Test plan
- [x] `bash tests/run-all.sh` — 6946/6946 passed, 0 failed (verifier-confirmed, serial run).
- [x] test-draft-plan-args-smoke.sh 43/43 incl. both-orders cases (fail pre-fix).
- [x] #914 non-regression: `auto brainstorm X` + `Build a brainstorm app` → neither flag (brainstorm stays first-token-anchored).
- [x] mirror-parity + conformance pass. (Implementer's transient dashboard-ui failures were parallel-run port contention — did not reproduce serially; diff touches zero dashboard files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
