### PR TITLE
fix(nudge): user-visible restart nudge via systemMessage (#1088)

### DIFF
--- a/hooks/nudge-restart-to-materialise.sh
+++ b/hooks/nudge-restart-to-materialise.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # nudge-restart-to-materialise.sh — UserPromptSubmit restart nudge (#1080).
 #
 # THE GAP: after `/plugin install zs@zskills` -> `/reload-plugins`, the
@@ -84,11 +84,43 @@ MARKER="$MARKER_DIR/restart-nudge-shown-$SESSION_ID"
 mkdir -p "$MARKER_DIR" 2>/dev/null || true
 : > "$MARKER" 2>/dev/null || true
 
-# Print the nudge to stdout (advisory; UserPromptSubmit stdout is surfaced to
-# the user as additional context).
-cat <<'NUDGE'
-zskills: the plugin is loaded but setup isn't finished. /reload-plugins does not run the one-time materialisation step, so the verifier/implementer agents, two hooks, the rendered rules file, and your .claude/zskills-config.json have NOT been written yet. Run /clear (or exit and restart Claude Code) to fire the SessionStart hook and finish setup. This only needs to happen once.
-NUDGE
+# Emit the nudge as UserPromptSubmit JSON on stdout. We use TWO channels:
+#
+#   * top-level `systemMessage` — the USER-VISIBLE channel. A live Claude Code
+#     spike (#1088) confirmed a UserPromptSubmit hook returning `systemMessage`
+#     renders to the user as a NON-BLOCKING notice (CLI-prefixed with
+#     "UserPromptSubmit says:") while the prompt STILL reaches the model. Bare
+#     stdout (the prior implementation) only reached the model — the bug #1088
+#     fixes. NOTE: the "UserPromptSubmit says:" prefix is CLI-applied and not
+#     controllable here, so the message is worded to read well after it (it does
+#     NOT begin with "UserPromptSubmit").
+#   * hookSpecificOutput.additionalContext (UserPromptSubmit) — the MODEL-FACING
+#     channel, so the agent is also aware and can reinforce the nudge.
+#
+# The text is essentially static. Build the JSON with Python (json.dumps -> safe
+# escaping) via the shared resolver sourced from detect-install-state.sh; if no
+# Python is reachable, fall back to a carefully hand-escaped printf with the same
+# fixed strings (the message has no shell/JSON metacharacters, so this is safe).
+SYSMSG="zskills: the plugin is loaded but setup isn't finished. /reload-plugins does not run the one-time materialisation step, so the verifier/implementer agents, two hooks, the rendered rules file, and your .claude/zskills-config.json have NOT been written yet. Run /clear (or exit and restart Claude Code) to fire the SessionStart hook and finish setup. This only needs to happen once."
+CTXMSG="zskills setup is incomplete: the plugin is loaded but the SessionStart materialiser has not run (/reload-plugins does not fire it), so the 5 consumer-side artifacts and .claude/zskills-config.json are not written yet. Tell the user to run /clear (or restart Claude Code) to finish setup — this only needs to happen once."
+
+PY="$(zskills_resolve_python 2>/dev/null || true)"
+if [ -n "$PY" ]; then
+  ZS_SYSMSG="$SYSMSG" ZS_CTXMSG="$CTXMSG" "$PY" - <<'PYJSON' 2>/dev/null || printf '%s\n' "{\"systemMessage\":\"$SYSMSG\",\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"$CTXMSG\"}}"
+import json, os
+print(json.dumps({
+    "systemMessage": os.environ["ZS_SYSMSG"],
+    "hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": os.environ["ZS_CTXMSG"],
+    },
+}))
+PYJSON
+else
+  # No Python. The two messages contain no JSON metacharacters (no quotes,
+  # backslashes, or control chars), so direct interpolation is safe.
+  printf '%s\n' "{\"systemMessage\":\"$SYSMSG\",\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"$CTXMSG\"}}"
+fi
 
 # Advisory hook — always succeed, never block.
 exit 0

--- a/tests/test-nudge-restart-to-materialise.sh
+++ b/tests/test-nudge-restart-to-materialise.sh
@@ -7,12 +7,22 @@
 # consumer is stuck half-installed (lane==fresh) with nothing telling them to
 # restart. This hook fires on the next prompt and prints a one-time nudge.
 #
+# #1088 — the nudge MUST reach the USER, not just the model. The hook now
+# emits UserPromptSubmit JSON with a top-level `systemMessage` field (the
+# user-visible, non-blocking channel — confirmed by a live Claude Code spike)
+# plus hookSpecificOutput.additionalContext (model-facing). The prior
+# implementation emitted bare stdout, which only reached the model. This test
+# asserts the user-visible `systemMessage` field is emitted and that the output
+# is valid JSON with a non-empty `systemMessage` — NOT merely "something on
+# stdout".
+#
 # Hermetic: a tmpdir fixture $PROJ (consumer) + a fixture $PLUGIN carrying
 # detect-install-state.sh. We feed a UserPromptSubmit JSON on stdin and drive
 # the hook directly.
 #
 # Cases:
-#   (a) fresh + plugin-root set + no marker  -> nudge emitted + marker created.
+#   (a) fresh + plugin-root set + no marker  -> systemMessage JSON emitted +
+#                                               valid JSON + marker created.
 #   (b) marker already present               -> silent (no nudge).
 #   (c) lane == plugin (sentinelled artifact)-> silent.
 #   (d) lane == update-zskills (legacy)      -> silent.
