### PR TITLE
do: fix github org typo zeroskills→zeveck in draft-plan.md

### DIFF
--- a/docs/skills/draft-plan.md
+++ b/docs/skills/draft-plan.md
@@ -43,7 +43,7 @@
 
 ## Brainstorm mode (`brainstorm`)
 
-Loads [`references/brainstorm.md`](https://github.com/zeroskills/zskills/blob/main/skills/draft-plan/references/brainstorm.md) and runs an 8-step interactive dialogue **before Phase 1**:
+Loads [`references/brainstorm.md`](https://github.com/zeveck/zskills/blob/main/skills/draft-plan/references/brainstorm.md) and runs an 8-step interactive dialogue **before Phase 1**:
 
 1. Restate the seed idea in 1-2 sentences.
 2. Optionally offer a visual companion (live HTML demo or `playwright-cli` screenshot) when the idea is visual.
@@ -58,7 +58,7 @@ The notes file is a **resumable state machine** -- if compaction interrupts the 
 
 ## Quiz mode (`quiz`)
 
-Loads [`references/quiz.md`](https://github.com/zeroskills/zskills/blob/main/skills/draft-plan/references/quiz.md) and runs an interactive **requirements interview** before any research:
+Loads [`references/quiz.md`](https://github.com/zeveck/zskills/blob/main/skills/draft-plan/references/quiz.md) and runs an interactive **requirements interview** before any research:
 
 - **No research during the interview** -- conversation runs against the agent's existing knowledge. Codebase uncertainties are deferred to the post-interview fan-out as open questions, never interrogated out of the user.
 - **Ask vs defer rule:** ask the *user* about intent, scope, priorities, preferences, and success criteria; defer any *codebase fact* the agent is unsure of to the fan-out's open-questions list.


### PR DESCRIPTION
## Summary

Fix two broken GitHub URLs in `docs/skills/draft-plan.md` that referenced the non-existent `github.com/zeroskills/zskills` org. The correct org is `zeveck/zskills`.

Discovered via the active-user docs assessment that followed PR #975 (DOC_VIEWER plan landing).

## Test plan

- [x] `grep -c 'zeroskills/zskills' docs/skills/draft-plan.md` returns 0 after the edit.
- [x] `grep -rn 'zeroskills/zskills' --include='*.md' .` returns no hits in source paths.
- [x] Only `docs/skills/draft-plan.md` in the staged diff.
- [ ] PR CI (plugin-mode + skill-conformance) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
