### PR TITLE
do: scope verifier lane-detect to zskills-owned skills

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.04+81a7d5"
+  version: "2026.06.04+6a971d"
 ---
 
 # Update Z Skills Infrastructure

--- a/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -102,9 +102,14 @@ vi_detect_lane() {
     fi
   done
 
-  if [ -d "$proj/.claude/skills" ] \
-     && [ -n "$(ls -A "$proj/.claude/skills" 2>/dev/null)" ] \
-     && [ -f "$proj/.claude/settings.json" ]; then
+  # Legacy signal: ZSKILLS-OWNED evidence only (matches detect-install-state.sh,
+  # #1064/#1067). Either a zskills-named .claude/skills/<name>/SKILL.md mirror
+  # OR a settings.json registering a hook under .claude/hooks/ is sufficient.
+  # We key on zskills-OWNED content (not bare file existence) so a plugin
+  # consumer's OWN non-zskills skills/settings never false-classify the install
+  # as legacy/dual (the bug this fix closes).
+  if vi_has_zskills_mirror "$proj" \
+     || vi_settings_has_zskills_hook "$proj/.claude/settings.json"; then
     legacy_sig=1
   fi
 
@@ -220,6 +225,59 @@ vi_hook_has_version_stamp() {
   local f="$1"
   [ -f "$f" ] || return 1
   sed -n '2p' "$f" 2>/dev/null | grep -Eq '^#[[:space:]]*zskills-hook-version:[[:space:]]'
+}
+
+# vi_has_zskills_mirror <project_dir> → 0 if .claude/skills/<name>/SKILL.md
+# exists for at least one ZSKILLS-OWNED <name>. This scopes the "legacy mirror
+# present" signal to ZSKILLS' OWN skills, so a plugin consumer who ships their
+# OWN, non-zskills skills (e.g. playwright-cli, social-seo) is NOT misclassified
+# as carrying a legacy mirror (the #1064 bug class, fixed in
+# hooks/_lib/detect-install-state.sh by #1067 — that fix never reached this
+# self-contained lib).
+#
+# The anchor set below is kept BYTE-IDENTICAL to detect-install-state.sh's
+# `_dis_zskills_skills` list (#1067). It is staleness-tolerant: a real legacy
+# mirror ALWAYS carries `update-zskills` (the installer) plus the stable core,
+# so a future new skill not yet in this list never breaks lane detection — the
+# mirror still carries the anchors. Derived from the repo's `skills/` directory
+# names (excludes block-diagram add-ons). Kept INLINE: this lib must stay
+# standalone (it deliberately does NOT source detect-install-state.sh, which is
+# not mirrored to a legacy consumer).
+vi_has_zskills_mirror() {
+  local proj="$1"
+  local zskills_skills="briefing cleanup-merged commit create-worktree do draft-plan draft-tests fix-issues fix-report investigate land-pr manual-testing plans qe-audit refine-plan research-and-go research-and-plan run-plan session-report update-zskills verify-changes work-on-plans zskills-dashboard"
+  local name
+  for name in $zskills_skills; do
+    if [ -f "$proj/.claude/skills/$name/SKILL.md" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# vi_settings_has_zskills_hook <settings_json> → 0 if settings.json registers at
+# least one hook command whose resolved path-token lives UNDER .claude/hooks/.
+# This scopes the "legacy settings.json" signal to ZSKILLS-owned hook
+# registrations: a consumer's OWN, non-zskills hook (or an empty `{}`) does NOT
+# count, so a plugin consumer's own settings.json no longer false-classifies the
+# install as legacy/dual. Mere file existence must NOT count — only a registered
+# command resolving under .claude/hooks/. Mirrors the supplementary settings.json
+# cross-check in detect-install-state.sh (#1067).
+vi_settings_has_zskills_hook() {
+  local settings="$1"
+  [ -f "$settings" ] || return 1
+  local cmd token
+  while IFS= read -r cmd; do
+    [ -n "$cmd" ] || continue
+    # Last whitespace-separated token, stripped of surrounding quotes.
+    token="${cmd##* }"
+    token="${token%\"}"; token="${token#\"}"
+    token="${token%\'}"; token="${token#\'}"
+    case "$token" in
+      */.claude/hooks/*|.claude/hooks/*) return 0 ;;
+    esac
+  done < <(vi_settings_hook_commands "$settings")
+  return 1
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -429,15 +487,19 @@ vi_check_plugin() {
     fi
   done
 
-  # (2) Mirror-less: .claude/skills/ must be ABSENT in a clean plugin consumer.
-  # NOTE: a populated .claude/skills/ alongside CLAUDE_PLUGIN_ROOT is detected
-  # as the `dual` lane upstream (vi_detect_lane), so this WARN is reached only
-  # when skills/ exists but is empty — a genuine residue worth surfacing, never
-  # a false positive on a clean mirror-less install.
-  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
-    vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
+  # (2) Mirror-less: NO ZSKILLS mirror under .claude/skills/ in a clean plugin
+  # consumer. We key on a ZSKILLS-OWNED mirror (vi_has_zskills_mirror), NOT on
+  # the bare presence of .claude/skills/: a plugin consumer who ships their OWN,
+  # non-zskills skills (playwright-cli, social-seo, …) is a perfectly healthy
+  # mirror-less install and must PASS, not WARN (the #1064 bug class). A genuine
+  # zskills mirror present alongside the plugin lane is the `dual` lane upstream
+  # (vi_detect_lane); this WARN is reached only when a zskills mirror exists but
+  # the plugin-sig also fired in a way that did not collapse to dual — a real
+  # residue worth surfacing.
+  if vi_has_zskills_mirror "$proj"; then
+    vi_emit WARN "plugin.mirror-less" "zskills mirror present under .claude/skills/ on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
   else
-    vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
+    vi_emit PASS "plugin.mirror-less" "no zskills mirror under .claude/skills/ (mirror-less plugin install)"
   fi
 
   # (3) ${CLAUDE_PLUGIN_ROOT} reachability (#1008 medium gap). The materialised
@@ -506,7 +568,7 @@ vi_run_cheap() {
       vi_check_legacy "$proj"
       ;;
     none)
-      vi_emit FAIL "lane.none" "no zskills install detected (no \${CLAUDE_PLUGIN_ROOT}, no .claude/skills + settings.json)"
+      vi_emit FAIL "lane.none" "no zskills install detected (no materialised plugin artifacts, no zskills mirror + no zskills settings.json hooks)"
       ;;
   esac
 }

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.04+81a7d5"
+  version: "2026.06.04+6a971d"
 ---
 
 # Update Z Skills Infrastructure

--- a/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -102,9 +102,14 @@ vi_detect_lane() {
     fi
   done
 
-  if [ -d "$proj/.claude/skills" ] \
-     && [ -n "$(ls -A "$proj/.claude/skills" 2>/dev/null)" ] \
-     && [ -f "$proj/.claude/settings.json" ]; then
+  # Legacy signal: ZSKILLS-OWNED evidence only (matches detect-install-state.sh,
+  # #1064/#1067). Either a zskills-named .claude/skills/<name>/SKILL.md mirror
+  # OR a settings.json registering a hook under .claude/hooks/ is sufficient.
+  # We key on zskills-OWNED content (not bare file existence) so a plugin
+  # consumer's OWN non-zskills skills/settings never false-classify the install
+  # as legacy/dual (the bug this fix closes).
+  if vi_has_zskills_mirror "$proj" \
+     || vi_settings_has_zskills_hook "$proj/.claude/settings.json"; then
     legacy_sig=1
   fi
 
@@ -220,6 +225,59 @@ vi_hook_has_version_stamp() {
   local f="$1"
   [ -f "$f" ] || return 1
   sed -n '2p' "$f" 2>/dev/null | grep -Eq '^#[[:space:]]*zskills-hook-version:[[:space:]]'
+}
+
+# vi_has_zskills_mirror <project_dir> → 0 if .claude/skills/<name>/SKILL.md
+# exists for at least one ZSKILLS-OWNED <name>. This scopes the "legacy mirror
+# present" signal to ZSKILLS' OWN skills, so a plugin consumer who ships their
+# OWN, non-zskills skills (e.g. playwright-cli, social-seo) is NOT misclassified
+# as carrying a legacy mirror (the #1064 bug class, fixed in
+# hooks/_lib/detect-install-state.sh by #1067 — that fix never reached this
+# self-contained lib).
+#
+# The anchor set below is kept BYTE-IDENTICAL to detect-install-state.sh's
+# `_dis_zskills_skills` list (#1067). It is staleness-tolerant: a real legacy
+# mirror ALWAYS carries `update-zskills` (the installer) plus the stable core,
+# so a future new skill not yet in this list never breaks lane detection — the
+# mirror still carries the anchors. Derived from the repo's `skills/` directory
+# names (excludes block-diagram add-ons). Kept INLINE: this lib must stay
+# standalone (it deliberately does NOT source detect-install-state.sh, which is
+# not mirrored to a legacy consumer).
+vi_has_zskills_mirror() {
+  local proj="$1"
+  local zskills_skills="briefing cleanup-merged commit create-worktree do draft-plan draft-tests fix-issues fix-report investigate land-pr manual-testing plans qe-audit refine-plan research-and-go research-and-plan run-plan session-report update-zskills verify-changes work-on-plans zskills-dashboard"
+  local name
+  for name in $zskills_skills; do
+    if [ -f "$proj/.claude/skills/$name/SKILL.md" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# vi_settings_has_zskills_hook <settings_json> → 0 if settings.json registers at
+# least one hook command whose resolved path-token lives UNDER .claude/hooks/.
+# This scopes the "legacy settings.json" signal to ZSKILLS-owned hook
+# registrations: a consumer's OWN, non-zskills hook (or an empty `{}`) does NOT
+# count, so a plugin consumer's own settings.json no longer false-classifies the
+# install as legacy/dual. Mere file existence must NOT count — only a registered
+# command resolving under .claude/hooks/. Mirrors the supplementary settings.json
+# cross-check in detect-install-state.sh (#1067).
+vi_settings_has_zskills_hook() {
+  local settings="$1"
+  [ -f "$settings" ] || return 1
+  local cmd token
+  while IFS= read -r cmd; do
+    [ -n "$cmd" ] || continue
+    # Last whitespace-separated token, stripped of surrounding quotes.
+    token="${cmd##* }"
+    token="${token%\"}"; token="${token#\"}"
+    token="${token%\'}"; token="${token#\'}"
+    case "$token" in
+      */.claude/hooks/*|.claude/hooks/*) return 0 ;;
+    esac
+  done < <(vi_settings_hook_commands "$settings")
+  return 1
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -429,15 +487,19 @@ vi_check_plugin() {
     fi
   done
 
-  # (2) Mirror-less: .claude/skills/ must be ABSENT in a clean plugin consumer.
-  # NOTE: a populated .claude/skills/ alongside CLAUDE_PLUGIN_ROOT is detected
-  # as the `dual` lane upstream (vi_detect_lane), so this WARN is reached only
-  # when skills/ exists but is empty — a genuine residue worth surfacing, never
-  # a false positive on a clean mirror-less install.
-  if [ -d "$claude/skills" ] && [ -n "$(ls -A "$claude/skills" 2>/dev/null)" ]; then
-    vi_emit WARN "plugin.mirror-less" ".claude/skills/ present on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
+  # (2) Mirror-less: NO ZSKILLS mirror under .claude/skills/ in a clean plugin
+  # consumer. We key on a ZSKILLS-OWNED mirror (vi_has_zskills_mirror), NOT on
+  # the bare presence of .claude/skills/: a plugin consumer who ships their OWN,
+  # non-zskills skills (playwright-cli, social-seo, …) is a perfectly healthy
+  # mirror-less install and must PASS, not WARN (the #1064 bug class). A genuine
+  # zskills mirror present alongside the plugin lane is the `dual` lane upstream
+  # (vi_detect_lane); this WARN is reached only when a zskills mirror exists but
+  # the plugin-sig also fired in a way that did not collapse to dual — a real
+  # residue worth surfacing.
+  if vi_has_zskills_mirror "$proj"; then
+    vi_emit WARN "plugin.mirror-less" "zskills mirror present under .claude/skills/ on the plugin lane (dual-install? run scripts/switch-install-path.sh)"
   else
-    vi_emit PASS "plugin.mirror-less" ".claude/skills/ absent (mirror-less plugin install)"
+    vi_emit PASS "plugin.mirror-less" "no zskills mirror under .claude/skills/ (mirror-less plugin install)"
   fi
 
   # (3) ${CLAUDE_PLUGIN_ROOT} reachability (#1008 medium gap). The materialised
@@ -506,7 +568,7 @@ vi_run_cheap() {
       vi_check_legacy "$proj"
       ;;
     none)
-      vi_emit FAIL "lane.none" "no zskills install detected (no \${CLAUDE_PLUGIN_ROOT}, no .claude/skills + settings.json)"
+      vi_emit FAIL "lane.none" "no zskills install detected (no materialised plugin artifacts, no zskills mirror + no zskills settings.json hooks)"
       ;;
   esac
 }

--- a/tests/test-verify-install.sh
+++ b/tests/test-verify-install.sh
@@ -441,6 +441,110 @@ else
   fail "7. dual install" "expected FAIL on lane.dual-unsupported; records=$(grep '^FAIL' "$OUT")"
 fi
 
+# ── PLUGIN + consumer's OWN non-zskills skills → still plugin, mirror-less PASS
+# (#1071) A healthy mirror-less plugin consumer may ship their OWN, non-zskills
+# skills under .claude/skills/ (playwright-cli, social-seo, …). The lane-detect
+# legacy signal and the plugin.mirror-less check key on a ZSKILLS-OWNED mirror,
+# NOT on bare .claude/skills/ presence — so these MUST classify as `plugin`,
+# PASS plugin.mirror-less (not WARN), and produce 0 FAIL. CLAUDE_PLUGIN_ROOT is
+# still the good fake-plugin-root from case 4 (so plugin.root-reachable PASSes).
+POS="$(make_plugin_good 7)"
+mkdir -p "$POS/.claude/skills/playwright-cli" "$POS/.claude/skills/social-seo"
+printf '%s\n' '---' 'name: playwright-cli' '---' '# pw' > "$POS/.claude/skills/playwright-cli/SKILL.md"
+printf '%s\n' '---' 'name: social-seo' '---' '# seo' > "$POS/.claude/skills/social-seo/SKILL.md"
+OUT="$TMP/out-plugin-own-skills.txt"
+run_cheap_capture "$POS" "$OUT"
+if grep -q '^PASS	lane.detect	detected lane: plugin' "$OUT"; then
+  pass "7d. plugin + consumer's OWN non-zskills skills → lane detected as plugin (not dual/legacy)"
+else
+  fail "7d. plugin own-skills lane detect" "lane.detect not 'plugin': $(grep lane.detect "$OUT")"
+fi
+if has_warn_id "$OUT" "plugin.mirror-less"; then
+  fail "7e. plugin own-skills mirror-less" "plugin.mirror-less WARNed on a non-zskills mirror (should PASS): $(grep mirror-less "$OUT")"
+else
+  pass "7e. plugin + own non-zskills skills → plugin.mirror-less PASS (not WARN on consumer's own skills)"
+fi
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "7f. plugin + own non-zskills skills → 0 FAIL"
+else
+  fail "7f. plugin own-skills no-fail" "expected 0 FAIL, got $(grep '^FAIL' "$OUT")"
+fi
+
+# ── PLUGIN + consumer's OWN settings.json (non-zskills hook) → still plugin ───
+# (#1071, the exact dual FALSE-FAIL) The consumer's own settings.json registers
+# only a NON-zskills hook AND they ship their own skills. Before the fix this
+# false-classified as `dual` → lane.dual-unsupported FAIL. The legacy signal now
+# keys on a zskills-owned mirror OR a settings.json hook under .claude/hooks/,
+# so a foreign hook outside .claude/hooks/ (or an empty {}) does NOT count. MUST
+# classify as `plugin` (NOT dual), with 0 FAIL.
+PCS="$(make_plugin_good 8)"
+mkdir -p "$PCS/.claude/skills/playwright-cli"
+printf '%s\n' '---' 'name: playwright-cli' '---' '# pw' > "$PCS/.claude/skills/playwright-cli/SKILL.md"
+# A consumer's own settings.json registering only a NON-zskills hook whose path
+# does NOT resolve under .claude/hooks/ (lives in their own .config/ tree).
+cat > "$PCS/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.config/my-own-hook.sh\"", "timeout": 5 }
+      ] }
+    ]
+  }
+}
+JSON
+OUT="$TMP/out-plugin-own-settings.txt"
+run_cheap_capture "$PCS" "$OUT"
+if grep -q '^PASS	lane.detect	detected lane: plugin' "$OUT"; then
+  pass "7g. plugin + consumer's OWN settings.json (non-zskills hook) → lane plugin (not dual — the dual FALSE-FAIL)"
+else
+  fail "7g. plugin own-settings lane detect" "lane.detect not 'plugin': $(grep lane.detect "$OUT")"
+fi
+if has_fail_id "$OUT" "lane.dual-unsupported"; then
+  fail "7h. plugin own-settings dual-false-fail" "lane.dual-unsupported FAILed on a consumer's own settings.json: $(grep '^FAIL' "$OUT")"
+else
+  pass "7h. plugin + own settings.json → NO lane.dual-unsupported FAIL (dual FALSE-FAIL closed)"
+fi
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "7i. plugin + own settings.json (empty/non-zskills hook) → 0 FAIL"
+else
+  fail "7i. plugin own-settings no-fail" "expected 0 FAIL, got $(grep '^FAIL' "$OUT")"
+fi
+
+# ── GENUINE dual: zskills-named mirror + settings.json with a REAL zskills ────
+# .claude/hooks/ entry → must STILL be `dual` (proves the fix does not blind the
+# verifier to a real dual install). Both legacy signals fire: a zskills-owned
+# mirror (update-zskills) AND a settings.json hook resolving under .claude/hooks/.
+PGD="$(make_plugin_good 9)"
+mkdir -p "$PGD/.claude/skills/update-zskills" "$PGD/.claude/hooks"
+printf '%s\n' '---' 'name: update-zskills' '---' '# uz' > "$PGD/.claude/skills/update-zskills/SKILL.md"
+printf '%s\n' '#!/usr/bin/env bash' '# zskills-hook-version: 2026.06.0' 'exit 0' \
+  > "$PGD/.claude/hooks/block-unsafe-generic.sh"
+cat > "$PGD/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-unsafe-generic.sh\"", "timeout": 5 }
+      ] }
+    ]
+  }
+}
+JSON
+OUT="$TMP/out-genuine-dual.txt"
+run_cheap_capture "$PGD" "$OUT"
+if grep -q '^PASS	lane.detect	detected lane: dual' "$OUT" \
+   || grep -q '^FAIL	lane.detect	detected lane: dual' "$OUT"; then
+  pass "7j. genuine dual (zskills mirror + real .claude/hooks/ settings entry) → lane detected as dual"
+else
+  fail "7j. genuine dual lane detect" "lane.detect not 'dual': $(grep lane.detect "$OUT")"
+fi
+if has_fail_id "$OUT" "lane.dual-unsupported"; then
+  pass "7k. genuine dual → FAIL on lane.dual-unsupported (fix does not blind the verifier to a real dual install)"
+else
+  fail "7k. genuine dual unsupported" "expected FAIL on lane.dual-unsupported; records=$(grep '^FAIL' "$OUT")"
+fi
+
 # ── PLUGIN broken (D): CLAUDE_PLUGIN_ROOT pointing at an UNREACHABLE dir ──────
 # (#1008 medium gap) The 5 materialised artifacts are present in the consumer's
 # .claude/, but ${CLAUDE_PLUGIN_ROOT} points at a dir missing the plugin


### PR DESCRIPTION
The post-install verifier (`verify-install-lib.sh`) is deliberately self-contained, so #1064's lane-detect scoping fix (PR #1067) never reached it. Two checks keyed on bare file existence:
- `vi_detect_lane` `legacy_sig` — any non-empty `.claude/skills/` + any `.claude/settings.json` → `dual` → false `FAIL lane.dual-unsupported` on a healthy plugin install.
- `plugin.mirror-less` — WARNed on the mere presence of `.claude/skills/`.
A plugin consumer with their own skills (playwright-cli, social-seo) hit both.

Fix: added inline `vi_has_zskills_mirror` (anchor set byte-identical to detect-install-state.sh) + `vi_settings_has_zskills_hook`; rewired both checks to key on zskills-owned content. A consumer's own skills/settings no longer false-classify; a genuine dual (zskills mirror + real `.claude/hooks/` settings entry) still FAILs. Skill-version bumped; +3 test cases (proven to fail without the fix). Suite 7683/7683.

Closes #1071

Worktree: /tmp/zskills-do-verifier-scope-lane-checks
Commits: b66e224 fix(verify-install): scope lane-detect + mirror-less to zskills-owned content (#1071)
