### PR TITLE
fix(#976): block agents from recommending user-invocable:false skills

### DIFF
--- a/.claude/rules/zskills/managed.md
+++ b/.claude/rules/zskills/managed.md
@@ -283,6 +283,10 @@ If the verifying read is too expensive to do now, say so and stop -- do
 not substitute a guess and let downstream failure do the verification.
 The only research you can skip is what you just verified in this turn.
 
+### User-facing reports
+
+**Never recommend `/land-pr` (or any other `user-invocable: false` skill) to users in final reports, summaries, or "next step" suggestions.** `/land-pr` is an orchestrator-dispatch-only helper (8 caller skills dispatch it via the Skill tool). The slash runtime will not dispatch a `user-invocable: false` skill typed by a human, so telling the user to "run /land-pr ..." sends them down a dead end. When suggesting how to land a branch, recommend `/commit pr` (or one of the other 7 callers — `/run-plan`, `/do pr`, `/fix-issues pr`, `/quickfix`, `/draft-plan`, `/refine-plan`, `/draft-tests`) or plain `git push && gh pr create`. The current full list of `user-invocable: false` skills is just `/land-pr` today; the rule generalizes if more are added later.
+
 ## Migration scripts
 
 **Multi-step state-mutating scripts must write the idempotency lock LAST.** If

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.31+a44241"
+  version: "2026.06.01+979c6f"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -33,6 +33,10 @@ parsing, CI-fix-cycle agent dispatch) lives in
 `references/caller-loop-pattern.md`. The fix-cycle agent prompt template
 lives in `references/fix-cycle-agent-prompt-template.md`. Phases 2–5 of
 the PR_LANDING_UNIFICATION plan copy from these references.
+
+## Reporting back to the user
+
+When this skill returns to the orchestrator (via the result file written in Step 9), the orchestrator typically composes a user-facing summary of the landing outcome. **NEVER instruct the user to type `/land-pr` in that summary.** This skill carries `user-invocable: false` for a reason — the slash runtime will not dispatch it from a human-typed slash command in any useful way. If the PR landed cleanly, just report the PR URL + merge status. If the PR is in a non-terminal state (CI failing, OPEN/BEHIND, rebase conflict), recommend `/commit pr` to retry the landing (it dispatches `/land-pr` internally with the right arguments), or — for low-level recovery — `git push` + `gh pr create` directly. The other 7 caller skills (`/run-plan`, `/do pr`, `/fix-issues pr`, `/quickfix`, `/draft-plan`, `/refine-plan`, `/draft-tests`) all dispatch `/land-pr` internally and are valid recommendations depending on the workflow that originated the PR.
 
 ## When invoked
 

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -283,6 +283,10 @@ If the verifying read is too expensive to do now, say so and stop -- do
 not substitute a guess and let downstream failure do the verification.
 The only research you can skip is what you just verified in this turn.
 
+### User-facing reports
+
+**Never recommend `/land-pr` (or any other `user-invocable: false` skill) to users in final reports, summaries, or "next step" suggestions.** `/land-pr` is an orchestrator-dispatch-only helper (8 caller skills dispatch it via the Skill tool). The slash runtime will not dispatch a `user-invocable: false` skill typed by a human, so telling the user to "run /land-pr ..." sends them down a dead end. When suggesting how to land a branch, recommend `/commit pr` (or one of the other 7 callers — `/run-plan`, `/do pr`, `/fix-issues pr`, `/quickfix`, `/draft-plan`, `/refine-plan`, `/draft-tests`) or plain `git push && gh pr create`. The current full list of `user-invocable: false` skills is just `/land-pr` today; the rule generalizes if more are added later.
+
 ## Migration scripts
 
 **Multi-step state-mutating scripts must write the idempotency lock LAST.** If

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /quickfix, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.05.31+a44241"
+  version: "2026.06.01+979c6f"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -33,6 +33,10 @@ parsing, CI-fix-cycle agent dispatch) lives in
 `references/caller-loop-pattern.md`. The fix-cycle agent prompt template
 lives in `references/fix-cycle-agent-prompt-template.md`. Phases 2–5 of
 the PR_LANDING_UNIFICATION plan copy from these references.
+
+## Reporting back to the user
+
+When this skill returns to the orchestrator (via the result file written in Step 9), the orchestrator typically composes a user-facing summary of the landing outcome. **NEVER instruct the user to type `/land-pr` in that summary.** This skill carries `user-invocable: false` for a reason — the slash runtime will not dispatch it from a human-typed slash command in any useful way. If the PR landed cleanly, just report the PR URL + merge status. If the PR is in a non-terminal state (CI failing, OPEN/BEHIND, rebase conflict), recommend `/commit pr` to retry the landing (it dispatches `/land-pr` internally with the right arguments), or — for low-level recovery — `git push` + `gh pr create` directly. The other 7 caller skills (`/run-plan`, `/do pr`, `/fix-issues pr`, `/quickfix`, `/draft-plan`, `/refine-plan`, `/draft-tests`) all dispatch `/land-pr` internally and are valid recommendations depending on the workflow that originated the PR.
 
 ## When invoked
 

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -3466,6 +3466,44 @@ check_fixed session-report "report template Intent → status:" '**Intent → st
 check_fixed session-report "report template Next action:" '**Next action:**'
 check_fixed session-report "no-bulk-scans prohibition"  'Do not run bulk repo scans'
 
