### PR TITLE
do: fresh-config scaffolds docs/ path defaults

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.04+5865da"
+  version: "2026.06.04+1477e6"
 ---
 
 # Update Z Skills Infrastructure
@@ -567,12 +567,18 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    re-running on an already-backfilled config is a no-op.
    <!-- allow-hardcoded: re:^plans/ reason: forward-protection comment quoting pre-migration plan path -->
    ```markdown
-   > **Path-config keys are EXEMPT from auto-backfill.** `output.plans_dir`,
-   > `output.issues_dir`, and `output.reports_dir` MUST NOT be inserted into
-   > `.claude/zskills-config.json` during install or `--rerender`. Their
-   > absence is meaningful — the helper falls back to legacy `plans/`,
-   > preserving consumer-current behavior. Only `/update-zskills
-   > --migrate-paths` writes these keys (and writes BOTH or NEITHER).
+   > **Path-config keys: FRESH-SCAFFOLD writes them; auto-backfill does NOT.**
+   > A FRESH config scaffold (both lanes — this install's `Write` below and
+   > the plugin lane's SessionStart materialiser seed) DOES write
+   > `output.plans_dir = "docs/plans"`, `output.issues_dir = "docs/issues"`,
+   > and `output.reports_dir = "docs/reports"`, so a brand-new consumer's
+   > dashboard and plan-skills find plans in `docs/plans` out of the box.
+   > But these keys MUST NEVER be auto-BACKFILLED into an EXISTING config
+   > that lacks them during install or `--rerender`. Their absence in an
+   > existing config is meaningful — the helper falls back to legacy
+   > `plans/`, preserving consumer-current behavior. Relocating an EXISTING
+   > legacy layout is owned by `/update-zskills --migrate-paths`, which
+   > writes these keys (and writes BOTH or NEITHER).
    > See plan `docs/plans/ZSKILLS_PATH_CONFIG.md` (or
    > `plans/ZSKILLS_PATH_CONFIG.md` pre-migration).
    ```
@@ -631,6 +637,11 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
      "ci": {
        "auto_fix": true,
        "max_fix_attempts": 2
+     },
+     "output": {
+       "plans_dir": "docs/plans",
+       "issues_dir": "docs/issues",
+       "reports_dir": "docs/reports"
      }
    }
    ```

--- a/hooks/session-start-materialise.sh
+++ b/hooks/session-start-materialise.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.5
+# zskills-hook-version: 2026.06.6
 # session-start-materialise.sh — W2.1 SessionStart materialiser (D11, D20, D27).
 #
 # Plugins cannot write to the consumer repo at install time (research §10),
@@ -356,6 +356,11 @@ cfg = {
     "ci": {
         "auto_fix": True,
         "max_fix_attempts": 2,
+    },
+    "output": {
+        "plans_dir": "docs/plans",
+        "issues_dir": "docs/issues",
+        "reports_dir": "docs/reports",
     },
 }
 with open(sys.argv[1], "w") as f:

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.04+5865da"
+  version: "2026.06.04+1477e6"
 ---
 
 # Update Z Skills Infrastructure
@@ -567,12 +567,18 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
    re-running on an already-backfilled config is a no-op.
    <!-- allow-hardcoded: re:^plans/ reason: forward-protection comment quoting pre-migration plan path -->
    ```markdown
