### PR TITLE
do: drop manifest hooks ref + delist zsbd from marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,6 @@
   "description": "Z Skills — agent-discipline skill framework",
   "version": "1",
   "plugins": [
-    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills-dev", "ref": "main" } },
-    { "name": "zsbd", "source": "./block-diagram" }
+    { "name": "zs", "source": { "source": "github", "repo": "zeveck/zskills-dev", "ref": "main" } }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,6 +8,5 @@
   "repository": "https://github.com/zeveck/zskills",
   "license": "MIT",
   "keywords": ["zskills", "agent", "claude-code", "skills", "plans"],
-  "skills": ["./skills/", "./block-diagram/"],
-  "hooks": "./hooks/hooks.json"
+  "skills": ["./skills/", "./block-diagram/"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Skill distribution repo and presentation site for Z Skills.
 - `hooks/` — source hook scripts
 - `scripts/` — consumer-customizable stubs (stop-dev.sh, test-all.sh) and release-only repo tooling (build-prod.sh, mirror-skill.sh); skill machinery moved to `.claude/skills/<owner>/scripts/` (port.sh, clear-tracking.sh, statusline.sh in `update-zskills`; plan-drift-correct.sh in `run-plan`; full mapping in `skills/update-zskills/references/script-ownership.md`)
 - `CLAUDE_TEMPLATE.md` — template for CLAUDE.md generation in target projects
-- `.claude-plugin/` — plugin lane manifests: `plugin.json` (the `zs` plugin) + `marketplace.json` (lists `zs` and `zsbd`); `block-diagram/.claude-plugin/plugin.json` is the `zsbd` addon manifest
+- `.claude-plugin/` — plugin lane manifests: `plugin.json` (the `zs` plugin) + `marketplace.json` (interim: lists a SINGLE plugin, `zs`; the `zsbd` addon has been delisted from the marketplace and its block-diagram skills ride bundled inside `zs`'s `skills` field); `block-diagram/.claude-plugin/plugin.json` is the `zsbd` addon manifest, still shipped on disk pending a future separate-repo split. Note `plugin.json` carries NO `hooks` field — Claude Code auto-loads `hooks/hooks.json` from the plugin root, so a manifest reference to it causes a duplicate-hooks load error.
 - `hooks/hooks.json` — plugin-lane hook registrations (mirrors `.claude/settings.json` but points at `${CLAUDE_PLUGIN_ROOT}`); `hooks/_lib/plugin-hook-skip-if-mirrored.sh` is the D16(a) conditional-skip shim that prevents double-fire when both lanes are installed
 - `PRESENTATION.html` — main site (index.html redirects here)
 - `README.md`, `CHANGELOG.md` — documentation

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ From inside a Claude Code session in your project:
 /plugin install zs@zskills
 ```
 
-Add the block-diagram add-on with `/plugin install zsbd@zskills`. See
+The `zs` plugin bundles the block-diagram add-on skills, so a single install
+gives you everything. (The block-diagram add-on currently ships inside `zs`
+and will move to its own separately-installable plugin in a future repo.) See
 [`docs/guides/installing-zskills.md`](docs/guides/installing-zskills.md) for what gets
 materialised, version pinning, and the bare-slash prose tradeoff.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,10 +25,15 @@ Release steps:
 
 1. **Bump BOTH `plugin.json.version` files in lockstep** (D10):
    `.claude-plugin/plugin.json` (the `zs` plugin) and
-   `block-diagram/.claude-plugin/plugin.json` (the `zsbd` addon). They MUST
-   stay equal — `tests/test-plugin-marketplace.sh` asserts
-   `zs.version == zsbd.version`. Choose the next `YYYY.MM.N` value (same
-   scheme as the git tag). Commit the bump on dev.
+   `block-diagram/.claude-plugin/plugin.json` (the `zsbd` addon manifest,
+   still shipped on disk). They MUST stay equal —
+   `tests/test-plugin-marketplace.sh` asserts `zs.version == zsbd.version`.
+   Choose the next `YYYY.MM.N` value (same scheme as the git tag). Commit the
+   bump on dev. **Interim note:** the marketplace now lists a SINGLE plugin
+   (`zs`); the `zsbd` addon has been delisted from the marketplace and its
+   block-diagram skills ride bundled inside `zs`. The `zsbd` manifest stays on
+   disk pending a future separate-repo split, which is why the lockstep bump
+   still touches both files.
 2. **(Optional) Dry-build / inspect locally.** Two ways:
    - **Workflow dry-run:** click Run workflow with **Dry run** checked — it
      builds the prod tree and shows the file diff in the run summary, pushing

--- a/tests/test-plugin-live-load.sh
+++ b/tests/test-plugin-live-load.sh
@@ -315,8 +315,7 @@ MARKERHOOK
 {
   "name": "zsrepoloadprobe",
   "version": "2026.05.0",
-  "description": "Synthetic repo-load hookfire probe plugin (test fixture).",
-  "hooks": "./hooks/hooks.json"
+  "description": "Synthetic repo-load hookfire probe plugin (test fixture)."
 }
 PLUGINJSON
   cat > "$synmarker/hooks/hooks.json" <<'PLUGINHOOKS'
@@ -372,6 +371,23 @@ PLUGINHOOKS
     sed 's/^/      /' "$out"
   else
     pass "  [attended] (A2)-runtime: live --plugin-dir load tolerated 2 missing suffixless D4 hooks (hook side-effect fired; no fatal missing-hook error)"
+  fi
+
+  # ── ITEM 3: /doctor duplicate-hooks regression guard ───────────────────────
+  # A real `claude plugin install` once reported "Duplicate hooks file
+  # detected: ./hooks/hooks.json" because the manifest referenced the standard
+  # hooks/hooks.json that Claude Code already auto-loads from the plugin root.
+  # The fix removed the manifest `hooks` field. Guard the regression: run
+  # /doctor under a real --plugin-dir load of the repo and FAIL if it reports a
+  # plugin hook load error. (Same attended gate as ITEMs 1-2 above; the session
+  # is already known authed here since we passed the /login check.)
+  local doctor_out="$TMP/attended-repoload-doctor.out"
+  run_isolated_claude -p '/doctor' --plugin-dir "$REPO_ROOT" --dangerously-skip-permissions > "$doctor_out" 2>&1 || true
+  if grep -qiE 'Duplicate hooks file detected|Hook load failed|resolves to already-loaded' "$doctor_out"; then
+    fail "  [attended] /doctor reports a plugin hook load error (duplicate-hooks regression)"
+    sed 's/^/      /' "$doctor_out"
+  else
+    pass "  [attended] /doctor shows no plugin hook load errors under real --plugin-dir load"
   fi
 }
 
@@ -442,8 +458,7 @@ PLUGINHOOK
 {
   "name": "zsdualprobe",
   "version": "2026.05.0",
-  "description": "Synthetic dual-install probe plugin (test fixture).",
-  "hooks": "./hooks/hooks.json"
+  "description": "Synthetic dual-install probe plugin (test fixture)."
 }
 PLUGINJSON
   cat > "$synplug/hooks/hooks.json" <<'PLUGINHOOKS'

--- a/tests/test-plugin-manifest.sh
+++ b/tests/test-plugin-manifest.sh
@@ -15,7 +15,10 @@
 #     enumerates exactly the 4 SKILL.md-bearing block-diagram dirs
 #     (RE-DERIVED at run time via find — NOT a frozen list, per D2);
 #   - the zs `skills` field references both ./skills/ and ./block-diagram/
-#     and `hooks` points at ./hooks/hooks.json; NO `agents` field on either.
+#     and there is NO `hooks` field (the standard hooks/hooks.json is
+#     auto-loaded by Claude Code from the plugin root — a manifest `hooks`
+#     reference to it causes a duplicate-hooks load error); NO `agents`
+#     field on either.
 
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -104,8 +107,8 @@ if zs is not None:
     skills = zs.get("skills")
     out(isinstance(skills, list) and "./skills/" in skills and "./block-diagram/" in skills,
         "zs: skills references ./skills/ and ./block-diagram/", repr(skills))
-    out(zs.get("hooks") == "./hooks/hooks.json",
-        "zs: hooks points at ./hooks/hooks.json", repr(zs.get("hooks")))
+    out("hooks" not in zs,
+        "zs: no 'hooks' field (standard hooks/hooks.json auto-loaded)", repr(zs.get("hooks")))
 
 # ---- zsbd skills field + roster re-derivation ----
 if zsbd is not None:

--- a/tests/test-plugin-marketplace.sh
+++ b/tests/test-plugin-marketplace.sh
@@ -2,21 +2,29 @@
 # tests/test-plugin-marketplace.sh
 #
 # W1.5 (D8 / D1 / D2) — validates the marketplace manifest at
-# .claude-plugin/marketplace.json. Covers BOTH plugin entries (zs + zsbd).
+# .claude-plugin/marketplace.json.
+#
+# INTERIM: the marketplace lists EXACTLY ONE plugin (`zs`). The `zsbd` addon
+# has been delisted from the marketplace so consumers see one clean plugin;
+# the block-diagram skills already ride bundled inside `zs` (its `skills`
+# field is ["./skills/", "./block-diagram/"]), so delisting loses nothing for
+# end users. The zsbd PLUGIN manifest (block-diagram/.claude-plugin/plugin.json)
+# still ships on disk pending a future separate-repo split, so the on-disk
+# dual-manifest cross-checks below read that file DIRECTLY (not via a
+# marketplace entry).
 #
 # Uses Python json (no jq — per `## Python is required`). Asserts:
 #   - manifest parses + carries required top-level fields (name, owner,
 #     plugins, and — strict-mode requirement — a top-level `description`);
-#   - exactly two plugin entries named `zs` and `zsbd`;
+#   - exactly one plugin entry named `zs`;
 #   - the `zs` entry's source is the github object form the current
 #     validator accepts: { "source": "github", "repo": ..., "ref": ... }
 #     (the plan's nested-`github` example form is rejected by claude
 #     2.1.153 — see W1.5 implementer note);
-#   - the `zsbd` entry's source is the relative-path string "./block-diagram"
-#     (D1 / F-R2-1);
 #   - `dependencies` lives on the zsbd PLUGIN manifest (cross-checked here
-#     against block-diagram/.claude-plugin/plugin.json), present on zsbd and
-#     absent on zs.
+#     directly against block-diagram/.claude-plugin/plugin.json), present on
+#     zsbd and absent on zs;
+#   - D10 version lockstep across the two on-disk plugin.json files.
 
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -65,8 +73,8 @@ out(mp.get("name") == "zskills", "marketplace: name == 'zskills'", repr(mp.get("
 
 plugins = mp.get("plugins", [])
 by_name = {p.get("name"): p for p in plugins if isinstance(p, dict)}
-out(set(by_name) == {"zs", "zsbd"},
-    "marketplace: exactly two plugins (zs, zsbd)", repr(sorted(by_name)))
+out(set(by_name) == {"zs"},
+    "marketplace: exactly one plugin (zs)", repr(sorted(by_name)))
 
 # zs source — github object form accepted by the current validator:
 # { "source": "github", "repo": ..., "ref": ... }
@@ -83,13 +91,13 @@ ok_zs = (isinstance(zs_src, dict)
          and zs_src.get("ref") == "main")
 out(ok_zs, "marketplace: zs source is github {source,repo,ref}", repr(zs_src))
 
-# zsbd source — relative-path string (D1).
-zsbd = by_name.get("zsbd", {})
-out(zsbd.get("source") == "./block-diagram",
-    "marketplace: zsbd source is './block-diagram' relative path", repr(zsbd.get("source")))
+# zsbd is no longer a marketplace entry (delisted — see interim note above).
+out("zsbd" not in by_name,
+    "marketplace: zsbd NOT listed (delisted; bundled inside zs)", repr(sorted(by_name)))
 
-# dependencies live on the PLUGIN manifest (cross-check): present on zsbd,
-# absent on zs.
+# dependencies live on the PLUGIN manifest (cross-check, read directly off
+# disk since zsbd is no longer in the marketplace): present on zsbd, absent
+# on zs.
 zsbd_plugin, perr = load(ZSBD_PLUGIN)
 out(zsbd_plugin is not None, f"{ZSBD_PLUGIN} parses as JSON", perr or "")
 if zsbd_plugin is not None:

--- a/tests/test-plugin-self-load.sh
+++ b/tests/test-plugin-self-load.sh
@@ -34,7 +34,7 @@ echo "=== plugin self-load (zs + zsbd) ==="
 
 # ── (a) claude plugin validate --strict ──────────────────────────────────
 if command -v claude >/dev/null 2>&1; then
-  # Marketplace manifest (covers both plugin entries).
+  # Marketplace manifest (now lists a single entry: zs).
   if claude plugin validate "$REPO_ROOT" --strict 2>&1 | grep -q 'Validation passed'; then
     pass "(a) claude plugin validate --strict: marketplace manifest passes"
   else


### PR DESCRIPTION
Two-part interim plugin cleanup (surfaced by a real `claude plugin install`).

**A — hooks duplicate-load fix.** Removed `"hooks": "./hooks/hooks.json"` from `.claude-plugin/plugin.json`. Claude Code auto-loads the standard `hooks/hooks.json` from the plugin root, so the manifest reference double-loaded it → `/doctor` "Duplicate hooks file detected". The auto-loaded copy still registers/fires (SessionStart materialiser unaffected). Flipped test-plugin-manifest.sh (zs asserts NO hooks field), de-bugged both synthetic fixtures in test-plugin-live-load.sh, and added a /doctor duplicate-hooks regression guard.

**B — delist zsbd from the marketplace.** Removed the `zsbd` entry from `marketplace.json` so consumers see ONE clean plugin (`zs`). `zs` already bundles the block-diagram skills via its `skills` field, so nothing is lost for end users; standalone `zsbd@zskills` install is deferred to a future separate repo. The zsbd manifest stays on disk. test-plugin-marketplace.sh now asserts one marketplace entry while keeping the on-disk dual-manifest version lockstep.

Both on-disk plugin.json versions stay equal. No skill SKILL.md edits. Suite 7648/7648.

Worktree: /tmp/zskills-do-fix-plugin-hooks-zsbd
Commits: 1b4169e fix(plugin): drop manifest hooks ref (duplicate-load) + delist zsbd from marketplace
