### PR TITLE
do: nudge restart after reload + Step 0.7 pre-materialise guard

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.04+57521a"
+  version: "2026.06.04+85d690"
 ---
 
 # Update Z Skills Infrastructure
@@ -1110,8 +1110,42 @@ gap-fill (Steps A–G below), or any `.claude/`-mirroring step.
   `/update-zskills --switch-install-path=...`).
   ```
 
+**Plugin-pre-materialise guard (`LANE == fresh` AND `$CLAUDE_PLUGIN_ROOT`
+set) — #1080.** Before the bare-preset / Default-Mode dispatch below, handle
+the half-installed plugin state: a consumer who ran `/plugin install
+zs@zskills` then `/reload-plugins` (which does NOT fire SessionStart, so the
+materialiser never ran) lands here with `LANE == fresh` (no on-disk evidence
+of either lane yet) AND `$CLAUDE_PLUGIN_ROOT` set (the plugin IS loaded).
+Running the fresh-install mirror here would copy in ~23 skills + the hooks +
+render `managed.md`, dual-installing the legacy lane alongside the plugin —
+the exact dual state the rest of the system pushes to consolidate. Instead,
+recognize "plugin-pre-materialise", direct the user to finish setup via
+`/clear` (or restart), and exit WITHOUT mirroring:
+
+```bash
+# #1080 — plugin loaded but not yet materialised (SessionStart didn't fire on
+# /reload-plugins). Keying on $CLAUDE_PLUGIN_ROOT is SAFE *in the `fresh`
+# branch specifically* because the dev repo ALWAYS carries a legacy
+# `.claude/skills/` mirror -> it is NEVER classified `fresh` (it classifies
+# `update-zskills` or `dual`). So this guard can never false-positive in the
+# dogfooding repo, even though $CLAUDE_PLUGIN_ROOT is set there too.
+if [ "$LANE" = fresh ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  echo "The zskills plugin is loaded, but setup isn't finished yet." >&2
+  echo "/reload-plugins does NOT run the one-time materialisation step, so the" >&2
+  echo "verifier/implementer agents, the timeout/validate hooks, the rendered" >&2
+  echo "rules file, and your .claude/zskills-config.json have not been written." >&2
+  echo "Run /clear (or exit and restart Claude Code) to fire the SessionStart" >&2
+  echo "hook and finish setup. Re-running /update-zskills is NOT the fix —" >&2
+  echo "it would dual-install the legacy mirror alongside the plugin." >&2
+  exit 0
+fi
+```
+
 **Else** (`LANE` is `update-zskills`, `dual`, or `fresh`, OR detection was
-unreachable): proceed to the existing behavior. **First** check for a bare
+unreachable): proceed to the existing behavior. (The `fresh` + plugin-loaded
+sub-case was intercepted by the plugin-pre-materialise guard immediately
+above; a `fresh` arrival WITHOUT `$CLAUDE_PLUGIN_ROOT` is a genuine legacy
+first-time install and proceeds normally.) **First** check for a bare
 preset: if `$PRESET_ARG` is non-empty AND `$MODE` is NOT `install`, jump to
 **`## Bare-preset config-only short-circuit`** (config-only — no audit, no
 pull, no fill) and exit there. Otherwise (no preset, or `install <preset>`)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -52,6 +52,13 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/nudge-restart-to-materialise.sh\"", "timeout": 5 }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/hooks/nudge-restart-to-materialise.sh
