### PR TITLE
do: session-logging OFF by default

### DIFF
--- a/.claude/hooks/log-permission-request.sh
+++ b/.claude/hooks/log-permission-request.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.3
 # log-permission-request.sh — PermissionRequest hook. Session-logging.
 #
 # Fires ONLY when a permission dialog would appear (Claude Code does NOT
@@ -75,8 +75,12 @@ PERMISSION_SUMMARY_MAX = 200
 
 
 def read_config(project_dir):
+    # Defaults: enabled=False — session logging is OFF by default. A missing
+    # / unparseable config, or an absent logging.enabled field, leaves
+    # logging off. The consumer opts in with logging.enabled:true. KEEP
+    # IDENTICAL to log-session-stop.sh read_config.
     cfg_path = os.path.join(project_dir, ".claude", "zskills-config.json")
-    enabled = True
+    enabled = False
     log_dir_cfg = ""
     try:
         with open(cfg_path) as f:

--- a/.claude/hooks/log-session-stop.sh
+++ b/.claude/hooks/log-session-stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.3
 # log-session-stop.sh — Stop / SubagentStop hook. Session-logging.
 #
 # Re-renders the session transcript JSONL (the `transcript_path` field of
@@ -24,9 +24,10 @@
 # hook): ZSKILLS_LOG_DIR env > logging.dir config > per-OS cache default
 # (${XDG_CACHE_HOME:-~/.cache}/zskills-session-logs/<project> on Linux,
 # ~/Library/Caches/... on macOS, %LOCALAPPDATA%\... on Windows). The
-# `logging` config object also carries `enabled` (default true) — when
-# false this hook no-ops immediately. Resolution + the master-toggle read
-# happen INSIDE the embedded Python (cross-platform, no jq).
+# `logging` config object also carries `enabled` (default FALSE — session
+# logging is OFF unless the consumer opts in with logging.enabled:true) —
+# when false (or absent) this hook no-ops immediately. Resolution + the
+# master-toggle read happen INSIDE the embedded Python (cross-platform, no jq).
 #
 # PUBLISH-WHERE-IT-WROTE REGISTRY (issue #1059). The drift bug: the reader
 # (session-logs.sh) used to re-resolve the path independently via
