### PR TITLE
do: Ship-to-Prod publishes complete plugin tree + ref->main fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   "description": "Z Skills — agent-discipline skill framework",
   "version": "1",
   "plugins": [
-    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "prod/main" } },
+    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "main" } },
     { "name": "zsbd", "source": "./block-diagram" }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026.06.0
 
-### Added — Plugin distribution lane (marketplace + prod/2026.06.0)
+### Added — Plugin distribution lane (marketplace + 2026.06.0)
 
 zskills is now distributed via **two permanent, first-class install lanes**
 (a consumer picks exactly one):
@@ -11,9 +11,9 @@ zskills is now distributed via **two permanent, first-class install lanes**
   `/plugin marketplace add zeveck/zskills && /plugin install zs@zskills`
   reads `.claude-plugin/marketplace.json` (the `zskills` marketplace listing
   the `zs` plugin + the `zsbd` block-diagram addon) and resolves the plugin
-  tree from the prod repo's `prod/main` ref (pin a release via the
-  `prod/<version>` tag, e.g. `prod/2026.06.0`). Skills surface under the
-  `/zs:` slash prefix.
+  tree from the prod repo's `main` branch (pin a release via the bare
+  `<version>` tag, e.g. `2026.06.0`). Skills surface under the `/zs:` slash
+  prefix.
 - **`/update-zskills` lane** — the existing legacy mirror installer
   (`.claude/skills/` mirror + hooks + rendered `managed.md`).
 
@@ -31,15 +31,28 @@ Plugin-lane machinery shipped this release:
   tool (`--to-plugin` / `--to-update-zskills`); dual-install is a tolerated
   transient, not a supported end-state, and this is the consolidation entry
   point.
