### PR TITLE
do: self-ref dev marketplace; translate to prod on publish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   "description": "Z Skills — agent-discipline skill framework",
   "version": "1",
   "plugins": [
-    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "main" } },
+    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills-dev", "ref": "main" } },
     { "name": "zsbd", "source": "./block-diagram" }
   ]
 }

--- a/DEV-QUAL.md
+++ b/DEV-QUAL.md
@@ -105,19 +105,33 @@ writing the 5 consumer artifacts, and **no `.claude/skills/` mirror**.
   carries the `.claude/skills/` mirror — the dogfooding exception, case 3 in
   the mental model — so it does NOT validate mirror-less resolution. Use
   Scenario 5 for that.)
-- For the **real consumer path**: a marketplace install
-  (`/plugin marketplace add zeveck/zskills` → `/plugin install zs@zskills`)
-  in a clean consumer repo — the marketplace install resolves, clones, and
-  caches the plugin tree, then the SessionStart materialiser seeds the
-  consumer artifacts.
+- For the **genuine PRE-PUBLISH consumer path**: the dev manifest
+  self-references the dev repo, so qual uses the SAME two-line flow a real
+  consumer runs — just pointed at `zeveck/zskills-dev` instead of the
+  not-yet-published `zeveck/zskills`:
+  ```
+  /plugin marketplace add zeveck/zskills-dev
+  /plugin install zs@zskills
+  ```
+  run in a clean consumer repo. The marketplace install resolves the dev
+  manifest, clones + caches the dev plugin tree, then the SessionStart
+  materialiser seeds the consumer artifacts — no hand-rolled local test
+  marketplace needed. (POST-publish, the same flow against `zeveck/zskills`
+  is what end consumers run; the publish path rewrites `zs` `source.repo`
+  dev→prod — see RELEASING.md "Marketplace self-reference, translated on
+  publish".)
 
 **Steps.**
-1. Launch the plugin-loaded session:
+1. Launch the plugin-loaded session. Either in-place dogfood, or — for the
+   genuine pre-publish consumer flow — the two-line dev-marketplace install:
    ```bash
    claude --plugin-dir .        # in-place dogfood from zskills-dev
    ```
-   (Real consumers instead use the `/plugin marketplace add` +
-   `/plugin install zs@zskills` flow.)
+   ```
+   # genuine pre-publish consumer path (in a CLEAN consumer repo):
+   /plugin marketplace add zeveck/zskills-dev
+   /plugin install zs@zskills
+   ```
 2. Confirm the plugin loaded: the skills are namespaced under `/zs:`
    (e.g. `/zs:do`, `/zs:fix-issues`).
 3. On SessionStart, `hooks/session-start-materialise.sh` runs. In a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,18 +53,41 @@ Release steps:
    skills/hooks and re-renders `managed.md`). The CHANGELOG entry is the
    per-line summary for both.
 
+### Marketplace self-reference, translated on publish
+
+The dev manifest's `zs` `source.repo` SELF-REFERENCES the dev repo
+(`zeveck/zskills-dev`), NOT prod. This is deliberate: it lets pre-publish
+plugin qual use the GENUINE consumer flow — `/plugin marketplace add
+zeveck/zskills-dev` + `/plugin install zs@zskills` — against the dev repo's own
+manifest, instead of a hand-rolled local test marketplace. On publish the prod
+tree must instead point consumers at prod, so the build path REWRITES it,
+exactly analogous to the dev→prod URL rewrite: the shared finalizer
+(`scripts/_lib/finalize-prod-tree.sh`) runs `rewrite_marketplace_repo` over the
+prod tree's `.claude-plugin/marketplace.json`, swapping `zeveck/zskills-dev` →
+`zeveck/zskills` in ONLY the `zs` `source.repo` field (a field-scoped Python
+round-trip, NOT a blanket sed; `ref`, `source.source`, and the `zsbd`
+`./block-diagram` source are untouched). A **residue invariant** immediately
+after the rewrite asserts the built manifest carries ZERO `zskills-dev` (bare
+substring) and `return 1`s the build if any survives — and because
+`build-prod.sh` runs `set -euo pipefail`, that aborts the publish BEFORE any
+push. `tests/test-build-rewrite-marketplace-repo.sh` unit-tests the rewrite,
+and `tests/test-prod-tree-no-dev-urls.sh` asserts the BUILT tree's manifest is
+prod-pointing.
+
 ### Cross-lane invariant
 
 For `/plugin marketplace add zeveck/zskills` **without an explicit ref**,
 Claude Code reads `marketplace.json` from the prod repo's **default branch,
 `main`** — which is exactly where the button publishes. No special default-
 branch setting is needed: prod's default branch is `main` (correct), the
