### PR TITLE
do: refresh TECHNICAL stats report with current measurements

### DIFF
--- a/reports/TECHNICAL.html
+++ b/reports/TECHNICAL.html
@@ -162,7 +162,7 @@
   <p>How much code, how many tests, how many commits.</p>
   <p style="font-size: 0.95em;"><strong>All counts come straight from the repo:</strong> <code>find</code>/<code>wc</code> for LOC, <code>git log</code> for commits, <code>gh</code> for issues. Reproducible from a clean checkout of <code>main</code>; commands listed in the methodology section.</p>
   <p style="font-size: 0.95em;"><strong>Companion reports: <a href="COSTS.html">Cost Estimate &rarr;</a> &middot; <a href="PERMISSIONS.html">Permission Prompts &rarr;</a></strong></p>
-  <p style="font-size: 0.9em;">As of <strong>2026-05-21</strong>. The <a href="../PRESENTATION.html">main presentation</a> covers what skills <em>do</em>; this page covers their <em>composition</em>.</p>
+  <p style="font-size: 0.9em;">As of <strong>2026-06-01</strong>. The <a href="../PRESENTATION.html">main presentation</a> covers what skills <em>do</em>; this page covers their <em>composition</em>.</p>
 </section>
 
 <section id="numbers" class="fade-in">
@@ -170,23 +170,23 @@
 
   <h4>Codebase</h4>
   <div class="stat-grid">
-    <div class="stat"><div class="val">24 + 2</div><div class="label">Skills</div><div class="sub">24 user-facing + 2 internal helpers (<code>/land-pr</code>, <code>/create-worktree</code>)</div></div>
-    <div class="stat green"><div class="val">42,759</div><div class="label">LOC in skills</div><div class="sub">md + sh + py across <code>skills/</code> &amp; <code>block-diagram/</code></div></div>
-    <div class="stat"><div class="val">23,239</div><div class="label">Lines of SKILL.md prose</div><div class="sub">26 skill bodies + 3 block-diagram add-ons</div></div>
+    <div class="stat"><div class="val">15 + 10</div><div class="label">Skills</div><div class="sub">15 user-facing (model-invokable) + 10 internal helpers (slash-invoke-only via <code>disable-model-invocation</code> or <code>user-invocable: false</code>); 25 source skills + 3 block-diagram add-ons = <strong>28 total</strong></div></div>
+    <div class="stat green"><div class="val">52,351</div><div class="label">LOC in skills</div><div class="sub">md + sh + py across <code>skills/</code> &amp; <code>block-diagram/</code></div></div>
+    <div class="stat"><div class="val">18,040</div><div class="label">Lines of SKILL.md prose</div><div class="sub">28 SKILL.md bodies (25 source + 3 add-ons). Down from 23,239 in the 2026-05-21 snapshot &mdash; <code>/fix-issues</code>, <code>/run-plan</code>, <code>/quickfix</code>, <code>/draft-tests</code>, and <code>/work-on-plans</code> all decomposed top-level prose into <code>modes/</code>, <code>references/</code>, and <code>subcommands/</code> subfiles.</div></div>
   </div>
 
   <h4>Tests &amp; Hooks</h4>
   <div class="stat-grid">
-    <div class="stat orange"><div class="val">114</div><div class="label">Test scripts</div><div class="sub">49,341 LOC under <code>tests/</code></div></div>
-    <div class="stat"><div class="val">10 + 2</div><div class="label">PreToolUse hooks</div><div class="sub">10 hook entry points + 2 lib helpers; 5,403 LOC under <code>hooks/</code></div></div>
-    <div class="stat"><div class="val">13</div><div class="label">Scripts</div><div class="sub">1,999 LOC of shared infra under <code>scripts/</code></div></div>
+    <div class="stat orange"><div class="val">193</div><div class="label">Test scripts</div><div class="sub">73,335 LOC under <code>tests/</code></div></div>
+    <div class="stat"><div class="val">12 + 4</div><div class="label">PreToolUse hooks</div><div class="sub">12 hook entry points + 4 lib helpers; 5,552 LOC under <code>hooks/</code></div></div>
+    <div class="stat"><div class="val">17</div><div class="label">Scripts</div><div class="sub">2,536 LOC of shared infra under <code>scripts/</code></div></div>
   </div>
 
   <h4>Git activity (since 2026-03-26)</h4>
   <div class="stat-grid">
