### PR TITLE
do: fix stale skill-count figures after /doc removal

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+16b79a"
+  version: "2026.06.03+807992"
 ---
 
 # Update Z Skills Infrastructure
@@ -124,7 +124,7 @@ Behavior by invocation:
 - `--with-block-diagram-addons` — install/update core skills + block-diagram
   add-on (3 skills: `/add-block`, `/add-example`, `/model-design`)
 
-Without an add-on flag, only the 25 core skills are installed/updated.
+Without an add-on flag, only the 24 core skills are installed/updated.
 If core is already installed, adding an add-on flag just copies the
 add-on skills (the audit detects core is satisfied and skips it).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ direct — your choice).
 - [`docs/README.md`](docs/README.md) — full doc index (guides, plans, reports, per-skill reference).
 - [`docs/guides/workflows.md`](docs/guides/workflows.md) — end-to-end recipes that chain skills (plan-driven dev, backlog sprints, post-merge cleanup, …).
 - [`docs/guides/installing-zskills.md`](docs/guides/installing-zskills.md) — install via the plugin marketplace or the `/update-zskills` script.
-- [`docs/skills/README.md`](docs/skills/README.md) — per-skill reference for the 23 user-facing skills + 2 helpers.
+- [`docs/skills/README.md`](docs/skills/README.md) — per-skill reference for the 22 user-facing skills + 2 helpers.
 - [`docs/guides/inspecting-and-monitoring.md`](docs/guides/inspecting-and-monitoring.md) — observe a running zskills project.
 
 **[View the full presentation](https://zeveck.github.io/zskills-dev/PRESENTATION.html)**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 # Z Skills documentation
 
-Z Skills turns Claude Code into a disciplined engineering team — 23 user-facing slash commands that plan, build, test, fix, and ship with verification at every step.
+Z Skills turns Claude Code into a disciplined engineering team — 22 user-facing slash commands that plan, build, test, fix, and ship with verification at every step.
 
 These docs are organised in two halves:
 
 - **[Guides](guides/README.md)** — install instructions, end-to-end workflows, and operational concepts. **Start here if you're new to zskills.**
-- **[Skills reference](skills/README.md)** — per-skill detail pages for the 23 user-facing slash commands plus 2 internal helpers. Reach for this when you need to know exactly what a single skill does, its arguments, and its modes.
+- **[Skills reference](skills/README.md)** — per-skill detail pages for the 22 user-facing slash commands plus 2 internal helpers. Reach for this when you need to know exactly what a single skill does, its arguments, and its modes.
 
 ## New here? Read in this order
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,4 +18,4 @@ Practical guides for installing zskills and working with it day to day. Start wi
 
 ## See also
 
-- **[Skills reference](../skills/README.md)** — per-skill details for the 23 user-facing slash commands.
+- **[Skills reference](../skills/README.md)** — per-skill details for the 22 user-facing slash commands.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,6 +1,6 @@
 # Z Skills Reference
 
-Per-skill reference for the **23 user-facing Z Skills**, plus the **2 internal
+Per-skill reference for the **22 user-facing Z Skills**, plus the **2 internal
 helpers** they dispatch (`/land-pr` and `/manual-testing` — not for direct use;
 in the docs viewer they appear under their own **Internal Skills** section).
 Looking for how to *combine* these skills into end-to-end workflows? See

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+16b79a"
+  version: "2026.06.03+807992"
 ---
 
 # Update Z Skills Infrastructure
@@ -124,7 +124,7 @@ Behavior by invocation:
 - `--with-block-diagram-addons` — install/update core skills + block-diagram
   add-on (3 skills: `/add-block`, `/add-example`, `/model-design`)
 
-Without an add-on flag, only the 25 core skills are installed/updated.
+Without an add-on flag, only the 24 core skills are installed/updated.
 If core is already installed, adding an add-on flag just copies the
 add-on skills (the audit detects core is satisfied and skips it).
 


### PR DESCRIPTION
Task: Fix stale skill-count figures left over from the /doc skill removal (#1061).

After removing /doc, ground-truth counts are **24 core / 22 user-facing / 2 helpers / 3 block-diagram add-ons**, but several files still carried the pre-removal numbers. Corrected:
- `README.md`, `docs/README.md` (×2), `docs/guides/README.md`, `docs/skills/README.md` — "23 user-facing" → "22 user-facing"
- `skills/update-zskills/SKILL.md` + its `.claude/skills/` mirror — "25 core skills" → "24 core skills" (metadata.version bumped + re-mirrored)

Content-only (markdown). Historical artifacts under docs/issues, docs/plans, docs/reports intentionally left at their old numbers. A completeness grep of the live tree shows zero remaining stale counts.

Verification: `bash tests/run-all.sh` → 7636/7636 passed, 0 failed.

Worktree: /tmp/zskills-do-fix-stale-skill-counts
Commits: 2f1ccff do: fix stale skill-count figures after /doc removal
