### PR TITLE
fix(#959): /do stops on a stray #N held by a foreign pipeline; add --no-claim

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+f85099"
+  version: "2026.06.01+e6d3b6"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -72,6 +72,15 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
   immediately AND schedules. Without `every`, `now` is the default behavior.
 - **--force** (optional) — bypass triage redirect and review reject. Persists
   into the cron prompt verbatim when used with `every`.
+- **--no-claim** (optional) — treat every bare `#N` in the description as a
+  mere mention. Suppresses the stray-`#N` pre-flight check (#959): /do
+  normally STOPS when the description references an issue currently held
+  in-flight by a foreign pipeline (to prevent duplicating its work — the
+  closed-PR-#888-vs-landed-#901 footgun), and warns on any other stray `#N`.
+  Pass `--no-claim` when the reference is deliberate ("fix tooltip, related
+  to #340") and you do NOT want /do to halt or warn on it. Claim-positioned
+  `#N` (a leading `#N` or `Fix #N …`) are unaffected — they still acquire
+  their claim through the mode files' normal acquire-or-decline.
 - **--rounds N** (optional) — max review/refine cycles (default 1; `0` skips
   review with stderr WARN).
 - **stop** — cancel `/do` cron(s). Bare `/do stop` → all crons.
@@ -215,6 +224,16 @@ FORCE=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])--force($|[[:space:]]) ]]; then
   FORCE=1
 fi
+# Issue #959: `--no-claim` opt-out. When present, the stray-`#N` pre-flight
+# (the #907 loop below) treats every bare `#N` as a mere mention — it
+# suppresses BOTH the new foreign-held STOP and the #907 warn. Use it when a
+# /do legitimately references an issue it is NOT working (e.g. "fix tooltip,
+# related to #340"). Claim-positioned `#N` (in ISSUE_NUMS) are independent of
+# this flag — they still go through the mode files' A5.5 acquire-or-decline.
+NO_CLAIM=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])--no-claim($|[[:space:]]) ]]; then
+  NO_CLAIM=1
+fi
 # Issue #297: positional `auto` token (case-insensitive, anywhere in the
 # args) opts /do pr into /land-pr's auto-merge path. Mirrors /quickfix,
 # /run-plan, /fix-issues. Pre-parsed here so Phase 1.5's strip chain and
