### PR TITLE
docs: reword references citations and fix Step 4 scripts audit for issue 1049

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.03+47adf9"
+  version: "2026.06.03+022278"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -998,9 +998,9 @@ Verification intensity matches the change type (from Phase 1):
 
 ### Code changes (js, css, html)
 
-- **Run `$FULL_TEST_CMD`** (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) — all suites must pass, not just unit tests.
+- **Run `$FULL_TEST_CMD`** (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) — all
+  suites must pass, not just unit tests.
   **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
   min); default 120000ms is shorter than the suite's runtime (~3-4
   min). Do NOT recover from a Bash timeout by retrying with

--- a/.claude/skills/do/modes/direct.md
+++ b/.claude/skills/do/modes/direct.md
@@ -84,9 +84,9 @@ fi
 
 **Commit discipline (Paths B and C):**
 - **On main (Path C):** commit when the work is complete. Clean, descriptive
-  message. `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) before committing if
+  message. `$FULL_TEST_CMD` (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) before
+  committing if
   code was touched. If tests fail after two fix attempts on the same error,
   STOP — report what you tried and let the user decide.
 - **In worktree (Path B):** the verification agent commits after tests pass.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   newsletter entries (/doc newsletter). Use when the user asks to "write a
   newsletter entry", "add to the newsletter", or "update the newsletter".
 metadata:
-  version: "2026.05.31+b7e813"
+  version: "2026.06.03+509cf0"
 ---
 
 # /doc [blocks|examples|\<description>] — Documentation Audit & Fix
@@ -280,9 +280,9 @@ For each gap found:
 - Check all markdown formatting (links, images, tables)
 - Verify image references point to existing files
 - Verify model files load without errors (if dev server is up)
-- `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) if any code files
+- `$FULL_TEST_CMD` (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) if any
+  code files
   were touched (component explorer, registry file, docs-registry.js,
   examples-dropdown.js)
 
@@ -315,8 +315,8 @@ Remaining gaps:
 - **Update all cross-references** — a new example needs entries in
   component explorer, `examples/README.md`, and relevant block
   explorer entries. Don't create orphaned docs.
-- **`$FULL_TEST_CMD` before committing** (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) if code files were touched.
+- **`$FULL_TEST_CMD` before committing** (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) if code
+  files were touched.
 - **Content-only changes skip tests** — if only markdown/images were
   changed, no test run needed.

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.03+33f652"
+  version: "2026.06.03+bd2e69"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -378,9 +378,9 @@ Do not proceed until you have read the file.
 - **Never close GH issues, update trackers, or remove worktrees** — that's
   `/fix-report`'s job.
 - **One issue per commit** — clean git history in worktrees.
-- **`$FULL_TEST_CMD` before every commit** (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) — not just `npm test`.
+- **`$FULL_TEST_CMD` before every commit** (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) — not
+  just `npm test`.
 - **Never weaken tests** — fix the code, not the test. Do not loosen
   tolerances, skip assertions, or remove test cases.
 - **Never defer the hard parts** — finish all phases of the plan. Do not

--- a/.claude/skills/fix-issues/modes/sprint.md
+++ b/.claude/skills/fix-issues/modes/sprint.md
@@ -1724,9 +1724,9 @@ Each agent follows this fix workflow:
 2. Reproduce the bug (unit test or manual)
 3. Implement the fix
 4. Write regression tests (unit and/or E2E as appropriate)
-5. Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-   references/canonical-config-prelude.md §1 if you don't already have it in
-   your environment) — all suites must pass.
+5. Run `$FULL_TEST_CMD` (canonical form — maintainers: see
+   `references/canonical-config-prelude.md` §1 in the zskills source) — all
+   suites must pass.
    **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
    min). The default 120000ms is shorter than the suite's actual runtime
    (~3-4 min in zskills). **Do NOT recover from a timeout by retrying

--- a/.claude/skills/fix-report/SKILL.md
+++ b/.claude/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.06.03+a92e4f"
+  version: "2026.06.03+5b244a"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -473,9 +473,9 @@ not "3 fixes in category" but one per fix.
   synthetic event limitations)
 - **Pre-existing Bugs Discovered** — bugs found during verification,
   not related to sprint fixes (Bug, Found During, Location, Severity)
-- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via the dual-lane
-  prelude in references/canonical-config-prelude.md §1 if you don't already
-  have it in your environment) + per-suite counts
+- **Test Suite Status** — `Command: $FULL_TEST_CMD` (canonical form —
+  maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
+  source) + per-suite counts
 
 **Append, don't overwrite** — new items go at the top of each domain
 section. Already-verified items stay as `✅`. Returning from a fix

--- a/.claude/skills/qe-audit/SKILL.md
+++ b/.claude/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.06.03+5bdda3"
+  version: "2026.06.03+050ebb"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -506,9 +506,9 @@ Run when `bash` IS present in arguments.
    - **ONLY use `todo` for bugs you just DISCOVERED during this bash
      session.** NEVER use `todo` to skip a test that was passing before
      and now fails due to your changes — that's weakening, not discovery.
-   - Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-     references/canonical-config-prelude.md §1 if you don't already have it in
-     your environment) before committing —
+   - Run `$FULL_TEST_CMD` (canonical form — maintainers: see
+     `references/canonical-config-prelude.md` §1 in the zskills source) before
+     committing —
      all suites must pass (todo-skipped tests are acceptable)
    - Commit all tests (passing + skipped) with descriptive message
 

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.03+8a2f39"
+  version: "2026.06.03+071829"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -541,9 +541,9 @@ If this phase used delegate execution, verification runs on **main**:
 1. **Verify commits landed** — check `git log --oneline -10` for the
    delegate's commits. If expected commits are missing, the delegate
    failed to land — invoke Failure Protocol.
-2. **Run `$FULL_TEST_CMD` on main** (resolve via the dual-lane prelude in
-   references/canonical-config-prelude.md §1 if you don't already have it in
-   your environment) — the delegate already tested, but
+2. **Run `$FULL_TEST_CMD` on main** (canonical form — maintainers: see
+   `references/canonical-config-prelude.md` §1 in the zskills source) — the
+   delegate already tested, but
    /run-plan verifies against the plan's acceptance criteria.
 3. **Check acceptance criteria** from the verbatim plan text — the delegate
    skill doesn't know the plan's criteria, only /run-plan does.

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+a0528a"
+  version: "2026.06.03+7c9f46"
 ---
 
 # Update Z Skills Infrastructure
@@ -805,22 +805,29 @@ Look in `.claude/hooks/` for these 2 files:
 
 ### Step 4 — Check scripts
 
-Look in `scripts/` for these files (all required by installed skills):
+Tier-1 machinery moved out of root `scripts/` and into the owning skill's
+mirror at `.claude/skills/<owner>/scripts/<name>` (see
+`references/script-ownership.md` for the authoritative tier → owner table).
+Check each Tier-1 script at its owner's path — NOT at root `scripts/`:
 
