### PR TITLE
do: capability-gate plugin runtime checks (#991)

### DIFF
--- a/tests/lib/attended-gate.sh
+++ b/tests/lib/attended-gate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# tests/lib/attended-gate.sh
+#
+# Capability-gate + throttle decision for the live (attended) plugin runtime
+# checks in tests/test-plugin-live-load.sh §B.
+#
+# This is a SOURCEABLE library, NOT a suite — it exposes the pure decision
+# function `attended_gate_should_run` so a deterministic unit test
+# (tests/test-attended-gate.sh) can exercise every branch WITHOUT a live
+# `claude` CLI. tests/run-all.sh sources it right before it runs the
+# test-plugin-live-load.sh suite and uses the decision to (only then) export
+# ZSKILLS_LIVE_ATTENDED=1 for that one suite.
+#
+# Rationale (#991): the §B checks (hookfire, dual-install, (A2)-runtime) are
+# real and passing but only ran when a human set ZSKILLS_LIVE_ATTENDED=1 —
+# nobody does, so they rotted. We instead gate on machine CAPABILITY (claude +
+# credentials present) and a throttle window, so they auto-run in an authed
+# devcontainer and SKIP cleanly on CI (no `claude`) — byte-for-byte unchanged
+# there.
+#
+# No jq — Python json per `## Python is required` (not needed here).
+
+# Default capability probes. Both are overridable: a caller (or the
+# deterministic test) may redefine these functions BEFORE calling
+# attended_gate_should_run to simulate presence/absence without a real CLI or
+# credential file. The env overrides ZSKILLS_GATE_FORCE_CLAUDE /
+# ZSKILLS_GATE_FORCE_CREDS (values "1"=present, "0"=absent) take precedence,
+# so the test can drive the decision purely through the environment too.
+
+_attended_gate_have_claude() {
+  case "${ZSKILLS_GATE_FORCE_CLAUDE:-}" in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
+  command -v claude >/dev/null 2>&1
+}
+
+_attended_gate_have_creds() {
+  case "${ZSKILLS_GATE_FORCE_CREDS:-}" in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
+  [ -f "${HOME:-/nonexistent}/.claude/.credentials.json" ]
+}
+
+# attended_gate_should_run <marker_path> <now_epoch> <throttle_seconds>
+#
+# Returns 0 (gate PASSES — run §B, caller should export the flag and refresh
+# the marker) iff ALL hold:
+#   1. a `claude` CLI is available    (_attended_gate_have_claude)
+#   2. credentials are present        (_attended_gate_have_creds)
+#   3. the throttle window has elapsed: the marker is absent, unreadable, or
+#      its stored epoch is more than <throttle_seconds> before <now_epoch>.
+#
+# Returns 1 (gate FAILS — leave the flag unset so §B SKIPs as today) otherwise.
+attended_gate_should_run() {
+  local marker_path="$1" now_epoch="$2" throttle_seconds="$3"
+
+  # 1 + 2: capability.
+  _attended_gate_have_claude || return 1
+  _attended_gate_have_creds  || return 1
+
+  # 3: throttle. Never run / unreadable marker => stale => run.
+  if [ ! -f "$marker_path" ]; then
+    return 0
+  fi
+  local last
+  last="$(cat "$marker_path" 2>/dev/null)"
+  # A non-numeric / empty marker is treated as stale (re-run, then refresh).
+  case "$last" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  if [ "$((now_epoch - last))" -gt "$throttle_seconds" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# attended_gate_refresh_marker <marker_path> <now_epoch>
+#
+# Write the throttle timestamp atomically. Creates the parent dir (e.g.
+# ~/.zskills) if needed. Best-effort: a failure to write must not break the
+# test run (the worst case is the throttle simply doesn't take and §B runs
+# again next time).
+attended_gate_refresh_marker() {
+  local marker_path="$1" now_epoch="$2" dir
+  dir="$(dirname "$marker_path")"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  printf '%s\n' "$now_epoch" > "$marker_path" 2>/dev/null || return 0
+}

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -239,7 +239,30 @@ run_suite "test-plugin-manifest.sh" "tests/test-plugin-manifest.sh"
 run_suite "test-plugin-marketplace.sh" "tests/test-plugin-marketplace.sh"
 run_suite "test-plugin-ref-consistency.sh" "tests/test-plugin-ref-consistency.sh"
 run_suite "test-plugin-self-load.sh" "tests/test-plugin-self-load.sh"
-run_suite "test-plugin-live-load.sh" "tests/test-plugin-live-load.sh"
+# #991 — deterministic unit test for the attended capability-gate decision
+# (runs without live `claude`); the gate itself wires in just below.
+run_suite "test-attended-gate.sh" "tests/test-attended-gate.sh"
+
+# #991 — capability-gate + throttle the live plugin runtime checks (§B of
+# test-plugin-live-load.sh) so they auto-run when the machine CAN (claude CLI +
+# credentials present) and SKIP cleanly when it can't (CI: no `claude`), with a
+# throttle so we don't add live-`claude` time to EVERY full-suite run. The
+# marker is stored OUT OF TREE (~/.zskills/last-attended-plugin-run) so it never
+# pollutes `git status`, survives worktree removal, and applies globally. When
+# the gate fails (CI, or throttled) we leave ZSKILLS_LIVE_ATTENDED unset → §B
+# SKIPs exactly as before, so CI behavior is byte-for-byte unchanged.
+. "$REPO_ROOT/tests/lib/attended-gate.sh"
+ATTENDED_MARKER="${HOME:-/tmp}/.zskills/last-attended-plugin-run"
+ATTENDED_THROTTLE_SECONDS="${ZSKILLS_ATTENDED_THROTTLE_SECONDS:-14400}"  # ~4h
+ATTENDED_NOW="$(date +%s)"
+if attended_gate_should_run "$ATTENDED_MARKER" "$ATTENDED_NOW" "$ATTENDED_THROTTLE_SECONDS"; then
+  echo ""
+  echo "[#991] attended gate PASSED (claude + creds present, throttle window elapsed) — running §B live."
+  ZSKILLS_LIVE_ATTENDED=1 run_suite "test-plugin-live-load.sh" "tests/test-plugin-live-load.sh"
+  attended_gate_refresh_marker "$ATTENDED_MARKER" "$ATTENDED_NOW"
+else
+  run_suite "test-plugin-live-load.sh" "tests/test-plugin-live-load.sh"
+fi
 run_suite "test-plugin-mirrorless-resolution.sh" "tests/test-plugin-mirrorless-resolution.sh"
 run_suite "test-plugin-d4-hook-siblings.sh" "tests/test-plugin-d4-hook-siblings.sh"
 run_suite "test-plugin-hooks-integrity.sh" "tests/test-plugin-hooks-integrity.sh"

--- a/tests/test-attended-gate.sh
+++ b/tests/test-attended-gate.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# tests/test-attended-gate.sh
+#
+# Deterministic unit test for the #991 capability-gate + throttle decision in
+# tests/lib/attended-gate.sh. Exercises every branch of
+# attended_gate_should_run WITHOUT a live `claude` CLI or real credentials —
+# capability presence is injected via the ZSKILLS_GATE_FORCE_CLAUDE /
+# ZSKILLS_GATE_FORCE_CREDS env overrides, and the throttle is driven with a
+# synthetic "now" epoch and a temp marker file.
+#
+# No jq — Python json per `## Python is required` (not needed here).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$REPO_ROOT/tests/lib/attended-gate.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+echo "=== attended-gate (#991 capability-gate + throttle) ==="
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+THROTTLE=14400           # ~4h, same default as run-all.sh
+NOW=1000000             # synthetic "now" epoch
+
+# Helper: assert the gate decision. Usage:
+#   expect_gate <expected: run|skip> <description> <marker_path>
+# Capability is set by the caller via the FORCE env overrides.
+expect_gate() {
+  local expected="$1" desc="$2" marker="$3"
+  if attended_gate_should_run "$marker" "$NOW" "$THROTTLE"; then
+    local got="run"
+  else
+    local got="skip"
+  fi
+  if [ "$got" = "$expected" ]; then
+    pass "$desc (gate=$got)"
+  else
+    fail "$desc — expected gate=$expected, got gate=$got"
+  fi
+}
+
+# ── Branch 1: claude absent → gate FALSE (SKIP), regardless of creds/marker ──
+# This is the CI path. No marker present (would otherwise be stale → run).
+ZSKILLS_GATE_FORCE_CLAUDE=0 ZSKILLS_GATE_FORCE_CREDS=1 \
+  expect_gate skip "claude absent → SKIP (CI path)" "$TMP/marker-noclaude"
+
+# ── Branch 2: creds absent → gate FALSE (SKIP), even with claude present ──────
+ZSKILLS_GATE_FORCE_CLAUDE=1 ZSKILLS_GATE_FORCE_CREDS=0 \
+  expect_gate skip "creds absent → SKIP" "$TMP/marker-nocreds"
+
+# ── Branch 3: marker FRESH (within window) → gate FALSE (throttled) ──────────
+# Write a marker timestamped just inside the throttle window.
+FRESH_MARKER="$TMP/marker-fresh"
+printf '%s\n' "$((NOW - THROTTLE + 60))" > "$FRESH_MARKER"
+ZSKILLS_GATE_FORCE_CLAUDE=1 ZSKILLS_GATE_FORCE_CREDS=1 \
+  expect_gate skip "claude+creds present, marker fresh → SKIP (throttled)" "$FRESH_MARKER"
+
+# ── Branch 4a: marker STALE (older than window) + claude + creds → gate TRUE ──
+STALE_MARKER="$TMP/marker-stale"
+printf '%s\n' "$((NOW - THROTTLE - 60))" > "$STALE_MARKER"
+ZSKILLS_GATE_FORCE_CLAUDE=1 ZSKILLS_GATE_FORCE_CREDS=1 \
+  expect_gate run "claude+creds present, marker stale → RUN" "$STALE_MARKER"
+
+# ── Branch 4b: marker ABSENT (never run) + claude + creds → gate TRUE ─────────
+ZSKILLS_GATE_FORCE_CLAUDE=1 ZSKILLS_GATE_FORCE_CREDS=1 \
+  expect_gate run "claude+creds present, marker absent → RUN (never run yet)" "$TMP/marker-absent"
+
+# ── Extra: malformed (non-numeric) marker is treated as stale → RUN ──────────
+BAD_MARKER="$TMP/marker-bad"
+printf '%s\n' "garbage" > "$BAD_MARKER"
+ZSKILLS_GATE_FORCE_CLAUDE=1 ZSKILLS_GATE_FORCE_CREDS=1 \
+  expect_gate run "claude+creds present, marker malformed → RUN (treated as stale)" "$BAD_MARKER"
+
+# ── refresh_marker writes a numeric epoch and creates the parent dir ─────────
+REFRESH_MARKER="$TMP/newdir/last-attended-plugin-run"
+attended_gate_refresh_marker "$REFRESH_MARKER" "$NOW"
+if [ -f "$REFRESH_MARKER" ] && [ "$(cat "$REFRESH_MARKER")" = "$NOW" ]; then
+  pass "refresh_marker creates parent dir and writes the epoch"
+else
+  fail "refresh_marker — expected $NOW at $REFRESH_MARKER, got '$(cat "$REFRESH_MARKER" 2>/dev/null)'"
+fi
+
+# ── End-to-end throttle: after a refresh, an immediate re-check SKIPs ─────────
+ZSKILLS_GATE_FORCE_CLAUDE=1 ZSKILLS_GATE_FORCE_CREDS=1 \
+  expect_gate skip "after refresh at NOW, immediate re-check → SKIP (throttled)" "$REFRESH_MARKER"
+
+echo ""
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, %d failed\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT"
+else
+  printf '\033[31mResults: %d passed, %d failed\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT"
+  exit 1
+fi


### PR DESCRIPTION
Task: Fix #991 — capability-gate + throttle the plugin runtime checks (test-plugin-live-load.sh §B) into run-all.sh so they auto-run when an authed claude is present, SKIP on CI, instead of rotting behind a manual ZSKILLS_LIVE_ATTENDED flag nobody sets.

Closes #991.

## Problem
`test-plugin-live-load.sh`'s §B runtime checks (hookfire, dual-install, (A2)-runtime) are real and passing, but only run when a human sets `ZSKILLS_LIVE_ATTENDED=1` — which nobody does. So in every normal full-suite run they SKIP, even in the authed devcontainer, purely because `run-all.sh` never set the flag → they rot. (Rot is the exact thing this whole verification effort exists to kill.)

## Fix — capability-gate, not flag-gate (+ throttle)
- **`tests/lib/attended-gate.sh`** (new): `attended_gate_should_run <marker> <now> <throttle>` returns true iff a `claude` CLI **and** `~/.claude/.credentials.json` are present **and** §B hasn't run in the throttle window. Capability probes are overridable for testing.
- **`tests/run-all.sh`**: before the `test-plugin-live-load.sh` suite, if the gate passes, run it with `ZSKILLS_LIVE_ATTENDED=1` (scoped to that suite only — verified no leak) and refresh the marker; otherwise leave it unset → §B SKIPs as today. Throttle ~4h via an **out-of-tree** marker (`~/.zskills/last-attended-plugin-run`) so §B runs at most ~once/4h (not on every agent's run-all) and never pollutes `git status`.
- **CI unchanged:** runners have no `claude` → gate always false → §B SKIPs, byte-for-byte as today.

## Out of scope (per the reframed issue)
No new verifier script; no rebuild of already-covered coverage (materialiser sentinels → `test-sessionstart-materialise.sh`; mirror-less → `test-plugin-mirrorless-resolution.sh`; hooks-firing → §B). Consumer post-install verifier is separate (#999/#1004). `dogfood-plugin-install.sh` left alone. Test/harness change only — no skill/hook version bumps.

## Verification
- `tests/test-attended-gate.sh` (new, deterministic, no live claude) → 8 passed, 0 failed across all branches (claude-absent, creds-absent, throttled, stale/absent/malformed marker, refresh).
- CI-path sim (force no-claude) → gate SKIP, §B unrun (`4 passed, 0 failed, 3 skipped` — identical to today).
- End-to-end in the authed devcontainer: gate fired, §B ran live → **7 passed, 0 failed, 0 skipped**; marker refreshed; re-check SKIPs (throttle confirmed).
- Full `bash tests/run-all.sh` → 7383/7383, 0 failed. Marker is out-of-tree (clean `git status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
