### PR TITLE
fix(claim): plan-claim staleness rule reads last_progress_at, not started_at (#1029)

### DIFF
--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.03+f2ff71"
+  version: "2026.06.03+41e0f2"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.02+e6435b"
+  version: "2026.06.03+f2ff71"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/scripts/claim-plan.sh
+++ b/.claude/skills/run-plan/scripts/claim-plan.sh
@@ -50,12 +50,19 @@
 #       <slug>\t<pipeline_id>\t<age_seconds>
 #
 # Schema (claim.json, D5):
-#   {schema_version, kind, slug, pipeline_id, started_at, current_phase
-#    [, dispatch_mode]}
+#   {schema_version, kind, slug, pipeline_id, started_at, current_phase,
+#    last_progress_at [, dispatch_mode]}
 #   sorted-keys, schema_version=1.
 #   current_phase is initialised to "Phase 0 — acquired" at acquire and
 #   updated by the `set-phase` subcommand. age_seconds is derived from
 #   started_at.
+#   last_progress_at (#1029): heartbeat-style progress signal. Initialised
+#   to the same ISO timestamp as started_at on acquire; bumped to "now"
+#   on every successful set-phase. The dashboard's staleness rule uses
+#   this field (not started_at) — answering "has the pipeline made
+#   progress recently?" instead of the wrong "how old is the
+#   acquisition?". Pre-#1029 claims missing the field fall back to
+#   started_at on the reader side.
 #   dispatch_mode is OPTIONAL (#874). When --dispatch-mode is `phase` or
 #   `finish`, the field is set verbatim. When omitted or `inherit`, the
 #   field is NOT written — pre-#874 callers and back-compat readers see
@@ -299,6 +306,9 @@ body = {
     "pipeline_id":        pipeline_id,
     "started_at":         now,
     "current_phase":      "Phase 0 — acquired",
+    # #1029 heartbeat: on initial acquire, last_progress_at == started_at
+    # (same instant). Bumped to "now" on every set-phase call.
+    "last_progress_at":   now,
 }
 if dispatch_mode and dispatch_mode != "inherit":
     body["dispatch_mode"] = dispatch_mode
@@ -482,7 +492,7 @@ cmd_set_phase() {
   fi
 
   "$_CLAIM_PYTHON" - "$claim_file" "$claim_tmp" "$require_pipeline" "$current_phase" <<'PY'
-import json, os, sys
+import json, os, sys, datetime
 claim_file, tmp_path, required, new_phase = sys.argv[1:5]
 with open(claim_file) as f:
     body = json.load(f)
@@ -493,6 +503,14 @@ if stored != required:
     )
     sys.exit(12)
 body["current_phase"] = new_phase
+# #1029 heartbeat: every successful set-phase is a "pipeline made
+# progress" signal — bump last_progress_at to now. The dashboard's
+# staleness rule reads this field, so a long-but-healthy pipeline that
+# crosses the 6h threshold but is still actively calling set-phase
+# stays correctly tagged not-stale.
+body["last_progress_at"] = datetime.datetime.now(
+    datetime.timezone.utc
+).isoformat(timespec="seconds")
 with open(tmp_path, "w") as f:
     json.dump(body, f, sort_keys=True)
     f.write("\n")

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.02+aa8d65"
+  version: "2026.06.03+0e2251"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.03+0e2251"
+  version: "2026.06.03+36df3f"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1854,6 +1854,9 @@ def _annotate_plans_queue(
                 # stale (#912): drives the client's in-UI release
                 # affordance for dead-pipeline claims.
                 "stale":          bool(c.get("stale")),
+                # #1029: heartbeat field — used by app.js fingerprint
+                # so re-renders fire when only the heartbeat bumps.
+                "last_progress_at": c.get("last_progress_at"),
             }
         # Phase 2 (DASHBOARD_RUNSTATUS_CLEANUP) — plans.skipped[slug]
         # surfaces as plan.skip_reason for the dashboard SKIP chip render.
@@ -2350,15 +2353,27 @@ def _resolve_effective_skip_reason(
 _CLAIM_DIR_RE = re.compile(r"^issue-(\d+)$")
 _PLAN_CLAIM_DIR_RE = re.compile(r"^plan-(.+)$")
 
-# Staleness threshold for plan claims (#912). A `/run-plan` pipeline that
-# died mid-flight (kill -9, OOM, container restart) leaves claim.json on
-# disk indefinitely, which the dashboard renders as a permanently
-# claim-locked card with no in-UI recovery. A claim older than this is
-# tagged `stale: true` so the renderer can offer a release affordance
-# (it is NOT filtered out — the card must still render so the user sees
-# and can dismiss it). 6h is comfortably longer than any healthy phase or
-# inter-phase idle gap. Fail toward NOT stale: a claim whose age cannot be
-# computed (missing/malformed started_at) is never tagged stale, so a live
+# Staleness threshold for plan claims (#912, refined by #1029). A
+# `/run-plan` pipeline that died mid-flight (kill -9, OOM, container
+# restart) leaves claim.json on disk indefinitely, which the dashboard
+# renders as a permanently claim-locked card with no in-UI recovery.
+#
+# #1029 — the staleness rule asks "has the pipeline made progress
+# recently?" not "how old is the acquisition?". The check therefore
+# uses `last_progress_at` (the heartbeat bumped on every claim-plan.sh
+# set-phase call) rather than `started_at` (fixed at acquire time). A
+# long-but-healthy `/run-plan finish auto` run that legitimately needs
+# >6h of wall-clock keeps bumping last_progress_at at each phase
+# boundary and stays correctly tagged not-stale.
+#
+# Backward-compat: claims missing `last_progress_at` (pre-#1029
+# acquires) fall back to `started_at`. The chip is now labelled
+# "no progress in 6h+" rather than "dead pipeline" — accurate to the
+# rule and not a guess about cause.
+#
+# 6h is comfortably longer than any healthy inter-set-phase gap.
+# Fail toward NOT stale: a claim whose age cannot be computed
+# (missing/malformed both fields) is never tagged stale, so a live
 # claim is never wrongly offered for release.
 PLAN_CLAIM_STALE_SECONDS = 21600  # 6h
 
@@ -2492,7 +2507,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
 
     Returns `{slug: claim_dict}` keyed by string slug. Each dict carries:
         pipeline_id, started_at, current_phase, age_seconds,
-        pipeline_short, dispatch_mode, stale
+        pipeline_short, dispatch_mode, stale, last_progress_at
 
     `stale` (#912) is `True` when `age_seconds` exceeds
     `PLAN_CLAIM_STALE_SECONDS` (6h) — the signal that the owning pipeline
@@ -2557,6 +2572,9 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
                 # Null-metadata sweep-race entry has no age → fail toward
                 # not-stale (#912).
                 "stale": False,
+                # #1029: keep the field on the allow-list even when null
+                # so the renderer's fingerprint shape is consistent.
+                "last_progress_at": None,
             }
             continue
         try:
@@ -2577,6 +2595,9 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_id = body.get("pipeline_id")
         started_at = body.get("started_at")
         current_phase = body.get("current_phase")
+        # last_progress_at (#1029): heartbeat field bumped by every
+        # claim-plan.sh set-phase. Drives the staleness rule below.
+        last_progress_at = body.get("last_progress_at")
         # dispatch_mode (#874): persisted by claim-plan.sh acquire
         # --dispatch-mode. Only `phase` / `finish` are valid persisted
         # values; anything else (including absence) surfaces as None and
@@ -2602,12 +2623,36 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_short: Optional[str] = None
         if isinstance(pipeline_id, str) and pipeline_id:
             pipeline_short = _derive_pipeline_short(pipeline_id)
-        # Staleness (#912): fail toward NOT stale — only a successfully
-        # computed age that exceeds the threshold marks the claim stale.
-        # A None age (missing/malformed/unparseable started_at) leaves a
-        # live claim hard-locked rather than wrongly offering it for
-        # release.
-        stale = isinstance(age_seconds, (int, float)) and age_seconds > PLAN_CLAIM_STALE_SECONDS
+        # Staleness (#912, refined #1029): the rule asks "has the
+        # pipeline made progress recently?" — check the age of
+        # last_progress_at, not started_at. Pre-#1029 claims missing
+        # the heartbeat field fall back to started_at-based check
+        # (graceful migration; behaviour identical to the original
+        # #912 rule for those claims).
+        #
+        # Fail toward NOT stale: if both fields are missing/malformed
+        # the claim is NEVER marked stale, so a live claim is never
+        # wrongly offered for release.
+        progress_for_stale: Optional[str]
+        if isinstance(last_progress_at, str) and last_progress_at:
+            progress_for_stale = last_progress_at
+        elif isinstance(started_at, str) and started_at:
+            progress_for_stale = started_at
+        else:
+            progress_for_stale = None
+        stale_age_seconds: Optional[float] = None
+        if progress_for_stale:
+            try:
+                parsed_p = datetime.fromisoformat(progress_for_stale)
+                if parsed_p.tzinfo is None:
+                    parsed_p = parsed_p.replace(tzinfo=timezone.utc)
+                stale_age_seconds = (now - parsed_p).total_seconds()
+            except ValueError:
+                stale_age_seconds = None
+        stale = (
+            isinstance(stale_age_seconds, (int, float))
+            and stale_age_seconds > PLAN_CLAIM_STALE_SECONDS
+        )
         out[slug] = {
             "pipeline_id": pipeline_id if isinstance(pipeline_id, str) else None,
             "started_at": started_at if isinstance(started_at, str) else None,
@@ -2616,6 +2661,10 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
             "pipeline_short": pipeline_short,
             "dispatch_mode": dispatch_mode,
             "stale": bool(stale),
+            # #1029: surface last_progress_at to the renderer so the
+            # chip fingerprint can include it (re-render on heartbeat
+            # bumps). None when the source claim.json is pre-#1029.
+            "last_progress_at": last_progress_at if isinstance(last_progress_at, str) else None,
         }
     return out
 

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -858,14 +858,12 @@ function fingerprintPlans(plans, queues) {
         -1,
         null,
       ],
-      // Claim state — symmetric to fingerprintIssues' claim tuple.
-      // We track `current_phase` (post-#684 cleanup removed
-      // `last_heartbeat_at` as a duplicate of `started_at`). Phase
-      // changes drive re-renders so the chip's `phase N/M` segment
-      // updates as the pipeline progresses. The 2-tuple is enough —
-      // pipeline_id changes when a new pipeline claims; current_phase
-      // changes at each phase boundary; both null when no claim.
-      p.claim ? [p.claim.pipeline_id || null, p.claim.current_phase || null] : null,
+      // Claim state — symmetric to fingerprintIssues. current_phase
+      // (#684 dropped last_heartbeat_at) drives phase-boundary
+      // re-renders. last_progress_at (#1029) is the heartbeat: a
+      // long-running pipeline bumps it on every set-phase call, so
+      // the chip's stale state re-renders between phase boundaries.
+      p.claim ? [p.claim.pipeline_id || null, p.claim.current_phase || null, p.claim.last_progress_at || null] : null,
       // Phase 2 (DASHBOARD_RUNSTATUS_CLEANUP) — skip_reason tuple.
       // Without this, × clicks and pin-toggle clears mutate the state
       // but the next poll's diff-suppression hides the change for one
@@ -1023,7 +1021,7 @@ function buildPlanCard(plan, slug, col) {
     ? "Locked while plan is being worked (pipeline " + claimLockPidShort + ")."
     : null;
   const claimStaleTip = isClaimStale
-    ? "Pipeline appears dead (claim >6h old, pipeline " + claimLockPidShort +
+    ? "No progress signalled in 6h+ (pipeline " + claimLockPidShort +
       ") — click to release."
     : null;
   const card = el("li", { cls: "card", attrs: cardAttrs });
@@ -1107,9 +1105,12 @@ function buildPlanCard(plan, slug, col) {
       const m = cp.match(/Phase\s+(\d+)/i);
       phaseFragment = m ? "working on phase " + m[1] : "working on " + cp;
     }
-    // Issue #912 — stale claims read as "stale (dead pipeline)" rather
+    // Issue #912 — stale claims read with a no-progress framing rather
     // than the live "working on phase N" framing, and carry the release
     // hint as their chip tooltip.
+    // Issue #1029 — the stale label dropped the "(dead pipeline)" guess
+    // (the rule observes lack of heartbeat, not actual death) in favour
+    // of the literal "no progress in 6h+".
     const tip = isClaimStale
       ? claimStaleTip
       : (c.pipeline_id
@@ -1118,7 +1119,7 @@ function buildPlanCard(plan, slug, col) {
           " current_phase=" + (c.current_phase || "?")
         : "claim metadata pending");
     const chipText = isClaimStale
-      ? "stale (dead pipeline) · " + pidShort + " · " + ageStr
+      ? "stale (no progress in 6h+) · " + pidShort + " · " + ageStr
       : phaseFragment + " · " + pidShort + " · " + ageStr;
     const row = el("div", { cls: "card-sub" });
     row.appendChild(el("span", {

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.03+f2ff71"
+  version: "2026.06.03+41e0f2"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.02+e6435b"
+  version: "2026.06.03+f2ff71"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/scripts/claim-plan.sh
+++ b/skills/run-plan/scripts/claim-plan.sh
@@ -50,12 +50,19 @@
 #       <slug>\t<pipeline_id>\t<age_seconds>
 #
 # Schema (claim.json, D5):
-#   {schema_version, kind, slug, pipeline_id, started_at, current_phase
-#    [, dispatch_mode]}
+#   {schema_version, kind, slug, pipeline_id, started_at, current_phase,
+#    last_progress_at [, dispatch_mode]}
 #   sorted-keys, schema_version=1.
 #   current_phase is initialised to "Phase 0 — acquired" at acquire and
 #   updated by the `set-phase` subcommand. age_seconds is derived from
 #   started_at.
+#   last_progress_at (#1029): heartbeat-style progress signal. Initialised
+#   to the same ISO timestamp as started_at on acquire; bumped to "now"
+#   on every successful set-phase. The dashboard's staleness rule uses
+#   this field (not started_at) — answering "has the pipeline made
+#   progress recently?" instead of the wrong "how old is the
+#   acquisition?". Pre-#1029 claims missing the field fall back to
+#   started_at on the reader side.
 #   dispatch_mode is OPTIONAL (#874). When --dispatch-mode is `phase` or
 #   `finish`, the field is set verbatim. When omitted or `inherit`, the
 #   field is NOT written — pre-#874 callers and back-compat readers see
@@ -299,6 +306,9 @@ body = {
     "pipeline_id":        pipeline_id,
     "started_at":         now,
     "current_phase":      "Phase 0 — acquired",
+    # #1029 heartbeat: on initial acquire, last_progress_at == started_at
+    # (same instant). Bumped to "now" on every set-phase call.
+    "last_progress_at":   now,
 }
 if dispatch_mode and dispatch_mode != "inherit":
     body["dispatch_mode"] = dispatch_mode
@@ -482,7 +492,7 @@ cmd_set_phase() {
   fi
 
   "$_CLAIM_PYTHON" - "$claim_file" "$claim_tmp" "$require_pipeline" "$current_phase" <<'PY'
-import json, os, sys
+import json, os, sys, datetime
 claim_file, tmp_path, required, new_phase = sys.argv[1:5]
 with open(claim_file) as f:
     body = json.load(f)
@@ -493,6 +503,14 @@ if stored != required:
     )
     sys.exit(12)
 body["current_phase"] = new_phase
+# #1029 heartbeat: every successful set-phase is a "pipeline made
+# progress" signal — bump last_progress_at to now. The dashboard's
+# staleness rule reads this field, so a long-but-healthy pipeline that
+# crosses the 6h threshold but is still actively calling set-phase
+# stays correctly tagged not-stale.
+body["last_progress_at"] = datetime.datetime.now(
+    datetime.timezone.utc
+).isoformat(timespec="seconds")
 with open(tmp_path, "w") as f:
     json.dump(body, f, sort_keys=True)
     f.write("\n")

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.02+aa8d65"
+  version: "2026.06.03+0e2251"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.03+0e2251"
+  version: "2026.06.03+36df3f"
 ---
 
 # /zskills-dashboard — Local Dashboard

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -1854,6 +1854,9 @@ def _annotate_plans_queue(
                 # stale (#912): drives the client's in-UI release
                 # affordance for dead-pipeline claims.
                 "stale":          bool(c.get("stale")),
+                # #1029: heartbeat field — used by app.js fingerprint
+                # so re-renders fire when only the heartbeat bumps.
+                "last_progress_at": c.get("last_progress_at"),
             }
         # Phase 2 (DASHBOARD_RUNSTATUS_CLEANUP) — plans.skipped[slug]
         # surfaces as plan.skip_reason for the dashboard SKIP chip render.
@@ -2350,15 +2353,27 @@ def _resolve_effective_skip_reason(
 _CLAIM_DIR_RE = re.compile(r"^issue-(\d+)$")
 _PLAN_CLAIM_DIR_RE = re.compile(r"^plan-(.+)$")
 
-# Staleness threshold for plan claims (#912). A `/run-plan` pipeline that
-# died mid-flight (kill -9, OOM, container restart) leaves claim.json on
-# disk indefinitely, which the dashboard renders as a permanently
-# claim-locked card with no in-UI recovery. A claim older than this is
-# tagged `stale: true` so the renderer can offer a release affordance
-# (it is NOT filtered out — the card must still render so the user sees
-# and can dismiss it). 6h is comfortably longer than any healthy phase or
-# inter-phase idle gap. Fail toward NOT stale: a claim whose age cannot be
-# computed (missing/malformed started_at) is never tagged stale, so a live
+# Staleness threshold for plan claims (#912, refined by #1029). A
+# `/run-plan` pipeline that died mid-flight (kill -9, OOM, container
+# restart) leaves claim.json on disk indefinitely, which the dashboard
+# renders as a permanently claim-locked card with no in-UI recovery.
+#
+# #1029 — the staleness rule asks "has the pipeline made progress
+# recently?" not "how old is the acquisition?". The check therefore
+# uses `last_progress_at` (the heartbeat bumped on every claim-plan.sh
+# set-phase call) rather than `started_at` (fixed at acquire time). A
+# long-but-healthy `/run-plan finish auto` run that legitimately needs
+# >6h of wall-clock keeps bumping last_progress_at at each phase
+# boundary and stays correctly tagged not-stale.
+#
+# Backward-compat: claims missing `last_progress_at` (pre-#1029
+# acquires) fall back to `started_at`. The chip is now labelled
+# "no progress in 6h+" rather than "dead pipeline" — accurate to the
+# rule and not a guess about cause.
+#
+# 6h is comfortably longer than any healthy inter-set-phase gap.
+# Fail toward NOT stale: a claim whose age cannot be computed
+# (missing/malformed both fields) is never tagged stale, so a live
 # claim is never wrongly offered for release.
 PLAN_CLAIM_STALE_SECONDS = 21600  # 6h
 
@@ -2492,7 +2507,7 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
 
     Returns `{slug: claim_dict}` keyed by string slug. Each dict carries:
         pipeline_id, started_at, current_phase, age_seconds,
-        pipeline_short, dispatch_mode, stale
+        pipeline_short, dispatch_mode, stale, last_progress_at
 
     `stale` (#912) is `True` when `age_seconds` exceeds
     `PLAN_CLAIM_STALE_SECONDS` (6h) — the signal that the owning pipeline
@@ -2557,6 +2572,9 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
                 # Null-metadata sweep-race entry has no age → fail toward
                 # not-stale (#912).
                 "stale": False,
+                # #1029: keep the field on the allow-list even when null
+                # so the renderer's fingerprint shape is consistent.
+                "last_progress_at": None,
             }
             continue
         try:
@@ -2577,6 +2595,9 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_id = body.get("pipeline_id")
         started_at = body.get("started_at")
         current_phase = body.get("current_phase")
+        # last_progress_at (#1029): heartbeat field bumped by every
+        # claim-plan.sh set-phase. Drives the staleness rule below.
+        last_progress_at = body.get("last_progress_at")
         # dispatch_mode (#874): persisted by claim-plan.sh acquire
         # --dispatch-mode. Only `phase` / `finish` are valid persisted
         # values; anything else (including absence) surfaces as None and
@@ -2602,12 +2623,36 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
         pipeline_short: Optional[str] = None
         if isinstance(pipeline_id, str) and pipeline_id:
             pipeline_short = _derive_pipeline_short(pipeline_id)
-        # Staleness (#912): fail toward NOT stale — only a successfully
-        # computed age that exceeds the threshold marks the claim stale.
-        # A None age (missing/malformed/unparseable started_at) leaves a
-        # live claim hard-locked rather than wrongly offering it for
-        # release.
-        stale = isinstance(age_seconds, (int, float)) and age_seconds > PLAN_CLAIM_STALE_SECONDS
+        # Staleness (#912, refined #1029): the rule asks "has the
+        # pipeline made progress recently?" — check the age of
+        # last_progress_at, not started_at. Pre-#1029 claims missing
+        # the heartbeat field fall back to started_at-based check
+        # (graceful migration; behaviour identical to the original
+        # #912 rule for those claims).
+        #
+        # Fail toward NOT stale: if both fields are missing/malformed
+        # the claim is NEVER marked stale, so a live claim is never
+        # wrongly offered for release.
+        progress_for_stale: Optional[str]
+        if isinstance(last_progress_at, str) and last_progress_at:
+            progress_for_stale = last_progress_at
+        elif isinstance(started_at, str) and started_at:
+            progress_for_stale = started_at
+        else:
+            progress_for_stale = None
+        stale_age_seconds: Optional[float] = None
+        if progress_for_stale:
+            try:
+                parsed_p = datetime.fromisoformat(progress_for_stale)
+                if parsed_p.tzinfo is None:
+                    parsed_p = parsed_p.replace(tzinfo=timezone.utc)
+                stale_age_seconds = (now - parsed_p).total_seconds()
+            except ValueError:
+                stale_age_seconds = None
+        stale = (
+            isinstance(stale_age_seconds, (int, float))
+            and stale_age_seconds > PLAN_CLAIM_STALE_SECONDS
+        )
         out[slug] = {
             "pipeline_id": pipeline_id if isinstance(pipeline_id, str) else None,
             "started_at": started_at if isinstance(started_at, str) else None,
@@ -2616,6 +2661,10 @@ def _read_plan_claims(main_root: pathlib.Path) -> Dict[str, Dict[str, Any]]:
             "pipeline_short": pipeline_short,
             "dispatch_mode": dispatch_mode,
             "stale": bool(stale),
+            # #1029: surface last_progress_at to the renderer so the
+            # chip fingerprint can include it (re-render on heartbeat
+            # bumps). None when the source claim.json is pre-#1029.
+            "last_progress_at": last_progress_at if isinstance(last_progress_at, str) else None,
         }
     return out
 

--- a/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/static/app.js
@@ -858,14 +858,12 @@ function fingerprintPlans(plans, queues) {
         -1,
         null,
       ],
-      // Claim state — symmetric to fingerprintIssues' claim tuple.
-      // We track `current_phase` (post-#684 cleanup removed
-      // `last_heartbeat_at` as a duplicate of `started_at`). Phase
-      // changes drive re-renders so the chip's `phase N/M` segment
-      // updates as the pipeline progresses. The 2-tuple is enough —
-      // pipeline_id changes when a new pipeline claims; current_phase
-      // changes at each phase boundary; both null when no claim.
-      p.claim ? [p.claim.pipeline_id || null, p.claim.current_phase || null] : null,
+      // Claim state — symmetric to fingerprintIssues. current_phase
+      // (#684 dropped last_heartbeat_at) drives phase-boundary
+      // re-renders. last_progress_at (#1029) is the heartbeat: a
+      // long-running pipeline bumps it on every set-phase call, so
+      // the chip's stale state re-renders between phase boundaries.
+      p.claim ? [p.claim.pipeline_id || null, p.claim.current_phase || null, p.claim.last_progress_at || null] : null,
       // Phase 2 (DASHBOARD_RUNSTATUS_CLEANUP) — skip_reason tuple.
       // Without this, × clicks and pin-toggle clears mutate the state
       // but the next poll's diff-suppression hides the change for one
@@ -1023,7 +1021,7 @@ function buildPlanCard(plan, slug, col) {
     ? "Locked while plan is being worked (pipeline " + claimLockPidShort + ")."
     : null;
   const claimStaleTip = isClaimStale
-    ? "Pipeline appears dead (claim >6h old, pipeline " + claimLockPidShort +
+    ? "No progress signalled in 6h+ (pipeline " + claimLockPidShort +
       ") — click to release."
     : null;
   const card = el("li", { cls: "card", attrs: cardAttrs });
@@ -1107,9 +1105,12 @@ function buildPlanCard(plan, slug, col) {
       const m = cp.match(/Phase\s+(\d+)/i);
       phaseFragment = m ? "working on phase " + m[1] : "working on " + cp;
     }
-    // Issue #912 — stale claims read as "stale (dead pipeline)" rather
+    // Issue #912 — stale claims read with a no-progress framing rather
     // than the live "working on phase N" framing, and carry the release
     // hint as their chip tooltip.
+    // Issue #1029 — the stale label dropped the "(dead pipeline)" guess
+    // (the rule observes lack of heartbeat, not actual death) in favour
+    // of the literal "no progress in 6h+".
     const tip = isClaimStale
       ? claimStaleTip
       : (c.pipeline_id
@@ -1118,7 +1119,7 @@ function buildPlanCard(plan, slug, col) {
           " current_phase=" + (c.current_phase || "?")
         : "claim metadata pending");
     const chipText = isClaimStale
-      ? "stale (dead pipeline) · " + pidShort + " · " + ageStr
+      ? "stale (no progress in 6h+) · " + pidShort + " · " + ageStr
       : phaseFragment + " · " + pidShort + " · " + ageStr;
     const row = el("div", { cls: "card-sub" });
     row.appendChild(el("span", {

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -238,6 +238,7 @@ run_suite "test-plan-claim-handleaction-guard.sh" "tests/test-plan-claim-handlea
 run_suite "test-plan-claim-moveall-skip.sh" "tests/test-plan-claim-moveall-skip.sh"
 run_suite "test-plan-claim-fingerprint.sh" "tests/test-plan-claim-fingerprint.sh"
 run_suite "test-plan-claim-conformance.sh" "tests/test-plan-claim-conformance.sh"
+run_suite "test-claim-plan-heartbeat.sh" "tests/test-claim-plan-heartbeat.sh"
 run_suite "test-claim-self-reentry.sh" "tests/test-claim-self-reentry.sh"
 run_suite "test-inflight-batch-guard.sh" "tests/test-inflight-batch-guard.sh"
 run_suite "test-demo-sim.sh" "tests/test-demo-sim.sh"

--- a/tests/test-claim-plan-heartbeat.sh
+++ b/tests/test-claim-plan-heartbeat.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# tests/test-claim-plan-heartbeat.sh — Issue #1029.
+#
+# Plan-claim staleness now keys on `last_progress_at` (heartbeat) instead
+# of `started_at` (acquire age). This file pins:
+#   1. acquire writes claim.json with last_progress_at == started_at.
+#   2. set-phase bumps last_progress_at to a strictly-later ISO timestamp.
+#   3. The collector's `_read_plan_claims` returns stale=False when
+#      last_progress_at is fresh even if started_at is >6h old.
+#   4. Backward-compat: claims missing last_progress_at fall back to
+#      started_at; old-shape with old started_at → stale; old-shape with
+#      fresh started_at → not stale.
+#   5. Both-fields-missing → not stale (fail-toward-not-stale).
+#
+# Path: /tmp/zskills-tests/$(basename $(pwd))/.test-results.txt capture
+# is handled by run-all.sh — this script just emits pass/fail lines.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLAIM_SH="$REPO_ROOT/skills/run-plan/scripts/claim-plan.sh"
+COLLECT_PY="$REPO_ROOT/skills/zskills-dashboard/scripts/zskills_monitor/collect.py"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+if [ -z "$PYTHON" ]; then
+  echo "FATAL: no Python interpreter available" >&2
+  exit 1
+fi
+
+SCRATCH_ROOT="/tmp/test-claim-plan-heartbeat-$$"
+cleanup() {
+  if [ -n "${TEST_KEEP_SCRATCH:-}" ]; then
+    echo "TEST_KEEP_SCRATCH set — leaving $SCRATCH_ROOT" >&2
+    return
+  fi
+  if [ -d "$SCRATCH_ROOT" ]; then
+    find "$SCRATCH_ROOT" -type d -exec chmod 0755 {} + 2>/dev/null || true
+    find "$SCRATCH_ROOT" -mindepth 1 -delete 2>/dev/null || true
+    rmdir "$SCRATCH_ROOT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH_ROOT"
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  (cd "$repo" && git init -q && git config user.email "t@t" && git config user.name "t" \
+    && git commit --allow-empty -q -m "init") || return 1
+}
+
+# Sanitizer + self-reentry helper lookup: claim-plan.sh resolves them
+# via CLAUDE_PROJECT_DIR fallback when not bundled into a sibling layout.
+export CLAUDE_PROJECT_DIR="$REPO_ROOT"
+
+echo "=== claim-plan.sh heartbeat (#1029) tests ==="
+
+# ---------------------------------------------------------------------
+# 1. acquire writes last_progress_at == started_at (same instant).
+# ---------------------------------------------------------------------
+REPO1="$SCRATCH_ROOT/r1"
+make_repo "$REPO1" || { echo "FATAL repo init"; exit 1; }
+(
+  cd "$REPO1"
+  bash "$CLAIM_SH" acquire heartbeat-acquire --pipeline-id "run-plan.heartbeat-acquire"
+) >/dev/null
+rc=$?
+CLAIM1="$REPO1/.zskills/claims/plan-heartbeat-acquire/claim.json"
+if [ "$rc" -ne 0 ]; then
+  fail "acquire heartbeat-acquire exit 0" "rc=$rc"
+elif [ ! -f "$CLAIM1" ]; then
+  fail "acquire heartbeat-acquire claim.json exists" "missing $CLAIM1"
+else
+  STARTED=$("$PYTHON" -c "import json; print(json.load(open('$CLAIM1'))['started_at'])")
+  PROGRESS=$("$PYTHON" -c "import json; print(json.load(open('$CLAIM1')).get('last_progress_at','<absent>'))")
+  if [ "$PROGRESS" = "$STARTED" ] && [ -n "$PROGRESS" ] && [ "$PROGRESS" != "<absent>" ]; then
+    pass "acquire writes last_progress_at == started_at (#1029)"
+  else
+    fail "acquire last_progress_at == started_at" "started=$STARTED progress=$PROGRESS"
+  fi
+fi
+
+# ---------------------------------------------------------------------
+# 2. set-phase bumps last_progress_at to a strictly-later ISO timestamp.
+# ---------------------------------------------------------------------
+sleep 1
+(
+  cd "$REPO1"
+  bash "$CLAIM_SH" set-phase heartbeat-acquire \
+    --require-pipeline "run-plan.heartbeat-acquire" \
+    --current-phase "Phase 2 — implement"
+) >/dev/null
+rc=$?
+NEW_PROGRESS=$("$PYTHON" -c "import json; print(json.load(open('$CLAIM1')).get('last_progress_at','<absent>'))")
+NEW_STARTED=$("$PYTHON" -c "import json; print(json.load(open('$CLAIM1'))['started_at'])")
+
+# Compare with Python to avoid bash-side ISO arithmetic.
+COMPARE=$("$PYTHON" -c "
+import datetime
+s = datetime.datetime.fromisoformat('$STARTED')
+p = datetime.datetime.fromisoformat('$NEW_PROGRESS')
+print('later' if p > s else ('same' if p == s else 'earlier'))
+")
+
+if [ "$rc" -eq 0 ] && [ "$COMPARE" = "later" ]; then
+  pass "set-phase bumps last_progress_at to a strictly-later timestamp (#1029)"
+else
+  fail "set-phase bumps last_progress_at" "rc=$rc compare=$COMPARE started=$STARTED new_progress=$NEW_PROGRESS"
+fi
+
+# Verify started_at was NOT touched (only last_progress_at moved).
+if [ "$NEW_STARTED" = "$STARTED" ]; then
+  pass "set-phase preserves started_at (only last_progress_at moves)"
+else
+  fail "set-phase preserves started_at" "before=$STARTED after=$NEW_STARTED"
+fi
+
+# ---------------------------------------------------------------------
+# 3. Collector staleness: fresh last_progress_at + old started_at → NOT stale.
+# ---------------------------------------------------------------------
+REPO2="$SCRATCH_ROOT/r2"
+make_repo "$REPO2" || { echo "FATAL repo init r2"; exit 1; }
+mkdir -p "$REPO2/.zskills/claims/plan-longrun"
+FRESH_PROGRESS=$("$PYTHON" -c "
+import datetime
+now = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5)
+print(now.isoformat(timespec='seconds'))
+")
+OLD_STARTED=$("$PYTHON" -c "
+import datetime
+old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=10)
+print(old.isoformat(timespec='seconds'))
+")
+cat > "$REPO2/.zskills/claims/plan-longrun/claim.json" <<EOF
+{"current_phase":"Phase 3","kind":"plan","last_progress_at":"$FRESH_PROGRESS","pipeline_id":"run-plan.longrun","schema_version":1,"slug":"longrun","started_at":"$OLD_STARTED"}
+EOF
+
+STALE_OUT=$(cd "$REPO2" && "$PYTHON" -c "
+import sys, pathlib, json
+sys.path.insert(0, '$REPO_ROOT/skills/zskills-dashboard/scripts')
+from zskills_monitor import collect
+out = collect._read_plan_claims(pathlib.Path('$REPO2'))
+c = out['longrun']
+print('stale={} last_progress_at={} started_at={} age_seconds={}'.format(
+    c.get('stale'), c.get('last_progress_at'), c.get('started_at'),
+    c.get('age_seconds')))
+")
+
+case "$STALE_OUT" in
+  *stale=False*)
+    pass "collector: fresh last_progress_at + old started_at → not stale (#1029)"
+    ;;
+  *)
+    fail "collector longrun not-stale" "got: $STALE_OUT"
+    ;;
+esac
+
+# ---------------------------------------------------------------------
+# 4. Collector staleness: both fields old → stale.
+# ---------------------------------------------------------------------
+mkdir -p "$REPO2/.zskills/claims/plan-bothold"
+OLD_PROGRESS=$("$PYTHON" -c "
+import datetime
+old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=8)
+print(old.isoformat(timespec='seconds'))
+")
+cat > "$REPO2/.zskills/claims/plan-bothold/claim.json" <<EOF
+{"current_phase":"Phase 1","kind":"plan","last_progress_at":"$OLD_PROGRESS","pipeline_id":"run-plan.bothold","schema_version":1,"slug":"bothold","started_at":"$OLD_STARTED"}
+EOF
+BOTHOLD_OUT=$(cd "$REPO2" && "$PYTHON" -c "
+import sys, pathlib
+sys.path.insert(0, '$REPO_ROOT/skills/zskills-dashboard/scripts')
+from zskills_monitor import collect
+print(collect._read_plan_claims(pathlib.Path('$REPO2'))['bothold']['stale'])
+")
+if [ "$BOTHOLD_OUT" = "True" ]; then
+  pass "collector: both-old fields → stale=True (dead-pipeline case still caught)"
+else
+  fail "collector bothold stale" "got: $BOTHOLD_OUT"
+fi
+
+# ---------------------------------------------------------------------
+# 5. Back-compat: claim.json with only started_at (no last_progress_at).
+#    Old started_at >6h → stale.
+# ---------------------------------------------------------------------
+mkdir -p "$REPO2/.zskills/claims/plan-precompatold"
+cat > "$REPO2/.zskills/claims/plan-precompatold/claim.json" <<EOF
+{"current_phase":"Phase 2","kind":"plan","pipeline_id":"run-plan.precompatold","schema_version":1,"slug":"precompatold","started_at":"$OLD_STARTED"}
+EOF
+PRECOMPAT_OUT=$(cd "$REPO2" && "$PYTHON" -c "
+import sys, pathlib
+sys.path.insert(0, '$REPO_ROOT/skills/zskills-dashboard/scripts')
+from zskills_monitor import collect
+c = collect._read_plan_claims(pathlib.Path('$REPO2'))['precompatold']
+print('stale={} last_progress_at={}'.format(c.get('stale'), c.get('last_progress_at')))
+")
+case "$PRECOMPAT_OUT" in
+  *stale=True*last_progress_at=None*)
+    pass "back-compat: pre-#1029 claim with old started_at → stale (fallback works)"
+    ;;
+  *)
+    fail "back-compat pre-#1029 old started_at" "got: $PRECOMPAT_OUT"
+    ;;
+esac
+
+# ---------------------------------------------------------------------
+# 6. Back-compat: claim.json with only fresh started_at (no last_progress_at)
+#    → not stale.
+# ---------------------------------------------------------------------
+mkdir -p "$REPO2/.zskills/claims/plan-precompatfresh"
+FRESH_STARTED=$("$PYTHON" -c "
+import datetime
+now = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=30)
+print(now.isoformat(timespec='seconds'))
+")
+cat > "$REPO2/.zskills/claims/plan-precompatfresh/claim.json" <<EOF
+{"current_phase":"Phase 1","kind":"plan","pipeline_id":"run-plan.precompatfresh","schema_version":1,"slug":"precompatfresh","started_at":"$FRESH_STARTED"}
+EOF
+PCF_OUT=$(cd "$REPO2" && "$PYTHON" -c "
+import sys, pathlib
+sys.path.insert(0, '$REPO_ROOT/skills/zskills-dashboard/scripts')
+from zskills_monitor import collect
+print(collect._read_plan_claims(pathlib.Path('$REPO2'))['precompatfresh']['stale'])
+")
+if [ "$PCF_OUT" = "False" ]; then
+  pass "back-compat: pre-#1029 claim with fresh started_at → not stale"
+else
+  fail "back-compat pre-#1029 fresh started_at" "got: $PCF_OUT"
+fi
+
+# ---------------------------------------------------------------------
+# 7. Both fields missing → not stale (fail-toward-not-stale).
+# ---------------------------------------------------------------------
+mkdir -p "$REPO2/.zskills/claims/plan-bothmiss"
+cat > "$REPO2/.zskills/claims/plan-bothmiss/claim.json" <<EOF
+{"current_phase":"Phase 1","kind":"plan","pipeline_id":"run-plan.bothmiss","schema_version":1,"slug":"bothmiss"}
+EOF
+BM_OUT=$(cd "$REPO2" && "$PYTHON" -c "
+import sys, pathlib
+sys.path.insert(0, '$REPO_ROOT/skills/zskills-dashboard/scripts')
+from zskills_monitor import collect
+c = collect._read_plan_claims(pathlib.Path('$REPO2'))['bothmiss']
+print('stale={} last_progress_at={} started_at={}'.format(
+    c.get('stale'), c.get('last_progress_at'), c.get('started_at')))
+")
+case "$BM_OUT" in
+  *stale=False*)
+    pass "fail-toward-not-stale: both fields missing → not stale (no false-positive)"
+    ;;
+  *)
+    fail "fail-toward-not-stale both fields missing" "got: $BM_OUT"
+    ;;
+esac
+
+# ---------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (%d total)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (%d total)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-plan-claim-collector.py
+++ b/tests/test-plan-claim-collector.py
@@ -143,13 +143,18 @@ class ReadPlanClaimsTests(unittest.TestCase):
         self.assertEqual(
             set(c.keys()),
             {"pipeline_id", "started_at", "current_phase",
-             "age_seconds", "pipeline_short", "dispatch_mode", "stale"},
+             "age_seconds", "pipeline_short", "dispatch_mode", "stale",
+             "last_progress_at"},
         )
         # dispatch_mode (#874) is on the allow-list. Absent in the
         # source claim → surfaces as None.
         self.assertIsNone(c["dispatch_mode"])
         # stale (#912) is on the allow-list. A fresh claim → not stale.
         self.assertFalse(c["stale"])
+        # last_progress_at (#1029) is on the allow-list. Absent in the
+        # source claim → surfaces as None (back-compat: stale rule then
+        # falls back to started_at).
+        self.assertIsNone(c["last_progress_at"])
 
     def test_dispatch_mode_finish_persists(self) -> None:
         # #874: claim.json carrying dispatch_mode="finish" must surface
@@ -410,10 +415,14 @@ class AnnotatePlansQueueGatingTests(unittest.TestCase):
         self.assertEqual(
             set(c.keys()),
             {"pipeline_id", "started_at", "current_phase",
-             "age_seconds", "pipeline_short", "dispatch_mode", "stale"},
+             "age_seconds", "pipeline_short", "dispatch_mode", "stale",
+             "last_progress_at"},
         )
         # stale (#912) threads through onto plan["claim"] from the collector.
         self.assertIn("stale", c)
+        # last_progress_at (#1029) threads through onto plan["claim"]
+        # so the renderer fingerprint can include heartbeat bumps.
+        self.assertIn("last_progress_at", c)
         # Plan beta has no claim attached.
         self.assertNotIn("claim", plans[1])
 

--- a/tests/test-plan-claim-fingerprint.sh
+++ b/tests/test-plan-claim-fingerprint.sh
@@ -61,6 +61,14 @@ else
   fail "fingerprintPlans missing claim.pipeline_id reference"
 fi
 
+# #1029: fingerprintPlans must include last_progress_at so heartbeat
+# bumps (set-phase between phase boundaries) re-render the chip.
+if grep -A 30 "function fingerprintPlans" "$APP_JS" | grep -q 'last_progress_at'; then
+  pass "#1029: fingerprintPlans includes claim.last_progress_at (heartbeat re-renders)"
+else
+  fail "#1029: fingerprintPlans missing claim.last_progress_at — heartbeat is invisible to renderer"
+fi
+
 if ! command -v node >/dev/null 2>&1; then
   skip "node not available — fingerprint dispatch test skipped"
   print_summary_and_exit
@@ -160,11 +168,27 @@ const fullClaimPhaseAdvanced = {
     pipeline_short: "foo-abc",
   },
 };
+// #1029: a heartbeat-only bump (last_progress_at moves; current_phase
+// unchanged) must ALSO change the fingerprint so the chip re-renders.
+// Otherwise a long-running pipeline's heartbeat is invisible to the
+// renderer between phase boundaries.
+const fullClaimHeartbeatBumped = {
+  ...base,
+  claim: {
+    pipeline_id: "run-plan.foo",
+    started_at: "2026-05-22T01:00:00+00:00",
+    current_phase: "Phase 2",
+    age_seconds: 60,
+    pipeline_short: "foo-abc",
+    last_progress_at: "2026-05-22T01:30:00+00:00",
+  },
+};
 
 const fpNo      = fingerprintPlans([noClaim],                 queues, "phase");
 const fpPending = fingerprintPlans([pendingClaim],            queues, "phase");
 const fpFull    = fingerprintPlans([fullClaim],               queues, "phase");
 const fpFullAdv = fingerprintPlans([fullClaimPhaseAdvanced],  queues, "phase");
+const fpFullHb  = fingerprintPlans([fullClaimHeartbeatBumped], queues, "phase");
 
 expectTrue(fpNo !== fpPending,
   "fingerprint differs between no-claim and pending-claim");
@@ -174,6 +198,8 @@ expectTrue(fpNo !== fpFull,
   "fingerprint differs between no-claim and full-claim");
 expectTrue(fpFull !== fpFullAdv,
   "fingerprint differs after phase advance (chip re-renders so phase N/M updates)");
+expectTrue(fpFull !== fpFullHb,
+  "#1029: fingerprint differs after heartbeat-only bump (chip re-renders on set-phase even if current_phase string unchanged)");
 
 // Stability: same input shape → same fingerprint.
 const fpFull2 = fingerprintPlans([fullClaim], queues, "phase");

--- a/tests/test-plan-claim-render-dom.sh
+++ b/tests/test-plan-claim-render-dom.sh
@@ -515,7 +515,9 @@ function collectText(node) {
   expectTrue(chip && /claim-chip--stale/.test(chip.className),
     "#912: stale chip carries claim-chip--stale modifier");
   expectTrue(chip && chip.textContent.indexOf("stale") >= 0,
-    "#912: stale chip text reads as stale (dead pipeline)");
+    "#912/#1029: stale chip text reads as stale (no progress in 6h+)");
+  expectTrue(chip && chip.textContent.indexOf("no progress in 6h+") >= 0,
+    "#1029: stale chip text uses the literal 'no progress in 6h+' (not 'dead pipeline')");
   expectTrue(chip && /click to release/.test(chip.getAttribute("title") || ""),
     "#912: stale chip tooltip offers 'click to release'");
   // X is re-enabled with the existing plan-discard action.
@@ -564,6 +566,75 @@ function collectText(node) {
     expect(rmBtn.getAttribute("data-action"), null,
       "#912: fresh claim X has NO data-action (hard-lock unchanged)");
   }
+}
+
+// ------------------------------------------------------------------
+// T3.11.#1029.a — Healthy long-running pipeline: started_at >6h old,
+// last_progress_at <6h ago (recent set-phase). Stale rule keys on
+// last_progress_at, so the chip MUST render in the live framing, the
+// card MUST stay hard-locked (live claim semantics — no in-UI release),
+// and the chip MUST NOT carry the claim-chip--stale modifier.
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "longrun", title: "Long-running pipeline", status: "active",
+    phase_count: 4, phases_done: 2,
+    claim: {
+      pipeline_id: "run-plan.longrun",
+      started_at: new Date(Date.now() - 10 * 3600 * 1000).toISOString(),
+      last_progress_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      current_phase: "Phase 3",
+      age_seconds: 10 * 3600,
+      pipeline_short: "lr-abc",
+      // Collector emits stale=false because last_progress_at is fresh.
+      stale: false,
+    },
+  };
+  const card = buildPlanCard(plan, "longrun", "ready", "phase");
+  expect(card.getAttribute("aria-disabled"), "true",
+    "#1029: long-but-healthy claim card stays aria-disabled (live, hard-locked)");
+  expectTrue(/(^|\s)claim-locked(\s|$)/.test(card.className),
+    "#1029: long-but-healthy claim card retains claim-locked class");
+  const chip = findByClass(card, "claim-chip");
+  expectTrue(chip, "#1029: claim chip rendered for long-but-healthy claim");
+  expectTrue(chip && chip.textContent.indexOf("stale") < 0,
+    "#1029: long-but-healthy claim chip does NOT include 'stale'");
+  expectTrue(chip && !/claim-chip--stale/.test(chip.className),
+    "#1029: long-but-healthy claim chip does NOT carry claim-chip--stale modifier");
+}
+
+// ------------------------------------------------------------------
+// T3.11.#1029.b — Dead pipeline: BOTH started_at AND last_progress_at
+// >6h ago. Stale rule fires → chip MUST render with the "no progress
+// in 6h+" framing; card MUST stay draggable (no hard-lock); X MUST be
+// enabled. This is the post-#1029 framing of the dead-pipeline case
+// that previously fired purely on started_at age.
+// ------------------------------------------------------------------
+{
+  const plan = {
+    slug: "bothold", title: "Both-old dead pipeline", status: "active",
+    phase_count: 5, phases_done: 1,
+    claim: {
+      pipeline_id: "run-plan.bothold",
+      started_at: new Date(Date.now() - 10 * 3600 * 1000).toISOString(),
+      last_progress_at: new Date(Date.now() - 8 * 3600 * 1000).toISOString(),
+      current_phase: "Phase 1",
+      age_seconds: 10 * 3600,
+      pipeline_short: "bo-abc",
+      stale: true,
+    },
+  };
+  const card = buildPlanCard(plan, "bothold", "ready", "phase");
+  expect(card.getAttribute("aria-disabled"), null,
+    "#1029: both-old dead claim card is NOT aria-disabled (recovery enabled)");
+  expectTrue(!/(^|\s)claim-locked(\s|$)/.test(card.className),
+    "#1029: both-old dead claim card has NO claim-locked class");
+  const chip = findByClass(card, "claim-chip");
+  expectTrue(chip, "#1029: claim chip rendered for both-old dead claim");
+  expectTrue(chip && /claim-chip--stale/.test(chip.className),
+    "#1029: both-old dead claim chip carries claim-chip--stale modifier");
+  expectTrue(chip && chip.textContent.indexOf("no progress in 6h+") >= 0,
+    "#1029: both-old dead claim chip text reads 'no progress in 6h+'");
 }
 
 // ------------------------------------------------------------------

--- a/tests/test-plan-claim-script.sh
+++ b/tests/test-plan-claim-script.sh
@@ -80,11 +80,12 @@ import json
 d=json.load(open('$CLAIM_FILE'))
 print(','.join(sorted(d.keys())))
 ")
-    EXPECTED="current_phase,kind,pipeline_id,schema_version,slug,started_at"
+    # #1029: last_progress_at is now part of the D5 schema (7 fields).
+    EXPECTED="current_phase,kind,last_progress_at,pipeline_id,schema_version,slug,started_at"
     if [ "$KEYS" = "$EXPECTED" ]; then
-      pass "acquire writes 6-field D5 schema (sorted keys)"
+      pass "acquire writes 7-field D5 schema (sorted keys; includes last_progress_at #1029)"
     else
-      fail "acquire 6-field schema" "expected=$EXPECTED got=$KEYS"
+      fail "acquire 7-field schema" "expected=$EXPECTED got=$KEYS"
     fi
     # Spot-check fields.
     KIND=$("$PYTHON" -c "import json; print(json.load(open('$CLAIM_FILE'))['kind'])")


### PR DESCRIPTION
## Summary

Plan-claim staleness rule was reading the wrong proxy: `now - started_at > 6h`. This asks "how old is the claim's acquisition?" when the real question is "has the pipeline made progress recently?" Long-but-healthy `/run-plan finish auto` runs that legitimately need >6h of wall-clock (e.g. 3 phases × ~50 min implementer + ~50 min verifier) cross the threshold and get falsely tagged "stale (dead pipeline)" while still actively committing.

**Live evidence (this session):** a `/run-plan` pipeline with `started_at = 2026-06-02T22:50:51Z` flipped to "stale (dead pipeline)" at ~04:57Z (6h 7m later) — 25 min after committing Phase 3, 5 min after committing the frontmatter flip. The chip simultaneously read `Phase 3 (current)` AND `stale (dead pipeline)` — internally inconsistent.

## Changes

1. **`skills/run-plan/scripts/claim-plan.sh`** — add `last_progress_at` heartbeat:
   - `cmd_acquire` writes `last_progress_at = started_at` on initial acquire
   - `cmd_set_phase` bumps `last_progress_at = now` on every call
   - **Single canonical heartbeat source.** `step.*` marker writes do NOT bump; `claim-self-reentry.sh` does NOT bump. set-phase is the canonical "I'm making progress on this plan" signal — keeping the bump atomic to one site avoids spraying liveness signals across the codebase.

2. **`skills/zskills-dashboard/scripts/zskills_monitor/collect.py`** — flip the staleness check:
   - Uses `last_progress_at` for the `now - X > PLAN_CLAIM_STALE_SECONDS` check
   - Falls back to `started_at` when `last_progress_at` is missing/null (backward-compat for pre-fix claim.json files on disk at upgrade time)
   - Fail-toward-NOT-stale preserved (both fields missing → not stale)
   - Threshold unchanged at `PLAN_CLAIM_STALE_SECONDS = 21600` (6h) — only the field changed

3. **`skills/zskills-dashboard/scripts/zskills_monitor/static/app.js`** — cosmetic + correctness:
   - Chip label updated: `"stale (dead pipeline)"` → `"stale (no progress in 6h+)"` — "dead pipeline" was a guess, not a fact
   - Tooltip: `"No progress signalled in 6h+ (pipeline ...) — click to release."`
   - `fingerprintPlans` claim tuple extended to include `last_progress_at` so dashboard re-renders when the heartbeat bumps

4. **Skill version bumps:** `run-plan` → `2026.06.03+f2ff71`, `zskills-dashboard` → `2026.06.03+0e2251`. Mirror parity verified (`diff -rq` empty for both).

## Test plan

- [x] `bash tests/run-all.sh` → `Overall: 7486/7486 passed, 0 failed`
- [x] NEW `tests/test-claim-plan-heartbeat.sh` — 8 cases:
  - acquire writes `last_progress_at == started_at`
  - set-phase bumps `last_progress_at` strictly later
  - set-phase preserves `started_at`
  - fresh-progress (old started_at + fresh last_progress_at) → NOT stale
  - both-old → STALE
  - back-compat: pre-fix claim with old `started_at` only → STALE (via fallback)
  - back-compat: pre-fix claim with fresh `started_at` only → NOT stale
  - both fields missing → NOT stale (fail-safe)
- [x] Extended `tests/test-plan-claim-collector.py` (field allow-list + `_annotate_plans_queue` assertion)
- [x] Extended `tests/test-plan-claim-fingerprint.sh` (heartbeat-bump triggers fingerprint change)
- [x] Extended `tests/test-plan-claim-render-dom.sh` (long-but-healthy not stale; both-old stale; new chip-label substring asserted character-exact)
- [x] Updated `tests/test-plan-claim-script.sh` (schema field count 6→7)
- [x] Live smoke: `claim-plan.sh acquire test-slug --pipeline-id smoke.test` → inspect claim.json (both fields == initial ISO) → `set-phase test-slug --current-phase "Phase smoke"` after sleep 2 → re-inspect (`last_progress_at` 2s later, `started_at` unchanged) → `release` → claim dir gone
- [x] Mirror parity verified for both touched skills

## Verification verdict

Verifier (separate agent) re-ran every AC + invariant independently:
- AC 1-7 PASS, evidence cited inline
- 8 invariants PASS, evidence cited inline
- 5 backward-compat smoke cases PASS
- Mirror parity empty for both skills
- Playwright walk substituted by jsdom DOM-render test (defensible — pure DOM text-content + className + attribute change; no CSS/matchMedia surface where node-DOM stubs historically false-positive)

Closes #1029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