@@ -104,10 +105,11 @@ PERMISSION_SUMMARY_MAX = 200
 def read_config(project_dir):
     """Return (enabled, dir) from .claude/zskills-config.json logging.*.
 
-    Defaults: enabled=True, dir="". A missing / unparseable config means
-    defaults (logging on)."""
+    Defaults: enabled=False, dir="". Session logging is OFF by default — a
+    missing / unparseable config, or an absent logging.enabled field, means
+    logging stays off. The consumer opts in with logging.enabled:true."""
     cfg_path = os.path.join(project_dir, ".claude", "zskills-config.json")
-    enabled = True
+    enabled = False
     log_dir_cfg = ""
     try:
         with open(cfg_path) as f:

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+807992"
+  version: "2026.06.04+9bc9da"
 ---
 
 # Update Z Skills Infrastructure
@@ -1625,8 +1625,11 @@ matcher-less shape under `${CLAUDE_PLUGIN_ROOT}`. They drive the
 session-logging capability: `log-session-stop.sh` re-renders each
 transcript to per-session markdown (merging the permission sidecar by
 timestamp with a `[PERMISSION]` tag), and `log-permission-request.sh` is a
-passive, fail-open sidecar logger that NEVER blocks/approves/denies. Both
-no-op when `logging.enabled` is false.
+passive, fail-open sidecar logger that NEVER blocks/approves/denies.
+Session logging is OFF by default: both hooks no-op when `logging.enabled`
+is false OR absent — a fresh consumer (whose seeded config carries no
+`logging` block) gets logging off until they opt in with
+`logging.enabled: true`.
 
 **Session-init-only `settings.json` load (#460).** `.claude/settings.json`
 is loaded ONCE at session start. The in-memory hook table is fixed at

--- a/config/zskills-config.schema.json
+++ b/config/zskills-config.schema.json
@@ -162,8 +162,8 @@
       "properties": {
         "enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Master toggle for session logging. When true (default), the Stop/SubagentStop hook re-renders each session transcript to per-session markdown and the PermissionRequest hook appends a per-session permission sidecar. When false, BOTH hooks no-op immediately (exit 0, no files written)."
+          "default": false,
+          "description": "Master toggle for session logging. Default false — session logging is OFF unless the consumer opts in. When true, the Stop/SubagentStop hook re-renders each session transcript to per-session markdown and the PermissionRequest hook appends a per-session permission sidecar. When false or absent, BOTH hooks no-op immediately (exit 0, no files written)."
         },
         "dir": {
           "type": "string",

--- a/hooks/log-permission-request.sh
+++ b/hooks/log-permission-request.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.3
 # log-permission-request.sh — PermissionRequest hook. Session-logging.
 #
 # Fires ONLY when a permission dialog would appear (Claude Code does NOT
@@ -75,8 +75,12 @@ PERMISSION_SUMMARY_MAX = 200
 
 
 def read_config(project_dir):
+    # Defaults: enabled=False — session logging is OFF by default. A missing
+    # / unparseable config, or an absent logging.enabled field, leaves
+    # logging off. The consumer opts in with logging.enabled:true. KEEP
+    # IDENTICAL to log-session-stop.sh read_config.
     cfg_path = os.path.join(project_dir, ".claude", "zskills-config.json")
-    enabled = True
+    enabled = False
     log_dir_cfg = ""
     try:
         with open(cfg_path) as f:

--- a/hooks/log-session-stop.sh
+++ b/hooks/log-session-stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.3
 # log-session-stop.sh — Stop / SubagentStop hook. Session-logging.
 #
 # Re-renders the session transcript JSONL (the `transcript_path` field of
@@ -24,9 +24,10 @@
 # hook): ZSKILLS_LOG_DIR env > logging.dir config > per-OS cache default
 # (${XDG_CACHE_HOME:-~/.cache}/zskills-session-logs/<project> on Linux,
 # ~/Library/Caches/... on macOS, %LOCALAPPDATA%\... on Windows). The
-# `logging` config object also carries `enabled` (default true) — when
-# false this hook no-ops immediately. Resolution + the master-toggle read
-# happen INSIDE the embedded Python (cross-platform, no jq).
+# `logging` config object also carries `enabled` (default FALSE — session
+# logging is OFF unless the consumer opts in with logging.enabled:true) —
+# when false (or absent) this hook no-ops immediately. Resolution + the
+# master-toggle read happen INSIDE the embedded Python (cross-platform, no jq).
 #
 # PUBLISH-WHERE-IT-WROTE REGISTRY (issue #1059). The drift bug: the reader
 # (session-logs.sh) used to re-resolve the path independently via
@@ -104,10 +105,11 @@ PERMISSION_SUMMARY_MAX = 200
 def read_config(project_dir):
     """Return (enabled, dir) from .claude/zskills-config.json logging.*.
 
-    Defaults: enabled=True, dir="". A missing / unparseable config means
-    defaults (logging on)."""
+    Defaults: enabled=False, dir="". Session logging is OFF by default — a
+    missing / unparseable config, or an absent logging.enabled field, means
+    logging stays off. The consumer opts in with logging.enabled:true."""
     cfg_path = os.path.join(project_dir, ".claude", "zskills-config.json")
-    enabled = True
+    enabled = False
     log_dir_cfg = ""
     try:
         with open(cfg_path) as f:

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.03+807992"
+  version: "2026.06.04+9bc9da"
 ---
 
 # Update Z Skills Infrastructure