-- **Ref-consistency fix** — `scripts/build-plugin-release.sh --push` now
-  pushes to `prod/main` (branch) + `prod/<version>` (tag), matching what
-  `marketplace.json` and `docs/guides/PLUGIN_INSTALL.md` resolve (previously
-  it pushed to bare `main` / `<version>`, which left the plugin lane
-  unresolvable on first install). Guarded by a new
-  `tests/test-plugin-ref-consistency.sh` (fail-closed against regression).
-  The plugin builder also now rewrites dev→prod URLs
-  (`zeveck.github.io/zskills-dev` → `zskills.synapticnoise.com`) in the
-  staged README, mirroring `build-prod.sh`.
+- **Single-publish, complete-plugin model** — there is ONE publish path: the
+  **🚀 Ship to Prod** button (`ship-to-prod.yml` → `scripts/build-prod.sh`),
+  which pushes one complete, plugin-installable tree to the prod repo's `main`
+  branch + a bare `<version>` tag. `build-prod.sh` is now plugin-COMPLETE: it
+  keeps the plugin manifests AND, via the shared
+  `scripts/_lib/finalize-prod-tree.sh` finalizer, generates the D4 suffixless
+  hook siblings (`block-agents.sh`, `block-unsafe-project.sh` — without them
+  the plugin's `hooks.json` registered two safety hooks whose scripts didn't
+  exist, so they silently never fired) and strips the same dev-only set as the
+  local builder (`build-*.sh`, `hooks/canary*-bad.sh`, MW-EXAMPLE files). The
+  marketplace `zs` `source.ref` is `main` and the pin idiom is the bare
+  `<version>` tag — matching exactly what the button publishes (a prior cut
+  declared `prod/main` / `prod/<version>`, refs that never existed on prod, so
+  the first `/plugin install` could not resolve). `scripts/build-plugin-release.sh`
+  is now documented as a local dogfood/test-fixture builder (NOT the publish
+  path) and shares the finalizer with `build-prod.sh` so the two can't
+  diverge. Guarded by `tests/test-plugin-ref-consistency.sh` (marketplace ref
+  ↔ workflow push branch ↔ docs pin idiom) and `tests/test-plugin-d4-hook-siblings.sh`
+  (build-prod.sh's tree contains the D4 siblings), both fail-closed against
+  regression. The builders also rewrite dev→prod URLs
+  (`zeveck.github.io/zskills-dev` → `zskills.synapticnoise.com`) in the staged
+  README.
 
 ### Changed — paths defaults
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -98,13 +98,23 @@ lanes installed at once in a consumer repo: each plugin-registered hook
 defers to a settings.json-registered copy of the same hook (basename match,
 with a `# zskills-hook-version:` skew guard) so hooks never double-fire.
 
-## Dual-path release flow (plugin lane + legacy lane)
+## Release flow — ONE publish serves BOTH lanes
 
-A release ships BOTH lanes from the same dev commit. The legacy lane is
-served by the existing **🚀 Ship to Prod** workflow (`scripts/build-prod.sh`
-→ `prod/main` + `YYYY.MM.N` tag). The plugin lane is served by
-`scripts/build-plugin-release.sh`, which produces the prod-stripped plugin
-tree and a parallel `prod/<version>` tag. Release steps:
+There is a SINGLE publish path: the **🚀 Ship to Prod** button
+(`.github/workflows/ship-to-prod.yml` → `scripts/build-prod.sh`). It strips
+dev-only artifacts from the current dev HEAD and pushes ONE complete,
+plugin-installable tree to the prod repo's **`main` branch** plus a bare
+**`YYYY.MM.N` tag**. That single published tree serves BOTH the legacy
+`/update-zskills` lane (which mirrors `skills/` + hooks) AND the plugin lane
+(`build-prod.sh` keeps the plugin manifests AND generates the D4 suffixless
+hook siblings, so `/plugin install zs@zskills` gets a complete plugin).
+
+`scripts/build-plugin-release.sh` is **NOT the publish path** — it is a local
+dogfood / prod-tree builder (and the source of the D4/strip test fixtures). It
+shares the plugin-completion logic with `build-prod.sh` via
+`scripts/_lib/finalize-prod-tree.sh`, so the two builders cannot diverge.
+
+Release steps:
 
 1. **Bump BOTH `plugin.json.version` files in lockstep** (D10):
    `.claude-plugin/plugin.json` (the `zs` plugin) and
@@ -112,64 +122,42 @@ tree and a parallel `prod/<version>` tag. Release steps:
    stay equal — `tests/test-plugin-marketplace.sh` asserts
    `zs.version == zsbd.version`. Choose the next `YYYY.MM.N` value (same
    scheme as the git tag). Commit the bump on dev.
-2. **Run `bash scripts/build-plugin-release.sh`** (no `--push`) to dry-build
-   the prod-stripped plugin tree as LOCAL `prod/main` + `prod/<version>`
-   refs. It strips canary plans/hooks, `RELEASING.md`, `build-*.sh`,
-   `dev_only:` skills, and MW-EXAMPLE files; copies `CLAUDE_TEMPLATE.md`
-   into the plugin tree (D3, the fallback the SessionStart materialiser
-   renders `managed.md` from); and generates the suffixless sibling copies
-   of the `.template` hooks (D4). Verify the strip set:
-   `git ls-tree -r refs/heads/prod/main | grep -E 'CANARY|RELEASING|dev_only|build-.*\.sh|MW-EXAMPLE'`
-   must return 0 hits. Clean up the local refs after inspecting
-   (`git update-ref -d refs/heads/prod/main` +
-   `git update-ref -d refs/tags/prod/<version>`).
-3. **Push BOTH refs** — the moving window pointer AND the pinned tag. The
-   plugin builder pushes when invoked with `--push`
-   (`build-plugin-release.sh --version <version> --push`): it pushes
-   `prod/main` (the moving `prod/main` ref unpinned consumers track) and the
-   parallel `prod/<version>` tag (which reproducibility-minded consumers pin
-   via marketplace `source.ref` / `source.sha`). The actual push is a
-   deliberate, human-gated step — the build/dry-run never pushes.
-4. **Notify both lanes' consumers.** Plugin-lane consumers refresh via
-   `claude plugin marketplace update zskills` (or auto-update if enabled);
-   legacy-lane consumers run `/update-zskills` (smart-detect pulls the new
+2. **(Optional) Dry-build / inspect locally.** Two ways:
+   - **Workflow dry-run:** click Run workflow with **Dry run** checked — it
+     builds the prod tree and shows the file diff in the run summary, pushing
+     nothing.
+   - **Local builder:** `bash scripts/build-plugin-release.sh` (no `--push`)
+     materialises a LOCAL `prod/main` + `prod/<version>` staging ref you can
+     inspect with `git ls-tree -r refs/heads/prod/main`. Verify the strip set
+     returns 0 hits:
+     `git ls-tree -r refs/heads/prod/main | grep -E 'CANARY|RELEASING|DEV-QUAL|dev_only|build-.*\.sh|MW-EXAMPLE'`.
+     Clean up after (`git update-ref -d refs/heads/prod/main` +
+     `git update-ref -d refs/tags/prod/<version>`). NOTE: those `prod/...`
+     ref names are this builder's LOCAL staging namespace; on `--push` it
+     pushes them to prod's BARE `main` + bare `<version>` — exactly what the
+     button publishes.
+3. **Publish via the button.** Click **🚀 Ship to Prod** (Dry run unchecked).
+   The workflow gates on the full test suite, computes the next `YYYY.MM.N`
+   tag, runs `build-prod.sh`, and pushes the stripped tree to prod's `main`
+   branch + the bare tag (prod-first, so dev stays clean on any failure).
+4. **Notify consumers.** Plugin-lane consumers refresh via
+   `/plugin marketplace update` (or auto-update if enabled); legacy-lane
+   consumers run `/update-zskills install` (smart-detect pulls the new
    skills/hooks and re-renders `managed.md`). The CHANGELOG entry is the
    per-line summary for both.
 
-The two builders are independent: `build-prod.sh` serves the legacy mirror
-and `build-plugin-release.sh` serves the plugin tree, but both strip from
-the same dev HEAD and both target `prod/main`. A release runs whichever the
-maintainer chooses; for a full dual-path release, run both and push both.
+### Cross-lane invariant
 
-### Default-branch / cross-lane invariant (verify before first publish)
-
-For `/plugin marketplace add zeveck/zskills` **without an explicit ref** to
-resolve the release manifest, the prod repo's **default branch must be
-`prod/main`** — that is where the built plugin tree + `marketplace.json`
-live. `/plugin marketplace add zeveck/zskills` reads the manifest from the
-default branch, so if the prod repo's default branch is still `main` (or
-anything other than `prod/main`), the unpinned `add` will not find
-`marketplace.json`. **Verify this repo setting on `github.com/zeveck/zskills`
-before the first publish** (Settings → General → Default branch → `prod/main`).
-This is consistent with `marketplace.json`'s `zs` `source.ref: prod/main`
-and the `prod/<version>` pin idiom (`docs/guides/PLUGIN_INSTALL.md`); the
-build now pushes to `prod/main` + `prod/<version>` (NOT bare `main` /
-`<version>`), guarded by `tests/test-plugin-ref-consistency.sh`.
-
-> **PUBLISH-MODEL TODO (human): reconcile legacy vs plugin push targets on
-> `prod/main`.** Both lanes target `prod/main` from the same dev HEAD:
-> step 7 of the legacy **🚀 Ship to Prod** workflow pushes the *legacy
-> mirror* stripped commit to `prod/main`, while `build-plugin-release.sh
-> --push` pushes the *plugin* tree commit to `prod/main`. These are two
-> different trees pushed to the SAME branch — running both for one release
-> would have one overwrite the other (last-push-wins), and the plugin-lane
-> `/plugin marketplace add` resolution requires the PLUGIN tree on the
-> default branch. Decide the publish model before the first dual-path
-> publish: e.g. (a) the plugin tree owns `prod/main` and the legacy mirror
-> ships to a separate ref/repo, or (b) a single unified tree serves both
-> lanes. Do NOT assume "run both and push both" (above) is conflict-free —
-> it currently is not. This note is a flag for human resolution, not a
-> decision made here.
+For `/plugin marketplace add zeveck/zskills` **without an explicit ref**,
+Claude Code reads `marketplace.json` from the prod repo's **default branch,
+`main`** — which is exactly where the button publishes. No special default-
+branch setting is needed: prod's default branch is `main` (correct), the
+button pushes to `main`, and `marketplace.json`'s `zs` `source.ref` is `main`.
+The pin-by-version idiom is the bare `<version>` tag the button pushes (e.g.
+`2026.06.0`, NOT `prod/2026.06.0`). `tests/test-plugin-ref-consistency.sh`
+guards this consistency (marketplace ref ↔ workflow push branch ↔ docs pin
+idiom); `tests/test-plugin-d4-hook-siblings.sh` guards that `build-prod.sh`'s
+published tree actually contains the D4 hook siblings.
 
 ## TL;DR
 
@@ -212,12 +200,14 @@ On dispatch, it:
    `.0`, second is `.1`, etc.).
 5. Runs `scripts/build-prod.sh` to strip dev-only artifacts from the working
    tree (see that file's header for the full list of transforms).
-6. Writes the stripped tree as a new commit with `prod/main` as its parent,
-   so prod ends up with a linear history of release snapshots.
-7. **Prod-first push:** pushes the stripped commit to `prod/main`, then the
-   matching tag to prod. Only **after** prod succeeds does dev get tagged
-   and a GitHub Release created. Any failure before this point leaves dev
-   untouched — no orphan tags, no partial state.
+6. Writes the stripped tree as a new commit whose parent is prod's current
+   `main` (fetched as the `prod/main` remote-tracking ref), so prod ends up
+   with a linear history of release snapshots.
+7. **Prod-first push:** pushes the stripped commit to prod's BARE `main`
+   branch (`refs/heads/main`), then the matching bare `<version>` tag
+   (`refs/tags/${TAG}`) to prod. Only **after** prod succeeds does dev get
+   tagged and a GitHub Release created. Any failure before this point leaves
+   dev untouched — no orphan tags, no partial state.
 
 ## Who can release
 
@@ -249,12 +239,13 @@ Run the workflow in dry-run mode after any build-prod.sh change.
 
 ## Recovering from a bad release
 
-Because prod's main is always built on top of the previous prod/main (not
-force-pushed), a bad release leaves a bad commit at HEAD. To recover:
+Because prod's `main` is always built on top of the previous prod `main`
+commit (not force-pushed), a bad release leaves a bad commit at HEAD. To
+recover:
 
-- Simplest: ship a new release with the fix. Prod's main advances forward.
+- Simplest: ship a new release with the fix. Prod's `main` advances forward.
 - If the bad release must be expunged entirely, you'll need to force-push
-  prod/main manually (locally, authenticated as a prod collaborator) and
+  prod's `main` manually (locally, authenticated as a prod collaborator) and
   delete the bad tag from both repos. The workflow intentionally does not
   automate this — expunging history should be rare and deliberate.
 

--- a/docs/guides/PLUGIN_INSTALL.md
+++ b/docs/guides/PLUGIN_INSTALL.md
@@ -142,23 +142,23 @@ not a constraint.
 
 ## Pin-by-version idiom
 
-Each release pushes **both** a moving `prod/main` ref and a parallel
-`prod/<version>` tag (e.g. `prod/2026.06.0`). Unpinned consumers track the
-moving `prod/main` window; consumers who want reproducibility pin to a
-specific version.
+Each release publishes to the prod repo's **`main` branch** and a parallel
+**bare `<version>` tag** (e.g. `2026.06.0`). Unpinned consumers track the
+moving `main` window; consumers who want reproducibility pin to a specific
+version tag.
 
 The default marketplace entry tracks the moving window:
 
 ```json
-{ "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "prod/main" } }
+{ "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "main" } }
 ```
 
 To **pin to a specific release**, edit your marketplace's `zs` entry to either:
 
