### PR TITLE
do: align doc skill-usage framing + add viewer favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,8 @@ RUN_E2E=1 bash tests/run-all.sh          # + e2e-parallel-pipelines
 
 These work on any software project — web app, CLI tool, API service, game,
 data pipeline. All are slash-invocable by the user. Two additional
-helper skills (`/land-pr`, `/create-worktree`) are dispatched internally
+helper skills (`/land-pr`, `/manual-testing`) are marked
+`user-invocable: false` (hidden from the `/` menu) and dispatched internally
 by other skills — see Helpers below.
 
 #### Plan
@@ -456,7 +457,7 @@ by other skills — see Helpers below.
 | Skill | Purpose |
 |-------|---------|
 | `/run-plan` | Phase-by-phase plan execution with worktree isolation, verification gates, and auto-landing |
-| `/do` | Lightweight task dispatcher for ad-hoc work with optional worktree/push/scheduling |
+| `/do` | Everyday workhorse for ad-hoc work (docs, fixes, refactors, content); optional worktree/push/scheduling |
 | `/quickfix` | Low-ceremony PR from main: picks up in-flight edits (or agent-dispatches), no worktree, fire-and-forget CI |
 
 #### Quality
@@ -465,7 +466,6 @@ by other skills — see Helpers below.
 |-------|---------|
 | `/verify-changes` | 7-phase verification: diff review, test coverage audit, test run, manual UI check, fix, re-verify |
 | `/qe-audit` | Quality audit of recent commits — find test gaps, edge cases, file issues |
-| `/manual-testing` | Playwright-cli recipes: real mouse/keyboard events, not eval — test as a user would |
 
 #### Fix
 
@@ -486,13 +486,14 @@ by other skills — see Helpers below.
 | `/cleanup-merged` | Post-PR-merge normalization: fetch+prune, checkout main, pull, delete local feature branches whose PRs have merged |
 | `/doc` | Documentation audit, gap-filling, and changelog/newsletter entries |
 | `/update-zskills` | Install or update Z Skills infrastructure in any project |
+| `/create-worktree` | Unified worktree creation. Primarily dispatched internally by `/run-plan`, `/fix-issues`, `/do` (which pass `--pipeline-id` verbatim — the script rejects invocations without the flag, rc 5); invocable directly but rarely needed. |
 
-#### Helpers (internal — dispatched by other skills, not designed for direct user invocation)
+#### Helpers (`user-invocable: false` — hidden from the `/` menu, dispatched by other skills)
 
 | Skill | Purpose |
 |-------|---------|
 | `/land-pr` | PR landing helper — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched by `/run-plan`, `/commit pr`, `/do pr`, `/fix-issues`, and `/quickfix`. `user-invocable: false` hides it from the `/` menu. |
