### PR TITLE
do: dashboard cross-platform (Windows + plugin root)

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.04+771ba5"
+  version: "2026.06.04+1b3132"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -79,12 +79,18 @@ The PID file, log file, and tracking markers all live under
 ```bash
 if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ] && [ -d "$ZSKILLS_DASHBOARD_ROOT" ]; then
   MAIN_ROOT=$(cd "$ZSKILLS_DASHBOARD_ROOT" && pwd)
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR" ]; then
+  MAIN_ROOT=$(cd "$CLAUDE_PROJECT_DIR" && pwd)
 else
   MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 fi
 PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
 LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
-PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts" ]; then
+  PKG_PARENT="${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts"
+else
+  PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
+fi
 # Dual-lane resolution: plugin install (${CLAUDE_PLUGIN_ROOT}) first, then
 # .claude/skills/... mirror (legacy /update-zskills install lane), then
 # source-tree fallback (zskills repo + tests).
@@ -313,8 +319,10 @@ if [ "$SUB" = "start" ]; then
   # Launch detached. cd into MAIN_ROOT so the server's resolve_main_root
   # cwd-walk lands here. PYTHONPATH prepend keeps the package importable
   # without an install. nohup + disown survives parent-shell exit.
-  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to
-  # PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (per DA-5).
+  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to either
+  # PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts:... (plugin lane)
+  # or PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (source/legacy) —
+  # see PKG_PARENT dual-lane resolution above (per DA-5).
   # When ZSKILLS_DASHBOARD_ROOT is set, pass --main-root so the server's
   # collector reads state from the override path (worktree verification).
   MAIN_ROOT_FLAG=""
@@ -633,8 +641,10 @@ The dashboard reads `.claude/zskills-config.json` for one field:
 - **MAIN_ROOT-anchored paths.** Every read/write goes through
   `$MAIN_ROOT/.zskills/...`, never cwd-relative — invoking the skill
   from a worktree must still see the main repo's PID file.
-- **PYTHONPATH discipline.** `start` prepends
-  `$MAIN_ROOT/skills/zskills-dashboard/scripts` to `PYTHONPATH` so
+- **PYTHONPATH discipline.** `start` prepends `$PKG_PARENT` to
+  `PYTHONPATH` — resolved dual-lane to
+  `${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts` (plugin lane)
+  or `$MAIN_ROOT/skills/zskills-dashboard/scripts` (source/legacy) — so
   `python3 -m zskills_monitor.server` resolves the package without an
   install step (per DA-5).
 - **Verify after every state change.** `start` curls

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -36,7 +36,6 @@ import argparse
 import contextlib
 import copy
 import errno
-import fcntl
 import json
 import os
 import pathlib
@@ -48,6 +47,13 @@ import sys
 import threading
 import time
 import urllib.parse
+
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl
+    fcntl = None
+if sys.platform == "win32":
+    import msvcrt
 from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -285,10 +291,27 @@ def _state_lock(main_root: pathlib.Path):
         str(lock_path), os.O_RDWR | os.O_CREAT, 0o644
     )
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        with _STATE_THREAD_LOCK:
-            yield
-        fcntl.flock(fd, fcntl.LOCK_UN)
+        if sys.platform == "win32":
+            # msvcrt.locking locks `nbytes` from the CURRENT file position;
+            # ensure the lock file has >=1 byte to lock, then lock from offset 0.
+            os.lseek(fd, 0, os.SEEK_SET)
+            try:
+                os.write(fd, b"\0")
+            except OSError:
+                pass
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            try:
+                with _STATE_THREAD_LOCK:
+                    yield
+            finally:
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            with _STATE_THREAD_LOCK:
+                yield
+            fcntl.flock(fd, fcntl.LOCK_UN)
     finally:
         os.close(fd)
 

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.04+771ba5"
+  version: "2026.06.04+1b3132"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -79,12 +79,18 @@ The PID file, log file, and tracking markers all live under
 ```bash
 if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ] && [ -d "$ZSKILLS_DASHBOARD_ROOT" ]; then
   MAIN_ROOT=$(cd "$ZSKILLS_DASHBOARD_ROOT" && pwd)
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR" ]; then
+  MAIN_ROOT=$(cd "$CLAUDE_PROJECT_DIR" && pwd)
 else
   MAIN_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
 fi
 PID_FILE="$MAIN_ROOT/.zskills/dashboard-server.pid"
 LOG_FILE="$MAIN_ROOT/.zskills/dashboard-server.log"
-PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts" ]; then
+  PKG_PARENT="${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts"
+else
+  PKG_PARENT="$MAIN_ROOT/skills/zskills-dashboard/scripts"
+fi
 # Dual-lane resolution: plugin install (${CLAUDE_PLUGIN_ROOT}) first, then
 # .claude/skills/... mirror (legacy /update-zskills install lane), then
 # source-tree fallback (zskills repo + tests).