+++ b/hooks/nudge-restart-to-materialise.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# zskills-hook-version: 2026.06.0
+# nudge-restart-to-materialise.sh — UserPromptSubmit restart nudge (#1080).
+#
+# THE GAP: after `/plugin install zs@zskills` -> `/reload-plugins`, the
+# skills and hooks load, but the SessionStart hook does NOT fire on
+# `/reload-plugins` (only `/clear` or a full restart fires it). So
+# session-start-materialise.sh never runs — the 5 consumer-side artifacts
+# (verifier.md, implementer.md, inject-bash-timeout.sh,
+# verify-response-validate.sh, the rendered managed.md) and the seeded
+# .claude/zskills-config.json are NOT written. The consumer is stuck
+# half-installed with nothing telling them to restart.
+#
+# THE FIX: this UserPromptSubmit hook fires on the user's NEXT prompt after
+# `/reload-plugins` and prints a one-time advisory nudge telling them to
+# `/clear` (or restart) to fire SessionStart and finish setup.
+#
+# It is a COMMITTED .sh (fixed logic, like block-unsafe-generic.sh — NOT a
+# D4 .template/sibling pair), registered ONLY in hooks/hooks.json under a
+# UserPromptSubmit event. It has NO .claude/settings.json sibling (it is a
+# plugin-lane-only concern: the /update-zskills lane materialises at install
+# time and never reaches the half-installed state this nudges about). So it
+# does NOT source the D16(a) conditional-skip shim — there is no
+# same-basename sibling to double-fire against.
+#
+# TRIGGER PREDICATE — print the nudge ONLY when ALL of:
+#   * $CLAUDE_PLUGIN_ROOT set AND $CLAUDE_PROJECT_DIR set.
+#   * detect_install_state "$CLAUDE_PROJECT_DIR" == fresh. This is the
+#     half-installed state (plugin loaded, artifacts not yet materialised —
+#     fresh = neither lane's on-disk evidence present). It SELF-EXTINGUISHES:
+#     once SessionStart materialises, the 5 artifacts carry the materialiser
+#     sentinel -> lane==plugin -> predicate false. And it NEVER fires on the
+#     legacy (update-zskills) or dev (dual) lanes, which are never `fresh`.
+#   * No once-per-session marker yet (.zskills/restart-nudge-shown-<sid>).
+#
+# It is ADVISORY: it MUST `exit 0` always and never block the prompt. Any
+# error fails open (exit 0, no nudge).
+
+set -u
+
+# Without both env vars we are not a plugin-lane hook in a project — exit
+# silently (fail-open).
+PLUGIN="${CLAUDE_PLUGIN_ROOT:-}"
+PROJ="${CLAUDE_PROJECT_DIR:-}"
+[ -n "$PLUGIN" ] || exit 0
+[ -n "$PROJ" ] || exit 0
+
+# Read the UserPromptSubmit JSON from stdin once. Never fail on a read error.
+INPUT="$(cat 2>/dev/null)" || exit 0
+
+# Extract session_id with a TOLERANT grep/sed so a missing python can never
+# break the nudge. The hook JSON shape is `{"session_id":"abc",...}`. We
+# accept whitespace around the colon and a quoted value. A missing/empty
+# session_id is tolerated — we fall back to a fixed token so the marker still
+# de-dupes within the session (one nudge max either way).
+SESSION_ID="$(printf '%s' "$INPUT" \
+  | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  | head -n1 \
+  | sed -E 's/.*"session_id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+[ -n "$SESSION_ID" ] || SESSION_ID="nosid"
+
+# Locate detect-install-state.sh under the plugin root. If unreachable, we
+# cannot classify the lane — exit silently (fail-open).
+DIS="${PLUGIN}/hooks/_lib/detect-install-state.sh"
+[ -f "$DIS" ] || exit 0
+
+# Source the lane-detection helper and classify. Any error -> fail-open.
+# shellcheck disable=SC1090
+. "$DIS" 2>/dev/null || exit 0
+LANE="$(detect_install_state "$PROJ" 2>/dev/null || true)"
+
+# Fire ONLY in the half-installed (fresh) state.
+[ "$LANE" = fresh ] || exit 0
+
+# Once-per-session gate. The marker lives under $CLAUDE_PROJECT_DIR/.zskills/
+# (gitignored). If it already exists, we have nudged this session -> silent.
+MARKER_DIR="$PROJ/.zskills"
+MARKER="$MARKER_DIR/restart-nudge-shown-$SESSION_ID"
+[ -f "$MARKER" ] && exit 0
+
+# Create the marker BEFORE printing so a concurrent/duplicate fire in the
+# same session does not double-nudge. Marker-dir creation failure is
+# non-fatal (we still nudge once — better an extra nudge than none).
+mkdir -p "$MARKER_DIR" 2>/dev/null || true
+: > "$MARKER" 2>/dev/null || true
+
+# Print the nudge to stdout (advisory; UserPromptSubmit stdout is surfaced to
+# the user as additional context).
+cat <<'NUDGE'
+zskills: the plugin is loaded but setup isn't finished. /reload-plugins does not run the one-time materialisation step, so the verifier/implementer agents, two hooks, the rendered rules file, and your .claude/zskills-config.json have NOT been written yet. Run /clear (or exit and restart Claude Code) to fire the SessionStart hook and finish setup. This only needs to happen once.
+NUDGE
+
+# Advisory hook — always succeed, never block.
+exit 0

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.04+57521a"
+  version: "2026.06.04+85d690"
 ---
 
 # Update Z Skills Infrastructure
