### PR TITLE
fix(#940): force-unlock action on locked Default-mode chip toast

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+fbac6f"
+  version: "2026.06.01+38255f"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -2564,11 +2564,33 @@ function renderRunStatus(ws) {
 
 // ---------------------------------------------------------------- toasts
 
-function showToast(message, kind) {
+function showToast(message, kind, opts) {
   const region = $("toast-region");
   if (!region) return;
   const toast = el("div", { cls: "toast " + (kind === "info" ? "toast-info" : "") });
   toast.appendChild(el("span", { text: String(message || "") }));
+  // Issue #940 — optional action button rendered between message and close.
+  // When opts.actionLabel + opts.onAction are both provided, render a
+  // <button class="toast-action"> that invokes onAction() on click and
+  // dismisses the toast when the (possibly async) handler resolves.
+  // Used by the locked-chip toast to surface a "Force unlock" recovery
+  // path when an externally-killed cron leaves work-on-plans-state.json
+  // stuck at state=scheduled (see issue body for full rationale).
+  if (opts && opts.actionLabel && typeof opts.onAction === "function") {
+    const actionBtn = el("button", {
+      cls: "toast-action",
+      attrs: { type: "button" },
+      text: String(opts.actionLabel),
+    });
+    actionBtn.addEventListener("click", async () => {
+      try {
+        await opts.onAction();
+      } finally {
+        if (toast.parentNode) toast.parentNode.removeChild(toast);
+      }
+    });
+    toast.appendChild(actionBtn);
+  }
   const close = el("button", {
     cls: "toast-close",
     attrs: { type: "button", "aria-label": "Dismiss" },
@@ -2895,11 +2917,26 @@ async function setDefaultMode(mode) {
     && cronPinnedMode
     && cronPinnedMode !== "inherit"
   ) {
+    // Issue #940 — surface a "Force unlock" action for the case where the
+    // /work-on-plans cron was killed externally (Claude session ended
+    // without clean shutdown, REPL hard-killed). state stays at
+    // "scheduled" with schedule_mode pinned but no fire is coming, so
+    // the chip is locked indefinitely until the server-side staleness
+    // sweep (grace = schedule_period + 30 min). Force unlock POSTs to
+    // the existing /api/work-state/reset endpoint. Resilient to a live
+    // cron: if it's still firing, the next fire re-writes
+    // state=scheduled and the lock reappears; if gone, lock stays clear.
     showToast(
-      "Default mode is locked: the active /work-on-plans schedule pins mode to '" +
+      "Default mode is locked: /work-on-plans schedule pins mode to '" +
         cronPinnedMode +
-        "'. Stop the schedule and re-launch without a mode token to control via this chip.",
+        "'. If the cron is no longer running (Claude session ended or REPL killed), use Force unlock to clear the lock.",
       "info",
+      {
+        actionLabel: "Force unlock",
+        onAction: async () => {
+          await fetch("/api/work-state/reset", { method: "POST" });
+        },
+      },
     );
     return;
   }

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.01+fbac6f"
+  version: "2026.06.01+38255f"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -2564,11 +2564,33 @@ function renderRunStatus(ws) {
 
 // ---------------------------------------------------------------- toasts
 
-function showToast(message, kind) {
+function showToast(message, kind, opts) {
   const region = $("toast-region");
   if (!region) return;
   const toast = el("div", { cls: "toast " + (kind === "info" ? "toast-info" : "") });
   toast.appendChild(el("span", { text: String(message || "") }));
+  // Issue #940 — optional action button rendered between message and close.
+  // When opts.actionLabel + opts.onAction are both provided, render a
+  // <button class="toast-action"> that invokes onAction() on click and
+  // dismisses the toast when the (possibly async) handler resolves.
+  // Used by the locked-chip toast to surface a "Force unlock" recovery
+  // path when an externally-killed cron leaves work-on-plans-state.json
+  // stuck at state=scheduled (see issue body for full rationale).
+  if (opts && opts.actionLabel && typeof opts.onAction === "function") {
+    const actionBtn = el("button", {
+      cls: "toast-action",
+      attrs: { type: "button" },
+      text: String(opts.actionLabel),
+    });
+    actionBtn.addEventListener("click", async () => {
+      try {
+        await opts.onAction();
+      } finally {
+        if (toast.parentNode) toast.parentNode.removeChild(toast);
+      }
+    });
+    toast.appendChild(actionBtn);
+  }
   const close = el("button", {
     cls: "toast-close",
     attrs: { type: "button", "aria-label": "Dismiss" },
@@ -2895,11 +2917,26 @@ async function setDefaultMode(mode) {
     && cronPinnedMode
     && cronPinnedMode !== "inherit"
   ) {
+    // Issue #940 — surface a "Force unlock" action for the case where the
+    // /work-on-plans cron was killed externally (Claude session ended
+    // without clean shutdown, REPL hard-killed). state stays at
+    // "scheduled" with schedule_mode pinned but no fire is coming, so
+    // the chip is locked indefinitely until the server-side staleness
+    // sweep (grace = schedule_period + 30 min). Force unlock POSTs to
+    // the existing /api/work-state/reset endpoint. Resilient to a live
+    // cron: if it's still firing, the next fire re-writes
+    // state=scheduled and the lock reappears; if gone, lock stays clear.
     showToast(
-      "Default mode is locked: the active /work-on-plans schedule pins mode to '" +
+      "Default mode is locked: /work-on-plans schedule pins mode to '" +
         cronPinnedMode +
-        "'. Stop the schedule and re-launch without a mode token to control via this chip.",
+        "'. If the cron is no longer running (Claude session ended or REPL killed), use Force unlock to clear the lock.",
       "info",
+      {
+        actionLabel: "Force unlock",
+        onAction: async () => {
+          await fetch("/api/work-state/reset", { method: "POST" });
+        },
+      },
     );
     return;
   }

--- a/tests/test-dashboard-run-status-locks.sh
+++ b/tests/test-dashboard-run-status-locks.sh
@@ -387,4 +387,171 @@ if [ "$NODE_RC" != "0" ] && [ "$FAIL_COUNT" -eq 0 ]; then
   fail "node harness exited non-zero ($NODE_RC) with no per-test failures parsed"
 fi
 
+# ---------------------------------------------------------------------------
+# Issue #940 — showToast optional action-button arg (DOM-stubbed).
+#
+# The locked-chip toast now passes a 3rd arg {actionLabel, onAction} so the
+# user can recover from an externally-killed cron via the existing
+# /api/work-state/reset endpoint. Verify both backward-compat (2-arg) and
+# the new 3-arg form.
+# ---------------------------------------------------------------------------
+
+TOAST_NODE_OUT=$(APP_JS_PATH="$APP_JS" node - <<'NODE'
+const fs = require("fs");
+const src = fs.readFileSync(process.env.APP_JS_PATH, "utf8");
+
+function extractBlock(text, startRe, endMarker) {
+  const m = text.match(startRe);
+  if (!m) throw new Error("start pattern not found: " + startRe);
+  const startIdx = m.index;
+  const tail = text.slice(startIdx);
+  const endIdx = tail.indexOf(endMarker);
+  if (endIdx < 0) throw new Error("end marker not found: " + endMarker);
+  return tail.slice(0, endIdx + endMarker.length);
+}
+
+const showToastBlk = extractBlock(src, /\nfunction showToast\(message, kind, opts\)/, "\n}\n");
+const elBlock      = extractBlock(src, /\nfunction el\(tag, opts\)/, "\n}\n");
+
+function makeNode(id, tag) {
+  return {
+    id,
+    tagName: (tag || "div").toUpperCase(),
+    className: "",
+    textContent: "",
+    innerHTML: "",
+    attrs: {},
+    children: [],
+    parent: null,
+    _listeners: {},
+    setAttribute(k, v) { this.attrs[k] = String(v); },
+    getAttribute(k) { return this.attrs[k] == null ? null : this.attrs[k]; },
+    removeAttribute(k) { delete this.attrs[k]; },
+    appendChild(c) { c.parent = this; this.children.push(c); return c; },
+    removeChild(c) {
+      const i = this.children.indexOf(c);
+      if (i >= 0) { this.children.splice(i, 1); c.parent = null; }
+      return c;
+    },
+    get parentNode() { return this.parent; },
+    addEventListener(ev, fn) {
+      if (!this._listeners[ev]) this._listeners[ev] = [];
+      this._listeners[ev].push(fn);
+    },
+    dispatch(ev) {
+      const fns = this._listeners[ev] || [];
+      const results = [];
+      for (const fn of fns) results.push(fn());
+      return Promise.all(results);
+    },
+  };
+}
+
+const toastRegion = makeNode("toast-region", "div");
+const nodes = { "toast-region": toastRegion };
+const $stub = (id) => (id in nodes ? nodes[id] : null);
+const document = { createElement(tag) { return makeNode(null, tag); } };
+
+// Stub setTimeout (no-op so our DOM isn't auto-cleared mid-assert).
+const setTimeoutStub = () => 0;
+
+const harness = `
+${elBlock}
+${showToastBlk}
+globalThis.__showToast = showToast;
+`;
+
+(new Function("document", "$", "setTimeout", "globalThis", harness))(
+  document, $stub, setTimeoutStub, globalThis
+);
+
+const showToast = globalThis.__showToast;
+
+function expect(actual, expected, label) {
+  const aStr = JSON.stringify(actual);
+  const eStr = JSON.stringify(expected);
+  if (aStr !== eStr) {
+    console.log("FAIL " + label + " (got " + aStr + ", expected " + eStr + ")");
+    process.exitCode = 1;
+  } else {
+    console.log("OK " + label);
+  }
+}
+function expectTrue(actual, label) {
+  if (actual) console.log("OK " + label);
+  else { console.log("FAIL " + label + " (got falsy " + JSON.stringify(actual) + ")"); process.exitCode = 1; }
+}
+
+function findByClass(root, cls) {
+  if ((root.className || "").split(/\s+/).indexOf(cls) >= 0) return root;
+  for (const c of (root.children || [])) {
+    const hit = findByClass(c, cls);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function resetRegion() { toastRegion.children = []; }
+
+(async () => {
+  // Case J: 2-arg showToast does NOT render an action button (back-compat).
+  resetRegion();
+  showToast("hello", "info");
+  expect(toastRegion.children.length, 1, "2-arg showToast: one toast appended");
+  const toast2 = toastRegion.children[0];
+  expect(findByClass(toast2, "toast-action"), null,
+    "2-arg showToast: no toast-action button rendered");
+  expectTrue(findByClass(toast2, "toast-close"),
+    "2-arg showToast: close button still rendered");
+
+  // Case K: 3-arg showToast DOES render a button, click invokes onAction.
+  resetRegion();
+  let onActionCalls = 0;
+  showToast("locked", "info", {
+    actionLabel: "Force unlock",
+    onAction: async () => { onActionCalls += 1; },
+  });
+  expect(toastRegion.children.length, 1, "3-arg showToast: one toast appended");
+  const toast3 = toastRegion.children[0];
+  const actionBtn = findByClass(toast3, "toast-action");
+  expectTrue(actionBtn, "3-arg showToast: toast-action button rendered");
+  if (actionBtn) {
+    expect(actionBtn.tagName, "BUTTON",
+      "3-arg showToast: action element is a <button>");
+    expect(actionBtn.textContent, "Force unlock",
+      "3-arg showToast: action button label is 'Force unlock'");
+    expect(actionBtn.getAttribute("type"), "button",
+      "3-arg showToast: action button has type=button");
+  }
+  // Simulate click and let the async handler complete.
+  if (actionBtn) await actionBtn.dispatch("click");
+  expect(onActionCalls, 1, "3-arg showToast: clicking action invokes onAction once");
+  // After click, the toast is dismissed (removed from region).
+  expect(toastRegion.children.length, 0,
+    "3-arg showToast: toast removed from region after action click");
+
+  // Case L: 3-arg showToast with only actionLabel (no onAction) — no button.
+  resetRegion();
+  showToast("msg", "info", { actionLabel: "Nope" });
+  const toast4 = toastRegion.children[0];
+  expect(findByClass(toast4, "toast-action"), null,
+    "3-arg showToast missing onAction: action button NOT rendered");
+})();
+NODE
+)
+TOAST_NODE_RC=$?
+
+echo "$TOAST_NODE_OUT"
+
+while IFS= read -r line; do
+  case "$line" in
+    OK\ *) pass "${line#OK }" ;;
+    FAIL\ *) fail "${line#FAIL }" ;;
+  esac
+done <<< "$TOAST_NODE_OUT"
+
+if [ "$TOAST_NODE_RC" != "0" ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  fail "showToast node harness exited non-zero ($TOAST_NODE_RC) with no per-test failures parsed"
+fi
+
 print_summary_and_exit


### PR DESCRIPTION
## Summary

Closes #940.

PR #933's Default-mode chip lock is correct while a `/work-on-plans` cron is alive, but when the cron dies externally (Claude session ended, REPL hard-killed, container restart), `work-on-plans-state.json` remains at `state="scheduled"` with `schedule_mode` pinned, locking the chip indefinitely until the server-side staleness sweep fires (grace = schedule_period + 30 min — up to 6.5h for `every 6h`). The existing toast directed users to "stop the schedule" — but the schedule was already gone.

## Fix

Extend `showToast` with an optional `{actionLabel, onAction}` arg (backward-compatible — existing 2-arg calls unchanged) and thread a **"Force unlock"** action into the locked-chip toast that POSTs to the existing `/api/work-state/reset` endpoint.

Resilient to the live-cron case: if the cron is alive, its next fire re-writes `state=scheduled` and the lock reappears. If the cron is gone, the lock stays cleared.

Same class as #892 (sticky chip on poll failure) and #912 (stale plan-claim card with no in-UI recovery).

## Files

- `skills/zskills-dashboard/scripts/zskills_monitor/static/app.js` — `showToast(message, kind, opts)` + locked-chip toast site rewording + action wiring
- `tests/test-dashboard-run-status-locks.sh` — 12 new assertions (Cases J/K/L) extracting the real `showToast` from `app.js` and exercising 2-arg back-compat, 3-arg action-button render+click, and the "actionLabel without onAction → no button" rule
- `skills/zskills-dashboard/SKILL.md` — version bump to `2026.06.01+38255f`
- `.claude/skills/zskills-dashboard/...` — mirror

## Test plan

- [x] `bash tests/run-all.sh` — 6957/6957 passed
- [x] `bash tests/test-skill-conformance.sh` — 758/758 passed (version-bump gate satisfied)
- [x] `bash tests/test-dashboard-run-status-locks.sh` — all new Cases J/K/L pass; existing #930 lock cases unchanged
- [x] Independent scope re-verified `HEAD~1..HEAD` (5 files, +249/-8) — no extraneous edits
- [ ] Manual UI verification of "Force unlock" button — deferred (requires live `/work-on-plans` cron + REPL kill repro; test harness exercises the real `showToast` code path verbatim from app.js)
