### PR TITLE
docs: strip stray tags + leaked source citations (post-rewrite cleanup)

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -19,5 +19,3 @@ Practical guides for installing zskills and working with it day to day. Start wi
 ## See also
 
 - **[Skills reference](../skills/README.md)** — per-skill details for the 23 user-facing slash commands.
-</content>
-</invoke>

--- a/docs/guides/tracking-overview.md
+++ b/docs/guides/tracking-overview.md
@@ -133,5 +133,3 @@ the audit and issues state that lives alongside it) by accident.
 - **Claiming work items** is a related but distinct mechanism: before a pipeline
   works an issue or plan, it claims it so two pipelines don't pick up the same
   item. That is separate from the commit-gating tracking described here.
-</content>
-</invoke>

--- a/docs/skills/commit.md
+++ b/docs/skills/commit.md
@@ -96,13 +96,13 @@ which must come first.
 
 | Argument | What it does |
 |----------|--------------|
-| `pr` | Push the current branch and open a pull request to main. Must be the **first** token — this prevents a scope hint that happens to contain "pr" from triggering PR mode. Requires a clean working tree. (`skills/commit/SKILL.md:28`, `skills/commit/SKILL.md:25`, `skills/commit/SKILL.md:468`) |
-| `scope` | A free-text hint (e.g. `skill updates`, `parser reset button fix`) that guides which files count as related. Advisory — the skill still reads the diffs. (`skills/commit/SKILL.md:20`, `skills/commit/SKILL.md:464`) |
-| `push` | Commit, then push to the remote. (`skills/commit/SKILL.md:22`, `skills/commit/SKILL.md:419`) |
-| `land` | Cherry-pick the current worktree's commits onto main, run tests, and record that the work has landed. Only valid when you are in a worktree. (`skills/commit/SKILL.md:24`, `skills/commit/modes/land.md:10`) |
-| `auto` | In PR mode, request that the pull request auto-merge once CI passes. Has no effect with `push` or `land`. (`skills/commit/SKILL.md:154`, `skills/commit/SKILL.md:41`) |
+| `pr` | Push the current branch and open a pull request to main. Must be the **first** token — this prevents a scope hint that happens to contain "pr" from triggering PR mode. Requires a clean working tree. |
+| `scope` | A free-text hint (e.g. `skill updates`, `parser reset button fix`) that guides which files count as related. Advisory — the skill still reads the diffs. |
+| `push` | Commit, then push to the remote. |
+| `land` | Cherry-pick the current worktree's commits onto main, run tests, and record that the work has landed. Only valid when you are in a worktree. |
+| `auto` | In PR mode, request that the pull request auto-merge once CI passes. Has no effect with `push` or `land`. |
 
 If you give no mode token at all, `/commit` reads your project's configured
 default landing behavior to decide what to do — on a project that lands
 through pull requests, a bare `/commit` behaves like `/commit pr`.
-(`skills/commit/SKILL.md:31`, `skills/commit/SKILL.md:139`)
+

--- a/docs/skills/investigate.md
+++ b/docs/skills/investigate.md
@@ -49,7 +49,7 @@ When the input is an issue number, `/investigate` also claims that issue first, 
 |----------|----------|-------------|
 | `<description or #issue>` | Yes | The bug to investigate — either a plain-text symptom description, or a GitHub issue reference like `#387` |
 
-`/investigate` takes a single argument. Two forms are accepted (`skills/investigate/SKILL.md:40-43`):
+`/investigate` takes a single argument. Two forms are accepted:
 
 - **`#N`** — a GitHub issue number. The issue is fetched with `gh issue view`, and its title, body, and comments become the starting point. This form also triggers the issue claim described under Typical usage.
 - **Free text** — a description of the bug: an error message, an observed behavior, or a failing test name.


### PR DESCRIPTION
## Post-rewrite cleanup

Fixes the only blemishes the new-user + eng-expert assessors found after the 30-doc rewrite (#1042):

- **Stray output tags** — an implementer's `Write` leaked `</content>`/`</invoke>` into `docs/guides/README.md` and `docs/guides/tracking-overview.md`; they rendered as literal text. Removed.
- **Leaked source citations** — `skills/<name>/SKILL.md:NN` citation parentheticals (fact-sheet scaffolding) leaked into `docs/skills/commit.md`'s arguments table and `docs/skills/investigate.md`. Stripped.

Docs-only. Full suite green (7583/7583).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