-- `port.sh`
-- `test-all.sh`
-- `briefing.py`
-- `clear-tracking.sh`
-- `land-phase.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for atomic post-landing cleanup
-- `post-run-invariants.sh` — referenced by `/run-plan` as mandatory end-of-run gate (7 invariants)
-- `write-landed.sh` — referenced by `/run-plan`, `/fix-issues`, `/commit` for rc-checked atomic `.landed` marker writes
-- `worktree-add-safe.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for safe worktree creation (discriminates fresh vs poisoned stale branches)
-- `create-worktree.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for unified worktree creation
-- `sanitize-pipeline-id.sh` — shared PIPELINE_ID sanitizer (used by `/run-plan`, `/fix-issues`, `/do`, `/quickfix` before persisting ID)
-- `apply-preset.sh` — required by the preset UX (Step F); **config-only** — updates `execution.landing`/`execution.main_protected` in config (the hook reads `main_protected` at runtime; apply-preset does not touch it)
-- `compute-cron-fire.sh` — required by `/run-plan` (Phase 5c chunked finish-auto, verify-pending retry, re-entry) for computing one-shot cron expressions with correct minute/hour/day/month/year rollover
-- `stop-dev.sh` — sanctioned SIGTERM-only dev-server stopper (reads `.zskills/dev-server.pid`). The approved way for agents to stop a dev server without reaching for `kill -9` / `fuser -k` / `lsof -ti | xargs kill`
-- `statusline.sh` — session statusline helper (optional but should be installed if the user has it)
+- `.claude/skills/update-zskills/scripts/port.sh`
+- `.claude/skills/briefing/scripts/briefing.py` — also checked in Step 5; the /briefing skill requires it
+- `.claude/skills/update-zskills/scripts/clear-tracking.sh`
+- `.claude/skills/commit/scripts/land-phase.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for atomic post-landing cleanup
+- `.claude/skills/run-plan/scripts/post-run-invariants.sh` — referenced by `/run-plan` as mandatory end-of-run gate (7 invariants)
+- `.claude/skills/commit/scripts/write-landed.sh` — referenced by `/run-plan`, `/fix-issues`, `/commit` for rc-checked atomic `.landed` marker writes
+- `.claude/skills/create-worktree/scripts/worktree-add-safe.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for safe worktree creation (discriminates fresh vs poisoned stale branches)
+- `.claude/skills/create-worktree/scripts/create-worktree.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for unified worktree creation
+- `.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh` — shared PIPELINE_ID sanitizer (used by `/run-plan`, `/fix-issues`, `/do`, `/quickfix` before persisting ID)
+- `.claude/skills/update-zskills/scripts/apply-preset.sh` — required by the preset UX (Step F); **config-only** — updates `execution.landing`/`execution.main_protected` in config (the hook reads `main_protected` at runtime; apply-preset does not touch it)
+- `.claude/skills/run-plan/scripts/compute-cron-fire.sh` — required by `/run-plan` (Phase 5c chunked finish-auto, verify-pending retry, re-entry) for computing one-shot cron expressions with correct minute/hour/day/month/year rollover
+- `.claude/skills/update-zskills/scripts/statusline.sh` — session statusline helper (optional but should be installed if the user has it)
+
+Tier-2 release/consumer-tooling stays at root `scripts/` (per
+`references/script-ownership.md`) — check these there:
+
+- `scripts/test-all.sh`
+- `scripts/stop-dev.sh` — sanctioned SIGTERM-only dev-server stopper (reads `.zskills/dev-server.pid`). The approved way for agents to stop a dev server without reaching for `kill -9` / `fuser -k` / `lsof -ti | xargs kill`
 
 ### Step 5 — Check skills with additional requirements
 

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.06.03+d1da63"
+  version: "2026.06.03+36645c"
 ---
 
 # /verify-changes [scope] — Verify, Test & Fix Changes
@@ -340,8 +340,9 @@ crashes with exactly that phrase across 2026-04-29 and 2026-04-30
 sessions. Always foreground-Bash with explicit long timeout; capture
 to file as below; read the file when the call returns.
 
-1. **Run the full test suite with output captured to a file** (resolve via the
-   dual-lane prelude in references/canonical-config-prelude.md §1):
+1. **Run the full test suite with output captured to a file** (canonical form —
+   maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
+   source):
    ```bash
    if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
      export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
@@ -570,9 +571,9 @@ If any issues were found in Phases 2-4:
 
 After fixing any issues in Phase 5:
 
-1. **Run `$FULL_TEST_CMD` again** (resolve via the dual-lane prelude in
-   references/canonical-config-prelude.md §1 if you don't already have it in
-   your environment) — all suites must pass, including new tests
+1. **Run `$FULL_TEST_CMD` again** (canonical form — maintainers: see
+   `references/canonical-config-prelude.md` §1 in the zskills source) — all
+   suites must pass, including new tests
 2. **Re-check manual verifications** if fixes touched UI code
 3. **If new problems are found**, go back to Phase 5
 
@@ -780,9 +781,9 @@ printf 'skill: verify-changes\nid: %s\nscope: %s\nstatus: complete\ndate: %s\n' 
 - **Fix, don't just report.** When problems are found, fix them — then re-verify.
   The goal is a clean verification, not a list of issues left for the user.
 - **Start a dev server if needed.** "No dev server" is not an excuse to
-  skip manual verification. Run `$DEV_SERVER_CMD &` (resolve via the dual-lane
-  prelude in references/canonical-config-prelude.md §1 if you don't already
-  have it in your environment) — it takes 2 seconds.
+  skip manual verification. Run `$DEV_SERVER_CMD &` (canonical form —
+  maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
+  source) — it takes 2 seconds.
   Only report "cannot verify" for genuinely unavailable tooling (e.g.,
   no cargo for codegen).
 - **Be thorough but honest.** If something genuinely can't be verified,

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.03+47adf9"
+  version: "2026.06.03+022278"
 ---
 
 # /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -998,9 +998,9 @@ Verification intensity matches the change type (from Phase 1):
 
 ### Code changes (js, css, html)
 
-- **Run `$FULL_TEST_CMD`** (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) — all suites must pass, not just unit tests.
+- **Run `$FULL_TEST_CMD`** (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) — all
+  suites must pass, not just unit tests.
   **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
   min); default 120000ms is shorter than the suite's runtime (~3-4
   min). Do NOT recover from a Bash timeout by retrying with

--- a/skills/do/modes/direct.md
+++ b/skills/do/modes/direct.md
@@ -84,9 +84,9 @@ fi
 
 **Commit discipline (Paths B and C):**
 - **On main (Path C):** commit when the work is complete. Clean, descriptive
-  message. `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) before committing if
+  message. `$FULL_TEST_CMD` (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) before
+  committing if
   code was touched. If tests fail after two fix attempts on the same error,
   STOP — report what you tried and let the user decide.
 - **In worktree (Path B):** the verification agent commits after tests pass.

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   newsletter entries (/doc newsletter). Use when the user asks to "write a
   newsletter entry", "add to the newsletter", or "update the newsletter".
 metadata:
-  version: "2026.05.31+b7e813"
+  version: "2026.06.03+509cf0"
 ---
 
 # /doc [blocks|examples|\<description>] — Documentation Audit & Fix
@@ -280,9 +280,9 @@ For each gap found:
 - Check all markdown formatting (links, images, tables)
 - Verify image references point to existing files
 - Verify model files load without errors (if dev server is up)
-- `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) if any code files
+- `$FULL_TEST_CMD` (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) if any
+  code files
   were touched (component explorer, registry file, docs-registry.js,
   examples-dropdown.js)
 
@@ -315,8 +315,8 @@ Remaining gaps:
 - **Update all cross-references** — a new example needs entries in
   component explorer, `examples/README.md`, and relevant block
   explorer entries. Don't create orphaned docs.
-- **`$FULL_TEST_CMD` before committing** (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) if code files were touched.
+- **`$FULL_TEST_CMD` before committing** (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) if code
+  files were touched.
 - **Content-only changes skip tests** — if only markdown/images were
   changed, no test run needed.

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.03+33f652"
+  version: "2026.06.03+bd2e69"
 ---
 
 # /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -378,9 +378,9 @@ Do not proceed until you have read the file.
 - **Never close GH issues, update trackers, or remove worktrees** — that's
   `/fix-report`'s job.
 - **One issue per commit** — clean git history in worktrees.
-- **`$FULL_TEST_CMD` before every commit** (resolve via the dual-lane prelude in
-  references/canonical-config-prelude.md §1 if you don't already have it in
-  your environment) — not just `npm test`.
+- **`$FULL_TEST_CMD` before every commit** (canonical form — maintainers: see
+  `references/canonical-config-prelude.md` §1 in the zskills source) — not
+  just `npm test`.
 - **Never weaken tests** — fix the code, not the test. Do not loosen
   tolerances, skip assertions, or remove test cases.
 - **Never defer the hard parts** — finish all phases of the plan. Do not

--- a/skills/fix-issues/modes/sprint.md
+++ b/skills/fix-issues/modes/sprint.md
@@ -1724,9 +1724,9 @@ Each agent follows this fix workflow:
 2. Reproduce the bug (unit test or manual)
 3. Implement the fix
 4. Write regression tests (unit and/or E2E as appropriate)
-5. Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-   references/canonical-config-prelude.md §1 if you don't already have it in
-   your environment) — all suites must pass.
+5. Run `$FULL_TEST_CMD` (canonical form — maintainers: see
+   `references/canonical-config-prelude.md` §1 in the zskills source) — all
+   suites must pass.
    **CRITICAL — Bash tool timeout:** invoke with `timeout: 600000` (10
    min). The default 120000ms is shorter than the suite's actual runtime
    (~3-4 min in zskills). **Do NOT recover from a timeout by retrying

--- a/skills/fix-report/SKILL.md
+++ b/skills/fix-report/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   worktrees. Covers $ZSKILLS_REPORTS_DIR/SPRINT_REPORT.md and any
   landed-but-unclosed issues from prior sprints.
 metadata:
-  version: "2026.06.03+a92e4f"
+  version: "2026.06.03+5b244a"
 ---
 
 # /fix-report — Sprint Report Review & Landing
@@ -473,9 +473,9 @@ not "3 fixes in category" but one per fix.
   synthetic event limitations)
 - **Pre-existing Bugs Discovered** — bugs found during verification,
   not related to sprint fixes (Bug, Found During, Location, Severity)
-- **Test Suite Status** — `Command: $FULL_TEST_CMD` (resolve via the dual-lane
-  prelude in references/canonical-config-prelude.md §1 if you don't already
-  have it in your environment) + per-suite counts
+- **Test Suite Status** — `Command: $FULL_TEST_CMD` (canonical form —
+  maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
+  source) + per-suite counts
 
 **Append, don't overwrite** — new items go at the top of each domain
 section. Already-verified items stay as `✅`. Returning from a fix

--- a/skills/qe-audit/SKILL.md
+++ b/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.06.03+5bdda3"
+  version: "2026.06.03+050ebb"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -506,9 +506,9 @@ Run when `bash` IS present in arguments.
    - **ONLY use `todo` for bugs you just DISCOVERED during this bash
      session.** NEVER use `todo` to skip a test that was passing before
      and now fails due to your changes — that's weakening, not discovery.
-   - Run `$FULL_TEST_CMD` (resolve via the dual-lane prelude in
-     references/canonical-config-prelude.md §1 if you don't already have it in
-     your environment) before committing —
+   - Run `$FULL_TEST_CMD` (canonical form — maintainers: see
+     `references/canonical-config-prelude.md` §1 in the zskills source) before
+     committing —
      all suites must pass (todo-skipped tests are acceptable)
    - Commit all tests (passing + skipped) with descriptive message
 

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.03+8a2f39"
+  version: "2026.06.03+071829"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -541,9 +541,9 @@ If this phase used delegate execution, verification runs on **main**:
 1. **Verify commits landed** — check `git log --oneline -10` for the
    delegate's commits. If expected commits are missing, the delegate
    failed to land — invoke Failure Protocol.
-2. **Run `$FULL_TEST_CMD` on main** (resolve via the dual-lane prelude in
-   references/canonical-config-prelude.md §1 if you don't already have it in
-   your environment) — the delegate already tested, but
+2. **Run `$FULL_TEST_CMD` on main** (canonical form — maintainers: see
+   `references/canonical-config-prelude.md` §1 in the zskills source) — the
+   delegate already tested, but
    /run-plan verifies against the plan's acceptance criteria.
 3. **Check acceptance criteria** from the verbatim plan text — the delegate
    skill doesn't know the plan's criteria, only /run-plan does.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+a0528a"
+  version: "2026.06.03+7c9f46"
 ---
 
 # Update Z Skills Infrastructure
@@ -805,22 +805,29 @@ Look in `.claude/hooks/` for these 2 files:
 
 ### Step 4 — Check scripts
 
-Look in `scripts/` for these files (all required by installed skills):
+Tier-1 machinery moved out of root `scripts/` and into the owning skill's
+mirror at `.claude/skills/<owner>/scripts/<name>` (see
+`references/script-ownership.md` for the authoritative tier → owner table).
+Check each Tier-1 script at its owner's path — NOT at root `scripts/`:
 
-- `port.sh`
-- `test-all.sh`
-- `briefing.py`
-- `clear-tracking.sh`
-- `land-phase.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for atomic post-landing cleanup
-- `post-run-invariants.sh` — referenced by `/run-plan` as mandatory end-of-run gate (7 invariants)
-- `write-landed.sh` — referenced by `/run-plan`, `/fix-issues`, `/commit` for rc-checked atomic `.landed` marker writes
-- `worktree-add-safe.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for safe worktree creation (discriminates fresh vs poisoned stale branches)
-- `create-worktree.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for unified worktree creation
-- `sanitize-pipeline-id.sh` — shared PIPELINE_ID sanitizer (used by `/run-plan`, `/fix-issues`, `/do`, `/quickfix` before persisting ID)
-- `apply-preset.sh` — required by the preset UX (Step F); **config-only** — updates `execution.landing`/`execution.main_protected` in config (the hook reads `main_protected` at runtime; apply-preset does not touch it)
-- `compute-cron-fire.sh` — required by `/run-plan` (Phase 5c chunked finish-auto, verify-pending retry, re-entry) for computing one-shot cron expressions with correct minute/hour/day/month/year rollover
-- `stop-dev.sh` — sanctioned SIGTERM-only dev-server stopper (reads `.zskills/dev-server.pid`). The approved way for agents to stop a dev server without reaching for `kill -9` / `fuser -k` / `lsof -ti | xargs kill`
-- `statusline.sh` — session statusline helper (optional but should be installed if the user has it)
+- `.claude/skills/update-zskills/scripts/port.sh`
+- `.claude/skills/briefing/scripts/briefing.py` — also checked in Step 5; the /briefing skill requires it
+- `.claude/skills/update-zskills/scripts/clear-tracking.sh`
+- `.claude/skills/commit/scripts/land-phase.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for atomic post-landing cleanup
+- `.claude/skills/run-plan/scripts/post-run-invariants.sh` — referenced by `/run-plan` as mandatory end-of-run gate (7 invariants)
+- `.claude/skills/commit/scripts/write-landed.sh` — referenced by `/run-plan`, `/fix-issues`, `/commit` for rc-checked atomic `.landed` marker writes
+- `.claude/skills/create-worktree/scripts/worktree-add-safe.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for safe worktree creation (discriminates fresh vs poisoned stale branches)
+- `.claude/skills/create-worktree/scripts/create-worktree.sh` — referenced by `/run-plan`, `/fix-issues`, `/do` for unified worktree creation
+- `.claude/skills/create-worktree/scripts/sanitize-pipeline-id.sh` — shared PIPELINE_ID sanitizer (used by `/run-plan`, `/fix-issues`, `/do`, `/quickfix` before persisting ID)
+- `.claude/skills/update-zskills/scripts/apply-preset.sh` — required by the preset UX (Step F); **config-only** — updates `execution.landing`/`execution.main_protected` in config (the hook reads `main_protected` at runtime; apply-preset does not touch it)
+- `.claude/skills/run-plan/scripts/compute-cron-fire.sh` — required by `/run-plan` (Phase 5c chunked finish-auto, verify-pending retry, re-entry) for computing one-shot cron expressions with correct minute/hour/day/month/year rollover
+- `.claude/skills/update-zskills/scripts/statusline.sh` — session statusline helper (optional but should be installed if the user has it)
+
+Tier-2 release/consumer-tooling stays at root `scripts/` (per
+`references/script-ownership.md`) — check these there:
+
+- `scripts/test-all.sh`
+- `scripts/stop-dev.sh` — sanctioned SIGTERM-only dev-server stopper (reads `.zskills/dev-server.pid`). The approved way for agents to stop a dev server without reaching for `kill -9` / `fuser -k` / `lsof -ti | xargs kill`
 
 ### Step 5 — Check skills with additional requirements
 