@@ -303,28 +322,100 @@ unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _DO_ISSUE_FILLER _n
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
-# Unclaimed-reference warning (#907). If the description contains a `#N`
-# token that the claim-position rules above did NOT capture into
-# ISSUE_NUMS, the reference is real but UN-claimed. A silent no-claim is
-# the footgun that let `/do Build … for #877` run without claiming #877:
-# a parallel /fix-issues cron then picked up the unclaimed issue and
-# duplicated the work (closed PR #888 vs landed #901). Warn per stray
-# reference (non-fatal — some /do runs legitimately mention an issue
-# without working it; the run proceeds). Claim-positioned refs are already
-# in ISSUE_NUMS and are NOT re-warned.
-_DO_WARN_REMAINING="$ARGUMENTS"
-while [[ "$_DO_WARN_REMAINING" =~ \#([0-9]+) ]]; do
-  _DO_REF="${BASH_REMATCH[1]}"
-  _DO_WARN_REMAINING="${_DO_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
-  _DO_CLAIMED=0
-  for _n in "${ISSUE_NUMS[@]:-}"; do
-    [ "$_n" = "$_DO_REF" ] && { _DO_CLAIMED=1; break; }
-  done
-  if [ "$_DO_CLAIMED" -eq 0 ]; then
-    echo "WARN: /do: description references #${_DO_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_DO_REF} …\" or \"Fix #${_DO_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work." >&2
+# Unclaimed-reference check (#907 warn + #959 foreign-held STOP). If the
+# description contains a `#N` token that the claim-position rules above did
+# NOT capture into ISSUE_NUMS, the reference is real but UN-claimed by this
+# /do run. A silent no-claim is the footgun that let `/do Build … for #877`
+# run without claiming #877: a parallel /fix-issues cron then picked up the
+# unclaimed issue and duplicated the work (closed PR #888 vs landed #901).
+#
+# Two-tier handling per stray (non-ISSUE_NUMS) `#N` (#959):
+#   1. READ-ONLY foreign-held check. If issue N currently has a LIVE claim
+#      held by a DIFFERENT pipeline, STOP (clean exit 0 — decline, not an
+#      error). #907's warn fails UNSAFE in autonomous use (an agent reads
+#      the warn and proceeds anyway, re-creating the #877 duplication); the
+#      STOP fails SAFE and is recoverable via `--no-claim`. We DO NOT acquire
+#      on stray refs (that would spuriously claim "see #340" mentions — the
+#      over-capture the conservative ISSUE_NUMS parser deliberately avoids).
+#   2. Not held (or no claim.json) → keep the #907 warn and proceed.
+#
+# Foreign-vs-self is decided by READING `.zskills/claims/issue-N/claim.json`
+# and comparing its `pipeline_id` to THIS run's pipeline_id — exactly the
+# pattern hooks/block-fix-issue-unclaimed.sh uses. We do NOT use
+# filter-in-flight-issue-claims.sh alone: it drops the caller's OWN pipeline
+# claims too and cannot distinguish foreign from self, which would wrongly
+# stop on self-re-entry. Fail-OPEN discipline mirrors
+# block-fix-issue-unclaimed.sh: a missing/malformed claim.json, or a missing
+# pipeline_id, is treated as "not held" → warn-and-proceed, never a false
+# STOP. (In practice a stray ref is by definition never acquired by THIS /do
+# run, so any live claim on it is foreign; the self-exclusion below is the
+# belt-and-suspenders that keeps a hypothetical self-claim from stopping us.)
+#
+# Accepted residual (intentional, safe-direction): a false-STOP fires ONLY
+# when a /do mentions an issue that is in flight RIGHT NOW but isn't actually
+# being worked (`fix tooltip, related to #340` while #340 is live). Recover
+# with `--no-claim`. Mentions of closed/old issues never trigger (no live
+# claim). This is the irreducible cost of "issues optional + can't tell
+# work-from-mention out of free text" — the failure mode relocates from
+# "fails → duplicates silently" to "fails → halts with a clear message".
+#
+# `--no-claim` (NO_CLAIM=1, parsed in the pre-parse above) suppresses BOTH
+# the STOP and the warn — every bare `#N` is then a pure mention.
+#
+# Resolve MAIN_ROOT the same way block-fix-issue-unclaimed.sh does:
+# `git rev-parse --git-common-dir` parent, falling back to
+# ${CLAUDE_PROJECT_DIR:-$PWD}. This is correct from a worktree too (the
+# claims live under the MAIN repo's .zskills/).
+if [ "$NO_CLAIM" -ne 1 ]; then
+  _DO_MAIN_ROOT=""
+  if _DO_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) && [ -n "$_DO_COMMON_DIR" ]; then
+    if _DO_RESOLVED=$(cd "$_DO_COMMON_DIR/.." 2>/dev/null && pwd); then
+      _DO_MAIN_ROOT="$_DO_RESOLVED"
+    fi
   fi
-done
-unset _DO_WARN_REMAINING _DO_REF _DO_CLAIMED _n
+  [ -z "$_DO_MAIN_ROOT" ] && _DO_MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+  _DO_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+  # This run's pipeline_id, if already known (mode files set PIPELINE_ID as
+  # `do.<task-slug>`). In the pre-flight it is typically unset; an empty
+  # value can never equal a real stored pipeline_id, so every live claim on a
+  # stray ref reads as foreign — which is exactly right (stray refs are never
+  # self-claimed). When set, it provides the explicit self-exclusion.
+  _DO_SELF_PIPELINE_ID="${PIPELINE_ID:-}"
+  _DO_WARN_REMAINING="$ARGUMENTS"
+  while [[ "$_DO_WARN_REMAINING" =~ \#([0-9]+) ]]; do
+    _DO_REF="${BASH_REMATCH[1]}"
+    _DO_WARN_REMAINING="${_DO_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
+    _DO_CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_DO_REF" ] && { _DO_CLAIMED=1; break; }
+    done
+    [ "$_DO_CLAIMED" -eq 1 ] && continue
+    # Stray ref — read its claim.json (if any) and decide foreign vs not-held.
+    _DO_CLAIM_FILE="${_DO_MAIN_ROOT}/.zskills/claims/issue-${_DO_REF}/claim.json"
+    _DO_STORED_PID=""
+    if [ -f "$_DO_CLAIM_FILE" ] && [ -n "$_DO_PYTHON" ]; then
+      _DO_STORED_PID=$("$_DO_PYTHON" - "$_DO_CLAIM_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+    fi
+    if [ -n "$_DO_STORED_PID" ] && [ "$_DO_STORED_PID" != "$_DO_SELF_PIPELINE_ID" ]; then
+      # Foreign-held in-flight → STOP (decline, clean exit 0).
+      echo "STOP: /do: description references #${_DO_REF}, which is currently held by a foreign pipeline (claim pipeline_id: ${_DO_STORED_PID}, claim at ${_DO_CLAIM_FILE})." >&2
+      echo "      Another pipeline is already working #${_DO_REF}; proceeding would duplicate its work (the exact failure of closed PR #888 vs landed #901)." >&2
+      echo "      If you are ONLY referencing #${_DO_REF} and not working it, re-run with --no-claim to treat the reference as a mention and skip this check." >&2
+      exit 0
+    fi
+    # Not held (no claim.json / malformed / self) → #907 warn + proceed.
+    echo "WARN: /do: description references #${_DO_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_DO_REF} …\" or \"Fix #${_DO_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work. If you are only referencing #${_DO_REF} (not working it), pass --no-claim to silence this." >&2
+  done
+  unset _DO_WARN_REMAINING _DO_REF _DO_CLAIMED _n _DO_MAIN_ROOT _DO_COMMON_DIR _DO_RESOLVED _DO_PYTHON _DO_SELF_PIPELINE_ID _DO_CLAIM_FILE _DO_STORED_PID
+fi
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
 # `/do fix the bug --rounds in production` would otherwise capture "in" as
@@ -628,6 +719,7 @@ If `$ARGUMENTS` contains `every <schedule>`:
      | sed -E 's/(^|[[:space:]])every[[:space:]]+[^[:space:]]+($|[[:space:]])/ /' \
      | sed -E 's/(^|[[:space:]])now($|[[:space:]])/ /' \
      | sed -E 's/(^|[[:space:]])--force($|[[:space:]])/ /' \
+     | sed -E 's/(^|[[:space:]])--no-claim($|[[:space:]])/ /' \
      | sed -E 's/(^|[[:space:]])--rounds[[:space:]]+[0-9]+($|[[:space:]])/ /' \
      | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
    if [ -n "$QUOTED_HEAD" ] && [ -n "$STRIPPED_REST" ]; then
@@ -763,6 +855,7 @@ TASK_DESCRIPTION=$(echo "$REMAINING" \
   | sed -E 's/(^|[[:space:]])worktree($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--force($|[[:space:]])/ /' \
+  | sed -E 's/(^|[[:space:]])--no-claim($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--rounds[[:space:]]+[0-9]+($|[[:space:]])/ /' \
   | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
 if [ -z "$TASK_DESCRIPTION" ]; then
@@ -771,8 +864,9 @@ if [ -z "$TASK_DESCRIPTION" ]; then
 fi
 ```
 
-The `sed -E` lines strip `auto`, `--force`, and `--rounds N` (numeric N
-only) from `TASK_DESCRIPTION` so they don't leak into downstream prompts.
+The `sed -E` lines strip `auto`, `--force`, `--no-claim`, and `--rounds N`
+(numeric N only) from `TASK_DESCRIPTION` so they don't leak into downstream
+prompts.
 `auto` is the positional auto-merge opt-in (issue #297; mirrors /quickfix,
 /run-plan, /fix-issues) — it is pre-parsed at WI 2a.0 into `AUTO_FLAG`,
 read by `modes/pr.md` to inject `--auto` into the `/land-pr` invocation,

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+f85099"
+  version: "2026.06.01+e6d3b6"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -72,6 +72,15 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
   immediately AND schedules. Without `every`, `now` is the default behavior.
 - **--force** (optional) — bypass triage redirect and review reject. Persists
   into the cron prompt verbatim when used with `every`.
+- **--no-claim** (optional) — treat every bare `#N` in the description as a
+  mere mention. Suppresses the stray-`#N` pre-flight check (#959): /do
+  normally STOPS when the description references an issue currently held
+  in-flight by a foreign pipeline (to prevent duplicating its work — the
+  closed-PR-#888-vs-landed-#901 footgun), and warns on any other stray `#N`.
+  Pass `--no-claim` when the reference is deliberate ("fix tooltip, related
+  to #340") and you do NOT want /do to halt or warn on it. Claim-positioned
+  `#N` (a leading `#N` or `Fix #N …`) are unaffected — they still acquire
+  their claim through the mode files' normal acquire-or-decline.
 - **--rounds N** (optional) — max review/refine cycles (default 1; `0` skips
   review with stderr WARN).
 - **stop** — cancel `/do` cron(s). Bare `/do stop` → all crons.
@@ -215,6 +224,16 @@ FORCE=0
 if [[ "$ARGUMENTS" =~ (^|[[:space:]])--force($|[[:space:]]) ]]; then
   FORCE=1
 fi
+# Issue #959: `--no-claim` opt-out. When present, the stray-`#N` pre-flight
+# (the #907 loop below) treats every bare `#N` as a mere mention — it
+# suppresses BOTH the new foreign-held STOP and the #907 warn. Use it when a
+# /do legitimately references an issue it is NOT working (e.g. "fix tooltip,
+# related to #340"). Claim-positioned `#N` (in ISSUE_NUMS) are independent of
+# this flag — they still go through the mode files' A5.5 acquire-or-decline.
+NO_CLAIM=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])--no-claim($|[[:space:]]) ]]; then
+  NO_CLAIM=1
+fi
 # Issue #297: positional `auto` token (case-insensitive, anywhere in the
 # args) opts /do pr into /land-pr's auto-merge path. Mirrors /quickfix,
 # /run-plan, /fix-issues. Pre-parsed here so Phase 1.5's strip chain and
@@ -303,28 +322,100 @@ unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _DO_ISSUE_FILLER _n
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
-# Unclaimed-reference warning (#907). If the description contains a `#N`
-# token that the claim-position rules above did NOT capture into
-# ISSUE_NUMS, the reference is real but UN-claimed. A silent no-claim is
-# the footgun that let `/do Build … for #877` run without claiming #877:
-# a parallel /fix-issues cron then picked up the unclaimed issue and
-# duplicated the work (closed PR #888 vs landed #901). Warn per stray
-# reference (non-fatal — some /do runs legitimately mention an issue
-# without working it; the run proceeds). Claim-positioned refs are already
-# in ISSUE_NUMS and are NOT re-warned.
-_DO_WARN_REMAINING="$ARGUMENTS"
-while [[ "$_DO_WARN_REMAINING" =~ \#([0-9]+) ]]; do
-  _DO_REF="${BASH_REMATCH[1]}"
-  _DO_WARN_REMAINING="${_DO_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
-  _DO_CLAIMED=0
-  for _n in "${ISSUE_NUMS[@]:-}"; do
-    [ "$_n" = "$_DO_REF" ] && { _DO_CLAIMED=1; break; }
-  done
-  if [ "$_DO_CLAIMED" -eq 0 ]; then
-    echo "WARN: /do: description references #${_DO_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_DO_REF} …\" or \"Fix #${_DO_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work." >&2
+# Unclaimed-reference check (#907 warn + #959 foreign-held STOP). If the
+# description contains a `#N` token that the claim-position rules above did
+# NOT capture into ISSUE_NUMS, the reference is real but UN-claimed by this
+# /do run. A silent no-claim is the footgun that let `/do Build … for #877`
+# run without claiming #877: a parallel /fix-issues cron then picked up the
+# unclaimed issue and duplicated the work (closed PR #888 vs landed #901).
+#
+# Two-tier handling per stray (non-ISSUE_NUMS) `#N` (#959):
+#   1. READ-ONLY foreign-held check. If issue N currently has a LIVE claim
+#      held by a DIFFERENT pipeline, STOP (clean exit 0 — decline, not an
+#      error). #907's warn fails UNSAFE in autonomous use (an agent reads
+#      the warn and proceeds anyway, re-creating the #877 duplication); the
+#      STOP fails SAFE and is recoverable via `--no-claim`. We DO NOT acquire
+#      on stray refs (that would spuriously claim "see #340" mentions — the
+#      over-capture the conservative ISSUE_NUMS parser deliberately avoids).
+#   2. Not held (or no claim.json) → keep the #907 warn and proceed.
+#
+# Foreign-vs-self is decided by READING `.zskills/claims/issue-N/claim.json`
+# and comparing its `pipeline_id` to THIS run's pipeline_id — exactly the
+# pattern hooks/block-fix-issue-unclaimed.sh uses. We do NOT use
+# filter-in-flight-issue-claims.sh alone: it drops the caller's OWN pipeline
+# claims too and cannot distinguish foreign from self, which would wrongly
+# stop on self-re-entry. Fail-OPEN discipline mirrors
+# block-fix-issue-unclaimed.sh: a missing/malformed claim.json, or a missing
+# pipeline_id, is treated as "not held" → warn-and-proceed, never a false
+# STOP. (In practice a stray ref is by definition never acquired by THIS /do
+# run, so any live claim on it is foreign; the self-exclusion below is the
+# belt-and-suspenders that keeps a hypothetical self-claim from stopping us.)
+#
+# Accepted residual (intentional, safe-direction): a false-STOP fires ONLY
+# when a /do mentions an issue that is in flight RIGHT NOW but isn't actually
+# being worked (`fix tooltip, related to #340` while #340 is live). Recover
+# with `--no-claim`. Mentions of closed/old issues never trigger (no live
+# claim). This is the irreducible cost of "issues optional + can't tell
+# work-from-mention out of free text" — the failure mode relocates from
+# "fails → duplicates silently" to "fails → halts with a clear message".
+#
+# `--no-claim` (NO_CLAIM=1, parsed in the pre-parse above) suppresses BOTH
+# the STOP and the warn — every bare `#N` is then a pure mention.
+#
+# Resolve MAIN_ROOT the same way block-fix-issue-unclaimed.sh does:
+# `git rev-parse --git-common-dir` parent, falling back to
+# ${CLAUDE_PROJECT_DIR:-$PWD}. This is correct from a worktree too (the
+# claims live under the MAIN repo's .zskills/).
+if [ "$NO_CLAIM" -ne 1 ]; then
+  _DO_MAIN_ROOT=""
+  if _DO_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) && [ -n "$_DO_COMMON_DIR" ]; then
+    if _DO_RESOLVED=$(cd "$_DO_COMMON_DIR/.." 2>/dev/null && pwd); then
+      _DO_MAIN_ROOT="$_DO_RESOLVED"
+    fi
   fi
-done
-unset _DO_WARN_REMAINING _DO_REF _DO_CLAIMED _n
+  [ -z "$_DO_MAIN_ROOT" ] && _DO_MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+  _DO_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+  # This run's pipeline_id, if already known (mode files set PIPELINE_ID as
+  # `do.<task-slug>`). In the pre-flight it is typically unset; an empty
+  # value can never equal a real stored pipeline_id, so every live claim on a
+  # stray ref reads as foreign — which is exactly right (stray refs are never
+  # self-claimed). When set, it provides the explicit self-exclusion.
+  _DO_SELF_PIPELINE_ID="${PIPELINE_ID:-}"
+  _DO_WARN_REMAINING="$ARGUMENTS"
+  while [[ "$_DO_WARN_REMAINING" =~ \#([0-9]+) ]]; do
+    _DO_REF="${BASH_REMATCH[1]}"
+    _DO_WARN_REMAINING="${_DO_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
+    _DO_CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_DO_REF" ] && { _DO_CLAIMED=1; break; }
+    done
+    [ "$_DO_CLAIMED" -eq 1 ] && continue
+    # Stray ref — read its claim.json (if any) and decide foreign vs not-held.
+    _DO_CLAIM_FILE="${_DO_MAIN_ROOT}/.zskills/claims/issue-${_DO_REF}/claim.json"
+    _DO_STORED_PID=""
+    if [ -f "$_DO_CLAIM_FILE" ] && [ -n "$_DO_PYTHON" ]; then
+      _DO_STORED_PID=$("$_DO_PYTHON" - "$_DO_CLAIM_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+    fi
+    if [ -n "$_DO_STORED_PID" ] && [ "$_DO_STORED_PID" != "$_DO_SELF_PIPELINE_ID" ]; then
+      # Foreign-held in-flight → STOP (decline, clean exit 0).
+      echo "STOP: /do: description references #${_DO_REF}, which is currently held by a foreign pipeline (claim pipeline_id: ${_DO_STORED_PID}, claim at ${_DO_CLAIM_FILE})." >&2
+      echo "      Another pipeline is already working #${_DO_REF}; proceeding would duplicate its work (the exact failure of closed PR #888 vs landed #901)." >&2
+      echo "      If you are ONLY referencing #${_DO_REF} and not working it, re-run with --no-claim to treat the reference as a mention and skip this check." >&2
+      exit 0
+    fi
+    # Not held (no claim.json / malformed / self) → #907 warn + proceed.
+    echo "WARN: /do: description references #${_DO_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_DO_REF} …\" or \"Fix #${_DO_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work. If you are only referencing #${_DO_REF} (not working it), pass --no-claim to silence this." >&2
+  done
+  unset _DO_WARN_REMAINING _DO_REF _DO_CLAIMED _n _DO_MAIN_ROOT _DO_COMMON_DIR _DO_RESOLVED _DO_PYTHON _DO_SELF_PIPELINE_ID _DO_CLAIM_FILE _DO_STORED_PID
+fi
 ROUNDS=1
 # Greedy-fallthrough: only consume `--rounds <N>` when N is a numeric literal.
 # `/do fix the bug --rounds in production` would otherwise capture "in" as
@@ -628,6 +719,7 @@ If `$ARGUMENTS` contains `every <schedule>`:
      | sed -E 's/(^|[[:space:]])every[[:space:]]+[^[:space:]]+($|[[:space:]])/ /' \
      | sed -E 's/(^|[[:space:]])now($|[[:space:]])/ /' \
      | sed -E 's/(^|[[:space:]])--force($|[[:space:]])/ /' \
+     | sed -E 's/(^|[[:space:]])--no-claim($|[[:space:]])/ /' \
      | sed -E 's/(^|[[:space:]])--rounds[[:space:]]+[0-9]+($|[[:space:]])/ /' \
      | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
    if [ -n "$QUOTED_HEAD" ] && [ -n "$STRIPPED_REST" ]; then
@@ -763,6 +855,7 @@ TASK_DESCRIPTION=$(echo "$REMAINING" \
   | sed -E 's/(^|[[:space:]])worktree($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--force($|[[:space:]])/ /' \
+  | sed -E 's/(^|[[:space:]])--no-claim($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--rounds[[:space:]]+[0-9]+($|[[:space:]])/ /' \
   | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
 if [ -z "$TASK_DESCRIPTION" ]; then
@@ -771,8 +864,9 @@ if [ -z "$TASK_DESCRIPTION" ]; then
 fi
 ```
 
-The `sed -E` lines strip `auto`, `--force`, and `--rounds N` (numeric N
-only) from `TASK_DESCRIPTION` so they don't leak into downstream prompts.
+The `sed -E` lines strip `auto`, `--force`, `--no-claim`, and `--rounds N`
+(numeric N only) from `TASK_DESCRIPTION` so they don't leak into downstream
+prompts.
 `auto` is the positional auto-merge opt-in (issue #297; mirrors /quickfix,
 /run-plan, /fix-issues) — it is pre-parsed at WI 2a.0 into `AUTO_FLAG`,
 read by `modes/pr.md` to inject `--auto` into the `/land-pr` invocation,

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -845,6 +845,157 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
+# Case 18x — Foreign-held stray-`#N` STOP (#959). The #907 warn fails
+# UNSAFE in autonomous use; #959 upgrades it to a read-only foreign-held
+# check that STOPS (decline) when a stray `#N` is currently claimed by a
+# DIFFERENT pipeline. Foreign-vs-self is decided by reading
+# `.zskills/claims/issue-N/claim.json`'s pipeline_id and comparing to this
+# run's pipeline_id — exactly the pattern block-fix-issue-unclaimed.sh uses.
+# `--no-claim` suppresses the stop. Missing/malformed claim.json → not-held
+# → warn + proceed (fail-open). Self-claim (stored == caller) → no stop.
+#
+# Replicates the SKILL.md stray-ref loop against a fixture claims dir, in
+# the Case-18 style. Source-of-truth is SKILL.md (anchored by 18x-src).
+# ────────────────────────────────────────────────────────────────────
+PY_BIN="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+
+# do_stray_check replicates the SKILL.md #959 stray-ref decision. Echoes one
+# of: "STOP <ref> <stored_pid>", "WARN <ref>" per stray ref. Assumes
+# do_parse_issue_nums already populated ISSUE_NUMS. Args:
+#   $1 = description, $2 = claims-root dir, $3 = caller pipeline_id,
+#   $4 = NO_CLAIM (0/1).
+do_stray_check() {
+  local input="$1" claims_root="$2" self_pid="$3" no_claim="$4"
+  local _REM="$input" _REF _CLAIMED _n _claim_file _stored out=""
+  [ "$no_claim" -eq 1 ] && { printf ''; return; }
+  while [[ "$_REM" =~ \#([0-9]+) ]]; do
+    _REF="${BASH_REMATCH[1]}"
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+    _CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_REF" ] && { _CLAIMED=1; break; }
+    done
+    [ "$_CLAIMED" -eq 1 ] && continue
+    _claim_file="${claims_root}/issue-${_REF}/claim.json"
+    _stored=""
+    if [ -f "$_claim_file" ] && [ -n "$PY_BIN" ]; then
+      _stored=$("$PY_BIN" - "$_claim_file" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+    fi
+    if [ -n "$_stored" ] && [ "$_stored" != "$self_pid" ]; then
+      out+="STOP $_REF $_stored"$'\n'
+    else
+      out+="WARN $_REF"$'\n'
+    fi
+  done
+  printf '%s' "$out"
+}
+
+mk_claim() {
+  # $1 = claims-root, $2 = issue number, $3 = pipeline_id
+  local dir="$1/issue-$2"
+  mkdir -p "$dir"
+  printf '{"pipeline_id": "%s", "started_at": "now"}\n' "$3" > "$dir/claim.json"
+}
+
+# Fixture claims dir.
+STRAY_ROOT="$TEST_TMPDIR/claims-stray"
+register_fixture "$STRAY_ROOT"
+mkdir -p "$STRAY_ROOT"
+mk_claim "$STRAY_ROOT" 340 "fix-issues.sprint-foreign"   # foreign holder
+mk_claim "$STRAY_ROOT" 555 "do.this-run-slug"            # self holder
+
+# (a) stray #N with a foreign live claim → STOP signalled.
+do_parse_issue_nums "fix tooltip, related to #340"
+GOT=$(do_stray_check "fix tooltip, related to #340" "$STRAY_ROOT" "do.this-run-slug" 0)
+if printf '%s' "$GOT" | grep -qE '^STOP 340 fix-issues\.sprint-foreign$'; then
+  pass "18x foreign-held stray #340 → STOP (names holder)"
+else
+  fail "18x foreign-held stray #340 → STOP (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# (b) stray #N with NO claim → warn + proceed (no stop).
+do_parse_issue_nums "fix tooltip, related to #999"
+GOT=$(do_stray_check "fix tooltip, related to #999" "$STRAY_ROOT" "do.this-run-slug" 0)
+if printf '%s' "$GOT" | grep -qE '^WARN 999$' && ! printf '%s' "$GOT" | grep -q '^STOP'; then
+  pass "18x not-held stray #999 → WARN, no STOP"
+else
+  fail "18x not-held stray #999 → WARN (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# (c) stray #N whose claim.json pipeline_id == caller (self) → NO stop.
+do_parse_issue_nums "fix tooltip, related to #555"
+GOT=$(do_stray_check "fix tooltip, related to #555" "$STRAY_ROOT" "do.this-run-slug" 0)
+if printf '%s' "$GOT" | grep -qE '^WARN 555$' && ! printf '%s' "$GOT" | grep -q '^STOP'; then
+  pass "18x self-claimed stray #555 → no STOP (self-exclusion)"
+else
+  fail "18x self-claimed stray #555 → no STOP (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# (d) --no-claim present → stray-ref stop suppressed (no STOP, no WARN).
+do_parse_issue_nums "fix tooltip, related to #340"
+GOT=$(do_stray_check "fix tooltip, related to #340" "$STRAY_ROOT" "do.this-run-slug" 1)
+if [ -z "$GOT" ]; then
+  pass "18x --no-claim suppresses foreign-held STOP (and warn)"
+else
+  fail "18x --no-claim should suppress all stray output (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# 18x-src — anchor the foreign-held STOP + --no-claim handling to SKILL.md.
+if grep -qF 'is currently held by a foreign pipeline' "$SKILL" \
+   && grep -qF 'claims/issue-${_DO_REF}/claim.json' "$SKILL"; then
+  pass "18x-src SKILL.md carries the foreign-held stray-ref STOP (#959)"
+else
+  fail "18x-src SKILL.md missing the foreign-held stray-ref STOP (#959)"
+fi
+if grep -qE 'NO_CLAIM=0' "$SKILL" \
+   && grep -qF 'if [ "$NO_CLAIM" -ne 1 ]; then' "$SKILL"; then
+  pass "18x-src SKILL.md parses --no-claim and gates the stray check on it"
+else
+  fail "18x-src SKILL.md missing --no-claim parse / gate"
+fi
+# Both the STOP message AND the #907 warn must reference --no-claim.
+if grep -qF 're-run with --no-claim' "$SKILL" \
+   && grep -qF 'pass --no-claim to silence' "$SKILL"; then
+  pass "18x-src STOP + #907 warn both reference --no-claim"
+else
+  fail "18x-src STOP and/or #907 warn missing --no-claim reference"
+fi
+# Strip chains in Phase 1.5 Step 2 and Phase 0c must drop --no-claim.
+if [ "$(grep -cF "sed -E 's/(^|[[:space:]])--no-claim(\$|[[:space:]])/ /'" "$SKILL")" -ge 2 ]; then
+  pass "18x-src --no-claim stripped in BOTH Phase 1.5 Step 2 and Phase 0c chains"
+else
+  fail "18x-src --no-claim not stripped in both strip chains (expected >=2 occurrences)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 18y — Documentation discipline for --no-claim (#959):
+#   - argument-hint frontmatter must NOT contain --no-claim (per spec).
+#   - the ## Arguments body MUST document --no-claim.
+# ────────────────────────────────────────────────────────────────────
+if grep -qE '^argument-hint:' "$SKILL" \
+   && grep -E '^argument-hint:' "$SKILL" | grep -q -- '--no-claim'; then
+  fail "18y argument-hint frontmatter must NOT contain --no-claim"
+else
+  pass "18y argument-hint frontmatter does NOT contain --no-claim"
+fi
+# Arguments body documents --no-claim (a bullet with the flag in the
+# ## Arguments section). The Arguments section precedes Phase headings;
+# assert a `**--no-claim**` bullet exists.
+if grep -qE '^\- \*\*--no-claim\*\*' "$SKILL"; then
+  pass "18y ## Arguments body documents --no-claim (bullet present)"
+else
+  fail "18y ## Arguments body missing --no-claim bullet"
+fi
+
+# ────────────────────────────────────────────────────────────────────
 # Case 19 — Phase 0a triage rubric NO LONGER contains the
 # "References a GitHub issue number → /fix-issues" REDIRECT row.
 # After PR 825 wired ISSUE_NUM + claim-issue.sh into the mode files,


### PR DESCRIPTION
## Summary
Closes #959. `/do` now **stops** (instead of only warning) when the description references a `#N` that is **already in flight by a foreign pipeline** — closing the cross-session duplication hole that produced the #888-vs-#901 duplicate. Builds directly on #907's stray-`#N` detection.

## Behavior
In the existing #907 stray-`#N` pre-flight loop, each stray `#N` (one NOT claim-positioned, i.e. not in `ISSUE_NUMS`) gets a **read-only** check:
- **Foreign live claim → STOP** (clean `exit 0`), naming the holding pipeline and pointing the user at `--no-claim`. Prevents racing a pipeline already working the issue. Atomicity of `claim-issue.sh` does the rest once both sides participate.
- **Not held → keep the #907 warn, proceed.**
- **Read-only — no acquire on stray refs** (auto-claiming a mere mention like `see #340` would spuriously claim references). Foreign is determined by reading `.zskills/claims/issue-N/claim.json` and comparing `pipeline_id`, the `block-fix-issue-unclaimed.sh` way — *not* `filter-in-flight-issue-claims.sh`, which can't distinguish self. Missing/malformed/self → fail-open (warn + proceed).
- **Claim-positioned `#N` are unchanged** (existing A5.5 acquire-or-decline).

## `--no-claim`
New pre-flight flag that suppresses the stray-ref stop (treat all bare `#N` as mentions); claim-positioned acquire stays independent. Stripped from the task prompt and cron prompt like `--force`. **Documented in `## Arguments`, deliberately absent from `argument-hint`.** Both the stop message and the #907 warn reference it.

## Accepted residual
A false-stop only when a `/do` mentions an issue that's in flight *right now* but isn't being worked — recover with `--no-claim`. Mentions of closed/old issues never trigger (no live claim). The safe direction: stop (recoverable) over silent duplicate.

## Design provenance
Settled in a design conversation (claims are atomic, so the only hole is a worker that never *checks*; agents — not humans — author the `/do`, so phrasing discipline can't be the fix; read-only-don't-acquire avoids over-claiming mentions; foreign-held→stop fails safe).

## Test plan
- [x] `tests/test-do.sh` — 91/91, incl. foreign-STOP, not-held-warn, self-exclusion, `--no-claim` suppression, argument-hint-excludes / Arguments-documents (all revert-sensitive).
- [x] `bash tests/run-all.sh` — 7141/7141, 0 failed.
- [x] Independent verifier — CLEAN (foreign-vs-self trace, fail-open, `--no-claim` wiring, docs placement, mirror parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
