### PR TITLE
do: dashboard clean Windows/plugin start

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.04+1b3132"
+  version: "2026.06.04+160eac"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -319,20 +319,37 @@ if [ "$SUB" = "start" ]; then
   # Launch detached. cd into MAIN_ROOT so the server's resolve_main_root
   # cwd-walk lands here. PYTHONPATH prepend keeps the package importable
   # without an install. nohup + disown survives parent-shell exit.
-  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to either
-  # PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts:... (plugin lane)
-  # or PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (source/legacy) —
-  # see PKG_PARENT dual-lane resolution above (per DA-5).
+  # Note: PYTHONPATH resolves at runtime to either
+  # PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts (plugin lane)
+  # or PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts (source/legacy) —
+  # see PKG_PARENT dual-lane resolution above (per DA-5). The path-list
+  # separator is interpreter-derived (os.pathsep), NOT a hardcoded ':' —
+  # native Windows Python reports ';' even under Git Bash, so a hardcoded
+  # ':' (plus the trailing-empty colon from "$PKG_PARENT:${PYTHONPATH:-}")
+  # would yield one invalid entry and a ModuleNotFoundError: zskills_monitor.
+  DASH_PYSEP=$("$PYTHON" -c 'import os,sys; sys.stdout.write(os.pathsep)')
+  if [ -n "${PYTHONPATH:-}" ]; then
+    DASH_PYTHONPATH="$PKG_PARENT$DASH_PYSEP$PYTHONPATH"
+  else
+    DASH_PYTHONPATH="$PKG_PARENT"
+  fi
   # When ZSKILLS_DASHBOARD_ROOT is set, pass --main-root so the server's
   # collector reads state from the override path (worktree verification).
   MAIN_ROOT_FLAG=""
   if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ]; then
     MAIN_ROOT_FLAG="--main-root $MAIN_ROOT"
   fi
+  # Pass --port "$PORT" explicitly so the server binds the SAME port the
+  # health-check below probes. Without it the server self-resolves and can
+  # land on a different port (e.g. fallback 8080) than $PORT from port.sh,
+  # making a healthy server look broken. Export CLAUDE_PLUGIN_ROOT so the
+  # server's shipped-helper resolution (briefing.py, port.sh) can find the
+  # plugin lane on a mirror-less plugin install.
   ( cd "$MAIN_ROOT" && \
-    PYTHONPATH="$PKG_PARENT:${PYTHONPATH:-}" \
+    PYTHONPATH="$DASH_PYTHONPATH" \
+    CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}" \
     ZSKILLS_DASHBOARD_ROOT="${ZSKILLS_DASHBOARD_ROOT:-}" \
-    nohup "$PYTHON" -m zskills_monitor.server $MAIN_ROOT_FLAG \
+    nohup "$PYTHON" -m zskills_monitor.server --port "$PORT" $MAIN_ROOT_FLAG \
       > "$LOG_FILE" 2>&1 < /dev/null & disown )
 
   # Health-check loop — up to ~10s for bind + first response. Python
@@ -646,7 +663,10 @@ The dashboard reads `.claude/zskills-config.json` for one field:
   `${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts` (plugin lane)
   or `$MAIN_ROOT/skills/zskills-dashboard/scripts` (source/legacy) — so
   `python3 -m zskills_monitor.server` resolves the package without an
-  install step (per DA-5).
+  install step (per DA-5). The path-list separator is interpreter-derived
+  (`$("$PYTHON" -c '...os.pathsep')`), not a hardcoded `:` — native Windows
+  Python reports `;` even under Git Bash, and the prepend avoids a
+  trailing-empty separator so no invalid entry is produced.
 - **Verify after every state change.** `start` curls
   `/api/health`; `stop` polls `kill -0` then verifies the port is
   freed via `lsof`.

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -209,12 +209,32 @@ def _load_briefing(main_root: pathlib.Path) -> Any:
     global _BRIEFING_MODULE
     if _BRIEFING_MODULE is not None:
         return _BRIEFING_MODULE
