### PR TITLE
do: backfill completed: on PLUGIN_LANE_VERIFICATION

### DIFF
--- a/docs/plans/PLUGIN_LANE_VERIFICATION.md
+++ b/docs/plans/PLUGIN_LANE_VERIFICATION.md
@@ -2,6 +2,7 @@
 title: Plugin-Lane Verification — pre-launch gap-closing
 created: 2026-05-29
 status: complete
+completed: "2026-06-01T20:25:23Z"
 ---
 
 # Plan: Plugin-Lane Verification — pre-launch gap-closing


### PR DESCRIPTION
Surgical content-only fix for the dashboard's "Plugin-Lane Verification" card showing as active despite the plan being done.

PR #951 (commit 75f85a0, merged 2026-06-01T20:25:23Z) landed the final phase of `docs/plans/PLUGIN_LANE_VERIFICATION.md` with frontmatter `status: complete` but no `completed:` field. The dashboard's auto-route to the Completed column (`collect.py:_annotate_plans_queue` and the client-side mirror landed in PR #909 for #905) requires BOTH `status ∈ {complete, landed}` AND a parseable `completed:` timestamp. Without it, the plan stays pinned to whatever column `monitor-state.json` has it in (currently `discarded`), and the card is rendered ambiguously even though the work is fully done.

This PR adds the missing field with the PR #951 merge timestamp. One-line frontmatter addition; body unchanged; no other files modified.

The structural fix (make `/run-plan` auto-write `completed:` on phase-done landing so this gap doesn't recur) is tracked separately at #957.

Commits:
- 42a6d97 docs(plans): backfill completed: timestamp on PLUGIN_LANE_VERIFICATION (PR #951)