@@ -1110,8 +1110,42 @@ gap-fill (Steps A–G below), or any `.claude/`-mirroring step.
   `/update-zskills --switch-install-path=...`).
   ```
 
+**Plugin-pre-materialise guard (`LANE == fresh` AND `$CLAUDE_PLUGIN_ROOT`
+set) — #1080.** Before the bare-preset / Default-Mode dispatch below, handle
+the half-installed plugin state: a consumer who ran `/plugin install
+zs@zskills` then `/reload-plugins` (which does NOT fire SessionStart, so the
+materialiser never ran) lands here with `LANE == fresh` (no on-disk evidence
+of either lane yet) AND `$CLAUDE_PLUGIN_ROOT` set (the plugin IS loaded).
+Running the fresh-install mirror here would copy in ~23 skills + the hooks +
+render `managed.md`, dual-installing the legacy lane alongside the plugin —
+the exact dual state the rest of the system pushes to consolidate. Instead,
+recognize "plugin-pre-materialise", direct the user to finish setup via
+`/clear` (or restart), and exit WITHOUT mirroring:
+
+```bash
+# #1080 — plugin loaded but not yet materialised (SessionStart didn't fire on
+# /reload-plugins). Keying on $CLAUDE_PLUGIN_ROOT is SAFE *in the `fresh`
+# branch specifically* because the dev repo ALWAYS carries a legacy
+# `.claude/skills/` mirror -> it is NEVER classified `fresh` (it classifies
+# `update-zskills` or `dual`). So this guard can never false-positive in the
+# dogfooding repo, even though $CLAUDE_PLUGIN_ROOT is set there too.
+if [ "$LANE" = fresh ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  echo "The zskills plugin is loaded, but setup isn't finished yet." >&2
+  echo "/reload-plugins does NOT run the one-time materialisation step, so the" >&2
+  echo "verifier/implementer agents, the timeout/validate hooks, the rendered" >&2
+  echo "rules file, and your .claude/zskills-config.json have not been written." >&2
+  echo "Run /clear (or exit and restart Claude Code) to fire the SessionStart" >&2
+  echo "hook and finish setup. Re-running /update-zskills is NOT the fix —" >&2
+  echo "it would dual-install the legacy mirror alongside the plugin." >&2
+  exit 0
+fi
+```
+
 **Else** (`LANE` is `update-zskills`, `dual`, or `fresh`, OR detection was
-unreachable): proceed to the existing behavior. **First** check for a bare
+unreachable): proceed to the existing behavior. (The `fresh` + plugin-loaded
+sub-case was intercepted by the plugin-pre-materialise guard immediately
+above; a `fresh` arrival WITHOUT `$CLAUDE_PLUGIN_ROOT` is a genuine legacy
+first-time install and proceeds normally.) **First** check for a bare
 preset: if `$PRESET_ARG` is non-empty AND `$MODE` is NOT `install`, jump to
 **`## Bare-preset config-only short-circuit`** (config-only — no audit, no
 pull, no fill) and exit there. Otherwise (no preset, or `install <preset>`)

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -286,6 +286,8 @@ run_suite "test-session-logging.sh" "tests/test-session-logging.sh"
 run_suite "test-sessionstart-materialise.sh" "tests/test-sessionstart-materialise.sh"
 run_suite "test-sessionstart-materialise-overwrite-guard.sh" "tests/test-sessionstart-materialise-overwrite-guard.sh"
 run_suite "test-sessionstart-dual-install-detect.sh" "tests/test-sessionstart-dual-install-detect.sh"
+# #1080 — UserPromptSubmit restart nudge (post-/reload-plugins half-install).
+run_suite "test-nudge-restart-to-materialise.sh" "tests/test-nudge-restart-to-materialise.sh"
 run_suite "test-synthetic-consumer-install.sh" "tests/test-synthetic-consumer-install.sh"
 run_suite "test-verify-install.sh" "tests/test-verify-install.sh"
 run_suite "test-render-managed-rules-correctness.sh" "tests/test-render-managed-rules-correctness.sh"