-    <div class="stat green"><div class="val">709</div><div class="label">Commits on main</div><div class="sub">~8 weeks, ~88/week</div></div>
-    <div class="stat green"><div class="val">404</div><div class="label">Merged PRs</div><div class="sub">squash-merge commits; the other 305 main commits are direct (pre-PR-workflow + canary executions)</div></div>
-    <div class="stat orange"><div class="val">191</div><div class="label">GitHub issues filed</div><div class="sub">open + closed</div></div>
+    <div class="stat green"><div class="val">944</div><div class="label">Commits on main</div><div class="sub">~10 weeks, ~94/week</div></div>
+    <div class="stat green"><div class="val">639</div><div class="label">Merged PRs</div><div class="sub">squash-merge commits; the other 305 main commits are direct (pre-PR-workflow + early canary executions). Direct-commit count unchanged since 2026-05-21 &mdash; all new work since has gone through PRs (<code>main_protected: true</code>).</div></div>
+    <div class="stat orange"><div class="val">307</div><div class="label">GitHub issues filed</div><div class="sub">open + closed</div></div>
   </div>
 </section>
 
@@ -196,27 +196,28 @@
 
   <table>
     <tr><th>Surface</th><th>LOC</th><th>Files</th><th>What it is</th></tr>
-    <tr><td><code>skills/</code> + <code>block-diagram/</code></td><td>42,759</td><td>100</td><td>Skill bodies, modes/, references/, owned scripts (md + sh + py)</td></tr>
-    <tr><td>&nbsp;&nbsp;&nbsp;of which: SKILL.md prose</td><td>23,239</td><td>29</td><td>Top-level skill bodies (26 source + 3 add-on)</td></tr>
-    <tr><td><code>tests/</code></td><td>49,341</td><td>114</td><td>Conformance suite, integration, canary-failure fixtures</td></tr>
-    <tr><td><code>hooks/</code></td><td>5,403</td><td>10 + 2 lib</td><td>PreToolUse blockers, Bash timeout extension, response validation</td></tr>
-    <tr><td><code>scripts/</code></td><td>1,999</td><td>13</td><td>Release tooling, frontmatter mutators, version stage-checks</td></tr>
+    <tr><td><code>skills/</code> + <code>block-diagram/</code></td><td>52,351</td><td>129</td><td>Skill bodies, modes/, references/, owned scripts (md + sh + py)</td></tr>
+    <tr><td>&nbsp;&nbsp;&nbsp;of which: SKILL.md prose</td><td>18,040</td><td>28</td><td>Top-level skill bodies (25 source + 3 add-on)</td></tr>
+    <tr><td><code>tests/</code></td><td>73,335</td><td>193</td><td>Conformance suite, integration, canary-failure fixtures</td></tr>
+    <tr><td><code>hooks/</code></td><td>5,552</td><td>12 + 4 lib</td><td>PreToolUse blockers, Bash timeout extension, response validation</td></tr>
+    <tr><td><code>scripts/</code></td><td>2,536</td><td>17</td><td>Release tooling, frontmatter mutators, version stage-checks</td></tr>
   </table>
+  <p style="color: var(--text-dim); font-size: 0.9em;">Note the SKILL.md prose shrunk (23,239 &rarr; 18,040, &minus;22%) while total skill-tree LOC grew (42,759 &rarr; 52,351, +22%). That's deliberate decomposition: large skills (most prominently <code>/fix-issues</code>, which dropped from 2,862 to 367 lines &mdash; 87% shrinkage of its top-level body) extracted operational detail into per-mode and per-reference subfiles. The skill-body markdown stays load-bearing for orchestration; the extracted files load on-demand.</p>
 
   <h3>Largest skills by SKILL.md line count</h3>