@@ -1625,8 +1625,11 @@ matcher-less shape under `${CLAUDE_PLUGIN_ROOT}`. They drive the
 session-logging capability: `log-session-stop.sh` re-renders each
 transcript to per-session markdown (merging the permission sidecar by
 timestamp with a `[PERMISSION]` tag), and `log-permission-request.sh` is a
-passive, fail-open sidecar logger that NEVER blocks/approves/denies. Both
-no-op when `logging.enabled` is false.
+passive, fail-open sidecar logger that NEVER blocks/approves/denies.
+Session logging is OFF by default: both hooks no-op when `logging.enabled`
+is false OR absent — a fresh consumer (whose seeded config carries no
+`logging` block) gets logging off until they opt in with
+`logging.enabled: true`.
 
 **Session-init-only `settings.json` load (#460).** `.claude/settings.json`
 is loaded ONCE at session start. The in-memory hook table is fixed at

--- a/tests/test-session-logging.sh
+++ b/tests/test-session-logging.sh
@@ -14,8 +14,10 @@
 #   3. Sidecar + in-situ merge — a permission event whose ts falls BETWEEN
 #      two transcript events renders a [PERMISSION]-tagged line at the right
 #      position; grep -c returns the expected count.
-#   4. Config toggle — logging.enabled=false => both hooks no-op (no files
-#      written) and still exit 0.
+#   4. Config toggle / OFF-by-default — session logging is OFF unless the
+#      consumer opts in (logging.enabled:true). Asserts both hooks no-op
+#      (no files written, exit 0) for: explicit logging.enabled=false, an
+#      ABSENT logging.enabled field, and an empty config object {}.
 #   5. Helper — no args prints the resolved dir; dest arg copies the logs.
 
 set -u
@@ -43,7 +45,10 @@ trap cleanup EXIT
 
 PROJ="$WORK/proj"
 mkdir -p "$PROJ/.claude"
-echo '{}' > "$PROJ/.claude/zskills-config.json"
+# Session logging is OFF by default (absent logging.enabled => off), so the
+# renderer-positive cases (1, 3, 5, 6) MUST opt in explicitly. The
+# absent-field default is asserted separately in Case 4b/4c.
+echo '{"logging":{"enabled":true}}' > "$PROJ/.claude/zskills-config.json"
 
 # Synthetic transcript: user @00, assistant+tool @05, tool_result @08,
 # assistant @10. A permission event at @07 (between @05 and @08) is used in
@@ -173,7 +178,8 @@ fi
 
 # ──────────────────────────────────────────────────────────────────────────
 echo ""
-echo "=== Case 4 — logging.enabled=false no-ops both hooks ==="
+echo "=== Case 4 — logging OFF: explicit enabled=false AND absent field both no-op ==="
+# Explicit logging.enabled=false: both hooks no-op.
 PROJ_OFF="$WORK/proj-off"
 mkdir -p "$PROJ_OFF/.claude"
 echo '{"logging":{"enabled":false}}' > "$PROJ_OFF/.claude/zskills-config.json"
@@ -182,7 +188,7 @@ echo "{\"hook_event_name\":\"Stop\",\"session_id\":\"off1\",\"transcript_path\":
   ZSKILLS_LOG_DIR="$LOGD4" CLAUDE_PROJECT_DIR="$PROJ_OFF" bash "$STOP_HOOK"
 rc=$?
 if [ "$rc" -eq 0 ] && [ ! -d "$LOGD4" ]; then
-  pass "4a. stop hook no-ops (exit 0, no log dir created) when disabled"
+  pass "4a. stop hook no-ops (exit 0, no log dir created) when explicitly disabled"
 else
   fail "4a. stop disabled no-op" "rc=$rc dir_exists=$([ -d "$LOGD4" ] && echo y || echo n)"
 fi
@@ -190,9 +196,47 @@ out="$(printf '%s' '{"hook_event_name":"PermissionRequest","session_id":"off1","
   ZSKILLS_LOG_DIR="$LOGD4" CLAUDE_PROJECT_DIR="$PROJ_OFF" bash "$PERM_HOOK" 2>/dev/null)"
 rc=$?
 if [ "$rc" -eq 0 ] && [ -z "$out" ] && [ ! -d "$LOGD4" ]; then
