### PR TITLE
do: hide empty run-status pill in dashboard idle state

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.02+c198be"
+  version: "2026.06.02+59a592"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -725,6 +725,13 @@ code, pre, .mono {
   font-size: 0.85rem;
 }
 
+/* Issue #995 — explicit hide so `display: flex` above doesn't defeat
+   the [hidden] attribute set by renderRunStatus when no run-state pill
+   content was rendered (idle + no trigger + no warning). */
+.run-status[hidden] {
+  display: none;
+}
+
 .run-status.run-status-stale {
   border-color: var(--orange);
 }

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -2370,6 +2370,13 @@ function renderRunStatus(ws) {
   if (!root) return;
   clear(root);
   root.classList.remove("run-status-stale");
+  // Issue #995 — clear() removes children but does NOT reset `hidden`,
+  // so we must unhide on every render. The end-of-function guard below
+  // re-hides only when no children were appended (idle + no trigger + no
+  // warning — the demo's case). Without this top-level unhide, a state
+  // transition from idle-empty to scheduled would leave hidden=true and
+  // the scheduled pill invisible.
+  root.hidden = false;
   const state = (ws && ws.state) || "idle";
   const warning = ws && ws.warning;
 
@@ -2462,6 +2469,17 @@ function renderRunStatus(ws) {
   // when no /work-on-plans trigger is configured; the docs explain how
   // to feed the queue (matching the Issues / Branches columns, which
   // have always been state-only with no inline how-to).
+
+  // Issue #995 — fall-through reaches here when state===idle and
+  // trigger_configured is false (and no warning) — no children were
+  // appended. Hide the empty container so its border + padding don't
+  // draw a visible "phantom pill" (the demo's case). The early-return
+  // arms above all append children and skip this guard; root.hidden
+  // was unhidden at the top of the function so those paths render
+  // normally.
+  if (!root.firstChild) {
+    root.hidden = true;
+  }
 }
 
 // ---------------------------------------------------------------- toasts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Fixed — dashboard idle-state phantom pill (#995)
+
+- **Dashboard:** `renderRunStatus` now hides the `.run-status` container
+  (`root.hidden=true` + CSS `.run-status[hidden] { display: none; }`) when
+  no run-state content was rendered — idle + `trigger_configured=false` +
+  no warning. Previously the empty container's border, padding, and flex
+  layout still drew a visible "phantom pill" in the demo's idle state.
+  Live render arms (scheduled, sprint, stale-scheduled, stale-sprint,
+  idle-with-trigger, idle-with-warning) are unchanged; the top-of-function
+  `root.hidden=false` ensures state transitions from idle-empty back to a
+  live state correctly re-show the pill. Resolves #992 (URL question
+  parked there; prod URL adoption is a no-op against current main because
+  PR #984 has not yet landed — when it does, the source link will need
+  its path token flipped from `/demo/` to `/dashboard-demo/`).
+
 ### Changed — `/work-on-plans` default flips to `finish` (#988)
 
 - **Dashboard:** removed the "Default mode" segmented chip

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.02+c198be"
+  version: "2026.06.02+59a592"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.css
@@ -725,6 +725,13 @@ code, pre, .mono {
   font-size: 0.85rem;
 }
 
