### PR TITLE
fix: block-unsafe-generic push-target -C-aware for issue 1037

### DIFF
--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.0
 # Block unsafe commands that agents should never use.
 # GENERIC safety layer — works in any project with zero configuration.
 # No external dependencies — bash only.
@@ -941,13 +941,26 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # so no need to re-extract from the JSON.
   # Wrapper-recursion via is_git_subcommand_in_wrappers (#399) catches
   # `bash -c 'git push origin main'` / `eval 'git push'`.
-  PUSH_CMD="$COMMAND"
-
-  # Strip everything before "git push" (e.g., "cd /tmp/path &&")
-  PUSH_CMD="${PUSH_CMD##*git push}"
+  #
+  # Use the tokens AFTER `push` that is_git_subcommand already extracted into
+  # GIT_SUB_REST. That tokenizer is `-C`-aware (it skips `-C <dir>` / `-c <kv>`
+  # before matching the subcommand, lines ~310-315) and segment-scoped (it
+  # truncates at the first &&/||/;/| boundary). The previous ad-hoc
+  # `${COMMAND##*git push}` string strip assumed `git` and `push` were
+  # ADJACENT tokens, so the worktree form `git -C /tmp/wt push ...` — where the
+  # literal substring "git push" never appears — was returned UNCHANGED and the
+  # positional loop below misread `-C`'s directory argument as the remote and
+  # `push` as a refspec, producing a garbage PUSH_REMOTE/PUSH_TARGET (#1037).
+  # Reusing GIT_SUB_REST makes extraction consume the same `-C`-aware
+  # tokenization the detection helper already uses, so
+  # `git -C /tmp/wt push --force-with-lease origin feat/x` parses identically
+  # to `cd /tmp/wt && git push --force-with-lease origin feat/x`.
+  PUSH_CMD="$GIT_SUB_REST"
 
   # Parse positional args after "git push": [-u] [remote] [refspec]
-  # Strip flags (-u, --set-upstream, -f, --force, etc.) and find positional args
+  # Strip flags (-u, --set-upstream, -f, --force, etc.) and find positional args.
+  # GIT_SUB_REST is already segment-scoped (chaining stripped), but keep the
+  # chain-boundary guard for defense-in-depth.
   PUSH_ARGS=""
   for word in $PUSH_CMD; do
     case "$word" in

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.0
 # Block unsafe commands that agents should never use.
 # GENERIC safety layer — works in any project with zero configuration.
 # No external dependencies — bash only.
@@ -941,13 +941,26 @@ if is_git_subcommand_in_wrappers "$COMMAND" push; then
   # so no need to re-extract from the JSON.
   # Wrapper-recursion via is_git_subcommand_in_wrappers (#399) catches
   # `bash -c 'git push origin main'` / `eval 'git push'`.
-  PUSH_CMD="$COMMAND"
-
-  # Strip everything before "git push" (e.g., "cd /tmp/path &&")
-  PUSH_CMD="${PUSH_CMD##*git push}"
+  #
+  # Use the tokens AFTER `push` that is_git_subcommand already extracted into
+  # GIT_SUB_REST. That tokenizer is `-C`-aware (it skips `-C <dir>` / `-c <kv>`
+  # before matching the subcommand, lines ~310-315) and segment-scoped (it
+  # truncates at the first &&/||/;/| boundary). The previous ad-hoc
+  # `${COMMAND##*git push}` string strip assumed `git` and `push` were
+  # ADJACENT tokens, so the worktree form `git -C /tmp/wt push ...` — where the
+  # literal substring "git push" never appears — was returned UNCHANGED and the
+  # positional loop below misread `-C`'s directory argument as the remote and
+  # `push` as a refspec, producing a garbage PUSH_REMOTE/PUSH_TARGET (#1037).
+  # Reusing GIT_SUB_REST makes extraction consume the same `-C`-aware
+  # tokenization the detection helper already uses, so
+  # `git -C /tmp/wt push --force-with-lease origin feat/x` parses identically
+  # to `cd /tmp/wt && git push --force-with-lease origin feat/x`.
+  PUSH_CMD="$GIT_SUB_REST"
 
   # Parse positional args after "git push": [-u] [remote] [refspec]
-  # Strip flags (-u, --set-upstream, -f, --force, etc.) and find positional args
+  # Strip flags (-u, --set-upstream, -f, --force, etc.) and find positional args.
+  # GIT_SUB_REST is already segment-scoped (chaining stripped), but keep the
+  # chain-boundary guard for defense-in-depth.
   PUSH_ARGS=""
   for word in $PUSH_CMD; do
     case "$word" in

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -672,6 +672,34 @@ expect_deny "git push origin refs/heads/master (fully-qualified master — #470)
 expect_deny "git push origin +refs/heads/main (force + fully-qualified — #470)" "git push origin +refs/heads/main"
 expect_deny "git push origin feat:refs/heads/main (refspec + fully-qualified — #470)" "git push origin feat:refs/heads/main"
 