-   > **Path-config keys are EXEMPT from auto-backfill.** `output.plans_dir`,
-   > `output.issues_dir`, and `output.reports_dir` MUST NOT be inserted into
-   > `.claude/zskills-config.json` during install or `--rerender`. Their
-   > absence is meaningful — the helper falls back to legacy `plans/`,
-   > preserving consumer-current behavior. Only `/update-zskills
-   > --migrate-paths` writes these keys (and writes BOTH or NEITHER).
+   > **Path-config keys: FRESH-SCAFFOLD writes them; auto-backfill does NOT.**
+   > A FRESH config scaffold (both lanes — this install's `Write` below and
+   > the plugin lane's SessionStart materialiser seed) DOES write
+   > `output.plans_dir = "docs/plans"`, `output.issues_dir = "docs/issues"`,
+   > and `output.reports_dir = "docs/reports"`, so a brand-new consumer's
+   > dashboard and plan-skills find plans in `docs/plans` out of the box.
+   > But these keys MUST NEVER be auto-BACKFILLED into an EXISTING config
+   > that lacks them during install or `--rerender`. Their absence in an
+   > existing config is meaningful — the helper falls back to legacy
+   > `plans/`, preserving consumer-current behavior. Relocating an EXISTING
+   > legacy layout is owned by `/update-zskills --migrate-paths`, which
+   > writes these keys (and writes BOTH or NEITHER).
    > See plan `docs/plans/ZSKILLS_PATH_CONFIG.md` (or
    > `plans/ZSKILLS_PATH_CONFIG.md` pre-migration).
    ```
@@ -631,6 +637,11 @@ Check if `.claude/zskills-config.json` exists in the target project root (`$PROJ
      "ci": {
        "auto_fix": true,
        "max_fix_attempts": 2
+     },
+     "output": {
+       "plans_dir": "docs/plans",
+       "issues_dir": "docs/issues",
+       "reports_dir": "docs/reports"
      }
    }
    ```

--- a/tests/test-sessionstart-materialise.sh
+++ b/tests/test-sessionstart-materialise.sh
@@ -184,6 +184,25 @@ else
   fail "13. seeded config wrong: no config file"
 fi
 
+# 13b. Fresh seed defaults output.{plans,issues,reports}_dir to docs/ so a
+# brand-new consumer's dashboard + plan-skills find plans in docs/plans out of
+# the box (NOT the legacy plans/ fallback the resolver applies to an absent
+# output block). This seed MUST stay byte-identical to the /update-zskills
+# install scaffold in skills/update-zskills/SKILL.md (asserted symmetric in
+# tests/test-skill-conformance.sh).
+if [ -f "$SEED_CFG" ]; then
+  seed_plans=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["output"]["plans_dir"])' "$SEED_CFG" 2>/dev/null)
+  seed_issues=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["output"]["issues_dir"])' "$SEED_CFG" 2>/dev/null)
+  seed_reports=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["output"]["reports_dir"])' "$SEED_CFG" 2>/dev/null)
+  if [ "$seed_plans" = "docs/plans" ] && [ "$seed_issues" = "docs/issues" ] && [ "$seed_reports" = "docs/reports" ]; then
+    pass "13b. seeded config output block = docs/{plans,issues,reports}"
+  else
+    fail "13b. seeded config output wrong: plans=$seed_plans issues=$seed_issues reports=$seed_reports"
+  fi
+else
+  fail "13b. seeded config output check skipped: no config file"
+fi
+
 # 14. All 5 artifacts materialised now that the render gate passes.
 if [ -f "$SEED/.claude/agents/verifier.md" ] \
    && [ -f "$SEED/.claude/agents/implementer.md" ] \

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -2351,6 +2351,87 @@ else
 fi
 
 echo ""
+echo "=== Fresh-config scaffold: both lanes seed output.{plans,issues,reports}_dir = docs/ ==="
+# A FRESH config scaffold must default the output path keys to the documented
+# docs/ layout so a brand-new consumer's dashboard + plan-skills find plans in
+# docs/plans out of the box (resolver falls back to legacy plans/ only when the
+# output block is ABSENT — proven separately in tests/test-zskills-paths.sh
+# Case 1). Both scaffold sites must write the SAME output block:
+#   - plugin lane: hooks/session-start-materialise.sh seed dict
+#   - /update-zskills lane: skills/update-zskills/SKILL.md install scaffold JSON
+# This tightens the prior invariant (the seed used to carry NO output block).
+SCAFFOLD_PY="${ZSKILLS_PYTHON:-$(command -v python3 || command -v python)}"
+SCAFFOLD_HITS="$(ZS_REPO_ROOT="$REPO_ROOT" "$SCAFFOLD_PY" <<'PYEOF'
+import json, os, re, sys
+
+repo = os.environ["ZS_REPO_ROOT"]
+errs = []
+
+# --- (1) Plugin-lane seed: extract the `cfg = { ... }` dict literal from the
+#     materialiser and eval it as Python (it's a plain dict of literals; the
+#     only non-literal is os.environ["PROJECT_NAME"], which we stub).
+mat = os.path.join(repo, "hooks", "session-start-materialise.sh")
+src = open(mat, encoding="utf-8").read()
+m = re.search(r"\ncfg = (\{.*?\n\})\n", src, re.DOTALL)
+plugin_out = None
+if not m:
+    errs.append("could not locate `cfg = {...}` dict in session-start-materialise.sh")
+else:
+    ns = {"os": type("O", (), {"environ": {"PROJECT_NAME": "x"}})()}
+    try:
+        cfg = eval(m.group(1), {"__builtins__": {}, "True": True, "False": False}, ns)
+        plugin_out = cfg.get("output")
+    except Exception as e:  # noqa: BLE001
+        errs.append("failed to eval plugin seed cfg dict: %r" % (e,))
+
+# --- (2) /update-zskills lane: extract the install scaffold JSON block under
+#     the "Content to write to `.claude/zskills-config.json`:" heading, strip
+#     the <detected>/<preset.*> placeholders to JSON-valid dummies, json.load.
+skill = os.path.join(repo, "skills", "update-zskills", "SKILL.md")
+sk = open(skill, encoding="utf-8").read()
+idx = sk.find("Content to write to `.claude/zskills-config.json`:")
+scaffold_out = None
+if idx < 0:
+    errs.append("could not locate install scaffold heading in update-zskills/SKILL.md")
+else:
+    fence = re.search(r"```json\n(.*?)\n[ \t]*```", sk[idx:], re.DOTALL)
+    if not fence:
+        errs.append("could not locate ```json scaffold fence in update-zskills/SKILL.md")
+    else:
+        raw = fence.group(1)
+        # Replace placeholder tokens with JSON-valid dummies.
+        raw = raw.replace("<preset.main_protected>", "true")
+        raw = re.sub(r'"<[^"]*>"', '"x"', raw)   # quoted <detected>/<preset.landing>
+        raw = re.sub(r'\["<[^"]*>"\]', '["x"]', raw)  # ["<detected>"] arrays
+        try:
+            scaffold_out = json.loads(raw).get("output")
+        except Exception as e:  # noqa: BLE001
+            errs.append("install scaffold JSON does not parse after placeholder strip: %r" % (e,))
+
+EXPECTED = {"plans_dir": "docs/plans", "issues_dir": "docs/issues", "reports_dir": "docs/reports"}
+if plugin_out != EXPECTED:
+    errs.append("plugin seed output block != %r (got %r)" % (EXPECTED, plugin_out))
+if scaffold_out != EXPECTED:
+    errs.append("install scaffold output block != %r (got %r)" % (EXPECTED, scaffold_out))
+if plugin_out is not None and scaffold_out is not None and plugin_out != scaffold_out:
+    errs.append("the two seeds DISAGREE on the output block: plugin=%r scaffold=%r"
+                % (plugin_out, scaffold_out))
+
+for e in errs:
+    print(e)
+sys.exit(0)
+PYEOF
+)"
+if [ -z "$SCAFFOLD_HITS" ]; then
+  pass "fresh-config scaffold: both lanes seed identical output = docs/{plans,issues,reports}"
+else
+  fail "fresh-config scaffold output block (both-lanes symmetry)" "$SCAFFOLD_HITS"
+  printf '%s\n' "$SCAFFOLD_HITS" | while IFS= read -r h; do
+    [ -n "$h" ] && printf '    %s\n' "$h" >&2
+  done
+fi
+
+echo ""
 echo "=== No skill-file drift hardcodes (extended scope: hooks/, scripts/, *.py) ==="
 # Sibling deny-list scan over non-markdown sources that the existing
 # skills/**/*.md scanner above doesn't see:

