### PR TITLE
do: atomic materialise + self-heal 0-byte artifacts

### DIFF
--- a/hooks/_lib/detect-install-state.sh
+++ b/hooks/_lib/detect-install-state.sh
@@ -125,6 +125,9 @@ detect_install_state() {
     local hk
     for hk in "$claude"/hooks/*.sh; do
       [ -f "$hk" ] || continue
+      # #1079 — a 0-byte hook is a partial-materialise leftover, never a
+      # legacy install. Require non-empty before counting it as evidence.
+      [ -s "$hk" ] || continue
       if ! _dis_has_sentinel "$hk"; then
         uz_hit=1
         break
@@ -140,7 +143,9 @@ detect_install_state() {
       "$claude/agents/verifier.md" \
       "$claude/agents/implementer.md" \
       "$claude/rules/zskills/managed.md"; do
-      if [ -f "$art" ] && ! _dis_has_sentinel "$art"; then
+      # #1079 — a 0-byte artifact is a partial-materialise leftover, never a
+      # legacy install. Require non-empty before counting it as evidence.
+      if [ -f "$art" ] && [ -s "$art" ] && ! _dis_has_sentinel "$art"; then
         uz_hit=1
         break
       fi

--- a/hooks/session-start-materialise.sh
+++ b/hooks/session-start-materialise.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.5
 # session-start-materialise.sh — W2.1 SessionStart materialiser (D11, D20, D27).
 #
 # Plugins cannot write to the consumer repo at install time (research §10),
@@ -128,12 +128,20 @@ resolve_src() {
 # ── Sentinel + overwrite-guard helpers (D20(a)) ──────────────────────────
 SENTINEL_TAG="zskills-materialised:"
 
-# safe_to_write <dest> — true (0) when dest is absent OR carries a zskills
-# materialiser sentinel in its first 3 lines. A sentinel-less existing file
-# is consumer-authored → do NOT overwrite (return 1).
+# safe_to_write <dest> — true (0) when dest is absent, EMPTY (0-byte), OR
+# carries a zskills materialiser sentinel in its first 3 lines. A sentinel-less
+# NON-empty existing file is consumer-authored → do NOT overwrite (return 1).
+#
+# The 0-byte case (self-heal, #1079): a prior materialise that aborted
+# mid-write could leave a 0-byte artifact. An empty file is never a real
+# legacy/consumer artifact, so a fresh materialise must be allowed to heal the
+# partial leftover — otherwise the empty file wedges the consumer permanently
+# (the materialiser refuses to overwrite, and the lane detector reads it as
+# legacy evidence).
 safe_to_write() {
   local dest="$1"
   [ -f "$dest" ] || return 0
+  [ ! -s "$dest" ] && return 0
   if head -n 3 "$dest" 2>/dev/null | grep -Eq "^(#|<!--)[[:space:]]+${SENTINEL_TAG}[[:space:]]"; then
     return 0
   fi
@@ -150,10 +158,15 @@ safe_to_write() {
 # path as argv so the Python program (a heredoc, which itself consumes the
 # process stdin) can read the content separately.
 inject_sentinel() {
-  local kind="$1" version="$2" content_tmp
+  local kind="$1" version="$2" content_tmp inj_rc
   content_tmp="$(mktemp)"
   cat > "$content_tmp"
-  KIND="$kind" VERSION="$version" SENTINEL_TAG="$SENTINEL_TAG" "$PYTHON" - "$content_tmp" <<'PY'
+  # Capture the injector's exit status BEFORE the cleanup `rm` (#1079). Without
+  # this, a Python abort was masked by the trailing `rm` (which exits 0), so
+  # the function returned success and the caller wrote a truncated/partial
+  # artifact. We now propagate the Python rc so the caller can leave $dest
+  # untouched on failure.
+  if KIND="$kind" VERSION="$version" SENTINEL_TAG="$SENTINEL_TAG" "$PYTHON" - "$content_tmp" <<'PY'
 import os, sys
 kind = os.environ["KIND"]
 version = os.environ["VERSION"]
@@ -182,7 +195,13 @@ else:
     out = lines
 sys.stdout.write("\n".join(out))
 PY
+  then
+    inj_rc=0
+  else
+    inj_rc=$?
+  fi
   rm -f "$content_tmp"
+  return "$inj_rc"
 }
 
 # Strip a leading sentinel line (any kind) so two artifacts can be compared
@@ -239,13 +258,43 @@ materialise_static() {
   mv "$tmp" "$dest"
 }
 
+# materialise_artifact <kind> <src> <dest> — atomic, abort-safe materialise.
+#
+# #1079 — the sentinel injection is run to COMPLETION into a temp file and its
+# exit status is checked BEFORE any write to (or read by) materialise_static.
+# Previously `inject_sentinel ... | materialise_static` ran the injector and
+# the writer concurrently: an injector crash mid-output left a partial/empty
+# value in materialise_static's `$(cat)`, which it then mv'd into place — a
+# truncated artifact. Capturing the injector output into a temp first means a
+# non-zero injector exit (Python abort, etc.) leaves `$dest` UNTOUCHED (the
+# prior file, or absent, is preserved) instead of being clobbered with a
+# 0-byte/partial file.
+materialise_artifact() {
+  local kind="$1" src="$2" dest="$3" inj_tmp inj_rc
+  inj_tmp="$(mktemp)"
+  # Do not let an injector failure abort the script via pipefail/set -e;
+  # capture the rc and decide explicitly.
+  if inject_sentinel "$kind" "$PLUGIN_VERSION" < "$src" > "$inj_tmp"; then
+    inj_rc=0
+  else
+    inj_rc=$?
+  fi
+  if [ "$inj_rc" -ne 0 ]; then
+    # Injection failed — leave $dest untouched (no truncation, no partial).
+    rm -f "$inj_tmp"
+    echo "zskills: sentinel injection failed for $dest (rc=$inj_rc) — left untouched" >&2
+    return 1
+  fi
+  materialise_static "$kind" "$dest" < "$inj_tmp"
+  rm -f "$inj_tmp"
+}
+
 # ── Materialise the 4 static artifacts ────────────────────────────────────
 # Agents (frontmatter .md).
 for agent in verifier implementer; do
   if src="$(resolve_src "agents/$agent.md" ".claude/agents/$agent.md")"; then
     dest="$PROJ/.claude/agents/$agent.md"
-    inject_sentinel frontmatter-md "$PLUGIN_VERSION" < "$src" \
-      | materialise_static frontmatter-md "$dest"
+    materialise_artifact frontmatter-md "$src" "$dest" || true
   fi
 done
 
@@ -255,9 +304,8 @@ done
 for hook in inject-bash-timeout verify-response-validate; do
   if src="$(resolve_src "hooks/$hook.sh" "hooks/$hook.sh")"; then
     dest="$PROJ/.claude/hooks/$hook.sh"
-    inject_sentinel sh "$PLUGIN_VERSION" < "$src" \
-      | materialise_static sh "$dest"
-    [ -f "$dest" ] && chmod +x "$dest" 2>/dev/null || true
+    materialise_artifact sh "$src" "$dest" || true
+    [ -f "$dest" ] && [ -s "$dest" ] && chmod +x "$dest" 2>/dev/null || true
   fi
 done
 

--- a/tests/test-sessionstart-dual-install-detect.sh
+++ b/tests/test-sessionstart-dual-install-detect.sh
@@ -198,6 +198,53 @@ else
   sed 's/^/      /' "$err5"
 fi
 
+# ── 5'. partial-materialise leftover: 0-byte artifact is NOT legacy (#1079) ─
+#    A materialise that aborted mid-write can leave a 0-byte
+#    .claude/agents/verifier.md. A 0-byte file is never a real legacy install,
+#    so the detector must NOT classify it as update-zskills. With a plugin
+#    signal present (a sentinelled hook), the lane must resolve to `plugin`;
+#    with no other signal it must resolve to `fresh` — never `update-zskills`.
+#    (Confirm this FAILS without the part-3 [ -s ] non-empty guard: a 0-byte
+#    verifier.md would otherwise match the un-sentinelled agent-artifact rule.)
+P5b="$TMP/empty-artifact-plugin"
+base_fixture "$P5b"
+write_sentinelled_hook "$P5b/.claude/hooks/inject-bash-timeout.sh"   # plugin signal
+mkdir -p "$P5b/.claude/agents"
+: > "$P5b/.claude/agents/verifier.md"                                 # 0-byte leftover
+[ ! -s "$P5b/.claude/agents/verifier.md" ] || fail "5'-pre: planted verifier.md not 0-byte"
+got="$(detect_install_state "$P5b")"
+if [ "$got" != update-zskills ]; then
+  pass "5'a. 0-byte verifier.md + plugin signal → not update-zskills (got $got)"
+else
+  fail "5'a. 0-byte verifier.md mis-classified as update-zskills (part-3 [ -s ] guard missing)"
+fi
+[ "$got" = plugin ] && pass "5'b. 0-byte artifact + plugin signal resolves to plugin" \
+  || fail "5'b. expected plugin (0-byte artifact ignored, sentinelled hook wins), got $got"
+
+# 5''. 0-byte artifact ALONE (no other signal) → fresh, never update-zskills.
+P5c="$TMP/empty-artifact-only"
+base_fixture "$P5c"
+mkdir -p "$P5c/.claude/agents"
+: > "$P5c/.claude/agents/verifier.md"
+got="$(detect_install_state "$P5c")"
+if [ "$got" = fresh ]; then
+  pass "5''. 0-byte verifier.md alone → fresh (not update-zskills)"
+else
+  fail "5''. 0-byte verifier.md alone mis-classified as $got (expected fresh)"
+fi
+
+# 5'''. a 0-byte .claude/hooks/*.sh alone is likewise not legacy evidence.
+P5d="$TMP/empty-hook-only"
+base_fixture "$P5d"
+mkdir -p "$P5d/.claude/hooks"
+: > "$P5d/.claude/hooks/block-stale-skill-version.sh"
+got="$(detect_install_state "$P5d")"
+if [ "$got" = fresh ]; then
+  pass "5'''. 0-byte .claude/hooks/*.sh alone → fresh (not update-zskills)"
+else
+  fail "5'''. 0-byte hook alone mis-classified as $got (expected fresh)"
+fi
+
 # ── 6. W6.3 — the nag fires EVERY session (no once-per-session gate): a
 #    second materialise run on the uz fixture RE-EMITS the nag. ──────────────
 err3b="$TMP/err3b"; run_mat "$P3" "$err3b"

--- a/tests/test-sessionstart-materialise.sh
+++ b/tests/test-sessionstart-materialise.sh
@@ -283,6 +283,94 @@ else
 fi
 
 echo ""
+echo "=== Atomic write: injector abort leaves no partial/0-byte artifact (#1079) ==="
+
+# A materialise whose sentinel-injection aborts mid-write must NOT truncate or
+# partially write the destination. We point ZSKILLS_PYTHON at a stub that
+# PASSES the interpreter version probe (`python -c '...'`, delegated to the
+# real python3) but FAILS every other invocation — including the
+# inject_sentinel `python - <tmpfile>` form. The materialiser must leave a
+# pre-existing dest UNTOUCHED and never create a 0-byte file at an absent dest.
+STUB_DIR="$TMP/pystub"
+mkdir -p "$STUB_DIR"
+REAL_PY="$(command -v python3)"
+cat > "$STUB_DIR/python3" <<STUB
+#!/usr/bin/env bash
+# Delegate the version/-c probes to real python3 so zskills_resolve_python
+# accepts this stub; fail (exit 1) on the inject_sentinel "- <tmpfile>" form.
+if [ "\$1" = "-c" ]; then
+  exec "$REAL_PY" "\$@"
+fi
+exit 1
+STUB
+chmod +x "$STUB_DIR/python3"
+
+# (a-i) Pre-existing real artifact at a dest is NOT truncated on injector abort.
+ABORT="$TMP/abortproj"
+mkdir -p "$ABORT/.claude/agents"
+cp "$REPO_ROOT/CLAUDE_TEMPLATE.md" "$ABORT/"
+# Seed a config so the materialiser does not early-exit on a missing config.
+cp "$REPO_ROOT/.claude/zskills-config.json" "$ABORT/.claude/"
+# A pre-existing sentinelled verifier.md (so safe_to_write would normally
+# allow an overwrite — the point is the injector aborts BEFORE any write).
+PRE_BODY="$(printf '%s\n' '---' '# zskills-materialised: 0.0.0' 'name: verifier' 'PRESERVE ME')"
+printf '%s' "$PRE_BODY" > "$ABORT/.claude/agents/verifier.md"
+PRE_SIZE="$(stat -c %s "$ABORT/.claude/agents/verifier.md")"
+
+env ZSKILLS_PYTHON="$STUB_DIR/python3" \
+    CLAUDE_PROJECT_DIR="$ABORT" CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+    bash "$REPO_ROOT/$MAT" 2>/dev/null || true
+
+AFTER_BODY="$(cat "$ABORT/.claude/agents/verifier.md" 2>/dev/null || echo MISSING)"
+AFTER_SIZE="$(stat -c %s "$ABORT/.claude/agents/verifier.md" 2>/dev/null || echo -1)"
+if [ "$AFTER_BODY" = "$PRE_BODY" ] && [ "$AFTER_SIZE" = "$PRE_SIZE" ]; then
+  pass "21. injector abort leaves pre-existing artifact byte-identical (not truncated)"
+else
+  fail "21. injector abort truncated/altered the pre-existing artifact (size $PRE_SIZE -> $AFTER_SIZE)"
+fi
+
+# (a-ii) Absent dest stays absent (no 0-byte file created) on injector abort.
+# The implementer hook dest had no pre-existing file in the abort fixture.
+IMPL_DEST="$ABORT/.claude/agents/implementer.md"
+if [ ! -e "$IMPL_DEST" ]; then
+  pass "22. injector abort leaves an absent dest absent (no 0-byte file created)"
+elif [ -f "$IMPL_DEST" ] && [ ! -s "$IMPL_DEST" ]; then
+  fail "22. injector abort created a 0-byte implementer.md (partial leftover)"
+else
+  # A non-empty implementer.md would only appear if injection somehow
+  # succeeded — unexpected with the failing stub, but not a partial leftover.
+  pass "22. injector abort: implementer.md is non-empty (no partial leftover)"
+fi
+
+echo ""
+echo "=== Self-heal: a pre-existing 0-byte artifact is overwritten (#1079) ==="
+
+# A prior partial materialise can leave a 0-byte artifact. A subsequent working
+# materialise must HEAL it — overwrite the empty file with real sentinelled
+# content (safe_to_write treats a 0-byte file as overwritable).
+HEAL="$TMP/healproj"
+mkdir -p "$HEAL/.claude/agents"
+cp "$REPO_ROOT/.claude/zskills-config.json" "$HEAL/.claude/"
+cp "$REPO_ROOT/CLAUDE_TEMPLATE.md" "$HEAL/"
+# Plant a 0-byte verifier.md (the partial-materialise leftover).
+: > "$HEAL/.claude/agents/verifier.md"
+[ ! -s "$HEAL/.claude/agents/verifier.md" ] || fail "precondition: planted verifier.md not 0-byte"
+
+env CLAUDE_PROJECT_DIR="$HEAL" CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
+    bash "$REPO_ROOT/$MAT" 2>/dev/null
+
+HV="$HEAL/.claude/agents/verifier.md"
+if [ -s "$HV" ] \
+   && head -n 3 "$HV" | grep -Eq '^# zskills-materialised:' \
+   && grep -q '^name: verifier' "$HV"; then
+  pass "23. self-heal: 0-byte verifier.md overwritten with real sentinelled content"
+else
+  fail "23. self-heal: 0-byte verifier.md NOT healed"
+  printf '      size=%s\n' "$(stat -c %s "$HV" 2>/dev/null || echo MISSING)"
+  head -3 "$HV" 2>/dev/null | sed 's/^/      /'
+fi
+
+echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
 exit "$FAIL_COUNT"


### PR DESCRIPTION
A materialise that aborted mid-write left a 0-byte artifact that (a) the materialiser refused to overwrite and (b) the detector read as legacy-lane evidence — permanently wedging a plugin consumer.

Root cause was subtle: `inject_sentinel` returned the trailing `rm`'s exit code, so a crashed Python injector reported SUCCESS and the caller wrote the truncated output. Fix: (1) capture the injector rc before cleanup + gate the write on it; write atomically (temp→mv on success) so a failure leaves $dest untouched (no 0-byte); (2) `safe_to_write` treats a 0-byte dest as overwritable (self-heal a prior partial); (3) detector requires non-empty (`[ -s ]`) for an artifact to count as legacy evidence (both the agents/managed rule and the non-sentinelled-hooks rule). Defense-in-depth so a partial materialise (any cause) self-heals instead of poisoning. +tests (atomic/self-heal/detector, proven to fail without the guards). Suite 7519/7519.

Closes #1079

Worktree: /tmp/zskills-do-atomic-self-heal
Commits: f578781 fix(materialiser): atomic write + self-heal 0-byte artifacts (#1079)
