### PR TITLE
do: hooks normalize Windows tool paths

### DIFF
--- a/.claude/hooks/block-main-edits.sh
+++ b/.claude/hooks/block-main-edits.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.1
 # block-main-edits.sh — PreToolUse hook on Edit / Write.
 #
 # Honors execution.main_protected from .claude/zskills-config.json. When
@@ -36,6 +36,50 @@
 # executable line; the shim controls its own exit/return.
 [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
+# Inlined from hooks/_lib/normalize-tool-path.sh (source-of-truth). Drift gate:
+# tests/test-hook-helper-drift.sh. The legacy-mirror copy under .claude/hooks/
+# cannot reach _lib at runtime (.claude/hooks/_lib/ is not mirrored), so the
+# body is pasted in verbatim — mirroring the zskills_resolve_python convention.
+# zskills_normalize_tool_path — echo a POSIX form of "$1".
+#   - cygpath available  → `cygpath -u "$1"` (authoritative on MSYS/Cygwin).
+#   - else pure-bash fallback:
+#       * `^[A-Za-z]:[\\/]` (drive letter + sep) → `/<lowercased-drive>/<rest>`
+#         with every `\` turned into `/` (e.g. `D:\a\b` → `/d/a/b`;
+#         `C:/x` → `/c/x`).
+#       * any stray `\` in a backslash-relative path → `/` (`rel\path` →
+#         `rel/path`).
+#   - A pure-POSIX path (no drive letter, no backslash) passes through
+#     UNCHANGED — guaranteed no-op on Linux/Mac.
+#   - Empty input → empty output.
+# Side-effect free (no globals mutated); safe to call in a command
+# substitution.
+zskills_normalize_tool_path() {
+  local p="$1"
+  [ -n "$p" ] || { printf '%s' ""; return 0; }
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$p"
+    return 0
+  fi
+  # Pure-bash fallback (also the code path exercised on Linux/Mac, where
+  # cygpath is absent — so this is what the unit test verifies).
+  case "$p" in
+    [A-Za-z]:[\\/]*)
+      # Drive-letter absolute: `D:\a\b` or `C:/x`.
+      local drive="${p:0:1}"
+      local rest="${p:2}"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      rest="${rest//\\//}"
+      printf '%s' "/$drive$rest"
+      ;;
+    *)
+      # No drive letter: convert any stray backslash to forward slash. A
+      # pure-POSIX path (no backslash) is returned byte-for-byte unchanged.
+      printf '%s' "${p//\\//}"
+      ;;
+  esac
+  return 0
+}
+
 INPUT=$(cat 2>/dev/null) || exit 0
 [ -z "$INPUT" ] && exit 0
 
