### PR TITLE
do: verifier FAILs on de-hooked install (#1008)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.02+8b1630"
+  version: "2026.06.02+4a048a"
 ---
 
 # Update Z Skills Infrastructure

--- a/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -172,12 +172,42 @@ vi_resolve_hook_path() {
   printf '%s\n' "$path"
 }
 
+# vi_is_zskills_hook <basename> → 0 if <basename> is a zskills-OWNED hook
+# (one of the canonical settings.json-owned triples in update-zskills/SKILL.md,
+# plus the two non-registered-but-shipped hooks). Used to scope the integrity
+# checks (non-empty + line-2 version stamp) to zskills' OWN hooks — a foreign
+# (consumer-supplied) hook registered alongside zskills ones legitimately does
+# NOT carry the `# zskills-hook-version:` stamp, so blanket-checking every
+# registered hook would false-FAIL a valid install with foreign hooks.
+vi_is_zskills_hook() {
+  case "$1" in
+    block-unsafe-generic.sh|block-unsafe-project.sh|block-stale-skill-version.sh|\
+    block-bypassed-land-pr.sh|block-fix-issue-unclaimed.sh|block-run-plan-unclaimed.sh|\
+    block-agents.sh|block-bad-cron.sh|block-main-edits.sh|warn-config-drift.sh|\
+    inject-bash-timeout.sh|verify-response-validate.sh)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# vi_hook_has_version_stamp <path> → 0 if line 2 of the hook carries the
+# `# zskills-hook-version:` sentinel (the convention CLAUDE.md documents and
+# tests/test-skill-conformance.sh gates). 1 otherwise.
+vi_hook_has_version_stamp() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  sed -n '2p' "$f" 2>/dev/null | grep -Eq '^#[[:space:]]*zskills-hook-version:[[:space:]]'
+}
+
 # ───────────────────────────────────────────────────────────────────────────
 # LEGACY-lane cheap structural checks.
 #
 # vi_check_legacy <project_dir>
 #   - .claude/skills/ populated
 #   - every hook registered in .claude/settings.json resolves to a real file
+#   - AT LEAST ONE hook is registered (zero registered hooks == de-hooked
+#     install == broken; #1008 F1)
+#   - the canonical safety-hook set is registered in settings.json (#1008 F1)
 #   - .claude/rules/zskills/managed.md present AND rendered (no raw,
 #     un-substituted {{TOKEN}} template placeholders)
 #   - .claude/zskills-config.json present
