### PR TITLE
do: copy schema + neutral co_author in plugin config seed

### DIFF
--- a/hooks/session-start-materialise.sh
+++ b/hooks/session-start-materialise.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # session-start-materialise.sh — W2.1 SessionStart materialiser (D11, D20, D27).
 #
 # Plugins cannot write to the consumer repo at install time (research §10),
@@ -270,7 +270,7 @@ cfg = {
         "branch_prefix": "feat/",
     },
     "commit": {
-        "co_author": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>",
+        "co_author": "",
     },
     "testing": {
         "unit_cmd": "",
@@ -298,6 +298,17 @@ PY
   if [ -s "$config_tmp" ]; then
     mv "$config_tmp" "$CONFIG"
     CONFIG_SEEDED=1
+    # Copy the schema alongside the seeded config so the seeded
+    # `"$schema": "./zskills-config.schema.json"` ref resolves (the legacy
+    # lane does the same — see skills/update-zskills/SKILL.md). Absent-only,
+    # matching the seed's own no-clobber semantics: a consumer who edited
+    # their schema (or already has one) is never overwritten.
+    SCHEMA_SRC="$PLUGIN/config/zskills-config.schema.json"
+    SCHEMA_DEST="$PROJ/.claude/zskills-config.schema.json"
+    if [ -f "$SCHEMA_SRC" ] && [ ! -f "$SCHEMA_DEST" ]; then
+      cp "$SCHEMA_SRC" "$SCHEMA_DEST" \
+        || echo "zskills: failed to copy zskills-config.schema.json — the seeded config's \$schema ref will dangle" >&2
+    fi
   else
     rm -f "$config_tmp"
     echo "zskills: failed to seed default zskills-config.json — managed.md will NOT be rendered" >&2

--- a/tests/test-sessionstart-materialise.sh
+++ b/tests/test-sessionstart-materialise.sh
@@ -254,6 +254,35 @@ else
 fi
 
 echo ""
+echo "=== Config seeding: schema copied + co_author empty (#1069) ==="
+
+# A fresh seed must (a) copy zskills-config.schema.json alongside the seeded
+# config so the seeded "$schema": "./zskills-config.schema.json" ref resolves
+# rather than dangling, and (b) leave commit.co_author empty (the resolver
+# fills it) rather than a hardcoded stale model literal.
+SEED_SCHEMA="$SEED/.claude/zskills-config.schema.json"
+REPO_SCHEMA="$REPO_ROOT/config/zskills-config.schema.json"
+
+# 19. Schema file copied AND byte-equal to the repo source.
+if [ -f "$SEED_SCHEMA" ] && cmp -s "$SEED_SCHEMA" "$REPO_SCHEMA"; then
+  pass "19. seeded project: zskills-config.schema.json copied (byte-equal to repo source)"
+else
+  fail "19. seeded schema missing or differs from repo source ($SEED_SCHEMA)"
+fi
+
+# 20. Seeded commit.co_author is empty (no hardcoded model literal).
+if [ -f "$SEED_CFG" ]; then
+  seed_coauthor=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["commit"]["co_author"])' "$SEED_CFG" 2>/dev/null)
+  if [ -z "$seed_coauthor" ]; then
+    pass "20. seeded commit.co_author is empty"
+  else
+    fail "20. seeded commit.co_author is not empty: '$seed_coauthor'"
+  fi
+else
+  fail "20. seeded commit.co_author check skipped: no config file"
+fi
+
+echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
 exit "$FAIL_COUNT"


### PR DESCRIPTION
Two residual sub-bugs in the SessionStart materialiser's plugin-config seed (the seed itself was added in #801; now reachable on real installs after #1067 fixed the detector).

- **Dangling `$schema`:** the seed wrote `"$schema": "./zskills-config.schema.json"` but never copied the schema file. Now copies `${CLAUDE_PLUGIN_ROOT}/config/zskills-config.schema.json` → consumer `.claude/` when seeding (absent-only, source-guarded, visible WARN on failure).
- **Stale co_author:** seed hardcoded `Claude Opus 4.7`; now seeds `commit.co_author: ""` (resolver handles empty; a fresh consumer's trailer shouldn't claim a specific model). The broader 4.7→4.8 drift in the legacy template/repo config is left as a separate chore.
- Bumped the hook-version stamp. +2 test cases (schema byte-equal + co_author empty); both fail without the fix. Suite 7675/7675. No skill SKILL.md edits.

Closes #1069

Worktree: /tmp/zskills-do-plugin-config-seed-fixes
Commits: 4629317 fix(materialiser): copy schema + seed empty co_author on plugin config seed (#1069)
