### PR TITLE
fix(#986): narrow requires.* commit-gate carve-out to land-pr only

### DIFF
--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -912,21 +912,29 @@ if is_git_subcommand_in_wrappers "$COMMAND" commit; then
 
       PIPELINE_SUBDIR="$TRACKING_DIR/$PIPELINE_ID"
 
-      # Delegation check: requires.* must have matching fulfilled.*
-      # Subdir-only reader (Phase 6: dual-read fallback removed; all writers migrated).
+      # Delegation check at commit-time.
       #
-      # Fire ONLY when committing on main (issue #547). The gate's purpose is
-      # to protect the actual landing event — commits hitting `main`. Commits
-      # on feature branches (`feat/*`, `fix/*`, `cp-*`, worktree branches) are
-      # legitimate intermediate work that will be PR-merged or cherry-picked
-      # later, and must not be blocked by a `requires.land-pr.<id>` marker
-      # whose fulfillment can only happen AFTER those very commits land.
-      # PR #211's protection is preserved: a `finish-auto` exit before
-      # /land-pr leaves `requires.land-pr` unfulfilled, and any subsequent
-      # commit-to-main in that pipeline is still blocked.
-      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ] && is_on_main; then
+      # The carve-out below applies ONLY to `requires.land-pr.*` markers,
+      # not the whole `requires.*` family. `requires.land-pr.<id>` can only
+      # be fulfilled AFTER the PR merge happens, so blocking a feature-branch
+      # commit on it would deadlock — that's the original #547 reason.
+      # `requires.verify-changes.<id>` is fundamentally different: the verifier
+      # CAN and SHOULD run BEFORE any commit lands, on the feature branch
+      # itself. Blanket-skipping all `requires.*` on feature branches let
+      # PR #980 land with `requires.verify-changes.doc-viewer` unfulfilled
+      # (issue #986).
+      #
+      # Decision tree (per marker, evaluated inside the loop):
+      #   requires.land-pr.*  + feature branch → defer (would deadlock)
+      #   requires.land-pr.*  + main           → enforce (PR #211 intent)
+      #   requires.<other>.*  + any branch     → enforce (the #986 fix)
+      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ]; then
         for req in "$PIPELINE_SUBDIR"/requires.*; do
           [ -e "$req" ] || continue
+          # Defer requires.land-pr.* on feature branches (deadlock avoidance).
+          if [[ "$(basename "$req")" =~ ^requires\.land-pr\. ]] && ! is_on_main; then
+            continue
+          fi
           enforce_requires_marker "$req" "committing"
         done
       fi

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -912,21 +912,29 @@ if is_git_subcommand_in_wrappers "$COMMAND" commit; then
 
       PIPELINE_SUBDIR="$TRACKING_DIR/$PIPELINE_ID"
 
-      # Delegation check: requires.* must have matching fulfilled.*
-      # Subdir-only reader (Phase 6: dual-read fallback removed; all writers migrated).
+      # Delegation check at commit-time.
       #
-      # Fire ONLY when committing on main (issue #547). The gate's purpose is
-      # to protect the actual landing event — commits hitting `main`. Commits
-      # on feature branches (`feat/*`, `fix/*`, `cp-*`, worktree branches) are
-      # legitimate intermediate work that will be PR-merged or cherry-picked
-      # later, and must not be blocked by a `requires.land-pr.<id>` marker
-      # whose fulfillment can only happen AFTER those very commits land.
-      # PR #211's protection is preserved: a `finish-auto` exit before
-      # /land-pr leaves `requires.land-pr` unfulfilled, and any subsequent
-      # commit-to-main in that pipeline is still blocked.
-      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ] && is_on_main; then
+      # The carve-out below applies ONLY to `requires.land-pr.*` markers,
+      # not the whole `requires.*` family. `requires.land-pr.<id>` can only
+      # be fulfilled AFTER the PR merge happens, so blocking a feature-branch
+      # commit on it would deadlock — that's the original #547 reason.
+      # `requires.verify-changes.<id>` is fundamentally different: the verifier
+      # CAN and SHOULD run BEFORE any commit lands, on the feature branch
+      # itself. Blanket-skipping all `requires.*` on feature branches let
+      # PR #980 land with `requires.verify-changes.doc-viewer` unfulfilled
+      # (issue #986).
+      #
+      # Decision tree (per marker, evaluated inside the loop):
+      #   requires.land-pr.*  + feature branch → defer (would deadlock)
+      #   requires.land-pr.*  + main           → enforce (PR #211 intent)
+      #   requires.<other>.*  + any branch     → enforce (the #986 fix)
+      if [ -n "$PIPELINE_ID" ] && [ -d "$PIPELINE_SUBDIR" ]; then
         for req in "$PIPELINE_SUBDIR"/requires.*; do
           [ -e "$req" ] || continue
+          # Defer requires.land-pr.* on feature branches (deadlock avoidance).
+          if [[ "$(basename "$req")" =~ ^requires\.land-pr\. ]] && ! is_on_main; then
+            continue
+          fi
           enforce_requires_marker "$req" "committing"
         done
       fi

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1252,6 +1252,35 @@ fi
 expect_project_deny "issue-547: commit on main with unfulfilled requires.land-pr (still blocked)" "git commit -m test"
 teardown_project_test
 