@@ -195,11 +225,32 @@ vi_check_legacy() {
   local proj="$1"
   local claude="$proj/.claude"
 
-  # (1) .claude/skills/ populated.
-  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
-    vi_emit PASS "legacy.skills-populated" ".claude/skills/ has $(ls -1 "$claude/skills" | wc -l | tr -d ' ') entries"
-  else
+  # (1) .claude/skills/ populated AND each skill dir carries a SKILL.md.
+  #
+  # #1008 medium gap (partial mirror): a half-finished `cp -r` can leave a skill
+  # DIRECTORY behind with no SKILL.md (e.g. only references/ copied). The bare
+  # `ls -A >= 1` check passed such a corrupt mirror. We now require every
+  # immediate subdirectory of .claude/skills/ to contain a SKILL.md — a skill
+  # dir without one is genuinely broken. (We do NOT compare subdir trees against
+  # a source: the verifier is self-contained and has no source to diff against,
+  # and many valid skills have no subdirs at all — so SKILL.md presence is the
+  # tightest assertion that can never false-FAIL a healthy install.)
+  if [ ! -d "$claude/skills" ] || [ -z "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
     vi_emit FAIL "legacy.skills-populated" ".claude/skills/ missing or empty"
+  else
+    local skilldir skill_missing="" skill_count=0
+    for skilldir in "$claude/skills"/*/; do
+      [ -d "$skilldir" ] || continue
+      skill_count=$((skill_count + 1))
+      if [ ! -f "${skilldir}SKILL.md" ]; then
+        skill_missing="$skill_missing $(basename "$skilldir")"
+      fi
+    done
+    if [ -n "$skill_missing" ]; then
+      vi_emit FAIL "legacy.skills-populated" "skill dir(s) missing SKILL.md (partial mirror?):$skill_missing"
+    else
+      vi_emit PASS "legacy.skills-populated" ".claude/skills/ has $skill_count skill(s), each with a SKILL.md"
+    fi
   fi
 
   # (2) settings.json present + valid JSON + every registered hook resolves.
@@ -210,19 +261,72 @@ vi_check_legacy() {
     vi_emit FAIL "legacy.settings-valid-json" ".claude/settings.json is not valid JSON"
   else
     vi_emit PASS "legacy.settings-present" ".claude/settings.json present and valid JSON"
-    local missing="" total=0 cmd hp
+    local missing="" total=0 cmd hp base registered="" empty_hooks="" unstamped=""
     while IFS= read -r cmd; do
       [ -n "$cmd" ] || continue
       total=$((total + 1))
       hp="$(vi_resolve_hook_path "$proj" "$cmd")"
       if [ -z "$hp" ] || [ ! -f "$hp" ]; then
         missing="$missing ${cmd##*/}"
+        continue
+      fi
+      # Record the resolved-path basename for the canonical-set cross-check.
+      base="${hp##*/}"
+      [ -n "$base" ] && registered="$registered $base "
+      # #1008 medium gaps — hook INTEGRITY, scoped to zskills-owned hooks so a
+      # foreign consumer hook never false-FAILs:
+      #   (a) corrupted/empty (0-byte) hook — `[ -f ]` alone passes a truncated
+      #       `cp`; require `[ -s ]`.
+      #   (b) drifted mirror — a consumer hook predating source carries a stale
+      #       (or absent) line-2 `# zskills-hook-version:` stamp.
+      if vi_is_zskills_hook "$base"; then
+        [ -s "$hp" ] || empty_hooks="$empty_hooks $base"
+        vi_hook_has_version_stamp "$hp" || unstamped="$unstamped $base"
       fi
     done < <(vi_settings_hook_commands "$settings")
-    if [ -z "$missing" ]; then
-      vi_emit PASS "legacy.hooks-resolve" "all $total registered hook commands resolve to existing files"
-    else
+
+    # (2a) ZERO registered hooks → a de-hooked install (#1008 F1). Every zskills
+    # safety hook (block-unsafe-*, block-stale-skill-version, block-agents, …)
+    # has been stripped from settings.json — the verifier exists to catch exactly
+    # this "install silently failed" case, so a count of 0 is a FAIL, not a PASS.
+    if [ "$total" -eq 0 ]; then
+      vi_emit FAIL "legacy.hooks-resolve" "no hooks registered in settings.json — a de-hooked install (every zskills safety hook stripped) is broken"
+    elif [ -n "$missing" ]; then
       vi_emit FAIL "legacy.hooks-resolve" "unresolved hook script(s):$missing"
+    else
+      vi_emit PASS "legacy.hooks-resolve" "all $total registered hook commands resolve to existing files"
+    fi
+
+    # (2b) Canonical safety-hook set (#1008 F1). Even with a NON-zero hook count,
+    # an install missing the core safety hooks is broken. We require the minimal
+    # set of settings.json-registered safety hooks that a HEALTHY legacy install
+    # ALWAYS registers (per the canonical zskills-owned triples table in
+    # update-zskills/SKILL.md). We deliberately do NOT require inject-bash-timeout.sh
+    # or verify-response-validate.sh here: SKILL.md states those have NO
+    # settings.json entry (loaded via verifier.md frontmatter / direct skill
+    # invocation), so requiring them would false-FAIL every valid legacy install.
+    local canon canon_missing=""
+    for canon in block-unsafe-generic.sh block-unsafe-project.sh block-stale-skill-version.sh block-agents.sh; do
+      case "$registered" in
+        *" $canon "*) : ;;
+        *) canon_missing="$canon_missing $canon" ;;
+      esac
+    done
+    if [ -n "$canon_missing" ]; then
+      vi_emit FAIL "legacy.canonical-hooks" "canonical safety hook(s) not registered in settings.json:$canon_missing"
+    else
+      vi_emit PASS "legacy.canonical-hooks" "canonical safety hooks registered (block-unsafe-generic/project, block-stale-skill-version, block-agents)"
+    fi
+
+    # (2c) Hook integrity (#1008 medium gaps) — scoped to zskills-owned hooks.
+    # Only meaningful when at least one zskills hook resolved (skipped on the
+    # zero/all-unresolved case, already FAILed above).
+    if [ -n "$empty_hooks" ]; then
+      vi_emit FAIL "legacy.hooks-integrity" "zskills hook(s) are 0-byte/truncated (corrupt mirror):$empty_hooks"
+    elif [ -n "$unstamped" ]; then
+      vi_emit FAIL "legacy.hooks-integrity" "zskills hook(s) missing line-2 # zskills-hook-version: stamp (drifted/corrupt mirror):$unstamped"
+    elif [ -n "$registered" ]; then
+      vi_emit PASS "legacy.hooks-integrity" "all registered zskills hooks are non-empty and version-stamped"
     fi
   fi
 