-  <p style="color: var(--text-dim); font-size: 0.9em;">Top-10 source skills by SKILL.md size — a rough proxy for workflow complexity. The biggest ones orchestrate multi-phase pipelines; the smallest are thin wrappers.</p>
+  <p style="color: var(--text-dim); font-size: 0.9em;">Top-10 source skills by SKILL.md size &mdash; a rough proxy for workflow complexity. The biggest ones orchestrate multi-phase pipelines; the smallest are thin wrappers. The 2026-05-21 snapshot's top-3 (<code>/fix-issues</code> 2,862, <code>/run-plan</code> 2,568, <code>/update-zskills</code> 1,934) shifted as skills decomposed &mdash; <code>/fix-issues</code> dropped to #20 at 367 lines (extracted into <code>modes/</code> + <code>references/</code> + <code>subcommands/</code>); <code>/update-zskills</code> grew to #1 at 2,145.</p>
   <table>
     <tr><th>Skill</th><th>SKILL.md lines</th><th style="width: 40%;">Relative</th></tr>
-    <tr><td><code>/fix-issues</code></td><td>2,862</td><td><span class="bar" style="width: 95%;"></span></td></tr>
-    <tr><td><code>/run-plan</code></td><td>2,568</td><td><span class="bar" style="width: 85%;"></span></td></tr>
-    <tr><td><code>/update-zskills</code></td><td>1,934</td><td><span class="bar" style="width: 64%;"></span></td></tr>
-    <tr><td><code>/draft-tests</code></td><td>1,922</td><td><span class="bar" style="width: 64%;"></span></td></tr>
-    <tr><td><code>/quickfix</code></td><td>1,369</td><td><span class="bar" style="width: 45%;"></span></td></tr>
-    <tr><td><code>/work-on-plans</code></td><td>1,295</td><td><span class="bar" style="width: 43%;"></span></td></tr>
-    <tr><td><code>/do</code></td><td>957</td><td><span class="bar" style="width: 32%;"></span></td></tr>
-    <tr><td><code>/cleanup-merged</code></td><td>883</td><td><span class="bar" style="width: 29%;"></span></td></tr>
-    <tr><td><code>/land-pr</code></td><td>874</td><td><span class="bar" style="width: 29%; background: var(--text-dim);"></span></td></tr>
-    <tr><td><code>/verify-changes</code></td><td>747</td><td><span class="bar" style="width: 25%;"></span></td></tr>
+    <tr><td><code>/update-zskills</code></td><td>2,145</td><td><span class="bar" style="width: 95%;"></span></td></tr>
+    <tr><td><code>/run-plan</code></td><td>1,276</td><td><span class="bar" style="width: 56%;"></span></td></tr>
+    <tr><td><code>/land-pr</code></td><td>1,208</td><td><span class="bar" style="width: 53%; background: var(--text-dim);"></span></td></tr>
+    <tr><td><code>/do</code></td><td>1,120</td><td><span class="bar" style="width: 50%;"></span></td></tr>
+    <tr><td><code>/draft-plan</code></td><td>1,054</td><td><span class="bar" style="width: 47%;"></span></td></tr>
+    <tr><td><code>/add-block</code> (block-diagram)</td><td>945</td><td><span class="bar" style="width: 42%;"></span></td></tr>
+    <tr><td><code>/refine-plan</code></td><td>886</td><td><span class="bar" style="width: 39%;"></span></td></tr>
+    <tr><td><code>/quickfix</code></td><td>869</td><td><span class="bar" style="width: 38%;"></span></td></tr>
+    <tr><td><code>/cleanup-merged</code></td><td>792</td><td><span class="bar" style="width: 35%;"></span></td></tr>
+    <tr><td><code>/verify-changes</code></td><td>783</td><td><span class="bar" style="width: 35%;"></span></td></tr>
   </table>
 </section>
 
@@ -224,16 +225,17 @@
   <h2>Methodology</h2>
 
   <h3>Code/test/commit counts</h3>