-  pass "4b. permission hook no-ops (exit 0, empty stdout, no dir) when disabled"
+  pass "4b. permission hook no-ops (exit 0, empty stdout, no dir) when explicitly disabled"
 else
   fail "4b. perm disabled no-op" "rc=$rc out=[$out] dir_exists=$([ -d "$LOGD4" ] && echo y || echo n)"
+fi
+
+# OFF-BY-DEFAULT: an absent logging.enabled field (fresh consumer config)
+# must ALSO no-op both hooks — session logging is opt-in. PROJ_ABSENT has a
+# config with NO logging block at all (exactly what /update-zskills seeds).
+PROJ_ABSENT="$WORK/proj-absent"
+mkdir -p "$PROJ_ABSENT/.claude"
+echo '{"project_name":"x"}' > "$PROJ_ABSENT/.claude/zskills-config.json"
+LOGD4A="$WORK/logs4a"
+echo "{\"hook_event_name\":\"Stop\",\"session_id\":\"abs1\",\"transcript_path\":\"$TR\"}" | \
+  ZSKILLS_LOG_DIR="$LOGD4A" CLAUDE_PROJECT_DIR="$PROJ_ABSENT" bash "$STOP_HOOK"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$LOGD4A" ]; then
+  pass "4c. stop hook no-ops when logging.enabled is ABSENT (off by default)"
+else
+  fail "4c. stop absent-field no-op" "rc=$rc dir_exists=$([ -d "$LOGD4A" ] && echo y || echo n)"
+fi
+out="$(printf '%s' '{"hook_event_name":"PermissionRequest","session_id":"abs1","tool_name":"Read","tool_input":{"file_path":"x"},"tool_use_id":"t"}' | \
+  ZSKILLS_LOG_DIR="$LOGD4A" CLAUDE_PROJECT_DIR="$PROJ_ABSENT" bash "$PERM_HOOK" 2>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ] && [ ! -d "$LOGD4A" ]; then
+  pass "4d. permission hook no-ops when logging.enabled is ABSENT (off by default)"
+else
+  fail "4d. perm absent-field no-op" "rc=$rc out=[$out] dir_exists=$([ -d "$LOGD4A" ] && echo y || echo n)"
+fi
+
+# And an EMPTY config object ({}) — the most minimal fresh state — also off.
+PROJ_EMPTY="$WORK/proj-empty"
+mkdir -p "$PROJ_EMPTY/.claude"
+echo '{}' > "$PROJ_EMPTY/.claude/zskills-config.json"
+LOGD4E="$WORK/logs4e"
+echo "{\"hook_event_name\":\"Stop\",\"session_id\":\"emp1\",\"transcript_path\":\"$TR\"}" | \
+  ZSKILLS_LOG_DIR="$LOGD4E" CLAUDE_PROJECT_DIR="$PROJ_EMPTY" bash "$STOP_HOOK"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$LOGD4E" ]; then
+  pass "4e. stop hook no-ops on empty config {} (off by default)"
+else
+  fail "4e. stop empty-config no-op" "rc=$rc dir_exists=$([ -d "$LOGD4E" ] && echo y || echo n)"
 fi
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -309,7 +353,9 @@ echo "=== Case 7 — cross-context agreement (issue #1059 regression test) ==="
 # asserts the reader still finds the logs (via the registry, NOT recompute).
 CC_PROJ="$WORK/ccproj"
 mkdir -p "$CC_PROJ/.claude"
-echo '{}' > "$CC_PROJ/.claude/zskills-config.json"
+# Opt in (logging is off by default); leave logging.dir blank so the per-OS
+# default resolution under test is exercised unchanged.
+echo '{"logging":{"enabled":true}}' > "$CC_PROJ/.claude/zskills-config.json"
 ( cd "$CC_PROJ" && git init -q . )
 # Write: blank logging.dir, no ZSKILLS_LOG_DIR -> per-OS default under
 # XDG_CACHE_HOME=cacheA; a deliberately DIFFERENT TMPDIR.