@@ -311,6 +415,30 @@ vi_check_plugin() {
     vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
   else
     vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
+  fi
+
+  # (3) ${CLAUDE_PLUGIN_ROOT} reachability (#1008 medium gap). The materialised
+  # artifacts above live in the CONSUMER's .claude/, but the live skills/hooks
+  # resolve under ${CLAUDE_PLUGIN_ROOT}. A CLAUDE_PLUGIN_ROOT pointing at a
+  # deleted/empty dir → the plugin "passes" the artifact checks yet has ZERO
+  # functional skills. Assert the two manifests a loaded plugin always carries.
+  # Reached only on the plugin lane (vi_detect_lane returned `plugin`, which
+  # requires CLAUDE_PLUGIN_ROOT set), so a healthy plugin install always has
+  # these — never a false positive.
+  local proot="${CLAUDE_PLUGIN_ROOT:-}"
+  local pmissing=""
+  if [ -z "$proot" ]; then
+    # Defensive: vi_check_plugin is only dispatched when CLAUDE_PLUGIN_ROOT is
+    # set, so an empty value here is itself broken.
+    vi_emit FAIL "plugin.root-reachable" "\${CLAUDE_PLUGIN_ROOT} is empty on the plugin lane"
+  else
+    [ -f "$proot/.claude-plugin/plugin.json" ] || pmissing="$pmissing .claude-plugin/plugin.json"
+    [ -f "$proot/hooks/hooks.json" ]           || pmissing="$pmissing hooks/hooks.json"
+    if [ -n "$pmissing" ]; then
+      vi_emit FAIL "plugin.root-reachable" "\${CLAUDE_PLUGIN_ROOT}=$proot missing required plugin file(s):$pmissing"
+    else
+      vi_emit PASS "plugin.root-reachable" "\${CLAUDE_PLUGIN_ROOT} resolves (.claude-plugin/plugin.json + hooks/hooks.json present)"
+    fi
   fi
 
   # NOTE (#1004): no `plugin.version-recorded` check — same rationale as the

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.02+8b1630"
+  version: "2026.06.02+4a048a"
 ---
 
 # Update Z Skills Infrastructure

--- a/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -172,12 +172,42 @@ vi_resolve_hook_path() {
   printf '%s\n' "$path"
 }
 
+# vi_is_zskills_hook <basename> → 0 if <basename> is a zskills-OWNED hook
+# (one of the canonical settings.json-owned triples in update-zskills/SKILL.md,
+# plus the two non-registered-but-shipped hooks). Used to scope the integrity
+# checks (non-empty + line-2 version stamp) to zskills' OWN hooks — a foreign
+# (consumer-supplied) hook registered alongside zskills ones legitimately does
+# NOT carry the `# zskills-hook-version:` stamp, so blanket-checking every
+# registered hook would false-FAIL a valid install with foreign hooks.
+vi_is_zskills_hook() {
+  case "$1" in
+    block-unsafe-generic.sh|block-unsafe-project.sh|block-stale-skill-version.sh|\
+    block-bypassed-land-pr.sh|block-fix-issue-unclaimed.sh|block-run-plan-unclaimed.sh|\
+    block-agents.sh|block-bad-cron.sh|block-main-edits.sh|warn-config-drift.sh|\
+    inject-bash-timeout.sh|verify-response-validate.sh)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# vi_hook_has_version_stamp <path> → 0 if line 2 of the hook carries the
+# `# zskills-hook-version:` sentinel (the convention CLAUDE.md documents and
+# tests/test-skill-conformance.sh gates). 1 otherwise.
+vi_hook_has_version_stamp() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  sed -n '2p' "$f" 2>/dev/null | grep -Eq '^#[[:space:]]*zskills-hook-version:[[:space:]]'
+}
+
 # ───────────────────────────────────────────────────────────────────────────
 # LEGACY-lane cheap structural checks.
 #
 # vi_check_legacy <project_dir>
 #   - .claude/skills/ populated
 #   - every hook registered in .claude/settings.json resolves to a real file
+#   - AT LEAST ONE hook is registered (zero registered hooks == de-hooked
+#     install == broken; #1008 F1)
+#   - the canonical safety-hook set is registered in settings.json (#1008 F1)
 #   - .claude/rules/zskills/managed.md present AND rendered (no raw,
 #     un-substituted {{TOKEN}} template placeholders)
 #   - .claude/zskills-config.json present
