### PR TITLE
fix(#957): mark-plan-complete.sh helper writes status+completed atomically

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.01+4c879a"
+  version: "2026.06.01+51e148"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -1455,13 +1455,15 @@ If the plan file has YAML frontmatter with an `issue:` field (e.g.,
 
 ### 3. Update plan frontmatter
 
-Change `status: active` (or `status: in-progress`) to `status: complete`
-in the plan file's YAML frontmatter. If the plan has no `status:` field,
-add one: `status: complete`. **Also write a `completed:` ISO-8601 UTC
-datetime field** so the dashboard's Completed-window inference and the
-backfill-script idempotency guard both have a canonical source of truth
-(D1 of the completed-backlog-sections plan). The path-config helper
-resolves `$ZSKILLS_PLANS_DIR` — NEVER hardcode `plans/<slug>.md`:
+Mark the plan complete via **`scripts/mark-plan-complete.sh`** — this
+helper writes BOTH `status: complete` AND `completed: <ISO-8601 UTC
+datetime>` atomically to the plan's YAML frontmatter (the dashboard's
+Completed-column inference at `collect.py:1795-1801` requires both
+fields; writing only `status:complete` is the half-write bug #957
+closed). NEVER write `status: complete` via a manual `Edit` to the
+frontmatter — that's the antipattern that caused #957; the helper is
+the only supported path. The path-config helper resolves
+`$ZSKILLS_PLANS_DIR` — NEVER hardcode `plans/<slug>.md`:
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -1478,19 +1480,17 @@ ZSKILLS_PATHS_ROOT="${WORKTREE_PATH:-$CLAUDE_PROJECT_DIR}" \
 # PR mode only: cd "$WORKTREE_PATH" first (cherry-pick/direct: stay on main)
 # Plan file path resolved via $ZSKILLS_PLANS_DIR — NEVER hardcoded plans/.
 PLAN_FILE="$ZSKILLS_PLANS_DIR/<slug>.md"
-bash scripts/frontmatter-set.sh "$PLAN_FILE" status complete
-completed_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-bash scripts/frontmatter-set.sh "$PLAN_FILE" completed "$completed_ts"
+bash scripts/mark-plan-complete.sh "$PLAN_FILE"
 git add "$PLAN_FILE"
 git commit -m "chore: mark plan complete — <plan-name>"
 ```
 
-The `completed:` field is **full ISO-8601 UTC datetime**
-(`YYYY-MM-DDTHH:MM:SSZ`), NOT a date-only string — matches GH's
-`closedAt` format so cross-source date comparison in the dashboard is
-uniform. Do not use `date -I` or `cut -c1-10`; both produce date-only
-strings that mix poorly with the full-datetime form the historical
-backfill emits.
+The helper writes the canonical **full ISO-8601 UTC datetime**
+(`YYYY-MM-DDTHH:MM:SSZ`) — matches GH's `closedAt` format so
+cross-source date comparison in the dashboard is uniform. The helper
+internalizes this format; do not work around it with `date -I` or
+`cut -c1-10` (both produce date-only strings that mix poorly with the
+full-datetime form the historical backfill emits).
 
 ### 4. Update sprint report
 

--- a/scripts/mark-plan-complete.sh
+++ b/scripts/mark-plan-complete.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/mark-plan-complete.sh <plan-file>
+#
+# Atomically marks a plan as complete by writing BOTH the status:complete
+# AND completed:<ISO-8601-UTC> fields to the YAML frontmatter via
+# frontmatter-set.sh. Prevents the half-write bug (#957) where a /run-plan
+# agent writes status:complete via manual frontmatter Edit and skips the
+# completed: timestamp, breaking the dashboard's Completed-column auto-route
+# (collect.py inference requires BOTH fields).
+#
+# Usage: bash scripts/mark-plan-complete.sh <plan-file>
+#
+# Always use this helper. Do NOT call frontmatter-set.sh for status:complete
+# directly — the both-or-nothing invariant is the whole point.
+set -u
+
+PLAN_FILE="${1:-}"
+if [ -z "$PLAN_FILE" ]; then
+  echo "ERROR: mark-plan-complete.sh: plan file path required" >&2
+  exit 2
+fi
+if [ ! -f "$PLAN_FILE" ]; then
+  echo "ERROR: mark-plan-complete.sh: plan file does not exist: $PLAN_FILE" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SET_SH="$SCRIPT_DIR/frontmatter-set.sh"
+if [ ! -x "$SET_SH" ] && [ ! -r "$SET_SH" ]; then
+  echo "ERROR: mark-plan-complete.sh: frontmatter-set.sh not found at $SET_SH" >&2
+  exit 2
+fi
+
+# ISO-8601 UTC full datetime (matches GH closedAt format for uniform
+# cross-source date comparison in the dashboard). NOT date -I — that's
+# date-only and mixes poorly with the full-datetime form the historical
+# backfill emits.
+COMPLETED_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+bash "$SET_SH" "$PLAN_FILE" status complete || {
+  echo "ERROR: mark-plan-complete.sh: frontmatter-set.sh status complete failed" >&2
+  exit 3
+}
+bash "$SET_SH" "$PLAN_FILE" completed "$COMPLETED_TS" || {
+  echo "ERROR: mark-plan-complete.sh: frontmatter-set.sh completed $COMPLETED_TS failed — plan is now in a HALF-WRITE state (status:complete but no completed:); re-run this script to recover" >&2
+  exit 4
+}
+
+echo "INFO: mark-plan-complete.sh: $PLAN_FILE marked complete (completed: $COMPLETED_TS)" >&2

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.01+4c879a"
+  version: "2026.06.01+51e148"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -1455,13 +1455,15 @@ If the plan file has YAML frontmatter with an `issue:` field (e.g.,
 
 ### 3. Update plan frontmatter
 
-Change `status: active` (or `status: in-progress`) to `status: complete`
-in the plan file's YAML frontmatter. If the plan has no `status:` field,
-add one: `status: complete`. **Also write a `completed:` ISO-8601 UTC
-datetime field** so the dashboard's Completed-window inference and the
-backfill-script idempotency guard both have a canonical source of truth
-(D1 of the completed-backlog-sections plan). The path-config helper
-resolves `$ZSKILLS_PLANS_DIR` — NEVER hardcode `plans/<slug>.md`:
+Mark the plan complete via **`scripts/mark-plan-complete.sh`** — this
+helper writes BOTH `status: complete` AND `completed: <ISO-8601 UTC
+datetime>` atomically to the plan's YAML frontmatter (the dashboard's
+Completed-column inference at `collect.py:1795-1801` requires both
+fields; writing only `status:complete` is the half-write bug #957
+closed). NEVER write `status: complete` via a manual `Edit` to the
+frontmatter — that's the antipattern that caused #957; the helper is
+the only supported path. The path-config helper resolves
+`$ZSKILLS_PLANS_DIR` — NEVER hardcode `plans/<slug>.md`:
 
 ```bash
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -1478,19 +1480,17 @@ ZSKILLS_PATHS_ROOT="${WORKTREE_PATH:-$CLAUDE_PROJECT_DIR}" \
 # PR mode only: cd "$WORKTREE_PATH" first (cherry-pick/direct: stay on main)
 # Plan file path resolved via $ZSKILLS_PLANS_DIR — NEVER hardcoded plans/.
 PLAN_FILE="$ZSKILLS_PLANS_DIR/<slug>.md"
-bash scripts/frontmatter-set.sh "$PLAN_FILE" status complete
-completed_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-bash scripts/frontmatter-set.sh "$PLAN_FILE" completed "$completed_ts"
+bash scripts/mark-plan-complete.sh "$PLAN_FILE"
 git add "$PLAN_FILE"
 git commit -m "chore: mark plan complete — <plan-name>"
 ```
 
-The `completed:` field is **full ISO-8601 UTC datetime**
-(`YYYY-MM-DDTHH:MM:SSZ`), NOT a date-only string — matches GH's
-`closedAt` format so cross-source date comparison in the dashboard is
-uniform. Do not use `date -I` or `cut -c1-10`; both produce date-only
-strings that mix poorly with the full-datetime form the historical
-backfill emits.
+The helper writes the canonical **full ISO-8601 UTC datetime**
+(`YYYY-MM-DDTHH:MM:SSZ`) — matches GH's `closedAt` format so
+cross-source date comparison in the dashboard is uniform. The helper
+internalizes this format; do not work around it with `date -I` or
+`cut -c1-10` (both produce date-only strings that mix poorly with the
+full-datetime form the historical backfill emits).
 
 ### 4. Update sprint report
 

--- a/tests/test-mark-plan-complete.sh
+++ b/tests/test-mark-plan-complete.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# tests/test-mark-plan-complete.sh
+# Asserts mark-plan-complete.sh writes BOTH status:complete AND completed:<ts>
+# in the same invocation (#957).
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0; FAIL=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PLAN="$TMP/plan.md"
+cat > "$PLAN" <<'EOF'
+---
+title: Test plan
+status: active
+---
+
+# Body
+EOF
+
+bash scripts/mark-plan-complete.sh "$PLAN" 2>/dev/null
+grep -qE '^status: "?complete"?$' "$PLAN" && pass "status field is complete" || fail "status field NOT complete"
+grep -qE '^completed: "?[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"?$' "$PLAN" \
+  && pass "completed field is ISO-8601 UTC datetime" || fail "completed field MISSING or wrong format"
+
+# Idempotency: re-run should not error and should refresh completed.
+sleep 1
+PRE="$(grep '^completed:' "$PLAN")"
+bash scripts/mark-plan-complete.sh "$PLAN" 2>/dev/null
+POST="$(grep '^completed:' "$PLAN")"
+[ "$PRE" != "$POST" ] && pass "re-run refreshes completed timestamp" || fail "re-run did NOT refresh completed timestamp"
+
+# Missing file → exit 2
+bash scripts/mark-plan-complete.sh "$TMP/missing.md" 2>/dev/null
+[ "$?" -eq 2 ] && pass "missing file → exit 2" || fail "missing file did NOT exit 2"
+
+# Missing arg → exit 2
+bash scripts/mark-plan-complete.sh 2>/dev/null
+[ "$?" -eq 2 ] && pass "missing arg → exit 2" || fail "missing arg did NOT exit 2"
+
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Closes #957.

When `/run-plan` finishes a plan, the dashboard's Completed-column auto-route (`collect.py:1795-1801`) requires BOTH `status: complete` AND a parseable `completed:` in the plan frontmatter. The skill prose at `execute-phase.md` already told agents to write both, and the bash fence did write both — but agents reading the prose sometimes used a manual `Edit` to the frontmatter and only mutated `status`, silently skipping `completed:`. PR #951's PLUGIN_LANE_VERIFICATION.md finish was the most recent live repro; #958 backfilled that one plan but didn't close the recurring class.

## Fix

Collapse the both-writes into `scripts/mark-plan-complete.sh` — a single mechanical helper that:

- Resolves `frontmatter-set.sh` from `$SCRIPT_DIR` (no hardcode)
- Uses `date -u +%Y-%m-%dT%H:%M:%SZ` (full ISO-8601 UTC — matches GH `closedAt` for cross-source date comparison)
- Writes `status: complete` first, then `completed: <ts>`
- Exits 3 on first-write failure, 4 on second-write failure with an explicit "HALF-WRITE state; re-run to recover" stderr message
- Exits 2 on missing arg / missing file

`execute-phase.md` now calls the helper and explicitly names "manual `Edit` to the frontmatter for `status:complete`" as the #957 antipattern. The mirror is byte-identical; SKILL.md version bumped to `2026.06.01+51e148`.

## Files

- `scripts/mark-plan-complete.sh` (new, +49) — the helper
- `skills/run-plan/modes/execute-phase.md` — fence replacement + prose update + antipattern callout
- `skills/run-plan/SKILL.md` — version bump
- `.claude/skills/run-plan/...` — mirrors (byte-identical)
- `tests/test-mark-plan-complete.sh` (new, +47) — 5 assertions: status:complete written, completed: ISO-8601 written, re-run refreshes timestamp, missing-file → exit 2, missing-arg → exit 2

## Test plan

- [x] `bash tests/test-mark-plan-complete.sh` — exit 0, 5/5 passed
- [x] `bash tests/run-all.sh` — 7131/7131 passed, 0 failed
- [x] Mirror parity: `diff -r skills/run-plan .claude/skills/run-plan` empty
- [x] Version bump: `bash scripts/skill-content-hash.sh skills/run-plan` returns `51e148` (matches metadata.version suffix)
- [x] Independent scope re-verified `HEAD~1..HEAD` (6 files, no extraneous edits)
- [x] Test sensitivity: helper test greps `^completed:` after invocation — a half-write regression fails immediately