-  <p>All reproducible from a clean checkout of <code>main</code> at <code>283db23</code> (the merge-base this branch was cut from):</p>
+  <p>All reproducible from a clean checkout of <code>main</code> (HEAD as of 2026-06-01):</p>
 <pre><code>find skills block-diagram -type f \( -name "*.md" -o -name "*.sh" -o -name "*.py" \) -exec cat {} + | wc -l
 find tests -type f -name "*.sh" -exec cat {} + | wc -l
-find hooks -type f -name "*.sh*" -exec cat {} + | wc -l
+find hooks -type f \( -name "*.sh" -o -name "*.json" \) -exec cat {} + | wc -l
 git rev-list --count main
-git log --oneline main | grep -cE '\(#[0-9]+\)'
-gh issue list --state all --limit 1000 --json number | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))'</code></pre>
+git log --oneline main | grep -cE '\(#[0-9]+\)$'
+gh issue list --state all --limit 2000 --json number | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))'</code></pre>
+  <p style="color: var(--text-dim); font-size: 0.92em;">Independent re-counts of each figure (via different command paths &mdash; <code>wc -l $(find ...)</code> vs <code>find ... -exec cat | wc</code>, <code>git rev-list</code> vs <code>git log | wc</code>, <code>gh pr list --state merged</code> vs the regex on log) match the figures above. The merged-PR count via <code>gh pr list --state merged</code> returns 638 (vs the 639 regex count) &mdash; a 1-PR delta most likely from a closed-cherry-picked PR; the regex-on-log count is what's reported here, consistent with the 2026-05-21 snapshot's methodology.</p>
 
   <h3>Commits vs. PRs</h3>
-  <p style="color: var(--text-dim); font-size: 0.92em;">709 total commits on main, of which 404 are PR squash-merges and 305 are direct. The 305 split as <strong>117 pre-PR-workflow</strong> commits (before the first PR landed on 2026-04-13, when main was unprotected) plus <strong>188 post-PR-workflow direct commits</strong>. The 188 break down (mutually exclusive) as ~95 direct-commit-style (fix/docs/test/feat/refactor/chore via <code>/commit direct</code> or non-PR <code>/quickfix</code>, ~50%), ~54 <code>/run-plan</code> cherry-pick-mode phase commits (~29%), 36 canary plan-execution chores (~19%), and 3 infra/build commits.</p>
+  <p style="color: var(--text-dim); font-size: 0.92em;">944 total commits on main, of which 639 are PR squash-merges and 305 are direct. The 305 direct-commit count is unchanged since the 2026-05-21 snapshot &mdash; all 235 new commits in the 2026-05-22 &rarr; 2026-06-01 window went through PRs (<code>main_protected: true</code>). The 305 split as <strong>117 pre-PR-workflow</strong> commits (before the first PR landed on 2026-04-13, when main was unprotected) plus <strong>188 post-PR-workflow direct commits</strong>. The 188 break down (mutually exclusive) as ~95 direct-commit-style (fix/docs/test/feat/refactor/chore via <code>/commit direct</code> or non-PR <code>/quickfix</code>, ~50%), ~54 <code>/run-plan</code> cherry-pick-mode phase commits (~29%), 36 canary plan-execution chores (~19%), and 3 infra/build commits.</p>
 
   <h3>What this <em>doesn't</em> measure</h3>
   <p style="color: var(--text-dim);">Wall-clock time, human review effort, the Claude.ai chat sessions used for architecture discussions outside Claude Code, the pre-2026-03-26 prototyping that fed into the initial commit, or cost &mdash; see the <a href="COSTS.html">Cost Estimate</a>.</p>
@@ -241,9 +243,9 @@ gh issue list --state all --limit 1000 --json number | python3 -c 'import json,s
 </section>
 
 <section class="fade-in" style="text-align:center; padding: 40px 0; border-top: 2px solid var(--border);">
