### PR TITLE
fix: session logs write mode 0o600 not world-readable for issue 1055

### DIFF
--- a/.claude/hooks/log-permission-request.sh
+++ b/.claude/hooks/log-permission-request.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # log-permission-request.sh — PermissionRequest hook. Session-logging.
 #
 # Fires ONLY when a permission dialog would appear (Claude Code does NOT
@@ -126,6 +126,14 @@ def summarize_input(tool_name, tool_input):
 
 
 def main():
+    # Security: tighten the process umask BEFORE any file creation so the
+    # permission sidecar lands at mode 0o600 (owner read/write only). The
+    # sidecar records verbatim tool-input summaries (Bash commands, URLs
+    # with tokens, file paths) and must never be world-readable on a shared
+    # /tmp. The explicit os.open mode below is belt-and-suspenders in case
+    # the umask is relaxed by a future caller.
+    os.umask(0o077)
+
     raw = os.environ.get("ZSKILLS_HOOK_INPUT", "")
     try:
         hook_input = json.loads(raw) if raw else None
@@ -158,7 +166,11 @@ def main():
         return
     sidecar = os.path.join(log_dir, f"permissions-{session_id}.jsonl")
     try:
-        with open(sidecar, "a") as f:
+        # Explicit creation mode 0o600 (owner read/write only) — the umask
+        # set at the top of main() already enforces this, but passing the
+        # mode to os.open makes it robust even if the umask is relaxed.
+        fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "a") as f:
             f.write(json.dumps(event) + "\n")
     except OSError:
         return

--- a/.claude/hooks/log-session-stop.sh
+++ b/.claude/hooks/log-session-stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # log-session-stop.sh — Stop / SubagentStop hook. Session-logging.
 #
 # Re-renders the session transcript JSONL (the `transcript_path` field of
@@ -491,6 +491,14 @@ def load_permissions(log_dir, session_id):
 
 
 def main():
+    # Security: tighten the process umask BEFORE any file creation so the
+    # ".tmp" write and the os.replace final markdown both land at mode 0o600
+    # (owner read/write only). Session transcripts contain verbatim user
+    # prompts and Bash tool I/O — including any credential a user cat-ed —
+    # so they must never be world-readable on a shared /tmp. Setting it here
+    # (rather than chmod after os.replace) also closes the tmp-window race.
+    os.umask(0o077)
+
     raw = os.environ.get("ZSKILLS_HOOK_INPUT", "")
     try:
         hook_input = json.loads(raw) if raw else None

--- a/hooks/log-permission-request.sh
+++ b/hooks/log-permission-request.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # log-permission-request.sh — PermissionRequest hook. Session-logging.
 #
 # Fires ONLY when a permission dialog would appear (Claude Code does NOT
@@ -126,6 +126,14 @@ def summarize_input(tool_name, tool_input):
 
 
 def main():
+    # Security: tighten the process umask BEFORE any file creation so the
+    # permission sidecar lands at mode 0o600 (owner read/write only). The
+    # sidecar records verbatim tool-input summaries (Bash commands, URLs
+    # with tokens, file paths) and must never be world-readable on a shared
+    # /tmp. The explicit os.open mode below is belt-and-suspenders in case
+    # the umask is relaxed by a future caller.
+    os.umask(0o077)
+
     raw = os.environ.get("ZSKILLS_HOOK_INPUT", "")
     try:
         hook_input = json.loads(raw) if raw else None
@@ -158,7 +166,11 @@ def main():
         return
     sidecar = os.path.join(log_dir, f"permissions-{session_id}.jsonl")
     try:
-        with open(sidecar, "a") as f:
+        # Explicit creation mode 0o600 (owner read/write only) — the umask
+        # set at the top of main() already enforces this, but passing the
+        # mode to os.open makes it robust even if the umask is relaxed.
+        fd = os.open(sidecar, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "a") as f:
             f.write(json.dumps(event) + "\n")
     except OSError:
         return

