### PR TITLE
do: dev/prod URL rewriting + prominent Docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ phase inside an isolated git worktree, verifying each phase with a fresh
 reviewer agent and landing the result to main (cherry-pick, PR, or
 direct — your choice).
 
-**[View the full presentation](https://zskills.synapticnoise.com/PRESENTATION.html)**
+## Docs
+
+- [`docs/README.md`](docs/README.md) — full doc index (guides, plans, reports, per-skill reference).
+- [`docs/guides/WORKFLOWS.md`](docs/guides/WORKFLOWS.md) — end-to-end recipes that chain skills (plan-driven dev, backlog sprints, post-merge cleanup, …).
+- [`docs/guides/PLUGIN_INSTALL.md`](docs/guides/PLUGIN_INSTALL.md) — install via the plugin marketplace or the `/update-zskills` script.
+- [`docs/skills/README.md`](docs/skills/README.md) — per-skill reference for the 23 user-facing skills + 2 helpers.
+- [`docs/guides/INSPECTING_AND_MONITORING.md`](docs/guides/INSPECTING_AND_MONITORING.md) — observe a running zskills project.
+
+**[View the full presentation](https://zeveck.github.io/zskills-dev/PRESENTATION.html)**
 for the architecture, workflow stages, enforcement model, and war
 stories.
 
@@ -42,10 +50,6 @@ stories.
 ![Quality and Fix skills](screenshots/skills-quality-fix.png)
 
 ![Utility and Reference skills](screenshots/skills-utility.png)
-
-For a per-skill reference see [`docs/skills/`](docs/skills/README.md), and for
-recipes that combine skills into end-to-end workflows see
-[`docs/guides/WORKFLOWS.md`](docs/guides/WORKFLOWS.md).
 
 ## Install
 

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -9,6 +9,10 @@
 #   1. `<!-- prod-strip:start --> … <!-- prod-strip:end -->` blocks from
 #      README.md — the dev-repo warning banner and ship-to-prod badge.
 #      (Same marker pattern can be added to any other markdown file later.)
+#   1b. Rewrite dev-only URLs (zeveck.github.io/zskills-dev →
+#      zskills.synapticnoise.com) in README.md so the dev README points at
+#      the dev Pages site while the prod README ships with the prod URL.
+#      (Same per-file pattern can be added to any other markdown file later.)
 #   2. `plans/CANARY_*.md` and any top-level `CANARY_*.md` — canaries are
 #      regression guards for zskills-dev internals; prod consumers don't
 #      need them.
@@ -53,7 +57,19 @@ strip_markers() {
   fi
 }
 
+rewrite_dev_urls() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  if grep -q 'zeveck\.github\.io/zskills-dev' "$file"; then
+    log "rewriting dev→prod URLs in $file"
+    sed -i 's|zeveck\.github\.io/zskills-dev|zskills.synapticnoise.com|g' "$file"
+  else
+    printf "  ${DIM}(no dev urls in $file)${RESET}\n"
+  fi
+}
+
 strip_markers README.md
+rewrite_dev_urls README.md
 
 # ─── 1b. Remove dev-maintainer-only files wholesale ────────────────────
 # RELEASING.md is entirely dev-maintainer-only (PAT setup, workflow


### PR DESCRIPTION
## Summary

Two README/build-pipeline polish changes wired through the existing
`prod-strip` machinery in `scripts/build-prod.sh`:

1. **README.md** now points at the dev Pages site for the PRESENTATION
   link (`zeveck.github.io/zskills-dev/PRESENTATION.html` instead of
   `zskills.synapticnoise.com/PRESENTATION.html`), and a new `## Docs`
   section near the top surfaces the five highest-value entry points
   (full index, workflows recipes, plugin install, per-skill reference,
   monitoring guide). The previously-tucked "For a per-skill reference
   …" paragraph that sat after the skill-card screenshots is removed
   — the new top-of-README section supersedes it.

2. **`scripts/build-prod.sh`** gains a `rewrite_dev_urls()` function
   modeled on the existing `strip_markers()`. At ship time the dev
   URLs flip back to the prod `zskills.synapticnoise.com` domain, so
   the prod README ships with the prod URL while the dev README keeps
   the dev URL. Idempotent (re-running is a no-op). Header comment
   extended to describe the new transform.

Pattern is per-file extensible: future markdown files can be added to
both `strip_markers` and `rewrite_dev_urls` call sites.

## Test plan

- [x] `bash -n scripts/build-prod.sh` clean
- [x] `## Docs` appears exactly once in README.md, positioned **before**
      `## The Skills`; 5 curated links present
- [x] `grep -c 'zskills\.synapticnoise\.com' README.md` → 0 (dev URL in
      place pre-ship); `grep -c 'zeveck\.github\.io/zskills-dev/PRESENTATION\.html' README.md` → 1
- [x] Stale "For a per-skill reference…" paragraph removed (grep → 0)
- [x] Idempotency: running `bash scripts/build-prod.sh` once rewrites
      the dev URL → prod URL; second run prints "(no dev urls in
      README.md)" — no-op
- [x] Scope: `git diff HEAD~1..HEAD --stat` is 2 files (README.md +
      scripts/build-prod.sh) +25/−5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
