### PR TITLE
do: post-install verifier in update-zskills (#999)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths | --switch-install-path={to-plugin|to-update-zskills}] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.01+9e1d01"
+  version: "2026.06.02+81a457"
 ---
 
 # Update Z Skills Infrastructure
@@ -1948,6 +1948,44 @@ printf '%s\n' "$delta_tsv" | awk -F'\t' -v show_addons="$show_addons" '
 `zskills_version` from Step F.5 (or `(unversioned)` if the source clone
 had no tags).
 
+#### Step G.5 — Post-install verification (#999, cheap tier, NON-FATAL)
+
+After the final report, run the bundled consumer post-install verifier's
+**cheap structural tier** and append its result to the success output. This
+catches the consumer-side of the dogfood-mask (#799/#831): environment-specific
+install breakage that dev-repo tests structurally cannot see (a registered hook
+that resolves to nothing, a leftover `<!-- TODO -->` placeholder in
+`managed.md`, a dropped artifact/sentinel, an accidental dual-install).
+
+**NON-FATAL — informative only.** The install already succeeded; this
+verification reports PASS/WARN/FAIL but **does NOT undo or fail the install**.
+A FAIL is surfaced to the user (so they can fix their environment) but the
+install stands. Run ONLY the cheap tier here — never `--deep` (the heavy
+live-`claude` probe is opt-in and must not run on the success path).
+
+Resolve the verifier path lane-awarely (it ships at
+`.claude/skills/update-zskills/verifiers/` on the legacy lane,
+`${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/` on the plugin lane):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh" ]; then
+  VERIFY_INSTALL="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh"
+else
+  VERIFY_INSTALL="$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/verifiers/verify-install.sh"
+fi
+if [ -f "$VERIFY_INSTALL" ]; then
+  # Cheap tier only (no --deep). Non-fatal: capture and report, never abort.
+  bash "$VERIFY_INSTALL" --project-dir "$CLAUDE_PROJECT_DIR" || \
+    echo "(post-install verification reported a FAIL above — the install still succeeded; review and fix your environment, then re-run /update-zskills to re-verify)"
+else
+  echo "(post-install verifier not found at $VERIFY_INSTALL — skipping verification)"
+fi
+```
+
+Report the verifier's per-check output and overall result as a final block of
+the success message. On WARN-only, note it's informative; on FAIL, tell the
+user the install succeeded but verification flagged an environment issue.
+
 ### Pull Latest and Update (already-installed path)
 
 1. **Pull latest from upstream.** Find the `zskills/` clone (Step 0) and
@@ -2071,6 +2109,24 @@ had no tags).
 
    `(unversioned)` placeholder applies to either side of the `Repo
    version:` arrow if the corresponding tag is missing.
+
+7. **Post-install verification (#999, cheap tier, NON-FATAL).** Same as
+   install-path **Step G.5**: run the bundled consumer verifier's cheap
+   structural tier and append its result. NON-FATAL — the update already
+   succeeded; a verifier FAIL is reported (so the consumer can fix their
+   environment) but never undoes the update. Cheap tier only (no `--deep`).
+
+   ```bash
+   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh" ]; then
+     VERIFY_INSTALL="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh"
+   else
+     VERIFY_INSTALL="$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/verifiers/verify-install.sh"
+   fi
+   if [ -f "$VERIFY_INSTALL" ]; then
+     bash "$VERIFY_INSTALL" --project-dir "$CLAUDE_PROJECT_DIR" || \
+       echo "(post-install verification reported a FAIL above — the update still succeeded; review and fix your environment, then re-run /update-zskills to re-verify)"
+   fi
+   ```
 
 ---
 

--- a/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# verify-install-lib.sh — consumer post-install verifier (assertion library).
+#
+# Issue #999. A one-shot "did my zskills install actually work in THIS
+# environment?" check, bundled in the update-zskills skill so it ships on
+# BOTH lanes (legacy mirror → .claude/skills/update-zskills/verifiers/,
+# plugin → ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/) and
+# auto-run at the end of a successful /update-zskills.
+#
+# This file is a SOURCEABLE library of pure-bash assertion functions. It is
+# the single source of truth for the check logic; the thin entry
+# (verify-install.sh) sources it, and the dev test (tests/test-verify-install.sh)
+# sources it and exercises it against synthetic installs.
+#
+# SELF-CONTAINED — deliberately depends on NOTHING outside this file. In
+# particular it does NOT source hooks/_lib/detect-install-state.sh: that lib
+# is NOT mirrored to a legacy consumer (.claude/hooks/_lib/ is absent), so a
+# verifier that sourced it would be broken on the very lane it ships to.
+# Lane detection is reimplemented here from the consumer-visible signals.
+#
+# Checks are the CHEAP STRUCTURAL TIER — fast file/config checks, no live
+# `claude`. The heavy live-probe tier is opt-in (vi_run_heavy) and is NOT on
+# the auto-run-at-success path.
+#
+# Result model: each check emits one record to stdout via vi_emit, of the
+# form "<status>\t<id>\t<detail>" where status ∈ {PASS,WARN,FAIL}. The
+# caller (entry or test) renders/aggregates. Functions also accumulate into
+# VI_PASS / VI_WARN / VI_FAIL counters so a caller can branch on totals
+# without re-parsing.
+#
+# No external JSON tools (no jq) — Python stdlib json per project convention.
+
+# Guard against double-source clobbering counters mid-run; callers reset
+# explicitly via vi_reset.
+VI_PASS=${VI_PASS:-0}
+VI_WARN=${VI_WARN:-0}
+VI_FAIL=${VI_FAIL:-0}
+
+# Resolve the Python interpreter once (project convention: python3, fall back
+# to python; ZSKILLS_PYTHON overrides). Used for JSON round-tripping.
+VI_PY="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python || true)}"
+
+# vi_reset — zero the counters. Call at the start of a verification run.
+vi_reset() {
+  VI_PASS=0
+  VI_WARN=0
+  VI_FAIL=0
+}
+
+# vi_emit <status> <id> [detail] — record one check result. Increments the
+# matching counter and prints a tab-separated record to stdout.
+vi_emit() {
+  local status="$1" id="$2" detail="${3:-}"
+  case "$status" in
+    PASS) VI_PASS=$((VI_PASS + 1)) ;;
+    WARN) VI_WARN=$((VI_WARN + 1)) ;;
+    FAIL) VI_FAIL=$((VI_FAIL + 1)) ;;
+  esac
+  printf '%s\t%s\t%s\n' "$status" "$id" "$detail"
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Lane detection (self-contained — no dependency on detect-install-state.sh).
+#
+# vi_detect_lane <project_dir> → prints one of: plugin | legacy | dual | none
+#
+#   ${CLAUDE_PLUGIN_ROOT} set            → plugin signal present
+#   .claude/skills/ AND .claude/settings.json present → legacy signal present
+#   both signals                         → dual (UNSUPPORTED — flagged)
+#   neither                              → none (no install detected)
+#
+# The plugin signal is the environment variable (a loaded plugin always sets
+# CLAUDE_PLUGIN_ROOT); the legacy signal is the on-disk mirror + settings.
+# This is exactly the consumer-visible state, matching the issue spec.
+# ───────────────────────────────────────────────────────────────────────────
+vi_detect_lane() {
+  local proj="$1"
+  local plugin_sig=0 legacy_sig=0
+
+  [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && plugin_sig=1
+
+  if [ -d "$proj/.claude/skills" ] \
+     && [ -n "$(ls -A "$proj/.claude/skills" 2>/dev/null)" ] \
+     && [ -f "$proj/.claude/settings.json" ]; then
+    legacy_sig=1
+  fi
+
+  if [ "$plugin_sig" -eq 1 ] && [ "$legacy_sig" -eq 1 ]; then
+    echo dual
+  elif [ "$plugin_sig" -eq 1 ]; then
+    echo plugin
+  elif [ "$legacy_sig" -eq 1 ]; then
+    echo legacy
+  else
+    echo none
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Small helpers.
+# ───────────────────────────────────────────────────────────────────────────
+
+# vi_config_version <config_path> → prints zskills_version field (empty if
+# absent/unreadable). Pure Python JSON read (no jq).
+vi_config_version() {
+  local cfg="$1"
+  [ -f "$cfg" ] || { echo ""; return 0; }
+  [ -n "$VI_PY" ] || { echo ""; return 0; }
+  "$VI_PY" - "$cfg" <<'PY' 2>/dev/null || echo ""
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get("zskills_version", "") or "")
+except Exception:
+    print("")
+PY
+}
+
+# vi_has_materialiser_sentinel <file> → 0 if the file carries a
+# `zskills-materialised:` sentinel in its first 3 lines (the exact detection
+# session-start-materialise.sh uses for its overwrite guard). 1 otherwise.
+vi_has_materialiser_sentinel() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  head -n 3 "$f" 2>/dev/null \
+    | grep -Eq "^(#|<!--)[[:space:]]+zskills-materialised:[[:space:]]"
+}
+
+# vi_settings_hook_commands <settings_json> → prints each registered hook
+# command (one per line) across PreToolUse/PostToolUse/SessionStart/Stop/etc.
+# Pure Python JSON read.
+vi_settings_hook_commands() {
+  local settings="$1"
+  [ -f "$settings" ] || return 0
+  [ -n "$VI_PY" ] || return 0
+  "$VI_PY" - "$settings" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for event, blocks in d.get("hooks", {}).items():
+    if not isinstance(blocks, list):
+        continue
+    for block in blocks:
+        for h in block.get("hooks", []):
+            cmd = h.get("command", "")
+            if cmd:
+                print(cmd)
+PY
+}
+
+# vi_resolve_hook_path <project_dir> <command> → prints the on-disk path the
+# command references, or empty if the command shape is unrecognised. Handles
+# the canonical form  bash "$CLAUDE_PROJECT_DIR/.claude/hooks/<base>"  and the
+# plugin form  bash "${CLAUDE_PLUGIN_ROOT}/hooks/<base>" .  Only the file path
+# is extracted (the last quoted token, or the last whitespace token).
+vi_resolve_hook_path() {
+  local proj="$1" cmd="$2" path=""
+  # Extract the path token: prefer a quoted "...path..." substring.
+  if [[ "$cmd" =~ \"([^\"]+)\" ]]; then
+    path="${BASH_REMATCH[1]}"
+  else
+    # Fall back to the last whitespace-separated token.
+    path="${cmd##* }"
+  fi
+  # Expand the two env vars the registration uses.
+  path="${path//\$\{CLAUDE_PROJECT_DIR\}/$proj}"
+  path="${path//\$CLAUDE_PROJECT_DIR/$proj}"
+  path="${path//\$\{CLAUDE_PLUGIN_ROOT\}/${CLAUDE_PLUGIN_ROOT:-}}"
+  path="${path//\$CLAUDE_PLUGIN_ROOT/${CLAUDE_PLUGIN_ROOT:-}}"
+  printf '%s\n' "$path"
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# LEGACY-lane cheap structural checks.
+#
+# vi_check_legacy <project_dir>
+#   - .claude/skills/ populated
+#   - every hook registered in .claude/settings.json resolves to a real file
+#   - .claude/rules/zskills/managed.md rendered with NO leftover
+#     <!-- TODO ... --> placeholders
+#   - .claude/zskills-config.json present
+#   - zskills version present (WARN if absent — informative, not fatal)
+# ───────────────────────────────────────────────────────────────────────────
+vi_check_legacy() {
+  local proj="$1"
+  local claude="$proj/.claude"
+
+  # (1) .claude/skills/ populated.
+  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
+    vi_emit PASS "legacy.skills-populated" ".claude/skills/ has $(ls -1 "$claude/skills" | wc -l | tr -d ' ') entries"
+  else
+    vi_emit FAIL "legacy.skills-populated" ".claude/skills/ missing or empty"
+  fi
+
+  # (2) settings.json present + valid JSON + every registered hook resolves.
+  local settings="$claude/settings.json"
+  if [ ! -f "$settings" ]; then
+    vi_emit FAIL "legacy.settings-present" ".claude/settings.json missing"
+  elif [ -n "$VI_PY" ] && ! "$VI_PY" -c 'import json,sys; json.load(open(sys.argv[1]))' "$settings" 2>/dev/null; then
+    vi_emit FAIL "legacy.settings-valid-json" ".claude/settings.json is not valid JSON"
+  else
+    vi_emit PASS "legacy.settings-present" ".claude/settings.json present and valid JSON"
+    local missing="" total=0 cmd hp
+    while IFS= read -r cmd; do
+      [ -n "$cmd" ] || continue
+      total=$((total + 1))
+      hp="$(vi_resolve_hook_path "$proj" "$cmd")"
+      if [ -z "$hp" ] || [ ! -f "$hp" ]; then
+        missing="$missing ${cmd##*/}"
+      fi
+    done < <(vi_settings_hook_commands "$settings")
+    if [ -z "$missing" ]; then
+      vi_emit PASS "legacy.hooks-resolve" "all $total registered hook commands resolve to existing files"
+    else
+      vi_emit FAIL "legacy.hooks-resolve" "unresolved hook script(s):$missing"
+    fi
+  fi
+
+  # (3) managed.md rendered with no leftover <!-- TODO ... --> placeholders.
+  local mm="$claude/rules/zskills/managed.md"
+  if [ ! -f "$mm" ]; then
+    vi_emit FAIL "legacy.managed-present" ".claude/rules/zskills/managed.md missing"
+  elif grep -qE '<!--[[:space:]]*TODO' "$mm"; then
+    vi_emit FAIL "legacy.managed-no-placeholders" "managed.md still contains <!-- TODO ... --> placeholder(s)"
+  else
+    vi_emit PASS "legacy.managed-no-placeholders" "managed.md rendered with no leftover TODO placeholders"
+  fi
+
+  # (4) zskills-config.json present.
+  local cfg="$claude/zskills-config.json"
+  if [ -f "$cfg" ]; then
+    vi_emit PASS "legacy.config-present" ".claude/zskills-config.json present"
+  else
+    vi_emit FAIL "legacy.config-present" ".claude/zskills-config.json missing"
+  fi
+
+  # (5) zskills version recorded (informative — WARN if absent).
+  local ver
+  ver="$(vi_config_version "$cfg")"
+  if [ -n "$ver" ]; then
+    vi_emit PASS "legacy.version-recorded" "zskills_version = $ver"
+  else
+    vi_emit WARN "legacy.version-recorded" "zskills_version absent from config (source clone may be untagged)"
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# PLUGIN-lane cheap structural checks.
+#
+# vi_check_plugin <project_dir>
+#   - the 5 materialised artifacts present, each carrying a
+#     `zskills-materialised:` sentinel:
+#       .claude/agents/verifier.md
+#       .claude/agents/implementer.md
+#       .claude/hooks/inject-bash-timeout.sh
+#       .claude/hooks/verify-response-validate.sh
+#       .claude/rules/zskills/managed.md
+#   - mirror-less (.claude/skills/ ABSENT in the consumer project)
+#   - zskills version present (WARN if absent)
+# ───────────────────────────────────────────────────────────────────────────
+vi_check_plugin() {
+  local proj="$1"
+  local claude="$proj/.claude"
+
+  # (1) The 5 materialised artifacts, each with a materialiser sentinel.
+  local -a artifacts=(
+    "agents/verifier.md"
+    "agents/implementer.md"
+    "hooks/inject-bash-timeout.sh"
+    "hooks/verify-response-validate.sh"
+    "rules/zskills/managed.md"
+  )
+  local a dest
+  for a in "${artifacts[@]}"; do
+    dest="$claude/$a"
+    if [ ! -f "$dest" ]; then
+      vi_emit FAIL "plugin.artifact.$a" "materialised artifact missing: .claude/$a"
+    elif ! vi_has_materialiser_sentinel "$dest"; then
+      vi_emit FAIL "plugin.artifact.$a" ".claude/$a present but missing zskills-materialised: sentinel"
+    else
+      vi_emit PASS "plugin.artifact.$a" ".claude/$a present with materialiser sentinel"
+    fi
+  done
+
+  # (2) Mirror-less: .claude/skills/ must be ABSENT in a clean plugin consumer.
+  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
+    vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
+  else
+    vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
+  fi
+
+  # (3) zskills version recorded (informative — WARN if absent).
+  local cfg="$claude/zskills-config.json" ver
+  ver="$(vi_config_version "$cfg")"
+  if [ -n "$ver" ]; then
+    vi_emit PASS "plugin.version-recorded" "zskills_version = $ver"
+  else
+    vi_emit WARN "plugin.version-recorded" "zskills_version absent from config (plugin seed config has no tag)"
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Dispatch by detected lane.
+#
+# vi_run_cheap <project_dir> — detect the lane and run the cheap structural
+# tier for it. Emits per-check records and leaves VI_PASS/WARN/FAIL populated.
+# A `dual` lane is flagged FAIL (unsupported client state) but still runs the
+# legacy checks so the consumer sees the full picture. `none` is a FAIL.
+# ───────────────────────────────────────────────────────────────────────────
+vi_run_cheap() {
+  local proj="$1"
+  local lane
+  lane="$(vi_detect_lane "$proj")"
+  vi_emit "$([ "$lane" = none ] && echo FAIL || echo PASS)" "lane.detect" "detected lane: $lane"
+
+  case "$lane" in
+    plugin)
+      vi_check_plugin "$proj"
+      ;;
+    legacy)
+      vi_check_legacy "$proj"
+      ;;
+    dual)
+      vi_emit FAIL "lane.dual-unsupported" "dual install (plugin + legacy mirror) is NOT a supported client state — run scripts/switch-install-path.sh"
+      vi_check_legacy "$proj"
+      ;;
+    none)
+      vi_emit FAIL "lane.none" "no zskills install detected (no \${CLAUDE_PLUGIN_ROOT}, no .claude/skills + settings.json)"
+      ;;
+  esac
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Heavy tier (opt-in — NOT on the auto-run-at-success path).
+#
+# vi_run_heavy <project_dir> — a live `claude` hook-fire / `/zs:` dispatch
+# probe. Intentionally a stub: it must NEVER run as part of /update-zskills
+# success. Implemented minimally so the opt-in path exists and is testable
+# without spawning a real `claude`. When `claude` is unavailable it WARNs
+# rather than FAILs (the live probe is informative, never a gate).
+# ───────────────────────────────────────────────────────────────────────────
+vi_run_heavy() {
+  local proj="$1"
+  if ! command -v claude >/dev/null 2>&1; then
+    vi_emit WARN "heavy.claude-available" "claude CLI not found — skipping live probe (heavy tier is opt-in only)"
+    return 0
+  fi
+  # A real live probe would dispatch a no-op /zs: command or trigger a hook
+  # fire and assert the expected sentinel/output. Kept minimal here; the
+  # important contract is that this is OPT-IN and never runs at success.
+  vi_emit WARN "heavy.live-probe" "live probe stub — implement a /zs: dispatch or hook-fire assertion as needed"
+  return 0
+}

--- a/.claude/skills/update-zskills/verifiers/verify-install.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# verify-install.sh — thin entry for the consumer post-install verifier.
+#
+# Issue #999. Detects the install lane and runs the CHEAP structural tier of
+# checks (fast file/config checks — no live `claude`), printing explicit
+# per-check PASS/WARN/FAIL lines and an overall result. Auto-run by
+# /update-zskills at the end of a successful install/update (NON-FATAL: a
+# FAIL here is reported but does not undo the install — verification is
+# informative).
+#
+# Usage:
+#   verify-install.sh [--project-dir <dir>] [--deep]
+#
+#   --project-dir <dir>   Consumer project root to verify. Defaults to
+#                         $CLAUDE_PROJECT_DIR, else the current directory.
+#   --deep                ALSO run the heavy live-probe tier (opt-in only —
+#                         NEVER passed on the /update-zskills success path).
+#
+# Exit codes:
+#   0  no FAILs (all PASS, possibly with WARNs)
+#   1  at least one FAIL
+#   2  usage error
+#
+# The library (verify-install-lib.sh) holds the assertion logic and is the
+# single source of truth; this entry only parses args, sources the lib, and
+# renders. It ships alongside the lib on both lanes
+# (.claude/skills/update-zskills/verifiers/ legacy,
+# ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/ plugin).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=verify-install-lib.sh
+. "$SCRIPT_DIR/verify-install-lib.sh"
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+RUN_DEEP=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir)
+      PROJECT_DIR="${2:-}"
+      [ -n "$PROJECT_DIR" ] || { echo "ERROR: --project-dir requires a value" >&2; exit 2; }
+      shift 2
+      ;;
+    --deep)
+      RUN_DEEP=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  echo "ERROR: project dir not found: $PROJECT_DIR" >&2
+  exit 2
+fi
+
+echo "zskills install verification — project: $PROJECT_DIR"
+echo "------------------------------------------------------------"
+
+# vi_emit increments VI_PASS/WARN/FAIL, but vi_run_cheap runs inside a process
+# substitution (a subshell), so those counters do NOT propagate back here.
+# Re-tally from the rendered record stream in THIS shell so the Result line and
+# exit code reflect reality.
+P_PASS=0; P_WARN=0; P_FAIL=0
+
+render_stream() {
+  # $1 = records-producing function; remaining args = its args.
+  local fn="$1"; shift
+  while IFS=$'\t' read -r status id detail; do
+    [ -n "$status" ] || continue
+    case "$status" in
+      PASS) P_PASS=$((P_PASS + 1)); marker="PASS" ;;
+      WARN) P_WARN=$((P_WARN + 1)); marker="WARN" ;;
+      FAIL) P_FAIL=$((P_FAIL + 1)); marker="FAIL" ;;
+      *)    marker="????" ;;
+    esac
+    printf '  %-4s  %-32s %s\n' "$marker" "$id" "$detail"
+  done < <("$fn" "$@")
+}
+
+vi_reset
+# Run the cheap tier and render each record as it arrives.
+render_stream vi_run_cheap "$PROJECT_DIR"
+
+if [ "$RUN_DEEP" -eq 1 ]; then
+  echo "--- heavy tier (--deep, opt-in) ---"
+  render_stream vi_run_heavy "$PROJECT_DIR"
+fi
+
+echo "------------------------------------------------------------"
+printf 'Result: %d PASS, %d WARN, %d FAIL\n' "$P_PASS" "$P_WARN" "$P_FAIL"
+
+if [ "$P_FAIL" -gt 0 ]; then
+  echo "Overall: FAIL"
+  exit 1
+elif [ "$P_WARN" -gt 0 ]; then
+  echo "Overall: PASS (with warnings)"
+  exit 0
+else
+  echo "Overall: PASS"
+  exit 0
+fi

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install | --rerender | --migrate-paths | --switch-install-path={to-plugin|to-update-zskills}] [cherry-pick | locked-main-pr | direct] [--with-addons | --with-block-diagram-addons]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.01+9e1d01"
+  version: "2026.06.02+81a457"
 ---
 
 # Update Z Skills Infrastructure
@@ -1948,6 +1948,44 @@ printf '%s\n' "$delta_tsv" | awk -F'\t' -v show_addons="$show_addons" '
 `zskills_version` from Step F.5 (or `(unversioned)` if the source clone
 had no tags).
 
+#### Step G.5 — Post-install verification (#999, cheap tier, NON-FATAL)
+
+After the final report, run the bundled consumer post-install verifier's
+**cheap structural tier** and append its result to the success output. This
+catches the consumer-side of the dogfood-mask (#799/#831): environment-specific
+install breakage that dev-repo tests structurally cannot see (a registered hook
+that resolves to nothing, a leftover `<!-- TODO -->` placeholder in
+`managed.md`, a dropped artifact/sentinel, an accidental dual-install).
+
+**NON-FATAL — informative only.** The install already succeeded; this
+verification reports PASS/WARN/FAIL but **does NOT undo or fail the install**.
+A FAIL is surfaced to the user (so they can fix their environment) but the
+install stands. Run ONLY the cheap tier here — never `--deep` (the heavy
+live-`claude` probe is opt-in and must not run on the success path).
+
+Resolve the verifier path lane-awarely (it ships at
+`.claude/skills/update-zskills/verifiers/` on the legacy lane,
+`${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/` on the plugin lane):
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh" ]; then
+  VERIFY_INSTALL="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh"
+else
+  VERIFY_INSTALL="$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/verifiers/verify-install.sh"
+fi
+if [ -f "$VERIFY_INSTALL" ]; then
+  # Cheap tier only (no --deep). Non-fatal: capture and report, never abort.
+  bash "$VERIFY_INSTALL" --project-dir "$CLAUDE_PROJECT_DIR" || \
+    echo "(post-install verification reported a FAIL above — the install still succeeded; review and fix your environment, then re-run /update-zskills to re-verify)"
+else
+  echo "(post-install verifier not found at $VERIFY_INSTALL — skipping verification)"
+fi
+```
+
+Report the verifier's per-check output and overall result as a final block of
+the success message. On WARN-only, note it's informative; on FAIL, tell the
+user the install succeeded but verification flagged an environment issue.
+
 ### Pull Latest and Update (already-installed path)
 
 1. **Pull latest from upstream.** Find the `zskills/` clone (Step 0) and
@@ -2071,6 +2109,24 @@ had no tags).
 
    `(unversioned)` placeholder applies to either side of the `Repo
    version:` arrow if the corresponding tag is missing.
+
+7. **Post-install verification (#999, cheap tier, NON-FATAL).** Same as
+   install-path **Step G.5**: run the bundled consumer verifier's cheap
+   structural tier and append its result. NON-FATAL — the update already
+   succeeded; a verifier FAIL is reported (so the consumer can fix their
+   environment) but never undoes the update. Cheap tier only (no `--deep`).
+
+   ```bash
+   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh" ]; then
+     VERIFY_INSTALL="${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/verify-install.sh"
+   else
+     VERIFY_INSTALL="$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/verifiers/verify-install.sh"
+   fi
+   if [ -f "$VERIFY_INSTALL" ]; then
+     bash "$VERIFY_INSTALL" --project-dir "$CLAUDE_PROJECT_DIR" || \
+       echo "(post-install verification reported a FAIL above — the update still succeeded; review and fix your environment, then re-run /update-zskills to re-verify)"
+   fi
+   ```
 
 ---
 

--- a/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# verify-install-lib.sh — consumer post-install verifier (assertion library).
+#
+# Issue #999. A one-shot "did my zskills install actually work in THIS
+# environment?" check, bundled in the update-zskills skill so it ships on
+# BOTH lanes (legacy mirror → .claude/skills/update-zskills/verifiers/,
+# plugin → ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/) and
+# auto-run at the end of a successful /update-zskills.
+#
+# This file is a SOURCEABLE library of pure-bash assertion functions. It is
+# the single source of truth for the check logic; the thin entry
+# (verify-install.sh) sources it, and the dev test (tests/test-verify-install.sh)
+# sources it and exercises it against synthetic installs.
+#
+# SELF-CONTAINED — deliberately depends on NOTHING outside this file. In
+# particular it does NOT source hooks/_lib/detect-install-state.sh: that lib
+# is NOT mirrored to a legacy consumer (.claude/hooks/_lib/ is absent), so a
+# verifier that sourced it would be broken on the very lane it ships to.
+# Lane detection is reimplemented here from the consumer-visible signals.
+#
+# Checks are the CHEAP STRUCTURAL TIER — fast file/config checks, no live
+# `claude`. The heavy live-probe tier is opt-in (vi_run_heavy) and is NOT on
+# the auto-run-at-success path.
+#
+# Result model: each check emits one record to stdout via vi_emit, of the
+# form "<status>\t<id>\t<detail>" where status ∈ {PASS,WARN,FAIL}. The
+# caller (entry or test) renders/aggregates. Functions also accumulate into
+# VI_PASS / VI_WARN / VI_FAIL counters so a caller can branch on totals
+# without re-parsing.
+#
+# No external JSON tools (no jq) — Python stdlib json per project convention.
+
+# Guard against double-source clobbering counters mid-run; callers reset
+# explicitly via vi_reset.
+VI_PASS=${VI_PASS:-0}
+VI_WARN=${VI_WARN:-0}
+VI_FAIL=${VI_FAIL:-0}
+
+# Resolve the Python interpreter once (project convention: python3, fall back
+# to python; ZSKILLS_PYTHON overrides). Used for JSON round-tripping.
+VI_PY="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python || true)}"
+
+# vi_reset — zero the counters. Call at the start of a verification run.
+vi_reset() {
+  VI_PASS=0
+  VI_WARN=0
+  VI_FAIL=0
+}
+
+# vi_emit <status> <id> [detail] — record one check result. Increments the
+# matching counter and prints a tab-separated record to stdout.
+vi_emit() {
+  local status="$1" id="$2" detail="${3:-}"
+  case "$status" in
+    PASS) VI_PASS=$((VI_PASS + 1)) ;;
+    WARN) VI_WARN=$((VI_WARN + 1)) ;;
+    FAIL) VI_FAIL=$((VI_FAIL + 1)) ;;
+  esac
+  printf '%s\t%s\t%s\n' "$status" "$id" "$detail"
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Lane detection (self-contained — no dependency on detect-install-state.sh).
+#
+# vi_detect_lane <project_dir> → prints one of: plugin | legacy | dual | none
+#
+#   ${CLAUDE_PLUGIN_ROOT} set            → plugin signal present
+#   .claude/skills/ AND .claude/settings.json present → legacy signal present
+#   both signals                         → dual (UNSUPPORTED — flagged)
+#   neither                              → none (no install detected)
+#
+# The plugin signal is the environment variable (a loaded plugin always sets
+# CLAUDE_PLUGIN_ROOT); the legacy signal is the on-disk mirror + settings.
+# This is exactly the consumer-visible state, matching the issue spec.
+# ───────────────────────────────────────────────────────────────────────────
+vi_detect_lane() {
+  local proj="$1"
+  local plugin_sig=0 legacy_sig=0
+
+  [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && plugin_sig=1
+
+  if [ -d "$proj/.claude/skills" ] \
+     && [ -n "$(ls -A "$proj/.claude/skills" 2>/dev/null)" ] \
+     && [ -f "$proj/.claude/settings.json" ]; then
+    legacy_sig=1
+  fi
+
+  if [ "$plugin_sig" -eq 1 ] && [ "$legacy_sig" -eq 1 ]; then
+    echo dual
+  elif [ "$plugin_sig" -eq 1 ]; then
+    echo plugin
+  elif [ "$legacy_sig" -eq 1 ]; then
+    echo legacy
+  else
+    echo none
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Small helpers.
+# ───────────────────────────────────────────────────────────────────────────
+
+# vi_config_version <config_path> → prints zskills_version field (empty if
+# absent/unreadable). Pure Python JSON read (no jq).
+vi_config_version() {
+  local cfg="$1"
+  [ -f "$cfg" ] || { echo ""; return 0; }
+  [ -n "$VI_PY" ] || { echo ""; return 0; }
+  "$VI_PY" - "$cfg" <<'PY' 2>/dev/null || echo ""
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get("zskills_version", "") or "")
+except Exception:
+    print("")
+PY
+}
+
+# vi_has_materialiser_sentinel <file> → 0 if the file carries a
+# `zskills-materialised:` sentinel in its first 3 lines (the exact detection
+# session-start-materialise.sh uses for its overwrite guard). 1 otherwise.
+vi_has_materialiser_sentinel() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  head -n 3 "$f" 2>/dev/null \
+    | grep -Eq "^(#|<!--)[[:space:]]+zskills-materialised:[[:space:]]"
+}
+
+# vi_settings_hook_commands <settings_json> → prints each registered hook
+# command (one per line) across PreToolUse/PostToolUse/SessionStart/Stop/etc.
+# Pure Python JSON read.
+vi_settings_hook_commands() {
+  local settings="$1"
+  [ -f "$settings" ] || return 0
+  [ -n "$VI_PY" ] || return 0
+  "$VI_PY" - "$settings" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for event, blocks in d.get("hooks", {}).items():
+    if not isinstance(blocks, list):
+        continue
+    for block in blocks:
+        for h in block.get("hooks", []):
+            cmd = h.get("command", "")
+            if cmd:
+                print(cmd)
+PY
+}
+
+# vi_resolve_hook_path <project_dir> <command> → prints the on-disk path the
+# command references, or empty if the command shape is unrecognised. Handles
+# the canonical form  bash "$CLAUDE_PROJECT_DIR/.claude/hooks/<base>"  and the
+# plugin form  bash "${CLAUDE_PLUGIN_ROOT}/hooks/<base>" .  Only the file path
+# is extracted (the last quoted token, or the last whitespace token).
+vi_resolve_hook_path() {
+  local proj="$1" cmd="$2" path=""
+  # Extract the path token: prefer a quoted "...path..." substring.
+  if [[ "$cmd" =~ \"([^\"]+)\" ]]; then
+    path="${BASH_REMATCH[1]}"
+  else
+    # Fall back to the last whitespace-separated token.
+    path="${cmd##* }"
+  fi
+  # Expand the two env vars the registration uses.
+  path="${path//\$\{CLAUDE_PROJECT_DIR\}/$proj}"
+  path="${path//\$CLAUDE_PROJECT_DIR/$proj}"
+  path="${path//\$\{CLAUDE_PLUGIN_ROOT\}/${CLAUDE_PLUGIN_ROOT:-}}"
+  path="${path//\$CLAUDE_PLUGIN_ROOT/${CLAUDE_PLUGIN_ROOT:-}}"
+  printf '%s\n' "$path"
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# LEGACY-lane cheap structural checks.
+#
+# vi_check_legacy <project_dir>
+#   - .claude/skills/ populated
+#   - every hook registered in .claude/settings.json resolves to a real file
+#   - .claude/rules/zskills/managed.md rendered with NO leftover
+#     <!-- TODO ... --> placeholders
+#   - .claude/zskills-config.json present
+#   - zskills version present (WARN if absent — informative, not fatal)
+# ───────────────────────────────────────────────────────────────────────────
+vi_check_legacy() {
+  local proj="$1"
+  local claude="$proj/.claude"
+
+  # (1) .claude/skills/ populated.
+  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
+    vi_emit PASS "legacy.skills-populated" ".claude/skills/ has $(ls -1 "$claude/skills" | wc -l | tr -d ' ') entries"
+  else
+    vi_emit FAIL "legacy.skills-populated" ".claude/skills/ missing or empty"
+  fi
+
+  # (2) settings.json present + valid JSON + every registered hook resolves.
+  local settings="$claude/settings.json"
+  if [ ! -f "$settings" ]; then
+    vi_emit FAIL "legacy.settings-present" ".claude/settings.json missing"
+  elif [ -n "$VI_PY" ] && ! "$VI_PY" -c 'import json,sys; json.load(open(sys.argv[1]))' "$settings" 2>/dev/null; then
+    vi_emit FAIL "legacy.settings-valid-json" ".claude/settings.json is not valid JSON"
+  else
+    vi_emit PASS "legacy.settings-present" ".claude/settings.json present and valid JSON"
+    local missing="" total=0 cmd hp
+    while IFS= read -r cmd; do
+      [ -n "$cmd" ] || continue
+      total=$((total + 1))
+      hp="$(vi_resolve_hook_path "$proj" "$cmd")"
+      if [ -z "$hp" ] || [ ! -f "$hp" ]; then
+        missing="$missing ${cmd##*/}"
+      fi
+    done < <(vi_settings_hook_commands "$settings")
+    if [ -z "$missing" ]; then
+      vi_emit PASS "legacy.hooks-resolve" "all $total registered hook commands resolve to existing files"
+    else
+      vi_emit FAIL "legacy.hooks-resolve" "unresolved hook script(s):$missing"
+    fi
+  fi
+
+  # (3) managed.md rendered with no leftover <!-- TODO ... --> placeholders.
+  local mm="$claude/rules/zskills/managed.md"
+  if [ ! -f "$mm" ]; then
+    vi_emit FAIL "legacy.managed-present" ".claude/rules/zskills/managed.md missing"
+  elif grep -qE '<!--[[:space:]]*TODO' "$mm"; then
+    vi_emit FAIL "legacy.managed-no-placeholders" "managed.md still contains <!-- TODO ... --> placeholder(s)"
+  else
+    vi_emit PASS "legacy.managed-no-placeholders" "managed.md rendered with no leftover TODO placeholders"
+  fi
+
+  # (4) zskills-config.json present.
+  local cfg="$claude/zskills-config.json"
+  if [ -f "$cfg" ]; then
+    vi_emit PASS "legacy.config-present" ".claude/zskills-config.json present"
+  else
+    vi_emit FAIL "legacy.config-present" ".claude/zskills-config.json missing"
+  fi
+
+  # (5) zskills version recorded (informative — WARN if absent).
+  local ver
+  ver="$(vi_config_version "$cfg")"
+  if [ -n "$ver" ]; then
+    vi_emit PASS "legacy.version-recorded" "zskills_version = $ver"
+  else
+    vi_emit WARN "legacy.version-recorded" "zskills_version absent from config (source clone may be untagged)"
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# PLUGIN-lane cheap structural checks.
+#
+# vi_check_plugin <project_dir>
+#   - the 5 materialised artifacts present, each carrying a
+#     `zskills-materialised:` sentinel:
+#       .claude/agents/verifier.md
+#       .claude/agents/implementer.md
+#       .claude/hooks/inject-bash-timeout.sh
+#       .claude/hooks/verify-response-validate.sh
+#       .claude/rules/zskills/managed.md
+#   - mirror-less (.claude/skills/ ABSENT in the consumer project)
+#   - zskills version present (WARN if absent)
+# ───────────────────────────────────────────────────────────────────────────
+vi_check_plugin() {
+  local proj="$1"
+  local claude="$proj/.claude"
+
+  # (1) The 5 materialised artifacts, each with a materialiser sentinel.
+  local -a artifacts=(
+    "agents/verifier.md"
+    "agents/implementer.md"
+    "hooks/inject-bash-timeout.sh"
+    "hooks/verify-response-validate.sh"
+    "rules/zskills/managed.md"
+  )
+  local a dest
+  for a in "${artifacts[@]}"; do
+    dest="$claude/$a"
+    if [ ! -f "$dest" ]; then
+      vi_emit FAIL "plugin.artifact.$a" "materialised artifact missing: .claude/$a"
+    elif ! vi_has_materialiser_sentinel "$dest"; then
+      vi_emit FAIL "plugin.artifact.$a" ".claude/$a present but missing zskills-materialised: sentinel"
+    else
+      vi_emit PASS "plugin.artifact.$a" ".claude/$a present with materialiser sentinel"
+    fi
+  done
+
+  # (2) Mirror-less: .claude/skills/ must be ABSENT in a clean plugin consumer.
+  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
+    vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
+  else
+    vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
+  fi
+
+  # (3) zskills version recorded (informative — WARN if absent).
+  local cfg="$claude/zskills-config.json" ver
+  ver="$(vi_config_version "$cfg")"
+  if [ -n "$ver" ]; then
+    vi_emit PASS "plugin.version-recorded" "zskills_version = $ver"
+  else
+    vi_emit WARN "plugin.version-recorded" "zskills_version absent from config (plugin seed config has no tag)"
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Dispatch by detected lane.
+#
+# vi_run_cheap <project_dir> — detect the lane and run the cheap structural
+# tier for it. Emits per-check records and leaves VI_PASS/WARN/FAIL populated.
+# A `dual` lane is flagged FAIL (unsupported client state) but still runs the
+# legacy checks so the consumer sees the full picture. `none` is a FAIL.
+# ───────────────────────────────────────────────────────────────────────────
+vi_run_cheap() {
+  local proj="$1"
+  local lane
+  lane="$(vi_detect_lane "$proj")"
+  vi_emit "$([ "$lane" = none ] && echo FAIL || echo PASS)" "lane.detect" "detected lane: $lane"
+
+  case "$lane" in
+    plugin)
+      vi_check_plugin "$proj"
+      ;;
+    legacy)
+      vi_check_legacy "$proj"
+      ;;
+    dual)
+      vi_emit FAIL "lane.dual-unsupported" "dual install (plugin + legacy mirror) is NOT a supported client state — run scripts/switch-install-path.sh"
+      vi_check_legacy "$proj"
+      ;;
+    none)
+      vi_emit FAIL "lane.none" "no zskills install detected (no \${CLAUDE_PLUGIN_ROOT}, no .claude/skills + settings.json)"
+      ;;
+  esac
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Heavy tier (opt-in — NOT on the auto-run-at-success path).
+#
+# vi_run_heavy <project_dir> — a live `claude` hook-fire / `/zs:` dispatch
+# probe. Intentionally a stub: it must NEVER run as part of /update-zskills
+# success. Implemented minimally so the opt-in path exists and is testable
+# without spawning a real `claude`. When `claude` is unavailable it WARNs
+# rather than FAILs (the live probe is informative, never a gate).
+# ───────────────────────────────────────────────────────────────────────────
+vi_run_heavy() {
+  local proj="$1"
+  if ! command -v claude >/dev/null 2>&1; then
+    vi_emit WARN "heavy.claude-available" "claude CLI not found — skipping live probe (heavy tier is opt-in only)"
+    return 0
+  fi
+  # A real live probe would dispatch a no-op /zs: command or trigger a hook
+  # fire and assert the expected sentinel/output. Kept minimal here; the
+  # important contract is that this is OPT-IN and never runs at success.
+  vi_emit WARN "heavy.live-probe" "live probe stub — implement a /zs: dispatch or hook-fire assertion as needed"
+  return 0
+}

--- a/skills/update-zskills/verifiers/verify-install.sh
+++ b/skills/update-zskills/verifiers/verify-install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# verify-install.sh — thin entry for the consumer post-install verifier.
+#
+# Issue #999. Detects the install lane and runs the CHEAP structural tier of
+# checks (fast file/config checks — no live `claude`), printing explicit
+# per-check PASS/WARN/FAIL lines and an overall result. Auto-run by
+# /update-zskills at the end of a successful install/update (NON-FATAL: a
+# FAIL here is reported but does not undo the install — verification is
+# informative).
+#
+# Usage:
+#   verify-install.sh [--project-dir <dir>] [--deep]
+#
+#   --project-dir <dir>   Consumer project root to verify. Defaults to
+#                         $CLAUDE_PROJECT_DIR, else the current directory.
+#   --deep                ALSO run the heavy live-probe tier (opt-in only —
+#                         NEVER passed on the /update-zskills success path).
+#
+# Exit codes:
+#   0  no FAILs (all PASS, possibly with WARNs)
+#   1  at least one FAIL
+#   2  usage error
+#
+# The library (verify-install-lib.sh) holds the assertion logic and is the
+# single source of truth; this entry only parses args, sources the lib, and
+# renders. It ships alongside the lib on both lanes
+# (.claude/skills/update-zskills/verifiers/ legacy,
+# ${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/verifiers/ plugin).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=verify-install-lib.sh
+. "$SCRIPT_DIR/verify-install-lib.sh"
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+RUN_DEEP=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir)
+      PROJECT_DIR="${2:-}"
+      [ -n "$PROJECT_DIR" ] || { echo "ERROR: --project-dir requires a value" >&2; exit 2; }
+      shift 2
+      ;;
+    --deep)
+      RUN_DEEP=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  echo "ERROR: project dir not found: $PROJECT_DIR" >&2
+  exit 2
+fi
+
+echo "zskills install verification — project: $PROJECT_DIR"
+echo "------------------------------------------------------------"
+
+# vi_emit increments VI_PASS/WARN/FAIL, but vi_run_cheap runs inside a process
+# substitution (a subshell), so those counters do NOT propagate back here.
+# Re-tally from the rendered record stream in THIS shell so the Result line and
+# exit code reflect reality.
+P_PASS=0; P_WARN=0; P_FAIL=0
+
+render_stream() {
+  # $1 = records-producing function; remaining args = its args.
+  local fn="$1"; shift
+  while IFS=$'\t' read -r status id detail; do
+    [ -n "$status" ] || continue
+    case "$status" in
+      PASS) P_PASS=$((P_PASS + 1)); marker="PASS" ;;
+      WARN) P_WARN=$((P_WARN + 1)); marker="WARN" ;;
+      FAIL) P_FAIL=$((P_FAIL + 1)); marker="FAIL" ;;
+      *)    marker="????" ;;
+    esac
+    printf '  %-4s  %-32s %s\n' "$marker" "$id" "$detail"
+  done < <("$fn" "$@")
+}
+
+vi_reset
+# Run the cheap tier and render each record as it arrives.
+render_stream vi_run_cheap "$PROJECT_DIR"
+
+if [ "$RUN_DEEP" -eq 1 ]; then
+  echo "--- heavy tier (--deep, opt-in) ---"
+  render_stream vi_run_heavy "$PROJECT_DIR"
+fi
+
+echo "------------------------------------------------------------"
+printf 'Result: %d PASS, %d WARN, %d FAIL\n' "$P_PASS" "$P_WARN" "$P_FAIL"
+
+if [ "$P_FAIL" -gt 0 ]; then
+  echo "Overall: FAIL"
+  exit 1
+elif [ "$P_WARN" -gt 0 ]; then
+  echo "Overall: PASS (with warnings)"
+  exit 0
+else
+  echo "Overall: PASS"
+  exit 0
+fi

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -248,6 +248,7 @@ run_suite "test-sessionstart-materialise.sh" "tests/test-sessionstart-materialis
 run_suite "test-sessionstart-materialise-overwrite-guard.sh" "tests/test-sessionstart-materialise-overwrite-guard.sh"
 run_suite "test-sessionstart-dual-install-detect.sh" "tests/test-sessionstart-dual-install-detect.sh"
 run_suite "test-synthetic-consumer-install.sh" "tests/test-synthetic-consumer-install.sh"