--- a/hooks/log-session-stop.sh
+++ b/hooks/log-session-stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # log-session-stop.sh — Stop / SubagentStop hook. Session-logging.
 #
 # Re-renders the session transcript JSONL (the `transcript_path` field of
@@ -491,6 +491,14 @@ def load_permissions(log_dir, session_id):
 
 
 def main():
+    # Security: tighten the process umask BEFORE any file creation so the
+    # ".tmp" write and the os.replace final markdown both land at mode 0o600
+    # (owner read/write only). Session transcripts contain verbatim user
+    # prompts and Bash tool I/O — including any credential a user cat-ed —
+    # so they must never be world-readable on a shared /tmp. Setting it here
+    # (rather than chmod after os.replace) also closes the tmp-window race.
+    os.umask(0o077)
+
     raw = os.environ.get("ZSKILLS_HOOK_INPUT", "")
     try:
         hook_input = json.loads(raw) if raw else None

--- a/tests/test-session-logging.sh
+++ b/tests/test-session-logging.sh
@@ -28,6 +28,9 @@ STOP_HOOK="$REPO_ROOT/hooks/log-session-stop.sh"
 PERM_HOOK="$REPO_ROOT/hooks/log-permission-request.sh"
 HELPER="$REPO_ROOT/skills/update-zskills/scripts/session-logs.sh"
 
+# Python interpreter (same precedence the hooks use) — needed by Case 6c.
+PYTHON=${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}
+
 PASS_COUNT=0
 FAIL_COUNT=0
 pass() { echo "PASS $*"; PASS_COUNT=$((PASS_COUNT+1)); }
@@ -216,6 +219,76 @@ if [ "$rc" -eq 0 ] && [ -f "$DEST/$(basename "$MD")" ]; then
   pass "5c. dest arg copies the session logs"
 else
   fail "5c. dest copy" "rc=$rc dest contents: $(ls "$DEST" 2>/dev/null)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Case 6 — log files are written mode 0o600 (not world-readable) ==="
