### PR TITLE
do: extract forbidden-literals scan to shared script

### DIFF
--- a/tests/lib/forbidden-literals-scan.sh
+++ b/tests/lib/forbidden-literals-scan.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# tests/lib/forbidden-literals-scan.sh — the forbidden-literals deny-list
+# scan over skills/**/*.md + block-diagram/**/*.md, extracted as a SINGLE
+# shared script so the single-source-of-truth guarantee is STRUCTURAL
+# (shared code), not merely a shared fixture (#948).
+#
+# CONSUMERS (both call THIS script, neither re-implements the scan):
+#   - tests/test-skill-conformance.sh — runs it against the REAL
+#     skills/ + block-diagram/ trees for its `.md` deny-list section;
+#     renders the emitted DRIFT lines via its own pass/fail and #458
+#     dual-root regression fixture. Behavior + output unchanged.
+#   - tests/test-hooks.sh — runs it DIRECTLY against a synthetic throwaway
+#     fixture tree (a copy of forbidden-literals.txt with an appended
+#     `__TEST_LITERAL__` + a synthetic SKILL.md containing that literal in
+#     a bash fence) for its "Fixture-extension coverage" Surface 2 probe.
+#     Sub-second — replaces the prior nested full-suite run (#587 #948).
+#
+# This is a SOURCEABLE-OR-EXECUTABLE library helper, NOT a suite. Do NOT
+# register it in run-all.sh as a `run_suite`.
+#
+# ─────────────────────────────────────────────────────────────────────
+# CONTRACT
+#   run_forbidden_literals_scan <scan-root> [fixture-path]
+#     <scan-root>     directory whose `skills/` and `block-diagram/`
+#                     subtrees are walked for *.md files. (Either subtree
+#                     may be absent; absent subtrees contribute no files.)
+#     [fixture-path]  path to the forbidden-literals.txt fixture.
+#                     Defaults to <scan-root>/tests/fixtures/forbidden-literals.txt.
+#
+#   STDOUT: one DRIFT line per hit (verbatim, including the remediation
+#           hint). Empty when the scan is clean.
+#   Exit:   0 when no hits, 1 when one or more hits were emitted, 2 when
+#           the fixture is missing/unreadable.
+#
+#   Matching semantics are IDENTICAL to the prior inline scan in
+#   test-skill-conformance.sh — same fixture format (FIXED substring
+#   entries + `re:` extended-regex entries), same blockquote
+#   normalisation, same exec-fence detection (bash/sh/shell/no-language),
+#   same allow-hardcoded marker handling, same prose-imperative detection,
+#   and the same tailored #179 skill-version-literal hint. This is a pure
+#   relocation of the scan's call site, not a change to what it detects.
+# ─────────────────────────────────────────────────────────────────────
+
+run_forbidden_literals_scan() {
+  local scan_root="$1"
+  local fixture="${2:-$scan_root/tests/fixtures/forbidden-literals.txt}"
+
+  if [ ! -r "$fixture" ]; then
+    echo "FORBIDDEN-SCAN-ERROR: fixture $fixture missing or unreadable" >&2
+    return 2
+  fi
+
+  # Read fixture once. Split into FIXED (substring) and REGEX (extended-regex) entries.
+  local -a FIXED_LITERALS=()
+  local -a REGEX_PATTERNS=()
+  local entry
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    [[ "$entry" =~ ^# ]] && continue
+    if [[ "$entry" =~ ^re: ]]; then
+      REGEX_PATTERNS+=("${entry#re:}")
+    else
+      FIXED_LITERALS+=("$entry")
+    fi
+  done < "$fixture"
+
+  local DRIFT_FAIL=0
+  local -a DRIFT_HITS=()
+
+  local skill_file line norm_line lang lit literal pattern
+  local in_fence fence_type line_no
+  local -A allowed_in_fence=()
+  local -a prev_lines=()
+
+  while IFS= read -r skill_file; do
+    in_fence=0
+    fence_type=""
+    unset allowed_in_fence; declare -A allowed_in_fence=()
+    prev_lines=()
+    line_no=0
+    while IFS= read -r line; do
+      line_no=$((line_no + 1))
+      # Blockquote normalisation: strip a leading `>` + optional space
+      # before applying any structural regex. Without this, blockquoted
+      # fenced bash blocks (` >    ```bash`) go undetected.
+      norm_line="$line"
+      if [[ "$norm_line" =~ ^[[:space:]]*\>[[:space:]]?(.*)$ ]]; then
+        norm_line="${BASH_REMATCH[1]}"
+      fi
+
+      if [ "$in_fence" -eq 0 ]; then
+        # Outside any fence.
+        if [[ "$norm_line" =~ ^[[:space:]]*\<!--[[:space:]]+allow-hardcoded:[[:space:]]+(.+)[[:space:]]+reason:.*--\>[[:space:]]*$ ]]; then
+          local captured="${BASH_REMATCH[1]}"
+          # Trim trailing whitespace.
+          captured="${captured%"${captured##*[![:space:]]}"}"
+          prev_lines+=("$captured")
+        elif [[ "$norm_line" =~ ^[[:space:]]*\`\`\`([a-zA-Z0-9_+-]*)[[:space:]]*$ ]]; then
+          # Fence-opener of any kind. Track exec vs other so non-shell
+          # fences (json, markdown, etc.) don't get scanned for shell
+          # literals — but their bounds are still tracked.
+          lang="${BASH_REMATCH[1]}"
+          in_fence=1
+          if [ -z "$lang" ] || [ "$lang" = "bash" ] || [ "$lang" = "sh" ] || [ "$lang" = "shell" ]; then
+            fence_type="exec"
+          else
+            fence_type="other"
+          fi
+          allowed_in_fence=()
+          if [ "$fence_type" = "exec" ]; then
+            for lit in "${prev_lines[@]:-}"; do
+              [ -n "$lit" ] && allowed_in_fence["$lit"]=1
+            done
+          fi
+          prev_lines=()
+          continue
+        else
+          # Any other non-blank line resets the marker block.
+          [ -n "$norm_line" ] && prev_lines=()
+        fi
+        # PROSE-IMPERATIVE detection: bullet/numbered line with a
+        # code-span AND a sentence-start imperative verb.
+        if [[ "$norm_line" =~ ^[[:space:]]*([-*]|[0-9]+\.) ]] \
+           && [[ "$norm_line" =~ \`[^\`]+\` ]] \
+           && [[ "$norm_line" =~ (^|[.\;\:][[:space:]]+|\*\*)(Run|Execute|Invoke)[[:space:]] ]]; then
+          for literal in "${FIXED_LITERALS[@]}"; do
+            if [[ "$norm_line" == *"$literal"* ]] && [ -z "${allowed_in_fence[$literal]:-}" ]; then
+              DRIFT_HITS+=("DRIFT (prose-imperative): $skill_file:$line_no contains '$literal'. Replace with \$VAR (preferred), OR add on the line ABOVE this bullet: <!-- allow-hardcoded: $literal reason: <why> -->")
+              DRIFT_FAIL=1
+            fi
+          done
+          for pattern in "${REGEX_PATTERNS[@]}"; do
+            if [[ "$norm_line" =~ $pattern ]] && [ -z "${allowed_in_fence[$pattern]:-}" ]; then
+              if [[ "$pattern" == '[0-9]{4}\.[0-9]{2}\.[0-9]{2}\+[0-9a-f]{6}' ]]; then
+                DRIFT_HITS+=("DRIFT (prose-imperative): $skill_file:$line_no matches the skill-version-literal regex '$pattern'. Per-skill version values belong in metadata.version frontmatter, not pasted into prose imperatives. To mark this bullet as an illustrative example, add on the line ABOVE: <!-- allow-hardcoded: $pattern reason: documenting the format with an example value -->")
+              else
+                DRIFT_HITS+=("DRIFT (prose-imperative): $skill_file:$line_no matches forbidden regex '$pattern'. Replace with \$VAR (preferred), OR add on the line ABOVE this bullet: <!-- allow-hardcoded: $pattern reason: <why> -->")
+              fi
+              DRIFT_FAIL=1
+            fi
+          done
+        fi
+        continue
+      fi
+
+      # Inside a fence.
+      if [[ "$norm_line" =~ ^[[:space:]]*\`\`\`[[:space:]]*$ ]]; then
+        in_fence=0
+        fence_type=""
+        allowed_in_fence=()
+        prev_lines=()
+        continue
+      fi
+      # Only scan exec-type fences (bash / sh / shell / no-language).
+      if [ "$fence_type" != "exec" ]; then
+        continue
+      fi
+      for literal in "${FIXED_LITERALS[@]}"; do
+        if [[ "$norm_line" == *"$literal"* ]] && [ -z "${allowed_in_fence[$literal]:-}" ]; then
+          DRIFT_HITS+=("DRIFT: $skill_file:$line_no contains '$literal' inside a bash fence without an allow-hardcoded marker. Replace with \$VAR (preferred), OR mark this fence as illustrative by adding on the line ABOVE the opening backticks: <!-- allow-hardcoded: $literal reason: <why> -->")
+          DRIFT_FAIL=1
+        fi
+      done
+      for pattern in "${REGEX_PATTERNS[@]}"; do
+        if [[ "$norm_line" =~ $pattern ]] && [ -z "${allowed_in_fence[$pattern]:-}" ]; then
+          # Tailored hint for the skill-version-literal regex (issue #179).
+          if [[ "$pattern" == '[0-9]{4}\.[0-9]{2}\.[0-9]{2}\+[0-9a-f]{6}' ]]; then
+            DRIFT_HITS+=("DRIFT: $skill_file:$line_no matches the skill-version-literal regex '$pattern' inside a bash fence. Per-skill version values belong in metadata.version frontmatter, not in fence bodies. To mark this fence as an illustrative example, add on the line ABOVE the opening backticks: <!-- allow-hardcoded: $pattern reason: documenting the format with an example value -->. Alternatively, switch the fence language to \`\`\`text (non-exec, not scanned).")
+          else
+            DRIFT_HITS+=("DRIFT: $skill_file:$line_no matches forbidden regex '$pattern' inside a bash fence without an allow-hardcoded marker. Replace with \$VAR (preferred), OR mark this fence as illustrative by adding on the line ABOVE the opening backticks: <!-- allow-hardcoded: $pattern reason: <why> -->")
+          fi
+          DRIFT_FAIL=1
+        fi
+      done
+    done < "$skill_file"
+  done < <(find "$scan_root/skills" "$scan_root/block-diagram" -name '*.md' 2>/dev/null | sort)
+
+  local h
+  for h in "${DRIFT_HITS[@]:-}"; do
+    [ -n "$h" ] && printf '%s\n' "$h"
+  done
+
+  return "$DRIFT_FAIL"
+}
+
+# When executed directly (not sourced), run the scan with argv.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  run_forbidden_literals_scan "$@"
+  exit $?
+fi

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -4723,34 +4723,30 @@ else
   fail "fixture-extension: drift-warn hook missed appended literal" "rc=$EXT_RC stderr=$EXT_ERR_CONTENT"
 fi
 
-# Surface 2: deny-list test (test-skill-conformance.sh) against the
-# synthetic skills/ tree. Run with REPO_ROOT pointing at the synthetic
-# fixture directory.
+# Surface 2: the forbidden-literals deny-list scan — the SAME shared
+# script tests/test-skill-conformance.sh calls (#948) — invoked DIRECTLY
+# against the synthetic skills/ tree. This is the structural single-
+# source-of-truth proof: both surfaces run identical scan code, not just
+# a shared fixture. Sub-second, and it removes the prior nested full-suite
+# run that re-ran the whole conformance suite against the throwaway tree
+# (~71s + #587 tally-line-leak risk into run_suite's parser).
 EXT_DENY_OUT=$(mktemp)
-REPO_ROOT="$FIXTURE_EXT_DIR" bash "$REPO_ROOT/tests/test-skill-conformance.sh" \
-  > "$EXT_DENY_OUT" 2>&1
+(
+  . "$REPO_ROOT/tests/lib/forbidden-literals-scan.sh"
+  run_forbidden_literals_scan "$FIXTURE_EXT_DIR" \
+    "$FIXTURE_EXT_DIR/tests/fixtures/forbidden-literals.txt"
+) > "$EXT_DENY_OUT" 2>&1
 EXT_DENY_RC=$?
-# We expect FAIL on the deny-list section; other sections will likely
-# also fail because the synthetic tree has no real skills — that's
-# expected and not what we are asserting. We only check that the new
-# synthetic literal surfaces in the deny-list output.
-if grep -q '__TEST_LITERAL__' "$EXT_DENY_OUT"; then
-  pass "fixture-extension: deny-list test picks up appended literal — DRIFT line emitted"
+# We expect a non-zero rc (hits found) and the synthetic literal in the
+# emitted DRIFT lines. Asserting on the literal is what proves the scan
+# reads the appended fixture entry.
+if [ "$EXT_DENY_RC" -ne 0 ] && grep -q '__TEST_LITERAL__' "$EXT_DENY_OUT"; then
+  pass "fixture-extension: deny-list scan picks up appended literal — DRIFT line emitted"
 else
-  fail "fixture-extension: deny-list test missed appended literal" "no __TEST_LITERAL__ in output (rc=$EXT_DENY_RC)"
-  # Surface ONLY the deny-list / forbidden-literals section of the
-  # conformance output — that's where __TEST_LITERAL__ should appear.
-  # Avoid dumping unrelated [run-plan]/[verify-changes] FAILs that fire
-  # because the synthetic fixture lacks real skills (expected) — those
-  # FAILs are noise (#587 root cause), and any inner "N passed, N failed"
-  # tally line leaked here would be miscounted by run_suite's parser.
-  echo "  -- relevant conformance output (deny-list / forbidden section) --" >&2
-  if ! grep -E 'deny-list|forbidden|__TEST_LITERAL__' "$EXT_DENY_OUT" \
-       | grep -v -E '^[[:space:]]*Results:[[:space:]]+[0-9]+ passed' \
-       | head -30 >&2; then
-    echo "  -- (no deny-list/forbidden lines in output; conformance may have crashed before reaching that section) --" >&2
-  fi
-  echo "  -- end relevant output --" >&2
+  fail "fixture-extension: deny-list scan missed appended literal" "no __TEST_LITERAL__ in output (rc=$EXT_DENY_RC)"
+  echo "  -- deny-list scan output --" >&2
+  head -30 "$EXT_DENY_OUT" >&2
+  echo "  -- end output --" >&2
 fi
 rm -f "$EXT_DENY_OUT"
 rm -rf "$FIXTURE_EXT_DIR"

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2151,118 +2151,27 @@ else
     fi
   done < "$FORBIDDEN_FIXTURE"
 
-  DRIFT_FAIL=0
-  DRIFT_HITS=()
-
-  while IFS= read -r skill_file; do
-    in_fence=0
-    fence_type=""
-    unset allowed_in_fence; declare -A allowed_in_fence=()
-    prev_lines=()
-    line_no=0
-    while IFS= read -r line; do
-      line_no=$((line_no + 1))
-      # Blockquote normalisation: strip a leading `>` + optional space
-      # before applying any structural regex. Without this, blockquoted
-      # fenced bash blocks (` >    ```bash`) go undetected.
-      norm_line="$line"
-      if [[ "$norm_line" =~ ^[[:space:]]*\>[[:space:]]?(.*)$ ]]; then
-        norm_line="${BASH_REMATCH[1]}"
-      fi
-
-      if [ "$in_fence" -eq 0 ]; then
-        # Outside any fence.
-        if [[ "$norm_line" =~ ^[[:space:]]*\<!--[[:space:]]+allow-hardcoded:[[:space:]]+(.+)[[:space:]]+reason:.*--\>[[:space:]]*$ ]]; then
-          captured="${BASH_REMATCH[1]}"
-          # Trim trailing whitespace.
-          captured="${captured%"${captured##*[![:space:]]}"}"
-          prev_lines+=("$captured")
-        elif [[ "$norm_line" =~ ^[[:space:]]*\`\`\`([a-zA-Z0-9_+-]*)[[:space:]]*$ ]]; then
-          # Fence-opener of any kind. Track exec vs other so non-shell
-          # fences (json, markdown, etc.) don't get scanned for shell
-          # literals — but their bounds are still tracked.
-          lang="${BASH_REMATCH[1]}"
-          in_fence=1
-          if [ -z "$lang" ] || [ "$lang" = "bash" ] || [ "$lang" = "sh" ] || [ "$lang" = "shell" ]; then
-            fence_type="exec"
-          else
-            fence_type="other"
-          fi
-          allowed_in_fence=()
-          if [ "$fence_type" = "exec" ]; then
-            for lit in "${prev_lines[@]:-}"; do
-              [ -n "$lit" ] && allowed_in_fence["$lit"]=1
-            done
-          fi
-          prev_lines=()
-          continue
-        else
-          # Any other non-blank line resets the marker block.
-          [ -n "$norm_line" ] && prev_lines=()
-        fi
-        # PROSE-IMPERATIVE detection: bullet/numbered line with a
-        # code-span AND a sentence-start imperative verb.
-        if [[ "$norm_line" =~ ^[[:space:]]*([-*]|[0-9]+\.) ]] \
-           && [[ "$norm_line" =~ \`[^\`]+\` ]] \
-           && [[ "$norm_line" =~ (^|[.\;\:][[:space:]]+|\*\*)(Run|Execute|Invoke)[[:space:]] ]]; then
-          for literal in "${FIXED_LITERALS[@]}"; do
-            if [[ "$norm_line" == *"$literal"* ]] && [ -z "${allowed_in_fence[$literal]:-}" ]; then
-              DRIFT_HITS+=("DRIFT (prose-imperative): $skill_file:$line_no contains '$literal'. Replace with \$VAR (preferred), OR add on the line ABOVE this bullet: <!-- allow-hardcoded: $literal reason: <why> -->")
-              DRIFT_FAIL=1
-            fi
-          done
-          for pattern in "${REGEX_PATTERNS[@]}"; do
-            if [[ "$norm_line" =~ $pattern ]] && [ -z "${allowed_in_fence[$pattern]:-}" ]; then
-              if [[ "$pattern" == '[0-9]{4}\.[0-9]{2}\.[0-9]{2}\+[0-9a-f]{6}' ]]; then
-                DRIFT_HITS+=("DRIFT (prose-imperative): $skill_file:$line_no matches the skill-version-literal regex '$pattern'. Per-skill version values belong in metadata.version frontmatter, not pasted into prose imperatives. To mark this bullet as an illustrative example, add on the line ABOVE: <!-- allow-hardcoded: $pattern reason: documenting the format with an example value -->")
-              else
-                DRIFT_HITS+=("DRIFT (prose-imperative): $skill_file:$line_no matches forbidden regex '$pattern'. Replace with \$VAR (preferred), OR add on the line ABOVE this bullet: <!-- allow-hardcoded: $pattern reason: <why> -->")
-              fi
-              DRIFT_FAIL=1
-            fi
-          done
-        fi
-        continue
-      fi
-
-      # Inside a fence.
-      if [[ "$norm_line" =~ ^[[:space:]]*\`\`\`[[:space:]]*$ ]]; then
-        in_fence=0
-        fence_type=""
-        allowed_in_fence=()
-        prev_lines=()
-        continue
-      fi
-      # Only scan exec-type fences (bash / sh / shell / no-language).
-      if [ "$fence_type" != "exec" ]; then
-        continue
-      fi
-      for literal in "${FIXED_LITERALS[@]}"; do
-        if [[ "$norm_line" == *"$literal"* ]] && [ -z "${allowed_in_fence[$literal]:-}" ]; then
-          DRIFT_HITS+=("DRIFT: $skill_file:$line_no contains '$literal' inside a bash fence without an allow-hardcoded marker. Replace with \$VAR (preferred), OR mark this fence as illustrative by adding on the line ABOVE the opening backticks: <!-- allow-hardcoded: $literal reason: <why> -->")
-          DRIFT_FAIL=1
-        fi
-      done
-      for pattern in "${REGEX_PATTERNS[@]}"; do
-        if [[ "$norm_line" =~ $pattern ]] && [ -z "${allowed_in_fence[$pattern]:-}" ]; then
-          # Tailored hint for the skill-version-literal regex (issue #179).
-          if [[ "$pattern" == '[0-9]{4}\.[0-9]{2}\.[0-9]{2}\+[0-9a-f]{6}' ]]; then
-            DRIFT_HITS+=("DRIFT: $skill_file:$line_no matches the skill-version-literal regex '$pattern' inside a bash fence. Per-skill version values belong in metadata.version frontmatter, not in fence bodies. To mark this fence as an illustrative example, add on the line ABOVE the opening backticks: <!-- allow-hardcoded: $pattern reason: documenting the format with an example value -->. Alternatively, switch the fence language to \`\`\`text (non-exec, not scanned).")
-          else
-            DRIFT_HITS+=("DRIFT: $skill_file:$line_no matches forbidden regex '$pattern' inside a bash fence without an allow-hardcoded marker. Replace with \$VAR (preferred), OR mark this fence as illustrative by adding on the line ABOVE the opening backticks: <!-- allow-hardcoded: $pattern reason: <why> -->")
-          fi
-          DRIFT_FAIL=1
-        fi
-      done
-    done < "$skill_file"
-  done < <(find "$REPO_ROOT/skills" "$REPO_ROOT/block-diagram" -name '*.md' | sort)
+  # The .md deny-list scan itself lives in the SHARED script
+  # tests/lib/forbidden-literals-scan.sh (#948) so the single-source-of-
+  # truth guarantee is STRUCTURAL: tests/test-hooks.sh's fixture-extension
+  # Surface 2 probe calls the SAME script directly against a synthetic
+  # tree, instead of nesting this whole suite. The scan's matching
+  # semantics, output (DRIFT lines), and gate behavior are unchanged — it
+  # still walks the real skills/ + block-diagram/ trees and fails on any
+  # forbidden literal. (The FIXED_LITERALS / REGEX_PATTERNS arrays parsed
+  # above remain in scope for the extended-scope sibling scan further down.)
+  # shellcheck source=tests/lib/forbidden-literals-scan.sh
+  . "$SCRIPT_DIR/lib/forbidden-literals-scan.sh"
+  DRIFT_HITS_OUT="$(run_forbidden_literals_scan "$REPO_ROOT" "$FORBIDDEN_FIXTURE")"
+  DRIFT_FAIL=$?
 
   if [ "$DRIFT_FAIL" -eq 0 ]; then
     pass "no skill-file drift hardcodes (deny-list clean against tests/fixtures/forbidden-literals.txt)"
   else
-    fail "skill-file drift hardcodes detected" "${#DRIFT_HITS[@]} hit(s)"
-    for h in "${DRIFT_HITS[@]}"; do
-      printf '    %s\n' "$h" >&2
+    DRIFT_HIT_COUNT=$(printf '%s' "$DRIFT_HITS_OUT" | grep -c .)
+    fail "skill-file drift hardcodes detected" "$DRIFT_HIT_COUNT hit(s)"
+    printf '%s\n' "$DRIFT_HITS_OUT" | while IFS= read -r h; do
+      [ -n "$h" ] && printf '    %s\n' "$h" >&2
     done
   fi
 
@@ -2273,20 +2182,30 @@ else
   # conformance. Inspect the live scanner source for the dual-root find
   # invocation. Fails closed if a future edit drops `block-diagram` from
   # any of the three sites.
+  #
+  # As of #948 the .md deny-list scan's dual-root find lives in the shared
+  # script tests/lib/forbidden-literals-scan.sh (it scans $scan_root/skills
+  # + $scan_root/block-diagram), NOT inline in this suite. Count both files
+  # so the #458 guarantee survives the relocation.
   SELF="$REPO_ROOT/tests/test-skill-conformance.sh"
+  SCAN_LIB="$REPO_ROOT/tests/lib/forbidden-literals-scan.sh"
+  # Prose-imperative coverage scan (still inline) + extended-scope are in $SELF.
   bd_root_hits=$(grep -cE 'find "\$REPO_ROOT/skills" "\$REPO_ROOT/block-diagram"' "$SELF" 2>/dev/null || echo 0)
+  # The deny-list scan's dual-root find now lives in the shared script,
+  # parameterised on $scan_root.
+  bd_lib_hits=$(grep -cE 'find "\$scan_root/skills" "\$scan_root/block-diagram"' "$SCAN_LIB" 2>/dev/null || echo 0)
   # Also count the positive-side scanner's `extra_root` plumbing (a 4th-arg
   # variant that passes the second root through the helper function).
   bd_extra_root_hits=$(grep -cE 'scan_positive_side "\$REPO_ROOT/skills".*"\$REPO_ROOT/block-diagram"' "$SELF" 2>/dev/null || echo 0)
-  # Expected: 2 dual-root find invocations (deny-list at ~line 1762, prose-
-  # imperative coverage at ~line 2408) + 1 scan_positive_side with extra_root
-  # (real-tree case). Total >= 3 references to block-diagram across the
-  # three scanner-root sites.
-  bd_total=$((bd_root_hits + bd_extra_root_hits))
+  # Expected: 1 dual-root find in the shared deny-list script + 1 dual-root
+  # find inline for prose-imperative coverage + 1 scan_positive_side with
+  # extra_root (real-tree case). Total >= 3 references to block-diagram
+  # across the three scanner-root sites.
+  bd_total=$((bd_root_hits + bd_lib_hits + bd_extra_root_hits))
   if [ "$bd_total" -ge 3 ]; then
     pass "deny-list/positive-side/coverage scanners all scope block-diagram/ (#458 regression fixture: found $bd_total of 3 expected block-diagram scan-root references)"
   else
-    fail "deny-list scanner scope regression" "expected 3 block-diagram scan-root references in $SELF (2 dual-root find + 1 scan_positive_side extra_root), got $bd_total — at least one of the three scanner roots has regressed to skills/-only (#458)"
+    fail "deny-list scanner scope regression" "expected 3 block-diagram scan-root references (1 dual-root find in $SCAN_LIB + 1 dual-root find + 1 scan_positive_side extra_root in $SELF), got $bd_total — at least one of the three scanner roots has regressed to skills/-only (#458)"
   fi
 fi
 


### PR DESCRIPTION
Closes #948

## What

Extracts the forbidden-literals `.md` deny-list scan out of `tests/test-skill-conformance.sh` into a shared `tests/lib/forbidden-literals-scan.sh` that BOTH consumers call:
- the real conformance CI gate (scans `skills/` + `block-diagram/`), and
- the `tests/test-hooks.sh` "fixture-extension coverage (single source of truth)" probe (Surface 2).

## Why

Surface 2 previously ran the **entire** conformance suite (~71s) as a nested subprocess against a synthetic tree just to assert one appended literal flows through the deny-list scan — ~75% of `test-hooks.sh`'s runtime, and the conformance suite ran **twice** per `run-all.sh` pass. The probe now calls the shared scan directly (sub-second). The single-source-of-truth guarantee is now **structural** (shared code), not just a shared fixture.

## Verification

- Byte-level semantic-faithfulness review confirmed the extracted scan flags **exactly the same set** as the old inline scan (fixture literal/`re:` parsing, two-root `*.md` globbing, fence + `allow-hardcoded` marker + prose-imperative rules all identical).
- Independent tmp-tree run: gate still fails on a real forbidden literal in a bash fence, still honors `allow-hardcoded` exemptions, still walks both roots; #458 dual-root regression fixture faithful (found 3 of 3).
- `bash tests/run-all.sh` → 7083/7083 passed, 0 failed. No nested `Results:` tally leak (#587) reintroduced.

## Scope

Extracted only the `.md` deny-list scan (the surface the probe exercises). The non-`.md` sibling scan (hooks/, scripts/, *.py) was intentionally left inline — different file-set/markers, untouched by the probe.

Worktree: /tmp/zskills-do-dedupe-forbidden-scan
Commits: 8235900 test(#948): extract forbidden-literals .md deny-list scan into shared script
