### PR TITLE
do: plugin test-suite honesty fixes (#987)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
           bash tests/test-plugin-manifest.sh
           echo "== marketplace.json schema (incl. D10 version lockstep) =="
           bash tests/test-plugin-marketplace.sh
-          echo "== build push targets ↔ consumer-resolved refs (prod/main + prod/<version>) =="
+          echo "== build push targets ↔ consumer-resolved refs (bare main + bare <version> tag) =="
           bash tests/test-plugin-ref-consistency.sh
 
       # Mirror-less prod-tree dogfood — builds a SHIPPED plugin tree (git
@@ -176,8 +176,9 @@ jobs:
           set -e
           bash tests/test-plugin-mirrorless-resolution.sh
 
-      # D4 existence gate — runs the REAL build-plugin-release.sh in an
-      # isolated throwaway clone and asserts the built prod/main tree CONTAINS
+      # D4 existence gate — runs the REAL publisher build-prod.sh (the script
+      # ship-to-prod.yml runs; refs are bare main + a bare <version> tag) in an
+      # isolated throwaway clone and asserts the built prod tree CONTAINS
       # a suffixless sibling of every hooks/*.sh.template (block-agents.sh +
       # block-unsafe-project.sh today — the safety hooks hooks.json registers
       # on the plugin lane), byte-equal to its .template. A regression that

--- a/tests/test-plugin-live-load.sh
+++ b/tests/test-plugin-live-load.sh
@@ -22,17 +22,21 @@
 #         partially observable non-interactively — see notes inline.
 #
 #   (B) ATTENDED, NOT CI gates (guarded behind ZSKILLS_LIVE_ATTENDED=1):
-#       - run_attended_hookfire_check
+#       - run_attended_repo_load_check (deterministic hookfire + the
+#         (A2)-RUNTIME graceful-degradation assertion, in ONE --plugin-dir load)
 #       - run_attended_dual_install_skip_shim_check
-#       Review VERIFIED that headless `claude -p "<prompt>"` with an isolated
-#       (credential-less) HOME prints "Not logged in · Please run /login" and
-#       exits WITHOUT running the prompt — so PreToolUse hooks NEVER fire
-#       headlessly in an unauthenticated sandbox. These two functions are
-#       therefore flag-guarded one-shots a human runs once in an authed env
-#       before launch. The CI path (flag unset) SKIPS them and records
-#       "skipped: attended-only, headless auth unavailable". They assert an
-#       OBSERVABLE hook side-effect with explicit PASS/FAIL. They are NEVER
-#       faked, NEVER prose-only, NEVER claimed as a recurring CI gate.
+#       With an isolated (credential-less) HOME, headless `claude -p "<prompt>"`
+#       prints "Not logged in · Please run /login" and exits — so these probes
+#       need credentials. Post-#964 the suite SEEDS a COPY of the real
+#       ~/.claude/.credentials.json into the isolated config dir, which lets
+#       headless `claude -p` AUTH + load the plugin + wire hooks (plugin-sync
+#       runs) — so PreToolUse hooks DO fire headlessly once authed. These
+#       functions are flag-guarded one-shots a human runs once in an authed env
+#       before launch. The CI / unauthed path (flag unset, OR flag set but no
+#       real credential to seed) SKIPS them with an honest reason. They assert an
+#       OBSERVABLE hook side-effect with explicit PASS/FAIL via a deterministic
+#       marker file. They are NEVER faked, NEVER prose-only, NEVER claimed as a
+#       recurring CI gate.
 #
 # No jq — Python json per `## Python is required` (not needed here; documented
 # for consistency with sibling plugin suites).
@@ -182,18 +186,22 @@ fi
 # absent here. Acceptance: a live plugin load from the source tree must NOT
 # FATALLY error on those two missing registered hooks.
 #
-# OBSERVABILITY FINDING (recorded — this is a real limitation, not padding):
-#   The fullest signal would be a `claude --plugin-dir . -p "<prompt>"` load
-#   that exercises plugin-sync + hook registration. But review VERIFIED (and
-#   this suite re-confirms in the attended section) that headless `claude -p`
-#   bails at "Not logged in" BEFORE plugin-sync/hook wiring runs — so the
-#   runtime hook-registration path is NOT observable non-interactively.
-#   What IS observable non-interactively and offline is `claude plugin
-#   validate`, which loads & checks the marketplace + plugin manifests
-#   (including hooks.json wiring) WITHOUT executing a session. We assert that
-#   validate does not fatally error in the presence of the missing suffixless
-#   hooks — i.e. the manifest/hooks.json registration of a not-yet-
-#   materialised hook is tolerated, not a hard load error.
+# TWO observability levels (split honestly):
+#   OFFLINE (here, CI-gateable): `claude plugin validate` loads & checks the
+#   marketplace + plugin manifests (including hooks.json wiring) WITHOUT
+#   executing a session. We assert that validate does not fatally error in the
+#   presence of the missing suffixless hooks — i.e. the manifest/hooks.json
+#   registration of a not-yet-materialised hook is tolerated, not a hard load
+#   error.
+#   RUNTIME (attended, below): a `claude --plugin-dir "$REPO_ROOT" -p "<benign>"`
+#   load that ACTUALLY exercises plugin-sync + hook registration in a live
+#   authed session. The #964 credential-seed plumbing proves headless
+#   `claude -p` DOES auth + load the plugin + wire hooks (the attended
+#   `run_attended_repo_load_check` below fires a real hook under exactly such a
+#   load) — so the runtime hook-registration path IS observable when authed.
+#   The earlier "headless claude -p bails at login before plugin-sync" premise
+#   was FALSE (predated #964); the runtime tolerance is now asserted attended,
+#   not skipped.
 #
 # First, sanity-check the premise (so a future source change that adds the
 # suffixless files turns this into a clear SKIP rather than a silent false
@@ -223,10 +231,18 @@ if [ "${#MISSING_HOOKS[@]}" -eq 2 ] && [ "$REGISTERED_BOTH" -eq 1 ]; then
     # validate failed for an unrelated reason; (A1) already flagged it.
     skip "(A2) graceful degradation: validate failed for an unrelated reason (see A1) — missing-hook tolerance not observable this run"
   fi
-  # Honest scope note: the RUNTIME hook-registration path (plugin-sync wiring
-  # the suffixless hooks into a live session) is only observable in an authed
-  # session; that confirmation lives in the attended dual-install function.
-  skip "(A2) graceful degradation — RUNTIME hook-registration tolerance is attended-only (headless 'claude -p' bails at login before plugin-sync); confirmed offline-only here"
+  # The RUNTIME hook-registration tolerance (plugin-sync wiring a live session
+  # with the 2 suffixless hooks ABSENT on disk) is observable only in an authed
+  # session, so it is gated behind ZSKILLS_LIVE_ATTENDED=1 — the SAME gate as
+  # the (B) checks. When the flag is unset (CI / unauthed dev) it SKIPs cleanly;
+  # when set it is asserted inside the attended `run_attended_repo_load_check`
+  # (which performs the real `--plugin-dir "$REPO_ROOT"` load and checks the
+  # session output named no fatal missing-hook error). We record the gated SKIP
+  # here so the offline section's accounting stays honest; the PASS/FAIL is
+  # emitted by the attended function.
+  if [ "${ZSKILLS_LIVE_ATTENDED:-}" != "1" ]; then
+    skip "(A2) graceful degradation — RUNTIME hook-registration tolerance is attended-only (set ZSKILLS_LIVE_ATTENDED=1 in an authed env); asserted by run_attended_repo_load_check"
+  fi
 else
   skip "(A2) graceful degradation: precondition changed (suffixless hooks now present on disk, or no longer both registered) — check no longer applicable"
 fi
@@ -238,46 +254,124 @@ fi
 # authed env. The CI path (flag unset) SKIPS them with the recorded reason.
 # They are NEVER faked and NEVER claimed as recurring CI gates.
 
-# run_attended_hookfire_check
-#   Intent: prove a PreToolUse hook actually FIRES under a real `--plugin-dir`
-#   session by observing a deny-envelope on a known-blocked command. The
-#   block-unsafe-generic.sh hook denies a recursive rm on a non-/tmp path; we
-#   ask the authed session to attempt one and assert the hook's deny side-
-#   effect is observable. (A human runs this once pre-launch; it requires
-#   credentials the isolated sandbox does not have.)
-run_attended_hookfire_check() {
-  echo "  [attended] run_attended_hookfire_check"
-  local proj="$TMP/attended-hookfire"
+# run_attended_repo_load_check
+#   Shared attended load that proves TWO properties in ONE real
+#   `--plugin-dir "$REPO_ROOT"` headless session (cheaper + cleaner than two
+#   `claude` spins):
+#
+#   ITEM 2 — DETERMINISTIC hookfire: prove a PreToolUse hook actually FIRES
+#     under a real `--plugin-dir` session. The OLD form asked the (safety-
+#     conscious) nested agent to run a destructive `rm -rf /etc/...` and grepped
+#     a deny-envelope — but whether the agent EMITS that command is non-
+#     deterministic (a refusal yields zero denies → FALSE FAIL). We instead
+#     register a tiny synthetic CONSUMER hook (via an isolated project
+#     settings.json, --add-dir) that fires on a BENIGN command and appends ONE
+#     line to a marker file. The benign command always runs, so the marker count
+#     is a verbatim, prose-immune proof that a hook fired under the real load.
+#     (Same deterministic-marker pattern run_attended_dual_install_skip_shim_check
+#     already uses.)
+#
+#   ITEM 1 — RUNTIME graceful degradation: the SAME load is a real
+#     `--plugin-dir "$REPO_ROOT"` plugin-sync, which wires the repo hooks.json —
+#     including the 2 suffixless D4 hooks (block-unsafe-project.sh,
+#     block-agents.sh) that are ABSENT on disk in the source tree. We assert the
+#     session completed its expected hook side-effect (marker fired) WITHOUT a
+#     fatal load error naming those missing hooks. This exercises the runtime
+#     hook-registration tolerance the offline (A2) validate can only check
+#     statically. (This replaces the stale unconditional (A2)-runtime perma-skip
+#     whose "headless claude -p bails at login" premise was FALSE post-#964.)
+#
+#   Never-fake: if auth fails despite the flag (no #964 credential seeded), we
+#   SKIP both — never fail, never fake a PASS.
+run_attended_repo_load_check() {
+  echo "  [attended] run_attended_repo_load_check"
+  local proj="$TMP/attended-repoload"
   mkdir -p "$proj"
-  local out="$TMP/attended-hookfire.out"
-  # A known-blocked command: recursive rm on a non-/tmp path. The generic
-  # hook (sourced by plugin-registered hooks) must DENY it. We observe the
-  # deny via the session's tool-error surface in --print mode.
-  #
-  # NOTE: the exact observable depends on the authed session's transcript
-  # format. We assert on a deny/blocked signal in the output. A SINGLE hook
-  # fire can score a deny-count >1 here because the model REPEATS the block
-  # message in its natural-language explanation (observed: count 3 for one
-  # fire). That prose-verbosity does NOT matter for THIS check — we only need
-  # "the hook fired at all" (≥1 deny signal), which is prose-robust. (The
-  # exactly-once assertion that IS sensitive to prose verbosity lives in the
-  # dual-install function below, where it uses a deterministic marker count
-  # instead of prose-grep.) If the prompt does not run (auth failed despite
-  # the flag), we SKIP — never fake a PASS.
+  local out="$TMP/attended-repoload.out"
+  local marker="$proj/.repoload-marker"
+  : > "$marker"
+
+  # Deterministic observable: a SECOND, tiny synthetic PLUGIN (loaded via its
+  # OWN --plugin-dir, alongside the real repo's --plugin-dir) whose Bash-matcher
+  # hook appends exactly one line to a marker file on a benign command. We use a
+  # plugin-lane hook (NOT a consumer settings.json registered via --add-dir,
+  # which the harness does not reliably load as project settings — observed: a
+  # consumer settings.json hook never fired) so the fire is guaranteed and the
+  # count is verbatim, prose-immune. `--plugin-dir` is repeatable, so loading
+  # the real repo AND this marker plugin in one session lets ONE load prove both
+  # item 1 (the real repo's 2 missing suffixless hooks are tolerated) and item 2
+  # (a hook fired under a real --plugin-dir session).
+  local synmarker="$TMP/attended-repoload-plugin"
+  mkdir -p "$synmarker/hooks" "$synmarker/.claude-plugin"
+  cat > "$synmarker/hooks/repoload-probe.sh" <<MARKERHOOK
+#!/usr/bin/env bash
+# Synthetic repo-load probe — PLUGIN LANE. Fires on a benign Bash call, appends
+# one marker line. Marker path hardcoded at write time (no env dependency).
+printf 'fired\n' >> "$marker"
+exit 0
+MARKERHOOK
+  chmod +x "$synmarker/hooks/repoload-probe.sh"
+  cat > "$synmarker/.claude-plugin/plugin.json" <<'PLUGINJSON'
+{
+  "name": "zsrepoloadprobe",
+  "version": "2026.05.0",
+  "description": "Synthetic repo-load hookfire probe plugin (test fixture).",
+  "hooks": "./hooks/hooks.json"
+}
+PLUGINJSON
+  cat > "$synmarker/hooks/hooks.json" <<'PLUGINHOOKS'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/repoload-probe.sh\"", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}
+PLUGINHOOKS
+
+  # ONE session, TWO --plugin-dir loads: the real repo (item 1 — its hooks.json
+  # registers the 2 suffixless hooks ABSENT on disk) + the synthetic marker
+  # plugin (item 2 — deterministic fire). The benign command always runs → the
+  # marker plugin's hook always fires → marker gets exactly one line. If auth
+  # failed, the session bails at /login and the marker stays empty (we SKIP).
   if run_isolated_claude -p \
-       'Run this exact bash command and report the tool result verbatim: rm -rf /etc/zzz-zskills-hookfire-probe' \
-       --plugin-dir "$REPO_ROOT" --dangerously-skip-permissions >"$out" 2>&1; then
+       'Run this exact bash command and report the tool result verbatim: echo zskills-repoload-probe' \
+       --plugin-dir "$REPO_ROOT" --plugin-dir "$synmarker" --add-dir "$proj" --dangerously-skip-permissions >"$out" 2>&1; then
     :
   fi
   if grep -qiE 'not logged in|please run /login' "$out"; then
-    skip "  [attended] hookfire: session not authed (no creds) — cannot observe hook fire"
+    skip "  [attended] repo-load: session not authed (no creds) — cannot observe hook fire or runtime degradation"
+    skip "  [attended] (A2)-runtime: session not authed — runtime missing-hook tolerance not observable"
     return
   fi
-  if grep -qiE 'BLOCKED|deny|recursive rm requires|block-unsafe' "$out"; then
-    pass "  [attended] hookfire: PreToolUse hook FIRED — deny-envelope observed on known-blocked command (≥1; prose-robust)"
+
+  # ── ITEM 2: deterministic hookfire (marker count, prose-immune) ────────────
+  local n
+  n="$(grep -c 'fired' "$marker" 2>/dev/null)"
+  [ -n "$n" ] || n=0
+  if [ "$n" -ge 1 ]; then
+    pass "  [attended] hookfire: PreToolUse hook FIRED under a real --plugin-dir load (marker count=$n; deterministic, prose-immune)"
   else
-    fail "  [attended] hookfire: NO deny-envelope observed on a known-blocked command (hook did not fire?)"
+    fail "  [attended] hookfire: hook did NOT fire under the --plugin-dir load (marker count=0 — no matching Bash tool call ran?)"
     sed 's/^/      /' "$out"
+  fi
+
+  # ── ITEM 1: runtime graceful degradation (no fatal missing-hook error) ─────
+  # The marker firing proves the live session loaded the plugin and reached the
+  # Bash matcher. Now assert that the same plugin-sync did NOT fatally error on
+  # the 2 suffixless D4 hooks absent on disk. A fatal load error would name the
+  # hook script or surface ENOENT / "no such file"; its absence (combined with a
+  # completed hook side-effect) is the runtime tolerance we want.
+  if grep -qiE 'block-unsafe-project\.sh.*(no such file|ENOENT|cannot|failed to load)|block-agents\.sh.*(no such file|ENOENT|cannot|failed to load)|ENOENT.*block-(unsafe-project|agents)|no such file.*block-(unsafe-project|agents)' "$out"; then
+    fail "  [attended] (A2)-runtime: live --plugin-dir load FATALLY errored on a missing suffixless D4 hook — REAL FINDING, STOP for audit (do not mask)"
+    sed 's/^/      /' "$out"
+  else
+    pass "  [attended] (A2)-runtime: live --plugin-dir load tolerated 2 missing suffixless D4 hooks (hook side-effect fired; no fatal missing-hook error)"
   fi
 }
 
@@ -427,10 +521,10 @@ JSON
 }
 
 if [ "${ZSKILLS_LIVE_ATTENDED:-}" = "1" ]; then