-| `/create-worktree` | Unified worktree creation. Tier 1 caller (bash inside `/run-plan`, `/fix-issues`, `/do`) must pass `--pipeline-id` verbatim — the script rejects invocations without the flag (rc 5). Tier 2 user/Claude invocation works ad-hoc but is rarely needed in practice. |
+| `/manual-testing` | Playwright-cli UI-verification recipes (real mouse/keyboard events). `user-invocable: false`; dispatched by `/verify-changes`. |
 
 ### Block Diagram Add-on (`block-diagram/`)
 

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4fc3f7"/>
+      <stop offset="50%" stop-color="#2196f3"/>
+      <stop offset="100%" stop-color="#7c4dff"/>
+    </linearGradient>
+  </defs>
+  <text x="16" y="26" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif" font-size="28" font-weight="700" fill="url(#g)">Z</text>
+</svg>

--- a/docs/guides/installing-zskills.md
+++ b/docs/guides/installing-zskills.md
@@ -37,6 +37,11 @@ upgrade, the plugin refreshes them. If you've edited one of these files
 yourself, your edited copy is left alone. See
 [`.gitignore` guidance](#gitignore-guidance) for whether to track them.
 
+By default the plugin install lands work in **`locked-main-pr`** mode
+(`execution.landing: pr`, `main_protected: true`): agents don't commit to
+`main` directly — finished work ships as a pull request from a worktree on a
+feature branch. To change it, see [Landing mode](#landing-mode).
+
 ## `/update-zskills` install
 
 Clone the repo, copy the skills into `.claude/skills/`, then run the installer

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -6,14 +6,18 @@ argument list, see the [per-skill reference](../skills/README.md).
 
 ## Philosophy
 
-Z Skills matches the skill to the work — not the other way around. A typo
-fix runs through `/quickfix` or `/do`; a backlog of small bugs through
-`/fix-issues`; a feature whose approach still needs to be worked out gets
-`/draft-plan` first; a broad goal that splits into several dependent
-sub-plans gets `/research-and-plan`. Plans are the exception, not the
-default — reach for `/draft-plan` only when the work has open design
-questions or needs to be staged into ordered phases, not just because it
-touches a lot of files.
+Z Skills matches the skill to the work — not the other way around. The
+everyday workhorse is `/do` (with its co-equal peer `/quickfix`): when you
+can describe the change and its approach is clear, `/do` it — whatever the
+size, from a typo to a wide refactor to plumbing a new UI element. A backlog
+of bugs to clear runs through `/fix-issues`. Reach for `/draft-plan` **freely**
+— lean toward it on a genuine toss-up — whenever the work has open design to
+work out or needs to be staged into ordered phases. A broad goal that splits
+into several dependent sub-plans gets `/research-and-plan`.
+
+The axis is **design-depth / staging, not file-count**: thirty files changed
+by one settled approach is still a `/do`; one change with unresolved design is
+a `/draft-plan`.
 
 **Your changes are checked before they land**, whichever skill you pick:
 tests run, a separate review pass re-checks the work, and nothing reaches
@@ -39,7 +43,29 @@ when needed; otherwise the configured default applies.
 
 ---
 
-## 1. Plan-driven feature
+## 1. Everyday change — just `/do` it
+
+**When:** Any change you can describe whose approach is clear — a doc edit, a
+bug fix, a refactor, a new UI element, a content update. This is the workhorse
+you reach for most; most "just ask Claude" work runs through it.
+
+```text
+/do "<task>" pr          # worktree-isolated; required when main is protected
+# or, only when main is NOT protected:
+/quickfix "<task>"       # in-place on main, no worktree
+```
+
+- `/do` and `/quickfix` are **peers, not tiers** — same lifecycle (triage →
+  review → commit → PR → land) and same one-commit-PR shape. The only
+  difference is *where the work tree lives*.
+- Choose by **project policy, not task size**: `main_protected: true`
+  projects must use `/do` (it isolates work in a worktree); `/quickfix` edits
+  in place on `main` and is valid only when `main_protected: false`.
+- "Lightweight" means **no staged phases and no open design** — *not* "small."
+  A wide but settled change is still a `/do`; reach for `/draft-plan` only when
+  the design is open or the work needs to be staged into ordered phases.
+
+## 2. Plan-driven feature
 
 **When:** You have a goal and want a reviewed plan before any code is written.
 
@@ -57,7 +83,7 @@ when needed; otherwise the configured default applies.
   next one) and `auto` lets it land each phase autonomously, so you can walk
   away. Drop `finish auto` to step through one phase at a time.
 
-## 2. Plan with test specs
+## 3. Plan with test specs
 
 **When:** You want test coverage designed into the plan up front, not bolted on.
 
@@ -75,7 +101,7 @@ when needed; otherwise the configured default applies.
   (design dialogue) or `quiz` (requirements interview) before `/draft-tests`
   appends test specs.
 
-## 3. Big goal decomposition
+## 4. Big goal decomposition
 
 **When:** The goal is too large for one plan and decomposes into several
 dependent sub-plans.
@@ -98,7 +124,7 @@ Or, to draft **and** execute everything in one autonomous pass:
 - `/research-and-go` uses the same drafting machinery but continues straight
   into execution. Use it when you've said "walk away."
 
-## 4. Mid-flight plan drift
+## 5. Mid-flight plan drift
 
 **When:** A plan is partway executed and reality has diverged from the spec.
 
@@ -112,7 +138,7 @@ Or, to draft **and** execute everything in one autonomous pass:
   original design.
 - Resume `/run-plan` to execute the corrected remaining phases.
 
-## 5. Backlog bug sprint
+## 6. Backlog bug sprint
 
 **When:** You have several small bugs or issues to clear in one batch.
 
@@ -127,7 +153,7 @@ Or, to draft **and** execute everything in one autonomous pass:
 - `/fix-report` walks the sprint results, gates landing on your review of each
   manual verification, lands the fixes, and closes the GitHub issues.
 
-## 6. Unclear bug → root cause
+## 7. Unclear bug → root cause
 
 **When:** Something is broken but the root cause is not yet proven.
 
@@ -141,23 +167,6 @@ Or, to draft **and** execute everything in one autonomous pass:
 - Once the root cause is known, ship the fix with `/do pr` (worktree) or
   `/quickfix` (no worktree) — the fix is now a known change, not an
   investigation.
-
-## 7. Small ad-hoc change
-
-**When:** A one-commit change you can describe directly, no plan needed.
-
-```text
-/do "<task>" pr          # worktree-isolated; required when main is protected
-# or, only when main is NOT protected:
-/quickfix "<task>"       # in-place on main, no worktree
-```
-
-- `/do` and `/quickfix` are **peers, not tiers** — same lifecycle (triage →
-  review → commit → PR → land) and same one-commit-PR shape. The only
-  difference is *where the work tree lives*.
-- Choose by **project policy, not task size**: `main_protected: true`
-  projects must use `/do` (it isolates work in a worktree); `/quickfix` edits
-  in place on `main` and is valid only when `main_protected: false`.
 
 ## 8. Pre-commit quality gate
 
@@ -189,20 +198,18 @@ Or, to draft **and** execute everything in one autonomous pass:
 
 ## 10. Proactive coverage
 
-**When:** You want to find test gaps before they bite, or verify UI behavior
-in a real browser.
+**When:** You want to find test gaps before they bite.
 
 ```text
 /qe-audit
-/manual-testing
 ```
 
 - `/qe-audit` proactively scans the repo for test-coverage gaps and likely
   bugs and **files GitHub issues** — it generates work, where
   `/verify-changes` only gates your current changes.
-- `/manual-testing` gives browser-based verification recipes (driven by
-  `playwright-cli`) for confirming user-facing behavior with real
-  mouse/keyboard events.
+- `/manual-testing` is an internal helper you don't run directly —
+  `/verify-changes` dispatches it to verify UI behavior with real
+  mouse/keyboard events (`playwright-cli`).
 
 ## 11. Status & monitoring
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Z Skills — Documentation</title>
+  <link rel="icon" type="image/svg+xml" href="./favicon.svg">
   <!--
     FOUC-prevention inline script. MUST run before the <link rel="stylesheet">
     below so the [data-theme="..."] selector on <html> is in place by first

--- a/docs/skills/do.md
+++ b/docs/skills/do.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-`/do` runs one small, self-contained task end to end: it researches the change, makes it, verifies it, and (when you ask) lands it. It is meant for work that doesn't warrant the heavier ceremony of `/run-plan` (multi-phase plans) or `/fix-issues` (batch bug fixing) — documentation, examples, small refactors, one-off fixes, and content updates.
+`/do` is the everyday workhorse: it takes a single self-contained task and runs it end to end — researching the change, making it, verifying it, and (when you ask) landing it. "Lightweight" here is relative to `/draft-plan`, not a size limit: it means no multi-phase plan and no open design to work out, *not* "small." Documentation, examples, refactors, a new UI element, plumbing new UI, one-off fixes, and content updates all fit. What sends a task elsewhere is unresolved design or work that needs staging into ordered phases (`/draft-plan`), or an issue backlog to clear (`/fix-issues`) — never the number of files touched.
 
 Given a plain-English description, `/do` first checks that the task is actually a good fit for it. If the description spans several unrelated areas, names many files, or asks for a feature-scale change, `/do` redirects you to a better skill (`/draft-plan` for plan-scale work, `/run-plan` when you point at an existing plan file) instead of attempting it. If the description is too vague to act on, it asks you to make it concrete. You can override a redirect with `--force`.
 

--- a/docs/skills/manual-testing.md
+++ b/docs/skills/manual-testing.md
@@ -1,11 +1,17 @@
 # /manual-testing
 
-> Support skill that helps playwright-cli interact with a UI the way a user would — clicking menus, click-and-dragging elements on canvases, typing into inputs, using keyboard shortcuts — and documents workarounds where playwright-cli is too limited to mimic a particular user action.
+> **An internal helper — you don't call this one directly.** `/manual-testing`
+> is marked `user-invocable: false`, so typing it at the slash prompt gets you
+> nowhere. Other skills — most often [`/verify-changes`](verify-changes.md) —
+> dispatch it behind the scenes when they need to confirm a UI change works by
+> driving the real interface the way a person would.
 
-`/manual-testing` is an **internal helper**, not a user-facing command
-(`user-invocable: false`). Other skills — most often `/verify-changes` —
-dispatch it when they need to confirm a UI change works by driving the real
-interface the way a person would.
+## What it does
+
+`/manual-testing` helps playwright-cli interact with a UI the way a user would —
+clicking menus, click-and-dragging elements on canvases, typing into inputs,
+using keyboard shortcuts — and documents workarounds where playwright-cli is too
+limited to mimic a particular user action.
 
 ## Prerequisites
 

--- a/docs/skills/work-on-plans.md
+++ b/docs/skills/work-on-plans.md
@@ -46,7 +46,7 @@ Run bare, it lists the ready queue. Give it a number to run that many plans from
 - **`/run-plan`** — the executor `/work-on-plans` calls for each plan. `/work-on-plans` is the batch driver; `/run-plan` does the actual phase-by-phase work on one plan. When you only have one plan to run, use `/run-plan` directly.
 - **`/plans`** — the read-only plan dashboard. Check `/plans` first to review what's ready and in what order before kicking off a batch.
 - **`/draft-plan`** — produces the plan files in the first place. A plan has to be drafted and marked ready before `/work-on-plans` will run it.
-- **`/zskills-dashboard`** — the interactive status UI for in-flight pipelines; it reads the same ready queue `/work-on-plans` drains, and is where you can interactively prioritize it.
+- **`/zskills-dashboard`** — the interactive status UI for in-flight pipelines; it surfaces the same ready queue `/work-on-plans` drains as the plan board's **Accepted** column. Drag a plan into Accepted (or out of it) to control what the next run picks up.
 - **`/fix-issues`** — the bug-backlog counterpart. Same batch-and-schedule shape, but it drives issues instead of plans.
 
 ## Arguments
@@ -132,4 +132,5 @@ Cancel the active recurring schedule.
 - Recurring `finish`-mode schedules require intervals of at least an hour; `phase` mode has no minimum.
 - A plan must be drafted and marked ready before `/work-on-plans` will run it — `/draft-plan` and `/plans` are how plans get there.
 - If a queued plan's file is missing, `/work-on-plans` stops and tells you instead of silently skipping it, so you can remove the stale entry.
+- The ready queue (its internal name) shows up on the `/zskills-dashboard` plan board as the **Accepted** column — drag plans into Accepted to enqueue them and reorder within it to set priority.
 - `/work-on-plans` does not choose how each plan lands — `/run-plan` decides that from its own configuration.

--- a/tests/test-doc-viewer-shell.sh
+++ b/tests/test-doc-viewer-shell.sh
@@ -94,11 +94,13 @@ assert_count_ge() {
   fi
 }
 
-# Password gate / newsletter / robots / favicon — all stripped.
+# Password gate / newsletter / robots — all stripped. The favicon is now
+# linked (Z glyph for the doc viewer) and asserted present below.
 assert_count_eq "index.html: no zl-gate" "$INDEX_HTML" "zl-gate" 0
 assert_count_eq "index.html: no Password gate comment" "$INDEX_HTML" "Password gate" 0
 assert_count_eq "index.html: no robots meta" "$INDEX_HTML" 'name="robots"' 0
-assert_count_eq "index.html: no favicon.svg" "$INDEX_HTML" "favicon.svg" 0
+assert_count_ge "index.html: favicon.svg linked" "$INDEX_HTML" "favicon.svg" 1
+assert_count_eq "index.html: favicon link tag present" "$INDEX_HTML" 'rel="icon"' 1
 
 # CSS path: absolute /docs/docs.css replaced with sibling-relative ./docs.css.
 assert_count_eq "index.html: no absolute /docs/docs.css" "$INDEX_HTML" 'href="/docs/docs.css"' 0


### PR DESCRIPTION
Surgical framing-consistency cleanup of the already-merged docs/ catalog (no rewrite — only the when-to-use / sizing / workflow-ordering layer), plus a Z favicon for the doc viewer and a root-README helper-taxonomy fix. Grounded in the verified skill-usage model (workhorse `/do`, reach-for-`/draft-plan`-freely, design-depth-not-file-count).

## Docs framing
- **workflows.md** — Philosophy drops the "plans are the exception" framing; recipes reordered so the everyday `/do` | `/quickfix` change is **#1**; `/manual-testing` removed from a user-typed code block and reframed as an internal helper `/verify-changes` dispatches.
- **do.md** — de-sized "What it does": "Lightweight" = relative to `/draft-plan` (no staged phases / open design), not "small."
- **installing-zskills.md** — restored the plugin **locked-main-pr** default landing callout (verified in `hooks/session-start-materialise.sh`).
- **manual-testing.md** — bold internal-helper lead-in matching `land-pr.md`.
- **work-on-plans.md** — clarifies the ready queue surfaces as the plan board's **Accepted** column.

## README
- Helper-taxonomy fix: `/manual-testing` (user-invocable:false) moved Quality → Helpers; `/create-worktree` (invocable) moved Helpers → Utility. Counts unchanged: **23 user-facing + 2 helpers = 25** (verified: the only two `user-invocable:false` skills are `/land-pr` and `/manual-testing`). "25 core skills" and "3 block-diagram add-ons" confirmed correct.

## Favicon
- New `docs/favicon.svg` (the Z gradient glyph) + `<link rel="icon">` in the viewer head; flipped the now-superseded `test-doc-viewer-shell.sh` favicon-absent assertion to require the favicon link. Browser-verified: `GET /favicon.svg → 200`.

Full suite: **7602/7602 passed** (+1 vs baseline, from the favicon assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
