### PR TITLE
do: refresh cost-topline slide with current stats

### DIFF
--- a/reports/slide-cost-topline.html
+++ b/reports/slide-cost-topline.html
@@ -34,33 +34,33 @@
 <div class="frame">
   <div class="eyebrow">Cost Topline</div>
   <h1>What Z Skills cost — at Claude API list prices</h1>
-  <p class="deck"><strong>Actual out-of-pocket:</strong> $200/mo Claude Max x20 subscription + ~$500 in extra usage. The numbers below are the API-list-price equivalent of the same work, computed from 1,617 JSONL session transcripts.</p>
+  <p class="deck"><strong>Actual out-of-pocket:</strong> $200/mo Claude Max x20 subscription + ~$500 in extra usage. The numbers below are the API-list-price equivalent of the same work, computed from 2,065 JSONL session transcripts.</p>
 
   <div class="stats">
     <div class="stat orange">
-      <div class="val">$8,916</div>
+      <div class="val">$12,204</div>
       <div class="label">Logged spend</div>
-      <div class="sub">Opus 4.7 + Haiku 4.5 across 34 days (2026-04-18 → 2026-05-22), 55,520 distinct API responses.</div>
+      <div class="sub">Opus 4.7/4.8 + Haiku 4.5 across 45 days (2026-04-18 → 2026-06-01), 70,988 distinct API responses.</div>
     </div>
     <div class="stat pink">
-      <div class="val">~$12.7k</div>
+      <div class="val">~$16k</div>
       <div class="label">Projected total</div>
-      <div class="sub">Logged plus an estimate for the 23-day Opus 4.6 era that pre-dates JSONL logging. Range ~$11.7k–$13.5k.</div>
+      <div class="sub">Logged plus an estimate for the 23-day Opus 4.6 era that pre-dates JSONL logging. Range ~$15k–$17k.</div>
     </div>
     <div class="stat green">
-      <div class="val">715 / 410</div>
+      <div class="val">940 / 635</div>
       <div class="label">Commits / merged PRs</div>
-      <div class="sub">What was actually built on <code>main</code>. ~5 commits and ~3 merged PRs per day on average.</div>
+      <div class="sub">What was actually built on <code>main</code>. ~14 commits and ~9 merged PRs per day on average across the 67-day project span.</div>
     </div>
     <div class="stat purple">
-      <div class="val">9.7 B</div>
+      <div class="val">13.4 B</div>
       <div class="label">Tokens processed</div>
-      <div class="sub">~9.74 B input-side + 41 M output across 55,520 API responses. Heavy prompt caching kept the bill at $8,916 rather than ~$50k.</div>
+      <div class="sub">~13.44 B input-side + 49 M output across 70,988 API responses. Heavy prompt caching kept the bill at $12,204 rather than ~$70k.</div>
     </div>
   </div>
 
   <div class="footnote">
-    Per-API-response billing (dedup by <code>message.id</code>). Rates from <code>platform.claude.com/docs/en/about-claude/pricing</code>, fetched 2026-05-21. Opus 4.5/4.6/4.7 share the same rate card.
+    Per-API-response billing (dedup by <code>message.id</code>). Rates from <code>platform.claude.com/docs/en/about-claude/pricing</code>, fetched 2026-05-21. Opus 4.5/4.6/4.7/4.8 share the same rate card.
   </div>
 </div>
 </body>


### PR DESCRIPTION
## Summary

Refresh the cost-topline summary slide (reports/slide-cost-topline.html) with reality-current numbers as of 2026-06-01. Content-only single-file edit — methodology unchanged.

Key updates vs the 2026-05-21 snapshot:
- **Logged spend:** $8,916 → **$12,204** (window extended from 34 days to 45 days; through 2026-06-01)
- **API responses:** 55,520 → **70,988**
- **Tokens:** 9.7 B → **13.44 B** input-side; 41 M → 49 M output
- **Commits / merged PRs on main:** 715 / 410 → **940 / 635**
- **Projected total** (logged + 4.6-era estimate): ~$12.7k → **~$16k** (range ~$15k–$17k)
- **Model coverage:** "Opus 4.7" → **"Opus 4.7/4.8"** (4.8 began 2026-05-29; shares the Opus 4.5+ rate card, so cost math is unaffected)
- **JSONL session count:** 1,617 → **2,065**
- **Footnote rate-card line:** extended to "Opus 4.5/4.6/4.7/4.8 share the same rate card."

Methodology unchanged: per-API-response billing, dedup by `message.id`, max(output_tokens) per id. Anthropic-published rates for Opus 4.5+ and Haiku 4.5. The 4.6-era $3,818 estimate is unchanged (historical period — its inputs don't move).

Worktree: `/tmp/zskills-do-refresh-cost-topline-stats`
Commits:
7a2169c do: refresh cost-topline slide with current stats

## Test plan

- [x] Diff vs dev/main shows only the documented field changes (8 fields), no extraneous edits
- [x] Source file (`/tmp/costs-preview/slide-cost-topline.html`) byte-matches the committed worktree copy
- [ ] Numbers reproducible from `~/.claude/projects/*zskills*` JSONL transcripts via dedup-by-message.id (manual re-run of recompute script if desired)
- [ ] Visual render check after merge — open `reports/slide-cost-topline.html` and confirm the four-card layout still renders cleanly with the new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