@@ -195,11 +225,32 @@ vi_check_legacy() {
   local proj="$1"
   local claude="$proj/.claude"
 
-  # (1) .claude/skills/ populated.
-  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
-    vi_emit PASS "legacy.skills-populated" ".claude/skills/ has $(ls -1 "$claude/skills" | wc -l | tr -d ' ') entries"
-  else
+  # (1) .claude/skills/ populated AND each skill dir carries a SKILL.md.
+  #
+  # #1008 medium gap (partial mirror): a half-finished `cp -r` can leave a skill
+  # DIRECTORY behind with no SKILL.md (e.g. only references/ copied). The bare
+  # `ls -A >= 1` check passed such a corrupt mirror. We now require every
+  # immediate subdirectory of .claude/skills/ to contain a SKILL.md — a skill
+  # dir without one is genuinely broken. (We do NOT compare subdir trees against
+  # a source: the verifier is self-contained and has no source to diff against,
+  # and many valid skills have no subdirs at all — so SKILL.md presence is the
+  # tightest assertion that can never false-FAIL a healthy install.)
+  if [ ! -d "$claude/skills" ] || [ -z "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
     vi_emit FAIL "legacy.skills-populated" ".claude/skills/ missing or empty"
+  else
+    local skilldir skill_missing="" skill_count=0
+    for skilldir in "$claude/skills"/*/; do
+      [ -d "$skilldir" ] || continue
+      skill_count=$((skill_count + 1))
+      if [ ! -f "${skilldir}SKILL.md" ]; then
+        skill_missing="$skill_missing $(basename "$skilldir")"
+      fi
+    done
+    if [ -n "$skill_missing" ]; then
+      vi_emit FAIL "legacy.skills-populated" "skill dir(s) missing SKILL.md (partial mirror?):$skill_missing"
+    else
+      vi_emit PASS "legacy.skills-populated" ".claude/skills/ has $skill_count skill(s), each with a SKILL.md"
+    fi
   fi
 
   # (2) settings.json present + valid JSON + every registered hook resolves.
@@ -210,19 +261,72 @@ vi_check_legacy() {
     vi_emit FAIL "legacy.settings-valid-json" ".claude/settings.json is not valid JSON"
   else
     vi_emit PASS "legacy.settings-present" ".claude/settings.json present and valid JSON"
-    local missing="" total=0 cmd hp
+    local missing="" total=0 cmd hp base registered="" empty_hooks="" unstamped=""
     while IFS= read -r cmd; do
       [ -n "$cmd" ] || continue
       total=$((total + 1))
       hp="$(vi_resolve_hook_path "$proj" "$cmd")"
       if [ -z "$hp" ] || [ ! -f "$hp" ]; then
         missing="$missing ${cmd##*/}"
+        continue
+      fi
+      # Record the resolved-path basename for the canonical-set cross-check.
+      base="${hp##*/}"
+      [ -n "$base" ] && registered="$registered $base "
+      # #1008 medium gaps — hook INTEGRITY, scoped to zskills-owned hooks so a
+      # foreign consumer hook never false-FAILs:
+      #   (a) corrupted/empty (0-byte) hook — `[ -f ]` alone passes a truncated
+      #       `cp`; require `[ -s ]`.
+      #   (b) drifted mirror — a consumer hook predating source carries a stale
+      #       (or absent) line-2 `# zskills-hook-version:` stamp.
+      if vi_is_zskills_hook "$base"; then
+        [ -s "$hp" ] || empty_hooks="$empty_hooks $base"
+        vi_hook_has_version_stamp "$hp" || unstamped="$unstamped $base"
       fi
     done < <(vi_settings_hook_commands "$settings")
-    if [ -z "$missing" ]; then
-      vi_emit PASS "legacy.hooks-resolve" "all $total registered hook commands resolve to existing files"
-    else
+
+    # (2a) ZERO registered hooks → a de-hooked install (#1008 F1). Every zskills
+    # safety hook (block-unsafe-*, block-stale-skill-version, block-agents, …)
+    # has been stripped from settings.json — the verifier exists to catch exactly
+    # this "install silently failed" case, so a count of 0 is a FAIL, not a PASS.
+    if [ "$total" -eq 0 ]; then
+      vi_emit FAIL "legacy.hooks-resolve" "no hooks registered in settings.json — a de-hooked install (every zskills safety hook stripped) is broken"
+    elif [ -n "$missing" ]; then
       vi_emit FAIL "legacy.hooks-resolve" "unresolved hook script(s):$missing"
+    else
+      vi_emit PASS "legacy.hooks-resolve" "all $total registered hook commands resolve to existing files"
+    fi
+
+    # (2b) Canonical safety-hook set (#1008 F1). Even with a NON-zero hook count,
+    # an install missing the core safety hooks is broken. We require the minimal
+    # set of settings.json-registered safety hooks that a HEALTHY legacy install
+    # ALWAYS registers (per the canonical zskills-owned triples table in
+    # update-zskills/SKILL.md). We deliberately do NOT require inject-bash-timeout.sh
+    # or verify-response-validate.sh here: SKILL.md states those have NO
+    # settings.json entry (loaded via verifier.md frontmatter / direct skill
+    # invocation), so requiring them would false-FAIL every valid legacy install.
+    local canon canon_missing=""
+    for canon in block-unsafe-generic.sh block-unsafe-project.sh block-stale-skill-version.sh block-agents.sh; do
+      case "$registered" in
+        *" $canon "*) : ;;
+        *) canon_missing="$canon_missing $canon" ;;
+      esac
+    done
+    if [ -n "$canon_missing" ]; then
+      vi_emit FAIL "legacy.canonical-hooks" "canonical safety hook(s) not registered in settings.json:$canon_missing"
+    else
+      vi_emit PASS "legacy.canonical-hooks" "canonical safety hooks registered (block-unsafe-generic/project, block-stale-skill-version, block-agents)"
+    fi
+
+    # (2c) Hook integrity (#1008 medium gaps) — scoped to zskills-owned hooks.
+    # Only meaningful when at least one zskills hook resolved (skipped on the
+    # zero/all-unresolved case, already FAILed above).
+    if [ -n "$empty_hooks" ]; then
+      vi_emit FAIL "legacy.hooks-integrity" "zskills hook(s) are 0-byte/truncated (corrupt mirror):$empty_hooks"
+    elif [ -n "$unstamped" ]; then
+      vi_emit FAIL "legacy.hooks-integrity" "zskills hook(s) missing line-2 # zskills-hook-version: stamp (drifted/corrupt mirror):$unstamped"
+    elif [ -n "$registered" ]; then
+      vi_emit PASS "legacy.hooks-integrity" "all registered zskills hooks are non-empty and version-stamped"
     fi
   fi
 