-button pushes to `main`, and `marketplace.json`'s `zs` `source.ref` is `main`.
-The pin-by-version idiom is the bare `<version>` tag the button pushes (e.g.
-`2026.06.0`, NOT `prod/2026.06.0`). `tests/test-plugin-ref-consistency.sh`
-guards this consistency (marketplace ref ↔ workflow push branch ↔ docs pin
-idiom); `tests/test-plugin-d4-hook-siblings.sh` guards that `build-prod.sh`'s
-published tree actually contains the D4 hook siblings.
+button pushes to `main`, and the PUBLISHED `marketplace.json`'s `zs`
+`source.ref` is `main` (the publish-time `rewrite_marketplace_repo` changes
+ONLY `source.repo`, never `ref`). The pin-by-version idiom is the bare
+`<version>` tag the button pushes (e.g. `2026.06.0`, NOT `prod/2026.06.0`).
+`tests/test-plugin-ref-consistency.sh` guards this consistency (marketplace ref
+↔ workflow push branch ↔ docs pin idiom — and `source.ref` is identical in dev
+and prod since only `source.repo` is translated); `tests/test-plugin-d4-hook-siblings.sh`
+guards that `build-prod.sh`'s published tree actually contains the D4 hook siblings.
 
 ## TL;DR
 

--- a/scripts/_lib/finalize-prod-tree.sh
+++ b/scripts/_lib/finalize-prod-tree.sh
@@ -113,6 +113,60 @@ rewrite_dev_urls() {
   fi
 }
 
