### PR TITLE
test(perf): Phase 0 — baseline capture + parse-results/suite-registry libs

### DIFF
--- a/docs/plans/TEST_SUITE_PARALLELIZATION_PLAN.md
+++ b/docs/plans/TEST_SUITE_PARALLELIZATION_PLAN.md
@@ -70,7 +70,7 @@ additive term and the attended gate pinned OFF.
 ## Progress Tracker
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 0 — Baseline capture + shared infra: result-parser + registry reader | ⬚ | | |
+| 0 — Baseline capture + shared infra: result-parser + registry reader | ✅ Done | 62475b4 | baseline: 7546 existing / 2384 test-hooks / 713 conformance; +23 new ⇒ 7569 |
 | 1a — Extract hooks-harness lib (incl. test-hooks-helpers); verify monolith still 2384 | ⬚ | | |
 | 1b — Relocate test-hooks sections into sub-suites | ⬚ | | |
 | 2 — Targeted isolation (apply-preset, paths-migration) | ⬚ | | |

--- a/tests/lib/parse-results.sh
+++ b/tests/lib/parse-results.sh
@@ -1,0 +1,44 @@
+# tests/lib/parse-results.sh — shared "Results:" line parser for the
+# serial (run-all.sh) and the future parallel suite runners.
+#
+# SOURCEABLE LIBRARY, NOT A SUITE. Do NOT register in run-all.sh as a
+# `run_suite`. `tests/test-parse-results.sh` is the registered self-test
+# that exercises this function.
+#
+# Factored verbatim out of tests/run-all.sh (the ANSI-strip + anchored
+# `Results:` regex, formerly run-all.sh:34–43) so serial and parallel
+# runners share ONE parsing contract and the #587-hardened regex lives in a
+# single place.
+#
+# parse_results <output>
+#   Echoes exactly "PASS FAIL" (two space-separated integers) extracted from
+#   the canonical `Results: <N> passed, <N> failed` line in <output>.
+#
+#   The parse is DELIBERATELY narrow:
+#     - It strips ANSI color codes first (some suites colorize Results
+#       red/green).
+#     - It anchors to the exact `^Results: <N> passed, ... <N> failed` line
+#       shape so any inner-test diagnostics (e.g. test-hooks.sh's
+#       fixture-extension synthetic-fixture run that nests a
+#       `tests/test-skill-conformance.sh` invocation — see #587) can't leak a
+#       count into the outer parser. The regex is the #587-hardened form and
+#       is preserved EXACTLY.
+#     - If no canonical line is found it echoes "0 0" (the no-Results-line
+#       fall-through). This function does NOT decide whether that 0/0 is a
+#       failure — the CALLER still owns exit-code capture and the OVERALL_EXIT
+#       flip on any non-zero suite rc, so an unparseable-but-nonzero-exit
+#       suite is NOT silently dropped.
+parse_results() {
+  local output="$1"
+  local passed failed results_line stripped
+  stripped=$(echo "$output" | sed -E $'s/\x1b\\[[0-9;]*m//g')
+  results_line=$(echo "$stripped" | grep -E '^Results: [0-9]+ passed,( [0-9]+ failed|.* [0-9]+ failed)' | tail -1)
+  if [[ -n "$results_line" ]]; then
+    passed=$(echo "$results_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+')
+    failed=$(echo "$results_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+')
+  else
+    passed=0
+    failed=0
+  fi
+  echo "${passed:-0} ${failed:-0}"
+}

--- a/tests/lib/suite-registry.sh
+++ b/tests/lib/suite-registry.sh
@@ -1,0 +1,87 @@
+# tests/lib/suite-registry.sh — registered-suite enumerator for the serial
+# (run-all.sh) and the future parallel suite runners.
+#
+# SOURCEABLE LIBRARY, NOT A SUITE. Do NOT register in run-all.sh as a
+# `run_suite`. `tests/test-suite-registry.sh` is the registered self-test
+# that exercises these functions.
+#
+# Statically parses the `run_suite "<name>" "<path>"` registration lines out
+# of tests/run-all.sh WITHOUT executing it, so a parallel runner can fan the
+# same set of suites the serial runner runs. The parse:
+#   (a) EXCLUDES the `run_suite() {` function-definition line.
+#   (b) DEDUPES tests/test-plugin-live-load.sh, which is registered twice via
+#       the attended-gate if/else (one ZSKILLS_LIVE_ATTENDED=1 arm, one
+#       plain arm) — it is one suite, counted once.
+#   (c) Treats the 3 conditional/gated suites as METADATA, not bare entries:
+#         RUN_RACE_TESTS  → tests/test-fixture-race-isolation.sh
+#         RUN_E2E         → tests/e2e-parallel-pipelines.sh
+#         attended        → tests/test-plugin-live-load.sh
+#       (test-plugin-live-load.sh is ALSO an unconditional suite — it always
+#       runs, gated only on whether §B runs live — so it appears in the
+#       unconditional list AND is flagged here as attended-gated metadata.)
+#
+# Resolve the path to run-all.sh relative to THIS file so callers in any cwd
+# get the right registry.
+_suite_registry_runall() {
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  echo "$self_dir/../run-all.sh"
+}
+
+# list_registered_suites
+#   Echoes the DISTINCT unconditional suite paths (one per line, in
+#   first-appearance order), with:
+#     - the `run_suite() {` function-definition line EXCLUDED, and
+#     - tests/test-plugin-live-load.sh DEDUPED to a single entry.
+#   Conditional/gated suites are NOT included here — they are metadata; see
+#   list_conditional_suites. Parses statically; does NOT execute run-all.sh.
+list_registered_suites() {
+  local runall
+  runall="$(_suite_registry_runall)"
+
+  # Match an actual registration CALL: optional leading whitespace, then
+  # `run_suite "<name>" "<path>"`. The function-definition line is
+  # `run_suite() {` — the `(` immediately after the name means it never
+  # matches this `run_suite[[:space:]]+"` shape, so (a) is satisfied by the
+  # pattern itself. Extract the 2nd quoted field (the path) and dedupe by
+  # first appearance. The 3 conditional/gated suite paths are EXCLUDED here
+  # (they are reported by list_conditional_suites as metadata); their
+  # registrations sit inside `if` blocks but still carry a `run_suite "..."`
+  # line, so they must be filtered by path.
+  awk '
+    BEGIN {
+      cond["tests/test-fixture-race-isolation.sh"] = 1
+      cond["tests/e2e-parallel-pipelines.sh"] = 1
+    }
+    match($0, /^[[:space:]]*run_suite[[:space:]]+"[^"]*"[[:space:]]+"[^"]*"/) {
+      # Pull the 2nd double-quoted field = the script path.
+      line = $0
+      # Strip up to and including the first quoted field.
+      sub(/^[[:space:]]*run_suite[[:space:]]+"[^"]*"[[:space:]]+"/, "", line)
+      sub(/".*$/, "", line)
+      if (line in cond) next
+      if (!(line in seen)) {
+        seen[line] = 1
+        print line
+      }
+    }
+  ' "$runall"
+}
+
+# list_conditional_suites
+#   Echoes the 3 conditional/gated suites as metadata, one per line, in the
+#   form "<gate>\t<path>" (tab-separated):
+#       RUN_RACE_TESTS  tests/test-fixture-race-isolation.sh
+#       RUN_E2E         tests/e2e-parallel-pipelines.sh
+#       attended        tests/test-plugin-live-load.sh
+#   This is a STATIC, intentional enumeration of the gated registrations in
+#   run-all.sh — the gates are env-var / capability conditions a static
+#   parse cannot evaluate, so they are reported as metadata for the caller
+#   to decide on. (test-plugin-live-load.sh additionally appears in
+#   list_registered_suites because it always runs; the attended gate only
+#   controls whether its §B runs live.)
+list_conditional_suites() {
+  printf 'RUN_RACE_TESTS\ttests/test-fixture-race-isolation.sh\n'
+  printf 'RUN_E2E\ttests/e2e-parallel-pipelines.sh\n'
+  printf 'attended\ttests/test-plugin-live-load.sh\n'
+}

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -6,6 +6,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 export CLAUDE_PROJECT_DIR="$REPO_ROOT"
 
+# Shared "Results:" line parser (#587-hardened anchored regex), factored out
+# so serial + parallel runners share one parsing contract. parse_results
+# echoes "PASS FAIL"; this caller retains exit-code capture, accumulation,
+# the 0/0 fall-through, and the OVERALL_EXIT flip on any non-zero suite rc.
+. "$SCRIPT_DIR/lib/parse-results.sh"
+
 TOTAL_PASS=0
 TOTAL_FAIL=0
 OVERALL_EXIT=0
@@ -23,24 +29,15 @@ run_suite() {
   echo "$output"
 
   # Extract counts from the canonical "Results: <N> passed, <N> failed"
-  # line. Anchor to that exact line shape so any inner-test diagnostics
-  # (e.g., test-hooks.sh's fixture-extension synthetic-fixture run that
-  # nests a `tests/test-skill-conformance.sh` invocation — see #587) can't
-  # leak a count into the outer parser. Strip ANSI color codes first
-  # (some suites colorize Results in red/green). If no canonical line is
-  # found in the output, fall through with 0/0 — the suite's own exit
-  # code still flips OVERALL_EXIT below, so an unparseable suite is not
-  # silently dropped.
-  local passed failed results_line stripped
-  stripped=$(echo "$output" | sed -E $'s/\x1b\\[[0-9;]*m//g')
-  results_line=$(echo "$stripped" | grep -E '^Results: [0-9]+ passed,( [0-9]+ failed|.* [0-9]+ failed)' | tail -1)
-  if [[ -n "$results_line" ]]; then
-    passed=$(echo "$results_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+')
-    failed=$(echo "$results_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+')
-  else
-    passed=0
-    failed=0
-  fi
+  # line via the shared parser (tests/lib/parse-results.sh). It strips ANSI
+  # color codes and anchors to that exact line shape so any inner-test
+  # diagnostics (e.g., test-hooks.sh's fixture-extension synthetic-fixture
+  # run that nests a `tests/test-skill-conformance.sh` invocation — see #587)
+  # can't leak a count into the outer parser. If no canonical line is found,
+  # parse_results returns "0 0"; the suite's own exit code still flips
+  # OVERALL_EXIT below, so an unparseable suite is not silently dropped.
+  local passed failed
+  read -r passed failed < <(parse_results "$output")
 
   TOTAL_PASS=$((TOTAL_PASS + ${passed:-0}))
   TOTAL_FAIL=$((TOTAL_FAIL + ${failed:-0}))
@@ -166,6 +163,12 @@ run_suite "test-land-pr-rebase-rc14-parser.sh" "tests/test-land-pr-rebase-rc14-p
 # exercises (tests/lib/extract-fence.sh, tests/lib/landpr-harness.sh) are
 # sourceable libraries, NOT suites, so they are intentionally NOT registered.
 run_suite "test-extract-fence-lib.sh" "tests/test-extract-fence-lib.sh"
+# TEST_SUITE_PARALLELIZATION Phase 0 — self-tests for the shared infra libs.
+# tests/lib/parse-results.sh (Results-line parser) + tests/lib/suite-registry.sh
+# (registered-suite enumerator) are sourceable libraries, NOT suites, so they
+# are intentionally NOT registered; these two ARE the registered self-tests.
+run_suite "test-parse-results.sh" "tests/test-parse-results.sh"
+run_suite "test-suite-registry.sh" "tests/test-suite-registry.sh"
 run_suite "test-land-pr-tracking-copy.sh" "tests/test-land-pr-tracking-copy.sh"
 run_suite "test-landed-schema.sh" "tests/test-landed-schema.sh"
 run_suite "test-landed-status-vocabulary.sh" "tests/test-landed-status-vocabulary.sh"

--- a/tests/test-parse-results.sh
+++ b/tests/test-parse-results.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# tests/test-parse-results.sh — self-test for tests/lib/parse-results.sh
+# (TEST_SUITE_PARALLELIZATION Phase 0).
+#
+# parse_results is the shared "Results:" line parser factored out of
+# run-all.sh so serial + parallel runners share one parsing contract. This
+# suite pins that contract:
+#   1. Plain (un-colorized) Results line → "PASS FAIL".
+#   2. ANSI-colorized Results line (green/red) → same "PASS FAIL".
+#   3. No Results line in the output → "0 0" fall-through.
+#   4. The #587 hardening: a nested inner `Results:` diagnostic line that is
+#      NOT column-anchored must NOT leak its count; only the canonical
+#      `^Results:` line is parsed, and the LAST one wins.
+#   5. A non-zero "failed" count is reported faithfully.
+#
+# If any of these break, both the serial and the future parallel runner would
+# miscount; this suite is the tripwire.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=tests/lib/parse-results.sh
+. "$SCRIPT_DIR/lib/parse-results.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+# Helper: assert parse_results <output> echoes exactly <expected>.
+expect() {
+  local label="$1" output="$2" expected="$3" got
+  got="$(parse_results "$output")"
+  if [ "$got" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label" "expected '$expected', got '$got'"
+  fi
+}
+
+# ── 1. Plain Results line ─────────────────────────────────────────────
+plain=$'  PASS something\n  PASS other\nResults: 42 passed, 0 failed (of 42)'
+expect "[plain] '42 passed, 0 failed' → '42 0'" "$plain" "42 0"
+
+# ── 2. ANSI-colorized Results line (green) ────────────────────────────
+green=$'  ok\n\033[32mResults: 713 passed, 0 failed (of 713)\033[0m'
+expect "[ansi-green] colorized line strips ANSI → '713 0'" "$green" "713 0"
+
+# ANSI-colorized failing Results line (red).
+red=$'  bad\n\033[31mResults: 10 passed, 3 failed (of 13)\033[0m'
+expect "[ansi-red] colorized failing line → '10 3'" "$red" "10 3"
+
+# ── 3. No Results line → 0/0 fall-through ─────────────────────────────
+noresults=$'  PASS a\n  PASS b\n(no canonical results line here)'
+expect "[fallthrough] no Results line → '0 0'" "$noresults" "0 0"
+
+# Empty output → 0/0.
+expect "[fallthrough] empty output → '0 0'" "" "0 0"
+
+# ── 4. #587 hardening: non-anchored inner Results must NOT leak ───────
+# A nested diagnostic line whose `Results:` is NOT at column 0 (indented /
+# prefixed) must be ignored; only the canonical `^Results:` line is parsed.
+nested=$'running nested suite...\n    Results: 999 passed, 99 failed (of 1098)\nResults: 50 passed, 0 failed (of 50)'
+expect "[hardening] indented inner Results ignored; canonical wins → '50 0'" "$nested" "50 0"
+
+# When two canonical `^Results:` lines appear, the LAST one wins (tail -1).
+twolines=$'Results: 5 passed, 0 failed (of 5)\nmore output\nResults: 7 passed, 1 failed (of 8)'
+expect "[hardening] last canonical Results line wins → '7 1'" "$twolines" "7 1"
+
+# ── 5. Non-zero failed count faithfully reported ──────────────────────
+failing=$'Results: 100 passed, 7 failed (of 107)'
+expect "[failcount] non-zero failed reported → '100 7'" "$failing" "100 7"
+
+echo ""
+echo "---"
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-suite-registry.sh
+++ b/tests/test-suite-registry.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# tests/test-suite-registry.sh — self-test for tests/lib/suite-registry.sh
+# (TEST_SUITE_PARALLELIZATION Phase 0).
+#
+# list_registered_suites STATICALLY parses the `run_suite "<name>" "<path>"`
+# registration lines out of run-all.sh so a parallel runner can fan the same
+# suite set the serial runner runs. This suite pins that contract:
+#   1. The `run_suite() {` function-DEFINITION line is EXCLUDED.
+#   2. tests/test-plugin-live-load.sh (registered twice via the attended
+#      if/else) is DEDUPED to a single entry.
+#   3. The 3 conditional/gated suites are reported by list_conditional_suites
+#      as METADATA (gate + path), and the two purely-conditional ones
+#      (race-isolation, e2e) are NOT in the unconditional list.
+#   4. A handful of known-registered suites ARE present (explicit
+#      enumeration — NOT a raw `grep -c '^[[:space:]]*run_suite'` count, which
+#      is 208 and wrong because it includes the function-def line and the
+#      double live-load registration).
+#   5. The parser does NOT execute run-all.sh (static parse only).
+#
+# If any of these break, a parallel runner would fan the wrong suite set;
+# this suite is the tripwire.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=tests/lib/suite-registry.sh
+. "$SCRIPT_DIR/lib/suite-registry.sh"
+
+PASS=0
+FAIL=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+SUITES="$(list_registered_suites)"
+
+# ── 1. function-def line excluded ─────────────────────────────────────
+# The bare token `run_suite` (the function definition `run_suite() {`) must
+# never appear as a suite path.
+if printf '%s\n' "$SUITES" | grep -qx 'run_suite'; then
+  fail "[funcdef] excluded" "bare 'run_suite' leaked as a suite entry"
+elif printf '%s\n' "$SUITES" | grep -q '() {'; then
+  fail "[funcdef] excluded" "function-def fragment leaked as a suite entry"
+else
+  pass "[funcdef] run_suite() function-definition line excluded"
+fi
+
+# ── 2. live-load deduped to exactly one entry ─────────────────────────
+LIVE_COUNT="$(printf '%s\n' "$SUITES" | grep -c '^tests/test-plugin-live-load\.sh$')"
+if [ "$LIVE_COUNT" -eq 1 ]; then
+  pass "[dedupe] test-plugin-live-load.sh appears exactly once (registered twice)"
+else
+  fail "[dedupe] live-load count" "expected 1, got $LIVE_COUNT"
+fi
+
+# ── 3. conditional suites are metadata; race/e2e NOT in unconditional ─
+COND="$(list_conditional_suites)"
+# Expect exactly the 3 gated registrations, tab-separated gate<TAB>path.
+expected_cond=$'RUN_RACE_TESTS\ttests/test-fixture-race-isolation.sh\nRUN_E2E\ttests/e2e-parallel-pipelines.sh\nattended\ttests/test-plugin-live-load.sh'
+if [ "$COND" = "$expected_cond" ]; then
+  pass "[metadata] list_conditional_suites returns the 3 gated suites with gate tags"
+else
+  fail "[metadata] conditional set" "got: $(printf '%s' "$COND" | tr '\n' '|')"
+fi
+
+# The two purely-conditional suites must NOT be in the unconditional list.
+if printf '%s\n' "$SUITES" | grep -qx 'tests/test-fixture-race-isolation.sh'; then
+  fail "[metadata] race-isolation excluded" "RUN_RACE_TESTS suite leaked into unconditional list"
+else
+  pass "[metadata] test-fixture-race-isolation.sh kept OUT of unconditional list"
+fi
+if printf '%s\n' "$SUITES" | grep -qx 'tests/e2e-parallel-pipelines.sh'; then
+  fail "[metadata] e2e excluded" "RUN_E2E suite leaked into unconditional list"
+else
+  pass "[metadata] e2e-parallel-pipelines.sh kept OUT of unconditional list"
+fi
+
+# ── 4. explicit enumeration of known-registered suites ────────────────
+# NOT a raw grep -c. Each of these is a real run_suite registration; assert
+# presence by exact path.
+for known in \
+  tests/test-hooks.sh \
+  tests/test-skill-conformance.sh \
+  tests/test-do.sh \
+  tests/test-fix-issues.sh \
+  tests/test-parse-results.sh \
+  tests/test-suite-registry.sh \
+  tests/test-plugin-live-load.sh \
+  tests/test-switch-install-path.sh ; do
+  if printf '%s\n' "$SUITES" | grep -qx "$known"; then
+    pass "[enum] $known is in the registered set"
+  else
+    fail "[enum] $known" "expected in registered set, absent"
+  fi
+done
+
+# Sanity: the unconditional count must be well below the naive raw count of
+# 208 (`grep -c '^[[:space:]]*run_suite' run-all.sh`), proving the function-def
+# line and the double live-load registration were collapsed — and at least
+# the bulk of the suites survived.
+COUNT="$(printf '%s\n' "$SUITES" | grep -c .)"
+RAW="$(grep -c '^[[:space:]]*run_suite' "$REPO_ROOT/tests/run-all.sh")"
+if [ "$COUNT" -lt "$RAW" ] && [ "$COUNT" -gt 150 ]; then
+  pass "[count] distinct unconditional count ($COUNT) < raw grep count ($RAW)"
+else
+  fail "[count] distinct vs raw" "distinct=$COUNT raw=$RAW (expected 150 < distinct < raw)"
+fi
+
+# ── 5. parser must NOT execute run-all.sh ─────────────────────────────
+# Poison run-all by making its execution observably fail: copy it to a temp
+# fixture, prepend an `exit 7 / touch SENTINEL` that WOULD fire if sourced or
+# run, point the lib at it, and confirm the parse still yields entries without
+# the sentinel existing. We do this by re-deriving the runall path via an
+# isolated copy of the lib in a temp dir.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/lib"
+cp "$SCRIPT_DIR/lib/suite-registry.sh" "$TMP/lib/suite-registry.sh"
+SENTINEL="$TMP/EXECUTED"
+{
+  echo '#!/bin/bash'
+  echo "touch \"$SENTINEL\""   # fires ONLY if run-all.sh is executed/sourced
+  echo 'run_suite "alpha" "tests/alpha.sh"'
+  echo 'run_suite "beta" "tests/beta.sh"'
+} > "$TMP/run-all.sh"
+
+# Source the copied lib so _suite_registry_runall resolves to $TMP/run-all.sh.
+(
+  . "$TMP/lib/suite-registry.sh"
+  out="$(list_registered_suites)"
+  echo "$out" > "$TMP/out.txt"
+)
+if [ -f "$SENTINEL" ]; then
+  fail "[static] no-execute" "run-all.sh was executed/sourced (sentinel created)"
+elif grep -qx 'tests/alpha.sh' "$TMP/out.txt" && grep -qx 'tests/beta.sh' "$TMP/out.txt"; then
+  pass "[static] parses run-all.sh statically without executing it"
+else
+  fail "[static] parse" "expected alpha/beta paths; got: $(tr '\n' '|' < "$TMP/out.txt")"
+fi
+
+echo ""
+echo "---"
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+fi


### PR DESCRIPTION
## Phase 0 of TEST_SUITE_PARALLELIZATION_PLAN

Baseline capture + shared infra (result-parser + registry reader). **Additive only** — extracts the `run-all.sh` Results parser into `tests/lib/parse-results.sh` (byte-identical #587 regex), adds `tests/lib/suite-registry.sh` (static `list_registered_suites`), + unit tests (`tests/test-parse-results.sh`, `tests/test-suite-registry.sh`, +23 assertions ⇒ 7569/7569). No existing suite changed; no test softened.

Baseline recorded: 7546 existing / 2384 test-hooks (Gate A ✓) / 713 conformance.

Verified by a separate agent: full suite **7569/7569, 0 failed**; #587 regex byte-identical; scope clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