@@ -311,6 +415,30 @@ vi_check_plugin() {
     vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
   else
     vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
+  fi
+
+  # (3) ${CLAUDE_PLUGIN_ROOT} reachability (#1008 medium gap). The materialised
+  # artifacts above live in the CONSUMER's .claude/, but the live skills/hooks
+  # resolve under ${CLAUDE_PLUGIN_ROOT}. A CLAUDE_PLUGIN_ROOT pointing at a
+  # deleted/empty dir → the plugin "passes" the artifact checks yet has ZERO
+  # functional skills. Assert the two manifests a loaded plugin always carries.
+  # Reached only on the plugin lane (vi_detect_lane returned `plugin`, which
+  # requires CLAUDE_PLUGIN_ROOT set), so a healthy plugin install always has
+  # these — never a false positive.
+  local proot="${CLAUDE_PLUGIN_ROOT:-}"
+  local pmissing=""
+  if [ -z "$proot" ]; then
+    # Defensive: vi_check_plugin is only dispatched when CLAUDE_PLUGIN_ROOT is
+    # set, so an empty value here is itself broken.
+    vi_emit FAIL "plugin.root-reachable" "\${CLAUDE_PLUGIN_ROOT} is empty on the plugin lane"
+  else
+    [ -f "$proot/.claude-plugin/plugin.json" ] || pmissing="$pmissing .claude-plugin/plugin.json"
+    [ -f "$proot/hooks/hooks.json" ]           || pmissing="$pmissing hooks/hooks.json"
+    if [ -n "$pmissing" ]; then
+      vi_emit FAIL "plugin.root-reachable" "\${CLAUDE_PLUGIN_ROOT}=$proot missing required plugin file(s):$pmissing"
+    else
+      vi_emit PASS "plugin.root-reachable" "\${CLAUDE_PLUGIN_ROOT} resolves (.claude-plugin/plugin.json + hooks/hooks.json present)"
+    fi
   fi
 
   # NOTE (#1004): no `plugin.version-recorded` check — same rationale as the

--- a/tests/test-verify-install.sh
+++ b/tests/test-verify-install.sh
@@ -84,15 +84,28 @@ make_legacy_good() {
            "$c/.claude/rules/zskills"
   printf '%s\n' '---' 'name: update-zskills' '---' '# Update Z Skills' \
     > "$c/.claude/skills/update-zskills/SKILL.md"
-  # A real hook file the registration will point at.
-  printf '#!/usr/bin/env bash\nexit 0\n' > "$c/.claude/hooks/block-unsafe-generic.sh"
-  # settings.json registering that hook via the canonical command form.
+  # Real hook files the registration will point at. A HEALTHY legacy install
+  # always registers the canonical safety-hook set (#1008 F1), and each shipped
+  # zskills hook carries a line-2 `# zskills-hook-version:` stamp (the integrity
+  # check the verifier now enforces, #1008 medium gaps). Seed all four canonical
+  # hooks, version-stamped + non-empty.
+  local h
+  for h in block-unsafe-generic block-unsafe-project block-stale-skill-version block-agents; do
+    printf '%s\n' '#!/usr/bin/env bash' "# zskills-hook-version: 2026.06.0" 'exit 0' \
+      > "$c/.claude/hooks/$h.sh"
+  done
+  # settings.json registering the canonical set via the canonical command form.
   cat > "$c/.claude/settings.json" <<'JSON'
 {
   "hooks": {
     "PreToolUse": [
       { "matcher": "Bash", "hooks": [
-        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"", "timeout": 5 }
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"", "timeout": 5 },
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh\"", "timeout": 5 },
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-stale-skill-version.sh\"", "timeout": 5 }
+      ] },
+      { "matcher": "Agent", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"", "timeout": 5 }
       ] }
     ]
   }