+# Issue #986: the carve-out is per-marker-type, not blanket-branch.
+# requires.verify-changes.* (and any non-land-pr requires.*) MUST enforce
+# on feature branches too — verify-changes can and should run pre-merge.
+# Past failure: PR #980 landed with requires.verify-changes.doc-viewer
+# unfulfilled because every commit was on the feature branch and the
+# outer is_on_main gate skipped all requires.* checks.
+
+# Positive case (#986 fix): commit on feature branch with UNFULFILLED
+# requires.verify-changes.* must be DENIED.
+setup_project_test
+mkdir -p "$TEST_TMPDIR/$DEFAULT_SUBDIR"
+touch "$TEST_TMPDIR/$DEFAULT_SUBDIR/requires.verify-changes.test-plan"
+# Switch to a feature branch.
+(cd "$TEST_TMPDIR" && git checkout -q -b fix/issue-986-test 2>/dev/null)
+(cd "$TEST_TMPDIR" && echo "var x=1;" > app.js && git add app.js)
+expect_project_deny "issue-986: commit on feature branch with unfulfilled requires.verify-changes (now blocked)" "git commit -m test"
+teardown_project_test
+
+# Negative case (#986 fix): commit on feature branch with FULFILLED
+# requires.verify-changes.* must be ALLOWED (the verifier ran).
+setup_project_test
+mkdir -p "$TEST_TMPDIR/$DEFAULT_SUBDIR"
+touch "$TEST_TMPDIR/$DEFAULT_SUBDIR/requires.verify-changes.test-plan"
+touch "$TEST_TMPDIR/$DEFAULT_SUBDIR/fulfilled.verify-changes.test-plan"
+(cd "$TEST_TMPDIR" && git checkout -q -b fix/issue-986-test 2>/dev/null)
+(cd "$TEST_TMPDIR" && echo "var x=1;" > app.js && git add app.js)
+expect_project_allow "issue-986: commit on feature branch with fulfilled requires.verify-changes (passes)" "git commit -m test"
+teardown_project_test
+
 echo ""
 echo "=== Project hook: step enforcement ==="
 


### PR DESCRIPTION
## Summary

Closes #986.

The commit-time delegation gate in `hooks/block-unsafe-project.sh` had `&& is_on_main` applied as a **blanket outer-loop carve-out**. The carve-out's stated intent (per the comment block landed in PR #552 for #547) was deadlock-avoidance for `requires.land-pr.*` — that marker can only be fulfilled AFTER the PR merge, so blocking feature-branch commits on it would deadlock. **But the implementation applied the carve-out to the WHOLE `requires.*` family**, not just `requires.land-pr.*`. As a result, `requires.verify-changes.*` (which CAN and SHOULD run pre-merge on the feature branch) was also skipped on every feature-branch commit.

Reproducer: PR #980 (DOC_VIEWER plan, 13 commits across 6 phases of UI code) landed carrying `requires.verify-changes.doc-viewer` UNFULFILLED. Every commit was on `feat/doc-viewer`; the outer carve-out skipped the entire `requires.*` loop. The verifier never ran.

## Fix

Narrow the carve-out from BRANCH-based to **MARKER-TYPE-based**. Outer `if` no longer checks `is_on_main`; the loop enters whenever PIPELINE_ID + PIPELINE_SUBDIR are valid. Inside the loop, defer ONLY `requires.land-pr.*` on feature branches:

| Marker type            | Branch          | Behavior                  |
|------------------------|-----------------|---------------------------|
| `requires.land-pr.*`   | feature branch  | defer (deadlock avoidance) |
| `requires.land-pr.*`   | main            | enforce (PR #211 intent)   |
| `requires.<other>.*`   | any branch      | **enforce** (the #986 fix) |

Push-time gate (line ~1124) **unchanged** — it already enforces on every branch with no `is_on_main` check. The separate mystery of why the push-time gate didn't catch #980 is flagged in #986's body as a follow-up investigation; intentionally not addressed here.

## Files

- `hooks/block-unsafe-project.sh.template` — gate restructured + line-2 version stamp bumped `2026.06.0` → `2026.06.1`
- `.claude/hooks/block-unsafe-project.sh` — mirror, byte-identical
- `tests/test-hooks.sh` — 2 new #986 cases (feature-branch + unfulfilled `requires.verify-changes` → DENY; feature-branch + fulfilled → ALLOW)

## Test plan

- [x] `bash tests/test-hooks.sh` — exit 0, 2373 passed, 0 failed. Existing 2 #547 cases (land-pr.* paths) STILL PASS unchanged. New 2 #986 cases PASS.
- [x] `bash tests/run-all.sh` — 7355/7355 passed
- [x] **Sensitivity verified load-bearing** — independently reverted the gate to its blanket-carve-out form and re-ran tests: exactly the new "issue-986: commit on feature branch with unfulfilled requires.verify-changes (now blocked)" case FAILS, confirming the test catches the regression. Post-restore: green + mirror parity restored.
- [x] Mirror parity: `diff hooks/block-unsafe-project.sh.template .claude/hooks/block-unsafe-project.sh` empty
- [x] Scope re-verified `HEAD~1..HEAD` — 3 files exactly