@@ -313,8 +319,10 @@ if [ "$SUB" = "start" ]; then
   # Launch detached. cd into MAIN_ROOT so the server's resolve_main_root
   # cwd-walk lands here. PYTHONPATH prepend keeps the package importable
   # without an install. nohup + disown survives parent-shell exit.
-  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to
-  # PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (per DA-5).
+  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to either
+  # PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts:... (plugin lane)
+  # or PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (source/legacy) —
+  # see PKG_PARENT dual-lane resolution above (per DA-5).
   # When ZSKILLS_DASHBOARD_ROOT is set, pass --main-root so the server's
   # collector reads state from the override path (worktree verification).
   MAIN_ROOT_FLAG=""
@@ -633,8 +641,10 @@ The dashboard reads `.claude/zskills-config.json` for one field:
 - **MAIN_ROOT-anchored paths.** Every read/write goes through
   `$MAIN_ROOT/.zskills/...`, never cwd-relative — invoking the skill
   from a worktree must still see the main repo's PID file.
-- **PYTHONPATH discipline.** `start` prepends
-  `$MAIN_ROOT/skills/zskills-dashboard/scripts` to `PYTHONPATH` so
+- **PYTHONPATH discipline.** `start` prepends `$PKG_PARENT` to
+  `PYTHONPATH` — resolved dual-lane to
+  `${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts` (plugin lane)
+  or `$MAIN_ROOT/skills/zskills-dashboard/scripts` (source/legacy) — so
   `python3 -m zskills_monitor.server` resolves the package without an
   install step (per DA-5).
 - **Verify after every state change.** `start` curls

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -36,7 +36,6 @@ import argparse
 import contextlib
 import copy
 import errno
-import fcntl
 import json
 import os
 import pathlib
@@ -48,6 +47,13 @@ import sys
 import threading
 import time
 import urllib.parse
+
+try:
+    import fcntl
+except ImportError:  # Windows has no fcntl
+    fcntl = None
+if sys.platform == "win32":
+    import msvcrt
 from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -285,10 +291,27 @@ def _state_lock(main_root: pathlib.Path):
         str(lock_path), os.O_RDWR | os.O_CREAT, 0o644
     )
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        with _STATE_THREAD_LOCK:
-            yield
-        fcntl.flock(fd, fcntl.LOCK_UN)
+        if sys.platform == "win32":
+            # msvcrt.locking locks `nbytes` from the CURRENT file position;
+            # ensure the lock file has >=1 byte to lock, then lock from offset 0.
+            os.lseek(fd, 0, os.SEEK_SET)
+            try:
+                os.write(fd, b"\0")
+            except OSError:
+                pass
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            try:
+                with _STATE_THREAD_LOCK:
+                    yield
+            finally:
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            with _STATE_THREAD_LOCK:
+                yield
+            fcntl.flock(fd, fcntl.LOCK_UN)
     finally:
         os.close(fd)
 


### PR DESCRIPTION
Task: Make the zskills-dashboard skill work on Windows (MSYS/Git-Bash) and on mirror-less plugin installs.

Three scoped, cross-platform fixes (stop-path process management deliberately deferred to a follow-up PR):

- **server.py — fcntl→msvcrt lock.** Guard the unconditional `import fcntl` (ModuleNotFoundError on Windows → server never started). `_state_lock()` now branches: POSIX keeps the original `fcntl.flock(LOCK_EX/LOCK_UN)` path byte-for-byte; Windows uses `msvcrt.locking(LK_LOCK/LK_UNLCK)`. Both auto-release on `os.close(fd)`.
- **SKILL.md — PKG_PARENT plugin fallback.** Add a `${CLAUDE_PLUGIN_ROOT}` dual-lane fallback (mirroring PORT_SCRIPT/SANITIZE_SCRIPT) so the `zskills_monitor` package resolves on mirror-less plugin installs.
- **SKILL.md — MAIN_ROOT fallback.** Fall back to `$CLAUDE_PROJECT_DIR` before `git rev-parse` so a non-git project dir resolves.

Verified on Linux: run-all 7546/7546, monitor-server suite 69/69 (POSIX lock path → zero regression), conformance 713/713, version bumped. The Windows `msvcrt` branch is verified by inspection here and exercised by the user on Windows post-merge.

Worktree: /tmp/zskills-do-dashboard-win-plugin-compat
Commits: 1b38882 do: dashboard cross-platform — fcntl→msvcrt lock, plugin/CLAUDE_PROJECT_DIR root fallbacks
