### PR TITLE
do: de-advertise stale landing tokens from skill hints

### DIFF
--- a/.claude/skills/briefing/SKILL.md
+++ b/.claude/skills/briefing/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: briefing
-argument-hint: "[report [period]] | verify | current | worktrees | [summary] | stop | next"
+argument-hint: "[report [period]] | verify | current | worktrees | [summary] | [every SCHEDULE] | stop | next"
 description: >-
   Generate a project briefing: worktree status, open checkboxes, recent commits.
   Modes: summary (default), report, verify, current, worktrees. Period: 1h, 6h, 24h, 2d, 7d.
 metadata:
-  version: "2026.06.03+d7f19f"
+  version: "2026.06.03+feab1d"
 ---
 
 # /briefing — Project Status Briefing

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: do
-argument-hint: "<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.03+022278"
+  version: "2026.06.03+c894ed"
 ---
 
-# /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or autonomous landing. Can be scheduled for recurring maintenance

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fix-issues
 disable-model-invocation: true
-argument-hint: "N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next"
+argument-hint: "N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next"
 description: >-
   Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue
   worktrees, verify, optionally auto-land via /land-pr. Recurring via
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.03+bd2e69"
+  version: "2026.06.03+8fdd72"
 ---
 
-# /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
+# /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
 
 Orchestrates large-scale bug fixing. Syncs trackers, prioritizes issues,
 dispatches agent teams in worktrees, verifies fixes, writes a persistent

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: investigate
 disable-model-invocation: false
-argument-hint: "<description or #issue>"
+argument-hint: "<description> | #<issue>"
 description: >-
   Deep debugging for one complex bug at a time. Disciplined workflow:
   reproduce, trace, state root cause, fix, verify. The agent must PROVE
   root-cause understanding before writing a fix.
 metadata:
-  version: "2026.06.03+e8151e"
+  version: "2026.06.03+ce9bb4"
 ---
 
-# /investigate \<description or #issue> — Root-Cause Debugging
+# /investigate \<description> | #<issue> — Root-Cause Debugging
 
 Systematic investigation of a single bug that's too complex for batch
 fixing. Enforces discipline: you must SEE the bug, TRACE the cause,

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [phase|finish|status] [auto] [pr|direct] [every SCHEDULE] [now] | stop | next"
+argument-hint: "<plan-file> [phase|finish|status] [auto] [every SCHEDULE] [now] | stop | next"
 description: >-
   Execute the next phase of a plan: parse status, dispatch implementation
   in a worktree, verify via a separate agent, update progress, write the
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.03+071829"
+  version: "2026.06.03+7d0000"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: briefing
-argument-hint: "[report [period]] | verify | current | worktrees | [summary] | stop | next"
+argument-hint: "[report [period]] | verify | current | worktrees | [summary] | [every SCHEDULE] | stop | next"
 description: >-
   Generate a project briefing: worktree status, open checkboxes, recent commits.
   Modes: summary (default), report, verify, current, worktrees. Period: 1h, 6h, 24h, 2d, 7d.
 metadata:
-  version: "2026.06.03+d7f19f"
+  version: "2026.06.03+feab1d"
 ---
 
 # /briefing — Project Status Briefing

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: do
-argument-hint: "<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.03+022278"
+  version: "2026.06.03+c894ed"
 ---
 
-# /do \<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--force] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or autonomous landing. Can be scheduled for recurring maintenance

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fix-issues
 disable-model-invocation: true
-argument-hint: "N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next"
+argument-hint: "N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next"
 description: >-
   Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue
   worktrees, verify, optionally auto-land via /land-pr. Recurring via
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.03+bd2e69"
+  version: "2026.06.03+8fdd72"
 ---
 
-# /fix-issues N [focus|dashboard] [auto] [every SCHEDULE] [now] [pr|direct] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
+# /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
 
 Orchestrates large-scale bug fixing. Syncs trackers, prioritizes issues,
 dispatches agent teams in worktrees, verifies fixes, writes a persistent

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: investigate
 disable-model-invocation: false
-argument-hint: "<description or #issue>"
+argument-hint: "<description> | #<issue>"
 description: >-
   Deep debugging for one complex bug at a time. Disciplined workflow:
   reproduce, trace, state root cause, fix, verify. The agent must PROVE
   root-cause understanding before writing a fix.
 metadata:
-  version: "2026.06.03+e8151e"
+  version: "2026.06.03+ce9bb4"
 ---
 
-# /investigate \<description or #issue> — Root-Cause Debugging
+# /investigate \<description> | #<issue> — Root-Cause Debugging
 
 Systematic investigation of a single bug that's too complex for batch
 fixing. Enforces discipline: you must SEE the bug, TRACE the cause,

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [phase|finish|status] [auto] [pr|direct] [every SCHEDULE] [now] | stop | next"
+argument-hint: "<plan-file> [phase|finish|status] [auto] [every SCHEDULE] [now] | stop | next"
 description: >-
   Execute the next phase of a plan: parse status, dispatch implementation
   in a worktree, verify via a separate agent, update progress, write the
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.03+071829"
+  version: "2026.06.03+7d0000"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor


### PR DESCRIPTION
Task: De-advertise stale landing-mode tokens from skill argument-hints (UI only; no behavior/parsing changes): do/run-plan/fix-issues drop worktree/pr/direct from hint+H1, fix-issues focus|dashboard -> <focus>|dashboard, investigate reformat, briefing adds [every SCHEDULE]; metadata.version bumped on all 5.

UI-only cleanup of skill argument-hints — no behavior or argument-parsing
changes (worktree/pr/direct are still accepted, just de-advertised). Edits
touch the frontmatter `argument-hint:` line and the H1 title line of each
skill; the in-body Arguments sections / parse logic are unchanged.
metadata.version bumped on all 5 edited skills; `.claude/skills/` mirrors synced.
Full suite: 7602/7602 passing.

Worktree: /tmp/zskills-do-deadvertise-hint-tokens
Commits:
070697b docs(skills): de-advertise stale arg-hint tokens in 5 skills' usage strings
