### PR TITLE
do: collapse /draft-plan brainstorm/quiz to one selector

### DIFF
--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] [quiz] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+9a3294"
+  version: "2026.06.01+dc143f"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -113,7 +113,7 @@ fi
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] [auto] [quiz] <description...>
+/draft-plan [output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>
 ```
 
 - **output FILE** (optional) — where to write the plan. Default:
@@ -142,26 +142,24 @@ fi
 - `rounds` followed by a number — max review cycles
 - `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
   for Phase 6's `/land-pr` dispatch
-- `brainstorm` (first token only, case-insensitive) — sets
-  `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
-  (`references/brainstorm.md`) before Phase 1. Anchored to the FIRST token
-  of `$ARGUMENTS` (mirroring the `.md` output-file detection's
-  first-position anchor) so it does NOT engage when `brainstorm` appears
-  anywhere else in the args buffer, e.g. `/draft-plan Build a brainstorm
-  app for kids` or `/draft-plan Add a brainstorm feature` (#914). Also
-  anchored so it does NOT match `brainstorming`/`brainstormed`/`brainstorms`.
-- `quiz` (recognized **ONLY as a leading flag token** — in the flag
-  cluster before the description begins, like `output`/`rounds`/`auto`,
-  case-insensitive) — sets `QUIZ_FLAG=1`, which conducts an interactive
-  requirements interview before drafting by loading
-  (`references/quiz.md`). A `quiz` appearing **within the description
-  text** is part of the description, NOT the flag — unlike `auto`, `quiz`
-  is NOT detected match-anywhere, so a description like "build a quiz app"
-  or a trailing "add dark mode quiz" does NOT trigger quiz mode (see the
-  detection note below and the Examples block). `brainstorm` and `quiz` are
-  **mutually exclusive** — both are pre-draft interactive interviews
-  occupying the same steering seam, so requesting both (`/draft-plan
-  brainstorm quiz …`) is a fail-loud error, not a silent mode drop (#936).
+- `brainstorm` | `quiz` (a single mutually-exclusive **steering selector**,
+  recognized **ONLY as a leading flag token** — in the flag cluster before
+  the description begins, like `output`/`rounds`/`auto`, case-insensitive) —
+  sets `STEERING_MODE` to one of `brainstorm` or `quiz` (default: empty).
+  `brainstorm` loads the interactive brainstorm dialogue
+  (`references/brainstorm.md`) before Phase 1; `quiz` conducts an interactive
+  requirements interview before drafting by loading (`references/quiz.md`).
+  Both are pre-draft interactive interviews occupying the SAME steering seam,
+  so they are **mutually exclusive** — requesting both (in either order,
+  `/draft-plan brainstorm quiz …` or `/draft-plan quiz brainstorm …`) is a
+  fail-loud error (`exit 2`), not a silent mode drop (#936, #944). A
+  `brainstorm`/`quiz` appearing **within the description text** is part of
+  the description, NOT the flag — unlike `auto`, the selector is NOT detected
+  match-anywhere, so a description like "build a quiz app" or "Build a
+  brainstorm app for kids" does NOT trigger either mode (the leading-cluster
+  scan `break`s at the first non-flag token; see the detection note below and
+  the Examples block) (#914). The exact-match `case` arms also mean
+  `brainstorming`/`brainstormed`/`brainstorms`/`quizzes` do NOT trigger.
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -172,51 +170,61 @@ if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
 fi
 ```
 
-`BRAINSTORM_FLAG` is detected by its OWN dedicated fence (kept separate
-from the `AUTO_FLAG` fence above so the args-smoke extractor that keys on
-the `AUTO_FLAG=0 … fi` block is not perturbed):
-
-```bash
-BRAINSTORM_FLAG=0
-# Anchor 'brainstorm' to the FIRST token of $ARGUMENTS (#914). Mirrors the
-# `.md` output-file first-position anchor in the args parser above. This
-# makes `/draft-plan Build a brainstorm app for kids` (and any other args
-# buffer where `brainstorm` is embedded in the description) correctly fall
-# through to Phase 1 instead of opening the 8-step brainstorm dialogue.
-# Read-array off $ARGUMENTS (word-split on whitespace, same as the args
-# parser above), lowercase the first token, compare to literal "brainstorm".
-read -r _bs_first _bs_rest <<<"$ARGUMENTS"
-_bs_lower=$(printf '%s' "$_bs_first" | tr '[:upper:]' '[:lower:]')
-if [ "$_bs_lower" = "brainstorm" ]; then
-  BRAINSTORM_FLAG=1
-fi
-unset _bs_first _bs_rest _bs_lower
-```
-
-**`QUIZ_FLAG` is detected by LEADING-FLAG recognition — NOT `auto`'s
-match-anywhere regex.** `quiz` fires **only** when it appears in the
-leading flag cluster, before the first description token. If a description
-word "quiz" set the flag (the way a description word "auto" trips
-`AUTO_FLAG` today — a pre-existing exposure NOT inherited here), then an
-autonomously-dispatched call from `/research-and-plan` (which passes the
-user description verbatim) or the `/run-plan` delegate
+**`STEERING_MODE` is detected by LEADING-FLAG recognition — NOT `auto`'s
+match-anywhere regex.** `brainstorm`/`quiz` fire **only** when they appear
+in the leading flag cluster, before the first description token. If a
+description word "quiz"/"brainstorm" set the mode (the way a description
+word "auto" trips `AUTO_FLAG` today — a pre-existing exposure NOT inherited
+here), then an autonomously-dispatched call from `/research-and-plan` (which
+passes the user description verbatim) or the `/run-plan` delegate
 (`/draft-plan plans/FOO.md <desc> auto`) would hang the pipeline on an
 interactive prompt with no human to answer. So the parse consumes the
-leading cluster first and only then tests for `quiz`. Tokenize the leading
-cluster: consume, **in any order**, the output-file token (either the
-literal `output <path>`, OR a bare leading `*.md` token), `rounds N`
-(consuming the numeric value token after `rounds`, so the bare `N` is not
-mis-read as the first description token), `auto`, and `quiz`. The **first
-token matching none of these** begins the description, and everything from
-there (including any later `quiz`) is description, not a flag:
+leading cluster first and only then tests for the steering tokens. Tokenize
+the leading cluster: consume, **in any order**, the output-file token
+(either the literal `output <path>`, OR a bare leading `*.md` token),
+`rounds N` (consuming the numeric value token after `rounds`, so the bare
+`N` is not mis-read as the first description token), `auto`, `brainstorm`,
+and `quiz`. The **first token matching none of these** begins the
+description, and everything from there (including any later
+`quiz`/`brainstorm`) is description, not a flag.
+
+`brainstorm` and `quiz` are **mutually exclusive** — both are pre-draft
+interactive interviews occupying the SAME steering seam (`brainstorm` makes
+the post-research steering checkpoint skip, "user already steered in the
+dialogue"; `quiz` REPLACES that same checkpoint with its interview loop,
+branch (a) of the 3-way steering checkpoint below), and running both at once
+is contradictory (two competing interviews, two separate
+`/tmp/draft-plan-{brainstorm,quiz}-$TRACKING_ID.md` notes files both
+claiming to be the pre-draft steering). Rather than represent-then-forbid
+the illegal "both" state with two booleans, a single `STEERING_MODE` (one of
+`""`, `brainstorm`, `quiz`) makes it **unrepresentable**: a `set_steering`
+helper sets the mode the first time, and FAILS LOUD (`exit 2`) if a second,
+DIFFERENT steering token is seen. Because both tokens are recognized by the
+SAME leading-cluster scan (no token[0]-only anchor for `brainstorm`), the
+conflict is detected regardless of order — `/draft-plan brainstorm quiz X`
+and `/draft-plan quiz brainstorm X` BOTH `exit 2` (#936, #944 — genuine
+order-independence; the prior two-parser design only errored on the first
+order). A repeated SAME token (`brainstorm brainstorm X`) is a harmless
+no-op:
 
 ```bash
-QUIZ_FLAG=0
+STEERING_MODE=""   # "" | brainstorm | quiz — single mutually-exclusive selector
+# set_steering MODE: set STEERING_MODE the first time; fail loud (exit 2) on
+# a conflicting second mode; no-op on a repeat of the same mode. The illegal
+# "both" state is unrepresentable, so the conflict is order-independent.
+set_steering() {
+  if [ -z "$STEERING_MODE" ]; then
+    STEERING_MODE="$1"
+  elif [ "$STEERING_MODE" != "$1" ]; then
+    echo "ERROR: brainstorm and quiz modes are mutually exclusive" >&2
+    exit 2
+  fi
+}
 # Leading-flag scan: walk the tokens, consuming recognized flags in any
 # order. Stop at the first token that is none of them — that begins the
-# description. A `quiz` AFTER the description start is description text,
-# never the flag. (Strip the description first; never match raw
-# $ARGUMENTS match-anywhere — that is exactly auto's false-positive.)
+# description. A `quiz`/`brainstorm` AFTER the description start is
+# description text, never the flag. (Strip the description first; never match
+# raw $ARGUMENTS match-anywhere — that is exactly auto's false-positive.)
 expect_value=0   # 1 = the previous token was `output`/`rounds`; this one is its value
 for tok in $ARGUMENTS; do
   if [ "$expect_value" = "1" ]; then
@@ -227,39 +235,16 @@ for tok in $ARGUMENTS; do
   fi
   ltok=$(printf '%s' "$tok" | tr '[:upper:]' '[:lower:]')
   case "$ltok" in
-    output)   expect_value=1 ;;                 # output <path> — value consumed next iter
-    rounds)   expect_value=1 ;;                 # rounds N — value consumed next iter
-    auto)     ;;                                # recognized flag — consume, keep scanning
-    brainstorm) ;;                              # leading brainstorm flag — consume, keep scanning (#936)
-    quiz)     QUIZ_FLAG=1 ;;                     # leading quiz flag
-    *.md)     ;;                                # bare leading *.md output token
-    */*.md)   ;;                                # path-form leading *.md output token
-    *)        break ;;                          # first description token — stop
+    output)     expect_value=1 ;;               # output <path> — value consumed next iter
+    rounds)     expect_value=1 ;;               # rounds N — value consumed next iter
+    auto)       ;;                              # recognized flag — consume, keep scanning
+    brainstorm) set_steering brainstorm ;;      # leading brainstorm flag (#944)
+    quiz)       set_steering quiz ;;            # leading quiz flag
+    *.md)       ;;                              # bare leading *.md output token
+    */*.md)     ;;                              # path-form leading *.md output token
+    *)          break ;;                        # first description token — stop
   esac
 done
-```
-
-**`brainstorm` and `quiz` are mutually exclusive.** Both are pre-draft
-interactive interviews that occupy the SAME steering seam — `brainstorm`
-makes the post-research steering checkpoint skip ("user already steered in
-the dialogue"), and `quiz` REPLACES that same checkpoint with its interview
-loop (branch (a) of the 3-way steering checkpoint below). Running both at
-once is contradictory (two competing interviews, two separate
-`/tmp/draft-plan-{brainstorm,quiz}-$TRACKING_ID.md` notes files both
-claiming to be the pre-draft steering), so the parse FAILS LOUD rather than
-silently picking one. This guard also makes the result **order-independent**:
-`/draft-plan brainstorm quiz X` and `/draft-plan quiz brainstorm X` both
-error identically (#936 — before this guard, the leading-cluster tokenizer
-recognized `quiz` but broke at `brainstorm`, so token order silently decided
-which mode survived). The guard is detection-only — it does not touch the
-`brainstorm` first-token anchor (#914) or the `quiz` leading-flag scan, so
-neither mode's positive/negative behavior regresses:
-
-```bash
-if [ "${BRAINSTORM_FLAG:-0}" = "1" ] && [ "${QUIZ_FLAG:-0}" = "1" ]; then
-  echo "ERROR: brainstorm and quiz modes are mutually exclusive" >&2
-  exit 2
-fi
 ```
 
 Examples:
@@ -269,12 +254,15 @@ Examples:
 - `/draft-plan output plans/THERMAL_PLAN.md rounds 5 Implement thermal domain`
 - `/draft-plan rounds 5 Implement thermal domain with multi-domain coupling`
 - `/draft-plan Fix the README.md formatting` → description only, no output file detected
-- `/draft-plan quiz Add dark mode to the editor` → `QUIZ_FLAG=1` (leading flag) — runs the interactive requirements interview first
-- `/draft-plan output p.md quiz rounds 5 Add dark mode` → `QUIZ_FLAG=1` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
-- `/draft-plan output p.md build a quiz app` → `QUIZ_FLAG` NOT set — "quiz" is a description word, not the leading flag (NEGATIVE example; `quiz` is leading-only, never match-anywhere like `auto`)
-- `/draft-plan add dark mode quiz` → `QUIZ_FLAG` NOT set — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable quiz mode, lead with the flag (`/draft-plan quiz add dark mode`).
-- `/draft-plan brainstorm quiz Add dark mode` → **ERROR (exit 2)** — `brainstorm` (first-token flag, #914) and `quiz` (leading-cluster flag) BOTH engage, and the two modes are mutually exclusive (#936). This is the only way to request both modes in one invocation, and it fails loud instead of silently dropping one.
-- `/draft-plan quiz brainstorm Add dark mode` → `QUIZ_FLAG=1`, `BRAINSTORM_FLAG=0` — quiz mode with description "brainstorm Add dark mode". Per #914, `brainstorm` is a flag ONLY as the first token; here it is at position 2, so it is description text, not the brainstorm flag. NOT a both-modes case, so no error. (The `brainstorm) ;;` tokenizer arm above only lets the quiz scan *walk past* a leading `brainstorm`; it never sets `BRAINSTORM_FLAG`, which remains first-token-anchored.)
+- `/draft-plan brainstorm Add dark mode to the editor` → `STEERING_MODE=brainstorm` (leading flag) — runs the interactive brainstorm dialogue first
+- `/draft-plan quiz Add dark mode to the editor` → `STEERING_MODE=quiz` (leading flag) — runs the interactive requirements interview first
+- `/draft-plan output p.md quiz rounds 5 Add dark mode` → `STEERING_MODE=quiz` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
+- `/draft-plan output p.md brainstorm Add dark mode` → `STEERING_MODE=brainstorm` (brainstorm is in the leading flag cluster — composability parity with quiz; #944 — no longer token[0]-only)
+- `/draft-plan output p.md build a quiz app` → `STEERING_MODE` empty — "quiz" is a description word, not the leading flag (NEGATIVE example; the selector is leading-only, never match-anywhere like `auto`)
+- `/draft-plan Build a brainstorm app for kids` → `STEERING_MODE` empty — "brainstorm" is a description word; the leading-cluster scan `break`s at the first non-flag token "Build" before it is reached (#914)
+- `/draft-plan add dark mode quiz` → `STEERING_MODE` empty — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable a mode, lead with the flag (`/draft-plan quiz add dark mode`).
+- `/draft-plan brainstorm quiz Add dark mode` → **ERROR (exit 2)** — both `brainstorm` and `quiz` are leading-cluster flags and the two modes are mutually exclusive (#936, #944). Fails loud instead of silently dropping one.
+- `/draft-plan quiz brainstorm Add dark mode` → **ERROR (exit 2)** — same conflict, OTHER order. Because both tokens are recognized by the same leading-cluster scan, the mutual-exclusion error is **order-independent** (#944 — the prior two-parser design errored only on the `brainstorm quiz` order and silently swallowed `brainstorm` here).
 
 ## Pre-check — Existing file
 
@@ -290,17 +278,17 @@ This handles the common case of modernizing old-format plans:
 
 ## Brainstorm mode (only when the `brainstorm` flag is present)
 
-If `BRAINSTORM_FLAG=1`, **Read [references/brainstorm.md](references/brainstorm.md)** via the
+If `STEERING_MODE = brainstorm`, **Read [references/brainstorm.md](references/brainstorm.md)** via the
 Read tool and execute its dialogue loop now, before Phase 1 — UNLESS the notes file
 `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` already exists with `status: ready` (a prior,
 completed dialogue — proceed straight to Phase 1 using it as the seed). If the notes file
 exists with `status: in-progress` (a dialogue interrupted by compaction/crash), RESUME it from
-its captured state rather than restarting. If `BRAINSTORM_FLAG=0`, **ignore the reference file
+its captured state rather than restarting. If `STEERING_MODE != brainstorm`, **ignore the reference file
 entirely** and proceed straight to Phase 1.
 
 ## Quiz mode (only when the `quiz` flag is present) — research sequencing
 
-When `QUIZ_FLAG=1` **and** running interactively (the same predicate as the
+When `STEERING_MODE = quiz` **and** running interactively (the same predicate as the
 subagent-skip in "Post-research tracking" below — quiz never fires under a
 subagent caller in practice, since the research-and-* callers don't pass
 `quiz`), the conversational requirements interview runs **FIRST, before any
@@ -310,11 +298,11 @@ split, moved, or interleaved — the fan-out is simply gated behind the quiz
 and seeded with the interview file. Concretely:
 
 1. **Defer the research fan-out** until the quiz produces its go-signal. Do
-   NOT dispatch the Phase-1 Research agents while `QUIZ_FLAG=1` and the quiz
+   NOT dispatch the Phase-1 Research agents while `STEERING_MODE = quiz` and the quiz
    has not yet exited.
 2. **Conduct the interview now.** The conditional-load directive and the
    quiz loop are emitted at the "Post-research tracking" seam below (Work
-   Item 5's 3-way branch); when `QUIZ_FLAG=1` that seam is reached with the
+   Item 5's 3-way branch); when `STEERING_MODE = quiz` that seam is reached with the
    research fan-out still deferred, the directive fires, and the interview
    runs to its explicit go-signal.
 3. **On the go-signal, run the existing Phase-1 fan-out UNCHANGED**
@@ -330,7 +318,7 @@ and seeded with the interview file. Concretely:
    re-derived one.
 4. **Then Phase 2 drafts** from the seeded research.
 
-When `QUIZ_FLAG=0`, research runs **exactly as today** — the full Phase-1
+When `STEERING_MODE != quiz`, research runs **exactly as today** — the full Phase-1
 fan-out runs immediately, followed by the single-shot post-research
 checkpoint. quiz.md is never read and no `step.*.quiz` marker is written.
 
@@ -371,7 +359,7 @@ printf 'skill: draft-plan\nid: %s\noutput: %s\nstatus: started\ndate: %s\n' \
 Dispatch multiple Explore agents in parallel to investigate the problem space.
 Each agent gets the full description and a specific research focus:
 
-**Brainstorm feed-forward.** When `BRAINSTORM_FLAG=1`, inject the literal
+**Brainstorm feed-forward.** When `STEERING_MODE = brainstorm`, inject the literal
 path `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` into EACH research
 agent's PROMPT, with an instruction to read it as the **primary design
 seed** (the user already steered the design in the brainstorm dialogue).
@@ -379,7 +367,7 @@ Inject the path into the prompts — NOT into the research consolidation
 file, which does not exist until after dispatch. The Codebase / Patterns /
 Prior-art agents still run to ground the design against the repo; the
 Domain agent's "what to build" work is largely pre-answered by the
-brainstorm and may be reduced to verification. When `BRAINSTORM_FLAG=0`,
+brainstorm and may be reduced to verification. When `STEERING_MODE != brainstorm`,
 dispatch the agents normally with no notes-file injection.
 
 1. **Codebase agent** — find all relevant source files, understand current
@@ -475,7 +463,7 @@ printf 'completed: %s\n' "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.research"
 ```
 
-**Skip this steering checkpoint when `BRAINSTORM_FLAG=1`** — the user
+**Skip this steering checkpoint when `STEERING_MODE = brainstorm`** — the user
 already steered the design, in depth, during the brainstorm dialogue, so
 re-prompting here is redundant; proceed directly to Phase 2. (This is an
 ADDITIVE condition; the existing "if running as a subagent, skip" branch
@@ -484,7 +472,7 @@ below is unchanged.)
 This steering checkpoint is a **3-way branch.** The branch sits AFTER the
 scope-check decomposition `exit` above and BEFORE Phase 2:
 
-**(a) When `QUIZ_FLAG=1` and running interactively** (the same predicate
+**(a) When `STEERING_MODE = quiz` and running interactively** (the same predicate
 as the subagent-skip in branch (c) below — interactive, not a subagent):
 emit the conditional-load directive
 
@@ -496,7 +484,7 @@ explicit go-signal**. Note: per "Quiz mode" above, this branch is reached
 with the Phase-1 research fan-out still DEFERRED — the interview runs first,
 and the (seeded) fan-out runs only after the go-signal, before Phase 2.
 
-**(b) When `QUIZ_FLAG=0`** (default), the existing single-shot checkpoint,
+**(b) When `STEERING_MODE != quiz`** (default), the existing single-shot checkpoint,
 verbatim and unchanged:
 
 **Present the research summary to the user.** If running interactively
@@ -521,7 +509,7 @@ predicate and must remain — it is load-bearing for those callers.)
 
 #### Quiz exit — transcript capture + optional step marker
 
-These steps run **only when `QUIZ_FLAG=1`** (i.e., branch (a) above ran the
+These steps run **only when `STEERING_MODE = quiz`** (i.e., branch (a) above ran the
 quiz to its go-signal). A normal (non-quiz) run does NONE of this.
 
 1. **Transcript-capture merge (R5).** After the quiz exits, merge the
@@ -537,13 +525,13 @@ quiz to its go-signal). A normal (non-quiz) run does NONE of this.
 
 2. **Optional `step.*.quiz` tracking marker** (convention symmetry with the
    research/review/finalize markers; informational only, NOT hook-gated).
-   Gated behind `QUIZ_FLAG=1` so a normal run never emits it. This clones the
+   Gated behind `STEERING_MODE = quiz` so a normal run never emits it. This clones the
    FULL research-marker fence above — including the `MAIN_ROOT` +
    `PIPELINE_ID` derivation and the pipeline-id sanitize call — NOT just
    the `printf`, to avoid an empty-`PIPELINE_ID` flat-marker write:
 
 ```bash
-if [ "${QUIZ_FLAG:-0}" = "1" ]; then
+if [ "${STEERING_MODE:-}" = "quiz" ]; then
   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
     . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
   else
@@ -827,14 +815,14 @@ After each round of review + refinement:
    | 3     | 0 issues          | 0 issues                  | Converged|
    ```
 
-   **When `QUIZ_FLAG=1`**, also add a **"Requirements captured via quiz"**
+   **When `STEERING_MODE = quiz`**, also add a **"Requirements captured via quiz"**
    subsection to this Plan Quality section — a short record (a few lines)
    noting the requirements were elicited through a quiz interview and listing
    the key decisions/assumptions confirmed. This documents *how* the plan's
    requirements were grounded without reproducing the conversation. Produce it
    from the transcript-capture distillation per
    [references/quiz.md](references/quiz.md) ("Transcript capture — distill,
-   don't dump"); distill, do NOT dump the raw chat. When `QUIZ_FLAG=0`, omit
+   don't dump"); distill, do NOT dump the raw chat. When `STEERING_MODE != quiz`, omit
    this subsection entirely.
 
 2. **Write the plan file** to the output path. The user can't review what

--- a/.claude/skills/draft-plan/references/brainstorm.md
+++ b/.claude/skills/draft-plan/references/brainstorm.md
@@ -221,7 +221,7 @@ compaction-survival pattern (`SKILL.md:222-228`). Accumulate, as the dialogue pr
 
 **The notes file IS a resumable state machine.** The dialogue is multi-turn and WILL
 sometimes span a context compaction. After compaction, the in-context dialogue state and
-the `BRAINSTORM_FLAG` shell variable are gone, and nothing would otherwise re-trigger the
+the `STEERING_MODE` shell variable are gone, and nothing would otherwise re-trigger the
 loop — the orchestrator could wrongly jump to Phase 1 with a half-finished seed. Defend
 this structurally with a header status line:
 
@@ -254,7 +254,7 @@ tracking_id: <$TRACKING_ID>
 - <URL or .playwright/output/ screenshot path>
 ```
 
-**Resume-on-reentry semantics.** When SKILL.md (re)enters with `BRAINSTORM_FLAG=1`, it
+**Resume-on-reentry semantics.** When SKILL.md (re)enters with `STEERING_MODE = brainstorm`, it
 checks for the notes file (Phase 2 wires the SKILL.md side):
 
 - **Notes file exists with `status: ready`** → a prior dialogue already completed.

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] [brainstorm] [quiz] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.01+9a3294"
+  version: "2026.06.01+dc143f"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -113,7 +113,7 @@ fi
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] [auto] [quiz] <description...>
+/draft-plan [output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>
 ```
 
 - **output FILE** (optional) — where to write the plan. Default:
@@ -142,26 +142,24 @@ fi
 - `rounds` followed by a number — max review cycles
 - `auto` (whitespace-anchored, case-insensitive) — sets `AUTO_FLAG=1`
   for Phase 6's `/land-pr` dispatch
-- `brainstorm` (first token only, case-insensitive) — sets
-  `BRAINSTORM_FLAG=1`, which loads the interactive brainstorm dialogue
-  (`references/brainstorm.md`) before Phase 1. Anchored to the FIRST token
-  of `$ARGUMENTS` (mirroring the `.md` output-file detection's
-  first-position anchor) so it does NOT engage when `brainstorm` appears
-  anywhere else in the args buffer, e.g. `/draft-plan Build a brainstorm
-  app for kids` or `/draft-plan Add a brainstorm feature` (#914). Also
-  anchored so it does NOT match `brainstorming`/`brainstormed`/`brainstorms`.
-- `quiz` (recognized **ONLY as a leading flag token** — in the flag
-  cluster before the description begins, like `output`/`rounds`/`auto`,
-  case-insensitive) — sets `QUIZ_FLAG=1`, which conducts an interactive
-  requirements interview before drafting by loading
-  (`references/quiz.md`). A `quiz` appearing **within the description
-  text** is part of the description, NOT the flag — unlike `auto`, `quiz`
-  is NOT detected match-anywhere, so a description like "build a quiz app"
-  or a trailing "add dark mode quiz" does NOT trigger quiz mode (see the
-  detection note below and the Examples block). `brainstorm` and `quiz` are
-  **mutually exclusive** — both are pre-draft interactive interviews
-  occupying the same steering seam, so requesting both (`/draft-plan
-  brainstorm quiz …`) is a fail-loud error, not a silent mode drop (#936).
+- `brainstorm` | `quiz` (a single mutually-exclusive **steering selector**,
+  recognized **ONLY as a leading flag token** — in the flag cluster before
+  the description begins, like `output`/`rounds`/`auto`, case-insensitive) —
+  sets `STEERING_MODE` to one of `brainstorm` or `quiz` (default: empty).
+  `brainstorm` loads the interactive brainstorm dialogue
+  (`references/brainstorm.md`) before Phase 1; `quiz` conducts an interactive
+  requirements interview before drafting by loading (`references/quiz.md`).
+  Both are pre-draft interactive interviews occupying the SAME steering seam,
+  so they are **mutually exclusive** — requesting both (in either order,
+  `/draft-plan brainstorm quiz …` or `/draft-plan quiz brainstorm …`) is a
+  fail-loud error (`exit 2`), not a silent mode drop (#936, #944). A
+  `brainstorm`/`quiz` appearing **within the description text** is part of
+  the description, NOT the flag — unlike `auto`, the selector is NOT detected
+  match-anywhere, so a description like "build a quiz app" or "Build a
+  brainstorm app for kids" does NOT trigger either mode (the leading-cluster
+  scan `break`s at the first non-flag token; see the detection note below and
+  the Examples block) (#914). The exact-match `case` arms also mean
+  `brainstorming`/`brainstormed`/`brainstorms`/`quizzes` do NOT trigger.
 - Everything else (from the first unrecognized non-flag token onward) is
   the description
 
@@ -172,51 +170,61 @@ if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
 fi
 ```
 
-`BRAINSTORM_FLAG` is detected by its OWN dedicated fence (kept separate
-from the `AUTO_FLAG` fence above so the args-smoke extractor that keys on
-the `AUTO_FLAG=0 … fi` block is not perturbed):
-
-```bash
-BRAINSTORM_FLAG=0
-# Anchor 'brainstorm' to the FIRST token of $ARGUMENTS (#914). Mirrors the
-# `.md` output-file first-position anchor in the args parser above. This
-# makes `/draft-plan Build a brainstorm app for kids` (and any other args
-# buffer where `brainstorm` is embedded in the description) correctly fall
-# through to Phase 1 instead of opening the 8-step brainstorm dialogue.
-# Read-array off $ARGUMENTS (word-split on whitespace, same as the args
-# parser above), lowercase the first token, compare to literal "brainstorm".
-read -r _bs_first _bs_rest <<<"$ARGUMENTS"
-_bs_lower=$(printf '%s' "$_bs_first" | tr '[:upper:]' '[:lower:]')
-if [ "$_bs_lower" = "brainstorm" ]; then
-  BRAINSTORM_FLAG=1
-fi
-unset _bs_first _bs_rest _bs_lower
-```
-
-**`QUIZ_FLAG` is detected by LEADING-FLAG recognition — NOT `auto`'s
-match-anywhere regex.** `quiz` fires **only** when it appears in the
-leading flag cluster, before the first description token. If a description
-word "quiz" set the flag (the way a description word "auto" trips
-`AUTO_FLAG` today — a pre-existing exposure NOT inherited here), then an
-autonomously-dispatched call from `/research-and-plan` (which passes the
-user description verbatim) or the `/run-plan` delegate
+**`STEERING_MODE` is detected by LEADING-FLAG recognition — NOT `auto`'s
+match-anywhere regex.** `brainstorm`/`quiz` fire **only** when they appear
+in the leading flag cluster, before the first description token. If a
+description word "quiz"/"brainstorm" set the mode (the way a description
+word "auto" trips `AUTO_FLAG` today — a pre-existing exposure NOT inherited
+here), then an autonomously-dispatched call from `/research-and-plan` (which
+passes the user description verbatim) or the `/run-plan` delegate
 (`/draft-plan plans/FOO.md <desc> auto`) would hang the pipeline on an
 interactive prompt with no human to answer. So the parse consumes the
-leading cluster first and only then tests for `quiz`. Tokenize the leading
-cluster: consume, **in any order**, the output-file token (either the
-literal `output <path>`, OR a bare leading `*.md` token), `rounds N`
-(consuming the numeric value token after `rounds`, so the bare `N` is not
-mis-read as the first description token), `auto`, and `quiz`. The **first
-token matching none of these** begins the description, and everything from
-there (including any later `quiz`) is description, not a flag:
+leading cluster first and only then tests for the steering tokens. Tokenize
+the leading cluster: consume, **in any order**, the output-file token
+(either the literal `output <path>`, OR a bare leading `*.md` token),
+`rounds N` (consuming the numeric value token after `rounds`, so the bare
+`N` is not mis-read as the first description token), `auto`, `brainstorm`,
+and `quiz`. The **first token matching none of these** begins the
+description, and everything from there (including any later
+`quiz`/`brainstorm`) is description, not a flag.
+
+`brainstorm` and `quiz` are **mutually exclusive** — both are pre-draft
+interactive interviews occupying the SAME steering seam (`brainstorm` makes
+the post-research steering checkpoint skip, "user already steered in the
+dialogue"; `quiz` REPLACES that same checkpoint with its interview loop,
+branch (a) of the 3-way steering checkpoint below), and running both at once
+is contradictory (two competing interviews, two separate
+`/tmp/draft-plan-{brainstorm,quiz}-$TRACKING_ID.md` notes files both
+claiming to be the pre-draft steering). Rather than represent-then-forbid
+the illegal "both" state with two booleans, a single `STEERING_MODE` (one of
+`""`, `brainstorm`, `quiz`) makes it **unrepresentable**: a `set_steering`
+helper sets the mode the first time, and FAILS LOUD (`exit 2`) if a second,
+DIFFERENT steering token is seen. Because both tokens are recognized by the
+SAME leading-cluster scan (no token[0]-only anchor for `brainstorm`), the
+conflict is detected regardless of order — `/draft-plan brainstorm quiz X`
+and `/draft-plan quiz brainstorm X` BOTH `exit 2` (#936, #944 — genuine
+order-independence; the prior two-parser design only errored on the first
+order). A repeated SAME token (`brainstorm brainstorm X`) is a harmless
+no-op:
 
 ```bash
-QUIZ_FLAG=0
+STEERING_MODE=""   # "" | brainstorm | quiz — single mutually-exclusive selector
+# set_steering MODE: set STEERING_MODE the first time; fail loud (exit 2) on
+# a conflicting second mode; no-op on a repeat of the same mode. The illegal
+# "both" state is unrepresentable, so the conflict is order-independent.
+set_steering() {
+  if [ -z "$STEERING_MODE" ]; then
+    STEERING_MODE="$1"
+  elif [ "$STEERING_MODE" != "$1" ]; then
+    echo "ERROR: brainstorm and quiz modes are mutually exclusive" >&2
+    exit 2
+  fi
+}
 # Leading-flag scan: walk the tokens, consuming recognized flags in any
 # order. Stop at the first token that is none of them — that begins the
-# description. A `quiz` AFTER the description start is description text,
-# never the flag. (Strip the description first; never match raw
-# $ARGUMENTS match-anywhere — that is exactly auto's false-positive.)
+# description. A `quiz`/`brainstorm` AFTER the description start is
+# description text, never the flag. (Strip the description first; never match
+# raw $ARGUMENTS match-anywhere — that is exactly auto's false-positive.)
 expect_value=0   # 1 = the previous token was `output`/`rounds`; this one is its value
 for tok in $ARGUMENTS; do
   if [ "$expect_value" = "1" ]; then
@@ -227,39 +235,16 @@ for tok in $ARGUMENTS; do
   fi
   ltok=$(printf '%s' "$tok" | tr '[:upper:]' '[:lower:]')
   case "$ltok" in
-    output)   expect_value=1 ;;                 # output <path> — value consumed next iter
-    rounds)   expect_value=1 ;;                 # rounds N — value consumed next iter
-    auto)     ;;                                # recognized flag — consume, keep scanning
-    brainstorm) ;;                              # leading brainstorm flag — consume, keep scanning (#936)
-    quiz)     QUIZ_FLAG=1 ;;                     # leading quiz flag
-    *.md)     ;;                                # bare leading *.md output token
-    */*.md)   ;;                                # path-form leading *.md output token
-    *)        break ;;                          # first description token — stop
+    output)     expect_value=1 ;;               # output <path> — value consumed next iter
+    rounds)     expect_value=1 ;;               # rounds N — value consumed next iter
+    auto)       ;;                              # recognized flag — consume, keep scanning
+    brainstorm) set_steering brainstorm ;;      # leading brainstorm flag (#944)
+    quiz)       set_steering quiz ;;            # leading quiz flag
+    *.md)       ;;                              # bare leading *.md output token
+    */*.md)     ;;                              # path-form leading *.md output token
+    *)          break ;;                        # first description token — stop
   esac
 done
-```
-
-**`brainstorm` and `quiz` are mutually exclusive.** Both are pre-draft
-interactive interviews that occupy the SAME steering seam — `brainstorm`
-makes the post-research steering checkpoint skip ("user already steered in
-the dialogue"), and `quiz` REPLACES that same checkpoint with its interview
-loop (branch (a) of the 3-way steering checkpoint below). Running both at
-once is contradictory (two competing interviews, two separate
-`/tmp/draft-plan-{brainstorm,quiz}-$TRACKING_ID.md` notes files both
-claiming to be the pre-draft steering), so the parse FAILS LOUD rather than
-silently picking one. This guard also makes the result **order-independent**:
-`/draft-plan brainstorm quiz X` and `/draft-plan quiz brainstorm X` both
-error identically (#936 — before this guard, the leading-cluster tokenizer
-recognized `quiz` but broke at `brainstorm`, so token order silently decided
-which mode survived). The guard is detection-only — it does not touch the
-`brainstorm` first-token anchor (#914) or the `quiz` leading-flag scan, so
-neither mode's positive/negative behavior regresses:
-
-```bash
-if [ "${BRAINSTORM_FLAG:-0}" = "1" ] && [ "${QUIZ_FLAG:-0}" = "1" ]; then
-  echo "ERROR: brainstorm and quiz modes are mutually exclusive" >&2
-  exit 2
-fi
 ```
 
 Examples:
@@ -269,12 +254,15 @@ Examples:
 - `/draft-plan output plans/THERMAL_PLAN.md rounds 5 Implement thermal domain`
 - `/draft-plan rounds 5 Implement thermal domain with multi-domain coupling`
 - `/draft-plan Fix the README.md formatting` → description only, no output file detected
-- `/draft-plan quiz Add dark mode to the editor` → `QUIZ_FLAG=1` (leading flag) — runs the interactive requirements interview first
-- `/draft-plan output p.md quiz rounds 5 Add dark mode` → `QUIZ_FLAG=1` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
-- `/draft-plan output p.md build a quiz app` → `QUIZ_FLAG` NOT set — "quiz" is a description word, not the leading flag (NEGATIVE example; `quiz` is leading-only, never match-anywhere like `auto`)
-- `/draft-plan add dark mode quiz` → `QUIZ_FLAG` NOT set — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable quiz mode, lead with the flag (`/draft-plan quiz add dark mode`).
-- `/draft-plan brainstorm quiz Add dark mode` → **ERROR (exit 2)** — `brainstorm` (first-token flag, #914) and `quiz` (leading-cluster flag) BOTH engage, and the two modes are mutually exclusive (#936). This is the only way to request both modes in one invocation, and it fails loud instead of silently dropping one.
-- `/draft-plan quiz brainstorm Add dark mode` → `QUIZ_FLAG=1`, `BRAINSTORM_FLAG=0` — quiz mode with description "brainstorm Add dark mode". Per #914, `brainstorm` is a flag ONLY as the first token; here it is at position 2, so it is description text, not the brainstorm flag. NOT a both-modes case, so no error. (The `brainstorm) ;;` tokenizer arm above only lets the quiz scan *walk past* a leading `brainstorm`; it never sets `BRAINSTORM_FLAG`, which remains first-token-anchored.)
+- `/draft-plan brainstorm Add dark mode to the editor` → `STEERING_MODE=brainstorm` (leading flag) — runs the interactive brainstorm dialogue first
+- `/draft-plan quiz Add dark mode to the editor` → `STEERING_MODE=quiz` (leading flag) — runs the interactive requirements interview first
+- `/draft-plan output p.md quiz rounds 5 Add dark mode` → `STEERING_MODE=quiz` (quiz is in the leading flag cluster, in any order with `output`/`rounds`)
+- `/draft-plan output p.md brainstorm Add dark mode` → `STEERING_MODE=brainstorm` (brainstorm is in the leading flag cluster — composability parity with quiz; #944 — no longer token[0]-only)
+- `/draft-plan output p.md build a quiz app` → `STEERING_MODE` empty — "quiz" is a description word, not the leading flag (NEGATIVE example; the selector is leading-only, never match-anywhere like `auto`)
+- `/draft-plan Build a brainstorm app for kids` → `STEERING_MODE` empty — "brainstorm" is a description word; the leading-cluster scan `break`s at the first non-flag token "Build" before it is reached (#914)
+- `/draft-plan add dark mode quiz` → `STEERING_MODE` empty — a **trailing** `quiz` is description text, not the flag. This is the accepted ergonomic limitation of leading-only parsing: to enable a mode, lead with the flag (`/draft-plan quiz add dark mode`).
+- `/draft-plan brainstorm quiz Add dark mode` → **ERROR (exit 2)** — both `brainstorm` and `quiz` are leading-cluster flags and the two modes are mutually exclusive (#936, #944). Fails loud instead of silently dropping one.
+- `/draft-plan quiz brainstorm Add dark mode` → **ERROR (exit 2)** — same conflict, OTHER order. Because both tokens are recognized by the same leading-cluster scan, the mutual-exclusion error is **order-independent** (#944 — the prior two-parser design errored only on the `brainstorm quiz` order and silently swallowed `brainstorm` here).
 
 ## Pre-check — Existing file
 
@@ -290,17 +278,17 @@ This handles the common case of modernizing old-format plans:
 
 ## Brainstorm mode (only when the `brainstorm` flag is present)
 
-If `BRAINSTORM_FLAG=1`, **Read [references/brainstorm.md](references/brainstorm.md)** via the
+If `STEERING_MODE = brainstorm`, **Read [references/brainstorm.md](references/brainstorm.md)** via the
 Read tool and execute its dialogue loop now, before Phase 1 — UNLESS the notes file
 `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` already exists with `status: ready` (a prior,
 completed dialogue — proceed straight to Phase 1 using it as the seed). If the notes file
 exists with `status: in-progress` (a dialogue interrupted by compaction/crash), RESUME it from
-its captured state rather than restarting. If `BRAINSTORM_FLAG=0`, **ignore the reference file
+its captured state rather than restarting. If `STEERING_MODE != brainstorm`, **ignore the reference file
 entirely** and proceed straight to Phase 1.
 
 ## Quiz mode (only when the `quiz` flag is present) — research sequencing
 
-When `QUIZ_FLAG=1` **and** running interactively (the same predicate as the
+When `STEERING_MODE = quiz` **and** running interactively (the same predicate as the
 subagent-skip in "Post-research tracking" below — quiz never fires under a
 subagent caller in practice, since the research-and-* callers don't pass
 `quiz`), the conversational requirements interview runs **FIRST, before any
@@ -310,11 +298,11 @@ split, moved, or interleaved — the fan-out is simply gated behind the quiz
 and seeded with the interview file. Concretely:
 
 1. **Defer the research fan-out** until the quiz produces its go-signal. Do
-   NOT dispatch the Phase-1 Research agents while `QUIZ_FLAG=1` and the quiz
+   NOT dispatch the Phase-1 Research agents while `STEERING_MODE = quiz` and the quiz
    has not yet exited.
 2. **Conduct the interview now.** The conditional-load directive and the
    quiz loop are emitted at the "Post-research tracking" seam below (Work
-   Item 5's 3-way branch); when `QUIZ_FLAG=1` that seam is reached with the
+   Item 5's 3-way branch); when `STEERING_MODE = quiz` that seam is reached with the
    research fan-out still deferred, the directive fires, and the interview
    runs to its explicit go-signal.
 3. **On the go-signal, run the existing Phase-1 fan-out UNCHANGED**
@@ -330,7 +318,7 @@ and seeded with the interview file. Concretely:
    re-derived one.
 4. **Then Phase 2 drafts** from the seeded research.
 
-When `QUIZ_FLAG=0`, research runs **exactly as today** — the full Phase-1
+When `STEERING_MODE != quiz`, research runs **exactly as today** — the full Phase-1
 fan-out runs immediately, followed by the single-shot post-research
 checkpoint. quiz.md is never read and no `step.*.quiz` marker is written.
 
@@ -371,7 +359,7 @@ printf 'skill: draft-plan\nid: %s\noutput: %s\nstatus: started\ndate: %s\n' \
 Dispatch multiple Explore agents in parallel to investigate the problem space.
 Each agent gets the full description and a specific research focus:
 
-**Brainstorm feed-forward.** When `BRAINSTORM_FLAG=1`, inject the literal
+**Brainstorm feed-forward.** When `STEERING_MODE = brainstorm`, inject the literal
 path `/tmp/draft-plan-brainstorm-$TRACKING_ID.md` into EACH research
 agent's PROMPT, with an instruction to read it as the **primary design
 seed** (the user already steered the design in the brainstorm dialogue).
@@ -379,7 +367,7 @@ Inject the path into the prompts — NOT into the research consolidation
 file, which does not exist until after dispatch. The Codebase / Patterns /
 Prior-art agents still run to ground the design against the repo; the
 Domain agent's "what to build" work is largely pre-answered by the
-brainstorm and may be reduced to verification. When `BRAINSTORM_FLAG=0`,
+brainstorm and may be reduced to verification. When `STEERING_MODE != brainstorm`,
 dispatch the agents normally with no notes-file injection.
 
 1. **Codebase agent** — find all relevant source files, understand current
@@ -475,7 +463,7 @@ printf 'completed: %s\n' "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
   > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/step.draft-plan.$TRACKING_ID.research"
 ```
 
-**Skip this steering checkpoint when `BRAINSTORM_FLAG=1`** — the user
+**Skip this steering checkpoint when `STEERING_MODE = brainstorm`** — the user
 already steered the design, in depth, during the brainstorm dialogue, so
 re-prompting here is redundant; proceed directly to Phase 2. (This is an
 ADDITIVE condition; the existing "if running as a subagent, skip" branch
@@ -484,7 +472,7 @@ below is unchanged.)
 This steering checkpoint is a **3-way branch.** The branch sits AFTER the
 scope-check decomposition `exit` above and BEFORE Phase 2:
 
-**(a) When `QUIZ_FLAG=1` and running interactively** (the same predicate
+**(a) When `STEERING_MODE = quiz` and running interactively** (the same predicate
 as the subagent-skip in branch (c) below — interactive, not a subagent):
 emit the conditional-load directive
 
@@ -496,7 +484,7 @@ explicit go-signal**. Note: per "Quiz mode" above, this branch is reached
 with the Phase-1 research fan-out still DEFERRED — the interview runs first,
 and the (seeded) fan-out runs only after the go-signal, before Phase 2.
 
-**(b) When `QUIZ_FLAG=0`** (default), the existing single-shot checkpoint,
+**(b) When `STEERING_MODE != quiz`** (default), the existing single-shot checkpoint,
 verbatim and unchanged:
 
 **Present the research summary to the user.** If running interactively
@@ -521,7 +509,7 @@ predicate and must remain — it is load-bearing for those callers.)
 
 #### Quiz exit — transcript capture + optional step marker
 
-These steps run **only when `QUIZ_FLAG=1`** (i.e., branch (a) above ran the
+These steps run **only when `STEERING_MODE = quiz`** (i.e., branch (a) above ran the
 quiz to its go-signal). A normal (non-quiz) run does NONE of this.
 
 1. **Transcript-capture merge (R5).** After the quiz exits, merge the
@@ -537,13 +525,13 @@ quiz to its go-signal). A normal (non-quiz) run does NONE of this.
 
 2. **Optional `step.*.quiz` tracking marker** (convention symmetry with the
    research/review/finalize markers; informational only, NOT hook-gated).
-   Gated behind `QUIZ_FLAG=1` so a normal run never emits it. This clones the
+   Gated behind `STEERING_MODE = quiz` so a normal run never emits it. This clones the
    FULL research-marker fence above — including the `MAIN_ROOT` +
    `PIPELINE_ID` derivation and the pipeline-id sanitize call — NOT just
    the `printf`, to avoid an empty-`PIPELINE_ID` flat-marker write:
 
 ```bash
-if [ "${QUIZ_FLAG:-0}" = "1" ]; then
+if [ "${STEERING_MODE:-}" = "quiz" ]; then
   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
     . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
   else
@@ -827,14 +815,14 @@ After each round of review + refinement:
    | 3     | 0 issues          | 0 issues                  | Converged|
    ```
 
-   **When `QUIZ_FLAG=1`**, also add a **"Requirements captured via quiz"**
+   **When `STEERING_MODE = quiz`**, also add a **"Requirements captured via quiz"**
    subsection to this Plan Quality section — a short record (a few lines)
    noting the requirements were elicited through a quiz interview and listing
    the key decisions/assumptions confirmed. This documents *how* the plan's
    requirements were grounded without reproducing the conversation. Produce it
    from the transcript-capture distillation per
    [references/quiz.md](references/quiz.md) ("Transcript capture — distill,
-   don't dump"); distill, do NOT dump the raw chat. When `QUIZ_FLAG=0`, omit
+   don't dump"); distill, do NOT dump the raw chat. When `STEERING_MODE != quiz`, omit
    this subsection entirely.
 
 2. **Write the plan file** to the output path. The user can't review what

--- a/skills/draft-plan/references/brainstorm.md
+++ b/skills/draft-plan/references/brainstorm.md
@@ -221,7 +221,7 @@ compaction-survival pattern (`SKILL.md:222-228`). Accumulate, as the dialogue pr
 
 **The notes file IS a resumable state machine.** The dialogue is multi-turn and WILL
 sometimes span a context compaction. After compaction, the in-context dialogue state and
-the `BRAINSTORM_FLAG` shell variable are gone, and nothing would otherwise re-trigger the
+the `STEERING_MODE` shell variable are gone, and nothing would otherwise re-trigger the
 loop — the orchestrator could wrongly jump to Phase 1 with a half-finished seed. Defend
 this structurally with a header status line:
 
@@ -254,7 +254,7 @@ tracking_id: <$TRACKING_ID>
 - <URL or .playwright/output/ screenshot path>
 ```
 
-**Resume-on-reentry semantics.** When SKILL.md (re)enters with `BRAINSTORM_FLAG=1`, it
+**Resume-on-reentry semantics.** When SKILL.md (re)enters with `STEERING_MODE = brainstorm`, it
 checks for the notes file (Phase 2 wires the SKILL.md side):
 
 - **Notes file exists with `status: ready`** → a prior dialogue already completed.

--- a/tests/test-draft-plan-args-smoke.sh
+++ b/tests/test-draft-plan-args-smoke.sh
@@ -124,45 +124,90 @@ else
   check_auto "use auto-land mode" 0 "'auto-land' (no whitespace boundary) rejected"
 fi
 
-# ── Surface 3: BRAINSTORM_FLAG regex (extract-and-run) ───────────────
-# The BRAINSTORM_FLAG fence is self-contained (pure `[[ =~ ]]`) and lives
-# in its OWN block (kept separate from AUTO_FLAG so the AUTO extractor that
-# stops at the first `^fi$` is not perturbed). Extract it verbatim and run.
-BRAINSTORM_BLOCK=$(awk '
-  /^BRAINSTORM_FLAG=0$/{capture=1}
+# ── Surface 3: STEERING_MODE leading-cluster selector (extract-and-run) ──
+# #944: brainstorm and quiz are a SINGLE mutually-exclusive selector
+# `STEERING_MODE ∈ {"", brainstorm, quiz}` detected by ONE leading-cluster
+# scan (the `set_steering` helper + the `for tok in $ARGUMENTS` case). The
+# fence is self-contained (no external deps), so EXTRACT-AND-RUN it. The
+# fence runs from `STEERING_MODE=""` through its closing `done`, so capture
+# from the assignment to the first standalone `done`. A conflicting second
+# steering token makes `set_steering` `exit 2`, so we run the fence in a
+# subshell and capture both STEERING_MODE and the exit code.
+STEERING_BLOCK=$(awk '
+  /^STEERING_MODE=""/{capture=1}
   capture {print}
-  capture && /^fi$/{exit}
+  capture && /^done$/{exit}
 ' "$SKILL")
 
-if [ -z "$BRAINSTORM_BLOCK" ]; then
-  fail "brainstorm-flag: could not extract BRAINSTORM_FLAG fence" "awk extract empty"
+if [ -z "$STEERING_BLOCK" ]; then
+  fail "steering-mode: could not extract STEERING_MODE fence" "awk extract empty"
 else
-  pass "brainstorm-flag: BRAINSTORM_FLAG fence extracted from SKILL.md"
-  check_brainstorm() { # $1=ARGUMENTS $2=expected(0/1) $3=label
-    local ARGUMENTS="$1"
-    local BRAINSTORM_FLAG
-    eval "$BRAINSTORM_BLOCK"
-    if [ "$BRAINSTORM_FLAG" = "$2" ]; then
-      pass "brainstorm-flag: $3 -> BRAINSTORM_FLAG=$2"
+  pass "steering-mode: STEERING_MODE leading-cluster fence extracted from SKILL.md"
+
+  # Tokenizer-arm parity: both steering arms route through set_steering (#944).
+  if grep -qF 'brainstorm) set_steering brainstorm ;;' "$SKILL" \
+     && grep -qF 'quiz)       set_steering quiz ;;' "$SKILL"; then
+    pass "steering-mode: both case arms route through set_steering (#944)"
+  else
+    fail "steering-mode: set_steering case arms drifted" "missing 'brainstorm) set_steering brainstorm' / 'quiz) set_steering quiz'"
+  fi
+
+  # Run the real fence against $ARGUMENTS in a subshell; STEERING_MODE is
+  # written to a dedicated file (NOT stderr) so set_steering's own stderr
+  # error message does not contaminate the capture; the `exit 2` becomes the
+  # subshell rc.
+  steer_for() { # $1=ARGUMENTS $2=modefile  -> exit code = set_steering rc
+    (
+      ARGUMENTS="$1"
+      STEERING_MODE=""
+      eval "$STEERING_BLOCK"
+      printf 'MODE=%s\n' "$STEERING_MODE" > "$2"
+    ) 2>/dev/null
+  }
+  check_steer() { # $1=ARGUMENTS $2=expected_mode $3=expected_rc $4=label
+    local rc md mf="/tmp/.draftplan-steering-mode-$$" want
+    steer_for "$1" "$mf"; rc=$?
+    md=$(cat "$mf" 2>/dev/null); rm -f "$mf"
+    # In the conflict path, set_steering's `exit 2` aborts the subshell BEFORE
+    # the MODE printf runs, so the modefile is never written and $md is empty.
+    # The exit code is the load-bearing assertion there. In the success path
+    # (rc 0) the modefile carries 'MODE=<mode>'.
+    if [ "$3" = "0" ]; then want="MODE=$2"; else want=""; fi
+    if [ "$md" = "$want" ] && [ "$rc" = "$3" ]; then
+      pass "steering-mode: $4 -> '${md:-<no-write>}', exit $rc"
     else
-      fail "brainstorm-flag: $3" "expected $2 got $BRAINSTORM_FLAG"
+      fail "steering-mode: $4" "expected mode-capture '$want' exit $3, got '$md' exit $rc"
     fi
   }
-  # Positives — first token only, case-insensitive (#914).
-  check_brainstorm "brainstorm Add dark mode" 1 "first-position 'brainstorm' engages"
-  check_brainstorm "BRAINSTORM Add dark mode" 1 "first-position uppercase 'BRAINSTORM' engages"
-  check_brainstorm "Brainstorm a new editor" 1 "first-position mixed-case 'Brainstorm' engages"
-  # Negatives — 'brainstorm' anywhere but first token must NOT engage (#914).
-  check_brainstorm "Add dark mode brainstorm" 0 "trailing 'brainstorm' does NOT engage (#914)"
-  check_brainstorm "output X.md brainstorm rounds 3 Add dark mode" 0 "mid 'brainstorm' does NOT engage (#914)"
-  check_brainstorm "Build a brainstorm app for kids" 0 "'brainstorm' inside description does NOT engage (#914)"
-  check_brainstorm "Add a brainstorm feature to the editor" 0 "'brainstorm' inside description does NOT engage (#914)"
-  check_brainstorm "Document our brainstorm process" 0 "'brainstorm' inside description does NOT engage (#914)"
-  check_brainstorm "auto brainstorm Add dark mode" 0 "'brainstorm' after 'auto' does NOT engage (not first token, #914)"
-  # Negatives — substring/inflection forms must NOT trip the flag (flag stays 0).
-  check_brainstorm "brainstorming the design" 0 "'brainstorming' (no boundary) rejected"
-  check_brainstorm "brainstormed yesterday" 0 "'brainstormed' (no boundary) rejected"
-  check_brainstorm "brainstorms" 0 "'brainstorms' (no boundary) rejected"
+
+  # Positives — leading flag, case-insensitive.
+  check_steer "brainstorm Add dark mode" brainstorm 0 "leading 'brainstorm' engages"
+  check_steer "BRAINSTORM Add dark mode" brainstorm 0 "leading uppercase 'BRAINSTORM' engages"
+  check_steer "Brainstorm a new editor" brainstorm 0 "leading mixed-case 'Brainstorm' engages"
+  check_steer "quiz Add dark mode" quiz 0 "leading 'quiz' engages"
+  # Composability parity (#944): brainstorm in the leading cluster (not token[0]).
+  check_steer "output p.md brainstorm Add dark mode" brainstorm 0 "'output p.md brainstorm' engages brainstorm (composability parity)"
+  check_steer "output p.md quiz rounds 5 Add dark mode" quiz 0 "'output p.md quiz rounds 5' engages quiz (leading cluster, any order)"
+  # Repeated SAME token is a harmless no-op (no error).
+  check_steer "brainstorm brainstorm Add dark mode" brainstorm 0 "repeated 'brainstorm' -> no-op, no error"
+  # Mutual exclusion (#936, #944) — order-independent: BOTH orders exit 2.
+  # set_steering's `exit 2` aborts the fence BEFORE the MODE printf runs, so
+  # the captured MODE is empty in BOTH error paths; the exit code is the
+  # load-bearing assertion (the order-independence proof).
+  check_steer "brainstorm quiz Add dark mode" "" 2 "'brainstorm quiz X' -> mutual-exclusion error (exit 2)"
+  check_steer "quiz brainstorm Add dark mode" "" 2 "'quiz brainstorm X' -> mutual-exclusion error (exit 2), ORDER-INDEPENDENT (#944)"
+  # Negatives — token anywhere but the leading cluster must NOT engage (#914).
+  check_steer "Add dark mode brainstorm" "" 0 "trailing 'brainstorm' does NOT engage (#914)"
+  check_steer "add dark mode quiz" "" 0 "trailing 'quiz' does NOT engage (#914)"
+  check_steer "Build a brainstorm app for kids" "" 0 "'brainstorm' inside description does NOT engage (#914)"
+  check_steer "build a quiz app" "" 0 "'quiz' inside description does NOT engage (#914)"
+  check_steer "Add a brainstorm feature to the editor" "" 0 "'brainstorm' inside description does NOT engage (#914)"
+  check_steer "auto brainstorm Add dark mode" brainstorm 0 "'auto brainstorm X' -> brainstorm (leading cluster, composes with auto; #944)"
+  # Negatives — substring/inflection forms must NOT trip the selector (exact-match arms).
+  check_steer "brainstorming the design" "" 0 "'brainstorming' (exact-match arm) does NOT engage"
+  check_steer "brainstormed yesterday" "" 0 "'brainstormed' (exact-match arm) does NOT engage"
+  check_steer "brainstorms" "" 0 "'brainstorms' (exact-match arm) does NOT engage"
+  check_steer "quizzes for the class" "" 0 "'quizzes' (exact-match arm) does NOT engage"
 fi
 
 # ── Surface 4: brainstorm-mode wiring parity greps (externally-sourced) ──
@@ -170,13 +215,13 @@ fi
 # Read-tool dispatch and $TRACKING_ID), so assert by fingerprint grep that
 # the wiring stays present, mirroring the Surface-1 `grep -qF` parity style.
 
-# Conditional-load parity: references/brainstorm.md is gated on BRAINSTORM_FLAG,
+# Conditional-load parity: references/brainstorm.md is gated on STEERING_MODE,
 # i.e. the Read is NOT unconditional. The "## Brainstorm mode" section opens
-# with the `If BRAINSTORM_FLAG=1, **Read [references/brainstorm.md]...` gate.
-if grep -qF 'If `BRAINSTORM_FLAG=1`, **Read [references/brainstorm.md](references/brainstorm.md)**' "$SKILL"; then
-  pass "conditional-load: brainstorm.md Read is gated on BRAINSTORM_FLAG=1"
+# with the `If STEERING_MODE = brainstorm, **Read [references/brainstorm.md]...` gate.
+if grep -qF 'If `STEERING_MODE = brainstorm`, **Read [references/brainstorm.md](references/brainstorm.md)**' "$SKILL"; then
+  pass "conditional-load: brainstorm.md Read is gated on STEERING_MODE = brainstorm"
 else
-  fail "conditional-load: brainstorm.md gate drifted" "missing BRAINSTORM_FLAG=1 Read gate"
+  fail "conditional-load: brainstorm.md gate drifted" "missing STEERING_MODE = brainstorm Read gate"
 fi
 # Regression guard: the gate must NOT re-introduce the inert ZSKILLS_PIPELINE_ID
 # check. Scope the assertion to the "## Brainstorm mode" section so unrelated
@@ -210,11 +255,11 @@ else
 fi
 
 # Checkpoint-skip: the post-research steering checkpoint is gated on
-# BRAINSTORM_FLAG=1 (skipped because the user already steered in dialogue).
-if grep -qF 'Skip this steering checkpoint when `BRAINSTORM_FLAG=1`' "$SKILL"; then
-  pass "checkpoint-skip: post-research checkpoint gated on BRAINSTORM_FLAG=1"
+# STEERING_MODE = brainstorm (skipped because the user already steered in dialogue).
+if grep -qF 'Skip this steering checkpoint when `STEERING_MODE = brainstorm`' "$SKILL"; then
+  pass "checkpoint-skip: post-research checkpoint gated on STEERING_MODE = brainstorm"
 else
-  fail "checkpoint-skip: checkpoint gate drifted" "missing 'Skip this steering checkpoint when BRAINSTORM_FLAG=1'"
+  fail "checkpoint-skip: checkpoint gate drifted" "missing 'Skip this steering checkpoint when STEERING_MODE = brainstorm'"
 fi
 
 # ── Surface 5: references/brainstorm.md idiom parity greps ───────────
@@ -250,95 +295,6 @@ else
   else
     pass "brainstorm.md idioms: no bare foreground 'sleep' in serve-wait"
   fi
-fi
-
-# ── Surface 6: QUIZ_FLAG leading-cluster scan + brainstorm/quiz mutual
-#    exclusion (extract-and-run) ───────────────────────────────────────
-# #936: the leading-cluster tokenizer must recognize `brainstorm` (walk
-# past it) so a leading `brainstorm` does not break the scan before `quiz`
-# is reached. Combined with the first-token-anchored BRAINSTORM_FLAG fence,
-# this makes `brainstorm quiz X` set BOTH flags, which the mutual-exclusion
-# guard converts into a fail-loud exit 2 instead of a silent mode drop.
-# The guard must NOT regress #914 (brainstorm is still first-token-only for
-# BRAINSTORM_FLAG; the tokenizer arm only lets the quiz scan walk past it).
-
-# Extract the QUIZ_FLAG leading-scan fence (QUIZ_FLAG=0 … done — a for-loop,
-# not an `if … fi`, so stop at the first standalone `done`).
-QUIZ_BLOCK=$(awk '
-  /^QUIZ_FLAG=0$/{capture=1}
-  capture {print}
-  capture && /^done$/{exit}
-' "$SKILL")
-
-# Extract the mutual-exclusion guard fence (the `if [ "${BRAINSTORM_FLAG...`
-# block that emits the error and `exit 2`). Stop at its closing `fi`.
-MUTEX_BLOCK=$(awk '
-  /^if \[ "\$\{BRAINSTORM_FLAG/{capture=1}
-  capture {print}
-  capture && /^fi$/{exit}
-' "$SKILL")
-
-if [ -z "$QUIZ_BLOCK" ]; then
-  fail "quiz-flag: could not extract QUIZ_FLAG fence" "awk extract empty"
-elif [ -z "$MUTEX_BLOCK" ]; then
-  fail "mutex: could not extract brainstorm/quiz mutual-exclusion fence" "awk extract empty"
-else
-  pass "quiz-flag: QUIZ_FLAG leading-scan fence extracted from SKILL.md"
-  pass "mutex: brainstorm/quiz mutual-exclusion fence extracted from SKILL.md"
-
-  # Tokenizer-arm parity: the brainstorm) ;; arm must be present (#936).
-  if grep -qF 'brainstorm) ;;' "$SKILL"; then
-    pass "mutex: leading-cluster tokenizer has 'brainstorm) ;;' arm (#936)"
-  else
-    fail "mutex: 'brainstorm) ;;' tokenizer arm missing" "leading scan would break at brainstorm"
-  fi
-
-  # Run BOTH the BRAINSTORM_FLAG and QUIZ_FLAG fences against $ARGUMENTS,
-  # then run the mutual-exclusion guard in a subshell so its `exit 2` is
-  # captured as a subshell exit code rather than killing the test. Echo the
-  # resolved flags so we can also assert the flag values directly.
-  # Run the real fences in a subshell. The flag values are written to a
-  # dedicated file (NOT stderr) so the guard's own stderr error message does
-  # not contaminate the capture; the guard's `exit 2` becomes the subshell rc.
-  flags_for() { # $1=ARGUMENTS $2=flagfile  -> exit code = guard rc
-    (
-      ARGUMENTS="$1"
-      BRAINSTORM_FLAG=
-      QUIZ_FLAG=
-      eval "$BRAINSTORM_BLOCK"
-      eval "$QUIZ_BLOCK"
-      printf 'B=%s Q=%s\n' "$BRAINSTORM_FLAG" "$QUIZ_FLAG" > "$2"
-      eval "$MUTEX_BLOCK"
-    ) 2>/dev/null
-  }
-  check_combo() { # $1=ARGUMENTS $2=expected_B $3=expected_Q $4=expected_rc $5=label
-    local rc fl ff="/tmp/.draftplan-mutex-flags-$$"
-    flags_for "$1" "$ff"; rc=$?
-    fl=$(cat "$ff" 2>/dev/null); rm -f "$ff"
-    if [ "$fl" = "B=$2 Q=$3" ] && [ "$rc" = "$4" ]; then
-      pass "mutex: $5 -> $fl, exit $rc"
-    else
-      fail "mutex: $5" "expected B=$2 Q=$3 exit $4, got '$fl' exit $rc"
-    fi
-  }
-
-  # The core #936 assertion: requesting BOTH modes (brainstorm first, quiz in
-  # the leading cluster) sets both flags and fails loud (exit 2) — NOT a
-  # silent drop of whichever mode wasn't first.
-  check_combo "brainstorm quiz Add dark mode" 1 1 2 "'brainstorm quiz X' -> both flags, mutual-exclusion error"
-  # Reverse order: per #914, a non-first 'brainstorm' is DESCRIPTION text, not
-  # the flag. So this is unambiguously single-mode quiz (no silent drop, no
-  # error). Order is no longer SILENTLY ambiguous: 'brainstorm quiz' errors
-  # loud; 'quiz brainstorm' is the defined #914 single-mode case.
-  check_combo "quiz brainstorm Add dark mode" 0 1 0 "'quiz brainstorm X' -> quiz-only (brainstorm is description per #914), no error"
-  # Single-mode cases must NOT error.
-  check_combo "brainstorm Add dark mode" 1 0 0 "'brainstorm X' -> brainstorm-only, no error"
-  check_combo "quiz Add dark mode" 0 1 0 "'quiz X' -> quiz-only, no error"
-  # #914 non-regression: 'auto brainstorm' must NOT set BRAINSTORM_FLAG, and
-  # the brainstorm) ;; tokenizer arm must not turn it into a both-modes case.
-  check_combo "auto brainstorm Add dark mode" 0 0 0 "'auto brainstorm X' -> neither flag (#914 preserved), no error"
-  # #914 non-regression: brainstorm embedded in description stays inert.
-  check_combo "Build a brainstorm app for kids" 0 0 0 "'Build a brainstorm app' -> neither flag (#914 preserved), no error"
 fi
 
 echo ""

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -775,17 +775,19 @@ check_in_file_near quickfix    "modes/execute.md"           "agent-dispatched pi
 check_in_file_near quickfix    "modes/land.md"              "fix-cycle pins implementer" 'subagent_type: "implementer"' 'Agent' 0
 
 # /draft-plan — quiz-mode conditional-load wiring (DRAFT_PLAN_QUIZ_MODE Phase
-# 3, R9). The interactive quiz interview is gated behind QUIZ_FLAG=1 and its
-# procedure lives in references/quiz.md, read via a conditional-load directive.
-# There is no orphan-reference gate today, so this is the ONLY automated check
-# that exercises the new wiring. Use check_in_file_near (NOT a bare grep for
+# 3, R9; #944 collapsed the two booleans into STEERING_MODE). The interactive
+# quiz interview is gated behind STEERING_MODE = quiz and its procedure lives
+# in references/quiz.md, read via a conditional-load directive. There is no
+# orphan-reference gate today, so this is the ONLY automated check that
+# exercises the new wiring. Use check_in_file_near (NOT a bare grep for
 # 'references/quiz.md') so the assertion verifies CO-OCCURRENCE: the
-# references/quiz.md reference must appear within 10 lines of a QUIZ_FLAG=1
-# conditional token. A bare substring grep would still pass if the conditional
-# guard were stripped (degraded to an unconditional read) or if the string
-# survived only in a comment elsewhere; the _near form fails closed in both
-# cases — removing the `QUIZ_FLAG=1`-guarded conditional load breaks it.
-check_in_file_near draft-plan  "SKILL.md"                   "quiz conditional-load wiring" 'references/quiz.md' 'QUIZ_FLAG=1' 10
+# references/quiz.md reference must appear within 10 lines of a
+# `STEERING_MODE = quiz` conditional token. A bare substring grep would still
+# pass if the conditional guard were stripped (degraded to an unconditional
+# read) or if the string survived only in a comment elsewhere; the _near form
+# fails closed in both cases — removing the `STEERING_MODE = quiz`-guarded
+# conditional load breaks it.
+check_in_file_near draft-plan  "SKILL.md"                   "quiz conditional-load wiring" 'references/quiz.md' 'STEERING_MODE = quiz' 10
 
 # Agent definition file exists with the expected frontmatter shape.
 if [ -f "$REPO_ROOT/.claude/agents/implementer.md" ]; then


### PR DESCRIPTION
Collapses /draft-plan's two pre-draft interview flags (`brainstorm`, `quiz`) into a single `STEERING_MODE` selector, fixing a residual order-dependence and a prose/code/test contradiction.

## What
- One `STEERING_MODE ∈ {"", brainstorm, quiz}` replaces the two booleans `BRAINSTORM_FLAG`/`QUIZ_FLAG`. The illegal "both" state is now unrepresentable.
- Both tokens are detected by the **existing leading-cluster tokenizer**, routed through a `set_steering` helper that fails loud (`exit 2`) on a conflicting second mode — so `brainstorm quiz X` **and** `quiz brainstorm X` both error (genuine order-independence; the old two-parser design errored only on one order and silently dropped the other).
- The separate token[0]-only `brainstorm` fence and the standalone mutex-guard fence are deleted.
- `argument-hint` becomes `[brainstorm|quiz]`.

## Why
The pre-#944 design made `brainstorm` token[0]-only (#914) and `quiz` leading-cluster (#936), with a runtime both-flags guard. That left: (1) `quiz brainstorm X` silently swallowed `brainstorm` (no error) while `brainstorm quiz X` errored; (2) `output p.md brainstorm <desc>` never engaged brainstorm (composability asymmetry); (3) SKILL.md prose claimed an order-independence the code/test didn't deliver.

## Invariants preserved
- #914: `Build a brainstorm app` / `build a quiz app` engage neither (the cluster scan `break`s at the first non-flag token).
- Exact-match arms keep `brainstorming`/`brainstormed`/`quizzes` inert.
- Autonomous-dispatch safety (leading-only detection).

## Test plan
- [x] `tests/test-draft-plan-args-smoke.sh` rewritten to the single-selector model (incl. `quiz brainstorm X` flipped to a conflict-error); composability + #914 negatives proven.
- [x] `bash tests/run-all.sh` — full suite green (6945/6945).
- [x] Mirror byte-identical (`scripts/mirror-skill.sh draft-plan`); `metadata.version` bumped.

Closes #944
