### PR TITLE
do: trim --force/default from argument-hints (#961)

### DIFF
--- a/.claude/skills/cleanup-merged/SKILL.md
+++ b/.claude/skills/cleanup-merged/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[apply] [local | remote | all] [--force] [<branch>...]"
+argument-hint: "[apply] [local | remote | all] [<branch>...]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
@@ -13,7 +13,7 @@ description: >-
   explicitly name. Protected branches from config are NEVER deleted (even
   with `--force`) — they are always skipped.
 metadata:
-  version: "2026.05.29+dd08af"
+  version: "2026.06.01+07db32"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: do
-argument-hint: "<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+e6d3b6"
+  version: "2026.06.01+fb2e19"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quickfix
-argument-hint: "[<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]"
+argument-hint: "[<description>] [auto] [from-here] [skip-tests] [--branch <name>] [--rounds N]"
 description: >-
   Ship an in-flight edit (or short agent-authored fix) from main as a
   one-commit PR without a worktree. Two auto-detected modes: user-edited
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.06.01+88285e"
+  version: "2026.06.01+58b49f"
 ---
 
 # /quickfix — In-Flight Fix → PR

--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next | (no args = list ready queue)"
+argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] | stop | next | (no args = list ready queue)"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
@@ -10,7 +10,7 @@ description: >-
   manages the queue (add/rank/remove/default) and recurring schedules.
   Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.06.01+a67fc0"
+  version: "2026.06.01+495d55"
 ---
 
 # /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor

--- a/skills/cleanup-merged/SKILL.md
+++ b/skills/cleanup-merged/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cleanup-merged
 disable-model-invocation: true
-argument-hint: "[apply] [local | remote | all] [--force] [<branch>...]"
+argument-hint: "[apply] [local | remote | all] [<branch>...]"
 description: >-
   Post-PR-merge local normalization: fetch-and-prune origin, switch off
   merged feature branches, pull main, and delete local branches whose
@@ -13,7 +13,7 @@ description: >-
   explicitly name. Protected branches from config are NEVER deleted (even
   with `--force`) — they are always skipped.
 metadata:
-  version: "2026.05.29+dd08af"
+  version: "2026.06.01+07db32"
 ---
 
 # /cleanup-merged — Post-PR-merge local normalization

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: do
-argument-hint: "<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+e6d3b6"
+  version: "2026.06.01+fb2e19"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quickfix
-argument-hint: "[<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]"
+argument-hint: "[<description>] [auto] [from-here] [skip-tests] [--branch <name>] [--rounds N]"
 description: >-
   Ship an in-flight edit (or short agent-authored fix) from main as a
   one-commit PR without a worktree. Two auto-detected modes: user-edited
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.06.01+88285e"
+  version: "2026.06.01+58b49f"
 ---
 
 # /quickfix — In-Flight Fix → PR

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next | (no args = list ready queue)"
+argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] | stop | next | (no args = list ready queue)"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
@@ -10,7 +10,7 @@ description: >-
   manages the queue (add/rank/remove/default) and recurring schedules.
   Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.06.01+a67fc0"
+  version: "2026.06.01+495d55"
 ---
 
 # /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor

--- a/tests/test-cleanup-merged-namelist.sh
+++ b/tests/test-cleanup-merged-namelist.sh
@@ -4,7 +4,7 @@
 #
 # Coverage:
 #   Static (skill-source + docs assertions):
-#     - argument-hint advertises local / --force / <branch>
+#     - argument-hint advertises local / <branch> (--force de-advertised, #961)
 #     - WI 1.2 parser accepts `local`, `--force`, and collects branch names
 #     - is_named() narrowing helper present
 #     - protected-skip is evaluated before any force logic (ordering)
@@ -41,11 +41,14 @@ echo "=== cleanup-merged branch-name-list + --force interface ==="
 
 # ── Static: skill source ────────────────────────────────────────────
 