@@ -236,16 +249,129 @@ else
   fail "3e. broken legacy unrendered managed" "expected FAIL on legacy.managed-rendered; records=$(grep '^FAIL' "$OUT")"
 fi
 
+# ── LEGACY broken (C): a DE-HOOKED install — empty {"hooks":{}} (#1008 F1) ────
+# Every zskills safety hook stripped from settings.json. This is the exact
+# "install silently failed" case the verifier exists to catch; before the F1
+# fix it false-PASSed with "all 0 registered hook commands resolve". MUST FAIL
+# on legacy.hooks-resolve (zero registered hooks) AND legacy.canonical-hooks
+# (canonical safety set absent).
+LDH="$(make_legacy_good 6)"
+printf '%s\n' '{"hooks":{}}' > "$LDH/.claude/settings.json"
+OUT="$TMP/out-legacy-dehooked.txt"
+run_cheap_capture "$LDH" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "legacy.hooks-resolve"; then
+  pass "3f. de-hooked legacy (empty {\"hooks\":{}}) → FAIL on legacy.hooks-resolve (was a false-PASS pre-#1008)"
+else
+  fail "3f. de-hooked legacy hooks-resolve" "expected FAIL on legacy.hooks-resolve; records=$(grep '^FAIL' "$OUT")"
+fi
+if has_fail_id "$OUT" "legacy.canonical-hooks"; then
+  pass "3g. de-hooked legacy → FAIL on legacy.canonical-hooks (canonical safety set absent)"
+else
+  fail "3g. de-hooked legacy canonical-hooks" "expected FAIL on legacy.canonical-hooks; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── LEGACY broken (D): only NON-canonical hooks registered (#1008 F1) ─────────
+# A non-zero hook count, but the canonical safety set is missing — the install
+# registered only a foreign/non-safety hook. MUST FAIL on legacy.canonical-hooks
+# even though legacy.hooks-resolve PASSes (the registered hook file exists).
+LNC="$(make_legacy_good 7)"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$LNC/.claude/hooks/my-custom-hook.sh"
+cat > "$LNC/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/my-custom-hook.sh\"", "timeout": 5 }
+      ] }
+    ]
+  }
+}
+JSON
+OUT="$TMP/out-legacy-noncanonical.txt"
+run_cheap_capture "$LNC" "$OUT"
+if has_fail_id "$OUT" "legacy.canonical-hooks"; then
+  pass "3h. only NON-canonical hook registered → FAIL on legacy.canonical-hooks"
+else
+  fail "3h. non-canonical-only canonical-hooks" "expected FAIL on legacy.canonical-hooks; records=$(grep '^FAIL' "$OUT")"
+fi
+# hooks-resolve must still PASS (the foreign hook file exists) — proving the
+# canonical-hooks check is what catches it, not a resolve failure.
+if has_fail_id "$OUT" "legacy.hooks-resolve"; then
+  fail "3i. non-canonical-only hooks-resolve" "legacy.hooks-resolve should PASS (file exists); records=$(grep '^FAIL' "$OUT")"
+else
+  pass "3i. only NON-canonical hook registered → legacy.hooks-resolve still PASSes (resolve != canonical-set)"
+fi
+
+# ── LEGACY broken (E): a corrupt (0-byte) canonical hook (#1008 medium gap) ───
+# A truncated `cp` leaves a registered zskills hook at 0 bytes. `[ -f ]` alone
+# passed it; the integrity check (`[ -s ]`) must FAIL.
+LEZ="$(make_legacy_good 12)"
+: > "$LEZ/.claude/hooks/block-unsafe-generic.sh"   # truncate to 0 bytes
+OUT="$TMP/out-legacy-empty-hook.txt"
+run_cheap_capture "$LEZ" "$OUT"
+if has_fail_id "$OUT" "legacy.hooks-integrity"; then
+  pass "3j. corrupt 0-byte canonical hook → FAIL on legacy.hooks-integrity"
+else
+  fail "3j. empty-hook integrity" "expected FAIL on legacy.hooks-integrity; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── LEGACY broken (F): a zskills hook missing its line-2 version stamp ────────
+# A drifted/corrupt mirror whose zskills hook lacks the `# zskills-hook-version:`
+# line-2 sentinel. MUST FAIL on legacy.hooks-integrity.
+LNS="$(make_legacy_good 13)"
+printf '%s\n' '#!/usr/bin/env bash' '# no version stamp here' 'exit 0' \
+  > "$LNS/.claude/hooks/block-agents.sh"
+OUT="$TMP/out-legacy-unstamped-hook.txt"
+run_cheap_capture "$LNS" "$OUT"
+if has_fail_id "$OUT" "legacy.hooks-integrity"; then
+  pass "3k. zskills hook missing line-2 version stamp → FAIL on legacy.hooks-integrity"
+else
+  fail "3k. unstamped-hook integrity" "expected FAIL on legacy.hooks-integrity; records=$(grep '^FAIL' "$OUT")"
+fi
+
+# ── LEGACY valid + a FOREIGN hook registered alongside canonical (no FP) ──────
+# A healthy install may register a consumer's OWN hook that legitimately carries
+# NO `# zskills-hook-version:` stamp. The integrity check is scoped to zskills
+# hooks, so the foreign hook must NOT trigger a FAIL — zero-false-positive bar.
+LFH="$(make_legacy_good 14)"
+printf '#!/usr/bin/env bash\necho hi\n' > "$LFH/.claude/hooks/consumer-own.sh"
+cat > "$LFH/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"", "timeout": 5 },
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-project.sh\"", "timeout": 5 },
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-stale-skill-version.sh\"", "timeout": 5 },
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/consumer-own.sh\"", "timeout": 5 }
+      ] },
+      { "matcher": "Agent", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-agents.sh\"", "timeout": 5 }
+      ] }
+    ]
+  }
+}
+JSON
+OUT="$TMP/out-legacy-foreign-hook.txt"
+run_cheap_capture "$LFH" "$OUT"
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "3l. valid legacy + FOREIGN (unstamped) hook alongside canonical → 0 FAIL (integrity scoped to zskills hooks)"
+else
+  fail "3l. foreign-hook no-false-positive" "expected 0 FAIL; foreign unstamped hook should not trip integrity: $(grep '^FAIL' "$OUT")"
+fi
+
 # ── PLUGIN: good layout → no FAIL ───────────────────────────────────────────
 # The plugin lane is keyed on CLAUDE_PLUGIN_ROOT being set. Set it (to any
 # non-empty value) for these cases ONLY.
 PG="$(make_plugin_good 1)"
 OUT="$TMP/out-plugin-good.txt"
 # The plugin lane keys on CLAUDE_PLUGIN_ROOT being set; export it (with a
