### PR TITLE
do: /do pr verifies before /land-pr (#1014)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+fb2e19"
+  version: "2026.06.02+7a73dc"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -666,7 +666,7 @@ written** (no tracking for /do). No worktree, no commits, no cron.
 
 On REJECT and `$FORCE -eq 1`: print override message. Continue to Phase 0c.
 
-Orthogonality with `/verify-changes` (Phase 3): pre-review judges PLAN; `/verify-changes` judges DIFF. Both run when both apply: `--rounds > 0` triggers this pre-review (any landing mode); code changes in `worktree`/`direct` mode trigger /verify-changes unconditionally after execution (issue #713 — `auto` controls landing, not verification). PR mode (Path A) handles its own push internally and does **not** invoke /verify-changes (per `skills/do/SKILL.md` Phase 4 'Not applicable to PR mode' note).
+Orthogonality with `/verify-changes` (Phase 3): pre-review judges PLAN; `/verify-changes` judges DIFF. Both run when both apply: `--rounds > 0` triggers this pre-review (any landing mode); code changes in `worktree`/`direct` mode trigger /verify-changes unconditionally after execution (issue #713 — `auto` controls landing, not verification). PR mode (Path A) ALSO runs the same DIFF verification gate before landing: it invokes /verify-changes (Layer-3 validated, STOP-on-fail) at its own Step A6.5 (`skills/do/modes/pr.md`) BEFORE dispatching /land-pr — closing the gap (issue #1014) where /do pr was the only PR-mode caller with no local verification gate and relied solely on CI. CI via /land-pr is the backstop, not the gate.
 
 ## Phase 0c — Schedule (if `every` is present)
 
@@ -1014,7 +1014,7 @@ Verification intensity matches the change type (from Phase 1):
 
 ## Phase 4 — Land (if auto flag present, Path C/B only)
 
-Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invocation) AND Phase 3 verification passed (Phase 3 verification runs unconditionally for code changes — see issue #713). Not applicable to PR mode (Path A — PR mode has its own push in Phase 2 Step A7; AUTO_FLAG in PR mode is consumed by `modes/pr.md` to request auto-merge via `--auto` to `/land-pr`).
+Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invocation) AND Phase 3 verification passed (Phase 3 verification runs unconditionally for code changes — see issue #713). This is the **push/land** step. Not applicable to PR mode (Path A — PR mode does its OWN push/land through `/land-pr` in Phase 2 Step A8, after its own verification gate in Step A6.5; AUTO_FLAG in PR mode is consumed by `modes/pr.md` to request auto-merge via `--auto` to `/land-pr`). Note this exclusion is about the push/land step only — PR mode DOES verify (Step A6.5), it just lands differently.
 
 1. **If on main (Path C):**
    ```bash

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -6,7 +6,7 @@ Full end-to-end PR flow: create branch, worktree, dispatch agents, open the PR, 
 Selected when the user passes `pr` explicitly, or when
 `execution.landing` in `.claude/zskills-config.json` is `"pr"`.
 
-**This path replaces the normal Phase 2–5 flow entirely. After the PR is created, skip to Phase 5 Report.**
+**This path runs its own end-to-end flow in place of the normal Phase 2–5 sequence. It performs its OWN verification gate (Step A6.5, equivalent to Phase 3) BEFORE handing off to `/land-pr`, then after the PR is created skips to Phase 5 Report. It does NOT re-run SKILL.md's Phase 3 or Phase 4 — those are folded into Step A6.5 (verify) and the `/land-pr` dispatch (push/land) here.**
 
 **Step A1 — Compose task slug (model-layer).** Set shell variable
 `TASK_SLUG` to a kebab-case identifier matching
@@ -230,6 +230,106 @@ branch: $BRANCH_NAME
 LANDED
 ```
 Exit with error directing the user to inspect `$WORKTREE_PATH`.
+
+**Step A6.5 — Verify (before push/land):**
+
+`/do pr` runs the SAME local verification gate as its worktree/direct
+siblings (`/do` Phase 3) and as the other PR-mode callers (`/quickfix`
+Phase 5.5, `/run-plan`, `/fix-issues`, `/commit`) BEFORE handing off to
+`/land-pr`. Issue #1014 — `/do pr` was previously the only PR-mode caller
+with no local verification gate: it relied solely on CI through
+`/land-pr`. CI (via `/land-pr`'s `pr-monitor.sh`) is the **backstop**, not
+the gate — a failing diff should be caught here, locally, before a branch
+is pushed and a PR is opened.
+
+Verification intensity matches the change type the implementation agent
+produced (the content/code/mixed split from `/do` Phase 1, exactly as
+Phase 3 applies it):
+
+- **Content-only changes** (markdown, images, presentations, docs):
+  dispatch a plain review agent — NO full test run. Tell the agent
+  explicitly: "These are content-only changes (no code). Review the diff
+  for correctness and completeness — do NOT run the full test suite. Your
+  job is: do these changes make sense? Are the right files included?
+  Anything accidentally staged? Formatting correct?" Do NOT invoke
+  `/verify-changes` for content-only changes (it would run the full suite
+  regardless).
+
+  **Dispatch shape.** Use the `Agent` tool with `subagent_type: "verifier"`.
+  The verifier's tool allowlist (`Read, Grep, Glob, Bash, Edit, Write`) is
+  sufficient for content review; the prose preamble above keeps it from
+  running tests.
+
+- **Code changes** (js, css, html, model files) **and mixed changes:**
+  dispatch a separate verification agent running `/verify-changes`. This
+  is the full 7-phase verification: diff review, test coverage audit,
+  full test suite, manual verification if UI, fix problems, re-verify
+  until clean. Push/land (Step A7/A8) only happens if this agent reports
+  clean.
+
+  **Dispatch shape.** Use the `Agent` tool with `subagent_type: "verifier"`.
+  This inherits the Layer 0 Bash-timeout extension
+  (`.claude/agents/verifier.md` + CLAUDE.md "Verifier-cannot-run rule") so
+  the verifier's long test runs don't trigger the bg+Monitor stall
+  pattern. The prompt should include the branch name (`$BRANCH_NAME`), the
+  task description (`$TASK_DESCRIPTION`), and the worktree path
+  (`$WORKTREE_PATH`) so the verifier has full context. Tell it to run
+  `/verify-changes` in `$WORKTREE_PATH`.
+
+In BOTH cases, after the dispatch returns, pipe `$VERIFIER_RESPONSE`
+through `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-response-validate.sh"`;
+on exit 1 STOP — do NOT push and do NOT dispatch `/land-pr`.
+
+**Layer 3 — verifier response validation:**
+
+```bash
+printf '%s' "$VERIFIER_RESPONSE" | bash "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-response-validate.sh"
+VALIDATE_EXIT=$?
+```
+
+On `VALIDATE_EXIT=1` — or when the verifier agent reports a verification
+FAILURE it could not resolve (tests still failing, diff unsound) — STOP.
+Do NOT push and do NOT dispatch `/land-pr`. Write the `.landed` marker
+(`status: pr-failed`) and release any acquired issue claim(s) before
+exiting, reusing Step A6's failure shape:
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: pr-failed
+date: $(TZ="${TIMEZONE:-UTC}" date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+reason: local verification failed before push/land (#1014)
+LANDED
+# C2 inline-release: this STOP is AFTER the Step A5.5 acquire and BEFORE
+# the explicit-finalize block in Step A8, so release the issue claim(s)
+# (only if any were acquired) before bailing or they leak. Same fan-out
+# over $ISSUE_NUMS the abandon paths use.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+  done
+  unset _ISSUE_N
+fi
+```
+
+Then emit the STOP message and exit (do NOT continue to Step A7/A8):
+
+```
+STOP: verifier returned without meaningful results.
+
+$(cat /tmp/last-validate-stderr)
+
+This is a verification FAIL, not a license to push. Surface to the
+user. If the verifier agent file is missing, run /update-zskills.
+```
+
+Only when verification is clean do you continue to Step A7.
 
 **Step A7 — Compose PR title and body BEFORE invoking /land-pr:**
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.01+fb2e19"
+  version: "2026.06.02+7a73dc"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -666,7 +666,7 @@ written** (no tracking for /do). No worktree, no commits, no cron.
 
 On REJECT and `$FORCE -eq 1`: print override message. Continue to Phase 0c.
 
-Orthogonality with `/verify-changes` (Phase 3): pre-review judges PLAN; `/verify-changes` judges DIFF. Both run when both apply: `--rounds > 0` triggers this pre-review (any landing mode); code changes in `worktree`/`direct` mode trigger /verify-changes unconditionally after execution (issue #713 — `auto` controls landing, not verification). PR mode (Path A) handles its own push internally and does **not** invoke /verify-changes (per `skills/do/SKILL.md` Phase 4 'Not applicable to PR mode' note).
+Orthogonality with `/verify-changes` (Phase 3): pre-review judges PLAN; `/verify-changes` judges DIFF. Both run when both apply: `--rounds > 0` triggers this pre-review (any landing mode); code changes in `worktree`/`direct` mode trigger /verify-changes unconditionally after execution (issue #713 — `auto` controls landing, not verification). PR mode (Path A) ALSO runs the same DIFF verification gate before landing: it invokes /verify-changes (Layer-3 validated, STOP-on-fail) at its own Step A6.5 (`skills/do/modes/pr.md`) BEFORE dispatching /land-pr — closing the gap (issue #1014) where /do pr was the only PR-mode caller with no local verification gate and relied solely on CI. CI via /land-pr is the backstop, not the gate.
 
 ## Phase 0c — Schedule (if `every` is present)
 
@@ -1014,7 +1014,7 @@ Verification intensity matches the change type (from Phase 1):
 
 ## Phase 4 — Land (if auto flag present, Path C/B only)
 
-Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invocation) AND Phase 3 verification passed (Phase 3 verification runs unconditionally for code changes — see issue #713). Not applicable to PR mode (Path A — PR mode has its own push in Phase 2 Step A7; AUTO_FLAG in PR mode is consumed by `modes/pr.md` to request auto-merge via `--auto` to `/land-pr`).
+Only reached if `AUTO_FLAG=1` (the `auto` token was present in the user's invocation) AND Phase 3 verification passed (Phase 3 verification runs unconditionally for code changes — see issue #713). This is the **push/land** step. Not applicable to PR mode (Path A — PR mode does its OWN push/land through `/land-pr` in Phase 2 Step A8, after its own verification gate in Step A6.5; AUTO_FLAG in PR mode is consumed by `modes/pr.md` to request auto-merge via `--auto` to `/land-pr`). Note this exclusion is about the push/land step only — PR mode DOES verify (Step A6.5), it just lands differently.
 
 1. **If on main (Path C):**
    ```bash

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -6,7 +6,7 @@ Full end-to-end PR flow: create branch, worktree, dispatch agents, open the PR, 
 Selected when the user passes `pr` explicitly, or when
 `execution.landing` in `.claude/zskills-config.json` is `"pr"`.
 
-**This path replaces the normal Phase 2–5 flow entirely. After the PR is created, skip to Phase 5 Report.**
+**This path runs its own end-to-end flow in place of the normal Phase 2–5 sequence. It performs its OWN verification gate (Step A6.5, equivalent to Phase 3) BEFORE handing off to `/land-pr`, then after the PR is created skips to Phase 5 Report. It does NOT re-run SKILL.md's Phase 3 or Phase 4 — those are folded into Step A6.5 (verify) and the `/land-pr` dispatch (push/land) here.**
 
 **Step A1 — Compose task slug (model-layer).** Set shell variable
 `TASK_SLUG` to a kebab-case identifier matching
@@ -230,6 +230,106 @@ branch: $BRANCH_NAME
 LANDED
 ```
 Exit with error directing the user to inspect `$WORKTREE_PATH`.
+
+**Step A6.5 — Verify (before push/land):**
+
+`/do pr` runs the SAME local verification gate as its worktree/direct
+siblings (`/do` Phase 3) and as the other PR-mode callers (`/quickfix`
+Phase 5.5, `/run-plan`, `/fix-issues`, `/commit`) BEFORE handing off to
+`/land-pr`. Issue #1014 — `/do pr` was previously the only PR-mode caller
+with no local verification gate: it relied solely on CI through
+`/land-pr`. CI (via `/land-pr`'s `pr-monitor.sh`) is the **backstop**, not
+the gate — a failing diff should be caught here, locally, before a branch
+is pushed and a PR is opened.
+
+Verification intensity matches the change type the implementation agent
+produced (the content/code/mixed split from `/do` Phase 1, exactly as
+Phase 3 applies it):
+
+- **Content-only changes** (markdown, images, presentations, docs):
+  dispatch a plain review agent — NO full test run. Tell the agent
+  explicitly: "These are content-only changes (no code). Review the diff
+  for correctness and completeness — do NOT run the full test suite. Your
+  job is: do these changes make sense? Are the right files included?
+  Anything accidentally staged? Formatting correct?" Do NOT invoke
+  `/verify-changes` for content-only changes (it would run the full suite
+  regardless).
+
+  **Dispatch shape.** Use the `Agent` tool with `subagent_type: "verifier"`.
+  The verifier's tool allowlist (`Read, Grep, Glob, Bash, Edit, Write`) is
+  sufficient for content review; the prose preamble above keeps it from
+  running tests.
+
+- **Code changes** (js, css, html, model files) **and mixed changes:**
+  dispatch a separate verification agent running `/verify-changes`. This
+  is the full 7-phase verification: diff review, test coverage audit,
+  full test suite, manual verification if UI, fix problems, re-verify
+  until clean. Push/land (Step A7/A8) only happens if this agent reports
+  clean.
+
+  **Dispatch shape.** Use the `Agent` tool with `subagent_type: "verifier"`.
+  This inherits the Layer 0 Bash-timeout extension
+  (`.claude/agents/verifier.md` + CLAUDE.md "Verifier-cannot-run rule") so
+  the verifier's long test runs don't trigger the bg+Monitor stall
+  pattern. The prompt should include the branch name (`$BRANCH_NAME`), the
+  task description (`$TASK_DESCRIPTION`), and the worktree path
+  (`$WORKTREE_PATH`) so the verifier has full context. Tell it to run
+  `/verify-changes` in `$WORKTREE_PATH`.
+
+In BOTH cases, after the dispatch returns, pipe `$VERIFIER_RESPONSE`
+through `bash "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-response-validate.sh"`;
+on exit 1 STOP — do NOT push and do NOT dispatch `/land-pr`.
+
+**Layer 3 — verifier response validation:**
+
+```bash
+printf '%s' "$VERIFIER_RESPONSE" | bash "$CLAUDE_PROJECT_DIR/.claude/hooks/verify-response-validate.sh"
+VALIDATE_EXIT=$?
+```
+
+On `VALIDATE_EXIT=1` — or when the verifier agent reports a verification
+FAILURE it could not resolve (tests still failing, diff unsound) — STOP.
+Do NOT push and do NOT dispatch `/land-pr`. Write the `.landed` marker
+(`status: pr-failed`) and release any acquired issue claim(s) before
+exiting, reusing Step A6's failure shape:
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
+fi
+cat > "$WORKTREE_PATH/.landed" <<LANDED
+status: pr-failed
+date: $(TZ="${TIMEZONE:-UTC}" date -Iseconds)
+source: do
+branch: $BRANCH_NAME
+reason: local verification failed before push/land (#1014)
+LANDED
+# C2 inline-release: this STOP is AFTER the Step A5.5 acquire and BEFORE
+# the explicit-finalize block in Step A8, so release the issue claim(s)
+# (only if any were acquired) before bailing or they leak. Same fan-out
+# over $ISSUE_NUMS the abandon paths use.
+if [ "${#ISSUE_NUMS[@]}" -gt 0 ]; then
+  for _ISSUE_N in "${ISSUE_NUMS[@]}"; do
+    bash "$ZSKILLS_SKILLS_ROOT/fix-issues/scripts/claim-issue.sh" release "$_ISSUE_N" --require-pipeline "$PIPELINE_ID"
+  done
+  unset _ISSUE_N
+fi
+```
+
+Then emit the STOP message and exit (do NOT continue to Step A7/A8):
+
+```
+STOP: verifier returned without meaningful results.
+
+$(cat /tmp/last-validate-stderr)
+
+This is a verification FAIL, not a license to push. Surface to the
+user. If the verifier agent file is missing, run /update-zskills.
+```
+
+Only when verification is clean do you continue to Step A7.
 
 **Step A7 — Compose PR title and body BEFORE invoking /land-pr:**
 

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -397,17 +397,54 @@ fi
 
 # ────────────────────────────────────────────────────────────────────
 # Case 10 — Phase 0b documents orthogonality with /verify-changes
-# (positive grep `pre-review judges PLAN`) AND PR-mode negation prose
-# present (positive grep on `PR mode (Path A) handles its own push
-# internally and does \*\*not\*\* invoke /verify-changes`). Closes R3.
+# (positive grep `pre-review judges PLAN`) AND the orthogonality note
+# now states PR mode ALSO verifies before landing (issue #1014). The
+# OLD assertion grepped for "does **not** invoke /verify-changes" — that
+# prose is now genuinely wrong (PR mode runs the gate at Step A6.5), so
+# this asserts the corrected prose instead. Closes R3 + #1014.
 # ────────────────────────────────────────────────────────────────────
 ORTHO_DOC=$(grep -c 'pre-review judges PLAN' "$SKILL")
-PR_NEG_DOC=$(grep -cE 'PR mode \(Path A\) handles its own push internally and does \*\*not\*\* invoke /verify-changes' "$SKILL")
+# Corrected: PR mode now invokes /verify-changes before /land-pr.
+PR_VERIFY_DOC=$(grep -cE 'PR mode \(Path A\) ALSO runs the same DIFF verification gate before landing' "$SKILL")
+# Negative: the stale "does not invoke /verify-changes" carve-out must be GONE.
+PR_STALE_DOC=$(grep -cE 'does \*\*not\*\* invoke /verify-changes' "$SKILL")
 
-if [ "$ORTHO_DOC" -ge 1 ] && [ "$PR_NEG_DOC" -ge 1 ]; then
-  pass "10 Phase 0b orthogonality: pre-review-judges-PLAN ($ORTHO_DOC) + PR-mode-negation ($PR_NEG_DOC)"
+if [ "$ORTHO_DOC" -ge 1 ] && [ "$PR_VERIFY_DOC" -ge 1 ] && [ "$PR_STALE_DOC" -eq 0 ]; then
+  pass "10 Phase 0b orthogonality: pre-review-judges-PLAN ($ORTHO_DOC) + PR-mode-verifies-before-land ($PR_VERIFY_DOC) + stale-carve-out-removed (#1014)"
 else
-  fail "10 Phase 0b orthogonality: ortho=$ORTHO_DOC pr-neg=$PR_NEG_DOC"
+  fail "10 Phase 0b orthogonality: ortho=$ORTHO_DOC pr-verify=$PR_VERIFY_DOC stale-still-present=$PR_STALE_DOC"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 10b — modes/pr.md runs the local verification gate (verifier
+# dispatch + Layer-3 verify-response-validate.sh) BEFORE dispatching
+# /land-pr (issue #1014). /do pr was the only PR-mode caller with no
+# local verification gate — it relied solely on CI via /land-pr. The
+# gate must appear ahead of the /land-pr dispatch in modes/pr.md, so a
+# refactor that drops it (or reorders it after land) fails closed.
+#
+#   10b-i.   modes/pr.md dispatches /verify-changes (verifier).
+#   10b-ii.  modes/pr.md runs the Layer-3 verify-response-validate.sh.
+#   10b-iii. Both appear BEFORE the /land-pr dispatch (line-order check).
+# ────────────────────────────────────────────────────────────────────
+PR_MODE_F="$REPO_ROOT/skills/do/modes/pr.md"
+C10b_i=0; C10b_ii=0; C10b_iii=0
+grep -qE '/verify-changes' "$PR_MODE_F" && C10b_i=1
+grep -qF 'verify-response-validate.sh' "$PR_MODE_F" && C10b_ii=1
+
+# Line-order: the FIRST verify-response-validate.sh occurrence must come
+# before the FIRST /land-pr Skill-tool dispatch (`Skill: { skill: "land-pr"`).
+VERIFY_LINE=$(grep -nF 'verify-response-validate.sh' "$PR_MODE_F" | head -1 | cut -d: -f1)
+LAND_LINE=$(grep -nE 'Skill: *\{ *skill: *"land-pr"' "$PR_MODE_F" | head -1 | cut -d: -f1)
+if [ -n "$VERIFY_LINE" ] && [ -n "$LAND_LINE" ] && [ "$VERIFY_LINE" -lt "$LAND_LINE" ]; then
+  C10b_iii=1
+fi
+
+if [ "$C10b_i" = "1" ] && [ "$C10b_ii" = "1" ] && [ "$C10b_iii" = "1" ]; then
+  pass "10b modes/pr.md: /verify-changes + Layer-3 validation BEFORE /land-pr dispatch (verify@$VERIFY_LINE < land@$LAND_LINE) (#1014)"
+else
+  fail "10b modes/pr.md: verify-changes=$C10b_i layer3=$C10b_ii order(verify@${VERIFY_LINE:-none}<land@${LAND_LINE:-none})=$C10b_iii"
+  grep -nE '/verify-changes|verify-response-validate|skill: "land-pr"' "$PR_MODE_F" | sed 's/^/    /' | head -10
 fi
 
 # ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1014.

`/do` PR mode was the only PR-mode caller with no local verification gate — it went impl-agent → `/land-pr` (CI-only). CI-less consumers got nothing; even with CI it was push-then-hope. The four sibling callers (`/quickfix`, `/run-plan`, `/fix-issues`, `/commit`) all run `/verify-changes` (verifier) before `/land-pr`, and `/do`'s own worktree/direct modes verify in Phase 3 — PR mode was the lone exception (likely from PR_LANDING_UNIFICATION).

This adds **Step A6.5 — Verify (before push/land)** to `modes/pr.md`: code/mixed → `verifier` subagent running `/verify-changes`, Layer-3 validated via `verify-response-validate.sh`, STOP-on-fail (writes `.landed`, releases the claim, no push/land); content-only → review agent. CI via `/land-pr` is now the backstop, not the gate. Updated the stale carve-out prose (orthogonality + Phase 4 notes); added test-do.sh Case 10b (verify ordered before land-pr) and corrected the old Case 10 carve-out assertion. Version-bumped (source + mirror).

Commits:
92f6e69 do: /do pr runs /verify-changes before /land-pr (#1014)