--- a/tests/test-hooks-mirror-parity.sh
+++ b/tests/test-hooks-mirror-parity.sh
@@ -41,6 +41,12 @@ fail() { echo "FAIL $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 EXCLUDE_BASENAMES=(
   "canary3-bad.sh"
   "session-start-materialise.sh"
+  # nudge-restart-to-materialise.sh (#1080) — PLUGIN-LANE-ONLY hook (registered
+  # in hooks/hooks.json under UserPromptSubmit, never in .claude/settings.json).
+  # Like session-start-materialise.sh, it addresses a plugin-only concern (the
+  # post-/reload-plugins half-installed state), so there is no /update-zskills
+  # mirror to byte-compare.
+  "nudge-restart-to-materialise.sh"
 )
 
 is_excluded() {

--- a/tests/test-nudge-restart-to-materialise.sh
+++ b/tests/test-nudge-restart-to-materialise.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# tests/test-nudge-restart-to-materialise.sh
+#
+# #1080 — the UserPromptSubmit restart nudge. After `/plugin install
+# zs@zskills` -> `/reload-plugins`, SessionStart does NOT fire (only `/clear`
+# or restart fires it), so session-start-materialise.sh never runs and the
+# consumer is stuck half-installed (lane==fresh) with nothing telling them to
+# restart. This hook fires on the next prompt and prints a one-time nudge.
+#
+# Hermetic: a tmpdir fixture $PROJ (consumer) + a fixture $PLUGIN carrying
+# detect-install-state.sh. We feed a UserPromptSubmit JSON on stdin and drive
+# the hook directly.
+#
+# Cases:
+#   (a) fresh + plugin-root set + no marker  -> nudge emitted + marker created.
+#   (b) marker already present               -> silent (no nudge).
+#   (c) lane == plugin (sentinelled artifact)-> silent.
+#   (d) lane == update-zskills (legacy)      -> silent.
+#   (e) $CLAUDE_PLUGIN_ROOT unset            -> silent.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+HOOK="$REPO_ROOT/hooks/nudge-restart-to-materialise.sh"
+# A stable substring of the nudge message (load-bearing assertion target).
+NUDGE_MARK="the plugin is loaded but setup isn't finished"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Fixture $PLUGIN: only needs detect-install-state.sh under hooks/_lib/.
+PLUGIN="$TMP/plugin"
+mkdir -p "$PLUGIN/hooks/_lib"
+cp "$REPO_ROOT/hooks/_lib/detect-install-state.sh" "$PLUGIN/hooks/_lib/"
+
+SID="sess-abcdef-1234"
+UPS_JSON='{"session_id":"'"$SID"'","prompt":"hello","cwd":"/tmp/x"}'
+
+# run_hook <project-dir> [extra-env...] — runs the hook with the given $PROJ,
+# feeding the UserPromptSubmit JSON on stdin. Echoes stdout; rc captured by
+# caller via the surrounding command substitution being non-fatal.
+run_hook() {
+  local proj="$1"; shift
+  printf '%s' "$UPS_JSON" | env "$@" CLAUDE_PROJECT_DIR="$proj" CLAUDE_PLUGIN_ROOT="$PLUGIN" bash "$HOOK"
+}
+
+echo "=== nudge-restart-to-materialise.sh (#1080) ==="
+
+# ── (a) fresh + plugin-root + no marker -> nudge + marker ─────────────────────
+PROJ_A="$TMP/proj_a"
+mkdir -p "$PROJ_A"   # truly empty .claude -> lane==fresh
+OUT_A="$(run_hook "$PROJ_A")"
+RC_A=$?
+
+if [ "$RC_A" -eq 0 ]; then
+  pass "a1. hook exits 0 (advisory, never blocks)"
+else
+  fail "a1. hook exited non-zero ($RC_A)"
+fi
+
+if printf '%s' "$OUT_A" | grep -qF "$NUDGE_MARK"; then
+  pass "a2. fresh+plugin-root+no-marker: nudge emitted to stdout"
+else
+  fail "a2. fresh+plugin-root+no-marker: nudge NOT emitted"
+  printf '      stdout: %s\n' "$OUT_A"
+fi
+
+MARKER_A="$PROJ_A/.zskills/restart-nudge-shown-$SID"
+if [ -f "$MARKER_A" ]; then
+  pass "a3. once-per-session marker created (.zskills/restart-nudge-shown-<sid>)"
+else
+  fail "a3. marker NOT created at $MARKER_A"
+fi
+
+# ── (b) marker already present -> silent ──────────────────────────────────────
+# Re-run against the SAME $PROJ_A (marker now exists from case a).
+OUT_B="$(run_hook "$PROJ_A")"
+if [ -z "$OUT_B" ]; then
+  pass "b. marker present (2nd run, same session): silent (no nudge)"
+else
+  fail "b. marker present: hook still emitted output"
+  printf '      stdout: %s\n' "$OUT_B"
+fi
+
+# ── (c) lane == plugin (sentinelled artifact) -> silent ───────────────────────
+# Stage a materialiser-sentinelled artifact so detect_install_state -> plugin.
+PROJ_C="$TMP/proj_c"
+mkdir -p "$PROJ_C/.claude/hooks"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' '# zskills-materialised: 1.2.3'
+  printf '%s\n' 'exit 0'
+} > "$PROJ_C/.claude/hooks/inject-bash-timeout.sh"
+OUT_C="$(run_hook "$PROJ_C")"
+if [ -z "$OUT_C" ]; then
+  pass "c. lane==plugin (sentinelled artifact present): silent (self-extinguishes)"
+else
+  fail "c. lane==plugin: hook still emitted output"
+  printf '      stdout: %s\n' "$OUT_C"
+fi
+# And no marker should have been written in the plugin-lane case.
+if [ ! -f "$PROJ_C/.zskills/restart-nudge-shown-$SID" ]; then
+  pass "c2. lane==plugin: no marker written"
+else
+  fail "c2. lane==plugin: marker unexpectedly written"
+fi
+
+# ── (d) lane == update-zskills (legacy fixture) -> silent ─────────────────────
+# A non-sentinelled zskills-owned skill mirror -> detect_install_state ->
+# update-zskills.
+PROJ_D="$TMP/proj_d"
+mkdir -p "$PROJ_D/.claude/skills/update-zskills"
+printf '%s\n' '# update-zskills SKILL (legacy mirror, no sentinel)' \
+  > "$PROJ_D/.claude/skills/update-zskills/SKILL.md"
+OUT_D="$(run_hook "$PROJ_D")"
+if [ -z "$OUT_D" ]; then
+  pass "d. lane==update-zskills (legacy mirror): silent (never fresh)"
+else
+  fail "d. lane==update-zskills: hook still emitted output"
+  printf '      stdout: %s\n' "$OUT_D"
+fi
+
+# ── (e) $CLAUDE_PLUGIN_ROOT unset -> silent ───────────────────────────────────
+PROJ_E="$TMP/proj_e"
+mkdir -p "$PROJ_E"
+OUT_E="$(printf '%s' "$UPS_JSON" | env -u CLAUDE_PLUGIN_ROOT CLAUDE_PROJECT_DIR="$PROJ_E" bash "$HOOK")"
+RC_E=$?
+if [ -z "$OUT_E" ] && [ "$RC_E" -eq 0 ]; then
+  pass "e. \$CLAUDE_PLUGIN_ROOT unset: silent + exit 0 (fail-open)"
+else
+  fail "e. plugin-root unset: output='$OUT_E' rc=$RC_E"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+exit "$FAIL_COUNT"

