### PR TITLE
do: simplify displayed argument-hints in 6 skills

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: do
-argument-hint: "<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.03+c894ed"
+  version: "2026.06.03+87b14f"
 ---
 
-# /do \<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or autonomous landing. Can be scheduled for recurring maintenance

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: doc
 disable-model-invocation: true
-argument-hint: "[blocks|examples|newsletter|<description>]"
+argument-hint: "<description>"
 description: >-
   Audit and fix documentation gaps: block library entries, example models,
   getting-started guides, presentations, README updates. Also handles
   newsletter entries (/doc newsletter). Use when the user asks to "write a
   newsletter entry", "add to the newsletter", or "update the newsletter".
 metadata:
-  version: "2026.06.03+509cf0"
+  version: "2026.06.03+7cdafd"
 ---
 
-# /doc [blocks|examples|\<description>] — Documentation Audit & Fix
+# /doc \<description> — Documentation Audit & Fix
 
 Finds documentation gaps and fills them. Can audit all blocks, all examples,
 or document a specific feature. Knows the project's documentation structure

--- a/.claude/skills/draft-tests/SKILL.md
+++ b/.claude/skills/draft-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-tests
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
 description: >-
   Draft test specifications into an existing plan through iterative
   adversarial review. Appends a `### Tests` subsection per pending phase
@@ -9,10 +9,10 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.06.03+fd8ce9"
+  version: "2026.06.03+a3e088"
 ---
 
-# /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
+# /draft-tests \<plan-file> [rounds N] [<guidance>] — Adversarial Test-Spec Drafter
 
 Sister skill to `/draft-plan`: same drafting + adversarial-review
 machinery, scoped to test specifications. Given the path to an existing

--- a/.claude/skills/refine-plan/SKILL.md
+++ b/.claude/skills/refine-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
 description: >-
   Refine an in-progress plan by reviewing remaining phases against
   completed work. Dispatches reviewer + devil's-advocate agents to surface
@@ -9,10 +9,10 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.06.03+122677"
+  version: "2026.06.03+be05a3"
 ---
 
-# /refine-plan \<plan-file> [rounds N] [guidance...] — Adversarial Plan Refiner
+# /refine-plan \<plan-file> [rounds N] [<guidance>] — Adversarial Plan Refiner
 
 Refines an existing plan that is partially executed. Completed phases
 represent real, shipped work — they are **immutable context**, never

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: update-zskills
-argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
+argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+3ee2e0"
+  version: "2026.06.03+891bc8"
 ---
 
 # Update Z Skills Infrastructure

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: verify-changes
 disable-model-invocation: false
-argument-hint: "[scope: worktree | branch | last [N]]"
+argument-hint: "[<scope> | last [N]]"
 description: >-
   Verify all recent changes: review diffs, check that unit/e2e tests cover
   the changes, run all tests, manually verify UI changes with
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.06.03+36645c"
+  version: "2026.06.03+05fb9c"
 ---
 
-# /verify-changes [scope] — Verify, Test & Fix Changes
+# /verify-changes [<scope> | last [N]] — Verify, Test & Fix Changes
 
 Thoroughly verify all recent changes in the working tree (or a specified scope).
 Reviews diffs, checks test coverage, runs tests, manually verifies UI changes,

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: do
-argument-hint: "<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.03+c894ed"
+  version: "2026.06.03+87b14f"
 ---
 
-# /do \<description> [auto] [every SCHEDULE] [now] [--rounds N] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
+# /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
 
 Execute small, ad-hoc tasks with structured research, verification, and
 optional isolation or autonomous landing. Can be scheduled for recurring maintenance

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: doc
 disable-model-invocation: true
-argument-hint: "[blocks|examples|newsletter|<description>]"
+argument-hint: "<description>"
 description: >-
   Audit and fix documentation gaps: block library entries, example models,
   getting-started guides, presentations, README updates. Also handles
   newsletter entries (/doc newsletter). Use when the user asks to "write a
   newsletter entry", "add to the newsletter", or "update the newsletter".
 metadata:
-  version: "2026.06.03+509cf0"
+  version: "2026.06.03+7cdafd"
 ---
 
-# /doc [blocks|examples|\<description>] — Documentation Audit & Fix
+# /doc \<description> — Documentation Audit & Fix
 
 Finds documentation gaps and fills them. Can audit all blocks, all examples,
 or document a specific feature. Knows the project's documentation structure

--- a/skills/draft-tests/SKILL.md
+++ b/skills/draft-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-tests
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
 description: >-
   Draft test specifications into an existing plan through iterative
   adversarial review. Appends a `### Tests` subsection per pending phase
@@ -9,10 +9,10 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.06.03+fd8ce9"
+  version: "2026.06.03+a3e088"
 ---
 
-# /draft-tests \<plan-file> [rounds N] [guidance...] — Adversarial Test-Spec Drafter
+# /draft-tests \<plan-file> [rounds N] [<guidance>] — Adversarial Test-Spec Drafter
 
 Sister skill to `/draft-plan`: same drafting + adversarial-review
 machinery, scoped to test specifications. Given the path to an existing

--- a/skills/refine-plan/SKILL.md
+++ b/skills/refine-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [guidance...]"
+argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
 description: >-
   Refine an in-progress plan by reviewing remaining phases against
   completed work. Dispatches reviewer + devil's-advocate agents to surface
@@ -9,10 +9,10 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.06.03+122677"
+  version: "2026.06.03+be05a3"
 ---
 
