### PR TITLE
docs(plans): add status:complete frontmatter so dashboard reflects PLUGIN_LANE_ROOT_RESOLUTION_FIX done

### DIFF
--- a/docs/plans/PLUGIN_LANE_ROOT_RESOLUTION_FIX.md
+++ b/docs/plans/PLUGIN_LANE_ROOT_RESOLUTION_FIX.md
@@ -1,3 +1,10 @@
+---
+title: Plugin-Lane Root Resolution Fix
+created: 2026-06-03
+status: complete
+completed: "2026-06-03T09:03:27-04:00"
+---
+
 # Plugin-Lane Root Resolution Fix
 
 **Status:** ✅ COMPLETE — all 3 phases executed, verified, and merged via PR #1046 (main @ `5c8fc9a`, 2026-06-03). Mirror-less plugin install verified working LIVE (`claude --plugin-dir` → `/zs:update-zskills` reports `lane: plugin`; bundled verifier `Overall: PASS`). Full suite `7601/7601`. See `docs/reports/plan-plugin-lane-root-resolution-fix.md`.


### PR DESCRIPTION
## Add `status: complete` frontmatter to PLUGIN_LANE_ROOT_RESOLUTION_FIX

The plan was hand-authored without YAML frontmatter, so the dashboard collector (which reads `fm.status`, defaulting to `active`, and counts done-phases from a progress-tracker table) rendered it as **0/3 ACTIVE** even though all phases merged in #1046. This adds the canonical `status: complete` + `completed:` frontmatter that `/run-plan` Phase 5b normally writes, so the card reflects **Complete**.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
