### PR TITLE
do: verifier no false-FAIL on valid installs (#1004)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.02+ff2cf6"
+  version: "2026.06.02+d76c61"
 ---
 
 # Update Z Skills Infrastructure
@@ -2060,8 +2060,13 @@ After the final report, run the bundled consumer post-install verifier's
 **cheap structural tier** and append its result to the success output. This
 catches the consumer-side of the dogfood-mask (#799/#831): environment-specific
 install breakage that dev-repo tests structurally cannot see (a registered hook
-that resolves to nothing, a leftover `<!-- TODO -->` placeholder in
-`managed.md`, a dropped artifact/sentinel, an accidental dual-install).
+that resolves to nothing, an un-rendered `managed.md` carrying raw `{{TOKEN}}`
+template placeholders, a dropped artifact/sentinel, an accidental dual-install).
+Per the zero-false-positive bar (#1004) it NEVER flags the renderer's designed
+`<!-- TODO -->` comments for unset OPTIONAL config, nor a missing
+`zskills_version` (an untagged source clone legitimately lacks one) — a FAIL
+always means the install is genuinely broken, never that an optional setting is
+unconfigured.
 
 **NON-FATAL — informative only.** The install already succeeded; this
 verification reports PASS/WARN/FAIL but **does NOT undo or fail the install**.

--- a/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -178,10 +178,18 @@ vi_resolve_hook_path() {
 # vi_check_legacy <project_dir>
 #   - .claude/skills/ populated
 #   - every hook registered in .claude/settings.json resolves to a real file
-#   - .claude/rules/zskills/managed.md rendered with NO leftover
-#     <!-- TODO ... --> placeholders
+#   - .claude/rules/zskills/managed.md present AND rendered (no raw,
+#     un-substituted {{TOKEN}} template placeholders)
 #   - .claude/zskills-config.json present
-#   - zskills version present (WARN if absent — informative, not fatal)
+#
+# ZERO-FALSE-POSITIVE BAR (#1004): every FAIL here means "your install is
+# genuinely broken." We do NOT flag the renderer's designed `<!-- TODO ... -->`
+# comments — those are the deliberate output for UNSET OPTIONAL config
+# (dev_server.cmd, ui.auth_bypass, testing.file_patterns, …; see
+# scripts/managed_rules_substitution.py's `_empty_or(..., "<!-- TODO -->")`).
+# Their presence PROVES managed.md rendered. We also do NOT check for a
+# recorded zskills_version: /update-zskills Step F.5 SKIPS writing it when the
+# source clone is untagged, so a valid install can legitimately lack it.
 # ───────────────────────────────────────────────────────────────────────────
 vi_check_legacy() {
   local proj="$1"
@@ -218,14 +226,24 @@ vi_check_legacy() {
     fi
   fi
 
-  # (3) managed.md rendered with no leftover <!-- TODO ... --> placeholders.
+  # (3) managed.md present AND rendered.
+  #
+  # A MISSING file is a real failure. But its mere presence does NOT prove it
+  # rendered: a copied-but-never-rendered CLAUDE_TEMPLATE.md would still carry
+  # raw `{{TOKEN}}` placeholders. So we flag ONLY raw, un-substituted template
+  # tokens — the unambiguous signature of "the renderer never ran." We do NOT
+  # flag `<!-- TODO ... -->` comments: those are the renderer's DESIGNED output
+  # for unset OPTIONAL config and their presence proves the render happened
+  # (scripts/render-managed-rules.py / managed_rules_substitution.py.apply()
+  # even RAISES if any `{{...}}` survives, so a real render can never leave one
+  # — making a surviving token a definitive "not rendered" signal).
   local mm="$claude/rules/zskills/managed.md"
   if [ ! -f "$mm" ]; then
     vi_emit FAIL "legacy.managed-present" ".claude/rules/zskills/managed.md missing"
-  elif grep -qE '<!--[[:space:]]*TODO' "$mm"; then
-    vi_emit FAIL "legacy.managed-no-placeholders" "managed.md still contains <!-- TODO ... --> placeholder(s)"
+  elif grep -qE '\{\{[A-Z_]+\}\}' "$mm"; then
+    vi_emit FAIL "legacy.managed-rendered" "managed.md contains un-substituted {{TOKEN}} template placeholder(s) — renderer did not run"
   else
-    vi_emit PASS "legacy.managed-no-placeholders" "managed.md rendered with no leftover TODO placeholders"
+    vi_emit PASS "legacy.managed-rendered" "managed.md present and rendered (no un-substituted {{TOKEN}} placeholders)"
   fi
 
   # (4) zskills-config.json present.
@@ -236,14 +254,11 @@ vi_check_legacy() {
     vi_emit FAIL "legacy.config-present" ".claude/zskills-config.json missing"
   fi
 
-  # (5) zskills version recorded (informative — WARN if absent).
-  local ver
-  ver="$(vi_config_version "$cfg")"
-  if [ -n "$ver" ]; then
-    vi_emit PASS "legacy.version-recorded" "zskills_version = $ver"
-  else
-    vi_emit WARN "legacy.version-recorded" "zskills_version absent from config (source clone may be untagged)"
-  fi
+  # NOTE (#1004): no `legacy.version-recorded` check. A missing zskills_version
+  # is NOT install breakage — /update-zskills Step F.5 deliberately skips
+  # writing it when the source clone is untagged, so a valid install can
+  # legitimately lack it. Flagging it (even as a WARN) violated the
+  # zero-false-positive bar.
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -258,7 +273,10 @@ vi_check_legacy() {
 #       .claude/hooks/verify-response-validate.sh
 #       .claude/rules/zskills/managed.md
 #   - mirror-less (.claude/skills/ ABSENT in the consumer project)
-#   - zskills version present (WARN if absent)
+#
+# ZERO-FALSE-POSITIVE BAR (#1004): no `plugin.version-recorded` check — the
+# plugin seed config can legitimately have no tag on a valid install, so its
+# absence is not breakage (mirrors the legacy-lane decision above).
 # ───────────────────────────────────────────────────────────────────────────
 vi_check_plugin() {
   local proj="$1"
@@ -285,20 +303,18 @@ vi_check_plugin() {
   done
 
   # (2) Mirror-less: .claude/skills/ must be ABSENT in a clean plugin consumer.
+  # NOTE: a populated .claude/skills/ alongside CLAUDE_PLUGIN_ROOT is detected
+  # as the `dual` lane upstream (vi_detect_lane), so this WARN is reached only
+  # when skills/ exists but is empty — a genuine residue worth surfacing, never
+  # a false positive on a clean mirror-less install.
   if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
     vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
   else
     vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
   fi
 
-  # (3) zskills version recorded (informative — WARN if absent).
-  local cfg="$claude/zskills-config.json" ver
-  ver="$(vi_config_version "$cfg")"
-  if [ -n "$ver" ]; then
-    vi_emit PASS "plugin.version-recorded" "zskills_version = $ver"
-  else
-    vi_emit WARN "plugin.version-recorded" "zskills_version absent from config (plugin seed config has no tag)"
-  fi
+  # NOTE (#1004): no `plugin.version-recorded` check — same rationale as the
+  # legacy lane: a missing zskills_version is not install breakage.
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.02+ff2cf6"
+  version: "2026.06.02+d76c61"
 ---
 
 # Update Z Skills Infrastructure
@@ -2060,8 +2060,13 @@ After the final report, run the bundled consumer post-install verifier's
 **cheap structural tier** and append its result to the success output. This
 catches the consumer-side of the dogfood-mask (#799/#831): environment-specific
 install breakage that dev-repo tests structurally cannot see (a registered hook
-that resolves to nothing, a leftover `<!-- TODO -->` placeholder in
-`managed.md`, a dropped artifact/sentinel, an accidental dual-install).
+that resolves to nothing, an un-rendered `managed.md` carrying raw `{{TOKEN}}`
+template placeholders, a dropped artifact/sentinel, an accidental dual-install).
+Per the zero-false-positive bar (#1004) it NEVER flags the renderer's designed
+`<!-- TODO -->` comments for unset OPTIONAL config, nor a missing
+`zskills_version` (an untagged source clone legitimately lacks one) — a FAIL
+always means the install is genuinely broken, never that an optional setting is
+unconfigured.
 
 **NON-FATAL — informative only.** The install already succeeded; this
 verification reports PASS/WARN/FAIL but **does NOT undo or fail the install**.

--- a/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -178,10 +178,18 @@ vi_resolve_hook_path() {
 # vi_check_legacy <project_dir>
 #   - .claude/skills/ populated
 #   - every hook registered in .claude/settings.json resolves to a real file
-#   - .claude/rules/zskills/managed.md rendered with NO leftover
-#     <!-- TODO ... --> placeholders
+#   - .claude/rules/zskills/managed.md present AND rendered (no raw,
+#     un-substituted {{TOKEN}} template placeholders)
 #   - .claude/zskills-config.json present
-#   - zskills version present (WARN if absent — informative, not fatal)
+#
+# ZERO-FALSE-POSITIVE BAR (#1004): every FAIL here means "your install is
+# genuinely broken." We do NOT flag the renderer's designed `<!-- TODO ... -->`
+# comments — those are the deliberate output for UNSET OPTIONAL config
+# (dev_server.cmd, ui.auth_bypass, testing.file_patterns, …; see
+# scripts/managed_rules_substitution.py's `_empty_or(..., "<!-- TODO -->")`).
+# Their presence PROVES managed.md rendered. We also do NOT check for a
+# recorded zskills_version: /update-zskills Step F.5 SKIPS writing it when the
+# source clone is untagged, so a valid install can legitimately lack it.
 # ───────────────────────────────────────────────────────────────────────────
 vi_check_legacy() {
   local proj="$1"
@@ -218,14 +226,24 @@ vi_check_legacy() {
     fi
   fi
 
-  # (3) managed.md rendered with no leftover <!-- TODO ... --> placeholders.
+  # (3) managed.md present AND rendered.
+  #
+  # A MISSING file is a real failure. But its mere presence does NOT prove it
+  # rendered: a copied-but-never-rendered CLAUDE_TEMPLATE.md would still carry
+  # raw `{{TOKEN}}` placeholders. So we flag ONLY raw, un-substituted template
+  # tokens — the unambiguous signature of "the renderer never ran." We do NOT
+  # flag `<!-- TODO ... -->` comments: those are the renderer's DESIGNED output
+  # for unset OPTIONAL config and their presence proves the render happened
+  # (scripts/render-managed-rules.py / managed_rules_substitution.py.apply()
+  # even RAISES if any `{{...}}` survives, so a real render can never leave one
+  # — making a surviving token a definitive "not rendered" signal).
   local mm="$claude/rules/zskills/managed.md"
   if [ ! -f "$mm" ]; then
     vi_emit FAIL "legacy.managed-present" ".claude/rules/zskills/managed.md missing"
-  elif grep -qE '<!--[[:space:]]*TODO' "$mm"; then
-    vi_emit FAIL "legacy.managed-no-placeholders" "managed.md still contains <!-- TODO ... --> placeholder(s)"
+  elif grep -qE '\{\{[A-Z_]+\}\}' "$mm"; then
+    vi_emit FAIL "legacy.managed-rendered" "managed.md contains un-substituted {{TOKEN}} template placeholder(s) — renderer did not run"
   else
-    vi_emit PASS "legacy.managed-no-placeholders" "managed.md rendered with no leftover TODO placeholders"
+    vi_emit PASS "legacy.managed-rendered" "managed.md present and rendered (no un-substituted {{TOKEN}} placeholders)"
   fi
 
   # (4) zskills-config.json present.
@@ -236,14 +254,11 @@ vi_check_legacy() {
     vi_emit FAIL "legacy.config-present" ".claude/zskills-config.json missing"
   fi
 
-  # (5) zskills version recorded (informative — WARN if absent).
-  local ver
-  ver="$(vi_config_version "$cfg")"
-  if [ -n "$ver" ]; then
-    vi_emit PASS "legacy.version-recorded" "zskills_version = $ver"
-  else
-    vi_emit WARN "legacy.version-recorded" "zskills_version absent from config (source clone may be untagged)"
-  fi
+  # NOTE (#1004): no `legacy.version-recorded` check. A missing zskills_version
+  # is NOT install breakage — /update-zskills Step F.5 deliberately skips
+  # writing it when the source clone is untagged, so a valid install can
+  # legitimately lack it. Flagging it (even as a WARN) violated the
+  # zero-false-positive bar.
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -258,7 +273,10 @@ vi_check_legacy() {
 #       .claude/hooks/verify-response-validate.sh
 #       .claude/rules/zskills/managed.md
 #   - mirror-less (.claude/skills/ ABSENT in the consumer project)
-#   - zskills version present (WARN if absent)
+#
+# ZERO-FALSE-POSITIVE BAR (#1004): no `plugin.version-recorded` check — the
+# plugin seed config can legitimately have no tag on a valid install, so its
+# absence is not breakage (mirrors the legacy-lane decision above).
 # ───────────────────────────────────────────────────────────────────────────
 vi_check_plugin() {
   local proj="$1"
@@ -285,20 +303,18 @@ vi_check_plugin() {
   done
 
   # (2) Mirror-less: .claude/skills/ must be ABSENT in a clean plugin consumer.
+  # NOTE: a populated .claude/skills/ alongside CLAUDE_PLUGIN_ROOT is detected
+  # as the `dual` lane upstream (vi_detect_lane), so this WARN is reached only
+  # when skills/ exists but is empty — a genuine residue worth surfacing, never
+  # a false positive on a clean mirror-less install.
   if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
     vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
   else
     vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
   fi
 
-  # (3) zskills version recorded (informative — WARN if absent).
-  local cfg="$claude/zskills-config.json" ver
-  ver="$(vi_config_version "$cfg")"
-  if [ -n "$ver" ]; then
-    vi_emit PASS "plugin.version-recorded" "zskills_version = $ver"
-  else
-    vi_emit WARN "plugin.version-recorded" "zskills_version absent from config (plugin seed config has no tag)"
-  fi
+  # NOTE (#1004): no `plugin.version-recorded` check — same rationale as the
+  # legacy lane: a missing zskills_version is not install breakage.
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/tests/test-verify-install.sh
+++ b/tests/test-verify-install.sh
@@ -11,14 +11,20 @@
 # Anti-hollow contract (the load-bearing requirement): the verifier must FAIL
 # on a deliberately-broken install, not only PASS on a good one. This file
 # asserts BOTH directions for BOTH lanes:
-#   - good legacy install            → verify_overall_rc == 0 (no FAIL)
-#   - broken legacy (hook file gone) → FAIL
-#   - broken legacy (managed.md TODO)→ FAIL
-#   - good plugin layout             → no FAIL
-#   - broken plugin (sentinel dropped)→ FAIL
-#   - broken plugin (artifact dropped)→ FAIL
-#   - dual install                   → FAIL
-#   - none                           → FAIL
+#   - good legacy install                  → verify_overall_rc == 0 (no FAIL)
+#   - good legacy + UNSET optional config  → 0 FAIL  (#1004 — the renderer's
+#       designed `<!-- TODO -->` placeholders for unset OPTIONAL config must
+#       NOT be flagged; this is the recurrence-proof case PR #1003 missed)
+#   - good legacy + NO zskills_version     → 0 FAIL / 0 WARN  (#1004 — Step F.5
+#       legitimately skips writing it on an untagged source clone)
+#   - broken legacy (hook file gone)       → FAIL
+#   - broken legacy (raw {{TOKEN}})        → FAIL  (renderer never ran)
+#   - good plugin layout                   → no FAIL
+#   - good plugin + NO zskills_version     → 0 FAIL / 0 WARN  (#1004)
+#   - broken plugin (sentinel dropped)     → FAIL
+#   - broken plugin (artifact dropped)     → FAIL
+#   - dual install                         → FAIL
+#   - none                                 → FAIL
 #
 # Sandbox-only: every consumer dir lives under $TMP; the real repo / $HOME are
 # never written. The verifier is read-only (it only inspects files), so even
@@ -63,6 +69,8 @@ run_cheap_capture() {
 count_fail() { grep -c '^FAIL' "$1" 2>/dev/null || echo 0; }
 # Does the captured output contain a FAIL whose id matches $2?
 has_fail_id() { grep -q "^FAIL	$2	" "$1"; }
+# Does the captured output contain a WARN whose id matches $2?
+has_warn_id() { grep -q "^WARN	$2	" "$1"; }
 
 # ── Synthetic LEGACY install builder ────────────────────────────────────────
 # Produces a consumer dir with: a populated .claude/skills/, a settings.json
@@ -154,16 +162,78 @@ else
   fail "2. broken legacy hook-resolve" "expected FAIL on legacy.hooks-resolve; VI_FAIL=$VI_FAIL records=$(grep '^FAIL' "$OUT")"
 fi
 
-# ── LEGACY broken (B): leave a TODO placeholder in managed.md → FAIL ─────────
-LB2="$(make_legacy_good 3)"
-printf '%s\n' '# rules' '<!-- TODO: dev_server.cmd not set -->' \
-  > "$LB2/.claude/rules/zskills/managed.md"
-OUT="$TMP/out-legacy-broken-managed.txt"
-run_cheap_capture "$LB2" "$OUT"
-if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "legacy.managed-no-placeholders"; then
-  pass "3. broken legacy (managed.md TODO placeholder) → FAIL on legacy.managed-no-placeholders"
+# ── LEGACY valid + UNSET optional config (#1004): managed.md carries the ─────
+# renderer's DESIGNED `<!-- TODO -->` placeholders for unset OPTIONAL config
+# (dev_server.cmd, ui.auth_bypass, testing.file_patterns, …). This is the
+# common real-world case — and ALWAYS the case for projects with no dev server
+# / no web-app auth gate. It is a VALID install and must PASS with 0 FAIL.
+# This is the recurrence-proof case the original clean-managed.md fixture
+# missed (the false-FAIL #1004 reported).
+LV="$(make_legacy_good 3)"
+cat > "$LV/.claude/rules/zskills/managed.md" <<'MD'
+# acme — Agent Reference
+
+## Dev Server
+<!-- TODO: dev_server.cmd not set in .claude/zskills-config.json -->
+
+**Auth gate:**
+<!-- TODO: ui.auth_bypass not set in .claude/zskills-config.json -->
+
+### Test files
+<!-- TODO: testing.file_patterns is empty -->
+
+## Architecture
+<!-- TODO: SOURCE_LAYOUT has no config field; fill in project's architecture summary -->
+MD
+OUT="$TMP/out-legacy-valid-unset-optional.txt"
+run_cheap_capture "$LV" "$OUT"
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "3. valid legacy install with UNSET optional config (<!-- TODO --> placeholders present) → 0 FAIL"
 else
-  fail "3. broken legacy managed placeholder" "expected FAIL on legacy.managed-no-placeholders; records=$(grep '^FAIL' "$OUT")"
+  fail "3. valid legacy unset-optional" "expected 0 FAIL on designed <!-- TODO --> placeholders, got $(grep '^FAIL' "$OUT")"
+fi
+# And it must PASS the managed-rendered check specifically (not merely avoid FAIL).
+if has_fail_id "$OUT" "legacy.managed-rendered" || has_fail_id "$OUT" "legacy.managed-present"; then
+  fail "3b. valid legacy unset-optional managed check" "managed.md check FAILed on designed placeholders: $(grep -E 'managed' "$OUT")"
+else
+  pass "3b. valid legacy unset-optional → managed.md check does not FAIL on <!-- TODO --> placeholders"
+fi
+
+# ── LEGACY valid + NO zskills_version (#1004): an untagged source clone ───────
+# legitimately leaves zskills_version unset (Step F.5 skips writing it). This
+# must produce 0 FAIL AND 0 WARN — absence of a version is NOT install
+# breakage, and must not even alarm with a WARN.
+LNV="$(make_legacy_good 4)"
+cat > "$LNV/.claude/zskills-config.json" <<'JSON'
+{ "project_name": "acme" }
+JSON
+OUT="$TMP/out-legacy-no-version.txt"
+run_cheap_capture "$LNV" "$OUT"
+if [ "$VI_FAIL" -eq 0 ] && [ "$VI_WARN" -eq 0 ]; then
+  pass "3c. valid legacy install with NO zskills_version → 0 FAIL / 0 WARN (no version-recorded check)"
+else
+  fail "3c. valid legacy no-version" "expected 0 FAIL / 0 WARN; FAIL=$(grep '^FAIL' "$OUT") WARN=$(grep '^WARN' "$OUT")"
+fi
+if has_warn_id "$OUT" "legacy.version-recorded" || has_fail_id "$OUT" "legacy.version-recorded"; then
+  fail "3d. legacy version-recorded removed" "legacy.version-recorded check still present — should be cut per #1004"
+else
+  pass "3d. legacy.version-recorded check removed (no false-positive WARN on untagged clone)"
+fi
+
+# ── LEGACY broken (B): a raw, UN-substituted {{TOKEN}} in managed.md → FAIL ───
+# This is the ONLY managed.md content that means "the renderer never ran" — a
+# copied-but-unrendered template. The renderer itself RAISES on a surviving
+# {{...}}, so this can never appear in a real render; its presence is genuine
+# breakage and MUST FAIL.
+LB2="$(make_legacy_good 5)"
+printf '%s\n' '# rules' 'Auth bypass: {{AUTH_BYPASS}}' \
+  > "$LB2/.claude/rules/zskills/managed.md"
+OUT="$TMP/out-legacy-broken-unrendered.txt"
+run_cheap_capture "$LB2" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "legacy.managed-rendered"; then
+  pass "3e. broken legacy (raw {{TOKEN}} in managed.md, renderer never ran) → FAIL on legacy.managed-rendered"
+else
+  fail "3e. broken legacy unrendered managed" "expected FAIL on legacy.managed-rendered; records=$(grep '^FAIL' "$OUT")"
 fi
 
 # ── PLUGIN: good layout → no FAIL ───────────────────────────────────────────
@@ -186,6 +256,26 @@ if grep -q '^PASS	lane.detect	detected lane: plugin' "$OUT"; then
   pass "4b. good plugin layout → lane detected as plugin"
 else
   fail "4b. good plugin lane detect" "lane.detect not 'plugin': $(grep lane.detect "$OUT")"
+fi
+
+# ── PLUGIN valid + NO zskills_version (#1004): plugin seed config has no tag ──
+# A valid mirror-less plugin install whose seed config carries no zskills_version
+# must produce 0 FAIL AND 0 WARN — same zero-false-positive bar as legacy.
+PNV="$(make_plugin_good 5)"
+cat > "$PNV/.claude/zskills-config.json" <<'JSON'
+{ "project_name": "acme" }
+JSON
+OUT="$TMP/out-plugin-no-version.txt"
+run_cheap_capture "$PNV" "$OUT"
+if [ "$VI_FAIL" -eq 0 ] && [ "$VI_WARN" -eq 0 ]; then
+  pass "4c. valid plugin install with NO zskills_version → 0 FAIL / 0 WARN (no version-recorded check)"
+else
+  fail "4c. valid plugin no-version" "expected 0 FAIL / 0 WARN; FAIL=$(grep '^FAIL' "$OUT") WARN=$(grep '^WARN' "$OUT")"
+fi
+if has_warn_id "$OUT" "plugin.version-recorded" || has_fail_id "$OUT" "plugin.version-recorded"; then
+  fail "4d. plugin version-recorded removed" "plugin.version-recorded check still present — should be cut per #1004"
+else
+  pass "4d. plugin.version-recorded check removed (no false-positive WARN on untagged seed config)"
 fi
 
 # ── PLUGIN broken (A): strip a sentinel from one artifact → FAIL ─────────────


### PR DESCRIPTION
Task: Fix #1004 — post-install verifier false-FAILed on valid installs (treated the renderer's designed <!-- TODO --> placeholders for unset optional config as breakage). Enforce zero-false-positive-on-valid-install.

Closes #1004.

## The bug (shipped in #999/#1003, caught before any real install)
The post-install verifier — wired into `/update-zskills` success — FAILed on any `<!-- TODO -->` in `managed.md`. But those are the renderer's **designed output for unset OPTIONAL config** (`dev_server.cmd`, `ui.auth_bypass`, …). A valid install with optional config unset (the common case; always for non-web-app projects) would have printed a **FAIL to the consumer**. It conflated "did the install deliver working artifacts" with "has the user configured optional settings."

## Fix — enforce zero false positives on a valid install
- **Replaced** the `<!-- TODO -->` FAIL with a raw-`{{TOKEN}}` check: the renderer *raises* on a surviving `{{...}}`, so an un-substituted token is a true "renderer never ran" signal, while `<!-- TODO -->` comments *prove* it rendered. (`managed.md` missing → FAIL kept.)
- **Cut** both `version-recorded` checks: the install deliberately skips writing `zskills_version` on an untagged source clone, so absent ≠ breakage.
- **Audited every check** (legacy + plugin) to the bar "only FAIL on a genuinely broken install"; the rest (skills populated, settings valid, hooks resolve, artifacts/sentinels present, mirror-less) are real-breakage checks and were kept.
- **Recurrence-proof tests:** a valid install with optional config unset (rendered placeholders present) → 0 FAIL; valid + no version → 0 FAIL/WARN; broken `{{TOKEN}}` → FAIL; all prior negatives (deleted hook, dropped artifact, stripped sentinel) preserved.

## Verification
- Verifier against the dev checkout (the case that FAILed before): now **6 PASS, 0 WARN, 0 FAIL, Overall: PASS**.
- `bash tests/test-verify-install.sh` → 20 passed, 0 failed. Full `bash tests/run-all.sh` → 7359/7359, 0 failed.
- update-zskills `metadata.version` bumped; `.claude/skills` mirror byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