+/* Issue #995 — explicit hide so `display: flex` above doesn't defeat
+   the [hidden] attribute set by renderRunStatus when no run-state pill
+   content was rendered (idle + no trigger + no warning). */
+.run-status[hidden] {
+  display: none;
+}
+
 .run-status.run-status-stale {
   border-color: var(--orange);
 }

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -2370,6 +2370,13 @@ function renderRunStatus(ws) {
   if (!root) return;
   clear(root);
   root.classList.remove("run-status-stale");
+  // Issue #995 — clear() removes children but does NOT reset `hidden`,
+  // so we must unhide on every render. The end-of-function guard below
+  // re-hides only when no children were appended (idle + no trigger + no
+  // warning — the demo's case). Without this top-level unhide, a state
+  // transition from idle-empty to scheduled would leave hidden=true and
+  // the scheduled pill invisible.
+  root.hidden = false;
   const state = (ws && ws.state) || "idle";
   const warning = ws && ws.warning;
 
@@ -2462,6 +2469,17 @@ function renderRunStatus(ws) {
   // when no /work-on-plans trigger is configured; the docs explain how
   // to feed the queue (matching the Issues / Branches columns, which
   // have always been state-only with no inline how-to).
+
+  // Issue #995 — fall-through reaches here when state===idle and
+  // trigger_configured is false (and no warning) — no children were
+  // appended. Hide the empty container so its border + padding don't
+  // draw a visible "phantom pill" (the demo's case). The early-return
+  // arms above all append children and skip this guard; root.hidden
+  // was unhidden at the top of the function so those paths render
+  // normally.
+  if (!root.firstChild) {
+    root.hidden = true;
+  }
 }
 
 // ---------------------------------------------------------------- toasts

--- a/tests/test-dashboard-run-status-locks.sh
+++ b/tests/test-dashboard-run-status-locks.sh
@@ -96,6 +96,10 @@ function makeNode(id, tag) {
     appendChild(c) { c.parent = this; this.children.push(c); return c; },
     closest() { return null; },
     addEventListener() {},
+    // DOM `firstChild` getter — surfaces children[0] so production-code
+    // checks like `if (!root.firstChild)` (issue #995's empty-render
+    // guard) behave like a real browser instead of always being truthy.
+    get firstChild() { return this.children.length > 0 ? this.children[0] : null; },
     classList: {
       _set: null,
       add(c) { this._set.add(c); },
@@ -161,6 +165,7 @@ function resetNodes() {
     nodes[k].children = [];
     nodes[k].classes.clear();
     nodes[k].className = "";
+    nodes[k].hidden = false;
   }
 }
 
@@ -215,6 +220,103 @@ function findByClass(root, cls) {
   });
   expect(findByClass(root, "run-stop-btn"), null,
     "scheduled + trigger_configured omitted: Stop button NOT rendered (defaults to false)");
+
+  // -----------------------------------------------------------------------
+  // Issue #995 — phantom-pill hide guard.
+  // The empty .run-status container would otherwise still draw a visible
+  // border + padding "pill" in the demo's idle + no-trigger + no-warning
+  // state. renderRunStatus must set root.hidden=true when no children
+  // were appended, and root.hidden=false on every live render path.
+  // -----------------------------------------------------------------------
+
+  // Case M: state==="idle", trigger_configured=false, no warning —
+  //   NO children appended AND root.hidden===true.
+  resetNodes();
+  renderRunStatus({
+    state: "idle",
+    trigger_configured: false,
+  });
+  expect(root.children.length, 0,
+    "idle + no trigger + no warning: no children appended");
+  expect(root.hidden, true,
+    "idle + no trigger + no warning: root.hidden=true (phantom pill suppressed)");
+
+  // Case N: state==="idle", trigger_configured=true — Run controls
+  //   ARE rendered AND root.hidden===false.
+  resetNodes();
+  renderRunStatus({
+    state: "idle",
+    trigger_configured: true,
+  });
+  expectTrue(findByClass(root, "run-btn"),
+    "idle + trigger_configured=true: ▶ Run top N button rendered");
+  expect(root.hidden, false,
+    "idle + trigger_configured=true: root.hidden=false (pill visible)");
+
+  // Case O: state==="idle" + warning present, no trigger — warning text
+  //   IS rendered AND root.hidden===false.
+  resetNodes();
+  renderRunStatus({
+    state: "idle",
+    trigger_configured: false,
+    warning: "Background process exited unexpectedly",
+  });
+  expectTrue(findByClass(root, "run-text"),
+    "idle + warning: warning text rendered");
+  expect(root.hidden, false,
+    "idle + warning: root.hidden=false (pill visible)");
+
+  // Case P: state==="scheduled" — pill always renders, root.hidden===false.
+  resetNodes();
+  renderRunStatus({
+    state: "scheduled",
+    schedule: "every 1h",
+    next_fire_at: "2026-06-01T12:00:00+00:00",
+    trigger_configured: true,
+  });
+  expect(root.hidden, false,
+    "scheduled: root.hidden=false (pill visible)");
+
+  // Case Q: state==="sprint" — pill always renders, root.hidden===false.
+  resetNodes();
+  renderRunStatus({
+    state: "sprint",
+    progress: { done: 1, total: 3, current_slug: "PLAN_X" },
+  });
+  expect(root.hidden, false,
+    "sprint: root.hidden=false (pill visible)");
+
+  // Case R: state==="stale-scheduled" — pill always renders, root.hidden===false.
+  resetNodes();
+  renderRunStatus({
+    state: "stale-scheduled",
+  });
+  expect(root.hidden, false,
+    "stale-scheduled: root.hidden=false (pill visible)");
+
+  // Case S: state==="stale-sprint" — pill always renders, root.hidden===false.
+  resetNodes();
+  renderRunStatus({
+    state: "stale-sprint",
+    updated_at: "2026-06-01T00:00:00+00:00",
+  });
+  expect(root.hidden, false,
+    "stale-sprint: root.hidden=false (pill visible)");
+
+  // Case T: transition from idle-empty (hidden=true) → scheduled — the
+  //   second render must unhide. This is the regression case the
+  //   top-of-function `root.hidden = false` guards against.
+  resetNodes();
+  renderRunStatus({ state: "idle", trigger_configured: false });
+  expect(root.hidden, true, "transition setup: idle-empty hidden=true");
+  renderRunStatus({
+    state: "scheduled",
+    schedule: "every 1h",
+    next_fire_at: "2026-06-01T12:00:00+00:00",
+    trigger_configured: true,
+  });
+  expect(root.hidden, false,
+    "transition: idle-empty → scheduled unhides root (no phantom invisible pill)");
 })();
 NODE
 )