+run_suite "test-verify-install.sh" "tests/test-verify-install.sh"
 run_suite "test-render-managed-rules-correctness.sh" "tests/test-render-managed-rules-correctness.sh"
 run_suite "test-managed-md-renderer-equivalence.sh" "tests/test-managed-md-renderer-equivalence.sh"
 run_suite "test-inject-bash-timeout-parity.sh" "tests/test-inject-bash-timeout-parity.sh"

--- a/tests/test-verify-install.sh
+++ b/tests/test-verify-install.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# tests/test-verify-install.sh
+#
+# Issue #999 — dev test for the consumer post-install verifier
+# (skills/update-zskills/verifiers/verify-install-lib.sh). SOURCES the shipped
+# assertion library (the dev repo has skills/, so no copy step — the lib that
+# ships IS the source of truth) and asserts it against SYNTHETIC installs built
+# in a mktemp sandbox, reusing the synthetic-consumer oracle pattern from
+# tests/test-synthetic-consumer-install.sh.
+#
+# Anti-hollow contract (the load-bearing requirement): the verifier must FAIL
+# on a deliberately-broken install, not only PASS on a good one. This file
+# asserts BOTH directions for BOTH lanes:
+#   - good legacy install            → verify_overall_rc == 0 (no FAIL)
+#   - broken legacy (hook file gone) → FAIL
+#   - broken legacy (managed.md TODO)→ FAIL
+#   - good plugin layout             → no FAIL
+#   - broken plugin (sentinel dropped)→ FAIL
+#   - broken plugin (artifact dropped)→ FAIL
+#   - dual install                   → FAIL
+#   - none                           → FAIL
+#
+# Sandbox-only: every consumer dir lives under $TMP; the real repo / $HOME are
+# never written. The verifier is read-only (it only inspects files), so even
+# the source-tree paths it might read are untouched.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LIB="$REPO_ROOT/skills/update-zskills/verifiers/verify-install-lib.sh"
+ENTRY="$REPO_ROOT/skills/update-zskills/verifiers/verify-install.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '  PASS %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '  FAIL %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The lib must exist and be sourceable.
+if [ ! -f "$LIB" ]; then
+  fail "0. lib present" "verify-install-lib.sh missing at $LIB"
+  echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+  exit 1
+fi
+# shellcheck source=../skills/update-zskills/verifiers/verify-install-lib.sh
+. "$LIB"
+pass "0. verify-install-lib.sh sourceable"
+
+# ── Result helpers ──────────────────────────────────────────────────────────
+# Run vi_run_cheap in THIS shell (no subshell) so VI_PASS/WARN/FAIL accumulate,
+# capturing the records to a file for content assertions.
+run_cheap_capture() {
+  local proj="$1" out="$2"
+  vi_reset
+  vi_run_cheap "$proj" > "$out"
+}
+
+# Count FAIL records in a captured output file.
+count_fail() { grep -c '^FAIL' "$1" 2>/dev/null || echo 0; }
+# Does the captured output contain a FAIL whose id matches $2?
+has_fail_id() { grep -q "^FAIL	$2	" "$1"; }
+
+# ── Synthetic LEGACY install builder ────────────────────────────────────────
+# Produces a consumer dir with: a populated .claude/skills/, a settings.json
+# registering a hook whose file EXISTS on disk, a rendered managed.md with NO
+# placeholders, and a zskills-config.json. This is a "working" legacy install.
+make_legacy_good() {
+  local c="$TMP/legacy-good-$1"
+  rm -rf -- "$c"
+  mkdir -p "$c/.claude/skills/update-zskills" \
+           "$c/.claude/hooks" \
+           "$c/.claude/rules/zskills"
+  printf '%s\n' '---' 'name: update-zskills' '---' '# Update Z Skills' \
+    > "$c/.claude/skills/update-zskills/SKILL.md"
+  # A real hook file the registration will point at.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$c/.claude/hooks/block-unsafe-generic.sh"
+  # settings.json registering that hook via the canonical command form.
+  cat > "$c/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"", "timeout": 5 }
+      ] }
+    ]
+  }
+}
+JSON
+  # Rendered managed.md — no TODO placeholders.
+  printf '%s\n' '# acme — Agent Reference' '' 'Rendered rules, no placeholders.' \
+    > "$c/.claude/rules/zskills/managed.md"
+  cat > "$c/.claude/zskills-config.json" <<'JSON'
+{ "project_name": "acme", "zskills_version": "2026.06.0" }
+JSON
+  echo "$c"
+}
+
+# ── Synthetic PLUGIN install builder ────────────────────────────────────────
+# Produces a consumer dir with the 5 materialised artifacts, each carrying a
+# `zskills-materialised:` sentinel, and NO .claude/skills/ mirror (mirror-less).
+make_plugin_good() {
+  local c="$TMP/plugin-good-$1"
+  rm -rf -- "$c"
+  mkdir -p "$c/.claude/agents" "$c/.claude/hooks" "$c/.claude/rules/zskills"
+  # frontmatter .md artifacts — sentinel as YAML-comment first line in ---.
+  for ag in verifier implementer; do
+    printf '%s\n' '---' '# zskills-materialised: 2026.06.0' "name: $ag" '---' "# $ag" \
+      > "$c/.claude/agents/$ag.md"
+  done
+  # *.sh artifacts — sentinel as shell-comment on line 2.
+  for h in inject-bash-timeout verify-response-validate; do
+    printf '%s\n' '#!/usr/bin/env bash' '# zskills-materialised: 2026.06.0' 'exit 0' \
+      > "$c/.claude/hooks/$h.sh"
+  done
+  # plain .md managed.md — sentinel as HTML-comment first line.
+  printf '%s\n' '<!-- zskills-materialised: 2026.06.0 -->' '# rules' \
+    > "$c/.claude/rules/zskills/managed.md"
+  cat > "$c/.claude/zskills-config.json" <<'JSON'
+{ "project_name": "acme", "zskills_version": "2026.06.0" }
+JSON
+  echo "$c"
+}
+
+echo "=== verify-install: synthetic good + broken installs ==="
+
+# ── LEGACY: good install → no FAIL ──────────────────────────────────────────
+LG="$(make_legacy_good 1)"
+OUT="$TMP/out-legacy-good.txt"
+run_cheap_capture "$LG" "$OUT"
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "1. good legacy install → 0 FAIL (lane detected, all cheap checks pass)"
+else
+  fail "1. good legacy install" "expected 0 FAIL, got $(grep '^FAIL' "$OUT")"
+fi
+# Sanity: the lane was actually detected as legacy (proves we ran the right tier).
+if grep -q '^PASS	lane.detect	detected lane: legacy' "$OUT"; then
+  pass "1b. good legacy install → lane detected as legacy"
+else
+  fail "1b. good legacy lane detect" "lane.detect record not 'legacy': $(grep lane.detect "$OUT")"
+fi
+
+# ── LEGACY broken (A): delete the registered hook FILE → hooks-resolve FAIL ──
+LB="$(make_legacy_good 2)"
+rm -f "$LB/.claude/hooks/block-unsafe-generic.sh"
+OUT="$TMP/out-legacy-broken-hook.txt"
+run_cheap_capture "$LB" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "legacy.hooks-resolve"; then
+  pass "2. broken legacy (registered hook file deleted) → FAIL on legacy.hooks-resolve"
+else
+  fail "2. broken legacy hook-resolve" "expected FAIL on legacy.hooks-resolve; VI_FAIL=$VI_FAIL records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── LEGACY broken (B): leave a TODO placeholder in managed.md → FAIL ─────────
+LB2="$(make_legacy_good 3)"
+printf '%s\n' '# rules' '<!-- TODO: dev_server.cmd not set -->' \
+  > "$LB2/.claude/rules/zskills/managed.md"
+OUT="$TMP/out-legacy-broken-managed.txt"
+run_cheap_capture "$LB2" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "legacy.managed-no-placeholders"; then
+  pass "3. broken legacy (managed.md TODO placeholder) → FAIL on legacy.managed-no-placeholders"
+else
+  fail "3. broken legacy managed placeholder" "expected FAIL on legacy.managed-no-placeholders; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── PLUGIN: good layout → no FAIL ───────────────────────────────────────────
+# The plugin lane is keyed on CLAUDE_PLUGIN_ROOT being set. Set it (to any
+# non-empty value) for these cases ONLY.
+PG="$(make_plugin_good 1)"
+OUT="$TMP/out-plugin-good.txt"
+# The plugin lane keys on CLAUDE_PLUGIN_ROOT being set; export it (with a
+# plugin.json so the version cross-check resolves) for all plugin cases.
+CLAUDE_PLUGIN_ROOT="$TMP/fake-plugin-root"; export CLAUDE_PLUGIN_ROOT
+mkdir -p "$CLAUDE_PLUGIN_ROOT/.claude-plugin"
+printf '{ "version": "2026.06.0" }\n' > "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json"
+run_cheap_capture "$PG" "$OUT"
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "4. good plugin layout → 0 FAIL (5 sentinelled artifacts, mirror-less)"
+else
+  fail "4. good plugin layout" "expected 0 FAIL, got $(grep '^FAIL' "$OUT")"
+fi
+if grep -q '^PASS	lane.detect	detected lane: plugin' "$OUT"; then
+  pass "4b. good plugin layout → lane detected as plugin"
+else
+  fail "4b. good plugin lane detect" "lane.detect not 'plugin': $(grep lane.detect "$OUT")"
+fi
+
+# ── PLUGIN broken (A): strip a sentinel from one artifact → FAIL ─────────────
+PB="$(make_plugin_good 2)"
+# Rewrite verifier.md WITHOUT the sentinel line.
+printf '%s\n' '---' 'name: verifier' '---' '# verifier' > "$PB/.claude/agents/verifier.md"
+OUT="$TMP/out-plugin-broken-sentinel.txt"
+run_cheap_capture "$PB" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "plugin.artifact.agents/verifier.md"; then
+  pass "5. broken plugin (sentinel stripped from verifier.md) → FAIL on plugin.artifact.agents/verifier.md"
+else
+  fail "5. broken plugin sentinel" "expected FAIL on plugin.artifact.agents/verifier.md; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── PLUGIN broken (B): drop an artifact entirely → FAIL ──────────────────────
+PB2="$(make_plugin_good 3)"
+rm -f "$PB2/.claude/hooks/inject-bash-timeout.sh"
+OUT="$TMP/out-plugin-broken-missing.txt"
+run_cheap_capture "$PB2" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "plugin.artifact.hooks/inject-bash-timeout.sh"; then
+  pass "6. broken plugin (inject-bash-timeout.sh dropped) → FAIL on plugin.artifact.hooks/inject-bash-timeout.sh"
+else
+  fail "6. broken plugin missing artifact" "expected FAIL on plugin.artifact.hooks/inject-bash-timeout.sh; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── PLUGIN broken (C): a .claude/skills/ mirror present → dual-install FAIL ──
+# With CLAUDE_PLUGIN_ROOT set AND a legacy mirror, lane detection returns dual.
+PB3="$(make_plugin_good 4)"
+mkdir -p "$PB3/.claude/skills/update-zskills"
+printf '%s\n' '---' 'name: update-zskills' '---' > "$PB3/.claude/skills/update-zskills/SKILL.md"
+printf '{}\n' > "$PB3/.claude/settings.json"
+OUT="$TMP/out-dual.txt"
+run_cheap_capture "$PB3" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "lane.dual-unsupported"; then
+  pass "7. dual install (plugin + legacy mirror) → FAIL on lane.dual-unsupported"
+else
+  fail "7. dual install" "expected FAIL on lane.dual-unsupported; records=$(grep '^FAIL' "$OUT")"
+fi
+
+unset CLAUDE_PLUGIN_ROOT
+
+# ── NONE: empty consumer, no plugin env → FAIL ──────────────────────────────
+NC="$TMP/none-consumer"
+mkdir -p "$NC/.claude"
+OUT="$TMP/out-none.txt"
+run_cheap_capture "$NC" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "lane.none"; then
+  pass "8. no install (empty consumer, no plugin env) → FAIL on lane.none"
+else
+  fail "8. no install" "expected FAIL on lane.none; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── Entry script end-to-end: good legacy → exit 0; broken → exit 1 ──────────
+LG2="$(make_legacy_good 9)"
+if bash "$ENTRY" --project-dir "$LG2" >/dev/null 2>&1; then
+  pass "9a. entry script: good legacy install → exit 0"
+else
+  fail "9a. entry good legacy exit" "expected exit 0"
+fi
+LB3="$(make_legacy_good 10)"
+rm -f "$LB3/.claude/hooks/block-unsafe-generic.sh"
+if bash "$ENTRY" --project-dir "$LB3" >/dev/null 2>&1; then
+  fail "9b. entry broken legacy exit" "expected exit 1 (FAIL), got exit 0"
+else
+  pass "9b. entry script: broken legacy install → exit 1"
+fi
+
+# ── Heavy tier is opt-in and inert: --deep WARNs, never FAILs on a good install
+LG3="$(make_legacy_good 11)"
+DEEP_OUT="$(bash "$ENTRY" --project-dir "$LG3" --deep 2>&1)"
+if printf '%s\n' "$DEEP_OUT" | grep -q 'heavy tier' \
+   && printf '%s\n' "$DEEP_OUT" | grep -qE 'Overall: PASS'; then
+  pass "10. --deep runs the heavy tier (opt-in) and does not turn a good install into FAIL"
+else
+  fail "10. --deep opt-in" "expected heavy-tier section + Overall: PASS on a good install"
+fi
+
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+exit "$FAIL_COUNT"