-# plugin.json so the version cross-check resolves) for all plugin cases.
+# plugin.json AND hooks/hooks.json so the #1008 reachability check resolves)
+# for all plugin cases.
 CLAUDE_PLUGIN_ROOT="$TMP/fake-plugin-root"; export CLAUDE_PLUGIN_ROOT
-mkdir -p "$CLAUDE_PLUGIN_ROOT/.claude-plugin"
+mkdir -p "$CLAUDE_PLUGIN_ROOT/.claude-plugin" "$CLAUDE_PLUGIN_ROOT/hooks"
 printf '{ "version": "2026.06.0" }\n' > "$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json"
+printf '{ "hooks": {} }\n' > "$CLAUDE_PLUGIN_ROOT/hooks/hooks.json"
 run_cheap_capture "$PG" "$OUT"
 if [ "$VI_FAIL" -eq 0 ]; then
   pass "4. good plugin layout → 0 FAIL (5 sentinelled artifacts, mirror-less)"
@@ -314,6 +440,30 @@ if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "lane.dual-unsupported"; then
 else
   fail "7. dual install" "expected FAIL on lane.dual-unsupported; records=$(grep '^FAIL' "$OUT")"
 fi
+
+# ── PLUGIN broken (D): CLAUDE_PLUGIN_ROOT pointing at an UNREACHABLE dir ──────
+# (#1008 medium gap) The 5 materialised artifacts are present in the consumer's
+# .claude/, but ${CLAUDE_PLUGIN_ROOT} points at a dir missing the plugin
+# manifests — so the live skills/hooks resolve to NOTHING. MUST FAIL on
+# plugin.root-reachable even though every artifact check PASSes.
+PB4="$(make_plugin_good 6)"
+SAVED_PROOT="$CLAUDE_PLUGIN_ROOT"
+CLAUDE_PLUGIN_ROOT="$TMP/empty-plugin-root"; export CLAUDE_PLUGIN_ROOT
+mkdir -p "$CLAUDE_PLUGIN_ROOT"   # exists but has no .claude-plugin/ or hooks/
+OUT="$TMP/out-plugin-unreachable.txt"
+run_cheap_capture "$PB4" "$OUT"
+if [ "$VI_FAIL" -gt 0 ] && has_fail_id "$OUT" "plugin.root-reachable"; then
+  pass "7b. plugin root unreachable (no plugin.json/hooks.json) → FAIL on plugin.root-reachable"
+else
+  fail "7b. plugin root unreachable" "expected FAIL on plugin.root-reachable; records=$(grep '^FAIL' "$OUT")"
+fi
+# Artifact checks must still PASS — proving root-reachable is what catches it.
+if has_fail_id "$OUT" "plugin.artifact.agents/verifier.md"; then
+  fail "7c. unreachable-root artifacts" "artifact checks should PASS (artifacts present); records=$(grep '^FAIL' "$OUT")"
+else
+  pass "7c. plugin root unreachable → artifact checks still PASS (root-reachable is the catcher)"
+fi
+CLAUDE_PLUGIN_ROOT="$SAVED_PROOT"; export CLAUDE_PLUGIN_ROOT
 
 unset CLAUDE_PLUGIN_ROOT
 