-    briefing_path = (
+    # Dual-lane resolution (mirrors the SKILL's PKG_PARENT idiom, #1093):
+    # on a mirror-less plugin install the shipped briefing.py lives under
+    # ${CLAUDE_PLUGIN_ROOT}/skills/..., NOT under the consumer's project
+    # dir. Prefer the plugin lane when CLAUDE_PLUGIN_ROOT is set AND the
+    # file exists there; otherwise resolve under main_root. Fall back to
+    # the last candidate so the RuntimeError below still names a sensible
+    # path when neither exists.
+    candidates: List[pathlib.Path] = []
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidates.append(
+            pathlib.Path(plugin_root)
+            / "skills"
+            / "briefing"
+            / "scripts"
+            / "briefing.py"
+        )
+    candidates.append(
         pathlib.Path(main_root)
         / "skills"
         / "briefing"
         / "scripts"
         / "briefing.py"
+    )
+    briefing_path = next(
+        (c for c in candidates if c.exists()), candidates[-1]
     )
     spec = importlib.util.spec_from_file_location(
         "_zskills_monitor_briefing", str(briefing_path)

--- a/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/.claude/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -146,11 +146,25 @@ def _read_default_port_from_config(main_root: pathlib.Path) -> Optional[int]:
 
 
 def _invoke_port_sh(main_root: pathlib.Path) -> Tuple[Optional[int], str]:
-    """Run port.sh and return (port, error_message). Search both
-    `.claude/skills/update-zskills/scripts/port.sh` (installed layout)
-    and `skills/update-zskills/scripts/port.sh` (source-tree).
+    """Run port.sh and return (port, error_message). Search, in order,
+    `${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/port.sh`
+    (mirror-less plugin install — the shipped helper is NOT under the
+    consumer's project dir), then
+    `.claude/skills/update-zskills/scripts/port.sh` (installed mirror
+    layout), then `skills/update-zskills/scripts/port.sh` (source-tree).
+    Mirrors the SKILL's dual-lane PORT_SCRIPT resolution.
     """
-    candidates = [
+    candidates = []
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidates.append(
+            pathlib.Path(plugin_root)
+            / "skills"
+            / "update-zskills"
+            / "scripts"
+            / "port.sh"
+        )
+    candidates += [
         main_root / ".claude" / "skills" / "update-zskills" / "scripts" / "port.sh",
         main_root / "skills" / "update-zskills" / "scripts" / "port.sh",
     ]

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.04+1b3132"
+  version: "2026.06.04+160eac"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -319,20 +319,37 @@ if [ "$SUB" = "start" ]; then
   # Launch detached. cd into MAIN_ROOT so the server's resolve_main_root
   # cwd-walk lands here. PYTHONPATH prepend keeps the package importable
   # without an install. nohup + disown survives parent-shell exit.
-  # Note: PYTHONPATH="$PKG_PARENT:..." resolves at runtime to either
-  # PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts:... (plugin lane)
-  # or PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts:... (source/legacy) —
-  # see PKG_PARENT dual-lane resolution above (per DA-5).
+  # Note: PYTHONPATH resolves at runtime to either
+  # PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts (plugin lane)
+  # or PYTHONPATH=$MAIN_ROOT/skills/zskills-dashboard/scripts (source/legacy) —
+  # see PKG_PARENT dual-lane resolution above (per DA-5). The path-list
+  # separator is interpreter-derived (os.pathsep), NOT a hardcoded ':' —
+  # native Windows Python reports ';' even under Git Bash, so a hardcoded
+  # ':' (plus the trailing-empty colon from "$PKG_PARENT:${PYTHONPATH:-}")
+  # would yield one invalid entry and a ModuleNotFoundError: zskills_monitor.
+  DASH_PYSEP=$("$PYTHON" -c 'import os,sys; sys.stdout.write(os.pathsep)')
+  if [ -n "${PYTHONPATH:-}" ]; then
+    DASH_PYTHONPATH="$PKG_PARENT$DASH_PYSEP$PYTHONPATH"
+  else
+    DASH_PYTHONPATH="$PKG_PARENT"
+  fi
   # When ZSKILLS_DASHBOARD_ROOT is set, pass --main-root so the server's
   # collector reads state from the override path (worktree verification).
   MAIN_ROOT_FLAG=""
   if [ -n "${ZSKILLS_DASHBOARD_ROOT:-}" ]; then
     MAIN_ROOT_FLAG="--main-root $MAIN_ROOT"
   fi
+  # Pass --port "$PORT" explicitly so the server binds the SAME port the
+  # health-check below probes. Without it the server self-resolves and can
+  # land on a different port (e.g. fallback 8080) than $PORT from port.sh,
+  # making a healthy server look broken. Export CLAUDE_PLUGIN_ROOT so the
+  # server's shipped-helper resolution (briefing.py, port.sh) can find the
+  # plugin lane on a mirror-less plugin install.
   ( cd "$MAIN_ROOT" && \
-    PYTHONPATH="$PKG_PARENT:${PYTHONPATH:-}" \
+    PYTHONPATH="$DASH_PYTHONPATH" \
+    CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}" \
     ZSKILLS_DASHBOARD_ROOT="${ZSKILLS_DASHBOARD_ROOT:-}" \
-    nohup "$PYTHON" -m zskills_monitor.server $MAIN_ROOT_FLAG \
+    nohup "$PYTHON" -m zskills_monitor.server --port "$PORT" $MAIN_ROOT_FLAG \
       > "$LOG_FILE" 2>&1 < /dev/null & disown )
 
   # Health-check loop — up to ~10s for bind + first response. Python
@@ -646,7 +663,10 @@ The dashboard reads `.claude/zskills-config.json` for one field:
   `${CLAUDE_PLUGIN_ROOT}/skills/zskills-dashboard/scripts` (plugin lane)
   or `$MAIN_ROOT/skills/zskills-dashboard/scripts` (source/legacy) — so
   `python3 -m zskills_monitor.server` resolves the package without an
-  install step (per DA-5).
+  install step (per DA-5). The path-list separator is interpreter-derived
+  (`$("$PYTHON" -c '...os.pathsep')`), not a hardcoded `:` — native Windows
+  Python reports `;` even under Git Bash, and the prepend avoids a
+  trailing-empty separator so no invalid entry is produced.
 - **Verify after every state change.** `start` curls
   `/api/health`; `stop` polls `kill -0` then verifies the port is
   freed via `lsof`.

--- a/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/collect.py
@@ -209,12 +209,32 @@ def _load_briefing(main_root: pathlib.Path) -> Any:
     global _BRIEFING_MODULE
     if _BRIEFING_MODULE is not None:
         return _BRIEFING_MODULE
-    briefing_path = (
+    # Dual-lane resolution (mirrors the SKILL's PKG_PARENT idiom, #1093):
+    # on a mirror-less plugin install the shipped briefing.py lives under
+    # ${CLAUDE_PLUGIN_ROOT}/skills/..., NOT under the consumer's project
+    # dir. Prefer the plugin lane when CLAUDE_PLUGIN_ROOT is set AND the
+    # file exists there; otherwise resolve under main_root. Fall back to
+    # the last candidate so the RuntimeError below still names a sensible
+    # path when neither exists.
+    candidates: List[pathlib.Path] = []
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidates.append(
+            pathlib.Path(plugin_root)
+            / "skills"
+            / "briefing"
+            / "scripts"
+            / "briefing.py"
+        )
+    candidates.append(
         pathlib.Path(main_root)
         / "skills"
         / "briefing"
         / "scripts"
         / "briefing.py"
+    )
+    briefing_path = next(
+        (c for c in candidates if c.exists()), candidates[-1]
     )
     spec = importlib.util.spec_from_file_location(
         "_zskills_monitor_briefing", str(briefing_path)

--- a/skills/zskills-dashboard/scripts/zskills_monitor/server.py
+++ b/skills/zskills-dashboard/scripts/zskills_monitor/server.py
@@ -146,11 +146,25 @@ def _read_default_port_from_config(main_root: pathlib.Path) -> Optional[int]:
 
 
 def _invoke_port_sh(main_root: pathlib.Path) -> Tuple[Optional[int], str]:
-    """Run port.sh and return (port, error_message). Search both
-    `.claude/skills/update-zskills/scripts/port.sh` (installed layout)
-    and `skills/update-zskills/scripts/port.sh` (source-tree).
+    """Run port.sh and return (port, error_message). Search, in order,
+    `${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/port.sh`
+    (mirror-less plugin install — the shipped helper is NOT under the
+    consumer's project dir), then
+    `.claude/skills/update-zskills/scripts/port.sh` (installed mirror
+    layout), then `skills/update-zskills/scripts/port.sh` (source-tree).
+    Mirrors the SKILL's dual-lane PORT_SCRIPT resolution.
     """
-    candidates = [
+    candidates = []
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        candidates.append(
+            pathlib.Path(plugin_root)
+            / "skills"
+            / "update-zskills"
+            / "scripts"
+            / "port.sh"
+        )
+    candidates += [
         main_root / ".claude" / "skills" / "update-zskills" / "scripts" / "port.sh",
         main_root / "skills" / "update-zskills" / "scripts" / "port.sh",
     ]

--- a/tests/test_zskills_monitor_collect.sh
+++ b/tests/test_zskills_monitor_collect.sh
@@ -2302,6 +2302,56 @@ fi
 rm -rf "$BR_TMP"
 
 # ---------------------------------------------------------------------------
+# _load_briefing dual-lane resolution (plugin-root vs main_root) — #1093 twin.
+# On a mirror-less plugin install briefing.py lives under
+# ${CLAUDE_PLUGIN_ROOT}/skills/..., NOT under the consumer's project dir.
+# ---------------------------------------------------------------------------
+echo "=== _load_briefing: plugin-root vs main_root dual-lane ==="
+
+LB_TMP=$(mktemp -d)
+LB_PLUGIN="$LB_TMP/plugin"
+LB_MAIN="$LB_TMP/main"
+# Both lanes carry a briefing.py, each printing a distinct sentinel so we
+# can prove WHICH copy got loaded.
+mkdir -p "$LB_PLUGIN/skills/briefing/scripts" "$LB_MAIN/skills/briefing/scripts"
+printf 'SENTINEL = "plugin"\n' > "$LB_PLUGIN/skills/briefing/scripts/briefing.py"
+printf 'SENTINEL = "main"\n'   > "$LB_MAIN/skills/briefing/scripts/briefing.py"
+
+# Case 1: CLAUDE_PLUGIN_ROOT set + plugin copy exists → plugin copy wins.
+LB_CASE1=$(CLAUDE_PLUGIN_ROOT="$LB_PLUGIN" PYTHONPATH="$PKG_PARENT" python3 -c '
+import pathlib, sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._BRIEFING_MODULE = None  # reset module-level cache so the test is honest
+mod = c._load_briefing(pathlib.Path("'"$LB_MAIN"'"))
+print("sentinel=" + getattr(mod, "SENTINEL", "<none>"))
+' 2>&1)
+if printf '%s\n' "$LB_CASE1" | grep -q "sentinel=plugin"; then
+  pass "_load_briefing: CLAUDE_PLUGIN_ROOT set resolves the plugin-lane briefing.py"
+else
+  fail "_load_briefing plugin lane: expected sentinel=plugin, got '$LB_CASE1'"
+fi
+
+# Case 2: CLAUDE_PLUGIN_ROOT unset → main_root copy resolves (no regression).
+LB_CASE2=$(env -u CLAUDE_PLUGIN_ROOT PYTHONPATH="$PKG_PARENT" python3 -c '
+import pathlib, sys
+sys.path.insert(0, "'"$PKG_PARENT"'")
+import zskills_monitor.collect as c
+c._BRIEFING_MODULE = None  # reset cache between cases
+mod = c._load_briefing(pathlib.Path("'"$LB_MAIN"'"))
+print("sentinel=" + getattr(mod, "SENTINEL", "<none>"))
+' 2>&1)
+if printf '%s\n' "$LB_CASE2" | grep -q "sentinel=main"; then
+  pass "_load_briefing: CLAUDE_PLUGIN_ROOT unset still resolves the main_root briefing.py"
+else
+  fail "_load_briefing main lane: expected sentinel=main, got '$LB_CASE2'"
+fi
+
+rm -rf "$LB_TMP"
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Task: Make the zskills-dashboard server start cleanly on a mirror-less plugin install and on native Windows Python. Follow-up to #1093 (fcntl), fixing three start-blocking bugs surfaced by a live Windows (MSYS) run.

- **PYTHONPATH separator (Windows).** The launch line built PYTHONPATH with a POSIX `:` separator + trailing-empty colon; native Windows python splits on `;` → `ModuleNotFoundError: zskills_monitor`. Now derives the separator from the interpreter (`$PYTHON -c 'import os;os.pathsep'`) and drops the trailing-empty entry — correct on both OSes.
- **Port propagation.** The launch passed no port, so the server self-resolved (→ fallback 8080) and could bind a different port than the skill health-checks. Now passes `--port "$PORT"`.
- **Server plugin-root awareness (the briefing-load + port.sh miss).** `collect.py:_load_briefing` and `server.py:_invoke_port_sh` resolved shipped helpers under `main_root` only — broken on a mirror-less plugin install. Now prefer `${CLAUDE_PLUGIN_ROOT}` when set+present (mirrors #1093's PKG_PARENT dual-lane idiom); the launch exports `CLAUDE_PLUGIN_ROOT`. State paths (.zskills, monitor-state, PID) are untouched.

Verified on Linux: run-all 7582/7582, new `_load_briefing` dual-lane tests (discriminating), conformance green, version bumped, mirror regen. The Windows `;` separator path is interpreter-derived (correct by construction) and re-verified by the user on Windows. Stop-path process management is a deliberate separate follow-up PR.

Worktree: /tmp/zskills-do-dashboard-start-plugin-win
Commits: ffbc1fe fix(dashboard): Windows-safe server launch — interpreter PYTHONPATH sep, port propagation, server plugin-root-aware helper paths
