### PR TITLE
docs(viewer+presentation): onboarding polish, addon de-listing, prod-URL fix

### DIFF
--- a/DEV-QUAL.md
+++ b/DEV-QUAL.md
@@ -5,45 +5,17 @@ This file is the **maintainer-facing manual dev-quality checklist** for
 zskills. It holds the five manual install scenarios a human runs to
 accept a release across both distribution lanes.
 
-Like `RELEASING.md`, this is **dev-maintainer-only and prod-stripped**: its
-entire content sits inside `<!-- prod-strip:start --> … <!-- prod-strip:end
--->` markers AND the build scripts remove the file wholesale, so it never
-ships to either lane's consumers. You will not see this file on
-`github.com/zeveck/zskills` or in any installed plugin tree. (If you are
-adding a new dev-only top-level doc, mirror BOTH mechanisms — the marker
-wrap and the `for f in RELEASING.md DEV-QUAL.md; do … done` removal loops in
-`scripts/build-prod.sh`, `scripts/build-plugin-release.sh`, and
-`tests/test-plugin-mirrorless-resolution.sh`.)
-
 ## How to use this checklist
 
-These are **manual** acceptance scenarios — a human runs them, by hand,
-against a release candidate. They complement, not replace, the automated
-gate (`bash tests/run-all.sh`).
-Each scenario states its **purpose**, **preconditions**, **step-by-step
-commands** (traced to the real install machinery — no invented commands),
-and **expected observable results** (what to check to call it a PASS).
+These are **manual** acceptance scenarios — a human runs them by hand against a
+release candidate. They complement, not replace, the automated gate
+(`bash tests/run-all.sh`). Each scenario states its purpose, preconditions,
+step-by-step commands, and the observable results that make it a PASS.
 