-  <p style="font-size: 1.05em; color: var(--text); max-width: 800px; margin: 0 auto;"><strong>26 skills (24 user-facing + 2 helpers), 709 commits / 404 merged PRs, 114 test scripts &mdash; a body of evidence about what disciplined-agent engineering looks like.</strong></p>
+  <p style="font-size: 1.05em; color: var(--text); max-width: 800px; margin: 0 auto;"><strong>28 skills (15 user-facing + 10 helpers + 3 add-ons), 944 commits / 639 merged PRs, 193 test scripts &mdash; a body of evidence about what disciplined-agent engineering looks like.</strong></p>
   <p style="margin-top: 16px;"><a href="../PRESENTATION.html">&larr; Main presentation</a> &middot; <a href="COSTS.html">Cost Estimate &rarr;</a> &middot; <a href="PERMISSIONS.html">Permission Prompts &rarr;</a> &middot; <a href="https://github.com/zeveck/zskills">github.com/zeveck/zskills</a></p>
-  <p style="margin-top: 24px; font-size: 0.85em; color: var(--text-dim);">Stats as of 2026-05-21. Built with Claude Code (Claude Opus 4.6 / 4.7).</p>
+  <p style="margin-top: 24px; font-size: 0.85em; color: var(--text-dim);">Stats as of 2026-06-01. Built with Claude Code (Claude Opus 4.6 / 4.7 / 4.8).</p>
 </section>
 
 </div>


### PR DESCRIPTION
## Summary

Refresh TECHNICAL.html (technical stats report) against 2026-06-01 state of main. No companion slide — report-only.

**Headline changes:**
- **Skills framing fixed:** "24 user-facing + 2 helpers" → **"15 user-facing + 10 helpers"** (per verifier audit of each SKILL.md's frontmatter — the old framing was stale; many skills now carry `disable-model-invocation: true`)
- skills/+block-diagram/ LOC: 42,759 → **52,351** (+22%)
- SKILL.md prose LOC: 23,239 → **18,040** (−22%, despite skill-tree LOC growing) — deliberate decomposition into modes/references/subcommands/ subfiles
- Test scripts: 114 → **193** (+69%); tests/ LOC: 49,341 → **73,335**
- Hooks: 10+2 → **12+4**; LOC: 5,403 → **5,552**
- Scripts: 13 → **17**; LOC: 1,999 → **2,536**
- Commits: 709 → **944**; merged PRs: 404 → **639**; issues: 191 → **307**
- **Direct-commit count (305) UNCHANGED** since 2026-05-21 — all 235 new commits went through PRs (main_protected)

**Top-10 SKILL.md table rewritten.** New top-3: `/update-zskills` (2,145), `/run-plan` (1,276), `/land-pr` (1,208). Old top-3 was `/fix-issues` (2,862), `/run-plan` (2,568), `/update-zskills` (1,934). The most dramatic shift: `/fix-issues` dropped from #1 (2,862 lines) to #20 (367 lines) — content extracted into `modes/` + `references/` + `subcommands/` subfiles. Same pattern for `/quickfix`, `/draft-tests`, `/work-on-plans`.

**Verification cross-checks:**
- 2 independent verifier agents recomputed LOC/commit/PR/issue counts via different command paths. All 13 numbers match exactly.
- One found a 1-PR delta between `gh pr list --state merged` (638) and the log-regex method (639) — likely a closed-cherry-picked PR. Report keeps the regex method consistent with the prior snapshot.
- Skill catalog independently classified into user-facing vs helpers by reading each SKILL.md's `disable-model-invocation` and `user-invocable` frontmatter flags.

**Sections refreshed:**
- Date stamp + 3 stat-grid sections (Codebase, Tests & Hooks, Git activity)
- Code Composition table + new explanatory note about prose-shrunk-but-tree-grew
- Top-10 SKILL.md table (full rewrite)
- Methodology: command list (hooks regex fixed: `*.sh*` → `\( -name "*.sh" -o -name "*.json" \)`), added verification note
- Commits-vs-PRs prose (305 direct unchanged, all new work via PRs)
- Conclusion footer

## Test plan

- [x] HTML tag balance check passes (script-verified)
- [x] 2 verifier agents independently cross-checked all 13 reference numbers via different command paths
- [x] Skill catalog manually classified by reading each SKILL.md frontmatter
- [ ] Visual render check after merge — open `reports/TECHNICAL.html`, confirm tables render
- [ ] Spot-check the methodology pre block actually reproduces the listed numbers from a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