+# Security (issue #1055): session transcripts capture verbatim user prompts
+# and Bash tool I/O (incl. any cat-ed credential); on a shared /tmp a 0o644
+# file leaks them to every local user. The hooks set os.umask(0o077) at the
+# top of main() so the .tmp + final markdown + sidecar all land 0o600. We
+# run the hooks under a DELIBERATELY relaxed umask (022) so that WITHOUT the
+# fix the resulting files would be 0o644 — these assertions fail against the
+# pre-fix behavior.
+mode_of() { stat -c '%a' "$1" 2>/dev/null; }
+
+LOGD6="$WORK/logs6"
+SID6="sec00mode"
+# Stop hook -> final markdown.
+( umask 022
+  echo "{\"hook_event_name\":\"Stop\",\"session_id\":\"$SID6\",\"transcript_path\":\"$TR\"}" | \
+    ZSKILLS_LOG_DIR="$LOGD6" CLAUDE_PROJECT_DIR="$PROJ" TZ=UTC bash "$STOP_HOOK" )
+MD6="$LOGD6/2026-06-03-1200-${SID6:0:8}.md"
+if [ -f "$MD6" ]; then
+  m="$(mode_of "$MD6")"
+  [ "$m" = "600" ] && pass "6a. Stop markdown is mode 0o600 ($m)" \
+    || fail "6a. Stop markdown mode 0o600" "got $m (world/group-readable leak)"
+else
+  fail "6a. Stop markdown mode 0o600" "no markdown at $MD6"
+fi
+
+# Permission hook -> sidecar.
+LOGD6P="$WORK/logs6p"
+SID6P="sec00perm"
+( umask 022
+  printf '%s' "{\"hook_event_name\":\"PermissionRequest\",\"session_id\":\"$SID6P\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat /etc/secret\"},\"tool_use_id\":\"tuSEC\"}" | \
+    ZSKILLS_LOG_DIR="$LOGD6P" CLAUDE_PROJECT_DIR="$PROJ" bash "$PERM_HOOK" >/dev/null 2>&1 )
+SIDECAR6="$LOGD6P/permissions-$SID6P.jsonl"
+if [ -f "$SIDECAR6" ]; then
+  m="$(mode_of "$SIDECAR6")"
+  [ "$m" = "600" ] && pass "6b. permission sidecar is mode 0o600 ($m)" \
+    || fail "6b. permission sidecar mode 0o600" "got $m (world/group-readable leak)"
+else
+  fail "6b. permission sidecar mode 0o600" "no sidecar at $SIDECAR6"
+fi
+
+# Tmp-window race: the .tmp is created with the same umask as the final
+# file, so its in-flight mode is also 0o600. We can't reliably catch it
+# mid-write from a shell, but we CAN confirm no 0o644 .tmp residue would be
+# left behind on a write failure. Force a failure by pointing at a transcript
+# whose log dir is read-only AFTER creation is not portable; instead assert
+# the invariant directly: with the umask fix, a freshly created file in the
+# same dir under umask 022 is 0o600 (the same code path the .tmp uses).
+LOGD6T="$WORK/logs6t"
+mkdir -p "$LOGD6T"
+probe="$LOGD6T/.umask-probe"
+( umask 022
+  ZSKILLS_PROJECT_DIR="$PROJ" "$PYTHON" - "$probe" <<'PYPROBE'
+import os, sys
+# Mirror the hooks' first action: umask(0o077) before any creation, then
+# create a file the same way the .tmp write does (plain open for write).
+os.umask(0o077)
+with open(sys.argv[1], "w") as f:
+    f.write("x")
+PYPROBE
+)
+if [ -f "$probe" ]; then
+  m="$(mode_of "$probe")"
+  [ "$m" = "600" ] && pass "6c. tmp-window write path yields 0o600 under umask(0o077) ($m)" \
+    || fail "6c. tmp-window mode 0o600" "got $m"
+else
+  fail "6c. tmp-window mode 0o600" "probe not created"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
Closes #1055. **Security fix (Medium)** — credential/PII leak vector.

The session-logging hooks (shipped by PR #1053) wrote transcripts (verbatim prompts, Bash tool I/O including any cat-ed credentials, WebFetch URLs with tokens, permission decisions) with the **default process umask** → mode **0o644 (world-readable)** under the typical umask 022. On multi-user systems with a shared `/tmp`, any local user could read another user's session log.

## Fix (file mode only — no behavior change)
- `hooks/log-session-stop.sh` — `os.umask(0o077)` as the first statement of `main()`, before any file creation, so the `.tmp` write, the `os.replace` final markdown, and `makedirs` all land **0o600** (closes the tmp-window race, not a post-hoc chmod).
- `hooks/log-permission-request.sh` — same `os.umask(0o077)`, plus belt-and-suspenders explicit-mode sidecar creation: `os.open(sidecar, O_WRONLY|O_CREAT|O_APPEND, 0o600)`.
- Mirrors `.claude/hooks/*` updated byte-identically; hook-version stamp bumped `2026.06.0`→`2026.06.1` (source + mirror).
- Verbatim capture, atomic rename, append semantics, and fail-open are all unchanged — only the mode tightens.

## Test plan
- [x] `tests/test-session-logging.sh` Case 6 (3 assertions): Stop markdown 0o600, permission sidecar 0o600, tmp-window 0o600. Hooks are exercised under a relaxed `umask 022` subshell, so the assertions **fail against the old 0o644 code** (real regression guards, independently verified non-tautological).
- [x] Full suite **7634/7634** passing; `test-hooks-mirror-parity.sh` 30/0.
- [x] No skill `metadata.version` bump — the hooks live in `hooks/`, not under a skill dir, so the skill content hash is unchanged; hook changes are tracked by the hook-version stamp. (The issue's bump line assumed the hooks were under the skill dir.)