-# /refine-plan \<plan-file> [rounds N] [guidance...] — Adversarial Plan Refiner
+# /refine-plan \<plan-file> [rounds N] [<guidance>] — Adversarial Plan Refiner
 
 Refines an existing plan that is partially executed. Completed phases
 represent real, shipped work — they are **immutable context**, never

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: update-zskills
-argument-hint: "[install] [cherry-pick|locked-main-pr|direct]"
+argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+3ee2e0"
+  version: "2026.06.03+891bc8"
 ---
 
 # Update Z Skills Infrastructure

--- a/skills/verify-changes/SKILL.md
+++ b/skills/verify-changes/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: verify-changes
 disable-model-invocation: false
-argument-hint: "[scope: worktree | branch | last [N]]"
+argument-hint: "[<scope> | last [N]]"
 description: >-
   Verify all recent changes: review diffs, check that unit/e2e tests cover
   the changes, run all tests, manually verify UI changes with
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.06.03+36645c"
+  version: "2026.06.03+05fb9c"
 ---
 
-# /verify-changes [scope] — Verify, Test & Fix Changes
+# /verify-changes [<scope> | last [N]] — Verify, Test & Fix Changes
 
 Thoroughly verify all recent changes in the working tree (or a specified scope).
 Reviews diffs, checks test coverage, runs tests, manually verifies UI changes,

--- a/tests/test-draft-tests.sh
+++ b/tests/test-draft-tests.sh
@@ -107,8 +107,8 @@ fi
 
 expect_skill_matches "AC-1.1: frontmatter name"               '^name:[[:space:]]+draft-tests'
 expect_skill_matches "AC-1.1: frontmatter disable-model-invocation" '^disable-model-invocation:[[:space:]]+false'
-expect_skill_matches "AC-1.1: frontmatter argument-hint with [auto] [guidance...]" \
-  '^argument-hint:[[:space:]]+"<plan-file>[[:space:]]+\[rounds N\][[:space:]]+\[auto\][[:space:]]+\[guidance\.\.\.\]"'
+expect_skill_matches "AC-1.1: frontmatter argument-hint with [auto] [<guidance>]" \
+  '^argument-hint:[[:space:]]+"<plan-file>[[:space:]]+\[rounds N\][[:space:]]+\[auto\][[:space:]]+\[<guidance>\]"'
 expect_skill_matches "AC-1.1: frontmatter description"        '^description:'
 
 # ----------------------------------------------------------------------

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -1830,9 +1830,9 @@ echo "=== /draft-tests — behavior contracts (WI 6.3) ==="
 # here in tandem; AC-6.2 is a list-membership invariant, not a literal
 # count. WI 6.3 is the authoritative enumeration source.
 #
-# 1. Frontmatter shape (incl. `[guidance...]` positional tail in argument-hint)
-check       draft-tests "frontmatter argument-hint with [auto] [guidance...]" \
-  '^argument-hint:[[:space:]]+"<plan-file> \[rounds N\] \[auto\] \[guidance\.\.\.\]"'
+# 1. Frontmatter shape (incl. `[<guidance>]` positional tail in argument-hint)
+check       draft-tests "frontmatter argument-hint with [auto] [<guidance>]" \
+  '^argument-hint:[[:space:]]+"<plan-file> \[rounds N\] \[auto\] \[<guidance>\]"'
 # 2. Tracking marker basename matches canonical scheme `fulfilled.draft-tests.<id>`
 check_fixed draft-tests "fulfilled marker basename" \
   'fulfilled.draft-tests.$TRACKING_ID'
@@ -3667,8 +3667,9 @@ echo "=== weak-skill static invariants — doc / qe-audit / session-report ==="
 # qe-audit's `## Files to change` is already asserted at the #681 section
 # above, so it is NOT re-asserted here.)
 
-# doc — documented modes present in argument-hint/mode prose + invocation flag.
-check_fixed doc "argument-hint lists blocks|examples|newsletter modes" '[blocks|examples|newsletter|<description>]'
+# doc — compact argument-hint is just <description>; modes stay documented
+# in the body (mode-prose checks below), de-advertised from the hint.
+check_fixed doc "argument-hint is compact <description>" 'argument-hint: "<description>"'
 check_fixed doc "mode prose: /doc blocks"      '/doc blocks'
 check_fixed doc "mode prose: /doc examples"    '/doc examples'
 check_fixed doc "mode prose: /doc newsletter"  '/doc newsletter'


### PR DESCRIPTION
Task: Display-only cleanup of skill argument-hints — simplify the compact hint surface (frontmatter `argument-hint:` + H1 title) across 6 skills. NO behavior or argument-parsing changes; all tokens/modes still parse.

Edits:
- do: move `[--rounds N]` up next to `<description>` (it read as scheduling-adjacent at the end)
- doc: compact hint → `<description>` (blocks/examples/newsletter still parse + stay documented in the body)
- refine-plan, draft-tests: `[guidance...]` → `[<guidance>]`
- update-zskills: reorder install modes → `[locked-main-pr|direct|cherry-pick]`
- verify-changes: drop `scope:` label → `[<scope> | last [N]]`

metadata.version bumped on all 6; `.claude/skills/` mirrors synced. Two conformance assertions (doc, draft-tests) updated to the new expected hint literals (expected-value updates, not weakening — verified). Full suite: 7631/7631.

Worktree: /tmp/zskills-do-simplify-arg-hints
Commits:
cfc708b docs: simplify skill argument-hints (display-only) + version bumps