### PR DESCRIPTION
Refs #995.

## Summary

Fixes the empty "run-status" pill that shows in the dashboard's idle + no-trigger + no-warning state — the case the deployed demo lands on. `renderRunStatus` falls through all five state arms without appending children in that case, leaving the `.run-status` container's border + padding visible as a phantom bar.

Two-line fix: clear `root.hidden` at the top of `renderRunStatus`, then at the end check `if (!root.firstChild) root.hidden = true`. Adds `.run-status[hidden] { display: none }` so the `hidden` attribute wins over `display: flex`. All five live render arms (scheduled / sprint / stale-scheduled / stale-sprint / idle+trigger) continue to render the pill normally.

## Verification

- `bash tests/run-all.sh` → 7339/7339 pass.
- 11 new test cases in `tests/test-dashboard-run-status-locks.sh` covering: empty-hide, all 4 live render arms, idle+trigger, idle+warning, idle-empty → scheduled transition.
- Playwright-cli on the live demo: idle-pill `hidden=true, display=none, 0 children`; scheduled-pill `hidden=false, display=flex`, content rendered. Bidirectional state transitions verified.

## Scope discovery — URL adoption deferred

Issue #995 also proposed sweeping consumer docs from `http://zskills.synapticnoise.com/demo/` to `/dashboard-demo/`. While implementing, the agent found that **no `synapticnoise.com` URL exists in source files**. The prod URL is synthesized at build time:

```
scripts/build-prod.sh:87:           sed -i 's|zeveck\.github\.io/zskills-dev|zskills.synapticnoise.com|g'
scripts/build-plugin-release.sh:137: (same)
```

Only the HOST is rewritten; the path token (`/demo/`) is unchanged from source. So adopting `/dashboard-demo/` as the prod path requires either (a) adding a second build-time sed rewrite for `/demo/` → `/dashboard-demo/`, scoped carefully to avoid touching `zskills-dev/demo/` (the dev-Pages URL), or (b) renaming the dev Pages publish path from `/demo/` to `/dashboard-demo/` (broader change). Neither was done here — the URL-decision discussion remains captured in #995's body for whoever picks up the build-script work.

This commit therefore addresses only the pill-fix half of #995. The URL adoption is a follow-up; **#995 should stay open** until that lands, OR be rescoped to just record the path decision.

## Out of scope

- Build-time URL path rewriting (the follow-up above).
- Regenerating `docs/guides/assets/zskills-dashboard.png` — the deployed image may show the phantom-pill bar, but the source-of-truth fix is in `app.js`/`app.css`; screenshot regen has no deterministic demo seed available in this worktree.