-Internalize the **plugin-lane mental model** from `CLAUDE.md` before running
-these:
-
-- A real consumer is **single-lane** — it installs zskills via the plugin
-  lane OR the legacy `/update-zskills` lane, never both.
-- **Mirror-less plugin is the norm and the goal**: a real plugin consumer
-  has NO `.claude/skills/` mirror — only the 5 materialised artifacts +
-  `.claude/zskills-config.json`, everything resolving under
-  `${CLAUDE_PLUGIN_ROOT}`.
-- **Dual install** (both lanes present at once) is NOT a supported consumer
-  state. It exists only in this dogfooding repo and transiently during a
-  lane switch; the system actively pushes to consolidate it.
-- **The dogfood trap**: zskills-dev itself carries a `.claude/skills/`
-  mirror because it is the source repo. Never treat the presence of that
-  mirror as evidence the plugin lane works — validate **mirror-less** or you
-  reproduce the "dogfood-mask" that shipped the non-functional plugin lanes
-  in #799/#831.
-
-The lane lock lives at `.claude/zskills-install-lane` (bare value `plugin`
-or `update-zskills`, written LAST by `scripts/switch-install-path.sh`).
+zskills ships **two install lanes**, and a real consumer uses exactly one: the
+**plugin lane** (`/plugin install zs@zskills`) and the legacy **`/update-zskills`**
+lane (which mirrors the skills into the project's `.claude/`). The scenarios
+below exercise each lane and the switch between them.
 
 ---
 

--- a/PRESENTATION.html
+++ b/PRESENTATION.html
@@ -282,7 +282,7 @@
 <section class="hero" style="margin-bottom: 6px; padding-bottom: 20px;">
   <h1>Z Skills System</h1>
   <p>Z Skills turns Claude Code into a disciplined engineering team. 23 core skills (21 user-facing slash commands + 2 internal helpers) that plan, build, test, fix, and ship &mdash; with verification at every step. Each skill encodes a workflow that used to need hands-on guidance, so it runs with a single command.</p>
-  <p>Currently: 21 user-facing skills, 2 internal helpers (<code>/land-pr</code>, <code>/create-worktree</code>), and 3 block-diagram extensions covering plan drafting, feature implementation, bug fixing, verification, testing, documentation, and safe code landing. Six support cron scheduling for unattended execution.</p>
+  <p>Currently: 21 user-facing skills, 2 internal helpers (<code>/land-pr</code>, <code>/manual-testing</code>), and 3 block-diagram extensions covering plan drafting, feature implementation, bug fixing, verification, testing, documentation, and safe code landing. Six support cron scheduling for unattended execution.</p>
   <p style="font-size: 0.95em; color: var(--text-dim);">Install via the plugin marketplace (<code>/plugin install zs@zskills</code>, slash prefix <code>/zs:</code>) or the <code>/update-zskills</code> script (bare slash prefix). Both lanes are first-class and permanent &mdash; full setup in the <a href="https://github.com/zeveck/zskills">README</a>.</p>
 </section>
 

--- a/PRESENTATION.html
+++ b/PRESENTATION.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/svg+xml" href="favicon.svg">
 <title>Z Skills System</title>
 <style>
   :root {
@@ -273,7 +274,8 @@
   <a href="#patterns">Patterns</a>
   <a href="#safety">Safety</a>
   <span class="nav-sep">&#9474;</span>
-  <a href="https://github.com/zeveck/zskills" class="cross">GitHub &rarr;</a>
+  <a href="https://zeveck.github.io/zskills-dev/docs/" class="cross">Docs &rarr;</a>
+  <a href="https://github.com/zeveck/zskills-dev" class="cross">GitHub &rarr;</a>
 </nav>
 
 <div class="container">
@@ -281,9 +283,9 @@
 <!-- HERO -->
 <section class="hero" style="margin-bottom: 6px; padding-bottom: 20px;">
   <h1>Z Skills System</h1>
-  <p>Z Skills turns Claude Code into a disciplined engineering team. 23 core skills (21 user-facing slash commands + 2 internal helpers) that plan, build, test, fix, and ship &mdash; with verification at every step. Each skill encodes a workflow that used to need hands-on guidance, so it runs with a single command.</p>
-  <p>Currently: 21 user-facing skills, 2 internal helpers (<code>/land-pr</code>, <code>/manual-testing</code>), and 3 block-diagram extensions covering plan drafting, feature implementation, bug fixing, verification, testing, documentation, and safe code landing. Six support cron scheduling for unattended execution.</p>
-  <p style="font-size: 0.95em; color: var(--text-dim);">Install via the plugin marketplace (<code>/plugin install zs@zskills</code>, slash prefix <code>/zs:</code>) or the <code>/update-zskills</code> script (bare slash prefix). Both lanes are first-class and permanent &mdash; full setup in the <a href="https://github.com/zeveck/zskills">README</a>.</p>
+  <p>Z Skills accelerates and automates engineering work, adding guardrails and guidance to help Claude Code with various software development workflows. Its 23 skills assist with planning, building, testing, fixing, verifying, and shipping, turning many tasks into disciplined commands gated by review and verification. Six can run on a schedule, for unattended, round-the-clock output.</p>
+  <p>Branches, worktrees, commits, and pull requests are how work gets planned, verified, and landed &mdash; so a git-based project is assumed.</p>
+  <p style="font-size: 0.95em; color: var(--text-dim);">Install via the plugin marketplace (<code>/plugin install zs@zskills</code>, slash prefix <code>/zs:</code>) or the <code>/update-zskills</code> script (bare slash prefix) &mdash; full setup in the <a href="https://github.com/zeveck/zskills-dev">README</a>.</p>
 </section>
 
 <!-- ALL 23 SKILLS -->
@@ -346,7 +348,7 @@
           <p>Commit audit: reviews recent commits for test gaps. Bash mode: adversarial stress-testing. Both file GitHub issues.</p>
         </div>
         <div class="skill-mini" style="border-color: var(--accent2);">
-          <h5><code>/manual-testing</code></h5>
+          <h5><code>/manual-testing</code> <span style="font-size: 0.7em; background: var(--surface2); padding: 2px 6px; border-radius: 4px; color: var(--text-dim); font-weight: 400; margin-left: 6px;">helper</span></h5>
           <p>Playwright-cli recipes with exact CSS selectors, event sequences, and auth bypass for browser-based verification.</p>
         </div>
       </div>
@@ -407,21 +409,6 @@
         </div>
       </div>
 
-      <h4 style="color: var(--accent); margin: 24px 0 12px;">Block Diagram Add-on</h4>
-      <div class="skill-mini-grid">
-        <div class="skill-mini" style="border-color: var(--pink);">
-          <h5><code>/add-block</code></h5>
-          <p>Full 13-step lifecycle for new block types: plan, implement, register, UI, docs, tests, example, codegen, verification, landing.</p>
-        </div>
-        <div class="skill-mini" style="border-color: var(--pink);">
-          <h5><code>/add-example</code></h5>
-          <p>Example model creation: research the concept, design layout, build model file, register, test, screenshot, verify.</p>
-        </div>
-        <div class="skill-mini" style="border-color: var(--pink);">
-          <h5><code>/model-design</code></h5>
-          <p>Layout guidelines for block diagrams and state charts, based on MAAB/NASA standards.</p>
-        </div>
-      </div>
 
 </section>
 
@@ -621,87 +608,13 @@
 
   <p>Skills add softer enforcement at decision points: pre-landing checklists, verification timeouts (45 min for verifiers, 2h for implementers), and a Failure Protocol that kills crons and preserves state on errors.</p>
 
-  <details>
-    <summary>Incident Log and Lessons Learned (click to expand)</summary>
-    <div class="details-body">
-
-      <p>Every safety rule traces back to a real incident. Here are the ones that shaped the system.</p>
-
-      <table>
-        <tr><th>Incident</th><th>What Happened</th><th>What It Drove</th></tr>
-        <tr>
-          <td><strong>17-File Wipe</strong></td>
-          <td>Agent "cleaned up" 17 files of other agents' uncommitted work</td>
-          <td>Hook blocks <code>git checkout --</code>, <code>git restore</code></td>
-        </tr>
-        <tr>
-          <td><strong>9-File Stash Drop</strong></td>
-          <td><code>git stash pop</code> failed; agent ran <code>git stash drop</code>, destroying the only copy</td>
-          <td>Hook blocks <code>git stash drop/clear</code></td>
-        </tr>
-        <tr>
-          <td><strong>Silent 13-Fix Revert</strong></td>
-          <td>Agent checked out old files to investigate, never restored them, committed -- reverting 13 fixes</td>
-          <td>Hook blocks <code>git checkout &lt;commit&gt; -- &lt;file&gt;</code></td>
-        </tr>
-        <tr>
-          <td><strong>50-Fix Sweep</strong></td>
-          <td><code>git add .</code> swept another session's unfinished changes into a 50-fix commit</td>
-          <td>Hook blocks <code>git add .</code> / <code>git add -A</code></td>
-        </tr>
-        <tr>
-          <td><strong>Visual Feature Disaster</strong></td>
-          <td>100% visual feature landed with zero manual testing or screenshots</td>
-          <td>Transcript hooks require <code>playwright-cli</code> for UI commits</td>
-        </tr>
-        <tr>
-          <td><strong>Issue Misread</strong></td>
-          <td>"Reset button" paraphrased as "clear canvas" -- wrong feature built</td>
-          <td>Verbatim issue body + plan text in all agent dispatches</td>
-        </tr>
-        <tr>
-          <td><strong>3-Hour Test Thrash</strong></td>
-          <td>Agents wasted 3 hours trying to run tests in worktrees without dev servers</td>
-          <td>Verbatim test recipe included in every agent dispatch</td>
-        </tr>
-        <tr>
-          <td><strong>Auto-mode Bleed</strong></td>
-          <td>After auto-mode execution, agent kept committing without permission in interactive mode. Context compaction preserved the auto-commit pattern.</td>
-          <td>Explicit mode reset after auto runs</td>
-        </tr>
-        <tr>
-          <td><strong>Pre-staged Sweep</strong></td>
-          <td>Commit swept 146 lines of another session's work because files were pre-staged in the index</td>
-          <td>Pre-staging index check in <code>/commit</code></td>
-        </tr>
-        <tr>
-          <td><strong>Force-removed Worktree Logs</strong></td>
-          <td>Agent dismissed modified logs as "just log files" and force-removed worktree, losing the build record</td>
-          <td>Log extraction requirement before worktree removal</td>
-        </tr>
-      </table>
-
-      <h4 style="color: var(--accent); margin: 24px 0 12px;">What we've learned about LLM compliance</h4>
-
-      <table>
-        <tr><th>Approach</th><th>Effectiveness</th></tr>
-        <tr><td>Hook hard blocks</td><td><span class="strength-high">High</span></td></tr>
-        <tr><td>Concrete recipes at decision points</td><td><span class="strength-high">High</span></td></tr>
-        <tr><td>Verbatim text requirements</td><td><span class="strength-high">High</span></td></tr>
-        <tr><td>Transcript-based verification</td><td><span class="strength-high">High</span></td></tr>
-        <tr><td>Past failure stories in prompts</td><td><span class="strength-low">Low-Med</span></td></tr>
-        <tr><td>Rules in long appendix sections</td><td><span class="strength-low">Low</span></td></tr>
-      </table>
-
-    </div>
-  </details>
 </section>
 
 <!-- CLOSING -->
 <section class="fade-in" style="text-align:center; padding: 40px 0; border-top: 2px solid var(--border);">
   <p style="font-size: 1.05em; color: var(--text); max-width: 800px; margin: 0 auto;"><strong>23 core skills (21 user-facing + 2 helpers) that plan, build, test, fix, and ship &mdash; so one developer can run a full engineering team.</strong></p>
-  <p style="margin-top: 16px;"><a href="https://github.com/zeveck/zskills">github.com/zeveck/zskills</a></p>
-  <p style="margin-top: 24px; font-size: 0.85em; color: var(--text-dim);">Built with Claude Code (Claude Opus 4.6 / 4.7) &mdash; Z Skills System.</p>
+  <p style="margin-top: 16px;"><a href="https://github.com/zeveck/zskills-dev">github.com/zeveck/zskills</a></p>
+  <p style="margin-top: 24px; font-size: 0.85em; color: var(--text-dim);">Z Skills System by Rich Conlan. Built with Claude Code (Claude Opus 4.6 / 4.7 / 4.8).</p>
 </section>
 
 </div>

--- a/docs/DocsRegistry.js
+++ b/docs/DocsRegistry.js
@@ -25,6 +25,7 @@ export const DOCS_CATALOG = [
       { name: "Installing zskills", path: "docs/guides/installing-zskills.md" },
       { name: "Z Skills Workflows", path: "docs/guides/workflows.md" },
       { name: "Inspecting & Monitoring a zskills Project", path: "docs/guides/inspecting-and-monitoring.md" },
+      { name: "Configuring zskills", path: "docs/guides/zskills-config.md" },
       { name: "Switching install lanes", path: "docs/guides/switching-install-lanes.md" },
       { name: "How tracking keeps pipelines safe", path: "docs/guides/tracking-overview.md" }
     ]
@@ -32,32 +33,62 @@ export const DOCS_CATALOG = [
   {
     section: "Skills",
     items: [
-      { name: "Z Skills Reference", path: "docs/skills/README.md" },
-      { name: "/briefing", path: "docs/skills/briefing.md" },
-      { name: "/cleanup-merged", path: "docs/skills/cleanup-merged.md" },
-      { name: "/commit", path: "docs/skills/commit.md" },
-      { name: "/create-worktree", path: "docs/skills/create-worktree.md" },
-      { name: "/do", path: "docs/skills/do.md" },
-      { name: "/draft-plan", path: "docs/skills/draft-plan.md" },
-      { name: "/draft-tests", path: "docs/skills/draft-tests.md" },
-      { name: "/fix-issues", path: "docs/skills/fix-issues.md" },
-      { name: "/fix-report", path: "docs/skills/fix-report.md" },
-      { name: "/investigate", path: "docs/skills/investigate.md" },
-      { name: "/plans", path: "docs/skills/plans.md" },
-      { name: "/qe-audit", path: "docs/skills/qe-audit.md" },
-      { name: "/refine-plan", path: "docs/skills/refine-plan.md" },
-      { name: "/research-and-go", path: "docs/skills/research-and-go.md" },
-      { name: "/research-and-plan", path: "docs/skills/research-and-plan.md" },
-      { name: "/run-plan", path: "docs/skills/run-plan.md" },
-      { name: "/session-report", path: "docs/skills/session-report.md" },
-      { name: "/update-zskills", path: "docs/skills/update-zskills.md" },
-      { name: "/verify-changes", path: "docs/skills/verify-changes.md" },
-      { name: "/work-on-plans", path: "docs/skills/work-on-plans.md" },
-      { name: "/zskills-dashboard", path: "docs/skills/zskills-dashboard.md" }
+      { name: "Z Skills Reference", path: "docs/skills/README.md" }
     ]
   },
   {
-    section: "Internal Skills",
+    section: "Execution",
+    items: [
+      { name: "/do", path: "docs/skills/do.md" },
+      { name: "/run-plan", path: "docs/skills/run-plan.md" },
+      { name: "/investigate", path: "docs/skills/investigate.md" }
+    ]
+  },
+  {
+    section: "Planning & Design",
+    items: [
+      { name: "/draft-plan", path: "docs/skills/draft-plan.md" },
+      { name: "/refine-plan", path: "docs/skills/refine-plan.md" },
+      { name: "/draft-tests", path: "docs/skills/draft-tests.md" },
+      { name: "/research-and-plan", path: "docs/skills/research-and-plan.md" },
+      { name: "/plans", path: "docs/skills/plans.md" }
+    ]
+  },
+  {
+    section: "Quality Assurance",
+    items: [
+      { name: "/verify-changes", path: "docs/skills/verify-changes.md" },
+      { name: "/qe-audit", path: "docs/skills/qe-audit.md" }
+    ]
+  },
+  {
+    section: "Automation",
+    items: [
+      { name: "/fix-issues", path: "docs/skills/fix-issues.md" },
+      { name: "/work-on-plans", path: "docs/skills/work-on-plans.md" },
+      { name: "/zskills-dashboard", path: "docs/skills/zskills-dashboard.md" },
+      { name: "/research-and-go", path: "docs/skills/research-and-go.md" }
+    ]
+  },
+  {
+    section: "Reporting",
+    items: [
+      { name: "/session-report", path: "docs/skills/session-report.md" },
+      { name: "/briefing", path: "docs/skills/briefing.md" },
+      { name: "/fix-report", path: "docs/skills/fix-report.md" }
+    ]
+  },
+  {
+    section: "Utilities",
+    items: [
+      { name: "/commit", path: "docs/skills/commit.md" },
+      { name: "/cleanup-merged", path: "docs/skills/cleanup-merged.md" },
+      { name: "/update-zskills", path: "docs/skills/update-zskills.md" },
+      { name: "/create-worktree", path: "docs/skills/create-worktree.md" }
+    ]
+  },
+  {
+    section: "Internal",
     items: [
       { name: "/land-pr", path: "docs/skills/land-pr.md" },
       { name: "/manual-testing", path: "docs/skills/manual-testing.md" }

--- a/docs/MarkdownRenderer.js
+++ b/docs/MarkdownRenderer.js
@@ -71,13 +71,26 @@ export function renderMarkdown(md, options) {
       closeList();
       const tagMatch = line.trim().match(/^<(\w+)/);
       const tag = tagMatch[1];
+      // Net open/close count for a single line — counts BOTH tags so a
+      // self-contained one-line block (e.g. `<div ...>x</div>`, and multiple
+      // such on one line) nets to 0. Without this, a one-line container line
+      // is mis-read as a bare opener and swallows/duplicates its siblings.
+      const opensRe = new RegExp(`<${tag}[\\s>]`, 'g');
+      const closesRe = new RegExp(`</${tag}>`, 'g');
+      const netDepth = (l) =>
+        (l.match(opensRe) || []).length - (l.match(closesRe) || []).length;
+      let depth = netDepth(lines[i]);
+      if (depth <= 0) {
+        // Complete block on one line — emit verbatim, do not recurse.
+        out.push(lines[i]);
+        i++;
+        continue;
+      }
       const htmlLines = [lines[i]];
       i++;
-      let depth = 1;
       while (i < lines.length && depth > 0) {
         const l = lines[i];
-        if (new RegExp(`<${tag}[\\s>]`).test(l)) depth++;
-        if (new RegExp(`</${tag}>`).test(l)) depth--;
+        depth += netDepth(l);
         htmlLines.push(l);
         i++;
       }
@@ -359,8 +372,15 @@ function inlineMarkdown(s, baseUrl) {
   // GFM task list checkboxes — prevent false matches on array[x], obj[ ] (word char before [)
   s = s.replace(/(?<!\w)\[x\]/gi, '<input type="checkbox" checked class="zl-task-checkbox">');
   s = s.replace(/(?<!\w)\[ \]/g, '<input type="checkbox" class="zl-task-checkbox">');
-  // Inline code
-  s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+  // Inline code. A bare slash-command (e.g. `/do`, `/draft-plan`) gets a
+  // `.skill` class so it renders in the accent color, matching how skill names
+  // already appear inside flow diagrams. Scoped to a single `/word` token so
+  // flags (`--rounds`), positional verbs (`pr`, `auto`), paths (`docs/plans/`),
+  // and config keys stay neutral.
+  s = s.replace(/`([^`]+)`/g, (_, code) =>
+    /^\/[a-z][a-z0-9-]*$/.test(code)
+      ? `<code class="skill">${code}</code>`
+      : `<code>${code}</code>`);
   // Bold
   s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
   // Italic

--- a/docs/MarkdownRenderer.js
+++ b/docs/MarkdownRenderer.js
@@ -369,6 +369,10 @@ function inlineMarkdown(s, baseUrl) {
     }
     return `<a href="${resolved}" target="_blank" rel="noopener">${text}</a>`;
   });
+  // Autolinks: <https://example.com> → a clickable link. escapeHtml() has
+  // already turned the angle brackets into &lt; / &gt;, so match those.
+  s = s.replace(/&lt;(https?:\/\/[^\s<>&]+)&gt;/g,
+    '<a href="$1" target="_blank" rel="noopener">$1</a>');
   // GFM task list checkboxes — prevent false matches on array[x], obj[ ] (word char before [)
   s = s.replace(/(?<!\w)\[x\]/gi, '<input type="checkbox" checked class="zl-task-checkbox">');
   s = s.replace(/(?<!\w)\[ \]/g, '<input type="checkbox" class="zl-task-checkbox">');

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 Z Skills turns Claude Code into a disciplined engineering team — 21 user-facing slash commands that plan, build, test, fix, and ship with verification at every step.
 
+It's **built for Claude Code** — that's where the skills, hooks, and slash commands are designed to run — though some pieces work with other agents too. It's also built around **git**: branches, worktrees, commits, and pull requests are how work gets planned, verified, and landed, so a git-based project is assumed.
+
+For the high-level tour, see the **[Z Skills presentation](https://zeveck.github.io/zskills-dev/PRESENTATION.html)**.
+
 These docs are organised in two halves:
 
 - **[Guides](guides/README.md)** — install instructions, end-to-end workflows, and operational concepts. **Start here if you're new to zskills.**

--- a/docs/docs-app.js
+++ b/docs/docs-app.js
@@ -283,7 +283,25 @@ function renderDoc(item, md) {
   // right edge (no mid-page scrollbar gutter).
   main.innerHTML = '<div class="zl-docs-content">' + rewritten + '</div>';
 
+  wireCollapsibles(item.path);
   main.scrollTop = 0;
+}
+
+// Persist <details> open/closed state per doc so collapsing a command's flow
+// (or any <details> on the page) survives a reload. Keyed by doc path + the
+// summary text, stored in localStorage; applied to every <details> rendered.
+function wireCollapsibles(path) {
+  main.querySelectorAll('details').forEach((d, idx) => {
+    const sum = d.querySelector('summary');
+    const label = sum ? sum.textContent.trim().slice(0, 80) : String(idx);
+    const key = 'zskills-docs-collapse:' + path + '#' + label;
+    const saved = localStorage.getItem(key);
+    if (saved === 'closed') d.removeAttribute('open');
+    else if (saved === 'open') d.setAttribute('open', '');
+    d.addEventListener('toggle', () => {
+      localStorage.setItem(key, d.open ? 'open' : 'closed');
+    });
+  });
 }
 
 // The renderer emits raw relative `<a href="X.md">` for internal doc links

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -83,10 +83,17 @@ html, body {
   font-size: 15px;
   color: var(--muted);
 }
+.zl-docs-header-link {
+  margin-left: auto;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 14px;
+}
+.zl-docs-header-link:hover { text-decoration: underline; }
 
 /* Theme toggle button (Phase 3 addition — not lifted). */
 .zl-docs-theme-toggle {
-  margin-left: auto;
+  margin-left: 0;
   background: transparent;
   border: 1px solid var(--line);
   color: var(--ink);

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -187,6 +187,10 @@ html, body {
 #zl-docs-main pre code { background: none; padding: 0; border: none; }
 #zl-docs-main hr { border: none; border-top: 1px solid var(--line); margin: 16px 0; }
 #zl-docs-main a { color: var(--accent); }
+/* Bare slash-command mentions (e.g. /do) — accent-colored like skill names in
+ * flow diagrams. The .skill class is applied by MarkdownRenderer's inline-code
+ * pass only to single `/word` tokens, so flags/verbs/paths stay neutral. */
+#zl-docs-main code.skill { color: var(--accent); }
 #zl-docs-main img { max-width: 100%; border-radius: 6px; margin: 10px 0; }
 
 /* Loading placeholder — shown before the first doc renders and during
@@ -248,3 +252,67 @@ html, body {
     padding: 16px 20px;
   }
 }
+
+/* ── Workflow flow strips (ported from PRESENTATION.html, themed to viewer vars) ── */
+/* Vertical flow: larger stacked boxes with down-arrow connectors — plenty of
+   room for the real wording (no horizontal scroll, no tiny text). */
+.flow {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;               /* room for the down-arrow between boxes */
+  margin: 20px auto;       /* centered column */
+  max-width: 580px;
+}
+.flow-step {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 13px 18px;
+  position: relative;
+  text-align: center;
+}
+.flow-step p { font-size: 0.95em; color: var(--ink); margin: 0; line-height: 1.5; }
+.flow-step strong { color: var(--accent); font-weight: 600; }
+/* down-arrow connector between stacked steps */
+.flow-step + .flow-step::before {
+  content: '';
+  position: absolute;
+  top: -15px; left: 50%;
+  transform: translateX(-50%);
+  width: 0; height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 8px solid var(--accent);   /* points down to this box */
+}
+/* optional / conditional step (brainstorm·quiz lead-in, "if auto" trailing) — dashed + dimmed */
+.flow-step.optional { border-style: dashed; background: transparent; }
+.flow-step.optional p { color: var(--muted); font-style: italic; }
+.flow-step.optional strong { color: var(--muted); }
+.flow-step.optional::before { border-top-color: var(--muted); }
+
+/* Collapsible per-command flow — framed as a callout card so it stands out
+   from the surrounding prose. Open/closed persisted by docs-app.js. */
+details.flow-cmd {
+  margin: 22px auto;
+  max-width: 620px;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);   /* accent stripe draws the eye */
+  border-radius: 10px;
+  background: var(--panel2);               /* fallback for older browsers */
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+}
+details.flow-cmd > summary {
+  cursor: pointer;
+  padding: 11px 18px;
+  font-size: 1.02em;
+  font-weight: 600;
+  color: var(--ink);
+  border-radius: 9px;
+  list-style-position: inside;
+}
+details.flow-cmd[open] > summary {
+  border-bottom: 1px solid var(--line);
+  border-radius: 9px 9px 0 0;
+}
+details.flow-cmd > summary:hover { color: var(--accent); }
+details.flow-cmd > summary code { color: var(--accent); }

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,6 +16,10 @@ Practical guides for installing zskills and working with it day to day. Start wi
 
 - **[Switching install lanes](switching-install-lanes.md)** — move an existing install from one lane to the other, in either direction, with a clean way to back out.
 
+## Reference
+
+- **[Configuring zskills](zskills-config.md)** — every field in `.claude/zskills-config.json`: landing mode, tests, dev server, paths, and what not to hand-edit.
+
 ## See also
 
 - **[Skills reference](../skills/README.md)** — per-skill details for the 21 user-facing slash commands.

--- a/docs/guides/inspecting-and-monitoring.md
+++ b/docs/guides/inspecting-and-monitoring.md
@@ -290,7 +290,28 @@ the dashboard, or `cat` the files:
 
 ---
 
-## 7. Cheat sheet
+## 7. Session logs — an opt-in transcript trail
+
+zskills can write a per-session log — what the agent did, plus every permission
+request — to disk, turning "what happened across sessions" into something you can
+read after the fact. Two config keys control it (see
+[Configuring zskills](zskills-config.md)):
+
+- `logging.enabled` (default `true`) — the master switch for the session-logging
+  hooks.
+- `logging.dir` — where logs land. Left empty they go to a temp directory keyed
+  by project name, and the hook records that path in the **main checkout's**
+  `.zskills/session-log-dirs` (newest last — one registry shared by all the
+  repo's worktrees) so you can always find where it logged. Point it at a stable
+  **absolute** path to keep a durable trail you can `cat` later.
+
+Because it captures the permission requests too, this is a useful monitoring and
+audit record for unattended (`auto` / scheduled) runs — set `logging.dir`
+somewhere persistent before you walk away.
+
+---
+
+## 8. Cheat sheet
 
 ```bash
 # --- live: what's running now ---

--- a/docs/guides/inspecting-and-monitoring.md
+++ b/docs/guides/inspecting-and-monitoring.md
@@ -104,7 +104,7 @@ without asking the agent anything.
 ![The zskills dashboard: plan columns (Drafted/Proposed/Accepted/…), per-plan status chips and phase progress, the Recent-activity feed.](assets/zskills-dashboard.png)
 
 > **Try it live:** an interactive, browser-only demo of this dashboard runs at
-> **<http://zskills.synapticnoise.com/dashboard-demo/>** — drop plans into *Accepted*
+> **<https://zeveck.github.io/zskills-dev/dashboard-demo/>** — drop plans into *Accepted*
 > (and issues into *Ready*) and watch them get worked, with the activity feed
 > and run-status chips updating live. *(The screenshot above is from that demo;
 > its plan names are illustrative placeholders.)*
@@ -293,21 +293,23 @@ the dashboard, or `cat` the files:
 ## 7. Session logs — an opt-in transcript trail
 
 zskills can write a per-session log — what the agent did, plus every permission
-request — to disk, turning "what happened across sessions" into something you can
-read after the fact. Two config keys control it (see
-[Configuring zskills](zskills-config.md)):
+request — to disk **once you turn it on**, turning "what happened across
+sessions" into something you can read after the fact. Two config keys control it
+(see [Configuring zskills](zskills-config.md)):
 
-- `logging.enabled` (default `true`) — the master switch for the session-logging
-  hooks.
-- `logging.dir` — where logs land. Left empty they go to a temp directory keyed
-  by project name, and the hook records that path in the **main checkout's**
+- `logging.enabled` (**default `false`** — opt-in) — the master switch; set it
+  `true` to turn session logging on. When off or absent, both hooks no-op.
+- `logging.dir` — where logs land. Left empty they go to a per-OS cache directory
+  keyed by project name (e.g. `~/.cache/zskills-session-logs/<project>` on Linux),
+  and the hook records that path in the **main checkout's**
   `.zskills/session-log-dirs` (newest last — one registry shared by all the
   repo's worktrees) so you can always find where it logged. Point it at a stable
   **absolute** path to keep a durable trail you can `cat` later.
 
 Because it captures the permission requests too, this is a useful monitoring and
-audit record for unattended (`auto` / scheduled) runs — set `logging.dir`
-somewhere persistent before you walk away.
+audit record for unattended (`auto` / scheduled) runs — turn it on
+(`logging.enabled: true`) and point `logging.dir` somewhere persistent before you
+walk away.
 
 ---
 

--- a/docs/guides/installing-zskills.md
+++ b/docs/guides/installing-zskills.md
@@ -29,13 +29,24 @@ The first command registers the `zskills` marketplace; the second installs the
 `zs` plugin (the full distribution). Restart the session when prompted so the
 plugin's hooks load.
 
-On the first session after install, the plugin writes a handful of files into
+> **If the install fails to clone with a git SSH error** — something like
+> `git@github.com: Permission denied (publickey)` followed by
+> `fatal: Could not read from remote repository` — your git is configured to
+> reach GitHub over **SSH** (usually a global `insteadOf` rewrite), but the
+> plugin clones over **HTTPS**. Tell Claude *"configure git to use HTTPS instead
+> of SSH so the install works"* and re-run `/plugin install zs@zskills`.
+
+On the first session after install, the plugin writes its managed files into
 your project's `.claude/`: the two agent definitions (`.claude/agents/`), two
 hook scripts (`.claude/hooks/`), and the agent-rules file
 (`.claude/rules/zskills/managed.md`). These are plugin-managed — when you
-upgrade, the plugin refreshes them. If you've edited one of these files
-yourself, your edited copy is left alone. See
-[`.gitignore` guidance](#gitignore-guidance) for whether to track them.
+upgrade, the plugin refreshes them, leaving any you've edited yourself alone.
+
+If you don't already have a `.claude/zskills-config.json`, the plugin also seeds
+a default one (plus its schema) so the skills have settings to read — review it
+and tune it for your project (see [Configuring zskills](zskills-config.md)). An
+existing config is never overwritten. See
+[`.gitignore` guidance](#gitignore-guidance) for whether to track these files.
 
 By default the plugin install lands work in **`locked-main-pr`** mode
 (`execution.landing: pr`, `main_protected: true`): agents don't commit to
@@ -52,6 +63,10 @@ git clone https://github.com/zeveck/zskills.git /tmp/zskills
 mkdir -p .claude/skills
 cp -r /tmp/zskills/skills/* .claude/skills/
 ```
+
+If `git clone` fails with the same `git@github.com: Permission denied` SSH error
+as under [Plugin install](#plugin-install), the cause and fix are identical —
+point git at HTTPS, then retry.
 
 ```
 /update-zskills install

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -185,18 +185,24 @@ it.
 
 </details>
 
-**When:** You want to find test gaps before they bite.
+**When:** You want to find test gaps and likely bugs before they bite — and, on
+a schedule, keep finding them as the codebase moves.
 
 ```text
-/qe-audit
+/qe-audit                     # commit audit: scan recent work for coverage gaps
+/qe-audit bash "undo/redo"    # bash mode: adversarially stress-test a feature for bugs
+/qe-audit every 1h            # continuous coverage — re-audit hourly in the background
 ```
 
-- `/qe-audit` proactively scans the repo for test-coverage gaps and likely
-  bugs and **files GitHub issues** — it generates work, where
-  `/verify-changes` only gates your current changes.
-- `/manual-testing` is an internal helper you don't run directly —
-  `/verify-changes` dispatches it to verify UI behavior with real
-  mouse/keyboard events (`playwright-cli`).
+- Two modes, both filing **GitHub issues**: the default **commit audit** scans
+  recent work for coverage gaps and likely bugs, while **`bash`** adversarially
+  stress-tests a feature to shake out bugs (`/qe-audit bash "undo/redo"`, or a
+  bare `/qe-audit bash` to let it pick under-tested areas). Either way it
+  *generates* work, where `/verify-changes` only gates your current changes.
+- **Pair it with a sprint for a hands-off QA loop:** leave `/qe-audit every 1h`
+  running on the side to keep filing issues as you work, and a scheduled
+  `/fix-issues 1 every 2h auto` (recipe 7) to clear them — the audit finds, the
+  sprint fixes. See [Run something on a schedule](#13-run-something-on-a-schedule).
 
 ## 7. Backlog bug sprint
 
@@ -224,7 +230,7 @@ it.
 - `/fix-report` walks the sprint results, gates landing on your review of each
   manual verification, lands the fixes, and closes the GitHub issues.
 - `/fix-issues` is schedulable — `/fix-issues 1 every 60m auto` clears one issue
-  an hour, unattended. See [Run something on a schedule](#12-run-something-on-a-schedule).
+  an hour, unattended. See [Run something on a schedule](#13-run-something-on-a-schedule).
 
 ## 8. Unclear bug → root cause
 
@@ -232,23 +238,26 @@ it.
 <summary><code>/investigate</code> → <code>/do</code></summary>
 
 <div class="flow">
-<div class="flow-step"><p><strong><code>/investigate</code></strong> proves the root cause and leaves a regression test</p></div>
-<div class="flow-step"><p><strong><code>/do</code></strong> ships the now-known fix as a PR</p></div>
+<div class="flow-step"><p><strong><code>/investigate</code></strong> proves the root cause and produces a verified fix + regression test — left in your tree, unlanded</p></div>
+<div class="flow-step"><p><strong><code>/do auto</code></strong> ships that now-proven change as a PR</p></div>
 </div>
 
 </details>
 
-**When:** Something is broken but the root cause is not yet proven.
+**When:** Something is broken and the root cause isn't proven yet.
 
 ```text
 /investigate <description or #issue>
-/do "fix <root cause>" pr
+/do "fix <root cause>" auto
 ```
 
-- `/investigate` does deep root-cause debugging: it proves *why* the bug
-  happens and produces a regression test, rather than guessing at a fix.
-- Once the root cause is known, ship the fix with `/do` — the fix is now a
-  known change, not an investigation.
+- `/investigate` does deep root-cause debugging: it reproduces the bug, proves
+  *why* it happens, writes a failing regression test, and applies the minimal
+  fix — verifying it against the suite. The catch: it stops there, leaving that
+  verified fix in your working tree; it doesn't commit, branch, or land.
+- So that fix is really a *proven input* — once the cause is nailed, you hand
+  the now-known change to `/do auto` to ship it as a clean PR (the practical
+  path, since an in-tree fix on a protected `main` can't simply be committed).
 
 ## 9. Verify changes
 
@@ -323,10 +332,9 @@ branches and worktrees they left behind.
 ## 11. Status & monitoring
 
 <details class="flow-cmd">
-<summary><code>/session-report</code> · <code>/briefing</code> · <code>/plans</code> · <code>/zskills-dashboard</code></summary>
+<summary><code>/briefing</code> · <code>/plans</code> · <code>/zskills-dashboard</code></summary>
 
 <div class="flow">
-<div class="flow-step"><p><strong><code>/session-report</code></strong> — what this session actually shipped vs. intended</p></div>
 <div class="flow-step"><p><strong><code>/briefing</code></strong> — project status: commits, worktrees, open checkboxes</p></div>
 <div class="flow-step"><p><strong><code>/plans</code></strong> — every plan's status and the next ready one</p></div>
 <div class="flow-step"><p><strong><code>/zskills-dashboard</code></strong> — local web UI for plans, issues, and tracking</p></div>
@@ -334,34 +342,59 @@ branches and worktrees they left behind.
 
 </details>
 
-**When:** You want to see where this session, the project, or your plans stand.
+**When:** You want to see where the project or your plans stand right now.
 
 ```text
-/session-report          # audit what THIS session actually shipped vs. intended
-/session-report handoff  # persist a durable, forward-looking end-of-session hand-off
 /briefing                # project status: commits, worktrees, open checkboxes
 /plans                   # plan dashboard: statuses, next ready plan
 /zskills-dashboard       # local web UI for plans, issues, and tracking
 ```
 
-- `/session-report` reconciles what the current session *intended* against what
-  actually landed — checked against git, PRs, and plans, not memory. Add
-  `handoff` to instead write a durable, forward-looking hand-off that you or the
-  next session can pick up from.
 - `/briefing` summarizes current project state at a glance.
 - `/plans` shows every plan's status and points you at the next ready one.
 - `/zskills-dashboard` serves a local web dashboard for plans, issues, and
   tracking markers.
 
+## 12. Review and hand off your session
+
+<details class="flow-cmd">
+<summary><code>/session-report</code> · <code>/session-report handoff</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> gathers what this session said it would do</p></div>
+<div class="flow-step"><p>It checks each claim against ground truth — git, PRs, plan markers — not memory</p></div>
+<div class="flow-step"><p>It reports what actually shipped, what's still open, and the next steps</p></div>
+<div class="flow-step optional"><p>With <strong>handoff</strong> it instead writes a durable, forward-looking hand-off doc to resume from</p></div>
+</div>
+
+</details>
+
+**When:** You're wrapping up and want an honest account of what landed, what's
+still open, and where to pick up — or a durable hand-off for the next session
+(or the next person).
+
+```text
+/session-report          # audit this session: shipped vs. intended, open items, next steps
+/session-report handoff  # persist a forward-looking hand-off to resume from
+```
+
+- `/session-report` reconciles what the session *intended* against what actually
+  landed — checked against git, PRs, and plan markers, not conversation memory,
+  so "I did X" only counts when the commit or PR proves it. The result is a
+  review with open items and next steps surfaced.
+- `handoff` turns that into a durable, forward-looking document — the state of
+  play plus what to do next — written to outlast the session, so your future
+  self or a teammate can pick up cleanly.
+
 ---
 
-## 12. Run something on a schedule
+## 13. Run something on a schedule
 
 <details class="flow-cmd">
 <summary><strong><code>every SCHEDULE</code></strong> — the shared scheduling mechanic</summary>
 
 <div class="flow">
-<div class="flow-step"><p>Add <strong>every 30m</strong> (or any interval) to any of the five schedulable skills</p></div>
+<div class="flow-step"><p>Add <strong>every 30m</strong> (or any interval) to any of the six schedulable skills</p></div>
 <div class="flow-step"><p>A self-perpetuating cron is registered</p></div>
 <div class="flow-step"><p>Each fire runs the flow and re-registers the next one</p></div>
 <div class="flow-step"><p>Manage it with <strong>stop</strong> or <strong>next</strong></p></div>
@@ -373,8 +406,8 @@ branches and worktrees they left behind.
 issues as they arrive, re-audit after each batch of work, or drain the plan queue
 through the day.
 
-Five skills take `every SCHEDULE` — `/do`, `/fix-issues`, `/run-plan`,
-`/qe-audit`, and `/work-on-plans`. Append the interval to any of them:
+Six skills take `every SCHEDULE` — `/briefing`, `/do`, `/fix-issues`,
+`/qe-audit`, `/run-plan`, and `/work-on-plans`. Append the interval to any of them:
 
 ```text
 /fix-issues 1 every 60m auto                 # fix one issue an hour, landing each itself

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,65 +1,51 @@
 # Z Skills Workflows
 
 This is a **recipes / playbook** doc: it shows how to chain Z Skills into
-real end-to-end workflows. For what an individual skill does and its full
-argument list, see the [per-skill reference](../skills/README.md).
-
-## Philosophy
-
-Z Skills matches the skill to the work — not the other way around. The
-everyday workhorse is `/do`: when you
-can describe the change and its approach is clear, `/do` it — whatever the
-size, from a typo to a wide refactor to plumbing a new UI element. A backlog
-of bugs to clear runs through `/fix-issues`. Reach for `/draft-plan` **freely**
-— lean toward it on a genuine toss-up — whenever the work has open design to
-work out or needs to be staged into ordered phases. A broad goal that splits
-into several dependent sub-plans gets `/research-and-plan`.
-
-The axis is **design-depth / staging, not file-count**: thirty files changed
-by one settled approach is still a `/do`; one change with unresolved design is
-a `/draft-plan`.
-
-**Your changes are checked before they land**, whichever skill you pick:
-tests run, a separate review pass re-checks the work, and nothing reaches
-`main` unchecked. The skill choice governs how much *ceremony* the work
-goes through; the checking is constant.
-
-Landing mode (cherry-pick / locked-main-pr / direct) is install-time
-configuration — covered in
-[Installing zskills → Landing mode](installing-zskills.md#landing-mode).
-The workflow snippets below pass `pr` or `direct` as a positional override
-when needed; otherwise the configured default applies.
-
-> **Argument syntax.** Most arguments you type are **positional tokens** —
-> mode/verb words like `auto`, `pr`, `direct`, `finish` with no dashes.
-> (For example: `/run-plan docs/plans/X.md finish auto pr`.) A few skills
-> also take dashed flags, which are reserved for overriding a safety gate:
-> `--force` (on `/do`, `/work-on-plans`, `/cleanup-merged`)
-> skips the triage and review step, and `--rounds N` (on `/do`) sets how
-> many review-and-refine cycles run. The one dashed flag you do **not**
-> type is `--auto`: that form belongs to the internal `/land-pr` helper
-> these skills dispatch for you. To auto-merge, pass the positional `auto`
-> token instead.
-
----
+real end-to-end workflows. For what an individual skill does on its own —
+its flow diagram, full description, and argument list — see the
+[Z Skills Reference](../skills/README.md), where every skill's page now
+opens with its flow.
 
 ## 1. Everyday change — just `/do` it
 
+<details class="flow-cmd">
+<summary><code>/do</code> → PR</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the change — its approach is already clear</p></div>
+<div class="flow-step"><p><strong><code>/do</code></strong> isolates the work in a worktree and lands it as a PR</p></div>
+</div>
+
+</details>
+
 **When:** Any change you can describe whose approach is clear — a doc edit, a
 bug fix, a refactor, a new UI element, a content update. This is the workhorse
-you reach for most; most "just ask Claude" work runs through it.
+you reach for most; most "just ask Claude" work runs through it. If the work
+has unknowns, turns out to be complicated, or would benefit from deeper review
+or staging into phases, reach for `/draft-plan` instead.
 
 ```text
-/do "<task>" pr          # worktree-isolated; runs triage → review → commit → PR → land
+/do "<task>"             # the everyday workhorse; lands per your configured mode
 ```
 
-- `/do` carries a change through the full lifecycle — triage → review →
-  commit → PR → land — in an isolated worktree, landing a one-commit PR.
 - "Lightweight" means **no staged phases and no open design** — *not* "small."
   A wide but settled change is still a `/do`; reach for `/draft-plan` only when
   the design is open or the work needs to be staged into ordered phases.
+- How the change reaches `main` — a worktree and cherry-pick, a PR, or direct on
+  `main` — follows your configured landing mode; see
+  [Configuring zskills](zskills-config.md).
 
 ## 2. Plan-driven feature
+
+<details class="flow-cmd">
+<summary><code>/draft-plan</code> → <code>/run-plan</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong><code>/draft-plan</code></strong> researches the goal and writes a reviewed plan file</p></div>
+<div class="flow-step"><p><strong><code>/run-plan finish auto</code></strong> executes every phase and lands them autonomously</p></div>
+</div>
+
+</details>
 
 **When:** You have a goal and want a reviewed plan before any code is written.
 
@@ -79,7 +65,20 @@ you reach for most; most "just ask Claude" work runs through it.
 
 ## 3. Plan with test specs
 
-**When:** You want test coverage designed into the plan up front, not bolted on.
+<details class="flow-cmd">
+<summary><code>/draft-plan</code> → <code>/draft-tests</code> → <code>/run-plan</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong><code>/draft-plan</code></strong> researches the goal and writes a reviewed plan file</p></div>
+<div class="flow-step"><p><strong><code>/draft-tests</code></strong> designs test specs into each pending phase</p></div>
+<div class="flow-step"><p><strong><code>/run-plan finish auto</code></strong> executes the phases, tests included</p></div>
+</div>
+
+</details>
+
+**When:** The work is test-critical and you want a dedicated QE pass that
+designs detailed test specs into the plan — going beyond the testable
+acceptance criteria `/draft-plan` already writes.
 
 ```text
 /draft-plan <goal>
@@ -87,15 +86,36 @@ you reach for most; most "just ask Claude" work runs through it.
 /run-plan docs/plans/<file>.md finish auto
 ```
 
-- `/draft-tests` reads an existing plan and writes test specifications into
-  its phases, so each phase ships with its tests defined rather than improvised.
-- `/run-plan` then executes phases whose acceptance criteria already include
-  those tests.
-- For an even more grounded plan, pre-seed `/draft-plan` with `brainstorm`
-  (design dialogue) or `quiz` (requirements interview) before `/draft-tests`
-  appends test specs.
+- `/draft-plan` already gives every phase testable acceptance criteria;
+  `/draft-tests` runs a separate senior-QE review loop that designs detailed
+  test specs — concrete cases and edge cases — into each pending phase, so the
+  implementing agent has them spelled out rather than improvising.
+- `/run-plan` then executes those phases with the specs riding along inside
+  them; there's no separate test document to maintain.
 
 ## 4. Big goal decomposition
+
+<details class="flow-cmd">
+<summary><code>/research-and-plan</code> → <code>/run-plan</code> — review the split first</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the broad goal</p></div>
+<div class="flow-step"><p><strong><code>/research-and-plan</code></strong> decomposes it into sub-plans and stops for your review</p></div>
+<div class="flow-step"><p>You review the meta-plan, then <strong><code>/run-plan finish auto</code></strong> executes each sub-plan in turn</p></div>
+</div>
+
+</details>
+
+<details class="flow-cmd">
+<summary><code>/research-and-go</code> — the same, bundled and hands-off</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the broad goal</p></div>
+<div class="flow-step"><p><strong><code>/research-and-go</code></strong> decomposes it, drafts every sub-plan, and runs them all — no review stop</p></div>
+<div class="flow-step optional"><p>It's <code>/research-and-plan</code> + <code>/run-plan</code> in one pass, so it takes some optimism — reach for it once you trust the setup and can walk away</p></div>
+</div>
+
+</details>
 
 **When:** The goal is too large for one plan and decomposes into several
 dependent sub-plans.
@@ -115,81 +135,55 @@ Or, to draft **and** execute everything in one autonomous pass:
 - `/research-and-plan` researches the domain, identifies sub-problems and
   their dependencies, and produces a meta-plan whose phases each delegate to
   `/run-plan` — then stops so you can review before commit-volume work begins.
-- `/research-and-go` uses the same drafting machinery but continues straight
-  into execution. Use it when you've said "walk away."
+- `/research-and-go` is `/research-and-plan` and `/run-plan` bundled into one
+  command: same drafting machinery, but it continues straight into execution
+  with no review checkpoint. That takes some optimism — reach for it once you
+  trust the setup and have genuinely said "walk away."
 
-## 5. Mid-flight plan drift
+## 5. Reconcile a plan with reality
 
-**When:** A plan is partway executed and reality has diverged from the spec.
+<details class="flow-cmd">
+<summary><code>/refine-plan</code> → <code>/run-plan</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong><code>/refine-plan</code></strong> reconciles the plan against current reality — the codebase, plus any completed phases</p></div>
+<div class="flow-step"><p><strong><code>/run-plan finish auto</code></strong> executes the corrected phases</p></div>
+</div>
+
+</details>
+
+**When:** You have an existing plan that no longer matches reality — maybe it
+was partly executed and the work diverged, or it was drafted a while ago and the
+codebase has since moved on. You want to build on the plan you have, not redraft
+it.
 
 ```text
 /refine-plan docs/plans/<file>.md
 /run-plan docs/plans/<file>.md finish auto
 ```
 
-- `/refine-plan` reconciles the plan against the work already completed,
-  rewriting remaining phases to match current reality instead of the stale
-  original design.
-- Resume `/run-plan` to execute the corrected remaining phases.
+- `/refine-plan` reviews the plan against what actually exists now — the
+  codebase, plus any completed phases — and rewrites the **remaining** phases to
+  match, keeping completed phases and the plan's structure intact instead of
+  starting over.
+- It's the *build on what you have* counterpart to `/draft-plan`: `/draft-plan`
+  drafts a fresh plan from the goal (even when you hand it an existing document),
+  while `/refine-plan` keeps and updates the document you already have. Reach for
+  it when you have a `/run-plan`-shaped plan you want to sync, not replace.
+- Resume `/run-plan` to execute the corrected phases.
 
-## 6. Backlog bug sprint
+## 6. Proactive coverage
 
-**When:** You have several small bugs or issues to clear in one batch.
+<details class="flow-cmd">
+<summary><code>/qe-audit</code></summary>
 
-```text
-/fix-issues 5 pr auto
-/fix-report
-```
+<div class="flow">
+<div class="flow-step"><p><strong><code>/qe-audit</code></strong> scans recent commits for risky changes</p></div>
+<div class="flow-step"><p><strong>Audit subagents</strong> comb them in parallel with fresh eyes</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> re-verifies each finding and files GitHub issues with repro recipes</p></div>
+</div>
 
-- `/fix-issues N` runs a batch sprint, fixing up to `N` issues each in its own
-  worktree. Add `pr` to land each via PR and `auto` for auto-merge; omit them
-  to use the default cherry-pick mode.
-- `/fix-report` walks the sprint results, gates landing on your review of each
-  manual verification, lands the fixes, and closes the GitHub issues.
-
-## 7. Unclear bug → root cause
-
-**When:** Something is broken but the root cause is not yet proven.
-
-```text
-/investigate <description or #issue>
-/do "fix <root cause>" pr
-```
-
-- `/investigate` does deep root-cause debugging: it proves *why* the bug
-  happens and produces a regression test, rather than guessing at a fix.
-- Once the root cause is known, ship the fix with `/do pr` (worktree) —
-  the fix is now a known change, not an investigation.
-
-## 8. Pre-commit quality gate
-
-**When:** You have changes ready and want them verified before they land.
-
-```text
-/verify-changes
-/commit pr
-```
-
-- `/verify-changes` reviews your recent changes end to end: diffs, test
-  coverage, a real test run, and manual UI checks where relevant. It gates the
-  commit — fix what it surfaces before proceeding.
-- `/commit pr` commits the work and opens a PR by dispatching `/land-pr` for
-  you (proper rebase, CI monitoring, fix-cycle on failure). Add `auto` for
-  auto-merge.
-
-## 9. Post-merge cleanup
-
-**When:** A PR has merged on GitHub and your local clone is behind.
-
-```text
-/cleanup-merged
-```
-
-- `/cleanup-merged` checks out `main`, pulls, and deletes merged feature
-  branches so your local clone matches the remote. It's safe to run anytime
-  and bails on a dirty tree.
-
-## 10. Proactive coverage
+</details>
 
 **When:** You want to find test gaps before they bite.
 
@@ -204,23 +198,197 @@ Or, to draft **and** execute everything in one autonomous pass:
   `/verify-changes` dispatches it to verify UI behavior with real
   mouse/keyboard events (`playwright-cli`).
 
-## 11. Status & monitoring
+## 7. Backlog bug sprint
 
-**When:** You want to see where the project, plans, or this session stand.
+<details class="flow-cmd">
+<summary><code>/fix-issues</code> → <code>/fix-report</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong><code>/fix-issues N</code></strong> fixes up to N issues, each in its own worktree</p></div>
+<div class="flow-step"><p><strong><code>/fix-report</code></strong> reviews the sprint, lands the fixes, and closes the issues</p></div>
+<div class="flow-step optional"><p>With <strong>auto</strong> the sprint lands and merges each fix itself — <code>/fix-report</code> is for the non-auto path</p></div>
+</div>
+
+</details>
+
+**When:** You have several small bugs or issues to clear in one batch.
 
 ```text
-/briefing             # project status: commits, worktrees, open checkboxes
-/plans                # plan dashboard: statuses, next ready plan
-/zskills-dashboard    # local web UI for plans, issues, and tracking
-/session-report       # audit what THIS session actually shipped vs. intended
+/fix-issues 5 pr auto
+/fix-report
 ```
 
+- `/fix-issues N` runs a batch sprint, fixing up to `N` issues each in its own
+  worktree. Add `pr` to land each via PR and `auto` for auto-merge; omit them
+  to use the default cherry-pick mode.
+- `/fix-report` walks the sprint results, gates landing on your review of each
+  manual verification, lands the fixes, and closes the GitHub issues.
+- `/fix-issues` is schedulable — `/fix-issues 1 every 60m auto` clears one issue
+  an hour, unattended. See [Run something on a schedule](#12-run-something-on-a-schedule).
+
+## 8. Unclear bug → root cause
+
+<details class="flow-cmd">
+<summary><code>/investigate</code> → <code>/do</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong><code>/investigate</code></strong> proves the root cause and leaves a regression test</p></div>
+<div class="flow-step"><p><strong><code>/do</code></strong> ships the now-known fix as a PR</p></div>
+</div>
+
+</details>
+
+**When:** Something is broken but the root cause is not yet proven.
+
+```text
+/investigate <description or #issue>
+/do "fix <root cause>" pr
+```
+
+- `/investigate` does deep root-cause debugging: it proves *why* the bug
+  happens and produces a regression test, rather than guessing at a fix.
+- Once the root cause is known, ship the fix with `/do` — the fix is now a
+  known change, not an investigation.
+
+## 9. Verify changes
+
+<details class="flow-cmd">
+<summary><code>/verify-changes</code> — review a feature end to end</summary>
+
+<div class="flow">
+<div class="flow-step"><p>A <strong>fresh verifier subagent</strong> reviews the diff and audits test coverage — fresh eyes on the actual code, not session memory</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> runs the full test suite</p></div>
+<div class="flow-step"><p>It dispatches <code>/manual-testing</code> for a real browser pass on UI changes</p></div>
+<div class="flow-step"><p>It fixes what surfaces and re-verifies, looping until clean</p></div>
+<div class="flow-step"><p>It reports findings and recommendations</p></div>
+</div>
+
+</details>
+
+**When:** You want to confirm a feature actually works — covered by tests,
+passing them, and behaving correctly in the UI. This is a **feature review**,
+not a code review: the question is "does this work and is it verified," not "is
+the code tidy."
+
+```text
+/verify-changes              # all uncommitted changes in the working tree (default)
+/verify-changes branch       # every commit on the current branch vs main
+/verify-changes last 3       # just the last 3 commits — recent or just-landed work
+```
+
+- `/verify-changes` reviews the diff, audits test coverage, runs the suite, and
+  drives the UI with `/manual-testing` where relevant — then fixes what it finds
+  and re-verifies until clean.
+- Point it at the scope you care about: the default checks current uncommitted
+  work; `worktree` checks a worktree against its base; `branch` checks the whole
+  branch; `last [N]` checks recent (or just-landed) commits. Run it before you
+  land to gate the work, or right after to confirm what shipped.
+- The review runs with **fresh eyes** — when it can dispatch, it hands the diff
+  and coverage review to a separate verifier subagent that reads the actual code
+  rather than trusting memory of what changed. That independence is what gives
+  the verdict weight: a real check, not a rubber stamp of what you think you did.
+
+## 10. Post-merge cleanup
+
+<details class="flow-cmd">
+<summary><code>/cleanup-merged</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> fetches and prunes the remote-tracking branches GitHub has already deleted</p></div>
+<div class="flow-step"><p>If you're on a now-merged branch, it switches to main and pulls</p></div>
+<div class="flow-step"><p>It removes the worktrees held by merged branches (clean ones only)</p></div>
+<div class="flow-step"><p>It deletes the merged local branches — and remote ones too, with <code>remote</code> / <code>all</code></p></div>
+</div>
+
+</details>
+
+**When:** Some of your PRs have merged on GitHub and you want to clear out the
+branches and worktrees they left behind.
+
+```text
+/cleanup-merged              # preview what would be removed (local)
+/cleanup-merged apply        # remove merged local branches + their worktrees
+/cleanup-merged all apply    # also delete the merged branches on the remote
+```
+
+- `/cleanup-merged` is mostly a **branch + worktree sweeper**: it removes the
+  worktrees held by merged branches (skipping any that are dirty) and deletes the
+  merged branches themselves. Switching to `main` and pulling is just the part
+  that gets you off a branch that's about to be deleted.
+- **Preview by default** — a bare invocation shows what it *would* remove; add
+  `apply` to act. `local` (default) / `remote` / `all` pick the scope.
+- It never deletes a branch with unpushed commits, never removes a dirty
+  worktree, and never touches protected branches from your config.
+
+## 11. Status & monitoring
+
+<details class="flow-cmd">
+<summary><code>/session-report</code> · <code>/briefing</code> · <code>/plans</code> · <code>/zskills-dashboard</code></summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong><code>/session-report</code></strong> — what this session actually shipped vs. intended</p></div>
+<div class="flow-step"><p><strong><code>/briefing</code></strong> — project status: commits, worktrees, open checkboxes</p></div>
+<div class="flow-step"><p><strong><code>/plans</code></strong> — every plan's status and the next ready one</p></div>
+<div class="flow-step"><p><strong><code>/zskills-dashboard</code></strong> — local web UI for plans, issues, and tracking</p></div>
+</div>
+
+</details>
+
+**When:** You want to see where this session, the project, or your plans stand.
+
+```text
+/session-report          # audit what THIS session actually shipped vs. intended
+/session-report handoff  # persist a durable, forward-looking end-of-session hand-off
+/briefing                # project status: commits, worktrees, open checkboxes
+/plans                   # plan dashboard: statuses, next ready plan
+/zskills-dashboard       # local web UI for plans, issues, and tracking
+```
+
+- `/session-report` reconciles what the current session *intended* against what
+  actually landed — checked against git, PRs, and plans, not memory. Add
+  `handoff` to instead write a durable, forward-looking hand-off that you or the
+  next session can pick up from.
 - `/briefing` summarizes current project state at a glance.
 - `/plans` shows every plan's status and points you at the next ready one.
 - `/zskills-dashboard` serves a local web dashboard for plans, issues, and
   tracking markers.
-- `/session-report` reconciles what the current session intended against what
-  actually landed.
+
+---
+
+## 12. Run something on a schedule
+
+<details class="flow-cmd">
+<summary><strong><code>every SCHEDULE</code></strong> — the shared scheduling mechanic</summary>
+
+<div class="flow">
+<div class="flow-step"><p>Add <strong>every 30m</strong> (or any interval) to any of the five schedulable skills</p></div>
+<div class="flow-step"><p>A self-perpetuating cron is registered</p></div>
+<div class="flow-step"><p>Each fire runs the flow and re-registers the next one</p></div>
+<div class="flow-step"><p>Manage it with <strong>stop</strong> or <strong>next</strong></p></div>
+</div>
+
+</details>
+
+**When:** You want a skill to run unattended on a recurring interval — clear new
+issues as they arrive, re-audit after each batch of work, or drain the plan queue
+through the day.
+
+Five skills take `every SCHEDULE` — `/do`, `/fix-issues`, `/run-plan`,
+`/qe-audit`, and `/work-on-plans`. Append the interval to any of them:
+
+```text
+/fix-issues 1 every 60m auto                 # fix one issue an hour, landing each itself
+/qe-audit every 6h                           # re-audit the repo every six hours
+/work-on-plans every 4h                      # drain the ready-plan queue through the day
+/do "check examples for broken links" every 12h now   # run now, then every 12h
+```
+
+- Add `now` to also run once immediately; pair with `auto` so scheduled fires
+  land without waiting for you.
+- The schedule is **session-scoped** — it ends when the session does.
+- `<skill> stop` cancels the cron; `<skill> next` shows its next fire time.
+- For unattended runs, set `logging.dir` so you have a transcript to review
+  afterward — see [Inspecting & monitoring](inspecting-and-monitoring.md).
 
 ---
 

--- a/docs/guides/zskills-config.md
+++ b/docs/guides/zskills-config.md
@@ -113,7 +113,7 @@ whether the project is PR-only or lets agents work on `main` directly.
 | `execution.dashboard_completed_limit` | Max closed issues fetched per dashboard snapshot. | `500` |
 
 `landing` and `main_protected` are usually set together by a **preset** rather
-than edited by hand — see [Landing & protection](#landing--protection).
+than edited by hand — see [Landing & protection](#landing-protection).
 
 ### `testing` — how tests run
 
@@ -148,12 +148,13 @@ Consumed (and toggled) by the session-logging hooks.
 
 | Field | What it does | Default |
 |---|---|---|
-| `logging.enabled` | Master switch. `false` makes the session-logging hooks no-op. | `true` |
-| `logging.dir` | Where session logs are written — used as-is, so give an **absolute** path. Empty = a temp directory keyed by project name, with the path recorded in the main checkout's `.zskills/session-log-dirs` registry (newest last) so you can always find where it logged; set this for a stable, predictable location. | `""` |
+| `logging.enabled` | Master switch — **off by default**; set `true` to opt in. When `false` or absent, the session-logging hooks no-op. | `false` |
+| `logging.dir` | Where session logs are written — used as-is, so give an **absolute** path. Empty = a per-OS cache directory keyed by project name (e.g. `~/.cache/zskills-session-logs/<project>` on Linux), with the path recorded in the main checkout's `.zskills/session-log-dirs` registry (newest last) so you can always find where it logged; set this for a stable, predictable location. | `""` |
 
-Pointing `logging.dir` at a persistent path gives you a readable per-session
-transcript and permission trail — a handy monitoring/audit record, especially
-for unattended runs (see [Inspecting & monitoring](inspecting-and-monitoring.md)).
+With logging turned on (`logging.enabled: true`), pointing `logging.dir` at a
+persistent path gives you a readable per-session transcript and permission trail
+— a handy monitoring/audit record, especially for unattended runs (see
+[Inspecting & monitoring](inspecting-and-monitoring.md)).
 
 ### `commit` — commit metadata
 

--- a/docs/guides/zskills-config.md
+++ b/docs/guides/zskills-config.md
@@ -1,0 +1,286 @@
+# Configuring zskills
+
+Every zskills install is steered by one file: `.claude/zskills-config.json`.
+It tells the skills, hooks, and helper scripts how *your* project works — how
+to run tests, how changes reach `main`, what the dev server command is, which
+timezone to stamp reports in, and more. This guide explains where the file
+comes from, what every field does, and which fields you should never hand-edit.
+
+You rarely write this file by hand. `/update-zskills` creates and maintains it
+for you (and on the plugin lane it's seeded automatically on first session).
+Reach for this guide when you want to understand a setting, change one
+deliberately, or debug why a skill behaved the way it did.
+
+## Where it lives
+
+| File | Role |
+|---|---|
+| `.claude/zskills-config.json` | Your project's settings (this guide). |
+| `.claude/zskills-config.schema.json` | The JSON Schema the config validates against — the authoritative list of every key and default. Editors that honor `$schema` will autocomplete and lint against it. |
+
+The config's first line points an editor at that schema:
+
+```json
+{
+  "$schema": "./zskills-config.schema.json",
+  ...
+}
+```
+
+The schema is the source of truth for field names and defaults; this guide is
+the explanation of what they *mean*. The canonical copy lives at
+[`config/zskills-config.schema.json`](../../config/zskills-config.schema.json)
+in the source repo.
+
+## How it's created and updated
+
+`/update-zskills` owns this file:
+
+- **First install** — `/update-zskills install` auto-detects what it can (test
+  command, dev-server command, timezone) and writes the rest as empty strings
+  for you to fill in. Running the command *is* the consent; it writes the file
+  directly.
+- **Re-install / update** — it **merges, never overwrites**: an existing
+  non-empty value always wins over a re-detected one, so your edits survive an
+  update. A missing `commit.co_author` is backfilled.
+- **Plugin lane** — plugins can't write files at install time, so a
+  `SessionStart` hook **seeds** a default config the first time you open the
+  project — but only when the file is *absent*. An existing config is never
+  clobbered. (The plugin seed defaults differ slightly; see
+  [Lane differences](#lane-differences) below.)
+
+A handful of fields are managed entirely by `/update-zskills` and should not be
+hand-edited — see [What not to hand-edit](#what-not-to-hand-edit).
+
+## A typical config
+
+This is roughly what `/update-zskills` writes for a Node project. Every block
+is optional; an absent key falls back to its default.
+
+```json
+{
+  "$schema": "./zskills-config.schema.json",
+  "project_name": "my-app",
+  "timezone": "America/New_York",
+  "execution": {
+    "landing": "pr",
+    "main_protected": true,
+    "branch_prefix": "feat/"
+  },
+  "commit": {
+    "co_author": "My Agent <agent@example.com>"
+  },
+  "testing": {
+    "unit_cmd": "npm test",
+    "full_cmd": "npm run test:all",
+    "output_file": ".test-results.txt",
+    "file_patterns": ["tests/**/*.test.js"]
+  },
+  "dev_server": {
+    "cmd": "npm start",
+    "default_port": 8080,
+    "main_repo_path": "/home/you/projects/my-app"
+  },
+  "ui": {
+    "file_patterns": "src/(components|ui)/.*\\.tsx?$",
+    "auth_bypass": "localStorage.setItem('token', 'test')"
+  },
+  "logging": {
+    "enabled": true,
+    "dir": "/home/you/projects/my-app/.zskills/session-logs"
+  },
+  "agents": {
+    "min_model": "auto"
+  }
+}
+```
+
+## Field reference
+
+### `execution` — how work is built and landed
+
+The most load-bearing block. `landing` and `main_protected` together decide
+whether the project is PR-only or lets agents work on `main` directly.
+
+| Field | What it does | Default |
+|---|---|---|
+| `execution.landing` | Default landing mode when a skill isn't given a positional mode token. One of `cherry-pick`, `pr`, `direct`. | `cherry-pick` |
+| `execution.main_protected` | When `true`, agents cannot edit, commit, cherry-pick, or push to `main` — every change must go through a worktree and PR. **Enforced** by hooks, not just convention. | `false` |
+| `execution.branch_prefix` | Prefix for PR-mode branch names (e.g. `feat/`, `agent/`, or `""`). | `feat/` |
+| `execution.worktree_root` | Parent directory for new worktrees (`<root>/<project>-<slug>`). Keeps ephemeral agent work off the repo tree. | `/tmp` |
+| `execution.max_concurrent_worktrees` | Cap on live worktrees during a `/fix-issues` sprint — prevents resource exhaustion in constrained containers. | `3` |
+| `execution.dashboard_completed_days` | How many days of closed work the dashboard's "Completed" column shows. | `14` |
+| `execution.dashboard_completed_limit` | Max closed issues fetched per dashboard snapshot. | `500` |
+
+`landing` and `main_protected` are usually set together by a **preset** rather
+than edited by hand — see [Landing & protection](#landing--protection).
+
+### `testing` — how tests run
+
+| Field | What it does | Default |
+|---|---|---|
+| `testing.unit_cmd` | The fast unit-test command (used while working). | — |
+| `testing.full_cmd` | The full-suite command (run before committing). Skills reference this instead of hardcoding a command, so the rule that says "run the suite before every commit" shows *your* command. | — |
+| `testing.output_file` | Filename skills capture test output to (kept out of the working tree). | `.test-results.txt` |
+| `testing.file_patterns` | Globs identifying test files, surfaced in your project rules. | — |
+
+### `dev_server` — running the app
+
+| Field | What it does | Default |
+|---|---|---|
+| `dev_server.cmd` | Command that starts your dev server. `scripts/start-dev.sh` runs it; `scripts/stop-dev.sh` stops the recorded PIDs. | — |
+| `dev_server.default_port` | The dev port for the **main** repo. Worktrees each get their own deterministic hash-derived port instead. | `8080` |
+| `dev_server.main_repo_path` | Absolute path to the main checkout, so worktree agents can tell main-vs-worktree apart when choosing a port. | — |
+
+If you set `main_repo_path` you must also set `default_port`, or the port
+helper fails loudly on the main repo.
+
+### `ui` — UI verification
+
+| Field | What it does | Default |
+|---|---|---|
+| `ui.file_patterns` | Regex matching UI files; changes to them flag that a manual browser pass is warranted. | — |
+| `ui.auth_bypass` | JavaScript run to bypass your app's auth during automated browser testing (`/manual-testing`). | — |
+
+### `logging` — session logs
+
+Consumed (and toggled) by the session-logging hooks.
+
+| Field | What it does | Default |
+|---|---|---|
+| `logging.enabled` | Master switch. `false` makes the session-logging hooks no-op. | `true` |
+| `logging.dir` | Where session logs are written — used as-is, so give an **absolute** path. Empty = a temp directory keyed by project name, with the path recorded in the main checkout's `.zskills/session-log-dirs` registry (newest last) so you can always find where it logged; set this for a stable, predictable location. | `""` |
+
+Pointing `logging.dir` at a persistent path gives you a readable per-session
+transcript and permission trail — a handy monitoring/audit record, especially
+for unattended runs (see [Inspecting & monitoring](inspecting-and-monitoring.md)).
+
+### `commit` — commit metadata
+
+| Field | What it does | Default |
+|---|---|---|
+| `commit.co_author` | The `Co-Authored-By:` trailer added to agent-authored commits. An empty string opts out of the trailer entirely. | (the installing agent's identity) |
+
+### `agents` — subagent floor
+
+| Field | What it does | Default |
+|---|---|---|
+| `agents.min_model` | The minimum model any subagent may be dispatched on — **enforced** by a hook that denies a below-floor dispatch. A literal model id (e.g. `claude-sonnet-4-6`) sets a fixed floor; the sentinel `auto` (or `inherit`) floors at the session's current model. | `auto` |
+
+### `cleanup` — branch cleanup
+
+| Field | What it does | Default |
+|---|---|---|
+| `cleanup.protected_branches` | Branch names `/cleanup-merged` must never delete (exact match). | `[]` |
+| `cleanup.long_running_patterns` | **Deprecated** — superseded by `protected_branches`. | `[]` |
+
+### `output` — where artifacts go (migration-managed)
+
+These point the plan, issue, and report directories somewhere other than their
+legacy locations. They are special: **only `/update-zskills --migrate-paths`
+writes them**, all-or-nothing, and their *absence is meaningful* — it preserves
+the legacy layout. Don't add them by hand (adding one without moving files
+strands artifacts).
+
+| Field | Points at | When absent (legacy) |
+|---|---|---|
+| `output.plans_dir` | User-curated plans (e.g. `docs/plans`). | `plans/` |
+| `output.issues_dir` | Issue trackers (e.g. `docs/issues`). | `plans/` |
+| `output.reports_dir` | Agent work-trail reports (e.g. `docs/reports`). | `.zskills/audit` |
+
+The `.zskills/` runtime subtree (tracking markers, audit dir, dev-server
+pid/log) is **not** configurable — those paths are fixed.
+
+### Top-level fields
+
+| Field | What it does | Default |
+|---|---|---|
+| `project_name` | Human-readable name used in PR titles, reports, worktree path stems, and log-dir names. | `""` |
+| `timezone` | IANA timezone for report and marker timestamps (e.g. `America/New_York`). | see [Lane differences](#lane-differences) |
+| `zskills_version` | The installed-version fingerprint, written by `/update-zskills` and read by `/briefing` to flag when a newer zskills is available. Don't hand-edit — it'd produce a false "up to date" or "stale" signal. | `""` |
+
+### Reserved (declared but not yet wired)
+
+`ci.auto_fix` and `ci.max_fix_attempts` appear in the schema and the default
+config, but no skill reads them at runtime today — the PR fix-cycle currently
+uses a fixed limit of two attempts. Treat them as reserved for a future
+release; changing them has no effect yet.
+
+## Landing & protection
+
+`execution.landing` and `execution.main_protected` are the two knobs that
+define how changes reach `main`. Because they belong together, `/update-zskills`
+sets them as a matched **preset** rather than expecting you to edit each one:
+
+| Preset (`/update-zskills <preset>`) | `landing` | `main_protected` |
+|---|---|---|
+| `cherry-pick` (default) | `cherry-pick` | `false` |
+| `locked-main-pr` | `pr` | `true` |
+| `direct` | `direct` | `false` |
+
+Run e.g. `/update-zskills locked-main-pr` to switch — it updates both fields
+through the supported path. (A bare preset is a pure landing-mode switch; it
+touches nothing else.) For a fuller explanation of what each mode means, see
+[Landing mode](installing-zskills.md#landing-mode) in the install guide.
+
+When `main_protected` is `true`, the protection is **enforced**, not advisory:
+separate hooks deny edits, commits/cherry-picks, and pushes that target `main`.
+This is what forces every change through a worktree and a PR rather than letting
+an agent edit `main` in place.
+
+## How values resolve
+
+There is no single "env > config > default" rule — resolution differs by field:
+
+- **Most string settings** (`testing.*`, `dev_server.cmd`, `commit.co_author`,
+  `timezone`) resolve to the config value with **no opinionated default**: when
+  absent, the consuming skill applies its own fallback (for example, timezone
+  falls back to UTC at the point of use). This is why an unset field is simply
+  empty rather than guessed.
+- **A few settings honor an environment override** for one-off runs:
+  - `logging.dir` ← `ZSKILLS_LOG_DIR` env > config > temp dir.
+  - the dev port ← `DEV_PORT` env > a `scripts/dev-port.sh` stub > `dev_server.default_port` (main repo) > a per-worktree hash port.
+- **The enforced keys** (`main_protected`, `agents.min_model`,
+  `logging.enabled`) are re-read from the config at runtime by their hooks, so
+  editing them takes effect on the next tool call — no reinstall needed.
+
+## Lane differences
+
+A consumer installs zskills through exactly one lane, and the two seed a fresh
+config slightly differently:
+
+| | `/update-zskills` lane | Plugin lane (auto-seed) |
+|---|---|---|
+| When written | At `install` time | First `SessionStart`, only if absent |
+| `timezone` | `America/New_York` | `UTC` |
+| Default preset | `cherry-pick` (unprotected) | `locked-main-pr` (protected) |
+
+Either way, the file is yours to refine afterward — the seed is only a starting
+point, and an existing config is never overwritten.
+
+## What not to hand-edit
+
+Most fields are safe to edit directly. These few are managed for you, and
+editing them by hand causes drift:
+
+- **`execution.landing` / `execution.main_protected`** — change them with a
+  `/update-zskills <preset>`, not by hand, so the install stays consistent.
+- **`output.plans_dir` / `issues_dir` / `reports_dir`** — only
+  `/update-zskills --migrate-paths` may write these (it also moves the files).
+- **`zskills_version`** — written from the source repo's release tag; a manual
+  value produces a false update signal.
+
+Editing the config through Claude Code also triggers a "re-render needed"
+warning, because some values are baked into your generated project rules — run
+`/update-zskills --rerender` afterward to refresh them.
+
+## See also
+
+- [Installing zskills](installing-zskills.md) — first-time setup and the
+  [Landing mode](installing-zskills.md#landing-mode) explainer.
+- [Switching install lanes](switching-install-lanes.md) — moving between the
+  plugin and `/update-zskills` lanes.
+- [`/update-zskills`](../skills/update-zskills.md) — the skill that writes and
+  maintains this file.
+- [`config/zskills-config.schema.json`](../../config/zskills-config.schema.json)
+  — the authoritative schema.

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
     <header id="zl-docs-header">
       <a href="#docs/README.md" class="zl-docs-logo" style="color:#5db0ff">Z Skills Docs</a>
       <span class="zl-docs-header-title">Documentation</span>
+      <a href="https://zeveck.github.io/zskills-dev/PRESENTATION.html" class="zl-docs-header-link">Presentation &rarr;</a>
       <button id="zl-docs-theme-toggle"
               class="zl-docs-theme-toggle"
               type="button"

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,101 +1,84 @@
 # Z Skills Reference
 
 Per-skill reference for the **21 user-facing Z Skills**, plus the **2 internal
-helpers** they dispatch (`/land-pr` and `/manual-testing` — not for direct use;
-in the docs viewer they appear under their own **Internal Skills** section).
-Looking for how to *combine* these skills into end-to-end workflows? See
+helpers** they dispatch (`/land-pr` and `/manual-testing` — not for direct use).
+Grouped and ordered the same as the docs-viewer nav sidebar. Looking for how to
+*combine* these skills into end-to-end workflows? See
 [Workflows](../guides/workflows.md).
 
-<details>
-<summary><strong>Quick reference table</strong> — alphabetical jump list (click to expand)</summary>
+The **Arguments** column is the real `argument-hint` from each skill's
+frontmatter (alternatives shown with `│`; `—` = no arguments).
 
-| Skill | Description |
-|-------|-------------|
-| [`/briefing`](briefing.md) | Generate a project briefing with status, commits, worktrees |
-| [`/cleanup-merged`](cleanup-merged.md) | Post-PR-merge local normalization |
-| [`/commit`](commit.md) | Safe commit workflow with optional push, land, or PR |
-| [`/create-worktree`](create-worktree.md) | Create an isolated git worktree for agent work |
-| [`/do`](do.md) | Lightweight task dispatcher for ad-hoc work |
-| [`/draft-plan`](draft-plan.md) | Draft plans through iterative adversarial review |
-| [`/draft-tests`](draft-tests.md) | Draft test specifications into existing plans |
-| [`/fix-issues`](fix-issues.md) | Orchestrate batch bug-fixing sprints |
-| [`/fix-report`](fix-report.md) | Review sprint results, land fixes, close issues |
-| [`/investigate`](investigate.md) | Deep debugging for complex bugs |
-| [`/plans`](plans.md) | Plan dashboard: view status, find next ready plan |
-| [`/qe-audit`](qe-audit.md) | Quality engineering audit for test coverage gaps |
-| [`/refine-plan`](refine-plan.md) | Refine in-progress plans against completed work |
-| [`/research-and-go`](research-and-go.md) | Full pipeline: decompose, plan, and execute autonomously |
-| [`/research-and-plan`](research-and-plan.md) | Decompose broad goals into executable sub-plans |
-| [`/run-plan`](run-plan.md) | Execute plan phases with verification and landing |
-| [`/session-report`](session-report.md) | Audit session intent vs. actual shipped state |
-| [`/update-zskills`](update-zskills.md) | Install or update Z Skills infrastructure |
-| [`/verify-changes`](verify-changes.md) | Verify recent changes: diffs, tests, manual checks |
-| [`/work-on-plans`](work-on-plans.md) | Batch-execute prioritized plan queue from dashboard |
-| [`/zskills-dashboard`](zskills-dashboard.md) | Local web dashboard for plans, issues, and tracking |
+## Execution
 
-#### Internal helpers
+Make one change, end to end.
+
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/do`](do.md) | `<description> [worktree] [pr] [auto] [every SCHEDULE] [now] [--rounds N] │ stop │ next │ now` | The everyday workhorse for ad-hoc work |
+| [`/run-plan`](run-plan.md) | `<plan-file> [phase│finish│status] [auto] [pr│direct] [every SCHEDULE] [now] │ stop │ next` | Execute plan phases with verify + land |
+| [`/investigate`](investigate.md) | `<description or #issue>` | Deep root-cause debugging |
+
+## Planning & Design
+
+Create, refine, and decompose plans before execution.
+
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/draft-plan`](draft-plan.md) | `[output FILE] [rounds N] [auto] [brainstorm│quiz] <description...>` | Adversarial plan drafting |
+| [`/refine-plan`](refine-plan.md) | `<plan-file> [rounds N] [auto] [guidance...]` | Refine in-progress plans against reality |
+| [`/draft-tests`](draft-tests.md) | `<plan-file> [rounds N] [auto] [guidance...]` | Draft test specs into a plan's phases |
+| [`/research-and-plan`](research-and-plan.md) | `[output FILE] <broad goal description>` | Decompose broad goals into sub-plans |
+| [`/plans`](plans.md) | `[rebuild │ next │ details]` | Plan dashboard / index |
+
+## Quality Assurance
+
+Test, audit, and verify changes.
+
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/verify-changes`](verify-changes.md) | `[scope: worktree │ branch │ last [N]]` | Verify recent changes end to end |
+| [`/qe-audit`](qe-audit.md) | `[bash [area]] [every SCHEDULE] [now] │ stop │ next` | Quality audit for test-coverage gaps |
+
+## Automation
+
+Batch, queue, and scheduled drivers that run unattended.
+
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/fix-issues`](fix-issues.md) | `N [focus│dashboard] [auto] [every SCHEDULE] [now] [pr│direct] │ sync │ plan │ stop │ next` | Batch bug-fixing sprints |
+| [`/work-on-plans`](work-on-plans.md) | `N│all [phase│finish] [every SCHEDULE] [now] [continue] │ stop │ next` | Batch-run the ready plan queue |
+| [`/zskills-dashboard`](zskills-dashboard.md) | `[start│stop│status│restart]` | Local web dashboard |
+| [`/research-and-go`](research-and-go.md) | `<broad goal description>` | Full autonomous decompose → plan → execute |
+
+## Reporting
+
+Generate reports and review project state.
+
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/session-report`](session-report.md) | `[handoff]` | Audit session intent vs. shipped |
+| [`/briefing`](briefing.md) | `[report [period]] │ verify │ current │ worktrees │ [summary] │ stop │ next` | Project briefing: status, commits, worktrees |
+| [`/fix-report`](fix-report.md) | — | Review sprint results, land fixes, close issues |
+
+## Utilities
+
+Supporting tools — committing, cleanup, docs, and framework setup.
+
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/commit`](commit.md) | `[pr] [scope] [push│land] [auto]` | Safe commit with optional push / land / PR |
+| [`/cleanup-merged`](cleanup-merged.md) | `[apply] [local │ remote │ all] [<branch>...]` | Post-PR-merge local normalization |
+| [`/update-zskills`](update-zskills.md) | `[install] [cherry-pick│locked-main-pr│direct]` | Install / update zskills infrastructure |
+| [`/create-worktree`](create-worktree.md) | `<slug> [--prefix P] [--branch-name REF] [--from B] [--purpose TEXT] [--pipeline-id ID] …` | Create an isolated worktree (mostly dispatched internally) |
+
+## Internal helpers
 
 Dispatched by other skills — not designed for direct user invocation (both carry
 `user-invocable: false`). In the docs viewer they appear under their own
-**Internal Skills** section. Listed here for reference only.
+**Internal** nav section.
 
-| Skill | Description |
-|-------|-------------|
-| [`/land-pr`](land-pr.md) | PR landing helper (rebase, push, create-or-detect, monitor CI, optional auto-merge) |
-| [`/manual-testing`](manual-testing.md) | Browser-based manual testing recipes (uses the `playwright-cli` tool) |
-
-</details>
-
-## Categories
-
-### Execution & Orchestration
-
-Core skills for running plans and fixing issues at scale.
-
-- [/run-plan](run-plan.md) -- Execute plan phases with implementation, verification, and landing
-- [/fix-issues](fix-issues.md) -- Batch bug-fixing sprints with per-issue worktrees
-- [/work-on-plans](work-on-plans.md) -- Batch-execute the prioritized ready queue from the dashboard
-- [/do](do.md) -- Lightweight task dispatcher for ad-hoc work
-- [/research-and-go](research-and-go.md) -- Full autonomous pipeline: decompose, plan, execute
-
-### Planning & Design
-
-Skills for creating, refining, and decomposing plans before execution.
-
-- [/draft-plan](draft-plan.md) -- Draft plans through iterative adversarial review
-- [/draft-tests](draft-tests.md) -- Draft test specifications into existing plan phases
-- [/refine-plan](refine-plan.md) -- Refine in-progress plans against completed work
-- [/research-and-plan](research-and-plan.md) -- Decompose broad goals into executable sub-plans
-- [/plans](plans.md) -- Plan dashboard: view status, find the next ready plan
-
-### Verification & Quality
-
-Skills for testing, auditing, and verifying changes.
-
-- [/verify-changes](verify-changes.md) -- Full verification: diffs, test coverage, test runs, manual checks
-- [/qe-audit](qe-audit.md) -- Quality engineering audit for test coverage gaps and bugs
-- [/investigate](investigate.md) -- Deep root-cause debugging for complex bugs
-- [/manual-testing](manual-testing.md) -- Browser-based manual testing recipes (uses the `playwright-cli` tool) *(internal helper)*
-
-### Git & Landing
-
-Skills for committing, landing, and cleaning up branches.
-
-- [/commit](commit.md) -- Safe commit workflow with push, land, or PR modes
-- [/cleanup-merged](cleanup-merged.md) -- Post-PR-merge local normalization and branch cleanup
-- [/create-worktree](create-worktree.md) -- Create isolated git worktrees for agent work
-
-### Reporting & Status
-
-Skills for generating reports and reviewing project state.
-
-- [/briefing](briefing.md) -- Generate a project briefing with worktrees, commits, checkboxes
-- [/session-report](session-report.md) -- Audit what this session shipped vs. what was planned
-- [/fix-report](fix-report.md) -- Review sprint results, land fixes, close issues
-
-### Infrastructure & Configuration
-
-Skills for managing the Z Skills framework itself.
-
-- [/update-zskills](update-zskills.md) -- Install or update Z Skills infrastructure
-- [/zskills-dashboard](zskills-dashboard.md) -- Local web dashboard for plans, issues, and tracking
+| Skill | Arguments | What it does |
+|-------|-----------|--------------|
+| [`/land-pr`](land-pr.md) | `--branch <name> --title <t> --body-file <p> --result-file <p> [--auto] [--worktree-path <p>] …` | PR landing helper (rebase, push, create-or-detect, monitor CI, optional auto-merge) |
+| [`/manual-testing`](manual-testing.md) | — | Browser-based UI-verification recipes (uses the `playwright-cli` tool) |

--- a/docs/skills/briefing.md
+++ b/docs/skills/briefing.md
@@ -2,6 +2,16 @@
 
 > Generate a project briefing: worktree status, open checkboxes, recent commits. Modes: summary (default), report, verify, current, worktrees. Period: 1h, 6h, 24h, 1d, 2d, 7d.
 
+<details class="flow-cmd" open>
+<summary>How it runs — project status</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> scans the current repo state</p></div>
+<div class="flow-step"><p>It reports commits, worktrees, and open checkboxes</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/briefing` gathers the current state of your project and presents it as a structured briefing. It looks at three things: the status of your worktrees, the open sign-off checkboxes (`[ ]` items) sitting in report files, and the recent commits that have landed on `main`. The result is a quick read on what needs your attention, what is in flight, and what has already landed.

--- a/docs/skills/cleanup-merged.md
+++ b/docs/skills/cleanup-merged.md
@@ -4,6 +4,18 @@
 > switch off a merged feature branch, pull main, and delete local branches
 > whose work is already on main. Preview by default.
 
+<details class="flow-cmd" open>
+<summary>How it runs — catch the clone up</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> fetches and prunes the remote-tracking branches GitHub has already deleted</p></div>
+<div class="flow-step"><p>If you're on a now-merged branch, it switches to main and pulls</p></div>
+<div class="flow-step"><p>It removes the worktrees held by merged branches (clean ones only)</p></div>
+<div class="flow-step"><p>It deletes the merged local branches — and remote ones too, with <code>remote</code> / <code>all</code></p></div>
+</div>
+
+</details>
+
 ## What it does
 
 After you merge a pull request on GitHub, your local clone still has the

--- a/docs/skills/commit.md
+++ b/docs/skills/commit.md
@@ -3,6 +3,18 @@
 > Commit your current work safely, and optionally push it, open a pull
 > request, or land worktree commits onto main.
 
+<details class="flow-cmd" open>
+<summary>How it runs — safe, scoped commit</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> inventories all uncommitted changes</p></div>
+<div class="flow-step"><p>It scopes the commit and traces imports and dependencies</p></div>
+<div class="flow-step"><p>A <strong>reviewer subagent</strong> checks the staged change</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> commits, then optionally pushes or opens a PR</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/commit` is the user-facing way to turn the changes in your working tree
@@ -77,9 +89,8 @@ it that way:
   branch, create the pull request, monitor CI, and run the fix cycle on a
   failure. `/land-pr` is an internal helper you do not type directly; reach
   for it through `/commit pr`.
-- **`/do`** — the workhorse for one-commit changes. It carries a change
-  through triage, review, and landing in an isolated worktree, and calls
-  `/commit` to land the work.
+- **`/do`** — the everyday skill for one-commit changes. It carries a change
+  through triage, review, and landing, and calls `/commit` to land its work.
 - **`/run-plan`** and **`/fix-issues`** — larger orchestration skills that
   also land their work through `/commit` and `/land-pr`.
 - **`/cleanup-merged`** — run this *after* a PR you opened with `/commit pr`

--- a/docs/skills/create-worktree.md
+++ b/docs/skills/create-worktree.md
@@ -2,6 +2,18 @@
 
 > Create a git worktree for agent work, on a fresh branch off `main`. Most of the time another skill runs this for you; you rarely call it by hand.
 
+<details class="flow-cmd" open>
+<summary>How it runs — set up a worktree</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> prunes, fetches, and ff-merges main</p></div>
+<div class="flow-step"><p>It creates the worktree on a branch</p></div>
+<div class="flow-step"><p>It writes the <code>.zskills-tracked</code> marker</p></div>
+<div class="flow-step"><p>It returns the path to the caller</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/create-worktree` sets up a fresh [git worktree](https://git-scm.com/docs/git-worktree) — a separate checkout of the repository in its own directory — so an agent can work on a change in isolation, without disturbing your main checkout. You give it a short slug; it picks a directory and a branch name from that slug, creates the worktree there, and prints the worktree's absolute path so the caller can `cd` into it and start working.

--- a/docs/skills/do.md
+++ b/docs/skills/do.md
@@ -2,6 +2,21 @@
 
 > Lightweight task dispatcher for ad-hoc work: documentation, examples, refactoring, content updates. Worktree/direct/pr landing modes via flag or config. Recurring via `every SCHEDULE`; `stop`/`next` manage the schedule.
 
+<details class="flow-cmd" open>
+<summary>How it runs — worktree → PR</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the task</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> turns your task into a plan</p></div>
+<div class="flow-step"><p>A <strong>reviewer subagent</strong> checks the plan and loops until it approves<br>(you can raise the round count with <code>--rounds</code> (default 1))</p></div>
+<div class="flow-step"><p>An <strong>implementer subagent</strong> builds it in a worktree</p></div>
+<div class="flow-step"><p>A <strong>verifier subagent</strong> verifies the change</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> lands it via a PR and monitors CI (up to 2 fix attempts)</p></div>
+<div class="flow-step optional"><p>If you pass <strong>auto</strong>, it requests merge — GitHub merges once required checks pass</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/do` is the everyday workhorse: it takes a single self-contained task and runs it end to end — researching the change, making it, verifying it, and (when you ask) landing it. "Lightweight" here is relative to `/draft-plan`, not a size limit: it means no multi-phase plan and no open design to work out, *not* "small." Documentation, examples, refactors, a new UI element, plumbing new UI, one-off fixes, and content updates all fit. What sends a task elsewhere is unresolved design or work that needs staging into ordered phases (`/draft-plan`), or an issue backlog to clear (`/fix-issues`) — never the number of files touched.
@@ -11,8 +26,6 @@ Given a plain-English description, `/do` first checks that the task is actually 
 Once it decides to proceed, `/do` dispatches a fresh review agent to sanity-check its plan before any code is written, then does the work, then verifies it. Verification matches the kind of change: code changes run the full test suite and a separate `/verify-changes` pass, while content-only changes (markdown, images, presentations) skip the test suite and instead get a focused review of the diff. The `auto` flag controls whether the result lands autonomously — it does not control whether verification runs; code changes are always verified.
 
 How the result reaches `main` depends on the landing mode (see Arguments). The common shape in a protected-`main` repo is a pull request: `/do` opens a worktree, makes the change there, runs the verification gate locally, opens a PR, and watches CI. Output is brief and inline — `/do` writes no persistent report file; the commit (or PR) is the artifact.
-
-`/do` is the everyday workhorse for one-commit changes: it isolates the work in a worktree, runs the verification gate, and lands a single-commit PR. Reach for it whenever a change is small enough not to warrant a full plan but you still want the review-and-verify lifecycle around it.
 
 ## Usage
 

--- a/docs/skills/draft-plan.md
+++ b/docs/skills/draft-plan.md
@@ -2,6 +2,20 @@
 
 > Draft a high-quality plan through iterative adversarial review: research, draft, review, devil's-advocate, refine -- repeated until convergence. Output is a plan file ready for `/run-plan` execution.
 
+<details class="flow-cmd" open>
+<summary>How it runs — adversarial drafting</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the goal</p></div>
+<div class="flow-step optional"><p>Optionally <strong>you</strong> open with <strong>brainstorm</strong> (design dialogue) or <strong>quiz</strong> (requirements interview) to seed the research</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> researches the problem and writes a first draft</p></div>
+<div class="flow-step"><p>A <strong>reviewer subagent</strong> and a <strong>devil's-advocate subagent</strong> attack the draft</p></div>
+<div class="flow-step"><p>A <strong>refiner subagent</strong> rewrites it, looping until the reviews converge</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> writes the plan file, ready for <code>/run-plan</code></p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/draft-plan` turns a description of work into a written plan file you can execute with `/run-plan`. It does this by drafting the plan and then attacking it: one pass researches the problem, another writes a first draft, and then reviewers and a deliberately adversarial "devil's advocate" poke holes in it while a refiner addresses every finding. This review-and-refine cycle repeats until the plan stops accumulating substantive problems (or hits the round budget you set).

--- a/docs/skills/draft-tests.md
+++ b/docs/skills/draft-tests.md
@@ -2,6 +2,18 @@
 
 > Drafts test specifications into an existing plan's pending phases through adversarial review. Adds a `### Tests` subsection to each phase that still needs work; already-completed phases are never touched. Sister skill to `/draft-plan`, scoped to test specs.
 
+<details class="flow-cmd" open>
+<summary>How it runs — test specs into a plan</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> reads the plan's pending phases — completed phases are never touched</p></div>
+<div class="flow-step"><p>A <strong>QE-reviewer subagent</strong> and a <strong>devil's-advocate subagent</strong> draft the test specs</p></div>
+<div class="flow-step"><p>A <strong>refiner subagent</strong> sharpens them, looping until converged</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> writes a Tests subsection into each pending phase</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/draft-tests` takes a plan file — the kind `/draft-plan` produces — and writes test specifications into it. For every phase that is still pending, it appends a `### Tests` subsection describing what that phase should be tested for. It then pressure-tests those specs through several rounds of adversarial review and refinement, the same way `/draft-plan` pressure-tests a plan, until the specs hold up.

--- a/docs/skills/fix-issues.md
+++ b/docs/skills/fix-issues.md
@@ -2,6 +2,19 @@
 
 > Work through a backlog of GitHub issues in one sprint: pick the issues, fix each in isolation, run the tests, and (optionally) open and land a pull request per fix. Recurring via `every SCHEDULE`; `stop`/`next` manage the schedule. `sync` refreshes issue trackers and closes already-fixed issues; `plan` drafts plans for issues too complex to fix in a sprint.
 
+<details class="flow-cmd" open>
+<summary>How it runs — batch sprint</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> picks N issues by priority or the dashboard Ready column</p></div>
+<div class="flow-step"><p><strong>Implementer subagents</strong> fix them in parallel worktrees</p></div>
+<div class="flow-step"><p><strong>Verifier subagents</strong> verify each fix</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> writes a sprint report</p></div>
+<div class="flow-step optional"><p>With <strong>auto</strong> it lands and merges each fix; otherwise it stops at the report for you to land via <code>/fix-report</code></p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/fix-issues N` runs a batch bug-fixing sprint over your GitHub issues. You give it a count `N`, and it prioritizes that many open issues, fixes each one in its own isolated worktree, runs the test suite before anything is committed, and writes a sprint report you can hand off to `/fix-report`. With the `auto` flag it lands each fix for you (via `/land-pr` in PR mode); without it, it asks for approval at the key gates first.

--- a/docs/skills/fix-report.md
+++ b/docs/skills/fix-report.md
@@ -2,6 +2,19 @@
 
 > The interactive review companion to `/fix-issues`. Walks you through every sprint result you haven't signed off yet — confirming fixes, landing them, closing the matching GitHub issues, updating trackers, and cleaning up. Always interactive; no arguments.
 
+<details class="flow-cmd" open>
+<summary>How it runs — interactive sign-off</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> gathers every unreviewed sprint result</p></div>
+<div class="flow-step"><p>It walks you through each fix — UI changes get a browser pass/fail check</p></div>
+<div class="flow-step"><p><strong>You</strong> approve each step</p></div>
+<div class="flow-step"><p>It lands the fixes, closes the issues, and removes the worktrees</p></div>
+<div class="flow-step"><p>It writes the final sign-off report</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/fix-issues` does the fixing; `/fix-report` clears the results. When `/fix-issues` runs a backlog — often unattended on a schedule — its results pile up unreviewed. `/fix-report` gathers all of that unreviewed work into one picture and walks you through clearing it. It covers everything outstanding, not just the most recent run: if `/fix-issues` has been working on a cron for a day, `/fix-report` presents all of it at once.

--- a/docs/skills/investigate.md
+++ b/docs/skills/investigate.md
@@ -2,6 +2,21 @@
 
 > Deep debugging for one complex bug at a time. A disciplined workflow — reproduce, trace, state the root cause, fix, verify — that makes the agent prove it understands the bug before it writes a fix.
 
+<details class="flow-cmd" open>
+<summary>How it runs — one agent, doesn't land</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the bug, or point at an issue</p></div>
+<div class="flow-step"><p>The <strong>agent</strong> reproduces it and watches it fail</p></div>
+<div class="flow-step"><p>It traces the code to the root cause</p></div>
+<div class="flow-step"><p>It states the cause and proves it — <strong>you</strong> confirm</p></div>
+<div class="flow-step"><p>It writes a regression test that fails first</p></div>
+<div class="flow-step"><p>It makes the minimal fix</p></div>
+<div class="flow-step"><p>It verifies the test passes, then runs the full suite</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/investigate` takes one bug whose cause is unclear and works it end to end: it reproduces the bug, traces the failure back to its source, states the root cause in writing, applies a minimal fix, and verifies that fix. The defining discipline is that no fix may be written until the root cause has been proven — the skill exists precisely because the natural instinct is to skip straight to "try a fix," and every step here is built to prevent that.
@@ -41,7 +56,7 @@ When the input is an issue number, `/investigate` also claims that issue first, 
 ## Companion skills
 
 - **`/fix-issues`** — the batch counterpart. `/investigate` is for one bug at a time; for working through several issues, use `/fix-issues`, which will redirect you here when a single bug needs deeper digging. When `/fix-issues` can't diagnose a bug within its normal flow (two failed attempts), it skips that issue with a note that it needs deeper investigation, and you then run `/investigate` on it. There is no automatic escalation — the hand-off is your decision.
-- **`/do`** — where the fix goes once the root cause is known. `/do` assumes the fix is already understood; `/investigate` is what you run first when it isn't. Once `/investigate` has proven the cause, the fix itself can be carried by `/do`, which isolates the work in a worktree and lands a one-commit PR.
+- **`/do`** — where the fix goes once the root cause is known. `/do` assumes the fix is already understood; `/investigate` is what you run first when it isn't. Once `/investigate` has proven the cause, `/do` carries the fix to a verified, landed change.
 
 ## Arguments
 

--- a/docs/skills/land-pr.md
+++ b/docs/skills/land-pr.md
@@ -9,6 +9,19 @@
 > other callers below). `/commit pr` figures out the title and body, then runs
 > `/land-pr` for you with the right setup.
 
+<details class="flow-cmd" open>
+<summary>How it runs — the PR-landing helper</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> rebases the branch onto main</p></div>
+<div class="flow-step"><p>It pushes the branch</p></div>
+<div class="flow-step"><p>It opens a new PR or detects an existing one</p></div>
+<div class="flow-step"><p>It monitors CI to completion — on failure an <strong>implementer subagent</strong> fixes and retries (up to 2 attempts)</p></div>
+<div class="flow-step optional"><p>With <strong>auto</strong> it requests merge — GitHub merges once required checks pass</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 When a skill has a feature branch that's ready to ship, it hands the branch to

--- a/docs/skills/manual-testing.md
+++ b/docs/skills/manual-testing.md
@@ -6,6 +6,17 @@
 > dispatch it behind the scenes when they need to confirm a UI change works by
 > driving the real interface the way a person would.
 
+<details class="flow-cmd" open>
+<summary>How it runs — browser-driven UI checks</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> starts the dev server and bypasses auth</p></div>
+<div class="flow-step"><p>It drives the UI with real mouse and keyboard events</p></div>
+<div class="flow-step"><p>It documents workarounds where playwright-cli falls short</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/manual-testing` helps playwright-cli interact with a UI the way a user would —

--- a/docs/skills/plans.md
+++ b/docs/skills/plans.md
@@ -2,6 +2,16 @@
 
 > Plan dashboard. View plan status, find the next ready plan. For batch execution, see `/work-on-plans`.
 
+<details class="flow-cmd" open>
+<summary>How it runs — read-only</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> scans the plans and parses each one's status</p></div>
+<div class="flow-step"><p>It shows every status and the next ready plan — read-only, nothing runs</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/plans` is a read-only dashboard over your plan files. Run it and it shows you,

--- a/docs/skills/qe-audit.md
+++ b/docs/skills/qe-audit.md
@@ -2,6 +2,18 @@
 
 > QE audit: check recent commits for test coverage gaps, or bash/stress-test features to find bugs. Files GitHub issues for findings. Recurring via `every SCHEDULE`; `stop`/`next` manage it.
 
+<details class="flow-cmd" open>
+<summary>How it runs — hunt gaps, file issues</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> scans recent commits for risky changes</p></div>
+<div class="flow-step"><p><strong>Audit subagents</strong> comb the batches in parallel with fresh eyes</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> re-verifies each finding</p></div>
+<div class="flow-step"><p>It files GitHub issues with repro recipes</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/qe-audit` runs a quality-engineering pass over your recent work and files GitHub issues for what it finds. It does not fix anything — it looks for missing tests, coverage gaps, and bugs, and turns each real finding into an issue you (or `/fix-issues`) can act on later.

--- a/docs/skills/refine-plan.md
+++ b/docs/skills/refine-plan.md
@@ -2,6 +2,18 @@
 
 > Refine an in-progress plan by reviewing its remaining phases against the work that has actually been built. Surfaces stale references, invalidated assumptions, and specification gaps, then refines until the review converges. Completed phases are never modified.
 
+<details class="flow-cmd" open>
+<summary>How it runs — re-align a mid-flight plan</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> reads the completed phases — read-only, they're never modified</p></div>
+<div class="flow-step"><p>A <strong>reviewer subagent</strong> and a <strong>devil's-advocate subagent</strong> check the remaining phases for drift</p></div>
+<div class="flow-step"><p>A <strong>refiner subagent</strong> rewrites the remaining phases, looping until converged</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> appends a Drift Log, ready to resume with <code>/run-plan</code></p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/refine-plan` takes a plan you are partway through executing and brings its **unfinished** phases back in line with reality. Plans drift during execution: the phases you have already shipped may have built something a little different from what was originally written down, while the phases still ahead of you keep referencing the original spec. `/refine-plan` closes that gap — it reviews only the remaining phases against what was *actually* built, not what was *planned*, and rewrites them so the rest of the execution stays accurate.

--- a/docs/skills/research-and-go.md
+++ b/docs/skills/research-and-go.md
@@ -2,6 +2,20 @@
 
 > Full pipeline in one command: decompose a broad goal into focused sub-plans, draft each with adversarial review, then execute all of them autonomously via `/run-plan`. Walk away.
 
+<details class="flow-cmd" open>
+<summary>How it runs — decompose, plan, execute</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the broad goal</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> researches the domain</p></div>
+<div class="flow-step"><p>It decomposes the goal into dependent sub-plans</p></div>
+<div class="flow-step"><p>Each sub-plan is drafted via <code>/draft-plan</code></p></div>
+<div class="flow-step"><p>Every plan is executed via <code>/run-plan</code> — no stop for review</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> runs a combined cross-branch check</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/research-and-go` takes a broad goal — too big to be a single plan — and carries it all the way from idea to landed code without pausing for approval. Given a plain-English description, it researches the domain, breaks the goal into focused sub-plans, identifies the dependencies between them, drafts each one through a round of adversarial review, writes a single meta-plan that ties them together, and then immediately runs that meta-plan to completion. You give it the goal once and it does the rest.

--- a/docs/skills/research-and-go.md
+++ b/docs/skills/research-and-go.md
@@ -38,7 +38,7 @@ The common form is a single broad-goal description in plain English:
 
 ```
 /research-and-go Add physical modeling support for thermal and mechanical domains
-/research-and-go Implement all missing block diagram tool blocks from the gap analysis
+/research-and-go Implement all the missing API endpoints from the gap analysis
 /research-and-go Close the runtime deployment parity gap
 ```
 
@@ -63,7 +63,7 @@ The description is the only argument. A landing keyword (`pr` or `direct`) appea
 
 ```
 /research-and-go Add physical modeling support for thermal and mechanical domains
-/research-and-go Implement all missing block diagram tool blocks from the gap analysis
+/research-and-go Implement all the missing API endpoints from the gap analysis
 /research-and-go Close the runtime deployment parity gap
 ```
 

--- a/docs/skills/research-and-plan.md
+++ b/docs/skills/research-and-plan.md
@@ -2,6 +2,20 @@
 
 > Decompose a broad goal into a sequence of executable sub-plans. Researches the domain, identifies sub-problems and dependencies, and produces a meta-plan whose phases each hand off to `/run-plan`. Stops once the meta-plan is ready for review.
 
+<details class="flow-cmd" open>
+<summary>How it runs — decompose, then stop for review</summary>
+
+<div class="flow">
+<div class="flow-step"><p><strong>You</strong> describe the broad goal</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> researches the domain</p></div>
+<div class="flow-step"><p>It decomposes the goal into dependent sub-plans</p></div>
+<div class="flow-step"><p><strong>You</strong> confirm the split</p></div>
+<div class="flow-step"><p>Each sub-plan is drafted via <code>/draft-plan</code> (its own reviewer, devil's-advocate, and refiner subagents)</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> writes a meta-plan and stops for your review</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/research-and-plan` takes a goal that's too large for a single plan and breaks it into a set of smaller, focused sub-plans. It researches the domain first — surveying what the goal covers, what already exists, and which pieces are genuinely separate sub-problems — then works out how those pieces depend on each other and roughly how big each one is. Sub-problems that would be too large to finish in one sitting get split further.

--- a/docs/skills/run-plan.md
+++ b/docs/skills/run-plan.md
@@ -2,6 +2,31 @@
 
 > Execute a drafted plan, one phase at a time: read the plan, implement the next incomplete phase in an isolated worktree, verify it with a separate agent, update the plan's progress, and land the result. Can run every remaining phase autonomously. `status` shows progress; `stop`/`next` manage scheduling.
 
+<details class="flow-cmd" open>
+<summary>How one run works — a single phase</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> reads the plan and picks the next phase</p></div>
+<div class="flow-step"><p>An <strong>implementer subagent</strong> builds that phase in a worktree</p></div>
+<div class="flow-step"><p>A <strong>verifier subagent</strong> verifies the phase</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> opens and lands the PR, monitoring CI (up to 2 fix attempts)</p></div>
+</div>
+
+</details>
+
+<details class="flow-cmd" open>
+<summary>How <code>finish auto</code> works — all phases, one PR</summary>
+
+<div class="flow">
+<div class="flow-step"><p>An <strong>implementer subagent</strong> builds the next phase in a worktree</p></div>
+<div class="flow-step"><p>A <strong>verifier subagent</strong> verifies it, and the commit accumulates on the one branch</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> re-fires the next phase as a fresh turn, looping until the plan is done</p></div>
+<div class="flow-step"><p>After the last phase, the <strong>original agent</strong> opens one PR for the whole plan</p></div>
+<div class="flow-step optional"><p>With <strong>auto</strong> it requests merge; plain <strong>finish</strong> pauses between every phase and leaves the PR for you to merge</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/run-plan` takes a plan file — the kind `/draft-plan` produces — and works through it phase by phase. For each phase it reads the plan to find the next incomplete phase, dispatches the implementation in an isolated worktree, hands the result to a separate verification agent, updates the plan's progress tracking, writes a report, and lands the change to `main`.

--- a/docs/skills/session-report.md
+++ b/docs/skills/session-report.md
@@ -2,6 +2,17 @@
 
 > Audit what THIS session said it would do versus what is actually shipped. Verifies session-mentioned items against ground truth — git, PRs, plans, worktrees — not conversation memory. `handoff` turns it into a durable, forward-looking end-of-session hand-off.
 
+<details class="flow-cmd" open>
+<summary>How it runs — shipped vs. intended</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> gathers what this session said it would do</p></div>
+<div class="flow-step"><p>It checks that against ground truth — git, PRs, and plans</p></div>
+<div class="flow-step"><p>It reports shipped versus intended</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/session-report` answers one question: have we actually shipped everything **we talked about doing in this conversation**? It lists the concrete deliverables the session discussed, checks each one against the filesystem and git, and reports tersely what is done, what is not, and where reality diverges from what you remember.
@@ -40,7 +51,7 @@ When you are about to wrap up and clear the conversation, run the hand-off form 
 ## Companion skills
 
 - **`/briefing`** — the cross-session, multi-pipeline status companion. `/session-report` is scoped to the one conversation you are in; `/briefing` reports on the activity of long-running orchestration work across sessions. Reach for `/briefing` when you want the wider picture, `/session-report` when you want to close out the session in front of you.
-- **`/run-plan`** and **`/do`** — examples of the landing skills whose output `/session-report` verifies. When the session executed a plan or shipped an ad-hoc change, the report checks the resulting commits, PR state, and plan phase markers against ground truth rather than taking your word for it.
+- **`/run-plan`** and **`/do`** — examples of the landing skills whose output `/session-report` verifies. When the session executed a plan or shipped a change, the report checks the resulting commits, PR state, and plan phase markers against ground truth rather than taking your word for it.
 
 ## Arguments
 

--- a/docs/skills/update-zskills.md
+++ b/docs/skills/update-zskills.md
@@ -29,7 +29,6 @@ After it finishes, it reports what it installed or updated and a one-line versio
 ```
 /update-zskills [install | --rerender | --migrate-paths | --switch-install-path={to-plugin|to-update-zskills}]
                 [cherry-pick | locked-main-pr | direct]
-                [--with-addons | --with-block-diagram-addons]
 ```
 
 ## Typical usage
@@ -54,7 +53,7 @@ The two everyday forms are `/update-zskills install` to set a project up from sc
 
 ## Arguments
 
-These can be combined: a mode token, a landing keyword, and an add-on flag are independent and may appear together (for example, `/update-zskills install locked-main-pr --with-addons`).
+These can be combined: a mode token and a landing keyword are independent and may appear together (for example, `/update-zskills install locked-main-pr`).
 
 | Argument | Required | Description |
 |----------|----------|-------------|
@@ -65,12 +64,8 @@ These can be combined: a mode token, a landing keyword, and an add-on flag are i
 | `cherry-pick` | No | Set landing to cherry-pick from a worktree onto an unprotected `main` |
 | `locked-main-pr` | No | Set landing to pull requests on a protected `main` |
 | `direct` | No | Set landing to direct commits on an unprotected `main` |
-| `--with-addons` | No | Also install/update the available add-on skill packs, not just the core skills |
-| `--with-block-diagram-addons` | No | Like `--with-addons`, but limited to the block-diagram add-on pack |
 
 The three landing keywords (`cherry-pick`, `locked-main-pr`, `direct`) are mutually exclusive — pass at most one. A bare landing keyword on its own (no `install`) only rewrites the two landing-related config fields and leaves everything else, including the rest of your config, untouched; it does not pull or update skills. Paired with `install`, it sets the landing mode as part of the full install.
-
-By default only the core skills are installed or updated. Add `--with-addons` (or the narrower `--with-block-diagram-addons`) to also bring in the add-on packs — these are extra, domain-specific skills layered on top of the core set.
 
 ## Examples
 
@@ -79,7 +74,6 @@ By default only the core skills are installed or updated. Add `--with-addons` (o
 /update-zskills install
 /update-zskills --rerender
 /update-zskills --migrate-paths
-/update-zskills install --with-addons
 /update-zskills install direct
 /update-zskills locked-main-pr
 ```

--- a/docs/skills/update-zskills.md
+++ b/docs/skills/update-zskills.md
@@ -2,6 +2,18 @@
 
 > Install or update the Z Skills supporting infrastructure: the CLAUDE.md agent rules, safety hooks, helper scripts, and skill dependencies the other skills rely on.
 
+<details class="flow-cmd" open>
+<summary>How it runs — install or update</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> audits what's installed on disk</p></div>
+<div class="flow-step"><p>It reports the gaps before changing anything</p></div>
+<div class="flow-step"><p>It writes the config, hooks, and rules</p></div>
+<div class="flow-step"><p>It renders the managed rules file</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/update-zskills` sets up and maintains the shared infrastructure that every other Z Skill depends on. That infrastructure is: the agent rules file (`.claude/rules/zskills/managed.md`, which Claude Code loads automatically each session), the safety hooks under `.claude/hooks/`, the helper scripts under `scripts/`, and the skill files themselves. Running it is how you bring a project from "no Z Skills" to "fully set up," and how you keep an already-set-up project current.

--- a/docs/skills/verify-changes.md
+++ b/docs/skills/verify-changes.md
@@ -2,6 +2,19 @@
 
 > Verify recent changes really work: review the diffs, check that tests cover them, run the suite, manually verify UI changes with playwright-cli, fix anything broken, re-verify until clean, then report with recommendations.
 
+<details class="flow-cmd" open>
+<summary>How it runs — full verification</summary>
+
+<div class="flow">
+<div class="flow-step"><p>A <strong>fresh verifier subagent</strong> reviews the diff and audits test coverage — fresh eyes on the actual code, not session memory</p></div>
+<div class="flow-step"><p>The <strong>original agent</strong> runs the full test suite</p></div>
+<div class="flow-step"><p>It dispatches <code>/manual-testing</code> for a real browser pass on UI changes</p></div>
+<div class="flow-step"><p>It fixes what surfaces and re-verifies, looping until clean</p></div>
+<div class="flow-step"><p>It reports findings and recommendations</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/verify-changes` confirms that the changes you just made actually work, before you commit or land them. It looks at the recent changes (by default everything uncommitted in your working tree), reads each changed file to understand what changed and whether it looks correct, checks that the tests cover the changes, runs the test suite, manually exercises any UI changes in a browser, fixes problems it finds, re-verifies, and then reports what passed and what still needs a human to sign off.

--- a/docs/skills/work-on-plans.md
+++ b/docs/skills/work-on-plans.md
@@ -2,6 +2,17 @@
 
 > Drive your ready plans as a batch: take the plans queued as ready and run each one with `/run-plan` until it lands. Curate the queue (`add`/`rank`/`remove`/`default`) and run on a recurring schedule. The plan-side counterpart to `/fix-issues` for bugs.
 
+<details class="flow-cmd" open>
+<summary>How it runs — drain the plan queue</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>original agent</strong> reads the queue from the dashboard "Accepted" column</p></div>
+<div class="flow-step"><p>It runs each plan via <code>/run-plan</code> (whose build and verify subagents do the work)</p></div>
+<div class="flow-step"><p>It moves to the next plan, looping until the count is done</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/work-on-plans` works through your queue of ready-to-run plans, running each one for you. It is the way to sprint across the plan backlog instead of starting plans one at a time: you give it a count (or `all`), and it runs that many plans from the front of the queue, each one through `/run-plan`.

--- a/docs/skills/zskills-dashboard.md
+++ b/docs/skills/zskills-dashboard.md
@@ -9,10 +9,18 @@
 <div class="flow-step"><p>The <strong>agent</strong> starts the dashboard server, detached</p></div>
 <div class="flow-step"><p><strong>You</strong> view plans, issues, and worktrees in the browser</p></div>
 <div class="flow-step"><p><strong>You</strong> drag cards to prioritize across the Accepted and Ready columns</p></div>
-<div class="flow-step optional"><p><strong>You</strong> can hit the Run button to trigger a run</p></div>
+<div class="flow-step"><p>Plans you queue in <strong>Accepted</strong> get run by <code>/work-on-plans</code><br>Issues in <strong>Ready</strong> get fixed by <code>/fix-issues</code></p></div>
 </div>
 
 </details>
+
+![The zskills dashboard — plan columns (Drafted → Accepted), per-plan status chips and phase progress, and the live Recent-activity feed.](../guides/assets/zskills-dashboard.png)
+
+> **Try it live:** a browser-only demo runs at
+> **<https://zeveck.github.io/zskills-dev/dashboard-demo/>** — drop plans into
+> *Accepted* (and issues into *Ready*) and watch them get worked, with the
+> activity feed and run-status chips updating live. *(Plan names in the demo are
+> illustrative placeholders.)*
 
 ## What it does
 

--- a/docs/skills/zskills-dashboard.md
+++ b/docs/skills/zskills-dashboard.md
@@ -2,6 +2,18 @@
 
 > Local web dashboard for plan, issue, and run status — plans, issues, worktrees, branches, tracking activity, and a drag-and-drop priority queue. `start` launches it, `stop` shuts it down, `status` reports whether it's running, `restart` picks up code changes.
 
+<details class="flow-cmd" open>
+<summary>How it runs — local web UI</summary>
+
+<div class="flow">
+<div class="flow-step"><p>The <strong>agent</strong> starts the dashboard server, detached</p></div>
+<div class="flow-step"><p><strong>You</strong> view plans, issues, and worktrees in the browser</p></div>
+<div class="flow-step"><p><strong>You</strong> drag cards to prioritize across the Accepted and Ready columns</p></div>
+<div class="flow-step optional"><p><strong>You</strong> can hit the Run button to trigger a run</p></div>
+</div>
+
+</details>
+
 ## What it does
 
 `/zskills-dashboard` runs a small web dashboard on your own machine that gives you one place to see what's in flight: your plan files, open issues, worktrees, branches, and the tracking activity of running pipelines. It serves a page you open in a browser at a `http://127.0.0.1:<port>/` URL the skill prints when it starts.

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4fc3f7"/>
+      <stop offset="50%" stop-color="#2196f3"/>
+      <stop offset="100%" stop-color="#7c4dff"/>
+    </linearGradient>
+  </defs>
+  <text x="16" y="26" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif" font-size="28" font-weight="700" fill="url(#g)">Z</text>
+</svg>

--- a/scripts/_lib/finalize-prod-tree.sh
+++ b/scripts/_lib/finalize-prod-tree.sh
@@ -222,7 +222,8 @@ finalize_prod_tree() {
   find "$tree" -type f -name '*CANARY*' -print -delete 2>/dev/null || true
 
   # ── 3. Dev→prod URL rewrite (#1002) — TREE WALK, run AFTER all strips ─────
-  # Walk docs/, skills/, README.md, CHANGELOG.md AND the .claude/ legacy-lane
+  # Walk docs/, skills/, README.md, CHANGELOG.md, the root marketing pages
+  # (PRESENTATION.html + index.html) AND the .claude/ legacy-lane
   # mirror (.md/.html/.js/.json) and rewrite every dev Pages/repo URL to the
   # prod equivalent. The .claude/ mirror is included because the prod tree
   # ships it for the /update-zskills lane, so its copies of run-plan/SKILL.md
@@ -231,11 +232,11 @@ finalize_prod_tree() {
   # the strip steps above are never processed. rewrite_dev_urls is idempotent
   # (grep-guarded) and honors the `zskills-dev-url-allow` marker, so files
   # without a dev URL — or allow-listed prose like CHANGELOG.md — are untouched.
-  _fpt_log "rewriting dev→prod URLs across $tree (docs, skills, .claude mirror, README, CHANGELOG)"
+  _fpt_log "rewriting dev→prod URLs across $tree (docs, skills, .claude mirror, README, CHANGELOG, PRESENTATION, index)"
   local _f
   while IFS= read -r -d '' _f; do
     rewrite_dev_urls "$_f"
-  done < <(cd "$tree" && find docs skills .claude README.md CHANGELOG.md \
+  done < <(cd "$tree" && find docs skills .claude README.md CHANGELOG.md PRESENTATION.html index.html \
                 \( -name '*.md' -o -name '*.html' -o -name '*.js' -o -name '*.json' \) \
                 -type f -print0 2>/dev/null | while IFS= read -r -d '' rel; do printf '%s\0' "$tree/$rel"; done)
 

--- a/scripts/build-catalog.sh
+++ b/scripts/build-catalog.sh
@@ -12,7 +12,7 @@
 #   - docs/README.md            → "Start here" (position 0, single entry)
 #   - docs/guides/*.md          → "Guides"
 #   - docs/skills/*.md          → "Skills" (user-facing skills)
-#   - docs/skills/<name>.md     → "Internal Skills" when the source skill
+#   - docs/skills/<name>.md     → "Internal" when the source skill
 #                                 skills/<name>/SKILL.md carries
 #                                 `user-invocable: false` in frontmatter.
 #                                 Classification is by reading frontmatter,
@@ -71,10 +71,19 @@ DOCS_DIR = os.path.join(REPO_ROOT, 'docs')
 # fixed-shape sections, except where the predicate explicitly defines a
 # nested path (e.g., archive canaries).
 SECTIONS = [
-    ('Start here',            None),  # special: single README entry
-    ('Guides',                'docs/guides'),
-    ('Skills',                'docs/skills'),
-    ('Internal Skills',       'docs/skills'),  # subset of docs/skills, split by frontmatter
+    ('Start here',                      None),  # special: single README entry
+    ('Guides',                         'docs/guides'),
+    ('Skills',                         'docs/skills'),  # the README section index only
+    # docs/skills user-facing skills, split into importance-ordered categories
+    # by SKILL_CATEGORY below (mirrors docs/skills/README.md "## Categories"
+    # and the viewer nav). Order here = nav order.
+    ('Execution',          'docs/skills'),
+    ('Planning & Design',  'docs/skills'),
+    ('Quality Assurance',  'docs/skills'),
+    ('Automation',         'docs/skills'),
+    ('Reporting',          'docs/skills'),
+    ('Utilities',          'docs/skills'),
+    ('Internal',           'docs/skills'),  # user-invocable:false, split by frontmatter
 ]
 
 # Curated per-section item order. Paths listed appear first (in this order);
@@ -86,10 +95,74 @@ SECTION_ORDER = {
         'docs/guides/installing-zskills.md',
         'docs/guides/workflows.md',
         'docs/guides/inspecting-and-monitoring.md',
+        'docs/guides/zskills-config.md',
         'docs/guides/switching-install-lanes.md',
         'docs/guides/tracking-overview.md',
     ],
+    # Skill categories — curated importance order within each (NOT alphabetical).
+    'Execution': [
+        'docs/skills/do.md',
+        'docs/skills/run-plan.md',
+        'docs/skills/investigate.md',
+    ],
+    'Planning & Design': [
+        'docs/skills/draft-plan.md',
+        'docs/skills/refine-plan.md',
+        'docs/skills/draft-tests.md',
+        'docs/skills/research-and-plan.md',
+        'docs/skills/plans.md',
+    ],
+    'Quality Assurance': [
+        'docs/skills/verify-changes.md',
+        'docs/skills/qe-audit.md',
+    ],
+    'Automation': [
+        'docs/skills/fix-issues.md',
+        'docs/skills/work-on-plans.md',
+        'docs/skills/zskills-dashboard.md',
+        'docs/skills/research-and-go.md',
+    ],
+    'Reporting': [
+        'docs/skills/session-report.md',
+        'docs/skills/briefing.md',
+        'docs/skills/fix-report.md',
+    ],
+    'Utilities': [
+        'docs/skills/commit.md',
+        'docs/skills/cleanup-merged.md',
+        'docs/skills/update-zskills.md',
+        'docs/skills/create-worktree.md',
+    ],
 }
+
+# Skill → category map. Distributes docs/skills/<name>.md (user-facing only;
+# README + user-invocable:false excluded) into the category sections above.
+# Mirrors docs/skills/README.md "## Categories". Every user-facing skill doc
+# MUST appear here, or it silently drops out of the nav.
+SKILL_CATEGORY = {
+    'docs/skills/do.md':                'Execution',
+    'docs/skills/run-plan.md':          'Execution',
+    'docs/skills/investigate.md':       'Execution',
+    'docs/skills/fix-issues.md':        'Automation',
+    'docs/skills/work-on-plans.md':     'Automation',
+    'docs/skills/zskills-dashboard.md': 'Automation',
+    'docs/skills/research-and-go.md':   'Automation',
+    'docs/skills/draft-plan.md':        'Planning & Design',
+    'docs/skills/refine-plan.md':       'Planning & Design',
+    'docs/skills/draft-tests.md':       'Planning & Design',
+    'docs/skills/research-and-plan.md': 'Planning & Design',
+    'docs/skills/plans.md':             'Planning & Design',
+    'docs/skills/verify-changes.md':    'Quality Assurance',
+    'docs/skills/qe-audit.md':          'Quality Assurance',
+    'docs/skills/session-report.md':    'Reporting',
+    'docs/skills/briefing.md':          'Reporting',
+    'docs/skills/fix-report.md':        'Reporting',
+    'docs/skills/commit.md':            'Utilities',
+    'docs/skills/cleanup-merged.md':    'Utilities',
+    'docs/skills/update-zskills.md':    'Utilities',
+    'docs/skills/create-worktree.md':   'Utilities',
+}
+CATEGORY_LABELS = set(SKILL_CATEGORY.values())
 
 # Display-name overrides for catalog items where the H1-derived name fights
 # the curated intent (e.g., a section's own README would show its section
@@ -185,14 +258,24 @@ def gather_section(label, rel_dir):
         ) else []
         return items
     paths = list_md_direct(rel_dir)
-    # docs/skills is split across two sections by frontmatter classification:
-    #   - "Skills"           → user-facing skills + the README section index
-    #   - "Internal Skills"  → docs whose source skill is user-invocable:false
+    # docs/skills is split across many sections:
+    #   - "Skills"             → ONLY the README section index
+    #   - <category>           → user-facing skills mapped by SKILL_CATEGORY
+    #   - "Internal"    → docs whose source skill is user-invocable:false
     if rel_dir == 'docs/skills':
-        if label == 'Internal Skills':
+        if label == 'Internal':
             paths = [p for p in paths if is_internal_skill(p)]
-        else:  # label == 'Skills'
-            paths = [p for p in paths if not is_internal_skill(p)]
+        elif label == 'Skills':
+            paths = [p for p in paths if os.path.basename(p) == 'README.md']
+        elif label in CATEGORY_LABELS:
+            paths = [
+                p for p in paths
+                if not is_internal_skill(p)
+                and os.path.basename(p) != 'README.md'
+                and SKILL_CATEGORY.get(p) == label
+            ]
+        else:
+            paths = []
     return [(derive_name(p), p) for p in paths]
 
 

--- a/tests/test-doc-viewer-catalog.sh
+++ b/tests/test-doc-viewer-catalog.sh
@@ -8,8 +8,8 @@
 #   - The committed docs/DocsRegistry.js byte-matches a fresh run (drift gate)
 #   - Per-section item ordering is path-ascending (sort stability)
 #   - Excluded dirs (docs/plans, docs/reports, docs/evals, docs/issues, docs/tracking) emit zero entries
-#   - Catalog scope: Guides + Skills + Internal Skills (user-facing onboarding; ~35 entries)
-#   - Internal Skills section holds the user-invocable:false skills (land-pr,
+#   - Catalog scope: Guides + Skills + Internal (user-facing onboarding; ~35 entries)
+#   - Internal section holds the user-invocable:false skills (land-pr,
 #     manual-testing today), absent from the user-facing Skills section
 #   - inspecting-and-monitoring.md is present (Phase 5 dependency)
 #   - tests/run-all.sh registers this file
@@ -93,11 +93,13 @@ else
   diff -u "$REGISTRY" "$TMP1" | head -80
 fi
 
-# Section ordering — user-facing scope (Internal Skills appended after Skills).
-EXPECTED_ORDER='Start here Guides Skills Internal Skills'
+# Section ordering — Start here, Guides, the Skills index, the 8 skill
+# categories (importance order, mirrors docs/skills/README.md + the nav),
+# then Internal last.
+EXPECTED_ORDER='Start here Guides Skills Execution Planning & Design Quality Assurance Automation Reporting Utilities Internal'
 ACTUAL_ORDER=$(grep -oE 'section: "[^"]+"' "$REGISTRY" | sed 's/section: "\(.*\)"/\1/' | tr '\n' ' ' | sed 's/ $//')
 if [ "$ACTUAL_ORDER" = "$EXPECTED_ORDER" ]; then
-  pass "4 sections present in fixed order"
+  pass "10 sections present in fixed order"
 else
   fail "section order mismatch — expected '$EXPECTED_ORDER', got '$ACTUAL_ORDER'"
 fi
@@ -110,12 +112,12 @@ else
   fail "catalog has $ENTRY_COUNT entries, expected 25..50 (Start here + Guides + Skills only)"
 fi
 
-# Internal Skills section membership — the user-invocable:false docs live
+# Internal section membership — the user-invocable:false docs live
 # here, NOT in the user-facing Skills section. Today that set is exactly
 # land-pr + manual-testing (classification is by source-skill frontmatter,
 # enumerated by the generator — this asserts the live result).
 INTERNAL_BLOCK=$(awk '
-  /section: "Internal Skills"/ { in_sec=1; next }
+  /section: "Internal"/ { in_sec=1; next }
   in_sec && /^    \]/          { exit }
   in_sec                       { print }
 ' "$REGISTRY")
@@ -126,26 +128,26 @@ SKILLS_BLOCK=$(awk '
 ' "$REGISTRY")
 for doc in land-pr manual-testing; do
   if printf '%s\n' "$INTERNAL_BLOCK" | grep -q "\"docs/skills/$doc.md\""; then
-    pass "Internal Skills section contains docs/skills/$doc.md"
+    pass "Internal section contains docs/skills/$doc.md"
   else
-    fail "Internal Skills section missing docs/skills/$doc.md"
+    fail "Internal section missing docs/skills/$doc.md"
   fi
   if printf '%s\n' "$SKILLS_BLOCK" | grep -q "\"docs/skills/$doc.md\""; then
-    fail "docs/skills/$doc.md still in user-facing Skills section (should be Internal Skills)"
+    fail "docs/skills/$doc.md still in user-facing Skills section (should be Internal)"
   else
     pass "docs/skills/$doc.md absent from user-facing Skills section"
   fi
 done
-# README is the section index — it stays under Skills, never Internal Skills.
+# README is the section index — it stays under Skills, never Internal.
 if printf '%s\n' "$SKILLS_BLOCK" | grep -q '"docs/skills/README.md"'; then
   pass "docs/skills/README.md remains in Skills section (section index)"
 else
   fail "docs/skills/README.md missing from Skills section"
 fi
 if printf '%s\n' "$INTERNAL_BLOCK" | grep -q '"docs/skills/README.md"'; then
-  fail "docs/skills/README.md wrongly classified into Internal Skills"
+  fail "docs/skills/README.md wrongly classified into Internal"
 else
-  pass "docs/skills/README.md not classified as Internal Skills"
+  pass "docs/skills/README.md not classified as Internal"
 fi
 
 # Internal/optional dirs must be excluded — this is an onboarding viewer.
@@ -175,7 +177,7 @@ fi
 # SECTION_ORDER (scripts/build-catalog.sh), which use a curated order.
 # Curated sections instead assert a verbatim sequence.
 SORT_CHECK_OUT=$(awk '
-  /section: "Guides"/  { skip_sec=1; in_sec=1; n=0; next }
+  /section: "(Guides|Execution|Planning & Design|Quality Assurance|Automation|Reporting|Utilities)"/ { skip_sec=1; in_sec=1; n=0; next }
   /section: "/         { skip_sec=0; in_sec=1; n=0; next }
   in_sec && /^    \]/ {
     if (!skip_sec) {
@@ -204,6 +206,7 @@ EXPECTED_GUIDES_PATHS='docs/guides/README.md
 docs/guides/installing-zskills.md
 docs/guides/workflows.md
 docs/guides/inspecting-and-monitoring.md
+docs/guides/zskills-config.md
 docs/guides/switching-install-lanes.md
 docs/guides/tracking-overview.md'
 ACTUAL_GUIDES_PATHS=$(awk '


### PR DESCRIPTION
## Onboarding doc + presentation polish, addon de-listing, prod-URL fix

Continuation of the doc-viewer / `PRESENTATION.html` onboarding overhaul, reconciled against current `main` and reviewed by four parallel agents (accuracy / style / links / prod-deploy). Full suite **7474/7474 passed**.

### PRESENTATION.html
- Reworked the intro topper: leads with **accelerating + automating engineering workflows** ("software factory" framing), drops the over-dramatic copy, keeps the 23-skill (21 user-facing + 2 helpers) count, folds in scheduling, restores a one-line git framing.
- Removed the **"Incident Log and Lessons Learned"** block.
- Footer credits **Rich Conlan** and adds **Claude Opus 4.8**.
- GitHub/Docs links use the `zskills-dev` dev form (rewritten to prod at build time).

### Docs viewer
- `inspecting-and-monitoring.md` / `zskills-config.md`: session logging is **opt-in** (default `false`); an empty `logging.dir` resolves to a **per-OS cache directory** recorded in the main checkout's `.zskills/session-log-dirs` registry.
- `workflows.md`: scheduling recipe now lists **all six** schedulable skills (adds `/briefing`).
- `zskills-config.md`: fixed broken `#landing-protection` anchor.
- `update-zskills.md` / `research-and-go.md`: dropped block-diagram/addon mentions from the public surface (the addon stays in the repo — this is doc/presentation de-listing only).
- `MarkdownRenderer.js`: render `<url>` autolinks; `docs.css` + `index.html`: docs ↔ presentation cross-links and favicon.

### Build
- `finalize-prod-tree.sh`: the dev→prod URL rewrite walk now includes root-level `PRESENTATION.html` + `index.html`, so the marketing pages' dev links actually map to prod. Previously they shipped un-rewritten — caught by `test-prod-tree-no-dev-urls.sh`, which builds both prod trees in isolated clones and scans them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