### PR DESCRIPTION
Task: Fix #999 — consumer post-install verifier bundled in the update-zskills skill (verifiers/ folder), lane-detecting cheap structural checks, auto-run non-fatally at /update-zskills success; dev test imports the lib with a load-bearing broken-install FAIL case.

Closes #999.

## What changed
A consumer **post-install verifier** bundled in the `update-zskills` skill so it ships on both lanes, auto-run at `/update-zskills` success.
- **`skills/update-zskills/verifiers/`** (+ byte-identical `.claude/` mirror): `verify-install-lib.sh` (sourceable assertions) + `verify-install.sh` (thin entry). **Self-contained lane detection** (`${CLAUDE_PLUGIN_ROOT}`→plugin; `.claude/skills`+`settings.json`→legacy; both→dual) — deliberately does NOT source `hooks/_lib/detect-install-state.sh` (not mirrored on the legacy lane → would be broken on the very lane it ships to).
- **Cheap structural checks** (no live claude): legacy = skills populated, every registered hook resolves to a real file, `managed.md` rendered with no `<!-- TODO -->` placeholders, config present, version; plugin = 5 materialised artifacts w/ `zskills-materialised:` sentinels, mirror-less, version. Dual → flag.
- **Trigger:** `/update-zskills` runs the cheap tier at install/update success — **non-fatal** (WARN/report; never undoes the install). Heavy live-claude probe is opt-in (`--deep`), NOT on the success path.
- **Anti-hollow:** the dev test (`tests/test-verify-install.sh`, imports the lib — nothing bundled) asserts BOTH good→PASS AND deliberately-broken (deleted registered hook / managed.md TODO / stripped sentinel / dropped artifact) → FAIL. During implementation a real subshell counter bug that made the verifier always report PASS was surfaced + fixed.

## Verification
- `bash tests/test-verify-install.sh` → 14 passed, 0 failed (incl. broken-install FAIL cases).
- Full suite `bash tests/run-all.sh` → 7353/7353, 0 failed.
- Independent run against the dev checkout correctly FAILs on the dev `managed.md` placeholders (proves it detects real problems); version bumped `2026.06.02+81a457`; mirror byte-identical (`diff -rq`); folder ships via the recursive skill mirror.

Out of scope (left for #991): wiring the runtime checks into `run-all.sh` (the autonomous-regression idea). No new skill / `/zs:` command / `verify` subcommand; no `tests/` bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