@@ -60,6 +104,19 @@ if [[ "$INPUT" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
 fi
 # No path extracted → can't decide → allow (defensive; never false-deny).
 [ -z "$FILE_PATH" ] && exit 0
+
+# ── Windows-native-path normalisation ─────────────────────────────────────
+# On a Windows (MSYS / Git-Bash) consumer the Edit/Write tool passes a
+# drive-letter / backslash path (e.g. `D:\proj\.zskills\x`). The
+# `case "$FILE_PATH" in /*)` classifier below would misread it as RELATIVE
+# (no leading `/`), break containment, and FALSE-DENY legitimate gitignored
+# `.zskills/` writes (issue #308's carve-out is dead on Windows). Normalise to
+# a POSIX form FIRST so containment (line ~127) and the `.zskills/*` carve-out
+# (line ~141) match — $MAIN_ROOT is already POSIX via `pwd -P`. No-op on
+# Linux/Mac (a pure-POSIX path passes through unchanged). Keep the ORIGINAL
+# for the user-facing deny message.
+ORIG_FILE_PATH="$FILE_PATH"
+FILE_PATH="$(zskills_normalize_tool_path "$FILE_PATH")"
 
 # ── Resolve $MAIN_ROOT ────────────────────────────────────────────────────
 # $CLAUDE_PROJECT_DIR is set by Claude Code at hook fire time to the project
@@ -148,7 +205,7 @@ esac
 STOP_MSG=$(cat <<EOF
 STOP: Edit/Write to main is blocked (main_protected: true in .claude/zskills-config.json).
 
-Target: $REL
+Target: $ORIG_FILE_PATH ($REL)
 
 Edits to the main repo working tree bypass the worktree discipline. Move
 this change into a worktree:

--- a/.claude/hooks/warn-config-drift.sh
+++ b/.claude/hooks/warn-config-drift.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.1
 # warn-config-drift.sh — PostToolUse hook, non-blocking warn.
 #
 # Two responsibilities:
@@ -29,6 +29,50 @@
 # executable line; the shim controls its own exit/return.
 [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
+# Inlined from hooks/_lib/normalize-tool-path.sh (source-of-truth). Drift gate:
+# tests/test-hook-helper-drift.sh. The legacy-mirror copy under .claude/hooks/
+# cannot reach _lib at runtime (.claude/hooks/_lib/ is not mirrored), so the
+# body is pasted in verbatim — mirroring the zskills_resolve_python convention.
+# zskills_normalize_tool_path — echo a POSIX form of "$1".
+#   - cygpath available  → `cygpath -u "$1"` (authoritative on MSYS/Cygwin).
+#   - else pure-bash fallback:
+#       * `^[A-Za-z]:[\\/]` (drive letter + sep) → `/<lowercased-drive>/<rest>`
+#         with every `\` turned into `/` (e.g. `D:\a\b` → `/d/a/b`;
+#         `C:/x` → `/c/x`).
+#       * any stray `\` in a backslash-relative path → `/` (`rel\path` →
+#         `rel/path`).
+#   - A pure-POSIX path (no drive letter, no backslash) passes through
+#     UNCHANGED — guaranteed no-op on Linux/Mac.
+#   - Empty input → empty output.
+# Side-effect free (no globals mutated); safe to call in a command
+# substitution.
+zskills_normalize_tool_path() {
+  local p="$1"
+  [ -n "$p" ] || { printf '%s' ""; return 0; }
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$p"
+    return 0
+  fi
+  # Pure-bash fallback (also the code path exercised on Linux/Mac, where
+  # cygpath is absent — so this is what the unit test verifies).
+  case "$p" in
+    [A-Za-z]:[\\/]*)
+      # Drive-letter absolute: `D:\a\b` or `C:/x`.
+      local drive="${p:0:1}"
+      local rest="${p:2}"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      rest="${rest//\\//}"
+      printf '%s' "/$drive$rest"
+      ;;
+    *)
+      # No drive letter: convert any stray backslash to forward slash. A
+      # pure-POSIX path (no backslash) is returned byte-for-byte unchanged.
+      printf '%s' "${p//\\//}"
+      ;;
+  esac
+  return 0
+}
+
 set -u
 
 INPUT=$(cat 2>/dev/null) || exit 0
@@ -50,6 +94,18 @@ FILE_PATH=""
 if [[ "$INPUT" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
   FILE_PATH="${BASH_REMATCH[1]}"
 fi
+
+# ── Windows-native-path normalisation ─────────────────────────────────────
+# On a Windows (MSYS / Git-Bash) consumer the Edit/Write tool passes a
+# drive-letter / backslash path (e.g. `D:\proj\skills\foo\SKILL.md`). All
+# three branches below classify $FILE_PATH against POSIX `/`-rooted forms:
+# Branch 1 suffix-matches `.claude/zskills-config.json`, Branch 2 anchors on
+# `(^|/)(skills|block-diagram)/`, and Branch 3 derives a repo-relative path via
+# `realpath --relative-to` / prefix-strip — all of which silently fail on a
+# backslash path, so the staged-file gate never fires. Normalise to a POSIX
+# form FIRST so every branch matches on Windows. No-op on Linux/Mac (a
+# pure-POSIX path passes through unchanged).
+FILE_PATH="$(zskills_normalize_tool_path "$FILE_PATH")"
 
 # --- Branch 1: config-file drift ---------------------------------------------
 # Suffix-match: handles absolute, repo-relative, cwd-relative paths.

--- a/hooks/_lib/normalize-tool-path.sh
+++ b/hooks/_lib/normalize-tool-path.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# hooks/_lib/normalize-tool-path.sh — source-of-truth body for the
+# Windows-native-path normaliser shared by the PreToolUse/PostToolUse hooks
+# that classify a tool `file_path` against the repo root.
+#
+# Why this exists: on a Windows (MSYS / Git-Bash) consumer the Edit / Write
+# tool passes a drive-letter / backslash path (e.g.
+# `D:\LocalDev\proj\.zskills\run-dashboard-start.sh`). Hooks that test
+# `case "$FILE_PATH" in /*)` to tell absolute from relative misclassify a
+# `D:\...` path as RELATIVE (it does not start with `/`), so the repo-relative
+# path they derive never matches the carve-out globs:
+#   - block-main-edits.sh then FALSE-DENIES legitimate gitignored `.zskills/`
+#     writes (issue #308's carve-out is dead on Windows), and
+#   - warn-config-drift.sh silently fails its staged-file gate.
+# Normalising the path to a POSIX form FIRST makes the existing `/`-rooted
+# containment + carve-out logic match on Windows exactly as on Linux/Mac.
+#
+# The function is inlined VERBATIM into each shipped consumer (the
+# legacy-mirror hooks under .claude/hooks/ cannot reach this _lib file at
+# runtime — .claude/hooks/_lib/ is not mirrored — so the body must be pasted
+# in, mirroring the zskills_resolve_python convention); the drift gate at
+# tests/test-hook-helper-drift.sh enforces byte-equality at CI time.
+#
+# Maintain HERE only.
+
+# zskills_normalize_tool_path — echo a POSIX form of "$1".
+#   - cygpath available  → `cygpath -u "$1"` (authoritative on MSYS/Cygwin).
+#   - else pure-bash fallback:
+#       * `^[A-Za-z]:[\\/]` (drive letter + sep) → `/<lowercased-drive>/<rest>`
+#         with every `\` turned into `/` (e.g. `D:\a\b` → `/d/a/b`;
+#         `C:/x` → `/c/x`).
+#       * any stray `\` in a backslash-relative path → `/` (`rel\path` →
+#         `rel/path`).
+#   - A pure-POSIX path (no drive letter, no backslash) passes through
+#     UNCHANGED — guaranteed no-op on Linux/Mac.
+#   - Empty input → empty output.
+# Side-effect free (no globals mutated); safe to call in a command
+# substitution.
+zskills_normalize_tool_path() {
+  local p="$1"
+  [ -n "$p" ] || { printf '%s' ""; return 0; }
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$p"
+    return 0
+  fi
+  # Pure-bash fallback (also the code path exercised on Linux/Mac, where
+  # cygpath is absent — so this is what the unit test verifies).
+  case "$p" in
+    [A-Za-z]:[\\/]*)
+      # Drive-letter absolute: `D:\a\b` or `C:/x`.
+      local drive="${p:0:1}"
+      local rest="${p:2}"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      rest="${rest//\\//}"
+      printf '%s' "/$drive$rest"
+      ;;
+    *)
+      # No drive letter: convert any stray backslash to forward slash. A
+      # pure-POSIX path (no backslash) is returned byte-for-byte unchanged.
+      printf '%s' "${p//\\//}"
+      ;;
+  esac
+  return 0
+}

--- a/hooks/block-main-edits.sh
+++ b/hooks/block-main-edits.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.1
 # block-main-edits.sh — PreToolUse hook on Edit / Write.
 #
 # Honors execution.main_protected from .claude/zskills-config.json. When
@@ -36,6 +36,50 @@
 # executable line; the shim controls its own exit/return.
 [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
+# Inlined from hooks/_lib/normalize-tool-path.sh (source-of-truth). Drift gate:
+# tests/test-hook-helper-drift.sh. The legacy-mirror copy under .claude/hooks/
+# cannot reach _lib at runtime (.claude/hooks/_lib/ is not mirrored), so the
+# body is pasted in verbatim — mirroring the zskills_resolve_python convention.
+# zskills_normalize_tool_path — echo a POSIX form of "$1".
+#   - cygpath available  → `cygpath -u "$1"` (authoritative on MSYS/Cygwin).
+#   - else pure-bash fallback:
+#       * `^[A-Za-z]:[\\/]` (drive letter + sep) → `/<lowercased-drive>/<rest>`
+#         with every `\` turned into `/` (e.g. `D:\a\b` → `/d/a/b`;
+#         `C:/x` → `/c/x`).
+#       * any stray `\` in a backslash-relative path → `/` (`rel\path` →
+#         `rel/path`).
+#   - A pure-POSIX path (no drive letter, no backslash) passes through
+#     UNCHANGED — guaranteed no-op on Linux/Mac.
+#   - Empty input → empty output.
+# Side-effect free (no globals mutated); safe to call in a command
+# substitution.
+zskills_normalize_tool_path() {
+  local p="$1"
+  [ -n "$p" ] || { printf '%s' ""; return 0; }
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$p"
+    return 0
+  fi
+  # Pure-bash fallback (also the code path exercised on Linux/Mac, where
+  # cygpath is absent — so this is what the unit test verifies).
+  case "$p" in
+    [A-Za-z]:[\\/]*)
+      # Drive-letter absolute: `D:\a\b` or `C:/x`.
+      local drive="${p:0:1}"
+      local rest="${p:2}"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      rest="${rest//\\//}"
+      printf '%s' "/$drive$rest"
+      ;;
+    *)
+      # No drive letter: convert any stray backslash to forward slash. A
+      # pure-POSIX path (no backslash) is returned byte-for-byte unchanged.
+      printf '%s' "${p//\\//}"
+      ;;
+  esac
+  return 0
+}
+
 INPUT=$(cat 2>/dev/null) || exit 0
 [ -z "$INPUT" ] && exit 0
 
@@ -60,6 +104,19 @@ if [[ "$INPUT" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
 fi
 # No path extracted → can't decide → allow (defensive; never false-deny).
 [ -z "$FILE_PATH" ] && exit 0
+
+# ── Windows-native-path normalisation ─────────────────────────────────────
+# On a Windows (MSYS / Git-Bash) consumer the Edit/Write tool passes a
+# drive-letter / backslash path (e.g. `D:\proj\.zskills\x`). The
+# `case "$FILE_PATH" in /*)` classifier below would misread it as RELATIVE
+# (no leading `/`), break containment, and FALSE-DENY legitimate gitignored
+# `.zskills/` writes (issue #308's carve-out is dead on Windows). Normalise to
+# a POSIX form FIRST so containment (line ~127) and the `.zskills/*` carve-out
+# (line ~141) match — $MAIN_ROOT is already POSIX via `pwd -P`. No-op on
+# Linux/Mac (a pure-POSIX path passes through unchanged). Keep the ORIGINAL
+# for the user-facing deny message.
+ORIG_FILE_PATH="$FILE_PATH"
+FILE_PATH="$(zskills_normalize_tool_path "$FILE_PATH")"
 
 # ── Resolve $MAIN_ROOT ────────────────────────────────────────────────────
 # $CLAUDE_PROJECT_DIR is set by Claude Code at hook fire time to the project
@@ -148,7 +205,7 @@ esac
 STOP_MSG=$(cat <<EOF
 STOP: Edit/Write to main is blocked (main_protected: true in .claude/zskills-config.json).
 
-Target: $REL
+Target: $ORIG_FILE_PATH ($REL)
 
 Edits to the main repo working tree bypass the worktree discipline. Move
 this change into a worktree:

--- a/hooks/warn-config-drift.sh
+++ b/hooks/warn-config-drift.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.05.0
+# zskills-hook-version: 2026.06.1
 # warn-config-drift.sh — PostToolUse hook, non-blocking warn.
 #
 # Two responsibilities:
@@ -29,6 +29,50 @@
 # executable line; the shim controls its own exit/return.
 [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh" ] && source "${CLAUDE_PLUGIN_ROOT}/hooks/_lib/plugin-hook-skip-if-mirrored.sh"
 
+# Inlined from hooks/_lib/normalize-tool-path.sh (source-of-truth). Drift gate:
+# tests/test-hook-helper-drift.sh. The legacy-mirror copy under .claude/hooks/
+# cannot reach _lib at runtime (.claude/hooks/_lib/ is not mirrored), so the
+# body is pasted in verbatim — mirroring the zskills_resolve_python convention.
+# zskills_normalize_tool_path — echo a POSIX form of "$1".
+#   - cygpath available  → `cygpath -u "$1"` (authoritative on MSYS/Cygwin).
+#   - else pure-bash fallback:
+#       * `^[A-Za-z]:[\\/]` (drive letter + sep) → `/<lowercased-drive>/<rest>`
+#         with every `\` turned into `/` (e.g. `D:\a\b` → `/d/a/b`;
+#         `C:/x` → `/c/x`).
+#       * any stray `\` in a backslash-relative path → `/` (`rel\path` →
+#         `rel/path`).
+#   - A pure-POSIX path (no drive letter, no backslash) passes through
+#     UNCHANGED — guaranteed no-op on Linux/Mac.
+#   - Empty input → empty output.
+# Side-effect free (no globals mutated); safe to call in a command
+# substitution.
+zskills_normalize_tool_path() {
+  local p="$1"
+  [ -n "$p" ] || { printf '%s' ""; return 0; }
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$p"
+    return 0
+  fi
+  # Pure-bash fallback (also the code path exercised on Linux/Mac, where
+  # cygpath is absent — so this is what the unit test verifies).
+  case "$p" in
+    [A-Za-z]:[\\/]*)
+      # Drive-letter absolute: `D:\a\b` or `C:/x`.
+      local drive="${p:0:1}"
+      local rest="${p:2}"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      rest="${rest//\\//}"
+      printf '%s' "/$drive$rest"
+      ;;
+    *)
+      # No drive letter: convert any stray backslash to forward slash. A
+      # pure-POSIX path (no backslash) is returned byte-for-byte unchanged.
+      printf '%s' "${p//\\//}"
+      ;;
+  esac
+  return 0
+}
+
 set -u
 
 INPUT=$(cat 2>/dev/null) || exit 0
@@ -50,6 +94,18 @@ FILE_PATH=""
 if [[ "$INPUT" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
   FILE_PATH="${BASH_REMATCH[1]}"
 fi
+
+# ── Windows-native-path normalisation ─────────────────────────────────────
+# On a Windows (MSYS / Git-Bash) consumer the Edit/Write tool passes a
+# drive-letter / backslash path (e.g. `D:\proj\skills\foo\SKILL.md`). All
+# three branches below classify $FILE_PATH against POSIX `/`-rooted forms:
+# Branch 1 suffix-matches `.claude/zskills-config.json`, Branch 2 anchors on
+# `(^|/)(skills|block-diagram)/`, and Branch 3 derives a repo-relative path via
+# `realpath --relative-to` / prefix-strip — all of which silently fail on a
+# backslash path, so the staged-file gate never fires. Normalise to a POSIX
+# form FIRST so every branch matches on Windows. No-op on Linux/Mac (a
+# pure-POSIX path passes through unchanged).
+FILE_PATH="$(zskills_normalize_tool_path "$FILE_PATH")"
 
 # --- Branch 1: config-file drift ---------------------------------------------
 # Suffix-match: handles absolute, repo-relative, cwd-relative paths.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -50,6 +50,7 @@ run_suite() {
 run_suite "test-hooks.sh" "tests/test-hooks.sh"
 run_suite "test-tokenize-then-walk.sh" "tests/test-tokenize-then-walk.sh"
 run_suite "test-hook-helper-drift.sh" "tests/test-hook-helper-drift.sh"
+run_suite "test-normalize-tool-path.sh" "tests/test-normalize-tool-path.sh"
 run_suite "test-resolve-effective-worktree-root.sh" "tests/test-resolve-effective-worktree-root.sh"
 run_suite "test-resolve-python.sh" "tests/test-resolve-python.sh"
 run_suite "test-python-resolver-drift.sh" "tests/test-python-resolver-drift.sh"

--- a/tests/test-block-main-edits.sh
+++ b/tests/test-block-main-edits.sh
@@ -246,6 +246,43 @@ else
   fail "C18a: STOP message recommends /do pr (issue #398)" "envelope=$HOOK_OUT"
 fi
 
+# ── Windows-native-path normalisation (MSYS / Git-Bash consumer) ──────────
+# On a Windows consumer the Edit/Write tool passes a backslash / drive-letter
+# path. The hook now normalises $FILE_PATH through zskills_normalize_tool_path
+# BEFORE the `case in /*)` classifier, so containment + the `.zskills/*`
+# carve-out match on a POSIX form.
+#
+# LINUX-REPRODUCIBILITY NOTE: a faithful drive-letter case (file_path =
+# `D:\proj\.zskills\x` with MAIN_ROOT = `D:\proj`) is NOT constructible on
+# Linux — the hook computes MAIN_ROOT via `cd "$MAIN_ROOT" && pwd -P`, and a
+# `D:\...` dir cannot be `cd`-ed into on a POSIX host. The drive-letter
+# transform itself is proven directly by tests/test-normalize-tool-path.sh
+# (cygpath is absent on Linux CI → that suite exercises the exact Windows
+# fallback logic). HERE we exercise the in-hook normalisation faithfully on
+# Linux by feeding a file_path whose RELATIVE TAIL uses backslash separators
+# (the form Git-Bash emits under MAIN_ROOT) — proving the hook converts the
+# separators so the carve-out / deny classification matches. Without the new
+# normalisation these would mis-classify: the backslash carve-out path would
+# FALSE-DENY (REL=`.zskills\audit\r.md` does not match `.zskills/*`).
+
+# ── C19: backslash relative tail under .zskills carve-out → ALLOW ─────────
+# Pre-fix this FALSE-DENIED (the exact issue: gitignored .zskills/ writes
+# blocked on Windows). normalize → `.zskills/audit/r.md` → carve-out matches.
+run_hook "$SANDBOX" "$(mkenv_write "$SANDBOX/.zskills\\audit\\r.md")"
+assert_allow "C19: Write backslash .zskills\\audit\\r.md → ALLOW (Win carve-out, was false-deny)" "$HOOK_EXIT" "$HOOK_OUT"
+
+# ── C20: backslash worktree-state marker tail → ALLOW (run-dashboard repro) ─
+# Mirrors the issue's `D:\…\.zskills\run-dashboard-start.sh` shape via the
+# Linux-reproducible backslash-tail form.
+run_hook "$SANDBOX" "$(mkenv_write "$SANDBOX/.zskills\\run-dashboard-start.sh")"
+assert_allow "C20: Write backslash .zskills\\run-dashboard-start.sh → ALLOW (issue repro)" "$HOOK_EXIT" "$HOOK_OUT"
+
+# ── C21: backslash tail to a tracked main file → still DENY ──────────────
+# Normalisation must NOT weaken the gate: a backslash path to a non-carve-out
+# main file (skills/foo/SKILL.md) normalises and is STILL denied.
+run_hook "$SANDBOX" "$(mkenv_edit "$SANDBOX/skills\\foo\\SKILL.md")"
+assert_deny "C21: Edit backslash skills\\foo\\SKILL.md on main → DENY (gate not weakened)" "$HOOK_OUT"
+
 # ── Summary ──────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"

--- a/tests/test-hook-helper-drift.sh
+++ b/tests/test-hook-helper-drift.sh
@@ -34,6 +34,8 @@ fn_source() {
       echo "hooks/_lib/resolve-effective-worktree-root.sh" ;;
     zskills_resolve_python)
       echo "hooks/_lib/resolve-python.sh" ;;
+    zskills_normalize_tool_path)
+      echo "hooks/_lib/normalize-tool-path.sh" ;;
     *)
       echo "" ;;
   esac
@@ -162,6 +164,34 @@ else
       pass "drift: $CONSUMER zskills_resolve_python matches source-of-truth"
     else
       fail "drift: $CONSUMER zskills_resolve_python drifted from $RP_SRC"
+    fi
+  done
+fi
+
+# ── zskills_normalize_tool_path drift (Windows-native-path normaliser) ──────
+# Source-of-truth body lives in hooks/_lib/normalize-tool-path.sh. Like the
+# resolver, it is inlined VERBATIM into each consuming hook (the legacy-mirror
+# hooks under .claude/hooks/ cannot reach _lib at runtime — .claude/hooks/_lib/
+# is not mirrored), so the body must be byte-identical to the source-of-truth.
+NORMALIZE_PATH_CONSUMERS=(
+  hooks/block-main-edits.sh
+  hooks/warn-config-drift.sh
+)
+NP_SRC="$(fn_source zskills_normalize_tool_path)"
+if [ -z "$NP_SRC" ] || [ ! -f "$NP_SRC" ]; then
+  fail "drift: zskills_normalize_tool_path source-of-truth file not found ($NP_SRC)"
+else
+  for CONSUMER in "${NORMALIZE_PATH_CONSUMERS[@]}"; do
+    if [ ! -f "$CONSUMER" ]; then
+      fail "drift: $CONSUMER zskills_normalize_tool_path consumer file not found"
+      continue
+    fi
+    if diff <(sed -n "/^zskills_normalize_tool_path()/,/^}$/p" "$CONSUMER") \
+            <(sed -n "/^zskills_normalize_tool_path()/,/^}$/p" "$NP_SRC") \
+            > /dev/null; then
+      pass "drift: $CONSUMER zskills_normalize_tool_path matches source-of-truth"
+    else
+      fail "drift: $CONSUMER zskills_normalize_tool_path drifted from $NP_SRC"
     fi
   done
 fi

--- a/tests/test-normalize-tool-path.sh
+++ b/tests/test-normalize-tool-path.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# tests/test-normalize-tool-path.sh — unit tests for
+# hooks/_lib/normalize-tool-path.sh's zskills_normalize_tool_path().
+#
+# The function normalises a tool `file_path` to a POSIX form so the
+# PreToolUse/PostToolUse hooks that classify a path against the repo root
+# (block-main-edits.sh, warn-config-drift.sh) work on a Windows (MSYS /
+# Git-Bash) consumer, where Edit/Write passes a drive-letter / backslash path
+# (e.g. `D:\proj\.zskills\x`). Without normalisation, `case in /*)` misreads
+# such a path as relative → containment breaks → block-main-edits.sh
+# FALSE-DENIES gitignored `.zskills/` writes and warn-config-drift.sh silently
+# skips its staged-file gate.
+#
+# This suite runs on Linux/Mac CI, where `cygpath` is ABSENT — so it exercises
+# the pure-bash fallback, which is exactly the Windows path-transform logic. It
+# is therefore a genuine test of the Windows behaviour WITHOUT a Windows box.
+# pass/fail inline (mirrors tests/test-hook-helper-drift.sh:22-25).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_ROOT/hooks/_lib/normalize-tool-path.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32mPASS\033[0m %s\n' "$*"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31mFAIL\033[0m %s\n' "$*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+if [ ! -f "$HELPER" ]; then
+  fail "source-of-truth helper not found: $HELPER"
+  echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+  exit "$FAIL_COUNT"
+fi
+
+# shellcheck source=/dev/null
+source "$HELPER"
+
+# Guard: this suite proves the pure-bash fallback. If cygpath is on PATH (i.e.
+# we are on an actual MSYS/Cygwin host), the cygpath branch takes over and the
+# expected POSIX strings below would not necessarily hold — note and skip the
+# fallback assertions rather than fail spuriously.
+if command -v cygpath >/dev/null 2>&1; then
+  echo "NOTE: cygpath present — fallback assertions skipped (cygpath branch active on this host)." >&2
+  echo "Results: 0 passed, 0 failed (of 0)"
+  exit 0
+fi
+
+check() {
+  local desc="$1" input="$2" want="$3" got
+  got="$(zskills_normalize_tool_path "$input")"
+  if [ "$got" = "$want" ]; then
+    pass "$desc: [$input] -> [$got]"
+  else
+    fail "$desc: [$input] -> [$got] (expected [$want])"
+  fi
+}
+
+# Drive-letter absolute, backslash separators (the canonical Windows form).
+check "drive-letter + backslashes lowercases drive, slashes separators" \
+  'D:\a\.zskills\x' '/d/a/.zskills/x'
+
+# Drive-letter absolute, forward slashes (Git-Bash sometimes emits this).
+check "drive-letter + forward slashes lowercases drive, keeps slashes" \
+  'C:/Users/x/SKILL.md' '/c/Users/x/SKILL.md'
+
+# Pure-POSIX absolute path — MUST pass through byte-for-byte (Linux/Mac no-op).
+check "pure-POSIX absolute path is unchanged" \
+  '/already/posix' '/already/posix'
+
+# Backslash-relative path — convert separators, no drive prefix added.
+check "backslash-relative path converts separators only" \
+  'rel\path' 'rel/path'
+
+# Empty input → empty output.
+check "empty input yields empty output" \
+  '' ''
+
+# Pure-POSIX relative path — no backslash, no drive → unchanged.
+check "pure-POSIX relative path is unchanged" \
+  'relative/posix/path' 'relative/posix/path'
+
+# The exact path from the issue report.
+check "issue-report path normalises end-to-end" \
+  'D:\LocalDev\proj\.zskills\run-dashboard-start.sh' \
+  '/d/LocalDev/proj/.zskills/run-dashboard-start.sh'
+
+# Lowercase drive letter stays lowercase (idempotent on already-lower drive).
+check "already-lowercase drive letter stays lowercase" \
+  'e:\Work\file.txt' '/e/Work/file.txt'
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed (of $((PASS_COUNT + FAIL_COUNT)))"
+exit "$FAIL_COUNT"

--- a/tests/test-skill-version-enforcement.sh
+++ b/tests/test-skill-version-enforcement.sh
@@ -357,6 +357,32 @@ else
   fail "case 12: expected WARN, got: $output"
 fi
 
+# Case 12b: $FILE_PATH fed as a WINDOWS-NATIVE backslash path → normalises
+# and warns. On a Windows (MSYS / Git-Bash) consumer the Edit/Write tool
+# passes a backslash path; pre-fix the Branch-2/3 anchor
+# `(^|/)(skills|block-diagram)/` and the realpath/prefix-strip staged-file
+# gate all silently miss it (a `\skills\` path doesn't match `/skills/`), so
+# the WARN never fires. The hook now normalises $FILE_PATH through
+# zskills_normalize_tool_path BEFORE Branch 1, so the staged-file gate fires.
+#
+# LINUX-REPRODUCIBILITY: a faithful drive-letter case (`D:\…`) is proven by
+# tests/test-normalize-tool-path.sh (cygpath absent on Linux → that suite
+# exercises the exact Windows fallback). HERE we use a backslash-separator
+# tail on the real POSIX sandbox root — the Git-Bash-under-MAIN_ROOT shape —
+# which faithfully drives the in-hook normalisation on Linux.
+case_no="12b"
+sandbox=$(make_sandbox "$case_no")
+echo "Edited body." >> "$sandbox/skills/foo/SKILL.md"
+(cd "$sandbox" && git add skills/foo/SKILL.md)
+# Backslash separators in the tail under the (POSIX) sandbox root.
+backslash_path="$sandbox/skills\\foo\\SKILL.md"
+output=$(run_hook "$sandbox" "$backslash_path")
+if [[ "$output" == *"WARN:"* ]] && [[ "$output" == *"content changed"* ]]; then
+  pass "case 12b: Windows backslash \$FILE_PATH normalises and warns (staged-gate fires)"
+else
+  fail "case 12b: expected WARN (Windows backslash path), got: $output"
+fi
+
 # ----------------------------------------------------------------------
 # STAGE-CHECK TESTS — scripts/skill-version-stage-check.sh.
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Task: Fix a Windows-native-path blindness shared by two PreToolUse hooks that classify a tool `file_path` against the repo root. Surfaced live: a `/zs:zskills-dashboard start` agent's `.zskills/run-dashboard-start.sh` write was wrongly DENIED on MSYS.

Root cause: `case "$FILE_PATH" in /*)` misreads a Windows-native `D:\…\.zskills\…` path as relative, so the derived repo-relative path never matches the carve-out globs → `block-main-edits.sh` false-DENIES gitignored `.zskills/` writes (issue #308's carve-out is dead on Windows), and `warn-config-drift.sh`'s staged-file gate silently misses (under-warns).

Fix:
- **New `hooks/_lib/normalize-tool-path.sh`** — `zskills_normalize_tool_path`: `cygpath -u` when present, else a pure-bash drive-letter/backslash→POSIX transform (`D:\a\b`→`/d/a/b`). A pure-POSIX path passes through byte-for-byte → guaranteed no-op on Linux/macOS.
- Both hooks normalize `$FILE_PATH` before classification. POSIX branches are byte-for-byte unchanged.
- The `.claude/hooks/` mirror has no `_lib/` subdir, so the function is **inlined** into both hooks (the `zskills_resolve_python` precedent), kept byte-identical to the canonical copy by `test-hook-helper-drift.sh` (drift-gated) + `test-hooks-mirror-parity.sh`.

Verified on Linux (cygpath absent → the bash fallback IS the Windows transform, so the Windows case is reproduced without a Windows box): run-all 7599/7599; new normalize unit test 8/8; block-main-edits 20/20 (Windows cases empirically proven to flip ALLOW↔DENY without the fix, and to still DENY a Windows-form `skills/…/SKILL.md` — no over-allow); hook-helper-drift + mirror-parity + conformance green; both hook stamps bumped.

**Out of scope (possible separate lower-risk audit):** `block-unsafe-generic.sh`, `block-unsafe-project.sh`, `block-stale-skill-version.sh`, `block-bypassed-land-pr.sh` basename-strip bash COMMAND tokens (a different mechanism than file_path containment). Loggers are cosmetic.

Worktree: /tmp/zskills-do-hooks-win-path-normalize
Commits: 6d04b7d do: hooks normalize Windows-native tool file_paths in main-edit + config-drift gates (fixes .zskills/ false-deny on MSYS)
