### PR TITLE
do: fix /do strong-separator issue-number over-capture

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.02+7a73dc"
+  version: "2026.06.03+ff9b8e"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -72,15 +72,17 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
   immediately AND schedules. Without `every`, `now` is the default behavior.
 - **--force** (optional) — bypass triage redirect and review reject. Persists
   into the cron prompt verbatim when used with `every`.
-- **--no-claim** (optional) — treat every bare `#N` in the description as a
-  mere mention. Suppresses the stray-`#N` pre-flight check (#959): /do
-  normally STOPS when the description references an issue currently held
-  in-flight by a foreign pipeline (to prevent duplicating its work — the
-  closed-PR-#888-vs-landed-#901 footgun), and warns on any other stray `#N`.
-  Pass `--no-claim` when the reference is deliberate ("fix tooltip, related
-  to #340") and you do NOT want /do to halt or warn on it. Claim-positioned
-  `#N` (a leading `#N` or `Fix #N …`) are unaffected — they still acquire
-  their claim through the mode files' normal acquire-or-decline.
+- **--no-claim** (optional) — claim absolutely NOTHING; treat every `#N` in
+  the description as a mere mention. This now suppresses ALL claims (#1032),
+  not just the stray-ref warning: the pre-flight forces `ISSUE_NUMS` empty so
+  the mode files acquire no claims AND skips the stray-`#N` check (#959). The
+  stray-`#N` check normally STOPS when the description references an issue
+  currently held in-flight by a foreign pipeline (to prevent duplicating its
+  work — the closed-PR-#888-vs-landed-#901 footgun), and warns on any other
+  stray `#N`. Pass `--no-claim` when you do NOT want /do to claim, halt, or
+  warn on any referenced issue — including claim-positioned ones. Concretely
+  `Fix #5 / #6 --no-claim` acquires neither #5 nor #6: under `--no-claim`
+  even a leading `#N` or `Fix #N …` is a pure mention.
 - **--rounds N** (optional) — max review/refine cycles (default 1; `0` skips
   review with stderr WARN).
 - **stop** — cancel `/do` cron(s). Bare `/do stop` → all crons.
@@ -283,21 +285,42 @@ _DO_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
 # Leading anchored match (optional close-keyword, optional leading quote,
 # optional `issue[s]?:?` filler between kw and `#N`). BASH_REMATCH groups
 # (kw branch): 1=kw outer, 2=kw inner, 3=optional filler, 4=digit capture.
+# `_DO_CHAIN_SUFFIX` records the description text IMMEDIATELY AFTER the
+# leading ref, and `_DO_HAS_ANCHOR` records whether the leading match
+# populated ISSUE_NUMS. The strong-separator loop below anchors on this
+# leading ref: a strong-separator `#N` is captured ONLY when it is
+# contiguously chained to the already-claimed leading ref (#1032). Without
+# a leading anchor (description starts mid-prose, no claim-positioned
+# leading `#N`), the chain captures nothing — so a slash-separated citation
+# like `supersedes #999/#1004` or a bare-cited `#960/#967` claims nothing.
+_DO_HAS_ANCHOR=0
+_DO_CHAIN_SUFFIX=""
 if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  _DO_HAS_ANCHOR=1
+  _DO_CHAIN_SUFFIX="${ARGUMENTS#*"${BASH_REMATCH[0]}"}"
 elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[1]}")
+  _DO_HAS_ANCHOR=1
+  _DO_CHAIN_SUFFIX="${ARGUMENTS#*"${BASH_REMATCH[0]}"}"
 fi
 # Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK; if
 # the keyword is present, the optional `issue[s]?:?` filler is also
-# permitted between the kw and `#N`. BASH_REMATCH groups: 1=outer kw+
-# filler wrapper, 2=kw outer, 3=kw inner, 4=optional filler, 5=digit
-# capture.
-_DO_REMAINING="$ARGUMENTS"
-while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
-  _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
-done
+# permitted between the kw and `#N`. The regex is `^`-ANCHORED and runs
+# against `_DO_CHAIN_SUFFIX` (the text right after the previous captured
+# ref), so it consumes ONLY a contiguous `(<sep> #N)+` chain starting
+# immediately after the leading claimed ref — arbitrary prose between the
+# anchor and a `<sep> #N` breaks the chain and stops the loop (#1032).
+# When there is no leading anchor, the loop body never runs. BASH_REMATCH
+# groups: 1=outer kw+filler wrapper, 2=kw outer, 3=kw inner, 4=optional
+# filler, 5=digit capture.
+if [ "$_DO_HAS_ANCHOR" -eq 1 ]; then
+  while [[ "$_DO_CHAIN_SUFFIX" =~ ^[[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+    _DO_CHAIN_SUFFIX="${_DO_CHAIN_SUFFIX#*"${BASH_REMATCH[0]}"}"
+  done
+fi
+unset _DO_HAS_ANCHOR _DO_CHAIN_SUFFIX
 # Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
 # close-keyword before `#N` so prose like "Closes #N, see also #M" doesn't
 # over-capture #M. Optional `issue[s]?:?` filler is allowed between kw and
@@ -322,6 +345,18 @@ unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _DO_ISSUE_FILLER _n
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+# `--no-claim` (#1032) means "claim absolutely nothing." Reset the populated
+# ISSUE_NUMS (and the back-compat scalar) to empty so the mode files' claim
+# fan-out acquires NOTHING — even for claim-positioned refs like `Fix #5 / #6`.
+# This is the deterministic escape hatch: any future parser edge case can be
+# neutralized with --no-claim. The stray-ref check below is still guarded by
+# the same NO_CLAIM flag, so an emptied ISSUE_NUMS does not cause a
+# contradictory STOP/warn (the whole stray-ref block is skipped when
+# NO_CLAIM=1).
+if [ "$NO_CLAIM" -eq 1 ]; then
+  ISSUE_NUMS=()
+  ISSUE_NUM=""
+fi
 # Unclaimed-reference check (#907 warn + #959 foreign-held STOP). If the
 # description contains a `#N` token that the claim-position rules above did
 # NOT capture into ISSUE_NUMS, the reference is real but UN-claimed by this
@@ -360,7 +395,9 @@ ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 # "fails → duplicates silently" to "fails → halts with a clear message".
 #
 # `--no-claim` (NO_CLAIM=1, parsed in the pre-parse above) suppresses BOTH
-# the STOP and the warn — every bare `#N` is then a pure mention.
+# the STOP and the warn — every bare `#N` is then a pure mention. It ALSO
+# forces ISSUE_NUMS empty above (#1032), so claim-positioned refs are not
+# acquired either; --no-claim means "claim absolutely nothing."
 #
 # Resolve MAIN_ROOT the same way block-fix-issue-unclaimed.sh does:
 # `git rev-parse --git-common-dir` parent, falling back to

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.02+7a73dc"
+  version: "2026.06.03+ff9b8e"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -72,15 +72,17 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
   immediately AND schedules. Without `every`, `now` is the default behavior.
 - **--force** (optional) — bypass triage redirect and review reject. Persists
   into the cron prompt verbatim when used with `every`.
-- **--no-claim** (optional) — treat every bare `#N` in the description as a
-  mere mention. Suppresses the stray-`#N` pre-flight check (#959): /do
-  normally STOPS when the description references an issue currently held
-  in-flight by a foreign pipeline (to prevent duplicating its work — the
-  closed-PR-#888-vs-landed-#901 footgun), and warns on any other stray `#N`.
-  Pass `--no-claim` when the reference is deliberate ("fix tooltip, related
-  to #340") and you do NOT want /do to halt or warn on it. Claim-positioned
-  `#N` (a leading `#N` or `Fix #N …`) are unaffected — they still acquire
-  their claim through the mode files' normal acquire-or-decline.
+- **--no-claim** (optional) — claim absolutely NOTHING; treat every `#N` in
+  the description as a mere mention. This now suppresses ALL claims (#1032),
+  not just the stray-ref warning: the pre-flight forces `ISSUE_NUMS` empty so
+  the mode files acquire no claims AND skips the stray-`#N` check (#959). The
+  stray-`#N` check normally STOPS when the description references an issue
+  currently held in-flight by a foreign pipeline (to prevent duplicating its
+  work — the closed-PR-#888-vs-landed-#901 footgun), and warns on any other
+  stray `#N`. Pass `--no-claim` when you do NOT want /do to claim, halt, or
+  warn on any referenced issue — including claim-positioned ones. Concretely
+  `Fix #5 / #6 --no-claim` acquires neither #5 nor #6: under `--no-claim`
+  even a leading `#N` or `Fix #N …` is a pure mention.
 - **--rounds N** (optional) — max review/refine cycles (default 1; `0` skips
   review with stderr WARN).
 - **stop** — cancel `/do` cron(s). Bare `/do stop` → all crons.
@@ -283,21 +285,42 @@ _DO_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
 # Leading anchored match (optional close-keyword, optional leading quote,
 # optional `issue[s]?:?` filler between kw and `#N`). BASH_REMATCH groups
 # (kw branch): 1=kw outer, 2=kw inner, 3=optional filler, 4=digit capture.
+# `_DO_CHAIN_SUFFIX` records the description text IMMEDIATELY AFTER the
+# leading ref, and `_DO_HAS_ANCHOR` records whether the leading match
+# populated ISSUE_NUMS. The strong-separator loop below anchors on this
+# leading ref: a strong-separator `#N` is captured ONLY when it is
+# contiguously chained to the already-claimed leading ref (#1032). Without
+# a leading anchor (description starts mid-prose, no claim-positioned
+# leading `#N`), the chain captures nothing — so a slash-separated citation
+# like `supersedes #999/#1004` or a bare-cited `#960/#967` claims nothing.
+_DO_HAS_ANCHOR=0
+_DO_CHAIN_SUFFIX=""
 if [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[4]}")
+  _DO_HAS_ANCHOR=1
+  _DO_CHAIN_SUFFIX="${ARGUMENTS#*"${BASH_REMATCH[0]}"}"
 elif [[ "$ARGUMENTS" =~ ^[[:space:]]*\"?#([0-9]+) ]]; then
   ISSUE_NUMS+=("${BASH_REMATCH[1]}")
+  _DO_HAS_ANCHOR=1
+  _DO_CHAIN_SUFFIX="${ARGUMENTS#*"${BASH_REMATCH[0]}"}"
 fi
 # Subsequent strong-separator matches (`/`, `+`, `&`): bare `#N` OK; if
 # the keyword is present, the optional `issue[s]?:?` filler is also
-# permitted between the kw and `#N`. BASH_REMATCH groups: 1=outer kw+
-# filler wrapper, 2=kw outer, 3=kw inner, 4=optional filler, 5=digit
-# capture.
-_DO_REMAINING="$ARGUMENTS"
-while [[ "$_DO_REMAINING" =~ [[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
-  ISSUE_NUMS+=("${BASH_REMATCH[5]}")
-  _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
-done
+# permitted between the kw and `#N`. The regex is `^`-ANCHORED and runs
+# against `_DO_CHAIN_SUFFIX` (the text right after the previous captured
+# ref), so it consumes ONLY a contiguous `(<sep> #N)+` chain starting
+# immediately after the leading claimed ref — arbitrary prose between the
+# anchor and a `<sep> #N` breaks the chain and stops the loop (#1032).
+# When there is no leading anchor, the loop body never runs. BASH_REMATCH
+# groups: 1=outer kw+filler wrapper, 2=kw outer, 3=kw inner, 4=optional
+# filler, 5=digit capture.
+if [ "$_DO_HAS_ANCHOR" -eq 1 ]; then
+  while [[ "$_DO_CHAIN_SUFFIX" =~ ^[[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
+    ISSUE_NUMS+=("${BASH_REMATCH[5]}")
+    _DO_CHAIN_SUFFIX="${_DO_CHAIN_SUFFIX#*"${BASH_REMATCH[0]}"}"
+  done
+fi
+unset _DO_HAS_ANCHOR _DO_CHAIN_SUFFIX
 # Subsequent weak-separator matches (`,`, `;`, ` and `, ` or `): require
 # close-keyword before `#N` so prose like "Closes #N, see also #M" doesn't
 # over-capture #M. Optional `issue[s]?:?` filler is allowed between kw and
@@ -322,6 +345,18 @@ unset _DO_SEEN _DO_UNIQUE _DO_REMAINING _DO_ISSUE_KW _DO_ISSUE_FILLER _n
 # files still reference $ISSUE_NUM in skip-empty guards; new fan-out code
 # iterates "${ISSUE_NUMS[@]}".
 ISSUE_NUM="${ISSUE_NUMS[0]:-}"
+# `--no-claim` (#1032) means "claim absolutely nothing." Reset the populated
+# ISSUE_NUMS (and the back-compat scalar) to empty so the mode files' claim
+# fan-out acquires NOTHING — even for claim-positioned refs like `Fix #5 / #6`.
+# This is the deterministic escape hatch: any future parser edge case can be
+# neutralized with --no-claim. The stray-ref check below is still guarded by
+# the same NO_CLAIM flag, so an emptied ISSUE_NUMS does not cause a
+# contradictory STOP/warn (the whole stray-ref block is skipped when
+# NO_CLAIM=1).
+if [ "$NO_CLAIM" -eq 1 ]; then
+  ISSUE_NUMS=()
+  ISSUE_NUM=""
+fi
 # Unclaimed-reference check (#907 warn + #959 foreign-held STOP). If the
 # description contains a `#N` token that the claim-position rules above did
 # NOT capture into ISSUE_NUMS, the reference is real but UN-claimed by this
@@ -360,7 +395,9 @@ ISSUE_NUM="${ISSUE_NUMS[0]:-}"
 # "fails → duplicates silently" to "fails → halts with a clear message".
 #
 # `--no-claim` (NO_CLAIM=1, parsed in the pre-parse above) suppresses BOTH
-# the STOP and the warn — every bare `#N` is then a pure mention.
+# the STOP and the warn — every bare `#N` is then a pure mention. It ALSO
+# forces ISSUE_NUMS empty above (#1032), so claim-positioned refs are not
+# acquired either; --no-claim means "claim absolutely nothing."
 #
 # Resolve MAIN_ROOT the same way block-fix-issue-unclaimed.sh does:
 # `git rev-parse --git-common-dir` parent, falling back to

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -110,6 +110,7 @@ run_suite "test-fix-issues-phase2-source-filter.sh" "tests/test-fix-issues-phase
 run_suite "test-fix-issues-skip-persistence.sh" "tests/test-fix-issues-skip-persistence.sh"
 run_suite "test-fix-issues-skip-effective-reason.sh" "tests/test-fix-issues-skip-effective-reason.sh"
 run_suite "test-do.sh" "tests/test-do.sh"
+run_suite "test-do-issue-num-parser.sh" "tests/test-do-issue-num-parser.sh"
 # SEAM_HARDENING_HIGH Phase 3 — extract-and-run the real /commit arg-parser
 # + the real /commit pr canonical /land-pr caller loop. These supersede the
 # static-grep coverage that used to live in tests/test-commit.sh (removed).

--- a/tests/test-do-issue-num-parser.sh
+++ b/tests/test-do-issue-num-parser.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Tests for /do's pre-flight `#N` issue-number parser (ISSUE_NUMS
+# population), issue #1032. Drives the REAL parser by extracting the
+# pre-flight bash fence from skills/do/SKILL.md and running it against
+# fixture descriptions — extract-and-run, so the test can't drift from
+# the shipped parser logic.
+#
+# Coverage:
+#   (c) Strong separator (`/`, `+`, `&`) only EXTENDS a contiguous chain
+#       anchored on an already-claimed leading ref. Slash/plus-separated
+#       CITATIONS with no claim-positioned leading ref capture nothing.
+#   (a) `--no-claim` forces ISSUE_NUMS empty (claim absolutely nothing),
+#       even for claim-positioned refs like `Fix #5 / #6`.
+#   Regression guards: bare-leading chain, weak-separator (`,`) discipline.
+#
+# Run from repo root: bash tests/test-do-issue-num-parser.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$REPO_ROOT/skills/do/SKILL.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+TEST_TMPDIR=$(mktemp -d -t "zskills-do-parser-XXXXXX")
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# Extract the leading pre-flight bash fence — the SAME extractor test-do.sh
+# uses (between `## Pre-flight` and `## Phase 0a`, the contiguous bash fence).
+PREFLIGHT_BLOCK=$(awk '
+  /^## Pre-flight/      { in_section = 1; next }
+  /^## Phase 0a/        { in_section = 0 }
+  !in_section           { next }
+  /^```bash$/           { infence = 1; next }
+  infence && /^```$/    { infence = 0; print ""; next }
+  infence               { print }
+' "$SKILL")
+
+if [ -z "$PREFLIGHT_BLOCK" ]; then
+  fail "extract pre-flight fence (block empty — SKILL.md structure changed?)"
+  printf 'PASS=%d FAIL=%d\n' "$PASS_COUNT" "$FAIL_COUNT"
+  exit 1
+fi
+
+# Build a runner that sets ARGUMENTS, runs the real parser, and emits the
+# resulting ISSUE_NUMS as a space-joined string. The parser's stray-ref
+# block touches the filesystem (.zskills/claims/...) only when NO_CLAIM != 1
+# and ISSUE_NUMS leaves a stray ref unclaimed; for the fixtures here it is
+# either short-circuited (NO_CLAIM) or has no stray refs, so running from a
+# throwaway dir is safe.
+PARSER_SCRIPT="$TEST_TMPDIR/parser.sh"
+{
+  echo '#!/bin/bash'
+  echo 'set -u'
+  echo 'ARGUMENTS="$1"'
+  echo "$PREFLIGHT_BLOCK"
+  echo 'printf "%s" "${ISSUE_NUMS[*]:-}"'
+} > "$PARSER_SCRIPT"
+chmod +x "$PARSER_SCRIPT"
+
+# Run the parser against $1, return the space-joined ISSUE_NUMS on stdout.
+run_parser() {
+  ( cd "$TEST_TMPDIR" && bash "$PARSER_SCRIPT" "$1" 2>/dev/null )
+}
+
+# assert_parse <description> <expected-space-joined> <label>
+assert_parse() {
+  local desc="$1" expected="$2" label="$3" got
+  got=$(run_parser "$desc")
+  if [ "$got" = "$expected" ]; then
+    pass "$label  ['$desc'] -> ISSUE_NUMS=[$got]"
+  else
+    fail "$label  ['$desc'] -> got ISSUE_NUMS=[$got], expected [$expected]"
+  fi
+}
+
+echo "=== /do ISSUE_NUMS parser (#1032) ==="
+
+# (c) Strong-separator chain anchored on a claimed leading ref.
+assert_parse "Fix #5 / #6"              "5 6"      "c1 slash-chain extends claimed leading ref"
+assert_parse "Fix #12 + #15 + #18"      "12 15 18" "c2 plus-chain extends claimed leading ref"
+
+# (c) Citations: strong separator with NO claim-positioned leading ref
+# captures NOTHING (the over-capture bug #1032 fixed).
+assert_parse "Refactor X (supersedes #999/#1004)" "" "c3 slash citation, no leading claim -> empty"
+assert_parse "Tweak Y, bare-cited #960/#967"      "" "c4 slash citation, no leading claim -> empty"
+
+# (a) --no-claim forces ISSUE_NUMS empty even for claim-positioned chains.
+assert_parse "Fix #5 / #6 --no-claim"   ""         "a1 --no-claim empties claim-positioned chain"
+assert_parse "#5 --no-claim"            ""         "a2 --no-claim empties bare leading ref"
+
+# Regression guards — behaviors that must be preserved.
+assert_parse "#5/#6"                    "5 6"      "r1 bare-leading ref anchors strong chain"
+assert_parse "Closes #832, Closes #833" "832 833"  "r2 weak-separator with keyword still captures"
+assert_parse "Closes #832, see also #999" "832"    "r3 weak-separator without keyword does not over-capture"
+
+echo
+printf 'test-do-issue-num-parser.sh: %d passed, %d failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary
Closes #1032.

The /do issue-number parser's strong-separator tier (`/ + &`) over-captured slash-separated issue *citations* into `ISSUE_NUMS`, so a description like `supersedes #999/#1004` would capture `1004` as a claim target that PR mode then tried to acquire (and could abort on). Two-part fix:

- **(c)** Strong-separator `#N` is now captured ONLY when contiguously chained to an already-claimed leading/keyword ref (`^`-anchored chain over the suffix). No claim-positioned leading ref → no strong-sep capture, so mid-prose citation pairs claim nothing.
- **(a)** `--no-claim` now forces `ISSUE_NUMS` empty (claim nothing, all modes); doc prose updated. Option (b) (keyword-before-every-strong-sep) was explicitly rejected.

## Test plan
- [x] New `tests/test-do-issue-num-parser.sh` — extract-and-run against the real parser, 9 cases: positive chains (`Fix #5 / #6`, `Fix #12 + #15 + #18`), negative citations (`supersedes #999/#1004`, bare-cited `#960/#967` → empty), `--no-claim` → empty, plus weak-sep regression guards.
- [x] Full suite 7547/7553; the 6 failures are an unrelated suite (`test_zskills_monitor_server.sh`) reproduced 69/69 green in isolation — I/O contention under heavy concurrent load, not a regression (HEAD touches no server files).
- [x] `metadata.version` bumped to 2026.06.03+ff9b8e; source + `.claude/` mirror in sync.

Worktree: /tmp/zskills-do-claim-overcapture-fix
Commits:
1cc9208 fix(do): strong-sep #N only extends a claimed chain; --no-claim claims nothing (#1032)
