### PR TITLE
do: refresh changed verbatim hooks on update (#1060)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+1bc8ab"
+  version: "2026.06.03+16b79a"
 ---
 
 # Update Z Skills Infrastructure
@@ -1448,6 +1448,68 @@ have NO entries in the canonical zskills-owned triples table below
 via direct skill invocation in dispatcher SKILL.md files. Copy them to
 `.claude/hooks/` only — do not register them.
 
+**Refresh changed verbatim-owned hooks (#1060).** The copy steps above
+only fill *missing* hooks. To propagate a hook fix shipped after a
+consumer's initial install (e.g. the session-log `0o600` security fix in
+`5148324`), follow the missing-hook copy with a REFRESH pass over the
+**verbatim-owned hook set** — the zskills-owned hooks that ship
+byte-for-byte (no per-consumer fill). For each such hook, if the installed
+copy differs from the source, BACK IT UP first (so a consumer who *did*
+edit a verbatim hook can recover), then overwrite from source. This
+mirrors the agent `cmp -s` cmp-and-overwrite loop below, plus a backup
+step — hooks are higher-stakes than agents (which do not back up).
+
+The verbatim-owned hook set is an EXPLICIT, CLOSED list — these are the
+zskills-owned hooks that Step C copies as-is (the registered
+`settings.json` triples that ship verbatim, plus the two frontmatter /
+direct-invocation hooks, plus the two session-logging hooks). It MUST NOT
+include the consumer-customizable `.template`-derived hooks
+(`block-unsafe-project.sh`, `block-agents.sh`) or any Tier-2 stub under
+`scripts/` — those stay governed by Key Rule 2 (never overwritten):
+
+```bash
+# Verbatim-owned, zskills-shipped hooks — refreshed when stale. This is a
+# CLOSED list; do NOT replace it with a glob/heuristic (a future
+# consumer-owned hook must never be caught). EXCLUDES the .template hooks
+# (block-unsafe-project.sh, block-agents.sh) and all Tier-2 scripts/ stubs.
+VERBATIM_OWNED_HOOKS=(
+  block-unsafe-generic.sh
+  block-stale-skill-version.sh
+  block-bypassed-land-pr.sh
+  block-fix-issue-unclaimed.sh
+  block-run-plan-unclaimed.sh
+  block-bad-cron.sh
+  block-main-edits.sh
+  warn-config-drift.sh
+  inject-bash-timeout.sh
+  verify-response-validate.sh
+  log-session-stop.sh
+  log-permission-request.sh
+)
+for hook in "${VERBATIM_OWNED_HOOKS[@]}"; do
+  src="$PORTABLE/hooks/$hook"
+  dst=".claude/hooks/$hook"
+  [ -e "$src" ] || continue
+  [ -f "$dst" ] || continue   # missing hooks are handled by the copy steps above
+  if ! cmp -s "$src" "$dst"; then
+    cp -a "$dst" "$dst.bak"   # back up before overwrite (recoverability)
+    # Report old→new zskills-hook-version stamp where the hook carries one.
+    oldv=$(sed -n 's/^# zskills-hook-version:[[:space:]]*//p' "$dst" | head -1)
+    newv=$(sed -n 's/^# zskills-hook-version:[[:space:]]*//p' "$src" | head -1)
+    cp -a "$src" "$dst"
+    if [ -n "$oldv" ] || [ -n "$newv" ]; then
+      echo "Refreshed hook: $hook (${oldv:-?} -> ${newv:-?}; backup: $dst.bak)"
+    else
+      echo "Refreshed hook: $hook (backup: $dst.bak)"
+    fi
+  fi
+done
+```
+
+Report each refreshed hook in the update summary (the `Refreshed hook:`
+lines above), noting the old→new `# zskills-hook-version:` stamp where the
+hook carries one.
+
 **Custom subagent definitions.** After hook copy, copy missing or
 changed agent definitions from `$PORTABLE/.claude/agents/*.md` to
 `$PROJECT_DIR/.claude/agents/`. `cp -a` preserves mode bits + mtime.
@@ -2344,11 +2406,22 @@ These rules are inviolable. They apply to all modes:
    Step B, which removes only lines matching both a rendered value
    AND the template's ±2-line context around that value. No other
    cross-writes.
-2. **NEVER overwrite existing hooks or scripts** — if a file already
+2. **NEVER overwrite existing consumer-customizable hooks or scripts** —
+   if a `.template`-derived hook (`block-unsafe-project.sh`,
+   `block-agents.sh`) or a Tier-2 `scripts/` stub
+   (`scripts/test-all.sh`, `scripts/start-dev.sh`, `scripts/stop-dev.sh`,
+   `scripts/dev-port.sh`, …; see `references/script-ownership.md`) already
    exists, skip it. The user may have customized it. (Presets do not edit
    any hook: `apply-preset.sh` is config-only, and
    `block-unsafe-generic.sh` derives its main-push gate from
-   `execution.main_protected` at runtime.)
+   `execution.main_protected` at runtime.) **Exception — verbatim-owned
+   zskills hooks ARE refreshed on update (#1060):** the closed
+   `VERBATIM_OWNED_HOOKS` set in Step C ships byte-for-byte with no
+   per-consumer fill, so a stale installed copy is overwritten from source
+   (after a `.bak` backup) to propagate hook fixes — including security
+   fixes — exactly as changed agents already are. This narrowing applies
+   ONLY to that closed set; every other existing hook/script stays
+   skip-if-exists.
 3. **Explain what hooks do when installing them** — don't just list
    filenames. The user needs to understand what each hook does.
 4. **Show the user what will be installed BEFORE doing it** — no silent

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+1bc8ab"
+  version: "2026.06.03+16b79a"
 ---
 
 # Update Z Skills Infrastructure
@@ -1448,6 +1448,68 @@ have NO entries in the canonical zskills-owned triples table below
 via direct skill invocation in dispatcher SKILL.md files. Copy them to
 `.claude/hooks/` only — do not register them.
 
+**Refresh changed verbatim-owned hooks (#1060).** The copy steps above
+only fill *missing* hooks. To propagate a hook fix shipped after a
+consumer's initial install (e.g. the session-log `0o600` security fix in
+`5148324`), follow the missing-hook copy with a REFRESH pass over the
+**verbatim-owned hook set** — the zskills-owned hooks that ship
+byte-for-byte (no per-consumer fill). For each such hook, if the installed
+copy differs from the source, BACK IT UP first (so a consumer who *did*
+edit a verbatim hook can recover), then overwrite from source. This
+mirrors the agent `cmp -s` cmp-and-overwrite loop below, plus a backup
+step — hooks are higher-stakes than agents (which do not back up).
+
+The verbatim-owned hook set is an EXPLICIT, CLOSED list — these are the
+zskills-owned hooks that Step C copies as-is (the registered
+`settings.json` triples that ship verbatim, plus the two frontmatter /
+direct-invocation hooks, plus the two session-logging hooks). It MUST NOT
+include the consumer-customizable `.template`-derived hooks
+(`block-unsafe-project.sh`, `block-agents.sh`) or any Tier-2 stub under
+`scripts/` — those stay governed by Key Rule 2 (never overwritten):
+
+```bash
+# Verbatim-owned, zskills-shipped hooks — refreshed when stale. This is a
+# CLOSED list; do NOT replace it with a glob/heuristic (a future
+# consumer-owned hook must never be caught). EXCLUDES the .template hooks
+# (block-unsafe-project.sh, block-agents.sh) and all Tier-2 scripts/ stubs.
+VERBATIM_OWNED_HOOKS=(
+  block-unsafe-generic.sh
+  block-stale-skill-version.sh
+  block-bypassed-land-pr.sh
+  block-fix-issue-unclaimed.sh
+  block-run-plan-unclaimed.sh
+  block-bad-cron.sh
+  block-main-edits.sh
+  warn-config-drift.sh
+  inject-bash-timeout.sh
+  verify-response-validate.sh
+  log-session-stop.sh
+  log-permission-request.sh
+)
+for hook in "${VERBATIM_OWNED_HOOKS[@]}"; do
+  src="$PORTABLE/hooks/$hook"
+  dst=".claude/hooks/$hook"
+  [ -e "$src" ] || continue
+  [ -f "$dst" ] || continue   # missing hooks are handled by the copy steps above
+  if ! cmp -s "$src" "$dst"; then
+    cp -a "$dst" "$dst.bak"   # back up before overwrite (recoverability)
+    # Report old→new zskills-hook-version stamp where the hook carries one.
+    oldv=$(sed -n 's/^# zskills-hook-version:[[:space:]]*//p' "$dst" | head -1)
+    newv=$(sed -n 's/^# zskills-hook-version:[[:space:]]*//p' "$src" | head -1)
+    cp -a "$src" "$dst"
+    if [ -n "$oldv" ] || [ -n "$newv" ]; then
+      echo "Refreshed hook: $hook (${oldv:-?} -> ${newv:-?}; backup: $dst.bak)"
+    else
+      echo "Refreshed hook: $hook (backup: $dst.bak)"
+    fi
+  fi
+done
+```
+
+Report each refreshed hook in the update summary (the `Refreshed hook:`
+lines above), noting the old→new `# zskills-hook-version:` stamp where the
+hook carries one.
+
 **Custom subagent definitions.** After hook copy, copy missing or
 changed agent definitions from `$PORTABLE/.claude/agents/*.md` to
 `$PROJECT_DIR/.claude/agents/`. `cp -a` preserves mode bits + mtime.
@@ -2344,11 +2406,22 @@ These rules are inviolable. They apply to all modes:
    Step B, which removes only lines matching both a rendered value
    AND the template's ±2-line context around that value. No other
    cross-writes.
-2. **NEVER overwrite existing hooks or scripts** — if a file already
+2. **NEVER overwrite existing consumer-customizable hooks or scripts** —
+   if a `.template`-derived hook (`block-unsafe-project.sh`,
+   `block-agents.sh`) or a Tier-2 `scripts/` stub
+   (`scripts/test-all.sh`, `scripts/start-dev.sh`, `scripts/stop-dev.sh`,
+   `scripts/dev-port.sh`, …; see `references/script-ownership.md`) already
    exists, skip it. The user may have customized it. (Presets do not edit
    any hook: `apply-preset.sh` is config-only, and
    `block-unsafe-generic.sh` derives its main-push gate from
-   `execution.main_protected` at runtime.)
+   `execution.main_protected` at runtime.) **Exception — verbatim-owned
+   zskills hooks ARE refreshed on update (#1060):** the closed
+   `VERBATIM_OWNED_HOOKS` set in Step C ships byte-for-byte with no
+   per-consumer fill, so a stale installed copy is overwritten from source
+   (after a `.bak` backup) to propagate hook fixes — including security
+   fixes — exactly as changed agents already are. This narrowing applies
+   ONLY to that closed set; every other existing hook/script stays
+   skip-if-exists.
 3. **Explain what hooks do when installing them** — don't just list
    filenames. The user needs to understand what each hook does.
 4. **Show the user what will be installed BEFORE doing it** — no silent

--- a/tests/test-update-zskills-agent-install.sh
+++ b/tests/test-update-zskills-agent-install.sh
@@ -17,6 +17,12 @@
 #   3.  Idempotency — re-running with no changes prints no "Updated" lines.
 #   4.  Update path — modifying consumer's verifier.md and re-running
 #       prints "Updated agent: verifier.md".
+#   5.  Verbatim-owned hook refresh (#1060) — a changed verbatim-owned hook
+#       (e.g. log-session-stop.sh) is refreshed from source AND backed up
+#       to <hook>.bak; the "Refreshed hook:" line is emitted.
+#   6.  Consumer-customizable hook NOT refreshed (#1060) — a changed
+#       .template-derived hook (block-unsafe-project.sh) is left untouched
+#       (no overwrite, no .bak); Key Rule 2 still governs it.
 #
 # Per CLAUDE.md test-output idiom, this script writes scratch fixtures
 # to /tmp/zskills-tests/$(basename "$REPO_ROOT")/agent-install-* so they
@@ -64,6 +70,45 @@ run_step_c_install() {
       cp -a "$src" "$dst" && echo "Installed hook: $hook"
     elif ! cmp -s "$src" "$dst"; then
       cp -a "$src" "$dst" && echo "Updated hook: $hook"
+    fi
+  done
+
+  # --- Refresh changed verbatim-owned hooks (#1060) ---
+  # Encodes the SKILL.md Step C "Refresh changed verbatim-owned hooks"
+  # bash block verbatim. The .template-derived hooks
+  # (block-unsafe-project.sh, block-agents.sh) are DELIBERATELY absent from
+  # this CLOSED list — they stay skip-if-exists per Key Rule 2.
+  local VERBATIM_OWNED_HOOKS=(
+    block-unsafe-generic.sh
+    block-stale-skill-version.sh
+    block-bypassed-land-pr.sh
+    block-fix-issue-unclaimed.sh
+    block-run-plan-unclaimed.sh
+    block-bad-cron.sh
+    block-main-edits.sh
+    warn-config-drift.sh
+    inject-bash-timeout.sh
+    verify-response-validate.sh
+    log-session-stop.sh
+    log-permission-request.sh
+  )
+  local hook
+  for hook in "${VERBATIM_OWNED_HOOKS[@]}"; do
+    local vsrc="$PORTABLE/hooks/$hook"
+    local vdst="$PROJECT_DIR/.claude/hooks/$hook"
+    [ -e "$vsrc" ] || continue
+    [ -f "$vdst" ] || continue
+    if ! cmp -s "$vsrc" "$vdst"; then
+      cp -a "$vdst" "$vdst.bak"
+      local oldv newv
+      oldv=$(sed -n 's/^# zskills-hook-version:[[:space:]]*//p' "$vdst" | head -1)
+      newv=$(sed -n 's/^# zskills-hook-version:[[:space:]]*//p' "$vsrc" | head -1)
+      cp -a "$vsrc" "$vdst"
+      if [ -n "$oldv" ] || [ -n "$newv" ]; then
+        echo "Refreshed hook: $hook (${oldv:-?} -> ${newv:-?}; backup: $vdst.bak)"
+      else
+        echo "Refreshed hook: $hook (backup: $vdst.bak)"
+      fi
     fi
   done
 
@@ -116,9 +161,19 @@ make_portable() {
   cp -a "$REPO_ROOT/hooks/inject-bash-timeout.sh" "$portable/hooks/"
   cp -a "$REPO_ROOT/hooks/verify-response-validate.sh" "$portable/hooks/"
 
+  # Copy a verbatim-owned hook (log-session-stop.sh — carries a
+  # zskills-hook-version stamp) for the #1060 refresh cases, and the
+  # .template-derived block-unsafe-project.sh (renamed; ships verbatim from
+  # the .template but is consumer-customizable, so it MUST NOT be refreshed).
+  cp -a "$REPO_ROOT/hooks/log-session-stop.sh" "$portable/hooks/"
+  cp -a "$REPO_ROOT/hooks/block-unsafe-project.sh.template" \
+        "$portable/hooks/block-unsafe-project.sh"
+
   # Ensure executable bits set (cp -a preserves; belt-and-suspenders).
   chmod +x "$portable/hooks/inject-bash-timeout.sh"
   chmod +x "$portable/hooks/verify-response-validate.sh"
+  chmod +x "$portable/hooks/log-session-stop.sh"
+  chmod +x "$portable/hooks/block-unsafe-project.sh"
 
   echo "$portable"
 }
@@ -227,6 +282,79 @@ test_case_4_update_on_change() {
   rm -rf -- "$portable" "$consumer"
 }
 
+# Case 5: Verbatim-owned hook refresh (#1060) — a stale verbatim-owned hook
+# is refreshed from source AND backed up to <hook>.bak.
+test_case_5_verbatim_hook_refresh() {
+  local label="case5"
+  local portable; portable=$(make_portable "$label")
+  local consumer; consumer=$(make_consumer "$label")
+
+  # Pre-install: place an OLD (stale) verbatim-owned hook in the consumer.
+  mkdir -p "$consumer/.claude/hooks"
+  cp -a "$portable/hooks/log-session-stop.sh" "$consumer/.claude/hooks/log-session-stop.sh"
+  # Make the consumer copy differ from source (simulate pre-fix version).
+  printf '#!/usr/bin/env bash\n# zskills-hook-version: 2026.06.0\n# STALE pre-fix copy (world-readable)\n' \
+    > "$consumer/.claude/hooks/log-session-stop.sh"
+
+  local out
+  out=$(run_step_c_install "$portable" "$consumer" 2>&1)
+
+  local ok=1
+  echo "$out" | grep -qF 'Refreshed hook: log-session-stop.sh' \
+    || { ok=0; fail "case 5: Refreshed hook line emitted" "out=$out"; }
+  [ -f "$consumer/.claude/hooks/log-session-stop.sh.bak" ] \
+    || { ok=0; fail "case 5: .bak backup created" "missing log-session-stop.sh.bak"; }
+  # The refreshed copy must now byte-match source.
+  cmp -s "$portable/hooks/log-session-stop.sh" "$consumer/.claude/hooks/log-session-stop.sh" \
+    || { ok=0; fail "case 5: refreshed hook byte-matches source" "still differs"; }
+  # The backup must preserve the OLD stale content (NOT the new source).
+  if cmp -s "$portable/hooks/log-session-stop.sh" "$consumer/.claude/hooks/log-session-stop.sh.bak"; then
+    ok=0; fail "case 5: .bak preserves OLD content" ".bak matches source — stale copy not preserved"
+  fi
+  # Old→new version stamp should appear in the report.
+  echo "$out" | grep -qF '2026.06.0 ->' \
+    || { ok=0; fail "case 5: old->new version stamp reported" "out=$out"; }
+
+  if [ "$ok" -eq 1 ]; then
+    pass "case 5: stale verbatim-owned hook refreshed + backed up + version reported"
+  fi
+  rm -rf -- "$portable" "$consumer"
+}
+
+# Case 6: Consumer-customizable .template-derived hook NOT refreshed (#1060)
+# — block-unsafe-project.sh stays untouched even when it differs from source.
+test_case_6_template_hook_not_refreshed() {
+  local label="case6"
+  local portable; portable=$(make_portable "$label")
+  local consumer; consumer=$(make_consumer "$label")
+
+  # Pre-install: a consumer-CUSTOMIZED block-unsafe-project.sh that differs
+  # from the shipped source.
+  mkdir -p "$consumer/.claude/hooks"
+  local custom='#!/usr/bin/env bash
+# CONSUMER-CUSTOMIZED block-unsafe-project.sh — must NOT be overwritten
+echo custom'
+  printf '%s\n' "$custom" > "$consumer/.claude/hooks/block-unsafe-project.sh"
+
+  local out
+  out=$(run_step_c_install "$portable" "$consumer" 2>&1)
+
+  local ok=1
+  echo "$out" | grep -qF 'Refreshed hook: block-unsafe-project.sh' \
+    && { ok=0; fail "case 6: block-unsafe-project.sh NOT refreshed" "it was refreshed (should be skip-if-exists)"; }
+  [ -f "$consumer/.claude/hooks/block-unsafe-project.sh.bak" ] \
+    && { ok=0; fail "case 6: no .bak created for template hook" ".bak exists"; }
+  # The consumer's customized content must be intact.
+  if ! grep -qF 'CONSUMER-CUSTOMIZED' "$consumer/.claude/hooks/block-unsafe-project.sh"; then
+    ok=0; fail "case 6: consumer customization preserved" "file was overwritten"
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    pass "case 6: customized .template-derived hook left untouched (Key Rule 2)"
+  fi
+  rm -rf -- "$portable" "$consumer"
+}
+
 # --- Run ------------------------------------------------------------------
 
 echo "Running tests/test-update-zskills-agent-install.sh"
@@ -234,6 +362,8 @@ test_case_1_fresh_install
 test_case_2_byte_equivalence
 test_case_3_idempotent_rerun
 test_case_4_update_on_change
+test_case_5_verbatim_hook_refresh
+test_case_6_template_hook_not_refreshed
 
 echo
 TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))