+# Issue #1037: `git -C <dir> push ...` (worktree form) — the push-target
+# EXTRACTION must be `-C`-aware, mirroring the `-C`-aware subcommand DETECTION
+# (is_git_subcommand skips `-C <dir>` at lines ~310-315). Pre-fix the
+# extraction used `${COMMAND##*git push}`, which assumes `git` and `push` are
+# ADJACENT tokens; for `git -C /tmp/wt push ...` the literal substring
+# "git push" never appears, so the strip was a no-op and the positional loop
+# misread `-C`'s DIRECTORY argument as the remote and `push` as a refspec —
+# garbage PUSH_REMOTE/PUSH_TARGET. Symptom: /land-pr Step 6b's
+# `git -C "$WT" push --force-with-lease` self-blocked / mis-targeted in a
+# main_protected repo. Post-fix, extraction reuses GIT_SUB_REST (the `-C`-aware
+# tokens after `push`), so `git -C <dir> push ...` parses identically to
+# `cd <dir> && git push ...`.
+#
+# (a) SECURITY preserved: the worktree form pushing to main/master must still
+# DENY (fail-closed, no config = main_protected default). Pre-fix these
+# silently ALLOWED because PUSH_TARGET resolved to the garbage directory token.
+expect_deny "git -C /tmp/wt push origin main (worktree form — #1037)" "git -C /tmp/wt push origin main"
+expect_deny "git -C /tmp/wt push -u origin main (worktree + upstream — #1037)" "git -C /tmp/wt push -u origin main"
+expect_deny "git -C /tmp/wt push --force origin main (worktree + force — #1037)" "git -C /tmp/wt push --force origin main"
+expect_deny "git -C /tmp/wt push origin feat:main (worktree + refspec — #1037)" "git -C /tmp/wt push origin feat:main"
+expect_deny "git -C /tmp/wt push origin +main (worktree + force-prefix — #1037)" "git -C /tmp/wt push origin +main"
+expect_deny "git -C /tmp/wt push origin refs/heads/master (worktree + qualified — #1037)" "git -C /tmp/wt push origin refs/heads/master"
+# (b) ALLOWED case: the worktree form pushing a FEATURE branch (the /land-pr
+# Step 6b auto-rebase push) must be allowed — identical to the cd-prefixed form.
+expect_allow "git -C /tmp/wt push --force-with-lease origin feat/x (worktree — #1037)" "git -C /tmp/wt push --force-with-lease origin feat/x"
+expect_allow "git -C /tmp/wt push origin feat/x (worktree — #1037)" "git -C /tmp/wt push origin feat/x"
+expect_allow "cd /tmp/wt && git push --force-with-lease origin feat/x (cd form parity — #1037)" "cd /tmp/wt && git push --force-with-lease origin feat/x"
+
 echo ""
 echo "=== Push: main-push block reads execution.main_protected from config ==="
 
@@ -719,6 +747,14 @@ toggle_test "main_protected:false allows git push on master" 0 "master" "allow"
 # refspec parsing.
 toggle_test "main_protected:false allows 'git push origin main' (explicit refspec)" 0 "feat/test" "allow" "git push origin main"
 toggle_test "main_protected:false allows 'git push -u origin main' (upstream + refspec)" 0 "feat/test" "allow" "git push -u origin main"
+
+# Issue #1037: worktree-form `git -C <dir> push` must resolve the SAME
+# PUSH_TARGET as the cd-prefixed form under both config toggles. Proves the
+# `-C`-aware extraction (GIT_SUB_REST reuse) is config-coherent: blocked under
+# main_protected:true, allowed under main_protected:false — identical to the
+# plain form on lines above.
+toggle_test "main_protected:true denies 'git -C <dir> push origin main' (worktree — #1037)" 1 "feat/test" "deny" "git -C /tmp/wt push origin main"
+toggle_test "main_protected:false allows 'git -C <dir> push origin main' (worktree — #1037)" 0 "feat/test" "allow" "git -C /tmp/wt push origin main"
 
 # Issue #515: `git push origin HEAD` from a `main` checkout resolves
 # server-side to remote `main` — defeats the main-protection regime via a


### PR DESCRIPTION
## Summary
Closes #1037.

`block-unsafe-generic.sh`'s push-target extraction used `${PUSH_CMD##*git push}`, which is a no-op when `git` and `push` aren't adjacent — i.e. the worktree form `git -C <dir> push ...`. That left the downstream positional loop misreading `-C`'s directory argument as the remote and `push` as a refspec, producing garbage `PUSH_REMOTE`/`PUSH_TARGET`.

**This was a latent security hole, not just a self-block:** verification empirically confirmed that pre-fix, `git -C <wt> push origin main` resolved `PUSH_TARGET=/tmp/<wt>` and was **silently ALLOWED** — the gate failed open on the worktree form.

## Fix
Replace the ad-hoc string-strip with `PUSH_CMD="$GIT_SUB_REST"` — the `-C`-aware remainder `is_git_subcommand` already produces (it skips `-C <dir>` / `-c <kv>` and truncates at the first command boundary). So `git -C <dir> push ...` now parses identically to `cd <dir> && git push ...`. All downstream force-push / main-match / refspec normalization / `main_protected` gating is unchanged — only the *source* of `PUSH_CMD` changed. Commit-side gates audited; they already consume `GIT_SUB_REST`, so the push gate was the only blind spot.

## Test plan
- [x] `tests/test-hooks.sh` +11 cases: 6 worktree-form deny-to-main (force, refspec, `+`, `refs/heads/`, master), 2 worktree-form allow feature-push, 1 cd-form parity, 2 config-toggle. Proven non-tautological (deny cases fail against the old code).
- [x] Full suite **7597/7597** passing (no flake). `test-hooks.sh` 2384/0, mirror-parity 26/0.
- [x] Hook version stamp bumped `2026.05.0`→`2026.06.0`; source + `.claude/` mirror byte-identical.
- [x] Independent verifier confirmed no existing deny weakened.