-- Override `source.ref` to the version tag:
+- Override `source.ref` to the bare version tag:
 
   ```json
-  { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "prod/2026.06.0" } }
+  { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "2026.06.0" } }
   ```
 
 - Or pin `source.sha` to the exact commit:
@@ -175,9 +175,12 @@ supported) on the relative-path entry. Pinning the `zs` entry's ref/sha
 therefore pins `zsbd` to the same snapshot.
 
 For how releases produce these refs, see
-[`RELEASING.md`](../RELEASING.md) (the dual-path release flow:
-`build-prod.sh` for the legacy mirror, `build-plugin-release.sh` for the
-plugin tree, both targeting `prod/main` plus a `prod/<version>` tag).
+[`RELEASING.md`](../RELEASING.md). The "🚀 Ship to Prod" button
+(`ship-to-prod.yml` → `scripts/build-prod.sh`) is the SINGLE publish path: it
+strips dev-only artifacts and pushes one complete, plugin-installable tree to
+the prod repo's `main` branch plus a bare `<version>` tag. (The legacy
+`/update-zskills` lane and the plugin lane both resolve against that same
+published tree.)
 
 ## `.gitignore` guidance
 
@@ -216,12 +219,13 @@ resolves) and promoting a release to it are **human-gated publish actions**
 performed by maintainers — not part of consumer onboarding. The mechanics live
 in [`RELEASING.md`](../RELEASING.md):
 
-- The release pushes the prod-stripped plugin tree to `prod/main` plus a
-  `prod/<version>` tag via `scripts/build-plugin-release.sh --push` (a
-  deliberate, human-gated step — the dry build never pushes).
+- The release pushes the prod-stripped, plugin-installable tree to the prod
+  repo's `main` branch plus a bare `<version>` tag via the "🚀 Ship to Prod"
+  button (`ship-to-prod.yml` → `scripts/build-prod.sh`) — a deliberate,
+  human-gated step (the dry-run never pushes).
 - The `.claude-plugin/marketplace.json` manifest at the repo root is what
   `/plugin marketplace add zeveck/zskills` reads; its `zs` entry's
-  `source.ref` (default `prod/main`) determines which release consumers track.
+  `source.ref` (default `main`) determines which release consumers track.
 
 Consumers do not perform any activation step — they only run the install
 commands above.

