### PR TITLE
do: fix stale line-16 comment in plugin skip-shim

### DIFF
--- a/hooks/_lib/plugin-hook-skip-if-mirrored.sh
+++ b/hooks/_lib/plugin-hook-skip-if-mirrored.sh
@@ -13,9 +13,10 @@
 #
 # Mechanism (D16(a), 7 steps — see docs/plans/PLUGIN_DISTRIBUTION.md):
 #   1. Plugin hook sources this shim as its first executable line.
-#   2. Shim computes MY_BASENAME from ${BASH_SOURCE[0]} — when sourced,
-#      [0] is the SOURCING hook's path (empirically confirmed under
-#      claude 2.1.149; NOT the shim's own path).
+#   2. Shim computes MY_BASENAME from the OUTERMOST (last) BASH_SOURCE
+#      entry — the path of the hook that sourced this shim. (See the
+#      detailed note at the my_path assignment for why the old hardcoded
+#      [0] was fragile across invocation styles.)
 #   3. Shim reads $CLAUDE_PROJECT_DIR/.claude/settings.json via Python and
 #      iterates hooks.<event>[].hooks[] entries.
 #   4. For each entry's command, extracts the last whitespace-separated


### PR DESCRIPTION
Task: Fix the stale line-16 'Mechanism' summary comment in hooks/_lib/plugin-hook-skip-if-mirrored.sh — it said the shim reads ${BASH_SOURCE[0]} but the code uses the outermost/last entry. Comment-only.

## What changed
`hooks/_lib/plugin-hook-skip-if-mirrored.sh` only — 4 insertions, 3 deletions, **all comment lines** (verified: no non-comment line changed). The header "Mechanism" step-2 summary (line 16) claimed the shim reads `${BASH_SOURCE[0]}`, but the code at line 65 uses the OUTERMOST/last entry (`${BASH_SOURCE[${#BASH_SOURCE[@]}-1]}`). Updated the summary to match the code and the already-correct detailed note at lines 53-64. Line 57's historical `[0]` reference left intact. No executable code, no behavior change, no `zskills-hook-version` bump.

Why it mattered: a future maintainer reading the stale summary could "fix" the code back to `[0]` and silently reintroduce the hook double-fire bug the detailed comment warns about.

## Verification
`bash tests/run-all.sh` → 7141/7141 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