+# ── #976 — agents must not recommend /land-pr (or any user-invocable:false
+#    skill) as a user-typeable next step. Catches the regression in skill
+#    SOURCE files only — agent chat output is not source-gated by this test;
+#    the rules in CLAUDE_TEMPLATE.md + land-pr/SKILL.md cover the runtime side.
+# ---------------------------------------------------------------------------
+echo "── #976 — no user-typed-recommendation of user-invocable:false skills ──"
+
+# Discover the current set of user-invocable:false skills (schema-driven).
+USER_INVOCABLE_FALSE_SKILLS=()
+while IFS= read -r f; do
+  slug=$(basename "$(dirname "$f")")
+  USER_INVOCABLE_FALSE_SKILLS+=("$slug")
+done < <(grep -l '^user-invocable: false$' "$REPO_ROOT"/skills/*/SKILL.md 2>/dev/null || true)
+
+if [ "${#USER_INVOCABLE_FALSE_SKILLS[@]}" -eq 0 ]; then
+  pass "#976: no user-invocable:false skills present in skills/ — assertion vacuous"
+else
+  # Antipattern verbs that read as user-typing instructions.
+  # (We deliberately omit "run", "dispatch", and "invoke" — they false-
+  # positive on legitimate prose like "/run-plan dispatches /land-pr
+  # internally" and "callers invoke /land-pr via the Skill tool". The
+  # narrow set "type" / "re-run" reliably reads as a human-typing
+  # recommendation in agent-report context.)
+  for slug in "${USER_INVOCABLE_FALSE_SKILLS[@]}"; do
+    HITS=$(grep -rEn "(^|[^a-zA-Z\`])(type|re-run)[[:space:]]+\`?/$slug\b" \
+      --include='*.md' \
+      "$REPO_ROOT"/skills/ 2>/dev/null \
+      | grep -vE "skills/$slug/SKILL.md.*user-invocable|references/.*self-defense|test-skill-conformance" \
+      || true)
+    if [ -z "$HITS" ]; then
+      pass "#976: no user-typed-recommendation of /$slug in skill bodies"
+    else
+      fail "#976: skill bodies contain user-typed-recommendation of /$slug" "(type|re-run) /$slug"
+      echo "$HITS" | sed 's/^/        /'
+    fi
+  done
+fi
+
 echo ""
 echo "---"
 TOTAL=$((PASS_COUNT + FAIL_COUNT))


### PR DESCRIPTION
## Summary

Closes #976.

`/land-pr` carries `user-invocable: false`. The slash runtime will not dispatch a `user-invocable: false` skill typed by a human in any useful way, but agents repeatedly recommend "run `/land-pr ...`" in final reports, sending users down a dead end.

Memory anchors don't propagate (they only fix the writing agent's future sessions). The right fix surfaces, per `feedback_propagate_to_skill_or_template`, are CLAUDE_TEMPLATE.md + skill prose + conformance gates.

## Fix — 3 propagating surfaces

1. **CLAUDE_TEMPLATE.md** — new "User-facing reports" subsection at the end of "## Git Rules": forbid recommending any `user-invocable: false` skill as a user-typeable next step; direct readers to `/commit pr` or one of the other 7 callers or `git push && gh pr create`. Generalized via the schema field (rule survives if more `user-invocable: false` skills are added later). Re-rendered into `.claude/rules/zskills/managed.md` so every consumer picks it up.

2. **skills/land-pr/SKILL.md** — new "## Reporting back to the user" section right after the overview, so the orchestrator (which has the skill body in context post-dispatch) has the reminder when composing the summary.

3. **tests/test-skill-conformance.sh** — schema-driven assertion that greps skill source for user-typed-recommendation patterns of any `user-invocable: false` skill. Catches source-file regressions. Verb set narrowed to `(type|re-run)` after the broader `(type|run|re-run|invoke|dispatch)` first cut false-positived on 12 legitimate prose lines (prohibitions like "do not invoke /land-pr yourself" and programmatic "will re-invoke /land-pr automatically").

## Files

- `CLAUDE_TEMPLATE.md` (+4)
- `.claude/rules/zskills/managed.md` (+4) — re-rendered from template (idempotent)
- `skills/land-pr/SKILL.md` (+6/-1) — new section + version bump → `2026.06.01+979c6f`
- `.claude/skills/land-pr/SKILL.md` (+6/-1) — mirror
- `tests/test-skill-conformance.sh` (+38) — #976 assertion

## Test plan

- [x] `bash tests/test-skill-conformance.sh` — exit 0, 759/759 passed; new "#976: no user-typed-recommendation of /land-pr" assertion PASS
- [x] `bash tests/run-all.sh` — 7159/7159 passed, 0 failed
- [x] managed.md re-render parity verified (idempotent: `python3 scripts/render-managed-rules.py` produces byte-identical output)
- [x] Mirror parity verified (`diff skills/land-pr/SKILL.md .claude/skills/land-pr/SKILL.md` empty)
- [x] Version bump verified (recomputed hash matches `979c6f`)
- [x] Sensitivity-of-conformance verified: a synthetic `type \`/land-pr --branch=foo\`` line is caught by the regex
- [x] Scope re-verified `HEAD~1..HEAD` — 5 files exactly, no extraneous edits