--- a/scripts/_lib/finalize-prod-tree.sh
+++ b/scripts/_lib/finalize-prod-tree.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# scripts/_lib/finalize-prod-tree.sh
+#
+# Shared "plugin-completion" finalizer for the prod tree. BOTH publishers
+# call this so they can NEVER diverge on what makes the prod tree a
+# COMPLETE, CORRECT plugin:
+#
+#   - scripts/build-prod.sh — the REAL publish path. The "🚀 Ship to Prod"
+#     button (.github/workflows/ship-to-prod.yml) runs build-prod.sh against
+#     a fresh dev checkout and pushes the result to prod `main` + a bare
+#     `<version>` tag. build-prod.sh operates IN-PLACE on the working tree.
+#   - scripts/build-plugin-release.sh — a LOCAL dogfood / prod-tree builder
+#     (and the source of the D4/strip test fixtures). NOT the publish path.
+#     It operates on a TEMP staging tree.
+#
+# Why a shared helper: the two builders drifted (build-prod.sh shipped an
+# INCOMPLETE plugin — no D4 suffixless hook siblings, plus dev-only cruft —
+# while build-plugin-release.sh was complete). That drift is the root cause
+# of the "dogfood-mask" that shipped non-functional plugin lanes. Factoring
+# the completion logic here makes divergence structurally impossible.
+#
+# What it does to the given tree:
+#   1. D4 — generate suffixless sibling copies of every hooks/*.sh.template,
+#      byte-equal to its .template. The plugin's hooks/hooks.json registers
+#      the suffixless safety hooks (block-agents.sh, block-unsafe-project.sh);
+#      without these siblings those hooks silently never fire for every
+#      plugin consumer. (tests/test-hook-template-sibling.sh gates byte-
+#      equality; tests/test-plugin-d4-hook-siblings.sh gates presence in the
+#      BUILT tree.)
+#   2. Shared dev-only strip set — files that must NOT ship to consumers:
+#      - scripts/build-*.sh   (release/dogfood tooling)
+#      - hooks/canary*-bad.sh (deliberately-broken regression fixtures)
+#      - any file containing the MW-EXAMPLE marker (dev-only worked examples)
+#
+# Usage:
+#   finalize_prod_tree <tree-dir> [<self-script-to-preserve>]
+#
+#   <tree-dir>                The root of the prod tree to finalize.
+#   <self-script-to-preserve> OPTIONAL absolute path of the currently-running
+#                             build script. When build-prod.sh finalizes the
+#                             working tree IN-PLACE, the build-*.sh strip would
+#                             otherwise delete the very script that is running;
+#                             passing its path here preserves it from the strip
+#                             (the ship-to-prod workflow's own `git add -A` does
+#                             not re-add it — see note below). Omit for staging-
+#                             tree builds (build-plugin-release.sh), where the
+#                             running script lives outside the tree.
+#
+# Note on build-prod.sh in-place self-preservation: build-prod.sh is run by
+# ship-to-prod.yml, which AFTER build-prod.sh does its own `git add -A` +
+# `git write-tree`. So whatever build-*.sh files remain on disk would be
+# committed. We therefore CANNOT leave build-prod.sh on disk in the prod tree.
+# Instead build-prod.sh passes its own path so we delete it LAST (after the
+# script has finished sourcing/reading this function), via a deferred unlink
+# the caller performs — see build-prod.sh. To keep this helper simple and
+# self-contained, when a self-path IS given we still delete it here; bash has
+# already fully parsed the calling script + this sourced function by the time
+# this runs, so removing the on-disk file is safe.
+
+# shellcheck disable=SC2317
+
+finalize_prod_tree() {
+  local tree="$1"
+  local self_script="${2:-}"
+
+  if [ -z "$tree" ] || [ ! -d "$tree" ]; then
+    echo "finalize_prod_tree: ERROR — tree dir missing or not a directory: '$tree'" >&2
+    return 1
+  fi
+
+  local _BOLD='\033[1m'; local _GREEN='\033[32m'; local _RESET='\033[0m'
+  _fpt_log()  { printf "${_BOLD}▸${_RESET} %s\n" "$1"; }
+  _fpt_done() { printf "${_GREEN}✓${_RESET} %s\n" "$1"; }
+
+  # ── 1. D4 — suffixless sibling copies of .template hooks ─────────────────
+  _fpt_log "D4: generating suffixless sibling copies of .template hooks"
+  shopt -s nullglob
+  local tmpl sibling
+  for tmpl in "$tree"/hooks/*.sh.template; do
+    sibling="${tmpl%.template}"
+    cp "$tmpl" "$sibling"
+    _fpt_done "D4: $(basename "$sibling") (byte-equal sibling of $(basename "$tmpl"))"
+  done
+  shopt -u nullglob
+
+  # ── 2. Shared dev-only strip set ─────────────────────────────────────────
+  # build-*.sh release/dogfood tooling. Deleted from <tree>/scripts/ only.
+  _fpt_log "stripping build-*.sh release tooling from $tree/scripts/"
+  find "$tree/scripts" -maxdepth 1 -type f -name 'build-*.sh' -print -delete 2>/dev/null || true
+
+  # canary*-bad.sh deliberately-broken regression fixtures.
+  _fpt_log "stripping hooks/canary*-bad.sh fixtures from $tree/hooks/"
+  find "$tree/hooks" -maxdepth 1 -type f -name 'canary*-bad.sh' -print -delete 2>/dev/null || true
+
+  # MW-EXAMPLE-marked files (dev-only worked examples). Matched by FILENAME
+  # (the documented `MW-EXAMPLE__<name>` tombstone convention, F-R1-13), NOT
+  # by content — a content grep would over-match every prose file that merely
+  # NAMES the marker (RELEASING.md, this helper, the build scripts, CHANGELOG,
+  # the strip-verification grep itself) and wrongly delete files that must
+  # ship (e.g. CHANGELOG.md). Filename matching is also exactly what the
+  # strip-verification grep checks (it greps the ls-tree PATH list).
+  _fpt_log "stripping MW-EXAMPLE*-named files from $tree"
+  find "$tree" -type f -name 'MW-EXAMPLE*' -print -delete 2>/dev/null || true
+
+  # If the caller is build-prod.sh finalizing IN-PLACE, its own running
+  # script matched the build-*.sh strip above and is already gone. The
+  # self_script arg is accepted for clarity / future-proofing but needs no
+  # extra handling — bash has fully read the script by now, so its on-disk
+  # removal is safe.
+  if [ -n "$self_script" ] && [ -f "$self_script" ]; then
+    rm -fv "$self_script" || true
+  fi
+
+  return 0
+}

--- a/scripts/build-plugin-release.sh
+++ b/scripts/build-plugin-release.sh
@@ -1,8 +1,25 @@
 #!/usr/bin/env bash
-# build-plugin-release.sh — W5.5 (D1/D3/D4). Build the prod-stripped plugin
-# release tree from the current dev HEAD and materialise it as a LOCAL
-# `prod/main` branch + a parallel `prod/<version>` tag. Push is GATED behind
-# an explicit `--push` flag (NOT passed during plan runs / dry runs).
+# build-plugin-release.sh — NOT the publish path.
+#
+# THE publish path is the "🚀 Ship to Prod" button
+# (.github/workflows/ship-to-prod.yml → scripts/build-prod.sh), which pushes
+# a single complete prod tree to prod `main` + a bare `<version>` tag. THIS
+# script is for LOCAL dogfood / prod-tree builds and for producing the
+# D4/strip test fixtures (tests/test-plugin-d4-hook-siblings.sh,
+# tests/test-plugin-mirrorless-resolution.sh exercise the same strip set).
+#
+# It shares the plugin-completion logic (D4 hook siblings + the dev-only
+# strip set) with build-prod.sh via scripts/_lib/finalize-prod-tree.sh, so
+# the two builders can never diverge on what makes the prod tree a complete
+# plugin.
+#
+# W5.5 (D1/D3/D4). Builds the prod-stripped plugin release tree from the
+# current dev HEAD and materialises it as a LOCAL `prod/main` branch + a
+# parallel `prod/<version>` tag. On `--push` it pushes those dev-local refs
+# to prod's BARE `main` branch + a BARE `<version>` tag — EXACTLY the refs
+# the "Ship to Prod" button publishes, so a local dogfood build resolves
+# identically to a real release. Push is GATED behind an explicit `--push`
+# flag (NOT passed during plan runs / dry runs).
 #
 # Modelled on scripts/build-prod.sh, with these differences:
 #   - Builds into a TEMP staging tree (git archive | tar -x), never the dev
@@ -51,6 +68,11 @@ cd "$PROJECT_ROOT"
 
 PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
 [ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+# Shared prod-tree finalizer (D4 hook siblings + dev-only strip set). The
+# SAME helper is sourced by build-prod.sh (the real publisher), so the two
+# builders cannot diverge on what makes the prod tree a complete plugin.
+source "$SCRIPT_DIR/_lib/finalize-prod-tree.sh"
 
 BOLD='\033[1m'; GREEN='\033[32m'; YELLOW='\033[33m'; DIM='\033[2m'; RESET='\033[0m'
 log()  { printf "${BOLD}▸${RESET} %s\n" "$1"; }
@@ -132,20 +154,14 @@ done
 # matches `CANARY` anywhere in the path) sees 0 survivors. The
 # canary*-bad.sh hooks use a lowercase `canary` basename, so they get an
 # explicit pass below.
-log "removing CANARY* plans / fixtures and canary*-bad hooks"
+log "removing CANARY* plans / fixtures"
 find "$STAGE" -type f -name '*CANARY*' -print -delete || true
-# Canary hooks (hooks/canary*-bad.sh — deliberately-broken regression
-# fixtures; lowercase basename, not matched by the *CANARY* glob above).
-find "$STAGE/hooks" -maxdepth 1 -type f -name 'canary*-bad.sh' -print -delete 2>/dev/null || true
+# NOTE: hooks/canary*-bad.sh (lowercase basename), build-*.sh release
+# tooling, and MW-EXAMPLE files are stripped by the SHARED finalizer
+# (finalize_prod_tree, step 8 below) so this builder and build-prod.sh
+# strip the IDENTICAL dev-only set.
 
-# ── 4. Remove build-*.sh release tooling (SELF-DELETION-SAFE) ───────────────
-# This strips build-*.sh from the STAGING tree only. The running script lives
-# in $SCRIPT_DIR (the dev scripts/ dir), which is NOT under $STAGE — so this
-# can never delete the script that is currently executing.
-log "removing build-*.sh release tooling from staging scripts/"
-find "$STAGE/scripts" -maxdepth 1 -type f -name 'build-*.sh' -print -delete 2>/dev/null || true
-
-# ── 5. Remove dev_only skills (+ mirrors) and MW-EXAMPLE files ─────────────
+# ── 4. Remove dev_only skills (+ mirrors) ──────────────────────────────────
 log "scanning for dev_only skills"
 dev_only_count=0
 for skill_file in "$STAGE"/skills/*/SKILL.md "$STAGE"/block-diagram/*/SKILL.md; do
@@ -166,15 +182,7 @@ for skill_file in "$STAGE"/skills/*/SKILL.md "$STAGE"/block-diagram/*/SKILL.md; 
 done
 [ "$dev_only_count" -eq 0 ] && printf "  ${DIM}(no dev_only: true skills)${RESET}\n"
 
-log "removing MW-EXAMPLE-marked files"
-mw_count=0
-while IFS= read -r mwfile; do
-  [ -n "$mwfile" ] || continue
-  rm -f "$mwfile" && mw_count=$((mw_count + 1))
-done < <(grep -rl 'MW-EXAMPLE' "$STAGE" 2>/dev/null || true)
-[ "$mw_count" -eq 0 ] && printf "  ${DIM}(no MW-EXAMPLE files)${RESET}\n"
-
-# ── 6. Version-bump-before-branch (D1/D10) ─────────────────────────────────
+# ── 5. Version-bump-before-branch (D1/D10) ─────────────────────────────────
 # Set BOTH plugin.json versions in the staging tree to $VERSION before the
 # prod commit is built, so marketplace version-resolution sees the bumped
 # value (never the commit-SHA fallback, research §11).
@@ -209,15 +217,13 @@ else
   warn "D3: repo-root CLAUDE_TEMPLATE.md not found — skipping copy"
 fi
 
-# ── 8. D4 — generate suffixless sibling copies of .template hooks ──────────
-log "D4: generating suffixless sibling copies of .template hooks"
-shopt -s nullglob
-for tmpl in "$PLUGIN_TREE"/hooks/*.sh.template; do
-  sibling="${tmpl%.template}"
-  cp "$tmpl" "$sibling"
-  done_ "D4: $(basename "$sibling") (byte-equal sibling of $(basename "$tmpl"))"
-done
-shopt -u nullglob
+# ── 8. Shared plugin-completion + dev-only strip set ───────────────────────
+# Generate the D4 suffixless hook siblings (block-agents.sh,
+# block-unsafe-project.sh) and strip the shared dev-only set (build-*.sh,
+# hooks/canary*-bad.sh, MW-EXAMPLE files). The SAME helper runs in
+# build-prod.sh, so the two builders cannot diverge. Operates on the STAGING
+# tree ($PLUGIN_TREE == $STAGE), never the dev working tree.
+finalize_prod_tree "$PLUGIN_TREE"
 
 # ── 9. Build the prod commit + LOCAL prod/main + prod/<version> tag ────────
 # Use a TEMPORARY git index so the dev working tree / index is never touched.
@@ -255,15 +261,17 @@ done_ "strip verification: 0 forbidden paths in prod/main"
 
 # ── 11. Push (GATED behind --push) ─────────────────────────────────────────
 if [ "$DO_PUSH" -eq 1 ]; then
-  log "pushing prod/main + prod/$VERSION to the prod remote"
-  # Push to the SAME refs everything else resolves: marketplace.json's `zs`
-  # source.ref is `prod/main`, and the pin-by-version idiom (docs/guides/
-  # PLUGIN_INSTALL.md) is `prod/<version>`. The dest refs MUST be `prod/main`
-  # (branch) and `prod/$VERSION` (tag), NOT bare `main` / `$VERSION` — pushing
-  # to bare refs would leave the marketplace/docs references unresolvable.
+  log "pushing prod main + $VERSION tag to the prod remote"
+  # Push the dev-LOCAL prod/main + prod/<version> refs to prod's BARE `main`
+  # branch + a BARE `<version>` tag — EXACTLY what the "Ship to Prod" button
+  # (ship-to-prod.yml → build-prod.sh) publishes. The dev-local ref names
+  # (refs/heads/prod/main, refs/tags/prod/$VERSION) are just this builder's
+  # staging namespace; the DEST refs on prod are bare so they match the
+  # publisher and so marketplace.json's `zs` source.ref (`main`) + the
+  # bare-`<version>` pin idiom (docs/guides/PLUGIN_INSTALL.md) resolve.
   # (tests/test-plugin-ref-consistency.sh guards this consistency.)
-  git push prod "refs/heads/prod/main:refs/heads/prod/main"
-  git push prod "refs/tags/prod/$VERSION:refs/tags/prod/$VERSION"
+  git push prod "refs/heads/prod/main:refs/heads/main"
+  git push prod "refs/tags/prod/$VERSION:refs/tags/$VERSION"
   done_ "pushed to prod"
 else
   log "--push NOT passed: prod refs are LOCAL only (dry run). Nothing pushed."

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-# build-prod.sh — Strip dev-only artifacts from the working tree in
-# preparation for shipping to zskills-prod. Runs in CI against a fresh
-# zskills-dev checkout; modifies the working tree but does NOT commit.
-# The caller (the ship-to-prod workflow) is responsible for writing the
-# tree into prod afterwards.
+# build-prod.sh — THE prod publisher. The "🚀 Ship to Prod" button
+# (.github/workflows/ship-to-prod.yml) runs THIS script against a fresh
+# zskills-dev checkout, then pushes the resulting tree to prod `main` +
+# a bare `<version>` tag. This is the SINGLE publish path for BOTH the
+# legacy `/update-zskills` lane and the plugin lane — the published prod
+# tree is a complete, plugin-installable tree (it keeps the plugin
+# manifests AND, via the shared finalizer below, the D4 suffixless hook
+# siblings the plugin's hooks.json registers). It modifies the working
+# tree but does NOT commit; the workflow writes the tree into prod after.
+#
+# (scripts/build-plugin-release.sh is NOT the publish path — it is a local
+# dogfood / prod-tree builder and the source of the D4/strip test fixtures.)
 #
 # What it strips:
 #   1. `<!-- prod-strip:start --> … <!-- prod-strip:end -->` blocks from
@@ -16,9 +23,19 @@
 #   2. `plans/CANARY_*.md` and any top-level `CANARY_*.md` — canaries are
 #      regression guards for zskills-dev internals; prod consumers don't
 #      need them.
-#   3. Any skill directory whose `SKILL.md` front-matter contains
+#   3. RELEASING.md + DEV-QUAL.md — dev-maintainer-only.
+#   4. Any skill directory whose `SKILL.md` front-matter contains
 #      `dev_only: true` — skills we keep in dev but don't distribute.
 #      Strips both `skills/<name>/` and any mirrored `.claude/skills/<name>/`.
+#   5. The SHARED plugin-completion + dev-only strip set (via
+#      scripts/_lib/finalize-prod-tree.sh, also called by
+#      build-plugin-release.sh so the two builders can never diverge):
+#        - D4 suffixless hook siblings (block-agents.sh,
+#          block-unsafe-project.sh) GENERATED so the plugin's safety hooks
+#          actually exist for consumers;
+#        - build-*.sh release/dogfood tooling STRIPPED;
+#        - hooks/canary*-bad.sh fixtures STRIPPED;
+#        - MW-EXAMPLE-marked files STRIPPED.
 #
 # Running against an already-stripped tree should be a no-op (idempotent).
 # Intended to grow: add transforms here as the dev/prod split widens.
@@ -34,6 +51,11 @@ cd "$PROJECT_ROOT"
 # on missing project root.
 ZSKILLS_PATHS_ROOT="$PROJECT_ROOT"
 source "$PROJECT_ROOT/.claude/skills/update-zskills/scripts/zskills-paths.sh"
+
+# Shared prod-tree finalizer (D4 hook siblings + dev-only strip set). The
+# SAME helper is sourced by build-plugin-release.sh, so the two builders
+# cannot diverge on what makes the prod tree a complete plugin.
+source "$SCRIPT_DIR/_lib/finalize-prod-tree.sh"
 
 BOLD='\033[1m'
 GREEN='\033[32m'
@@ -126,5 +148,16 @@ done
 if [ "$dev_only_count" -eq 0 ]; then
   printf "  ${DIM}(no dev_only: true skills found)${RESET}\n"
 fi
+
+# ─── 4. Shared plugin-completion + dev-only strip set ──────────────────────
+# Generate the D4 suffixless hook siblings (so the plugin's safety hooks
+# actually exist for consumers) and strip the shared dev-only set
+# (build-*.sh, hooks/canary*-bad.sh, MW-EXAMPLE files). Operates IN-PLACE on
+# the working tree ($PROJECT_ROOT). NOTE: this deletes build-*.sh — INCLUDING
+# this running script — from the prod tree; that is intentional (release
+# tooling must not ship to consumers, and the ship-to-prod workflow's
+# `git add -A` would otherwise re-commit it). bash has already fully read
+# this script by now, so its on-disk removal mid-run is safe.
+finalize_prod_tree "$PROJECT_ROOT"
 
 done_ "prod tree built"

--- a/tests/test-plugin-d4-hook-siblings.sh
+++ b/tests/test-plugin-d4-hook-siblings.sh
@@ -1,34 +1,40 @@
 #!/usr/bin/env bash
 # tests/test-plugin-d4-hook-siblings.sh
 #
-# D4 existence gate — assert the BUILT plugin prod tree CONTAINS suffixless
-# sibling copies of every hooks/*.sh.template, byte-equal to its .template.
+# D4 existence gate — assert the REAL PUBLISHER's built prod tree CONTAINS
+# suffixless sibling copies of every hooks/*.sh.template, byte-equal to its
+# .template.
+#
+# THE publisher is the "🚀 Ship to Prod" button:
+#   .github/workflows/ship-to-prod.yml → scripts/build-prod.sh
+# build-prod.sh's shared finalizer (scripts/_lib/finalize-prod-tree.sh)
+# generates suffixless sibling copies of every hooks/*.sh.template in the
+# prod tree (today block-agents.sh and block-unsafe-project.sh — the two
+# safety hooks hooks/hooks.json registers on the plugin lane). Those siblings
+# are BUILD-ONLY: they do not exist in the source/dev tree (only the
+# .template forms are committed).
 #
 # Why this exists (complements tests/test-hook-template-sibling.sh):
-# build-plugin-release.sh step 8 (D4) generates suffixless sibling copies of
-# every hooks/*.sh.template in the staged plugin tree (today block-agents.sh
-# and block-unsafe-project.sh — the two safety hooks hooks/hooks.json
-# registers on the plugin lane). Those siblings are BUILD-ONLY: they do not
-# exist in the source/dev tree (only the .template forms are committed).
-#
-# The sibling test only asserts "IF a suffixless sibling exists in the SOURCE
+# the sibling test only asserts "IF a suffixless sibling exists in the SOURCE
 # tree it is byte-equal to the .template" — and since the siblings are absent
-# in source, it VACUOUS-PASSES. NOTHING there asserts the BUILT plugin tree
-# actually CONTAINS those hooks. A regression that removes/breaks the D4 loop
-# in build-plugin-release.sh would ship a plugin missing 2 safety hooks,
-# completely uncaught.
+# in source, it VACUOUS-PASSES. NOTHING there asserts the BUILT prod tree
+# actually CONTAINS those hooks. A regression that removes/breaks the D4 fold
+# in build-prod.sh would ship a plugin missing 2 safety hooks whose
+# hooks.json registrations silently never fire — completely uncaught.
 #
-# This test closes that hole by running the REAL build end-to-end and
-# inspecting its OUTPUT (the prod ref). It deliberately does NOT replicate the
-# D4 copy loop — deriving the siblings only from the build's output is the
-# whole point: breaking D4 in build-plugin-release.sh makes THIS test fail red.
+# This test closes that hole by running the REAL publisher (build-prod.sh)
+# end-to-end and inspecting its OUTPUT. It deliberately does NOT replicate
+# the D4 copy loop — deriving the siblings only from the build's output is the
+# whole point: breaking D4 in build-prod.sh (or its shared finalizer) makes
+# THIS test fail red.
 #
-# Isolation: build-plugin-release.sh writes refs/heads/prod/main AND
-# refs/tags/prod/<version> into the repo's .git via `git update-ref` even
-# without --push (step 9). Running it in the live repo would pollute it, so we
-# run it inside a throwaway local git CLONE; the EXIT trap removes the clone,
-# fully un-polluting (the prod refs live inside the clone's .git, not the live
-# repo).
+# Isolation: build-prod.sh modifies the working tree IN PLACE (it strips
+# dev-only artifacts and generates the D4 siblings on disk; it does NOT
+# commit). Running it in the live repo would mutate it, so we run it inside a
+# throwaway local git CLONE; the EXIT trap removes the clone. (#844 lesson:
+# the clone gets its own clone-scoped git identity even though build-prod.sh
+# does not commit — kept for parity with the other plugin-build tests and to
+# survive any future commit step.)
 
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -40,17 +46,13 @@ FAIL_COUNT=0
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
-echo "=== D4: built prod tree contains suffixless hook siblings ==="
+echo "=== D4: REAL publisher (build-prod.sh) prod tree contains suffixless hook siblings ==="
 
-# ── Isolated throwaway clone (refs from the build land in the clone's .git) ──
+# ── Isolated throwaway clone (build-prod.sh mutates its working tree) ────────
 TMP="$(mktemp -d)"
 CLONE="$TMP/clone"
 trap 'rm -rf "$TMP"' EXIT
 
-# Local-path clone — works on BOTH a full dev checkout AND a shallow CI
-# checkout (actions/checkout@v4 fetch-depth:1). The build only `git archive
-# HEAD`s the tree and creates a PARENTLESS prod/main when none pre-exists
-# (always the case in a fresh clone), so no history walk is needed.
 if ! git clone --quiet "$REPO_ROOT" "$CLONE"; then
   fail "0. git clone of \$REPO_ROOT failed"
   TOTAL=$((PASS_COUNT + FAIL_COUNT))
@@ -58,33 +60,19 @@ if ! git clone --quiet "$REPO_ROOT" "$CLONE"; then
   exit "$FAIL_COUNT"
 fi
 
-# A fresh `git clone` writes a new .git/config that does NOT inherit the source
-# repo's local user.name/user.email, and CI runners have no global identity, so
-# the clone has NO git author/committer. build-plugin-release.sh step 9
-# (commit-tree, which builds the prod commit) then fails with "empty ident name".
-# Give the throwaway clone a local identity so that step succeeds on CI.
+# Clone-scoped git identity (#844) — a fresh clone inherits no user.name/
+# user.email and CI runners have no global identity.
 git -C "$CLONE" config user.email "d4-gate-test@zskills.invalid"
 git -C "$CLONE" config user.name  "zskills D4 gate test"
 
-# ── Run the REAL build (no --push, default version) inside the clone ─────────
-BUILD_OUT="$TMP/build.out"
-if ( cd "$CLONE" && bash scripts/build-plugin-release.sh ) > "$BUILD_OUT" 2>&1; then
-  pass "0. build-plugin-release.sh ran in isolated clone (rc=0)"
-else
-  fail "0. build-plugin-release.sh FAILED in isolated clone — output below:"
-  sed 's/^/      /' "$BUILD_OUT"
-  TOTAL=$((PASS_COUNT + FAIL_COUNT))
-  printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
-  exit "$FAIL_COUNT"
-fi
-
-# ── Enumerate every .template hook in the clone's HEAD working tree ──────────
+# ── Enumerate every .template hook in the clone's SOURCE tree BEFORE build ──
+# (Capture before the build runs — build-prod.sh leaves the .template files in
+# place, but we read the canonical source list up front to derive expected
+# siblings independently of the build's chatter.)
 shopt -s nullglob
 TEMPLATES=( "$CLONE"/hooks/*.sh.template )
 shopt -u nullglob
 
-# Guard against the empty-glob silent pass — D4 names at least
-# block-agents.sh.template and block-unsafe-project.sh.template today.
 if [ "${#TEMPLATES[@]}" -eq 0 ]; then
   fail "1. no hooks/*.sh.template found in clone (expected at least block-agents.sh.template + block-unsafe-project.sh.template)"
   TOTAL=$((PASS_COUNT + FAIL_COUNT))
@@ -92,25 +80,33 @@ if [ "${#TEMPLATES[@]}" -eq 0 ]; then
   exit "$FAIL_COUNT"
 fi
 
-# ── For each template, assert the built prod tree has the byte-equal sibling ─
+# ── Run the REAL publisher (build-prod.sh) inside the clone ──────────────────
+BUILD_OUT="$TMP/build.out"
+if ( cd "$CLONE" && bash scripts/build-prod.sh ) > "$BUILD_OUT" 2>&1; then
+  pass "0. build-prod.sh ran in isolated clone (rc=0)"
+else
+  fail "0. build-prod.sh FAILED in isolated clone — output below:"
+  sed 's/^/      /' "$BUILD_OUT"
+  TOTAL=$((PASS_COUNT + FAIL_COUNT))
+  printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit "$FAIL_COUNT"
+fi
+
+# ── For each template, assert the BUILT prod tree (on disk) has the sibling ──
 for tmpl in "${TEMPLATES[@]}"; do
   bn="$(basename "$tmpl")"            # e.g. block-agents.sh.template
   sib="${bn%.template}"              # e.g. block-agents.sh
-  tmpl_path="hooks/$bn"
-  sib_path="hooks/$sib"
+  tmpl_path="$CLONE/hooks/$bn"
+  sib_path="$CLONE/hooks/$sib"
 
-  # presence: the suffixless sibling exists in the committed prod tree.
-  if git -C "$CLONE" ls-tree -r --name-only refs/heads/prod/main -- hooks/ \
-       | grep -qx "$sib_path"; then
-    # byte-equality: sibling == its .template in the prod tree.
-    if diff <(git -C "$CLONE" show "refs/heads/prod/main:$tmpl_path") \
-            <(git -C "$CLONE" show "refs/heads/prod/main:$sib_path") >/dev/null 2>&1; then
+  if [ -f "$sib_path" ]; then
+    if diff "$tmpl_path" "$sib_path" >/dev/null 2>&1; then
       pass "$sib: present in built prod tree and byte-equal to $bn"
     else
       fail "$sib: present in built prod tree but DIFFERS from $bn (D4 byte-equality broken)"
     fi
   else
-    fail "$sib: MISSING from built prod tree (D4 generation loop did not produce it)"
+    fail "$sib: MISSING from built prod tree (D4 generation in build-prod.sh did not produce it)"
   fi
 done
 

--- a/tests/test-plugin-marketplace.sh
+++ b/tests/test-plugin-marketplace.sh
@@ -75,7 +75,7 @@ zs_src = zs.get("source")
 ok_zs = (isinstance(zs_src, dict)
          and zs_src.get("source") == "github"
          and zs_src.get("repo") == "zeveck/zskills"
-         and zs_src.get("ref") == "prod/main")
+         and zs_src.get("ref") == "main")
 out(ok_zs, "marketplace: zs source is github {source,repo,ref}", repr(zs_src))
 
 # zsbd source — relative-path string (D1).

--- a/tests/test-plugin-ref-consistency.sh
+++ b/tests/test-plugin-ref-consistency.sh
@@ -1,20 +1,34 @@
 #!/bin/bash
 # tests/test-plugin-ref-consistency.sh
 #
-# Pre-launch guard (fail-closed). Statically asserts that the refs
-# scripts/build-plugin-release.sh PUSHES on `--push` are CONSISTENT with what
-# consumers RESOLVE:
+# Pre-launch guard (fail-closed). Statically asserts that the refs the REAL
+# publisher PUSHES are CONSISTENT with what consumers RESOLVE.
 #
-#   - .claude-plugin/marketplace.json's `zs` source.ref (the moving window
-#     unpinned consumers track) — must equal the BRANCH the build pushes.
-#   - docs/guides/PLUGIN_INSTALL.md's pin-by-version idiom (`prod/<version>`)
-#     — must match the TAG namespace the build pushes (with $VERSION).
+# THE publisher is the "🚀 Ship to Prod" button:
+#   .github/workflows/ship-to-prod.yml → scripts/build-prod.sh
+#   → push to prod's BARE `main` branch + a BARE `<version>` tag
+#     (ship-to-prod.yml: `git push prod "${PROD_SHA}:refs/heads/main"` and
+#      `git push prod "${PROD_SHA}:refs/tags/${TAG}"`).
 #
-# Why this exists: a prior cut of build-plugin-release.sh pushed to bare
-# `main` / bare `<version>` while marketplace.json declared `prod/main` and
-# the docs documented `prod/<version>`. Those refs never existed on prod →
-# the first `/plugin install zs@zskills` could not resolve the ref. This test
-# FAILS-RED if anyone reverts the build to push to bare refs.
+# Consumers resolve:
+#   - .claude-plugin/marketplace.json's `zs` source.ref — the moving window
+#     unpinned consumers track — must equal the BRANCH the button pushes
+#     (`main`).
+#   - docs/guides/PLUGIN_INSTALL.md's pin-by-version idiom must be a BARE
+#     `<version>` tag (e.g. `2026.06.0`), matching the TAG namespace the
+#     button pushes (`refs/tags/${TAG}`, bare — NOT `prod/<version>`).
+#
+# Why this exists: a prior cut declared `prod/main` / `prod/<version>` in the
+# marketplace + docs while the REAL publisher (the button) pushes bare `main`
+# / bare `<version>`. Those `prod/...` refs never existed on prod → the first
+# `/plugin install zs@zskills` could not resolve the ref. This test FAILS-RED
+# if marketplace.json drifts back to `prod/main` or the docs go back to
+# `prod/<version>`, or if the workflow stops pushing bare `main` / bare tag.
+#
+# (scripts/build-plugin-release.sh is NOT the publish path; it is a local
+# dogfood builder. It pushes to the SAME bare refs on --push, but the
+# CONSUMER-FACING guarantee is anchored to the workflow, which is what the
+# button actually runs.)
 #
 # Uses Python stdlib json (no jq — per `## Python is required`).
 
@@ -26,7 +40,7 @@ cd "$REPO_ROOT"
 PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
 [ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
 
-BUILD="scripts/build-plugin-release.sh"
+WF=".github/workflows/ship-to-prod.yml"
 MP=".claude-plugin/marketplace.json"
 DOC="docs/guides/PLUGIN_INSTALL.md"
 
@@ -35,10 +49,10 @@ FAIL_COUNT=0
 pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
-echo "=== plugin ref consistency (build push targets ↔ consumer resolution) ==="
+echo "=== plugin ref consistency (REAL publisher push targets ↔ consumer resolution) ==="
 
 # Pre-flight: the files we parse must exist.
-for f in "$BUILD" "$MP" "$DOC"; do
+for f in "$WF" "$MP" "$DOC"; do
   if [ ! -f "$f" ]; then
     fail "required file present: $f"
   else
@@ -46,28 +60,28 @@ for f in "$BUILD" "$MP" "$DOC"; do
   fi
 done
 
-# ── Parse the two `git push prod ...` refspec lines out of the build ────────
-# Heads refspec: `git push prod "refs/heads/<src>:refs/heads/<dest-branch>"`
-# Tags  refspec: `git push prod "refs/tags/<src>:refs/tags/<dest-tag>"`
-HEADS_LINE="$(grep -E 'git push prod .*refs/heads/' "$BUILD" | head -1)"
-TAGS_LINE="$(grep -E 'git push prod .*refs/tags/' "$BUILD" | head -1)"
+# ── Parse the two `git push prod ...` refspec lines out of the WORKFLOW ─────
+# Heads refspec: git push prod "${PROD_SHA}:refs/heads/main"
+# Tags  refspec: git push prod "${PROD_SHA}:refs/tags/${TAG}"
+HEADS_LINE="$(grep -E 'git push prod .*:refs/heads/' "$WF" | head -1)"
+TAGS_LINE="$(grep -E 'git push prod .*:refs/tags/' "$WF" | head -1)"
 
 if [ -n "$HEADS_LINE" ]; then
-  pass "build has a heads-refspec push line"
+  pass "workflow has a heads-refspec push line"
 else
-  fail "build has a heads-refspec push line"
+  fail "workflow has a heads-refspec push line"
 fi
 if [ -n "$TAGS_LINE" ]; then
-  pass "build has a tags-refspec push line"
+  pass "workflow has a tags-refspec push line"
 else
-  fail "build has a tags-refspec push line"
+  fail "workflow has a tags-refspec push line"
 fi
 
 # Extract the DEST of each refspec (the part after the colon).
 # Heads dest: refs/heads/<DEST_BRANCH>
-PUSHED_BRANCH="$(printf '%s\n' "$HEADS_LINE" | sed -nE 's@.*refs/heads/[^:]*:refs/heads/([^"]*)".*@\1@p')"
-# Tags dest: refs/tags/<DEST_TAG> (contains $VERSION)
-PUSHED_TAG_DEST="$(printf '%s\n' "$TAGS_LINE" | sed -nE 's@.*refs/tags/[^:]*:(refs/tags/[^"]*)".*@\1@p')"
+PUSHED_BRANCH="$(printf '%s\n' "$HEADS_LINE" | sed -nE 's@.*:refs/heads/([A-Za-z0-9._/-]+)".*@\1@p')"
+# Tags dest: refs/tags/<DEST_TAG> (the workflow uses ${TAG}, a BARE version).
+PUSHED_TAG_DEST="$(printf '%s\n' "$TAGS_LINE" | sed -nE 's@.*:(refs/tags/[^"]*)".*@\1@p')"
 
 # ── marketplace.json: zs source.ref (read via Python stdlib json) ──────────
 MP_REF="$("$PYTHON" - "$MP" <<'PY'
@@ -84,39 +98,51 @@ print(ref)
 PY
 )"
 
-# ── Assertion 1: pushed BRANCH == marketplace zs source.ref ────────────────
+# ── Assertion 1: workflow-pushed BRANCH == marketplace zs source.ref ───────
 if [ -n "$PUSHED_BRANCH" ] && [ "$PUSHED_BRANCH" = "$MP_REF" ]; then
-  pass "pushed branch '$PUSHED_BRANCH' == marketplace zs source.ref '$MP_REF'"
+  pass "workflow-pushed branch '$PUSHED_BRANCH' == marketplace zs source.ref '$MP_REF'"
 else
-  fail "pushed branch '$PUSHED_BRANCH' must equal marketplace zs source.ref '$MP_REF' (both should be 'prod/main')"
+  fail "workflow-pushed branch '$PUSHED_BRANCH' must equal marketplace zs source.ref '$MP_REF' (both should be 'main')"
 fi
 
-# Belt-and-braces: both should be the literal 'prod/main'.
-if [ "$MP_REF" = "prod/main" ]; then
-  pass "marketplace zs source.ref is 'prod/main'"
+# Belt-and-braces: both should be the bare literal 'main' (NOT 'prod/main').
+if [ "$MP_REF" = "main" ]; then
+  pass "marketplace zs source.ref is bare 'main' (not 'prod/main')"
 else
-  fail "marketplace zs source.ref is 'prod/main' (got '$MP_REF')"
+  fail "marketplace zs source.ref must be bare 'main' (got '$MP_REF')"
 fi
-if [ "$PUSHED_BRANCH" = "prod/main" ]; then
-  pass "build pushes to branch 'prod/main' (not bare 'main')"
+if [ "$PUSHED_BRANCH" = "main" ]; then
+  pass "workflow pushes to bare branch 'main' (not 'prod/main')"
 else
-  fail "build pushes to branch 'prod/main' (not bare 'main') — got '$PUSHED_BRANCH'"
-fi
-
-# ── Assertion 2: pushed TAG namespace matches the doc pin idiom ────────────
-# The build's tag dest should be refs/tags/prod/$VERSION (i.e. the prod/
-# namespace), matching the documented `prod/<version>` pin idiom.
-if [ "$PUSHED_TAG_DEST" = 'refs/tags/prod/$VERSION' ]; then
-  pass "build pushes tag to 'refs/tags/prod/\$VERSION' (prod/<version> namespace)"
-else
-  fail "build pushes tag to 'refs/tags/prod/\$VERSION' — got '$PUSHED_TAG_DEST' (must NOT be bare 'refs/tags/\$VERSION')"
+  fail "workflow pushes to bare branch 'main' (not 'prod/main') — got '$PUSHED_BRANCH'"
 fi
 
-# The docs must document the `prod/<version>` pin idiom.
+# ── Assertion 2: workflow tag dest is the BARE-version namespace ────────────
+# The workflow pushes refs/tags/${TAG} where ${TAG} is the bare YYYY.MM.N
+# version — NOT refs/tags/prod/<version>. Assert it is exactly the bare form.
+if [ "$PUSHED_TAG_DEST" = 'refs/tags/${TAG}' ]; then
+  pass "workflow pushes tag to bare 'refs/tags/\${TAG}' (bare-version namespace)"
+else
+  fail "workflow pushes tag to bare 'refs/tags/\${TAG}' — got '$PUSHED_TAG_DEST' (must NOT be 'refs/tags/prod/...')"
+fi
+
+# ── Assertion 3: docs pin idiom is a BARE version tag, NOT prod/<version> ───
+# The docs must document a BARE `<version>` pin (e.g. 2026.06.0), matching
+# what the button pushes, and must NOT document the obsolete `prod/<version>`.
+if grep -Eq 'ref"?:?[^"]*"?[0-9]{4}\.[0-9]{2}\.[0-9]+' "$DOC"; then
+  pass "docs document a bare '<version>' tag pin idiom (YYYY.MM.N)"
+else
+  fail "docs must document a bare '<version>' tag pin idiom (YYYY.MM.N) in PLUGIN_INSTALL.md"
+fi
 if grep -q 'prod/<version>' "$DOC"; then
-  pass "docs document the 'prod/<version>' pin idiom"
+  fail "docs must NOT document the obsolete 'prod/<version>' pin idiom (found in PLUGIN_INSTALL.md)"
 else
-  fail "docs document the 'prod/<version>' pin idiom (PLUGIN_INSTALL.md)"
+  pass "docs do NOT reference the obsolete 'prod/<version>' pin idiom"
+fi
+if grep -q '"ref": "prod/' "$DOC"; then
+  fail "docs must NOT show a 'prod/...' source.ref example (found in PLUGIN_INSTALL.md)"
+else
+  pass "docs do NOT show a 'prod/...' source.ref example"
 fi
 
 echo ""


### PR DESCRIPTION
Corrects the plugin-lane publish model (supersedes the wrong approach in #979). Verified empirically + by two independent agents (both APPROVE); both guard tests fail-red-proven.

## Root cause
The ONLY real publish path is the README "Ship to Prod" button → `ship-to-prod.yml` → `build-prod.sh`, which pushes ONE tree to prod **bare `main` + a bare `<version>` tag**. `build-plugin-release.sh` is wired to no workflow. Two real defects:
1. **Ref bug** — published `marketplace.json` said `ref: prod/main` (a ref the button never creates).
2. **D4 safety gap (BLOCKER)** — `build-prod.sh` did NOT generate the suffixless hook siblings, so `hooks.json` registered `block-agents.sh` + `block-unsafe-project.sh` while the tree shipped only their `.template` → **two safety hooks silently never fired for every plugin consumer.** It also shipped dev cruft (`build-*.sh`, `canary*-bad.sh`, MW-EXAMPLE).

(#979 had made the *unused* `build-plugin-release.sh` self-consistent with the wrong `prod/main` convention — a dogfood-mask one layer up. Corrected here.)

## Fix
- **`marketplace.json`** zs ref `prod/main` → `main`; **`PLUGIN_INSTALL.md`** pin idiom → bare `<version>`, default ref → `main`.
- **New shared helper `scripts/_lib/finalize-prod-tree.sh`** (D4 sibling generation + dev-only strip) called by BOTH `build-prod.sh` and `build-plugin-release.sh` — so the publish builder and the dogfood builder can't diverge again (the root cause of the mask). `build-prod.sh` now produces a COMPLETE plugin tree.
- **`build-plugin-release.sh`** refspecs reverted to `prod/main:main` + bare tag (matches the button); header notes it's a dogfood/local builder, not the publish.
- **Guards repointed at the REAL publisher:** `test-plugin-ref-consistency.sh` now asserts `ship-to-prod.yml`'s push (bare `main` + bare tag) ↔ marketplace `main` ↔ docs bare pin; `test-plugin-d4-hook-siblings.sh` now runs `build-prod.sh`.
- **`RELEASING.md`** corrected: single button publish to bare `main` + bare tag; deleted the wrong "set default branch to `prod/main`" instruction + the publish-model TODO.
- Fixed a latent over-match (MW-EXAMPLE content-grep → filename-match).

## Test plan
- [x] Empirical: `build-prod.sh`'s tree now has the D4 siblings (byte-equal), strips the dev cruft, marketplace ref = `main`; all 12 `hooks.json` registrations resolve to present files (verified by a reviewer).
- [x] `bash tests/run-all.sh` — 7171/7171 pass (ref-consistency 12/12, d4-siblings 3/3, marketplace 17/17, conformance 759/759, hooks 2371/2371).
- [x] Both guards fail-red-proven (marketplace→prod/main; docs→prod/<version>; workflow→prod/main; D4 fold removed).

Remaining (human, post-merge): click "Ship to Prod" to publish, then the DEV-QUAL post-publish install check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
