### PR TITLE
do: plugin version 2026.06.0 + DEV-QUAL lane-switch fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zs",
   "displayName": "Z Skills",
-  "version": "2026.05.1",
+  "version": "2026.06.0",
   "description": "Agent-discipline skill framework: plans, fix-issues, draft-plan, run-plan, land-pr, and more.",
   "author": { "name": "Rich Conlan", "url": "https://github.com/zeveck/zskills" },
   "homepage": "https://github.com/zeveck/zskills",

--- a/DEV-QUAL.md
+++ b/DEV-QUAL.md
@@ -154,11 +154,13 @@ mirror artifacts are stripped, and the lane lock flips to `plugin`.
   mirror present, zskills hooks registered in `.claude/settings.json`.
 
 **Steps.**
-1. Run the switcher (also reachable as
-   `/update-zskills --switch-install-path=to-plugin`):
-   ```bash
-   bash scripts/switch-install-path.sh --to-plugin
+1. Run the switcher in your Claude session:
    ```
+   /update-zskills --switch-install-path=to-plugin
+   ```
+   (it dispatches the bundled `scripts/switch-install-path.sh --to-plugin`
+   for you; invoke the script directly only when debugging the switch
+   machinery.)
 2. It strips the zskills hook entries from `.claude/settings.json` FIRST
    (config write first), prints the
    `/plugin marketplace add zeveck/zskills` + `/plugin install zs@zskills`
@@ -179,7 +181,7 @@ mirror artifacts are stripped, and the lane lock flips to `plugin`.
   kept).
 - `.zskills/` runtime state (claim markers, tracking) is untouched
   (lane-independent).
-- Re-running `bash scripts/switch-install-path.sh --to-plugin` is a
+- Re-running `/update-zskills --switch-install-path=to-plugin` is a
   no-op-with-INFO ("Already on the plugin lane").
 
 ---
@@ -197,11 +199,13 @@ without deadlocking on Step 0.7's hard-refuse.
   sentinelled artifacts present, no `.claude/skills/` mirror.
 
 **Steps.**
-1. Run the switcher (also reachable as
-   `/update-zskills --switch-install-path=to-update-zskills`):
-   ```bash
-   bash scripts/switch-install-path.sh --to-update-zskills
+1. Run the switcher in your Claude session:
    ```
+   /update-zskills --switch-install-path=to-update-zskills
+   ```
+   (it dispatches the bundled `scripts/switch-install-path.sh
+   --to-update-zskills` for you; invoke the script directly only when
+   debugging the switch machinery.)
 2. It writes `.zskills/switch-in-progress` at its START. This marker is
    load-bearing: while it is present BOTH (i) the `/update-zskills` Step 0.7
    W6.1 hard-refuse skips itself (so the mandated `/update-zskills install`
@@ -232,7 +236,7 @@ without deadlocking on Step 0.7's hard-refuse.
 - `.zskills/switch-in-progress` is gone (cleared strictly AFTER the lock was
   written — lock-LAST contract preserved).
 - `.zskills/` runtime state is untouched.
-- Re-running `bash scripts/switch-install-path.sh --to-update-zskills` is a
+- Re-running `/update-zskills --switch-install-path=to-update-zskills` is a
   no-op-with-INFO ("Already on the /update-zskills lane").
 
 ---

--- a/block-diagram/.claude-plugin/plugin.json
+++ b/block-diagram/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zsbd",
   "displayName": "Z Skills — Block Diagram Addons",
-  "version": "2026.05.1",
+  "version": "2026.06.0",
   "description": "Block-diagram-editor skill addons (add-block, add-example, model-design).",
   "author": { "name": "Rich Conlan", "url": "https://github.com/zeveck/zskills" },
   "homepage": "https://github.com/zeveck/zskills",


### PR DESCRIPTION
Two small pre-launch corrections (no GitHub issue).

1. **Bump plugin manifest version 2026.05.1 → 2026.06.0** in both `.claude-plugin/plugin.json` (zs) and `block-diagram/.claude-plugin/plugin.json` (zsbd), kept equal (test-plugin-marketplace.sh asserts lockstep). This is the launch version (codename ZYMON).
2. **DEV-QUAL.md Scenarios 3 & 4** now show the user-facing `/update-zskills --switch-install-path={to-plugin,to-update-zskills}` slash command as the lane-switch a real consumer runs; the bundled `scripts/switch-install-path.sh` is demoted to a parenthetical "under-the-hood implementation" note. Scenario 5's maintainer build command is untouched.

Plugin-manifest + prod-stripped maintainer-doc only — no skill `metadata.version` bump.

## Test plan
- [x] `bash tests/run-all.sh` — 7141/7141 pass (test-plugin-marketplace.sh 17/17 incl. zs==zsbd lockstep; conformance green).
- [x] Both plugin.json versions = 2026.06.0 and equal.
- [x] DEV-QUAL Scenarios 3 & 4 lead with the slash command (Steps + Re-running line); prod-strip markers intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