--- a/tests/test-zskills-paths.sh
+++ b/tests/test-zskills-paths.sh
@@ -47,6 +47,14 @@ if [ ! -f "$HELPER" ]; then
 fi
 
 # --- Case 1: empty config → legacy fallback --------------------------------
+# REGRESSION ANCHOR: a fresh-config SCAFFOLD now seeds output.plans_dir =
+# "docs/plans" (both lanes — see hooks/session-start-materialise.sh and
+# skills/update-zskills/SKILL.md, locked symmetric in test-skill-conformance.sh).
+# That change MUST NOT touch the resolver's legacy fallback: an EXISTING config
+# with NO output block (or none at all) must still resolve to <root>/plans so
+# pre-migration consumers are preserved. Case 1 proves zskills-paths.sh keeps
+# that legacy behavior. If this case ever flips to docs/plans, the scaffold
+# change leaked into the resolver — STOP.
 echo "=== Case 1: empty config — $ZSKILLS_PLANS_DIR falls back to <root>/plans ==="
 T1=$(mktemp -d /tmp/zskills-paths-t1-XXXXXX)
 # No config file at all.


### PR DESCRIPTION
Task: Make a fresh zskills-config.json scaffold default the output path keys to the documented docs/ layout, so a new consumer's dashboard and plan-skills find plans in docs/plans out of the box.

Today a fresh install writes no `output` block, so the resolver falls back to legacy `plans/` and the dashboard reports "no plans found" even though plans live in docs/plans. Surfaced by a live Windows plugin-install run.

- **Both scaffold sites** now seed `output.{plans,issues,reports}_dir = docs/{plans,issues,reports}` — the plugin-lane materialiser (`hooks/session-start-materialise.sh`) and the `/update-zskills` install scaffold (`skills/update-zskills/SKILL.md`). A conformance test asserts the two seeds AGREE.
- **Legacy fallback unchanged (user directive).** `zskills-paths.sh` is untouched: an existing config with no `output` block still resolves to legacy `plans/`. A regression test pins this. `--migrate-paths` still owns relocating an existing legacy layout.
- Exemption prose reworked: fresh scaffold WRITES the docs/ defaults; auto-backfill into an existing config remains forbidden.

Verified on Linux: run-all 7584/7584, conformance + zskills-paths + sessionstart-materialise suites green, both seeds confirmed identical, version + hook stamp bumped, mirror regen.

Worktree: /tmp/zskills-do-config-scaffold-docs-default
Commits: 2a42845 do: fresh-config scaffold defaults output.{plans,issues,reports}_dir to docs/ (both lanes); legacy absent→plans/ fallback unchanged