### PR DESCRIPTION
Closes #1060.

The `/update-zskills` "Pull Latest and Update" lane refreshed changed **skills** and **agents** but only filled **missing** hooks — so a hook fix (including the `5148324` session-log 0o600 security fix) never reached an existing legacy-lane install on update. The plugin lane was already correct (its SessionStart materialiser does sentinel-gated cmp-and-refresh; directly-run plugin hooks auto-update on plugin update) and is untouched.

This adds a refresh pass to Step C: for an explicit CLOSED `VERBATIM_OWNED_HOOKS` list, if the installed copy differs from source, back it up to `<hook>.bak` then overwrite — mirroring the existing agent cmp-and-overwrite loop. Key Rule 2 is narrowed to cover only consumer-customizable (`.template` / Tier-2 stub) files, which stay skip-if-exists. Excludes `block-unsafe-project.sh`, `block-agents.sh`, and all `scripts/` stubs.

Tests: `tests/test-update-zskills-agent-install.sh` gains case 5 (stale verbatim hook refreshed + `.bak` preserves old content + old→new version stamp reported) and case 6 (customized `.template` hook left untouched). Full suite: Overall 7650/7650 passed, 0 failed.

Worktree: /tmp/zskills-do-refresh-changed-hooks
Commits: 503c8a4 fix(update-zskills): refresh changed verbatim-owned hooks on update (#1060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