+# rewrite_marketplace_repo <marketplace-json-path>
+#
+# Translate the DEV marketplace manifest to its PROD form on publish. The dev
+# repo's .claude-plugin/marketplace.json self-references the dev repo so that
+# pre-publish plugin qual uses the genuine consumer flow
+# (`/plugin marketplace add zeveck/zskills-dev` + `/plugin install zs@zskills`).
+# On publish the prod tree must instead point consumers at the prod repo, so
+# this function rewrites ONLY the `zs` plugin's `source.repo` field from
+# `zeveck/zskills-dev` back to `zeveck/zskills`. This is the bare-SLUG analog of
+# rewrite_dev_urls (which only matches URL forms `github.com/...`); the
+# marketplace manifest carries the bare slug `"repo": "zeveck/zskills-dev"`,
+# which the URL-anchored regex would never touch.
+#
+# A field-scoped Python json load/mutate/dump is used (NOT a blanket sed across
+# the file) so `ref`, `source.source`, the `zsbd` `./block-diagram` source, the
+# marketplace `name`/`version`/`$schema`, and key ordering survive intact — a
+# clean round-trip that changes ONLY that one value. Idempotent: a no-op when
+# the file is already prod-pointing (or has no `zs` github source). Defined at
+# file scope so the function unit test
+# (tests/test-build-rewrite-marketplace-repo.sh) can source this lib and call
+# it directly, exactly as tests/test-build-rewrite-dev-urls.sh does with
+# rewrite_dev_urls.
+rewrite_marketplace_repo() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  local PYTHON
+  PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+  [ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; return 1; }
+  "$PYTHON" - "$file" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+DEV = "zeveck/zskills-dev"
+PROD = "zeveck/zskills"
+
+with open(path) as f:
+    mp = json.load(f)
+
+changed = False
+for p in mp.get("plugins", []):
+    if not isinstance(p, dict) or p.get("name") != "zs":
+        continue
+    src = p.get("source")
+    if isinstance(src, dict) and src.get("source") == "github" and src.get("repo") == DEV:
+        src["repo"] = PROD
+        changed = True
+
+if changed:
+    with open(path, "w") as f:
+        json.dump(mp, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+PY
+}
+
 finalize_prod_tree() {
   local tree="$1"
   local self_script="${2:-}"
@@ -184,6 +238,28 @@ finalize_prod_tree() {
   done < <(cd "$tree" && find docs skills .claude README.md CHANGELOG.md \
                 \( -name '*.md' -o -name '*.html' -o -name '*.js' -o -name '*.json' \) \
                 -type f -print0 2>/dev/null | while IFS= read -r -d '' rel; do printf '%s\0' "$tree/$rel"; done)
+
+  # ── 4. Marketplace dev→prod repo rewrite (self-reference translation) ─────
+  # The dev manifest's `zs` source.repo self-references zeveck/zskills-dev so
+  # pre-publish plugin qual uses the genuine consumer flow. On publish the prod
+  # tree must point consumers at zeveck/zskills. .claude-plugin/ is NOT in the
+  # tree-walk above (find docs skills .claude README.md CHANGELOG.md), so invoke
+  # the field-scoped rewrite explicitly on the manifest (guard for existence).
+  local _mp="$tree/.claude-plugin/marketplace.json"
+  if [ -f "$_mp" ]; then
+    _fpt_log "rewriting marketplace zs source.repo dev→prod in $_mp"
+    rewrite_marketplace_repo "$_mp"
+    # Residue invariant (safety guard): the published marketplace manifest must
+    # carry ZERO `zskills-dev` — a BARE substring match (NOT the URL-anchored
+    # regex the dev-URL checks use; the bare slug would slip past a
+    # `github.com/...` regex). build-prod.sh runs `set -euo pipefail`, so this
+    # non-zero return aborts the publish before any push.
+    if grep -q 'zskills-dev' "$_mp"; then
+      echo "finalize_prod_tree: ERROR — prod marketplace manifest still contains 'zskills-dev': $_mp" >&2
+      return 1
+    fi
+    _fpt_done "marketplace zs source.repo is prod-pointing (0 zskills-dev residue)"
+  fi
 
   # If the caller is build-prod.sh finalizing IN-PLACE, its own running
   # script matched the build-*.sh strip above and is already gone. The

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -275,6 +275,7 @@ run_suite "test-plugin-mirrorless-resolution.sh" "tests/test-plugin-mirrorless-r
 run_suite "test-plugin-d4-hook-siblings.sh" "tests/test-plugin-d4-hook-siblings.sh"
 # #1002 — dev→prod URL rewrite + strip parity in the shared finalizer.
 run_suite "test-build-rewrite-dev-urls.sh" "tests/test-build-rewrite-dev-urls.sh"
+run_suite "test-build-rewrite-marketplace-repo.sh" "tests/test-build-rewrite-marketplace-repo.sh"
 run_suite "test-prod-tree-no-dev-urls.sh" "tests/test-prod-tree-no-dev-urls.sh"
 run_suite "test-build-prod-strip-parity.sh" "tests/test-build-prod-strip-parity.sh"
 run_suite "test-plugin-hooks-integrity.sh" "tests/test-plugin-hooks-integrity.sh"

--- a/tests/test-build-rewrite-marketplace-repo.sh
+++ b/tests/test-build-rewrite-marketplace-repo.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# tests/test-build-rewrite-marketplace-repo.sh
+#
+# Unit test for the SHARED rewrite_marketplace_repo helper in
+# scripts/_lib/finalize-prod-tree.sh. The dev repo's marketplace.json
+# self-references the dev repo (zeveck/zskills-dev) so pre-publish plugin qual
+# uses the genuine consumer flow; the publish path must translate the `zs`
+# plugin's source.repo back to the prod slug (zeveck/zskills). This sources the
+# lib, calls the function on fixture marketplace.json files, and asserts:
+#
+#   - dev slug (zeveck/zskills-dev) → prod slug (zeveck/zskills)
+#   - `ref: "main"` is left untouched
+#   - the `zsbd` `./block-diagram` relative-path source is left untouched
+#   - top-level name / version / $schema survive the round-trip
+#   - idempotent: a second call is a no-op
+#   - a fixture that is ALREADY prod-pointing is left unchanged
+#
+# Mirrors the pass/fail/exit-$FAIL_COUNT harness of
+# tests/test-build-rewrite-dev-urls.sh.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+[ -n "$PYTHON" ] || { echo "ERROR: install Python 3 (or set ZSKILLS_PYTHON)" >&2; exit 1; }
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+# Source the shared finalizer so rewrite_marketplace_repo is in scope.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/_lib/finalize-prod-tree.sh"
+
+if ! declare -F rewrite_marketplace_repo >/dev/null; then
+  fail "0. rewrite_marketplace_repo not defined after sourcing finalize-prod-tree.sh"
+  printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" 1
+  exit 1
+fi
+pass "0. rewrite_marketplace_repo is defined after sourcing the finalizer"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# field <file> <python-expr-on-mp> — read a field out of a marketplace.json via
+# Python json so assertions are structural, not substring-based.
+field() {
+  "$PYTHON" - "$1" "$2" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    mp = json.load(f)
+by = {p.get("name"): p for p in mp.get("plugins", []) if isinstance(p, dict)}
+print(eval(sys.argv[2], {"mp": mp, "by": by}))
+PY
+}
+
+# write_dev_fixture <path> — the dev-pointing manifest (self-reference form).
+write_dev_fixture() {
+  cat > "$1" <<'JSON'
+{
+  "$schema": "https://anthropic.com/schemas/claude-plugin-marketplace.json",
+  "name": "zskills",
+  "owner": { "name": "Rich Conlan", "url": "https://github.com/zeveck" },
+  "description": "Z Skills — agent-discipline skill framework",
+  "version": "1",
+  "plugins": [
+    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills-dev", "ref": "main" } },
+    { "name": "zsbd", "source": "./block-diagram" }
+  ]
+}
+JSON
+}
+
+# write_prod_fixture <path> — the already-prod-pointing manifest.
+write_prod_fixture() {
+  cat > "$1" <<'JSON'
+{
+  "$schema": "https://anthropic.com/schemas/claude-plugin-marketplace.json",
+  "name": "zskills",
+  "owner": { "name": "Rich Conlan", "url": "https://github.com/zeveck" },
+  "description": "Z Skills — agent-discipline skill framework",
+  "version": "1",
+  "plugins": [
+    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills", "ref": "main" } },
+    { "name": "zsbd", "source": "./block-diagram" }
+  ]
+}
+JSON
+}
+
+# ── 1. dev slug → prod slug, ref + zsbd + top-level fields untouched ──────────
+MP="$TMP/dev.json"
+write_dev_fixture "$MP"
+rewrite_marketplace_repo "$MP"
+
+if [ "$(field "$MP" 'by["zs"]["source"]["repo"]')" = "zeveck/zskills" ]; then
+  pass "1a. zs source.repo rewritten dev → prod (zeveck/zskills)"
+else
+  fail "1a. zs source.repo not rewritten to zeveck/zskills"
+fi
+if ! grep -q 'zskills-dev' "$MP"; then
+  pass "1b. no 'zskills-dev' bare-slug residue after rewrite"
+else
+  fail "1b. 'zskills-dev' still present after rewrite"
+fi
+if [ "$(field "$MP" 'by["zs"]["source"]["ref"]')" = "main" ]; then
+  pass "1c. zs source.ref left untouched (main)"
+else
+  fail "1c. zs source.ref changed (must stay 'main')"
+fi
+if [ "$(field "$MP" 'by["zs"]["source"]["source"]')" = "github" ]; then
+  pass "1d. zs source.source left untouched (github)"
+else
+  fail "1d. zs source.source changed (must stay 'github')"
+fi
+if [ "$(field "$MP" 'by["zsbd"]["source"]')" = "./block-diagram" ]; then
+  pass "1e. zsbd source './block-diagram' relative path untouched"
+else
+  fail "1e. zsbd source changed (must stay './block-diagram')"
+fi
+if [ "$(field "$MP" 'mp["name"]')" = "zskills" ] \
+   && [ "$(field "$MP" 'mp["version"]')" = "1" ] \
+   && [ "$(field "$MP" 'mp["$schema"]')" = "https://anthropic.com/schemas/claude-plugin-marketplace.json" ]; then
+  pass "1f. top-level name / version / \$schema survive the round-trip"
+else
+  fail "1f. top-level name / version / \$schema mangled by the round-trip"
+fi
+
+# ── 2. Idempotent: second call is a no-op ────────────────────────────────────
+AFTER_FIRST="$(cat "$MP")"
+rewrite_marketplace_repo "$MP"
+if [ "$(cat "$MP")" = "$AFTER_FIRST" ]; then
+  pass "2. idempotent: second call is a no-op"
+else
+  fail "2. idempotent: second call changed the file"
+fi
+
+# ── 3. Already-prod fixture is left unchanged ────────────────────────────────
+PRODMP="$TMP/prod.json"
+write_prod_fixture "$PRODMP"
+PROD_BEFORE="$(cat "$PRODMP")"
+rewrite_marketplace_repo "$PRODMP"
+if [ "$(cat "$PRODMP")" = "$PROD_BEFORE" ]; then
+  pass "3a. already-prod fixture: left byte-identical (no spurious rewrite)"
+else
+  fail "3a. already-prod fixture: was modified despite being prod-pointing"
+fi
+if [ "$(field "$PRODMP" 'by["zs"]["source"]["repo"]')" = "zeveck/zskills" ]; then
+  pass "3b. already-prod fixture: zs source.repo remains zeveck/zskills"
+else
+  fail "3b. already-prod fixture: zs source.repo no longer zeveck/zskills"
+fi
+
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+exit "$FAIL_COUNT"

--- a/tests/test-plugin-marketplace.sh
+++ b/tests/test-plugin-marketplace.sh
@@ -70,11 +70,16 @@ out(set(by_name) == {"zs", "zsbd"},
 
 # zs source — github object form accepted by the current validator:
 # { "source": "github", "repo": ..., "ref": ... }
+# This test runs against the DEV tree, whose manifest SELF-REFERENCES the dev
+# repo (zeveck/zskills-dev) so pre-publish plugin qual uses the genuine consumer
+# flow. The publish path (scripts/_lib/finalize-prod-tree.sh's
+# rewrite_marketplace_repo) translates this to zeveck/zskills in the prod tree;
+# tests/test-prod-tree-no-dev-urls.sh asserts the BUILT tree is prod-pointing.
 zs = by_name.get("zs", {})
 zs_src = zs.get("source")
 ok_zs = (isinstance(zs_src, dict)
          and zs_src.get("source") == "github"
-         and zs_src.get("repo") == "zeveck/zskills"
+         and zs_src.get("repo") == "zeveck/zskills-dev"
          and zs_src.get("ref") == "main")
 out(ok_zs, "marketplace: zs source is github {source,repo,ref}", repr(zs_src))
 

--- a/tests/test-prod-tree-no-dev-urls.sh
+++ b/tests/test-prod-tree-no-dev-urls.sh
@@ -107,6 +107,50 @@ assert_prod_url() {
   fi
 }
 
+# assert_marketplace_prod <label> <tree-dir>
+# The dev marketplace.json self-references the dev repo (zeveck/zskills-dev);
+# the publish path (finalize_prod_tree → rewrite_marketplace_repo) must
+# translate the `zs` source.repo back to zeveck/zskills in the BUILT tree.
+# DEV_URL_RE above is URL-only and will NOT catch the bare slug, so this uses a
+# BARE-substring `zskills-dev` check (mirroring the build-time residue
+# invariant) plus a structural zs source.repo assertion via Python json.
+assert_marketplace_prod() {
+  local label="$1" tree="$2"
+  local mp="$tree/.claude-plugin/marketplace.json"
+  if [ ! -f "$mp" ]; then
+    fail "$label: marketplace.json missing from built tree: $mp"
+    return
+  fi
+  # (i) zero bare 'zskills-dev' substring.
+  local hits
+  hits="$(grep -c 'zskills-dev' "$mp" 2>/dev/null || true)"
+  if [ "$hits" = "0" ]; then
+    pass "$label: 0 bare 'zskills-dev' hits in built marketplace.json"
+  else
+    fail "$label: built marketplace.json still contains 'zskills-dev' ($hits hit(s))"
+  fi
+  # (ii) zs source.repo == zeveck/zskills (structural, via Python json).
+  local PYTHON repo
+  PYTHON="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+  repo="$("$PYTHON" - "$mp" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    mp = json.load(f)
+for p in mp.get("plugins", []):
+    if isinstance(p, dict) and p.get("name") == "zs":
+        src = p.get("source")
+        if isinstance(src, dict):
+            print(src.get("repo", ""))
+        break
+PY
+)"
+  if [ "$repo" = "zeveck/zskills" ]; then
+    pass "$label: built marketplace zs source.repo == zeveck/zskills"
+  else
+    fail "$label: built marketplace zs source.repo is '$repo' (want zeveck/zskills)"
+  fi
+}
+
 # ── A. build-plugin-release.sh → its own STAGE (git ls-tree on the prod ref) ──
 echo "=== A. build-plugin-release.sh staged tree carries no dev URLs ==="
 PR_STAGE="$TMP/plugin-stage"
@@ -127,6 +171,7 @@ if snapshot_worktree_repo "$PR_CLONE"; then
       "$PR_STAGE/skills/run-plan/SKILL.md"
     assert_prod_url "A.inspecting-and-monitoring.md demo URL" \
       "$PR_STAGE/docs/guides/inspecting-and-monitoring.md"
+    assert_marketplace_prod "A.marketplace" "$PR_STAGE"
   else
     fail "0a. build-plugin-release.sh FAILED in isolated clone — output below:"
     sed 's/^/      /' "$TMP/pr-build.out"
@@ -151,6 +196,7 @@ if snapshot_worktree_repo "$BP_CLONE"; then
       "$BP_CLONE/skills/run-plan/SKILL.md"
     assert_prod_url "B.inspecting-and-monitoring.md demo URL" \
       "$BP_CLONE/docs/guides/inspecting-and-monitoring.md"
+    assert_marketplace_prod "B.marketplace" "$BP_CLONE"
   else
     fail "0b. build-prod.sh FAILED in isolated clone — output below:"
     sed 's/^/      /' "$TMP/bp-build.out"


### PR DESCRIPTION
Task: Make zskills-dev's plugin marketplace self-reference dev (zs source.repo = zeveck/zskills-dev) and translate it to prod on publish via a field-scoped rewrite in the shared finalize_prod_tree(), guarded by a residue invariant. So pre-publish plugin qual uses the genuine consumer flow.

The dev repo's plugin marketplace now self-references the dev repo so pre-publish plugin qual uses the genuine consumer flow (`/plugin marketplace add zeveck/zskills-dev` + `/plugin install zs@zskills`) instead of a hand-rolled /tmp test marketplace — mirroring how dev→prod URL rewriting already works on publish. The publish path (shared `finalize_prod_tree()`) rewrites the `zs` source.repo back to `zeveck/zskills`, guarded by a bare-`zskills-dev`-residue invariant that fails the build closed.

Worktree: /tmp/zskills-do-marketplace-self-ref
Commits: 864904b feat(plugin): self-reference dev marketplace; translate to prod on publish