-  run_attended_hookfire_check
+  run_attended_repo_load_check
   run_attended_dual_install_skip_shim_check
 else
-  skip "(B) run_attended_hookfire_check — skipped: attended-only, headless auth unavailable (set ZSKILLS_LIVE_ATTENDED=1 in an authed env to run)"
+  skip "(B) run_attended_repo_load_check — skipped: attended-only, headless auth unavailable (set ZSKILLS_LIVE_ATTENDED=1 in an authed env to run)"
   skip "(B) run_attended_dual_install_skip_shim_check — skipped: attended-only, headless auth unavailable (set ZSKILLS_LIVE_ATTENDED=1 in an authed env to run)"
 fi
 


### PR DESCRIPTION
Task: Fix #987 — three plugin test-suite-honesty fixes: revive the stale (A2)-runtime perma-skip + de-flake the hookfire check (tests/test-plugin-live-load.sh), and fix stale post-#982 CI prose (.github/workflows/test.yml).

Closes #987.

## What changed (2 files)
**`tests/test-plugin-live-load.sh`** (items 1+2, coordinated in the attended block):
- **Item 1 — revived the stale (A2)-runtime perma-skip.** It was an *unconditional* skip justified by a false "headless `claude -p` bails at login before plugin-sync" premise (disproved by the (B) hookfire check, which fires a hook via a seeded-cred `--plugin-dir` session). Now gated behind `ZSKILLS_LIVE_ATTENDED=1` like the (B) checks; when attended it asserts a real `--plugin-dir` load tolerated the 2 missing suffixless D4 hooks (`block-unsafe-project.sh`, `block-agents.sh`) with no fatal error. Offline (A2) pass unchanged. Stale comments corrected.
- **Item 2 — de-flaked the hookfire check** (`run_attended_hookfire_check` → `run_attended_repo_load_check`). The old observable depended on a nested agent's willingness to emit `rm -rf /etc/…` (a refusal → false FAIL). Replaced with a deterministic marker (same pattern as the dual-install check): a synthetic marker plugin loaded via a second `--plugin-dir` fires on a benign command and appends to a counted marker file. Items 1+2 share ONE `--plugin-dir` load. Tradeoff (issue-sanctioned): swaps "real `block-unsafe-generic.sh` denies a real blocked command" for a deterministic synthetic fire; the real hook's deny logic stays covered by direct unit tests.

**`.github/workflows/test.yml`** (item 3, comment/label-only — no workflow logic change): after #982 the marketplace ref is bare `main` (not `prod/main`), the D4 gate runs `build-prod.sh` (not `build-plugin-release.sh`), and refs are bare `main` + bare `<version>` tag. Updated the stale echo label + D4-gate comment. (Line-168 mirror-less comment verified still accurate — left alone.)

A real test-fixture defect was surfaced + fixed during implementation (a consumer `settings.json` hook via `--add-dir` didn't load → rerouted through the plugin lane), not masked.

## Verification
- **Authed (orchestrator session):** `ZSKILLS_LIVE_ATTENDED=1 bash tests/test-plugin-live-load.sh` → **7 passed, 0 failed, 0 skipped** — the revived (A2)-runtime check now RUNS and passes; hookfire marker=1; dual-install exactly-once. (CI can't run this — no authed `claude` on the runner.)
- **Full suite:** `bash tests/run-all.sh` → 7353/7353 passed, 0 failed.
- No skill `metadata.version` / hook-version bumps (only a test + a workflow comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