@@ -24,8 +34,21 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 HOOK="$REPO_ROOT/hooks/nudge-restart-to-materialise.sh"
-# A stable substring of the nudge message (load-bearing assertion target).
+# A stable substring of the nudge message (load-bearing assertion target). The
+# hook now delivers this via the user-visible top-level `systemMessage` JSON
+# field (#1088), not bare stdout.
 NUDGE_MARK="the plugin is loaded but setup isn't finished"
+
+# Resolve a working Python 3 for the JSON-shape assertions (#1088). The repo
+# requires Python 3 (no jq); the suite runs in a Python-3 environment.
+PY=""
+for cand in "${ZSKILLS_PYTHON:-}" python3 python; do
+  [ -n "$cand" ] || continue
+  command -v "$cand" >/dev/null 2>&1 || continue
+  if "$cand" -c 'import sys; sys.exit(0 if sys.version_info[0]==3 else 1)' >/dev/null 2>&1; then
+    PY="$(command -v "$cand")"; break
+  fi
+done
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -65,11 +88,51 @@ else
   fail "a1. hook exited non-zero ($RC_A)"
 fi
 
-if printf '%s' "$OUT_A" | grep -qF "$NUDGE_MARK"; then
-  pass "a2. fresh+plugin-root+no-marker: nudge emitted to stdout"
+# #1088 — the nudge MUST be delivered via the user-visible top-level
+# `systemMessage` JSON field, NOT bare stdout. Assert: (1) the output is valid
+# JSON, (2) it has a non-empty top-level `systemMessage`, and (3) that
+# systemMessage carries the nudge text. This tightens the contract from
+# "something on stdout" to "the user-visible field is populated".
+if [ -z "$PY" ]; then
+  fail "a2. no Python 3 available to validate systemMessage JSON (#1088)"
 else
-  fail "a2. fresh+plugin-root+no-marker: nudge NOT emitted"
-  printf '      stdout: %s\n' "$OUT_A"
+  A2_RESULT="$(ZS_OUT="$OUT_A" NUDGE_MARK="$NUDGE_MARK" "$PY" - <<'PYCHK'
+import os, json
+raw = os.environ.get("ZS_OUT", "")
+try:
+    d = json.loads(raw)
+except Exception as e:
+    print("NOTJSON:%s" % e); raise SystemExit(0)
+sm = d.get("systemMessage")
+if not isinstance(sm, str) or not sm.strip():
+    print("NOSYSMSG"); raise SystemExit(0)
+if os.environ["NUDGE_MARK"] not in sm:
+    print("MARKMISSING"); raise SystemExit(0)
+hso = d.get("hookSpecificOutput", {})
+if hso.get("hookEventName") != "UserPromptSubmit" or not (hso.get("additionalContext") or "").strip():
+    print("BADCTX"); raise SystemExit(0)
+print("OK")
+PYCHK
+)"
+  case "$A2_RESULT" in
+    OK)
+      pass "a2. fresh+plugin-root+no-marker: valid JSON with non-empty user-visible systemMessage carrying the nudge + UserPromptSubmit additionalContext (#1088)" ;;
+    NOTJSON:*)
+      fail "a2. emitted output is not valid JSON ($A2_RESULT)"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    NOSYSMSG)
+      fail "a2. emitted JSON has no non-empty top-level systemMessage (#1088: nudge must reach the user, not bare stdout)"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    MARKMISSING)
+      fail "a2. systemMessage present but missing the nudge text (\"$NUDGE_MARK\")"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    BADCTX)
+      fail "a2. hookSpecificOutput.additionalContext (UserPromptSubmit) missing/empty"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    *)
+      fail "a2. unexpected JSON-check result: $A2_RESULT"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+  esac
 fi
 
 MARKER_A="$PROJ_A/.zskills/restart-nudge-shown-$SID"


### PR DESCRIPTION
Closes #1088.

The post-`/reload-plugins` restart nudge (`hooks/nudge-restart-to-materialise.sh`) emitted **bare stdout**, which a `UserPromptSubmit` hook routes only to the model (`additionalContext`) — so it never proactively surfaced to the user. The green shell test asserted *emission*, not *visibility*, locking in the wrong contract.

## Fix
- The hook now emits **JSON with a top-level `systemMessage`** (the user-visible nudge) AND keeps `hookSpecificOutput.additionalContext` (so the agent is also aware). JSON built via the (now-fixed) python resolver's `json.dumps`, with a safe `printf` fallback; no jq.
- The maintainer's **live Claude Code spike** (recorded in #1088) confirmed `systemMessage` from a UserPromptSubmit hook renders to the user as a non-blocking notice (CLI-prefixed "UserPromptSubmit says:") while the prompt still reaches the model — so the channel is verified, not doc-guessed, and the blocking-gate fallback is ruled out.
- Message worded to read sensibly after the CLI prefix.

**Gating unchanged** — fires only on lane=`fresh` + plugin env set + once-per-session marker; self-extinguishes when lane→plugin; silent on legacy/dev/unset; always `exit 0` (fail-open). Only the output channel changed.

## Tests
`tests/test-nudge-restart-to-materialise.sh` now asserts the **user-visible `systemMessage`** field (valid JSON, non-empty systemMessage, hookEventName==UserPromptSubmit, non-empty additionalContext) instead of bare stdout — and it genuinely fails on a bare-stdout reversion (`NOTJSON`). No silence/gating case weakened. Hook stays plugin-only (mirror-parity + SHIM exclusions intact).

## Test plan
- [x] `bash tests/run-all.sh` — 0 failed (independently verified); nudge 8/8, mirror-parity 33/33, plugin-hooks-integrity 9/9.
- [x] Live `systemMessage`-renders-to-user spike confirmed by maintainer (#1088).

Touches only `hooks/` + `tests/` (no skill version bump; line-2 hook stamp bumped).