@@ -354,7 +400,7 @@ echo ""
 echo "=== Case 8 — registry semantics: header, append, dedup, union ==="
 RS_PROJ="$WORK/rsproj"
 mkdir -p "$RS_PROJ/.claude"
-echo '{}' > "$RS_PROJ/.claude/zskills-config.json"
+echo '{"logging":{"enabled":true}}' > "$RS_PROJ/.claude/zskills-config.json"
 ( cd "$RS_PROJ" && git init -q . )
 RS_REG="$RS_PROJ/.zskills/session-log-dirs"
 RS_A="$WORK/rs-logA"
@@ -414,7 +460,7 @@ echo ""
 echo "=== Case 9 — registry race-safe under concurrent writers ==="
 RC_PROJ="$WORK/rcproj"
 mkdir -p "$RC_PROJ/.claude"
-echo '{}' > "$RC_PROJ/.claude/zskills-config.json"
+echo '{"logging":{"enabled":true}}' > "$RC_PROJ/.claude/zskills-config.json"
 ( cd "$RC_PROJ" && git init -q . )
 RC_REG="$RC_PROJ/.zskills/session-log-dirs"
 RC_DIR="$WORK/rc-log"
@@ -457,7 +503,8 @@ echo '{}' > "$WT_MAIN/.claude/zskills-config.json"
 WT_LEAF="$WORK/wt-leaf"
 ( cd "$WT_MAIN" && git worktree add -q "$WT_LEAF" -b leafbranch ) 2>/dev/null
 mkdir -p "$WT_LEAF/.claude"
-echo '{}' > "$WT_LEAF/.claude/zskills-config.json"
+# The Stop hook runs with CLAUDE_PROJECT_DIR=WT_LEAF, so the leaf must opt in.
+echo '{"logging":{"enabled":true}}' > "$WT_LEAF/.claude/zskills-config.json"
 WT_LOG="$WORK/wt-log"
 # Write from the WORKTREE (CLAUDE_PROJECT_DIR = worktree path).
 echo "{\"hook_event_name\":\"Stop\",\"session_id\":\"wtsess01\",\"transcript_path\":\"$TR\"}" | \


### PR DESCRIPTION
Make session-logging **OFF by default**: a fresh consumer with no `logging` config now gets logging disabled. Opt-in remains `logging.enabled: true`.

## Change
- `read_config` in both hooks (`log-session-stop.sh`, `log-permission-request.sh`) now defaults `enabled=False` when `logging.enabled` is absent/unparseable (was `True`); docstrings/comments updated.
- `config/zskills-config.schema.json`: `logging.enabled` default `true` → `false`.
- The `/update-zskills` install seed already omits a `logging` block, so a fresh consumer is now off (absent ⇒ off) — no seed change needed; SKILL.md prose updated to document it.
- Helper `session-logs.sh` reads only `logging.dir` (never `enabled`) — unchanged.

Explicit `enabled:true` (writes logs) and explicit `enabled:false` (no logs) behaviors are unchanged. This repo's own `.claude/zskills-config.json` keeps its explicit `enabled:true` (untouched).

## Tests
`tests/test-session-logging.sh`: added genuine absent-field⇒off cases (4c/4d no `logging` block, 4e empty `{}`); retained explicit-true/false cases; renderer-positive cases switched to explicit opt-in (correction to the new default, no assertion weakened).

## Test plan
- [x] `bash tests/run-all.sh` — 7676/7676 passed, 0 failed (independently verified).
- [x] Absent-field⇒off and explicit-true⇒logs both asserted.

Both install lanes synced (source + `.claude/` mirrors byte-identical).

Commits:
6b223cf do: session-logging OFF by default (absent logging.enabled => off)
