### PR TITLE
test: trap-guard create-worktree case 17 synthetic root cleanup for issue 1036

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,16 @@ __pycache__/
 .claude/agents/canary-readonly.md
 DOC_PARTY_COMPARISON.md
 
+# test-create-worktree.sh case 17 synthetic-root backstop (#1036). The cwd-
+# invariance case deliberately resolves a relative --root that canonicalises
+# back INTO the repo root (cwdinv-root-cw-smoke-<pid>/...). Cleanup is now
+# trap-guarded, but ignore the slug stems at repo root as a belt-and-braces
+# backstop so an interrupted run's stray dir can never be committed. Anchored
+# to repo root (leading /) so these never shadow files in subdirectories; no
+# tracked file matches either stem.
+/cwdinv-*
+/cw-smoke-*
+
 # Playwright runtime artifacts (snapshots, console logs, video, traces).
 # Track only the cli.config.json that .devcontainer/setup.sh writes.
 .playwright/*

--- a/tests/test-create-worktree.sh
+++ b/tests/test-create-worktree.sh
@@ -82,9 +82,14 @@ ROLLBACK_BRANCH="test-rollback-base-$$"
 # Every path we may create. Populated per-case; cleanup iterates.
 WT_PATHS=()
 BRANCHES=()
+# Synthetic in-repo dirs (case 17's relative --root parent) that canonicalise
+# back INTO MAIN_ROOT and so are NOT covered by the WT_PATHS /tmp-only rm guard.
+# Trap-registered separately so an interrupted run still removes them (#1036).
+SYNTH_DIRS=()
 
 register_wt() { WT_PATHS+=("$1"); }
 register_branch() { BRANCHES+=("$1"); }
+register_synth_dir() { SYNTH_DIRS+=("$1"); }
 
 cleanup() {
   local p b
@@ -99,6 +104,16 @@ cleanup() {
   for b in "${BRANCHES[@]:-}"; do
     [ -z "$b" ] && continue
     git -C "$MAIN_ROOT" branch -D "$b" 2>/dev/null || true
+  done
+  # Synthetic in-repo dirs (case 17). Same /tmp-or-MAIN_ROOT guard as the
+  # straight-line cleanup at the end of case 17 — defence-in-depth so a
+  # malformed entry can never rm outside the repo or /tmp (#1036).
+  local d
+  for d in "${SYNTH_DIRS[@]:-}"; do
+    [ -z "$d" ] && continue
+    case "$d" in
+      /tmp/*|"$MAIN_ROOT"/*) rm -rf -- "$d" 2>/dev/null || true ;;
+    esac
   done
   git -C "$MAIN_ROOT" worktree prune 2>/dev/null || true
 
@@ -642,6 +657,12 @@ git -C "$MAIN_ROOT" branch -D "$BRANCH_16" 2>/dev/null || true
 SLUG_17="cwdinv-${SLUG_BASE}-c17"
 PREFIX_17="do"
 REL_ROOT_17="../${PROJECT_NAME}/cwdinv-root-${SLUG_BASE}"
+# The synthetic root-parent canonicalises back into MAIN_ROOT. Compute and
+# trap-register it BEFORE the worktree-create below, so an interrupted run
+# (killed between create and the straight-line cleanup at the end of this
+# case) still removes the leaked cwdinv-root-* dir from the repo root (#1036).
+SYNTH_ROOT_PARENT_17="$(cd "$MAIN_ROOT" && realpath -m "$REL_ROOT_17")"
+register_synth_dir "$SYNTH_ROOT_PARENT_17"
 # Expected = realpath-m of REL_ROOT_17/PREFIX_17-SLUG_17 resolved against MAIN_ROOT.
 EXPECTED_WT_17="$(cd "$MAIN_ROOT" && realpath -m "$REL_ROOT_17/${PREFIX_17}-${SLUG_17}")"
 BR_17="${PREFIX_17}-${SLUG_17}"
@@ -689,7 +710,8 @@ git -C "$MAIN_ROOT" worktree remove --force "$NESTED_WT_17" 2>/dev/null || true
 git -C "$MAIN_ROOT" branch -D "$NESTED_BR_17" 2>/dev/null || true
 
 # Remove the synthetic root-parent dir so it doesn't leak into main repo.
-SYNTH_ROOT_PARENT_17="$(cd "$MAIN_ROOT" && realpath -m "$REL_ROOT_17")"
+# (SYNTH_ROOT_PARENT_17 was computed + trap-registered above; this is the
+# straight-line success-path cleanup, kept idempotent alongside the trap.)
 case "$SYNTH_ROOT_PARENT_17" in
   /tmp/*|"$MAIN_ROOT"/*) rm -rf -- "$SYNTH_ROOT_PARENT_17" 2>/dev/null || true ;;
 esac


### PR DESCRIPTION
## Summary
Closes #1036.

`tests/test-create-worktree.sh` case 17 (cwd-invariance) deliberately creates a synthetic relative `--root` that canonicalizes into the repo root (`MAIN_ROOT/cwdinv-root-<slug>/`). The synthetic parent dir was removed only by straight-line cleanup at end-of-case, so an interrupted/killed run (common under concurrent load) leaked `cwdinv-root-*` dirs into the repo root — untracked entries that pollute `git status` and risk being swept into a commit.

## Fix (test-hygiene only — `create-worktree.sh` untouched)
1. **Trap-register the synthetic root parent.** New `SYNTH_DIRS` array + `register_synth_dir`, with a loop added to the EXIT-trapped `cleanup()` (same `/tmp/*|$MAIN_ROOT/*` path guard as the straight-line code). The parent is registered BEFORE worktree-create, so the interrupt window between create and end-of-case is now covered. Straight-line cleanup preserved (idempotent).
2. **`.gitignore` backstop** — anchored `/cwdinv-*` and `/cw-smoke-*` (repo-root only) so a stray dir can never be committed even if cleanup is skipped. Verified no tracked file is shadowed.

## Test plan
- [x] `tests/test-create-worktree.sh` 8/8 (case 17 PASS).
- [x] SIGTERM probe: EXIT trap fires and removes the in-repo dir on interrupt.
- [x] `.gitignore` anchoring proven via `git check-ignore` (repo-root only, no subdir shadowing).
- [x] Full suite 7594/7594; post-suite repo root clean.
