### PR TITLE
fix(#935): clear in-flight sentinel in /run-plan Phase 5c chunked transition

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.01+0f0dba"
+  version: "2026.06.01+ac7065"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/references/finish-mode.md
+++ b/.claude/skills/run-plan/references/finish-mode.md
@@ -53,6 +53,48 @@ After Phase 6 (land) succeeds for the current phase AND
 > schedule runs AFTER `post-run-invariants.sh` passes. If invariants
 > fail, do NOT schedule the next cron; invoke Failure Protocol.
 
+> **In-flight sentinel clear (issue #935) — REQUIRED before scheduling
+> the next-phase cron.** Phase 5c is a NON-terminal exit: it ends this
+> chunked turn and reschedules a cron for the next phase, but it is NOT
+> Phase 5b's already-complete no-op or Phase 6's terminal merge — the
+> only two sites that clear the same-plan in-flight sentinel written at
+> Phase 1 entry (issue #883). Without a clear here, this turn's still-fresh
+> sentinel persists into fire N+1, which runs in the SAME session with the
+> SAME `$PIPELINE_ID` (`run-plan.$TRACKING_ID`, stable across fires) — so
+> fire N+1's Phase 1 same-plan guard `check` MATCHES the stale sentinel and
+> SKIPS the whole turn ("skipping redundant cron re-fire"). The multi-phase
+> plan then silently stalls until the helper's 2h stale-sentinel escape —
+> functionally indistinguishable from a hung verifier. Between chunked
+> fires the pipeline is NOT in flight; it is idle waiting for the next cron
+> tick, so clearing the sentinel here is correct. The guard's actual job —
+> skipping a genuine OVERLAPPING re-fire (two cron ticks landing while one
+> turn is mid-execution) — is unaffected, because Phase 5c only runs when a
+> turn is ENDING (rescheduling), so the next fire writes a fresh sentinel
+> on entry that covers any later overlap. Use the EXACT canonical idiom
+> already used at the Phase 5b and Phase 6 clear sites in
+> `modes/execute-phase.md` (`$INFLIGHT_HELPER` and `$PIPELINE_ID` are both
+> resolved at Phase 1 entry — re-resolve them here the same way the other
+> clear sites do, since each chunked turn is a fresh process):
+>
+> ```bash
+> if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+>   . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+> else
+>   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+> fi
+> PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+> PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+> INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+> if [ -x "$INFLIGHT_HELPER" ]; then
+>   bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+> fi
+> ```
+>
+> This clear applies to BOTH cases 1 and 2 below (next-phase-in-this-plan
+> and sub-plan-delegate-to-meta-plan) — every path that reschedules a cron
+> and ends the turn. Case 3 (all phases done) routes through Phase 5b /
+> Phase 6, whose existing terminal clears cover it.
+
 1. **NEXT incomplete phase exists in this plan**: schedule a one-shot cron
    (`recurring: false`) for `/run-plan <plan-file> finish auto` ~5 min
    from now. The next cron-fired turn will pick up the next phase. Then

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.01+0f0dba"
+  version: "2026.06.01+ac7065"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/references/finish-mode.md
+++ b/skills/run-plan/references/finish-mode.md
@@ -53,6 +53,48 @@ After Phase 6 (land) succeeds for the current phase AND
 > schedule runs AFTER `post-run-invariants.sh` passes. If invariants
 > fail, do NOT schedule the next cron; invoke Failure Protocol.
 
+> **In-flight sentinel clear (issue #935) — REQUIRED before scheduling
+> the next-phase cron.** Phase 5c is a NON-terminal exit: it ends this
+> chunked turn and reschedules a cron for the next phase, but it is NOT
+> Phase 5b's already-complete no-op or Phase 6's terminal merge — the
+> only two sites that clear the same-plan in-flight sentinel written at
+> Phase 1 entry (issue #883). Without a clear here, this turn's still-fresh
+> sentinel persists into fire N+1, which runs in the SAME session with the
+> SAME `$PIPELINE_ID` (`run-plan.$TRACKING_ID`, stable across fires) — so
+> fire N+1's Phase 1 same-plan guard `check` MATCHES the stale sentinel and
+> SKIPS the whole turn ("skipping redundant cron re-fire"). The multi-phase
+> plan then silently stalls until the helper's 2h stale-sentinel escape —
+> functionally indistinguishable from a hung verifier. Between chunked
+> fires the pipeline is NOT in flight; it is idle waiting for the next cron
+> tick, so clearing the sentinel here is correct. The guard's actual job —
+> skipping a genuine OVERLAPPING re-fire (two cron ticks landing while one
+> turn is mid-execution) — is unaffected, because Phase 5c only runs when a
+> turn is ENDING (rescheduling), so the next fire writes a fresh sentinel
+> on entry that covers any later overlap. Use the EXACT canonical idiom
+> already used at the Phase 5b and Phase 6 clear sites in
+> `modes/execute-phase.md` (`$INFLIGHT_HELPER` and `$PIPELINE_ID` are both
+> resolved at Phase 1 entry — re-resolve them here the same way the other
+> clear sites do, since each chunked turn is a fresh process):
+>
+> ```bash
+> if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+>   . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+> else
+>   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+> fi
+> PIPELINE_ID="${ZSKILLS_PIPELINE_ID:-run-plan.$TRACKING_ID}"
+> PIPELINE_ID=$(bash "$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/sanitize-pipeline-id.sh" "$PIPELINE_ID")
+> INFLIGHT_HELPER="$ZSKILLS_SKILLS_ROOT/create-worktree/scripts/check-inflight-batch.sh"
+> if [ -x "$INFLIGHT_HELPER" ]; then
+>   bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true
+> fi
+> ```
+>
+> This clear applies to BOTH cases 1 and 2 below (next-phase-in-this-plan
+> and sub-plan-delegate-to-meta-plan) — every path that reschedules a cron
+> and ends the turn. Case 3 (all phases done) routes through Phase 5b /
+> Phase 6, whose existing terminal clears cover it.
+
 1. **NEXT incomplete phase exists in this plan**: schedule a one-shot cron
    (`recurring: false`) for `/run-plan <plan-file> finish auto` ~5 min
    from now. The next cron-fired turn will pick up the next phase. Then

--- a/tests/test-inflight-reentry-guard.sh
+++ b/tests/test-inflight-reentry-guard.sh
@@ -180,6 +180,42 @@ fi
 (cd "$FIXTURE" && bash "$HELPER" clear do --pipeline-id "do.fix-readme") >/dev/null 2>&1
 
 echo ""
+echo "=== chunked finish-auto: sentinel cleared between sequential fires (issue #935) ==="
+# Behavioral simulation of two SEQUENTIAL chunked finish-auto cron fires of
+# the same multi-phase plan. Fire N writes the same-plan sentinel at Phase 1
+# entry, runs its phase, and reaches the Phase 5c chunked transition which
+# (post-#935) MUST clear the sentinel before scheduling fire N+1. Fire N+1,
+# same session + same pipeline_id (run-plan.$TRACKING_ID is stable across
+# fires), then re-enters Phase 1 and runs its same-plan guard `check`. With
+# the Phase 5c clear in place the sentinel is gone, so fire N+1 PROCEEDS
+# (rc=1) and executes the next phase. Without it the stale-fresh sentinel
+# matches → fire N+1 SKIPS (rc=0) → the plan silently stalls until the 2h
+# escape. We assert the cleared-between-fires behavior the fix guarantees.
+CHUNK_SID="TEST-SID-935"
+CHUNK_PID="run-plan.multi-phase-plan"
+# --- Fire N: Phase 1 entry writes the sentinel ---
+(cd "$FIXTURE" && bash "$HELPER" write run-plan --pipeline-id "$CHUNK_PID" --session-id "$CHUNK_SID")
+# Sanity: a re-fire BEFORE Phase 5c clears (i.e. a genuine overlapping fire
+# while fire N is still mid-turn) MUST still skip — the guard's real job.
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "$CHUNK_SID" --pipeline-id "$CHUNK_PID" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "overlapping re-fire (before Phase 5c clear) still skips — guard intact (rc=0)"
+else
+  fail "overlapping re-fire (before Phase 5c clear) still skips" "got rc=$rc"
+fi
+# --- Phase 5c chunked transition: clears the sentinel before rescheduling ---
+(cd "$FIXTURE" && bash "$HELPER" clear run-plan --pipeline-id "$CHUNK_PID")
+# --- Fire N+1: Phase 1 same-plan guard check — must PROCEED, not skip ---
+(cd "$FIXTURE" && bash "$HELPER" check run-plan --session-id "$CHUNK_SID" --pipeline-id "$CHUNK_PID" >/dev/null 2>&1)
+rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "fire N+1 proceeds after Phase 5c clear — no silent stall (rc=1)"
+else
+  fail "fire N+1 proceeds after Phase 5c clear — no silent stall (rc=1)" "got rc=$rc (sentinel persisted → fire N+1 would SKIP, #935 deadlock)"
+fi
+
+echo ""
 echo "=== call-site wiring assertions ==="
 
 assert_wired() {
@@ -213,6 +249,18 @@ else
 fi
 assert_wired "run-plan execute-phase.md: clear w/ --pipeline-id" "$RP_EXEC" \
   '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
+
+# /run-plan references/finish-mode.md — Phase 5c chunked-transition clear
+# (issue #935). SKILL.md Phase 5c and modes/execute-phase.md Phase 5c both
+# delegate to references/finish-mode.md, which MUST clear the same-plan
+# sentinel before rescheduling the next-phase cron — mirroring the Phase 5b
+# / Phase 6 terminal clears — so a sequential chunked fire N+1 doesn't match
+# the stale-fresh sentinel and silently skip.
+RP_FINISH="$REPO_ROOT/skills/run-plan/references/finish-mode.md"
+assert_wired "run-plan finish-mode.md: Phase 5c clear w/ --pipeline-id (#935)" "$RP_FINISH" \
+  '"\$INFLIGHT_HELPER" clear run-plan --pipeline-id "\$PIPELINE_ID"'
+assert_wired "run-plan finish-mode.md: #935 annotation on Phase 5c clear" "$RP_FINISH" \
+  'issue #935'
 
 # /do mode files — entry-guard wiring.
 DO_PR="$REPO_ROOT/skills/do/modes/pr.md"
@@ -250,6 +298,7 @@ for pair in \
   "create-worktree/scripts/check-inflight-batch.sh" \
   "run-plan/SKILL.md" \
   "run-plan/modes/execute-phase.md" \
+  "run-plan/references/finish-mode.md" \
   "do/SKILL.md" \
   "do/modes/pr.md" \
   "do/modes/worktree.md" \


### PR DESCRIPTION
## Summary
Fixes #935. `/run-plan`'s cron-pickup in-flight sentinel (PR #911) was cleared ONLY at terminal sites — Phase 5b (already-complete) and Phase 6 (terminal-merge). But chunked finish-auto (`/run-plan PLAN finish auto every */N`) exits at the NON-terminal Phase 5c transition (reschedules the next cron, ends the turn) with no clear. So fire N+1 (same session, same plan-derived pipeline_id) hit the in-flight check, matched the still-fresh sentinel, and SKIPPED — the multi-phase plan silently stalled until the 2h stale-sentinel escape, indistinguishable from a hung verifier.

Reachability confirmed by trace: fire N+1 routes to the normal-proceed path (next phase stays ⬚), plan-claim self-re-enters rc=0, and the in-flight check matches the uncleared sentinel → SKIP.

Fix: add the canonical clear `bash "$INFLIGHT_HELPER" clear run-plan --pipeline-id "$PIPELINE_ID" || true` in the Phase 5c chunked transition (references/finish-mode.md) BEFORE rescheduling, mirroring the two terminal-clear sites. The clear runs only on the turn-ending reschedule path, so a genuine overlapping mid-turn re-fire still skips (the next fire writes a fresh sentinel at Phase 1 entry) — the guard's actual purpose stays intact.

## Test plan
- [x] `bash tests/run-all.sh` — 6937/6937 passed, 0 failed (verifier-confirmed).
- [x] test-inflight-reentry-guard.sh 40/40: fire N+1 proceeds after Phase 5c clear (rc=1), AND overlapping re-fire before clear still skips (rc=0). Wiring asserts fail pre-fix.
- [x] mirror-parity + conformance pass.

Note: test-inflight-reentry-guard.sh is not registered in run-all.sh (orphaned since #911) — tracking separately; assertions verified by direct run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