-# argument-hint advertises the new tokens.
-if grep -qE '^argument-hint:.*local.*remote.*all.*--force.*branch' "$SKILL"; then
-  pass "argument-hint advertises local | remote | all, --force, <branch>"
+# argument-hint advertises the scope tokens + <branch>, but NOT --force.
+# Issue #961: --force de-advertised from the slash-menu teaser; it stays
+# parsed + documented (see the WI 1.2 --force parser-arm test below).
+if grep -qE '^argument-hint:.*local.*remote.*all.*branch' "$SKILL" \
+   && ! grep -qE '^argument-hint:.*--force' "$SKILL"; then
+  pass "argument-hint advertises local | remote | all, <branch>; --force de-advertised (#961)"
 else
-  fail "argument-hint missing new tokens"
+  fail "argument-hint missing scope/<branch> tokens or still advertises --force"
 fi
 
 # WI 1.2 parser accepts `local` and `--force`.

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -3,7 +3,7 @@
 # review additions (the cron-zombie regression fix).
 #
 # Phase 2b cases (1–13):
-#   1.  argument-hint contains --force and --rounds N
+#   1.  argument-hint contains --rounds N but NOT --force (#961 de-advertise)
 #   2.  Phase 0a heading + rubric-table present AND comes BEFORE Phase 0c
 #       (cron-zombie regression guard: triage MUST run before CronCreate)
 #   3.  Phase 0b inline-plan + review prose present
