### PR TITLE
fix(#971): /quickfix claim-guard parity with /do (#907 warn + #959 stop + --no-claim)

### DIFF
--- a/.claude/skills/quickfix/SKILL.md
+++ b/.claude/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.06.01+58b49f"
+  version: "2026.06.01+66842d"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -48,7 +48,7 @@ ceremony than the change is worth, but a PR is still required.
 ## Argument parser (WI 1.2)
 
 Bash-regex idiom matching `skills/do/SKILL.md:70-92`. Recognized flags:
-`--branch <name>`, `--rounds N`, `--force`. Recognized positional tokens
+`--branch <name>`, `--rounds N`, `--force`, `--no-claim`. Recognized positional tokens
 (case-insensitive, anywhere in the arg vector): `auto`,
 `from-here`, `skip-tests`. The positional `auto` token enables
 auto-merge via `/land-pr` and matches the convention in `/run-plan`,
@@ -65,6 +65,20 @@ at parse time — mode detection (WI 1.5) decides whether it is fatal.
   proceed with `/quickfix` anyway. Dashed form to match `/do`,
   `/work-on-plans`, and `/cleanup-merged` — `--force` is a safety-gate
   override, distinct from the positional verb/mode tokens.
+- **--no-claim** (optional) — treat every bare `#N` in the description as a
+  mere mention. Suppresses the stray-`#N` pre-flight check (#959):
+  `/quickfix` normally STOPS when the description references an issue
+  currently held in-flight by a foreign pipeline (to prevent duplicating
+  its work — the closed-PR-#888-vs-landed-#901 footgun), and warns on any
+  other stray `#N` (#907). Pass `--no-claim` when the reference is
+  deliberate ("fix tooltip, related to #340") and you do NOT want
+  `/quickfix` to halt or warn on it. Claim-positioned `#N` (a leading `#N`
+  or `Fix #N …`) are unaffected — they still acquire their claim through WI
+  1.8's normal acquire-or-decline. **Accepted residual:** a false-STOP
+  fires ONLY when a `/quickfix` mentions an issue that is in flight RIGHT
+  NOW but isn't actually being worked; recover with `--no-claim`. Mentions
+  of closed/old issues never trigger (no live claim). Not advertised in the
+  `argument-hint` frontmatter (kept lean per #961); documented here.
 
 WI 1.5.5's confirmation prompt is bypassed when `AUTO_FLAG=1`.
 
@@ -83,6 +97,7 @@ BRANCH_OVERRIDE=""
 FROM_HERE=0
 SKIP_TESTS=0
 FORCE=0
+NO_CLAIM=0
 ROUNDS=1
 AUTO_FLAG=0
 
@@ -99,6 +114,17 @@ while [ $i -lt ${#ARGS[@]} ]; do
     # /cleanup-merged conventions). The positional bare `force` form was
     # retired in favor of this dashed form (issue #810).
     --force) FORCE=1 ;;
+    # Issue #959: `--no-claim` opt-out. When present, the stray-`#N`
+    # pre-flight (the #907 loop below) treats every bare `#N` as a mere
+    # mention — it suppresses BOTH the foreign-held STOP and the #907 warn.
+    # Use it when a /quickfix legitimately references an issue it is NOT
+    # working (e.g. "fix tooltip, related to #340"). Consumed by the case
+    # parser like `--force`, so it never falls through into DESCRIPTION and
+    # never leaks into the soft-redirect prompts (which interpolate
+    # `$DESCRIPTION`, not the raw arg vector). Claim-positioned `#N` (in
+    # ISSUE_NUMS) are independent of this flag — they still go through WI
+    # 1.8's acquire-or-decline.
+    --no-claim) NO_CLAIM=1 ;;
     # Positional `from-here` / `skip-tests` tokens (case-insensitive).
     # Bracket-class form matches each letter case-insensitively; the hyphen
     # between bracket classes is treated as a literal character (NOT inside
@@ -214,6 +240,103 @@ ISSUE_NUMS=("${_QF_UNIQUE[@]}")
 unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _QF_ISSUE_FILLER _n
 # Back-compat scalar (= first claimed issue, or empty when none).
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+# Unclaimed-reference check (#907 warn + #959 foreign-held STOP). If the
+# description contains a `#N` token that the claim-position rules above did
+# NOT capture into ISSUE_NUMS, the reference is real but UN-claimed by this
+# /quickfix run. A silent no-claim is the footgun that let `/do Build … for
+# #877` run without claiming #877: a parallel /fix-issues cron then picked
+# up the unclaimed issue and duplicated the work (closed PR #888 vs landed
+# #901). /quickfix lands issue work (one-commit PR), so the same risk
+# applies here.
+#
+# Two-tier handling per stray (non-ISSUE_NUMS) `#N` (#959):
+#   1. READ-ONLY foreign-held check. If issue N currently has a LIVE claim
+#      held by a DIFFERENT pipeline, STOP (clean exit 0 — decline, not an
+#      error). #907's warn fails UNSAFE in autonomous use (an agent reads
+#      the warn and proceeds anyway, re-creating the #877 duplication); the
+#      STOP fails SAFE and is recoverable via `--no-claim`. We DO NOT acquire
+#      on stray refs (that would spuriously claim "see #340" mentions — the
+#      over-capture the conservative ISSUE_NUMS parser deliberately avoids).
+#   2. Not held (or no claim.json) → keep the #907 warn and proceed.
+#
+# Foreign-vs-self is decided by READING `.zskills/claims/issue-N/claim.json`
+# and comparing its `pipeline_id` to THIS run's pipeline_id — exactly the
+# pattern hooks/block-fix-issue-unclaimed.sh uses. We do NOT use
+# filter-in-flight-issue-claims.sh alone: it drops the caller's OWN pipeline
+# claims too and cannot distinguish foreign from self, which would wrongly
+# stop on self-re-entry. Fail-OPEN discipline mirrors
+# block-fix-issue-unclaimed.sh: a missing/malformed claim.json, or a missing
+# pipeline_id, is treated as "not held" → warn-and-proceed, never a false
+# STOP. (In practice a stray ref is by definition never acquired by THIS
+# /quickfix run, so any live claim on it is foreign; the self-exclusion
+# below is the belt-and-suspenders that keeps a hypothetical self-claim from
+# stopping us.)
+#
+# Accepted residual (intentional, safe-direction): a false-STOP fires ONLY
+# when a /quickfix mentions an issue that is in flight RIGHT NOW but isn't
+# actually being worked (`fix tooltip, related to #340` while #340 is live).
+# Recover with `--no-claim`. Mentions of closed/old issues never trigger (no
+# live claim). This is the irreducible cost of "issues optional + can't tell
+# work-from-mention out of free text" — the failure mode relocates from
+# "fails → duplicates silently" to "fails → halts with a clear message".
+#
+# `--no-claim` (NO_CLAIM=1, parsed in the case loop above) suppresses BOTH
+# the STOP and the warn — every bare `#N` is then a pure mention.
+#
+# Resolve MAIN_ROOT the same way block-fix-issue-unclaimed.sh does:
+# `git rev-parse --git-common-dir` parent, falling back to
+# ${CLAUDE_PROJECT_DIR:-$PWD}. This is correct from a worktree too (the
+# claims live under the MAIN repo's .zskills/).
+if [ "$NO_CLAIM" -ne 1 ]; then
+  _QF_MAIN_ROOT=""
+  if _QF_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) && [ -n "$_QF_COMMON_DIR" ]; then
+    if _QF_RESOLVED=$(cd "$_QF_COMMON_DIR/.." 2>/dev/null && pwd); then
+      _QF_MAIN_ROOT="$_QF_RESOLVED"
+    fi
+  fi
+  [ -z "$_QF_MAIN_ROOT" ] && _QF_MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+  _QF_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+  # This run's pipeline_id, if already known. In the pre-flight it is
+  # typically unset; an empty value can never equal a real stored
+  # pipeline_id, so every live claim on a stray ref reads as foreign — which
+  # is exactly right (stray refs are never self-claimed). When set, it
+  # provides the explicit self-exclusion.
+  _QF_SELF_PIPELINE_ID="${PIPELINE_ID:-}"
+  _QF_WARN_REMAINING="$DESCRIPTION"
+  while [[ "$_QF_WARN_REMAINING" =~ \#([0-9]+) ]]; do
+    _QF_REF="${BASH_REMATCH[1]}"
+    _QF_WARN_REMAINING="${_QF_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
+    _QF_CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_QF_REF" ] && { _QF_CLAIMED=1; break; }
+    done
+    [ "$_QF_CLAIMED" -eq 1 ] && continue
+    # Stray ref — read its claim.json (if any) and decide foreign vs not-held.
+    _QF_CLAIM_FILE="${_QF_MAIN_ROOT}/.zskills/claims/issue-${_QF_REF}/claim.json"
+    _QF_STORED_PID=""
+    if [ -f "$_QF_CLAIM_FILE" ] && [ -n "$_QF_PYTHON" ]; then
+      _QF_STORED_PID=$("$_QF_PYTHON" - "$_QF_CLAIM_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+    fi
+    if [ -n "$_QF_STORED_PID" ] && [ "$_QF_STORED_PID" != "$_QF_SELF_PIPELINE_ID" ]; then
+      # Foreign-held in-flight → STOP (decline, clean exit 0).
+      echo "STOP: /quickfix: description references #${_QF_REF}, which is currently held by a foreign pipeline (claim pipeline_id: ${_QF_STORED_PID}, claim at ${_QF_CLAIM_FILE})." >&2
+      echo "      Another pipeline is already working #${_QF_REF}; proceeding would duplicate its work (the exact failure of closed PR #888 vs landed #901)." >&2
+      echo "      If you are ONLY referencing #${_QF_REF} and not working it, re-run with --no-claim to treat the reference as a mention and skip this check." >&2
+      exit 0
+    fi
+    # Not held (no claim.json / malformed / self) → #907 warn + proceed.
+    echo "WARN: /quickfix: description references #${_QF_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_QF_REF} …\" or \"Fix #${_QF_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work. If you are only referencing #${_QF_REF} (not working it), pass --no-claim to silence this." >&2
+  done
+  unset _QF_WARN_REMAINING _QF_REF _QF_CLAIMED _n _QF_MAIN_ROOT _QF_COMMON_DIR _QF_RESOLVED _QF_PYTHON _QF_SELF_PIPELINE_ID _QF_CLAIM_FILE _QF_STORED_PID
+fi
 ```
 
 ## Phase 1 — Pre-flight

--- a/skills/quickfix/SKILL.md
+++ b/skills/quickfix/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   '/do worktree' or '/commit' respectively. No .landed marker.
   Positional auto: auto-merge.
 metadata:
-  version: "2026.06.01+58b49f"
+  version: "2026.06.01+66842d"
 ---
 
 # /quickfix — In-Flight Fix → PR
@@ -48,7 +48,7 @@ ceremony than the change is worth, but a PR is still required.
 ## Argument parser (WI 1.2)
 
 Bash-regex idiom matching `skills/do/SKILL.md:70-92`. Recognized flags:
-`--branch <name>`, `--rounds N`, `--force`. Recognized positional tokens
+`--branch <name>`, `--rounds N`, `--force`, `--no-claim`. Recognized positional tokens
 (case-insensitive, anywhere in the arg vector): `auto`,
 `from-here`, `skip-tests`. The positional `auto` token enables
 auto-merge via `/land-pr` and matches the convention in `/run-plan`,
@@ -65,6 +65,20 @@ at parse time — mode detection (WI 1.5) decides whether it is fatal.
   proceed with `/quickfix` anyway. Dashed form to match `/do`,
   `/work-on-plans`, and `/cleanup-merged` — `--force` is a safety-gate
   override, distinct from the positional verb/mode tokens.
+- **--no-claim** (optional) — treat every bare `#N` in the description as a
+  mere mention. Suppresses the stray-`#N` pre-flight check (#959):
+  `/quickfix` normally STOPS when the description references an issue
+  currently held in-flight by a foreign pipeline (to prevent duplicating
+  its work — the closed-PR-#888-vs-landed-#901 footgun), and warns on any
+  other stray `#N` (#907). Pass `--no-claim` when the reference is
+  deliberate ("fix tooltip, related to #340") and you do NOT want
+  `/quickfix` to halt or warn on it. Claim-positioned `#N` (a leading `#N`
+  or `Fix #N …`) are unaffected — they still acquire their claim through WI
+  1.8's normal acquire-or-decline. **Accepted residual:** a false-STOP
+  fires ONLY when a `/quickfix` mentions an issue that is in flight RIGHT
+  NOW but isn't actually being worked; recover with `--no-claim`. Mentions
+  of closed/old issues never trigger (no live claim). Not advertised in the
+  `argument-hint` frontmatter (kept lean per #961); documented here.
 
 WI 1.5.5's confirmation prompt is bypassed when `AUTO_FLAG=1`.
 
@@ -83,6 +97,7 @@ BRANCH_OVERRIDE=""
 FROM_HERE=0
 SKIP_TESTS=0
 FORCE=0
+NO_CLAIM=0
 ROUNDS=1
 AUTO_FLAG=0
 
@@ -99,6 +114,17 @@ while [ $i -lt ${#ARGS[@]} ]; do
     # /cleanup-merged conventions). The positional bare `force` form was
     # retired in favor of this dashed form (issue #810).
     --force) FORCE=1 ;;
+    # Issue #959: `--no-claim` opt-out. When present, the stray-`#N`
+    # pre-flight (the #907 loop below) treats every bare `#N` as a mere
+    # mention — it suppresses BOTH the foreign-held STOP and the #907 warn.
+    # Use it when a /quickfix legitimately references an issue it is NOT
+    # working (e.g. "fix tooltip, related to #340"). Consumed by the case
+    # parser like `--force`, so it never falls through into DESCRIPTION and
+    # never leaks into the soft-redirect prompts (which interpolate
+    # `$DESCRIPTION`, not the raw arg vector). Claim-positioned `#N` (in
+    # ISSUE_NUMS) are independent of this flag — they still go through WI
+    # 1.8's acquire-or-decline.
+    --no-claim) NO_CLAIM=1 ;;
     # Positional `from-here` / `skip-tests` tokens (case-insensitive).
     # Bracket-class form matches each letter case-insensitively; the hyphen
     # between bracket classes is treated as a literal character (NOT inside
@@ -214,6 +240,103 @@ ISSUE_NUMS=("${_QF_UNIQUE[@]}")
 unset _QF_SEEN _QF_UNIQUE _QF_REMAINING _QF_ISSUE_KW _QF_ISSUE_FILLER _n
 # Back-compat scalar (= first claimed issue, or empty when none).
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+# Unclaimed-reference check (#907 warn + #959 foreign-held STOP). If the
+# description contains a `#N` token that the claim-position rules above did
+# NOT capture into ISSUE_NUMS, the reference is real but UN-claimed by this
+# /quickfix run. A silent no-claim is the footgun that let `/do Build … for
+# #877` run without claiming #877: a parallel /fix-issues cron then picked
+# up the unclaimed issue and duplicated the work (closed PR #888 vs landed
+# #901). /quickfix lands issue work (one-commit PR), so the same risk
+# applies here.
+#
+# Two-tier handling per stray (non-ISSUE_NUMS) `#N` (#959):
+#   1. READ-ONLY foreign-held check. If issue N currently has a LIVE claim
+#      held by a DIFFERENT pipeline, STOP (clean exit 0 — decline, not an
+#      error). #907's warn fails UNSAFE in autonomous use (an agent reads
+#      the warn and proceeds anyway, re-creating the #877 duplication); the
+#      STOP fails SAFE and is recoverable via `--no-claim`. We DO NOT acquire
+#      on stray refs (that would spuriously claim "see #340" mentions — the
+#      over-capture the conservative ISSUE_NUMS parser deliberately avoids).
+#   2. Not held (or no claim.json) → keep the #907 warn and proceed.
+#
+# Foreign-vs-self is decided by READING `.zskills/claims/issue-N/claim.json`
+# and comparing its `pipeline_id` to THIS run's pipeline_id — exactly the
+# pattern hooks/block-fix-issue-unclaimed.sh uses. We do NOT use
+# filter-in-flight-issue-claims.sh alone: it drops the caller's OWN pipeline
+# claims too and cannot distinguish foreign from self, which would wrongly
+# stop on self-re-entry. Fail-OPEN discipline mirrors
+# block-fix-issue-unclaimed.sh: a missing/malformed claim.json, or a missing
+# pipeline_id, is treated as "not held" → warn-and-proceed, never a false
+# STOP. (In practice a stray ref is by definition never acquired by THIS
+# /quickfix run, so any live claim on it is foreign; the self-exclusion
+# below is the belt-and-suspenders that keeps a hypothetical self-claim from
+# stopping us.)
+#
+# Accepted residual (intentional, safe-direction): a false-STOP fires ONLY
+# when a /quickfix mentions an issue that is in flight RIGHT NOW but isn't
+# actually being worked (`fix tooltip, related to #340` while #340 is live).
+# Recover with `--no-claim`. Mentions of closed/old issues never trigger (no
+# live claim). This is the irreducible cost of "issues optional + can't tell
+# work-from-mention out of free text" — the failure mode relocates from
+# "fails → duplicates silently" to "fails → halts with a clear message".
+#
+# `--no-claim` (NO_CLAIM=1, parsed in the case loop above) suppresses BOTH
+# the STOP and the warn — every bare `#N` is then a pure mention.
+#
+# Resolve MAIN_ROOT the same way block-fix-issue-unclaimed.sh does:
+# `git rev-parse --git-common-dir` parent, falling back to
+# ${CLAUDE_PROJECT_DIR:-$PWD}. This is correct from a worktree too (the
+# claims live under the MAIN repo's .zskills/).
+if [ "$NO_CLAIM" -ne 1 ]; then
+  _QF_MAIN_ROOT=""
+  if _QF_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) && [ -n "$_QF_COMMON_DIR" ]; then
+    if _QF_RESOLVED=$(cd "$_QF_COMMON_DIR/.." 2>/dev/null && pwd); then
+      _QF_MAIN_ROOT="$_QF_RESOLVED"
+    fi
+  fi
+  [ -z "$_QF_MAIN_ROOT" ] && _QF_MAIN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+  _QF_PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+  # This run's pipeline_id, if already known. In the pre-flight it is
+  # typically unset; an empty value can never equal a real stored
+  # pipeline_id, so every live claim on a stray ref reads as foreign — which
+  # is exactly right (stray refs are never self-claimed). When set, it
+  # provides the explicit self-exclusion.
+  _QF_SELF_PIPELINE_ID="${PIPELINE_ID:-}"
+  _QF_WARN_REMAINING="$DESCRIPTION"
+  while [[ "$_QF_WARN_REMAINING" =~ \#([0-9]+) ]]; do
+    _QF_REF="${BASH_REMATCH[1]}"
+    _QF_WARN_REMAINING="${_QF_WARN_REMAINING#*"${BASH_REMATCH[0]}"}"
+    _QF_CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_QF_REF" ] && { _QF_CLAIMED=1; break; }
+    done
+    [ "$_QF_CLAIMED" -eq 1 ] && continue
+    # Stray ref — read its claim.json (if any) and decide foreign vs not-held.
+    _QF_CLAIM_FILE="${_QF_MAIN_ROOT}/.zskills/claims/issue-${_QF_REF}/claim.json"
+    _QF_STORED_PID=""
+    if [ -f "$_QF_CLAIM_FILE" ] && [ -n "$_QF_PYTHON" ]; then
+      _QF_STORED_PID=$("$_QF_PYTHON" - "$_QF_CLAIM_FILE" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+    fi
+    if [ -n "$_QF_STORED_PID" ] && [ "$_QF_STORED_PID" != "$_QF_SELF_PIPELINE_ID" ]; then
+      # Foreign-held in-flight → STOP (decline, clean exit 0).
+      echo "STOP: /quickfix: description references #${_QF_REF}, which is currently held by a foreign pipeline (claim pipeline_id: ${_QF_STORED_PID}, claim at ${_QF_CLAIM_FILE})." >&2
+      echo "      Another pipeline is already working #${_QF_REF}; proceeding would duplicate its work (the exact failure of closed PR #888 vs landed #901)." >&2
+      echo "      If you are ONLY referencing #${_QF_REF} and not working it, re-run with --no-claim to treat the reference as a mention and skip this check." >&2
+      exit 0
+    fi
+    # Not held (no claim.json / malformed / self) → #907 warn + proceed.
+    echo "WARN: /quickfix: description references #${_QF_REF} but it is not in claim position — NO claim was acquired for it. Prefix the description with the issue number (e.g. \"#${_QF_REF} …\" or \"Fix #${_QF_REF} …\") to claim it and prevent a parallel pipeline from duplicating the work. If you are only referencing #${_QF_REF} (not working it), pass --no-claim to silence this." >&2
+  done
+  unset _QF_WARN_REMAINING _QF_REF _QF_CLAIMED _n _QF_MAIN_ROOT _QF_COMMON_DIR _QF_RESOLVED _QF_PYTHON _QF_SELF_PIPELINE_ID _QF_CLAIM_FILE _QF_STORED_PID
+fi
 ```
 
 ## Phase 1 — Pre-flight

--- a/tests/test-quickfix.sh
+++ b/tests/test-quickfix.sh
@@ -2175,6 +2175,204 @@ test_issue_nums_qf "Fix issue #832, see also issue #999"          "832"         
 test_issue_nums_qf "fixes issues #906 and #907"                   "906"         "plural 'issues' in leading does NOT loosen weak-sep guard (no kw before #907)"
 
 # ────────────────────────────────────────────────────────────────────
+# Case 71w — Unclaimed-reference WARNING (#907). When the description
+# carries a `#N` token that the claim-position rules did NOT capture into
+# ISSUE_NUMS, /quickfix warns (non-fatal) that no claim was acquired for
+# it — the footgun that let `/do Build … for #877` run unclaimed and
+# duplicate a parallel /fix-issues sprint (closed PR #888). Replicates the
+# SKILL.md warning loop (source-of-truth is SKILL.md; anchored by 71w-src).
+# Mirrors test-do.sh Case 18w.
+# ────────────────────────────────────────────────────────────────────
+# qf_warn_unclaimed echoes "WARN #N" per unclaimed reference (the real
+# skill writes the full sentence to stderr). Assumes qf_parse_issue_nums
+# already populated ISSUE_NUMS.
+qf_warn_unclaimed() {
+  local input="$1" _REM="$1" _REF _CLAIMED _n out=""
+  while [[ "$_REM" =~ \#([0-9]+) ]]; do
+    _REF="${BASH_REMATCH[1]}"
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+    _CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_REF" ] && { _CLAIMED=1; break; }
+    done
+    [ "$_CLAIMED" -eq 0 ] && out+="WARN #$_REF"$'\n'
+  done
+  printf '%s' "$out"
+}
+test_qf_warn() {
+  local input="$1" expected_csv="$2" label="$3"
+  qf_parse_issue_nums "$input"
+  local got_csv
+  got_csv=$(qf_warn_unclaimed "$input" | grep -oE '#[0-9]+' | tr -d '#' | paste -sd, -)
+  if [ "$got_csv" = "$expected_csv" ]; then
+    pass "71w warn: $label (got '${got_csv:-none}')"
+  else
+    fail "71w warn: $label (expected '$expected_csv', got '$got_csv')"
+  fi
+}
+test_qf_warn "Build the guard for #877"        "877" "bare mid-prose #N → WARN (the #888 footgun)"
+test_qf_warn "Fix #853 — auto-route"           ""    "claim-positioned #N → NO warn"
+test_qf_warn "Closes #832 / Closes #833"       ""    "both claimed (multi) → NO warn"
+test_qf_warn "Closes #832, see also #999"      "999" "claimed #832 + unclaimed #999 → warn only #999"
+test_qf_warn "Just a regular description"      ""    "no #N → NO warn"
+test_qf_warn "Edit collect.py:#142 line ref"   "142" "stray #N → WARN (accepted non-fatal false-positive)"
+# 71w-src — anchor the replication to the SKILL.md source so a future edit
+# that removes the warning fails closed.
+if grep -qF 'is not in claim position — NO claim was acquired' "$SKILL"; then
+  pass "71w-src SKILL.md carries the unclaimed-reference WARN (#907)"
+else
+  fail "71w-src SKILL.md missing the unclaimed-reference WARN (#907)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 71x — Foreign-held stray-`#N` STOP (#959). The #907 warn fails
+# UNSAFE in autonomous use; #959 upgrades it to a read-only foreign-held
+# check that STOPS (decline) when a stray `#N` is currently claimed by a
+# DIFFERENT pipeline. Foreign-vs-self is decided by reading
+# `.zskills/claims/issue-N/claim.json`'s pipeline_id and comparing to this
+# run's pipeline_id — exactly the pattern block-fix-issue-unclaimed.sh uses.
+# `--no-claim` suppresses the stop. Missing/malformed claim.json → not-held
+# → warn + proceed (fail-open). Self-claim (stored == caller) → no stop.
+# Mirrors test-do.sh Case 18x.
+# ────────────────────────────────────────────────────────────────────
+PY_BIN="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+
+# qf_stray_check replicates the SKILL.md #959 stray-ref decision. Echoes one
+# of: "STOP <ref> <stored_pid>", "WARN <ref>" per stray ref. Assumes
+# qf_parse_issue_nums already populated ISSUE_NUMS. Args:
+#   $1 = description, $2 = claims-root dir, $3 = caller pipeline_id,
+#   $4 = NO_CLAIM (0/1).
+qf_stray_check() {
+  local input="$1" claims_root="$2" self_pid="$3" no_claim="$4"
+  local _REM="$input" _REF _CLAIMED _n _claim_file _stored out=""
+  [ "$no_claim" -eq 1 ] && { printf ''; return; }
+  while [[ "$_REM" =~ \#([0-9]+) ]]; do
+    _REF="${BASH_REMATCH[1]}"
+    _REM="${_REM#*"${BASH_REMATCH[0]}"}"
+    _CLAIMED=0
+    for _n in "${ISSUE_NUMS[@]:-}"; do
+      [ "$_n" = "$_REF" ] && { _CLAIMED=1; break; }
+    done
+    [ "$_CLAIMED" -eq 1 ] && continue
+    _claim_file="${claims_root}/issue-${_REF}/claim.json"
+    _stored=""
+    if [ -f "$_claim_file" ] && [ -n "$PY_BIN" ]; then
+      _stored=$("$PY_BIN" - "$_claim_file" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        sys.stdout.write(json.load(f).get("pipeline_id", "") or "")
+except Exception:
+    pass
+PY
+)
+    fi
+    if [ -n "$_stored" ] && [ "$_stored" != "$self_pid" ]; then
+      out+="STOP $_REF $_stored"$'\n'
+    else
+      out+="WARN $_REF"$'\n'
+    fi
+  done
+  printf '%s' "$out"
+}
+
+qf_mk_claim() {
+  # $1 = claims-root, $2 = issue number, $3 = pipeline_id
+  local dir="$1/issue-$2"
+  mkdir -p "$dir"
+  printf '{"pipeline_id": "%s", "started_at": "now"}\n' "$3" > "$dir/claim.json"
+}
+
+# Fixture claims dir.
+QF_STRAY_ROOT="$TEST_TMPDIR/claims-stray"
+register_fixture "$QF_STRAY_ROOT"
+mkdir -p "$QF_STRAY_ROOT"
+qf_mk_claim "$QF_STRAY_ROOT" 340 "fix-issues.sprint-foreign"   # foreign holder
+qf_mk_claim "$QF_STRAY_ROOT" 555 "quickfix.this-run-slug"      # self holder
+
+# (a) stray #N with a foreign live claim → STOP signalled.
+qf_parse_issue_nums "fix tooltip, related to #340"
+GOT=$(qf_stray_check "fix tooltip, related to #340" "$QF_STRAY_ROOT" "quickfix.this-run-slug" 0)
+if printf '%s' "$GOT" | grep -qE '^STOP 340 fix-issues\.sprint-foreign$'; then
+  pass "71x foreign-held stray #340 → STOP (names holder)"
+else
+  fail "71x foreign-held stray #340 → STOP (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# (b) stray #N with NO claim → warn + proceed (no stop).
+qf_parse_issue_nums "fix tooltip, related to #999"
+GOT=$(qf_stray_check "fix tooltip, related to #999" "$QF_STRAY_ROOT" "quickfix.this-run-slug" 0)
+if printf '%s' "$GOT" | grep -qE '^WARN 999$' && ! printf '%s' "$GOT" | grep -q '^STOP'; then
+  pass "71x not-held stray #999 → WARN, no STOP"
+else
+  fail "71x not-held stray #999 → WARN (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# (c) stray #N whose claim.json pipeline_id == caller (self) → NO stop.
+qf_parse_issue_nums "fix tooltip, related to #555"
+GOT=$(qf_stray_check "fix tooltip, related to #555" "$QF_STRAY_ROOT" "quickfix.this-run-slug" 0)
+if printf '%s' "$GOT" | grep -qE '^WARN 555$' && ! printf '%s' "$GOT" | grep -q '^STOP'; then
+  pass "71x self-claimed stray #555 → no STOP (self-exclusion)"
+else
+  fail "71x self-claimed stray #555 → no STOP (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# (d) --no-claim present → stray-ref stop suppressed (no STOP, no WARN).
+qf_parse_issue_nums "fix tooltip, related to #340"
+GOT=$(qf_stray_check "fix tooltip, related to #340" "$QF_STRAY_ROOT" "quickfix.this-run-slug" 1)
+if [ -z "$GOT" ]; then
+  pass "71x --no-claim suppresses foreign-held STOP (and warn)"
+else
+  fail "71x --no-claim should suppress all stray output (got: '$(printf '%s' "$GOT" | tr '\n' '|')')"
+fi
+
+# 71x-src — anchor the foreign-held STOP + --no-claim handling to SKILL.md.
+if grep -qF 'is currently held by a foreign pipeline' "$SKILL" \
+   && grep -qF 'claims/issue-${_QF_REF}/claim.json' "$SKILL"; then
+  pass "71x-src SKILL.md carries the foreign-held stray-ref STOP (#959)"
+else
+  fail "71x-src SKILL.md missing the foreign-held stray-ref STOP (#959)"
+fi
+if grep -qE 'NO_CLAIM=0' "$SKILL" \
+   && grep -qF 'if [ "$NO_CLAIM" -ne 1 ]; then' "$SKILL"; then
+  pass "71x-src SKILL.md parses --no-claim and gates the stray check on it"
+else
+  fail "71x-src SKILL.md missing --no-claim parse / gate"
+fi
+# The case-parser arm must consume --no-claim (so it never falls through
+# into DESCRIPTION and never leaks into the soft-redirect prompts).
+if grep -qE '^[[:space:]]*--no-claim\) NO_CLAIM=1 ;;' "$SKILL"; then
+  pass "71x-src --no-claim consumed by the case parser (no leak into DESCRIPTION)"
+else
+  fail "71x-src --no-claim case arm missing (would leak into DESCRIPTION / redirect prompts)"
+fi
+# Both the STOP message AND the #907 warn must reference --no-claim.
+if grep -qF 're-run with --no-claim' "$SKILL" \
+   && grep -qF 'pass --no-claim to silence' "$SKILL"; then
+  pass "71x-src STOP + #907 warn both reference --no-claim"
+else
+  fail "71x-src STOP and/or #907 warn missing --no-claim reference"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 71y — Documentation discipline for --no-claim (#959):
+#   - argument-hint frontmatter must NOT contain --no-claim (#961 lean).
+#   - the Arguments body MUST document --no-claim (bullet present).
+# Mirrors test-do.sh Case 18y.
+# ────────────────────────────────────────────────────────────────────
+if grep -qE '^argument-hint:' "$SKILL" \
+   && grep -E '^argument-hint:' "$SKILL" | grep -q -- '--no-claim'; then
+  fail "71y argument-hint frontmatter must NOT contain --no-claim"
+else
+  pass "71y argument-hint frontmatter does NOT contain --no-claim"
+fi
+if grep -qE '^\- \*\*--no-claim\*\*' "$SKILL"; then
+  pass "71y Arguments body documents --no-claim (bullet present)"
+else
+  fail "71y Arguments body missing --no-claim bullet"
+fi
+
+# ────────────────────────────────────────────────────────────────────
 # Case 72 — Phase 0a triage rubric NO LONGER contains the
 # "References a GitHub issue number → /fix-issues" REDIRECT row.
 # After PR 825 wired ISSUE_NUM + claim-issue.sh into the mode files,


### PR DESCRIPTION
## Summary
Closes #971. Ports `/do`'s two claim guards (PRs #910 #907-warn and #966 #959-stop) into `/quickfix`, which shared `/do`'s free-text `#N` parser but had neither — and which *lands* issue work (and runs directly on `main` in non-`main_protected` consumers), so it was exposed to the same cross-session duplication hole (#888-vs-#901).

## Behavior (parity with /do)
In `/quickfix`'s `ISSUE_NUMS` parser, each stray (non-claim-positioned) `#N` now gets a **read-only** check: foreign live claim → **STOP** (`exit 0`, name the holder, point to `--no-claim`); not held → keep the #907 warn, proceed. Foreign determined by reading `.zskills/claims/issue-N/claim.json` + `pipeline_id` comparison (the `block-fix-issue-unclaimed.sh` pattern, *not* `filter-in-flight`); missing/malformed/self → fail-open. Claim-positioned `#N` unchanged. `--no-claim` suppresses the stray stop — documented in Arguments, kept out of `argument-hint` (lean per #961); both stop + warn reference it.

## Audit note
`/run-plan` (plan-frontmatter `issue:`, explicit) and `/fix-issues` (`block-fix-issue-unclaimed` hook) were already solid; `/investigate` claims only on bare-`#N` input but hands off to the now-guarded `/do`/`/quickfix` rather than landing work, so it's a deliberate low-stakes leave. `/quickfix` was the only remaining real hole.

## Test plan
- [x] `tests/test-quickfix.sh` — 155/155, incl. 71w/71x/71y (foreign STOP, not-held warn, self-exclusion, `--no-claim` suppression, argument-hint-excludes / Arguments-documents); revert-sensitive.
- [x] `bash tests/run-all.sh` — 7158/7158, 0 failed.
- [x] Independent verifier — CLEAN (line-identical parity to /do; 3 justified parser-idiom deviations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