--- a/skills/verify-changes/SKILL.md
+++ b/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.06.03+d1da63"
+  version: "2026.06.03+36645c"
 ---
 
 # /verify-changes [scope] — Verify, Test & Fix Changes
@@ -340,8 +340,9 @@ crashes with exactly that phrase across 2026-04-29 and 2026-04-30
 sessions. Always foreground-Bash with explicit long timeout; capture
 to file as below; read the file when the call returns.
 
-1. **Run the full test suite with output captured to a file** (resolve via the
-   dual-lane prelude in references/canonical-config-prelude.md §1):
+1. **Run the full test suite with output captured to a file** (canonical form —
+   maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
+   source):
    ```bash
    if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
      export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
@@ -570,9 +571,9 @@ If any issues were found in Phases 2-4:
 
 After fixing any issues in Phase 5:
 
-1. **Run `$FULL_TEST_CMD` again** (resolve via the dual-lane prelude in
-   references/canonical-config-prelude.md §1 if you don't already have it in
-   your environment) — all suites must pass, including new tests
+1. **Run `$FULL_TEST_CMD` again** (canonical form — maintainers: see
+   `references/canonical-config-prelude.md` §1 in the zskills source) — all
+   suites must pass, including new tests
 2. **Re-check manual verifications** if fixes touched UI code
 3. **If new problems are found**, go back to Phase 5
 
@@ -780,9 +781,9 @@ printf 'skill: verify-changes\nid: %s\nscope: %s\nstatus: complete\ndate: %s\n' 
 - **Fix, don't just report.** When problems are found, fix them — then re-verify.
   The goal is a clean verification, not a list of issues left for the user.
 - **Start a dev server if needed.** "No dev server" is not an excuse to
-  skip manual verification. Run `$DEV_SERVER_CMD &` (resolve via the dual-lane
-  prelude in references/canonical-config-prelude.md §1 if you don't already
-  have it in your environment) — it takes 2 seconds.
+  skip manual verification. Run `$DEV_SERVER_CMD &` (canonical form —
+  maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
+  source) — it takes 2 seconds.
   Only report "cannot verify" for genuinely unavailable tooling (e.g.,
   no cargo for codegen).
 - **Be thorough but honest.** If something genuinely can't be verified,

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -3177,11 +3177,12 @@ echo "=== PROSE-IMPERATIVE substitution-discipline coverage (WI 5.7) ==="
 # zskills-resolve-config.sh, OR (b) a pointer to a per-skill canonical-
 # prelude config-read block (existing `CONFIG_CONTENT=$(cat ...)` pattern).
 #
-# Annotation form (Phase 2 added these inline alongside the migration):
+# Annotation form (Phase 2 added these inline alongside the migration;
+# #1049 reworded the client-facing breadcrumb to a maintainer note):
 #
-#     run `$FULL_TEST_CMD` (resolve via
-#       `. "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"`
-#       if you don't already have it in your environment) before committing.
+#     run `$FULL_TEST_CMD` (canonical form — maintainers: see
+#       `references/canonical-config-prelude.md` §1 in the zskills source)
+#       before committing.
 #
 # This test re-derives the migrated-site set at execution time (line
 # numbers drift across edits) so it stays robust as files change.
@@ -3243,10 +3244,18 @@ while IFS= read -r skill_file; do
           #     config — see X)` / `(resolve via X)` — the migration introduced
           #     these in lieu of inline helper-source where the surrounding
           #     fence already had a resolver.