@@ -155,13 +155,17 @@ extract_task_description_for_cron_block() {
 echo "=== /do — Phase 2a structural and behavioral coverage ==="
 
 # ────────────────────────────────────────────────────────────────────
-# Case 1 — argument-hint contains --force and --rounds N (WI 2a.1)
+# Case 1 — argument-hint contains --rounds N but NOT --force (WI 2a.1)
+# Issue #961: --force de-advertised from the slash-menu teaser. It stays
+# fully parsed + documented (see Case 4 cron-persistence prose and Case 8
+# TASK_DESCRIPTION strip coverage, plus the --force prose in the Arguments
+# section); only the hint drops it.
 # ────────────────────────────────────────────────────────────────────
-if grep -qE '^argument-hint: ".*--force.*"' "$SKILL" \
-   && grep -qE '^argument-hint: ".*--rounds N.*"' "$SKILL"; then
-  pass "1  argument-hint: --force and --rounds N present"
+if grep -qE '^argument-hint: ".*--rounds N.*"' "$SKILL" \
+   && ! grep -qE '^argument-hint: ".*--force.*"' "$SKILL"; then
+  pass "1  argument-hint: --rounds N present, --force de-advertised (#961)"
 else
-  fail "1  argument-hint: missing --force or --rounds N"
+  fail "1  argument-hint: missing --rounds N or still advertises --force"
   grep -n '^argument-hint:' "$SKILL" | sed 's/^/    /'
 fi
 

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -1936,10 +1936,12 @@ fi
 
 # Case 69 — argument-hint shape (AC4.9): exact positional hint.
 # Issue #810: bare `force` → dashed `--force` for cross-skill consistency.
+# Issue #961: --force de-advertised from the slash-menu teaser (still parsed
+# + documented; see Case 66 parser coverage). The hint no longer lists it.
 HINT=$(grep '^argument-hint' "$SKILL" | sed -E 's/^argument-hint: "(.*)"$/\1/')
-EXPECTED='[<description>] [auto] [from-here] [skip-tests] [--force] [--branch <name>] [--rounds N]'
+EXPECTED='[<description>] [auto] [from-here] [skip-tests] [--branch <name>] [--rounds N]'
 if [ "$HINT" = "$EXPECTED" ]; then
-  pass "69 argument-hint (AC4.9, AC4.12, #810): positional shape (len=${#HINT})"
+  pass "69 argument-hint (AC4.9, AC4.12, #961): positional shape (len=${#HINT})"
 else
   fail "69 argument-hint: got='$HINT' expected='$EXPECTED'"
 fi

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -612,7 +612,7 @@ check_not   quickfix    "no YES_FLAG variable (AC4.13)"          'YES_FLAG'
 check_not   quickfix    "no `read -r answer` block (AC4.13)"     'read -r answer'
 check       quickfix    "argument-hint [from-here]"  'argument-hint:.*\[from-here\]'
 check_not   quickfix    "argument-hint NO [--yes]"   'argument-hint:.*\[--yes\]'
-check       quickfix    "argument-hint [--force] (issue #810)" 'argument-hint:.*\[--force\]'
+check_not   quickfix    "argument-hint NO [--force] (#961 reverses #810)" 'argument-hint:.*--force'
 check_not   quickfix    "argument-hint NO bare [force] (issue #810)" 'argument-hint:.*\[force\]'
 
 # Issue #810 — --force form normalization across all four skills.
@@ -632,7 +632,7 @@ check_fixed work-on-plans "--force in synopsis (issue #810)" '[--force]'
 # advertised in argument-hint.
 check_fixed cleanup-merged "--force) parser arm (issue #810)" '--force) FORCE=1'
 check_not   cleanup-merged "no bare 'force)' arm (issue #810)" '^[[:space:]]*force\)[[:space:]]+FORCE=1'
-check       cleanup-merged "argument-hint [--force] (issue #810)" 'argument-hint:.*\[--force\]'
+check_not   cleanup-merged "argument-hint NO [--force] (#961 reverses #810)" 'argument-hint:.*--force'
 
 check_fixed run-plan    "AUTO_FLAG init"        'AUTO_FLAG=0'
 

--- a/tests/test-work-on-plans.sh
+++ b/tests/test-work-on-plans.sh
@@ -211,17 +211,19 @@ fi
 
 # --- Test 4: argument-hint frontmatter advertises core surface ----------
 # Queue-mutation subcommands (add/rank/remove) were moved to the detail
-# docs page to shorten the hint under 120 chars. The hint still covers
-# the dispatch, schedule, default, and control subcommands. Post-#906
-# `every SCHEDULE` composes with the leading N|all count (it is no
-# longer a standalone subcommand listed beside default), so the order
-# is `... every SCHEDULE ... default ... stop`.
+# docs page to shorten the hint. Issue #961 further de-advertises
+# `default <phase|finish>` from the slash-menu teaser; `default` stays
+# fully parsed + documented (Test 1 sources the do_default heredoc; the
+# AC tests below exercise it). The hint still covers the dispatch,
+# schedule, and control surface. Post-#906 `every SCHEDULE` composes with
+# the leading N|all count, so the order is `N|all ... every SCHEDULE ...
+# stop`.
 if grep -q 'argument-hint:.*every SCHEDULE' "$SKILL" \
-   && grep -q 'argument-hint:.*default' "$SKILL" \
-   && grep -q 'argument-hint:.*stop' "$SKILL"; then
-  pass "argument-hint advertises core surface (every SCHEDULE/default/stop)"
+   && grep -q 'argument-hint:.*stop' "$SKILL" \
+   && ! grep -q 'argument-hint:.*default' "$SKILL"; then
+  pass "argument-hint advertises core surface (every SCHEDULE/stop); default de-advertised (#961)"
 else
-  fail "argument-hint missing one or more core subcommands"
+  fail "argument-hint missing core surface tokens or still advertises default"
 fi
 
 # --- Test 5: AC-1 (add bootstraps + appends) ---------------------------


### PR DESCRIPTION
Closes #961.

De-advertises `--force` from the `cleanup-merged` / `do` / `quickfix` / `work-on-plans` `argument-hint` slash-menu teasers, and `default <phase|finish>` from the `work-on-plans` hint. The `argument-hint` is length-budgeted (ellided in the menu) and `--force` is a safety-gate override we don't want surfaced casually.

**Functionality unchanged** — `--force`, `default`, `add`, `rank`, `remove` stay fully parsed and documented in the skill bodies + `docs/skills/`. Only the menu teaser changed.

Reverses #810's hint-advertising for `quickfix`/`cleanup-merged`: the two conformance assertions that locked `--force` INTO those argument-hints are flipped to `check_not`; the parser-arm and synopsis checks are retained. Four per-skill test files that hard-coded the old hint strings were updated to the new shape. All four skills version-bumped (source + mirror).

Commits:
d6b2bd4 do: trim --force and default from skill argument-hints (#961)
