### PR TITLE
fix(#983): block javascript:/vbscript:/data:text/html schemes in doc viewer

### DIFF
--- a/docs/MarkdownRenderer.js
+++ b/docs/MarkdownRenderer.js
@@ -13,6 +13,25 @@ function stripUnsafeHtml(s) {
   return s
     .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
     .replace(/<\/?(?:iframe|object|embed)\b[^>]*>/gi, '')
+    // Scheme-strip from href= / src= attribute values. Neutralize
+    // javascript:/vbscript:/data:text/html (and HTML-entity-encoded variants
+    // that decode to those schemes at render time) by replacing the scheme
+    // with about:blank#blocked-scheme-<original>. Apply BEFORE on*= stripping
+    // so the on*= regex's quote handling isn't disturbed by our edit.
+    //
+    // Defense covers: javascript:, vbscript:, data:text/html (case-insensitive,
+    // leading whitespace tolerated). Also catches HTML-entity-encoded forms
+    // like &#x6A;avascript: by neutralizing any href=/src= attribute value
+    // starting with &# (HTML numeric entities have no legitimate use in URL
+    // schemes — real URLs use percent-encoding for non-ASCII). Issue #983.
+    .replace(
+      /(\s(?:href|src)\s*=\s*["']?)[\s]*(javascript|vbscript|data:text\/html)/gi,
+      '$1about:blank#blocked-scheme-$2'
+    )
+    .replace(
+      /(\s(?:href|src)\s*=\s*["']?)[\s]*&#/gi,
+      '$1about:blank#blocked-entity-encoded&#'
+    )
     .replace(/\s+on\w+\s*=\s*"[^"]*"/gi, '')
     .replace(/\s+on\w+\s*=\s*'[^']*'/gi, '')
     .replace(/\s+on\w+\s*=\s*[^\s>]+/gi, '')
@@ -270,9 +289,25 @@ export function escapeHtml(s) {
 
 function inlineMarkdown(s, baseUrl) {
   s = escapeHtml(s);
+  // Helper: reject dangerous URLs. Checks the raw and resolved forms because
+  // baseUrl prefixing can mask a `javascript:` scheme behind the prefix. #983.
+  function isDangerousUrl(raw, resolved) {
+    return (
+      /^\s*(javascript|vbscript|data:text\/html)/i.test(raw) ||
+      /^\s*(javascript|vbscript|data:text\/html)/i.test(resolved) ||
+      /^\s*&#/.test(raw) ||
+      /^\s*&#/.test(resolved) ||
+      /^\s*\/\//.test(raw) ||
+      /^\s*\/\//.test(resolved)
+    );
+  }
   // Images: ![alt](url) — resolve relative paths against baseUrl
   s = s.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt, src) => {
     const resolved = src.startsWith('http') || src.startsWith('/') ? src : normalizePath(baseUrl + src);
+    // Reject dangerous schemes/protocol-relative on image src — emit alt only. #983.
+    if (isDangerousUrl(src, resolved)) {
+      return alt;
+    }
     return `<img src="${resolved}" alt="${alt}" class="zl-whatsnew-img">`;
   });
   // Links: [text](url) — anchor links and .md links stay internal, others open in new tab
@@ -282,6 +317,10 @@ function inlineMarkdown(s, baseUrl) {
     }
     // Resolve relative paths against baseUrl (skip absolute URLs and root-relative paths)
     const resolved = href.startsWith('http') || href.startsWith('/') ? href : normalizePath(baseUrl + href);
+    // Reject dangerous schemes / entity-encoded / protocol-relative — emit text only. #983.
+    if (isDangerousUrl(href, resolved)) {
+      return text;
+    }
     // .md links are internal doc navigation — no target="_blank"
     if (resolved.endsWith('.md') || resolved.includes('.md#')) {
       return `<a href="${resolved}" class="zl-docs-internal-link">${text}</a>`;

--- a/tests/test-doc-viewer-renderer.sh
+++ b/tests/test-doc-viewer-renderer.sh
@@ -26,6 +26,12 @@
 #   T14  Security strip: <script>alert(1)</script> — both tokens absent
 #   T15  Security strip: <div onclick=alert(2)> — both tokens absent
 #   T16  Inline-HTML escaping: <kbd>X</kbd> mid-paragraph renders escaped
+#   T17  Security: raw <a href="javascript:..."> neutralized (#983)
+#   T18  Security: raw <img onerror=...> handler stripped (#983 supplement)
+#   T19  Security: markdown [x](javascript:...) drops link, keeps text (#983)
+#   T20  Security: markdown ![alt](data:text/html,...) drops image (#983)
+#   T21  Security: markdown [x](//evil.com) protocol-relative dropped (#983)
+#   T22  Security: HTML-entity-encoded scheme &#x6A;avascript: neutralized (#983)
 #
 # Run from repo root: bash tests/test-doc-viewer-renderer.sh
 
@@ -228,6 +234,99 @@ function check(name, cond, msg) {
   check('T16.inline-html-escaped',
     h.includes('&lt;kbd&gt;') && h.includes('&lt;/kbd&gt;'),
     'expected &lt;kbd&gt;...&lt;/kbd&gt; (escaped); got: ' + h);
+}
+
+// T17: Raw HTML <a href="javascript:..."> is neutralized (issue #983).
+// The href= scheme-strip should rewrite the scheme to about:blank#blocked-scheme-
+// so that no live `javascript:` URL reaches main.innerHTML.
+{
+  const h = renderMarkdown('<a href="javascript:alert(1)">x</a>');
+  // After scheme rewrite, the literal substring 'href="javascript' (a live
+  // scheme in attribute position) must be absent. The string 'javascript'
+  // may still appear inside the about:blank#blocked-scheme-javascript:...
+  // fragment but that is not interpreted as a URL scheme.
+  check('T17.raw-anchor-javascript-no-live-href',
+    !/href\s*=\s*["']?\s*javascript:/i.test(h),
+    'expected no live href=javascript:; got: ' + h);
+  check('T17.raw-anchor-javascript-neutralized',
+    /about:blank#blocked-scheme/.test(h),
+    'expected about:blank#blocked-scheme- replacement; got: ' + h);
+}
+
+// T18: Raw HTML <img src="x" onerror="alert(1)"> — onerror stripped.
+// Supplements T15 (which covers onclick) with onerror, a common image-XSS handler.
+{
+  const h = renderMarkdown('<img src="x" onerror="alert(1)">');
+  check('T18.raw-img-onerror-stripped',
+    !/onerror/i.test(h),
+    'expected no onerror in output; got: ' + h);
+  check('T18.raw-img-onerror-body-stripped',
+    !/alert\(1\)/.test(h),
+    'expected no alert(1) in output; got: ' + h);
+}
+
+// T19: Markdown [x](javascript:...) produces text only — no <a href.
+// Markdown link parser stops at the first ')' so the regex captures
+// `href = "javascript:alert(1"`; the scheme check on the raw href must still
+// fire and drop the link entirely.
+{
+  const h = renderMarkdown('[click](javascript:alert(1))');
+  check('T19.md-link-javascript-no-scheme',
+    !/javascript:/i.test(h),
+    'expected no live javascript: in output; got: ' + h);
+  check('T19.md-link-javascript-no-href',
+    !/<a\s+href/i.test(h),
+    'expected no <a href in output; got: ' + h);
+  check('T19.md-link-javascript-text-preserved',
+    /click/.test(h),
+    'expected bracket-text preserved; got: ' + h);
+}
+
+// T20: Markdown ![alt](data:text/html,...) produces alt-text only.
+// data:text/html, even on an <img>, is an XSS surface (browsers may render).
+{
+  const h = renderMarkdown('![alt-text](data:text/html,<script>alert(1)</script>)');
+  check('T20.md-image-data-text-html-no-scheme',
+    !/data:text\/html/i.test(h),
+    'expected no data:text/html in output; got: ' + h);
+  check('T20.md-image-data-text-html-no-script',
+    !/<script/i.test(h),
+    'expected no <script tag in output; got: ' + h);
+  check('T20.md-image-data-text-html-alt-preserved',
+    /alt-text/.test(h),
+    'expected alt-text preserved; got: ' + h);
+}
+
+// T21: Markdown [x](//evil.com) — protocol-relative is open-redirect surface.
+// Should be dropped to text-only.
+{
+  const h = renderMarkdown('[click](//evil.com)');
+  check('T21.md-link-protocol-relative-no-href',
+    !/href\s*=\s*["']?\/\/evil\.com/.test(h),
+    'expected no protocol-relative href; got: ' + h);
+  check('T21.md-link-protocol-relative-text-preserved',
+    /click/.test(h),
+    'expected bracket-text preserved; got: ' + h);
+}
+
+// T22: HTML-entity-encoded scheme <a href="&#x6A;avascript:..."> is neutralized.
+// `&#x6A;` is the HTML numeric entity for `j`; when the browser decodes the
+// attribute value at render time, the result is `javascript:alert(1)` — a
+// live XSS scheme. The stripUnsafeHtml entity-encoded-href neutralizer must
+// rewrite this to about:blank#blocked-entity-encoded so the decoded form is
+// no longer a scheme.
+{
+  const h = renderMarkdown('<a href="&#x6A;avascript:alert(1)">x</a>');
+  // The href must NOT decode to a live javascript: scheme. The literal
+  // `&#x6A;avascript:` as the START of the href value is the dangerous form;
+  // after rewrite it lives inside `about:blank#blocked-entity-encoded&#x6A;...`
+  // which decodes harmlessly.
+  check('T22.entity-encoded-scheme-not-live-href',
+    !/href\s*=\s*["']\s*&#/.test(h),
+    'expected no href starting with &#; got: ' + h);
+  check('T22.entity-encoded-scheme-neutralized',
+    /about:blank#blocked-entity-encoded/.test(h),
+    'expected about:blank#blocked-entity-encoded replacement; got: ' + h);
 }
 
 console.log('__COUNTS__\t' + pass + '\t' + fail);


### PR DESCRIPTION
## Summary

Closes #983.

**Public-facing XSS in `docs/MarkdownRenderer.js`** introduced by PR #980. The hand-rolled `stripUnsafeHtml` strips `<script>`/`<iframe>`/on*=/comments but does NOT strip `javascript:`/`vbscript:`/`data:text/html` schemes from `href=`/`src=`. Combined with the `<a` block-level verbatim passthrough at line 43, raw markdown source `<a href="javascript:alert(document.cookie)">x</a>` reaches `main.innerHTML` and executes on click in the docs-site origin.

Trust boundary: anyone with merge access to docs. For an open-source project that's any approved PR.

## Fix — 3 defense layers in `docs/MarkdownRenderer.js`

1. **`stripUnsafeHtml`** — scheme-strip regex on `href=`/`src=` for `javascript`/`vbscript`/`data:text/html` (case-insensitive, leading-whitespace tolerated) + HTML-entity-encoded variants (any value starting with `&#`). Neutralizes to `about:blank#blocked-*`. Applied BEFORE the on*= strip so quote handling isn't disturbed.

2. **`inlineMarkdown` link branch** — new `isDangerousUrl(raw, resolved)` helper checks **both** the raw captured href AND the post-baseUrl-prefixing `resolved` form. The dual-check closed a spec hole: the markdown link regex `/\[([^\]]+)\]\(([^)]+)\)/` stops at the first `)` inside `alert(`, so the captured `href` is truncated; the baseUrl prefix then makes `resolved` no longer start with `javascript:`, which would slip past a resolved-only check. Patterns rejected: dangerous schemes, `&#` entity-prefix, `//` protocol-relative (open-redirect). Returns bracket-text only (already `escapeHtml`'d).

3. **`inlineMarkdown` image branch** — same `isDangerousUrl` rejection on `src`; returns alt-text only.

## Files

- `docs/MarkdownRenderer.js` (+39) — 3 defense layers + `isDangerousUrl` helper
- `tests/test-doc-viewer-renderer.sh` (+99) — 6 new XSS assertions (T17-T22) covering raw HTML, markdown link/image syntax, protocol-relative, entity-encoded scheme variants

## Test plan

- [x] `bash tests/test-doc-viewer-renderer.sh` — 41 passed, 0 failed; T14/T15 pre-existing XSS unchanged; T17-T22 all PASS
- [x] `bash tests/run-all.sh` — 7353/7353 passed
- [x] Independent verifier adversarial probe — 9 cases including mixed-case `jAvAsCrIpT:`, tab-whitespace, decimal entity `&#106;`, hex entity `&#X6A;`, single-quoted `'`, missing-space attribute `"id="x"`, empty-bracket markdown, `DATA:text/HTML` — all reported `safe`
- [x] Regression check — 5 benign cases (https, .md, png, #anchor, /absolute) render correctly with no over-stripping
- [x] Scope re-verified `HEAD~1..HEAD` — 2 files exactly

## Severity

**High** — public-facing XSS in a markdown renderer. The renderer's documented intent ("zero-deps hand-rolled, no supply-chain surface") claims to sanitize but didn't.