### PR DESCRIPTION
Task: Fix #1008 remaining defects — the post-install verifier false-PASSed on a de-hooked install (zero/missing safety hooks reported healthy). hooks-resolve now FAILs on zero hooks + a canonical-safety-hook-set assertion, plus medium structural gaps (hooks integrity, plugin root reachability, partial-mirror).

Closes #1008.

## The defect (F1 / Critical-2, found by the /qe-audit cron)
The post-install verifier (#999/#1003) emitted `PASS legacy.hooks-resolve — all 0 registered hook commands resolve` on an install with `{"hooks":{}}` — every safety hook stripped — and reported **Overall PASS**. A de-hooked install reported healthy is exactly the "install silently failed" case the verifier exists to catch: negative information value. (#1008's F2/Critical-1 — the false-FAIL on `<!-- TODO -->` placeholders — was already fixed in PR #1010 and is left untouched.)

## Fix (enforcing the verifier's job, keeping the zero-false-positive bar from #1004)
- **`legacy.hooks-resolve`**: when zero hooks are registered → **FAIL**.
- **New `legacy.canonical-hooks`**: the minimal settings.json-registered safety set (`block-unsafe-generic`, `block-unsafe-project`, `block-stale-skill-version`, `block-agents`) must be present. Deliberately **excludes** `inject-bash-timeout`/`verify-response-validate` — those load via `verifier.md` frontmatter, not settings.json, so requiring them would false-FAIL every valid install.
- **Medium gaps fixed:** `hooks-integrity` (0-byte or missing `# zskills-hook-version:` stamp → FAIL, **scoped to zskills-owned hooks** so foreign consumer hooks never false-FAIL); `plugin.root-reachable` (dangling `${CLAUDE_PLUGIN_ROOT}`); `skills-populated` now requires a SKILL.md per skill dir. One gap (malformed-hook-entry) consciously **deferred** — surfacing it risked a false-positive on foreign hook blocks for low structural value.
- **Tests:** `make_legacy_good()` now seeds the full canonical version-stamped set (the single-hook seed is what hid F1). New cases: empty-hooks→FAIL, non-canonical-only→FAIL, 0-byte/unstamped→FAIL, foreign-unstamped-alongside-canonical→0 FAIL (no-false-positive guard), unreachable plugin root→FAIL, and healthy+`<!-- TODO -->`→PASS (#1010 regression guard).

## Verification
- De-hooked `{"hooks":{}}` → now **Overall FAIL** (was PASS). Healthy dev checkout → **8 PASS, 0 FAIL** (no new false-positive — the careful canonical-set/integrity scoping holds).
- `tests/test-verify-install.sh` → 29 passed, 0 failed. Full `bash tests/run-all.sh` → 7389/7389, 0 failed.
- update-zskills `metadata.version` bumped; `.claude/skills` mirror byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