+          # (d) maintainer-note pointer-prose: `(canonical form — maintainers:
+          #     see references/canonical-config-prelude.md §1 ...)` — #1049
+          #     reworded the client-facing `(resolve via ...)` breadcrumb into
+          #     an explicit maintainer note so it no longer reads as a path a
+          #     client resolves. The annotation discipline is unchanged: every
+          #     prose $VAR site still carries a nearby resolution annotation;
+          #     this form is the maintainer-facing spelling of it.
           if [[ "$wline" == *"zskills-resolve-config.sh"* ]] \
              || [[ "$wline" =~ CONFIG_CONTENT=\$\(cat ]] \
              || [[ "$wline" =~ \(resolved\ from\ config ]] \
-             || [[ "$wline" =~ \(resolve\ via ]]; then
+             || [[ "$wline" =~ \(resolve\ via ]] \
+             || [[ "$wline" =~ \(canonical\ form ]]; then
             found=1
             break
           fi


### PR DESCRIPTION
## Summary
Closes #1049. Two scoped, non-breaking doc-hygiene fixes.

**Item 1 — reword dangling `references/canonical-config-prelude.md` citations (7 skills, 9 files).** The prose presented `references/...` as a path a *client* resolves, but it dangles on both install lanes (legacy never installs `references/`; plugin has it only under `${CLAUDE_PLUGIN_ROOT}`). Reworded each citation to an explicit maintainer note — `(canonical form — maintainers: see references/canonical-config-prelude.md §1 in the zskills source)`. **Every inlined dual-lane resolution fence is preserved** (the load-bearing part); only the prose breadcrumb changed.

**Item 2 — fix stale "Step 4 — Check scripts" audit in `update-zskills/SKILL.md`.** It checked ~12 Tier-1 machinery files at root `scripts/`, but per `references/script-ownership.md` they live at `.claude/skills/<owner>/scripts/` (would false-report gaps on a healthy install). Rewrote Step 4 to check each Tier-1 script at its owner path, kept Tier-2 (`test-all.sh`, `stop-dev.sh`) at root `scripts/`, and dropped the duplicate root `briefing.py` entry (now consistent with Step 5).

## Test plan
- [x] `tests/test-skill-conformance.sh` 765/0 — including `PROSE-IMPERATIVE coverage: all 11 sites have nearby resolution-discipline annotation`. The conformance check was EXPANDED (added `(canonical form` to the accepted-annotation OR-chain), NOT weakened — coverage logic + vacuous-pass guard unchanged; still fails for any unannotated site. Verified independently.
- [x] Full suite 7601/7601 passing.
- [x] Source↔`.claude/` mirror byte-identical (11/11); `metadata.version` bumped for all 8 edited skills (do, doc, fix-issues, fix-report, qe-audit, run-plan, update-zskills, verify-changes).
- [x] Step-4 owners cross-checked against `references/script-ownership.md`.