--- a/tests/test-plugin-hooks-integrity.sh
+++ b/tests/test-plugin-hooks-integrity.sh
@@ -97,10 +97,21 @@ if [ "$ZS_SRC_REPO" = "zeveck/zskills-dev" ]; then
   GAP1_TEMPLATE_ONLY=""
 fi
 
-# Gap-2 shim-sourcing exclusion: SessionStart materialiser. It carries its OWN
-# dual-install probe (detect-install-state.sh) and is NOT a double-fire-prone
-# PreToolUse hook, so it legitimately does NOT source the conditional-skip shim.
-SHIM_EXCLUDE="session-start-materialise.sh"
+# Gap-2 shim-sourcing exclusions — hooks that legitimately do NOT source the
+# D16(a) conditional-skip shim:
+#
+#   session-start-materialise.sh — carries its OWN dual-install probe
+#     (detect-install-state.sh) and is NOT a double-fire-prone PreToolUse hook.
+#
+#   nudge-restart-to-materialise.sh (#1080) — a PLUGIN-ONLY UserPromptSubmit
+#     hook with NO .claude/settings.json same-basename sibling. The shim exists
+#     to defer a plugin hook when a settings.json-registered sibling of the
+#     SAME basename would otherwise double-fire (dual-install); this hook has no
+#     such sibling (the /update-zskills lane materialises at install time and
+#     never reaches the half-installed state this nudges about), so there is
+#     nothing to double-fire against. It self-extinguishes once SessionStart
+#     materialises (lane flips fresh -> plugin), so it cannot leak across lanes.
+SHIM_EXCLUDE="session-start-materialise.sh nudge-restart-to-materialise.sh"
 
 in_list() {
   # in_list <needle> <space-separated-list>
@@ -343,6 +354,28 @@ if [ "$d4_ok" -eq 1 ]; then
   pass "2c. D4 .template pair (block-unsafe-project, block-agents) source the shim in their .template files"
 else
   fail "2c. a D4 .template hook does not source the shim"
+fi
+
+# 2d (#1080) — positive coverage for the nudge-restart-to-materialise.sh
+# UserPromptSubmit hook. It is a plugin-only hook with NO settings.json
+# sibling, so it legitimately does NOT source the shim and IS on SHIM_EXCLUDE.
+# Assert it is registered, exists in-tree, is excluded, and does NOT source
+# the shim — so a future edit that wrongly drops it from the exclusion list (or
+# adds a spurious shim line) fails closed.
+NUDGE_HOOK="nudge-restart-to-materialise.sh"
+nudge_reg=0
+for r in "${REGISTERED[@]}"; do [ "$r" = "$NUDGE_HOOK" ] && nudge_reg=1 && break; done
+nudge_problems=""
+[ "$nudge_reg" -eq 1 ] || nudge_problems="$nudge_problems not-registered"
+[ -f "$REPO_ROOT/hooks/$NUDGE_HOOK" ] || nudge_problems="$nudge_problems absent"
+in_list "$NUDGE_HOOK" "$SHIM_EXCLUDE" || nudge_problems="$nudge_problems not-excluded"
+if [ -f "$REPO_ROOT/hooks/$NUDGE_HOOK" ] && grep -q "$SHIM_REL" "$REPO_ROOT/hooks/$NUDGE_HOOK"; then
+  nudge_problems="$nudge_problems unexpectedly-sources-shim"
+fi
+if [ -z "$nudge_problems" ]; then
+  pass "2d. nudge-restart-to-materialise.sh is registered, in-tree, SHIM_EXCLUDE'd, and (correctly) does NOT source the shim"
+else
+  fail "2d. nudge-restart-to-materialise.sh wiring wrong:$nudge_problems"
 fi
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
After `/plugin install` → `/reload-plugins`, skills/hooks load but SessionStart doesn't fire (only `/clear`/restart fires it), so the materialiser hasn't run — and nothing told the user to restart. Two parts:

1. NEW `hooks/nudge-restart-to-materialise.sh` (UserPromptSubmit) — nudges "run /clear to finish setup" ONLY when the plugin is loaded but `detect_install_state == fresh`, once per session (marker keyed on session_id). Self-extinguishes once materialised (lane→plugin); silent on legacy/dev. Always exit 0 (advisory). Registered in hooks.json; SHIM_EXCLUDE + mirror-parity exclude (plugin-only).
2. Step 0.7 guard: a bare `/zs:update-zskills` in that pre-materialise window (`fresh` + `$CLAUDE_PLUGIN_ROOT` set) no longer mirrors ~23 skills (dual-install footgun) — it directs the user to `/clear` instead. Keying on $CLAUDE_PLUGIN_ROOT is safe here because the dev repo always has a legacy mirror → never `fresh`.

+new test-nudge-restart-to-materialise.sh (5 cases) + integrity updates. Suite green.

Closes #1080

Worktree: /tmp/zskills-do-restart-nudge
Commits: 2d9ed3b feat(plugin): restart nudge + Step 0.7 guard for post-/reload-plugins half-install (#1080)
