### PR TITLE
fix(tests): isolate test-create-worktree + test-port from cross-process collision (#1101)

### DIFF
--- a/tests/test-create-worktree.sh
+++ b/tests/test-create-worktree.sh
@@ -26,10 +26,56 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# MAIN_ROOT resolves via git-common-dir — may differ from REPO_ROOT when
-# this test runs from within a nested worktree. The script anchors all
-# paths on MAIN_ROOT, so the test must too (else default paths mismatch).
-MAIN_ROOT="$(cd "$(git -C "$REPO_ROOT" rev-parse --git-common-dir)/.." && pwd)"
+# ────────────────────────────────────────────────────────────────────
+# Per-invocation private clone (#1101) — cross-process isolation.
+#
+# create-worktree.sh anchors EVERYTHING on MAIN_ROOT, which it derives
+# from `git rev-parse --git-common-dir` at the invocation cwd. The bulk
+# of the cases (1-7, 9-16, 18-21) invoke the script WITHOUT cd-ing, so it
+# resolves MAIN_ROOT to the SHARED clone's `.git` — and registers/prunes
+# worktrees in `<clone>/.git/worktrees/`. When two `tests/run-all.sh`
+# invocations run concurrently in the SAME clone, one instance's
+# `git worktree list`/prune races the other's worktree removal →
+# `fatal: ... commondir: No such file or directory` → intermittent
+# false-fail (#1101).
+#
+# Fix: clone the shared repo into a unique, private working area (mktemp
+# honors $TMPDIR, which the parallel runner injects per-suite), then cd
+# the test PROCESS into it. Now BOTH the test's $MAIN_ROOT variable AND
+# the script-under-test's internally-derived MAIN_ROOT resolve to this
+# invocation's OWN clone, so its `.git/worktrees/` is never shared. The
+# script-under-test stays the in-flight worktree copy ($SCRIPT, anchored
+# on $REPO_ROOT below); only the git STATE the cases operate on is
+# privatised. Single-run behaviour is unchanged (the assertions are
+# identical; only PROJECT_NAME differs, and every case derives its
+# expected paths from PROJECT_NAME, so they track automatically).
+#
+# --local --no-hardlinks gives a self-contained object store (safe under
+# concurrent worktree churn). The clone preserves HEAD; we materialise a
+# local `main` ref when the source HEAD isn't already `main`, so the
+# `main`-preferring fixture anchors below resolve as they would in a
+# fresh main-branch checkout. The whole clone lives under $PRIVATE_CLONE_PARENT
+# (a mktemp dir) and is removed by the EXIT trap.
+# ────────────────────────────────────────────────────────────────────
+SHARED_MAIN_ROOT="$(cd "$(git -C "$REPO_ROOT" rev-parse --git-common-dir)/.." && pwd)"
+PRIVATE_CLONE_PARENT="$(mktemp -d)"
+MAIN_ROOT="$PRIVATE_CLONE_PARENT/$(basename "$SHARED_MAIN_ROOT")"
+git clone --quiet --local --no-hardlinks "$SHARED_MAIN_ROOT" "$MAIN_ROOT"
+# Hermetic identity for the clone (commit-tree fixtures need an author).
+git -C "$MAIN_ROOT" config user.email "test-create-worktree@test.invalid"
+git -C "$MAIN_ROOT" config user.name "test-create-worktree"
+# Ensure a local `main` ref exists (the source HEAD may be a feature
+# branch, e.g. this very fix branch). The clone has refs/remotes/origin/main
+# whenever the source has main; materialise a local main pointing at it so
+# the `main`-preferring anchors below behave like a main-branch checkout.
+if ! git -C "$MAIN_ROOT" rev-parse --verify --quiet main >/dev/null 2>&1; then
+  if git -C "$MAIN_ROOT" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    git -C "$MAIN_ROOT" branch main origin/main 2>/dev/null || true
+  fi
+fi
+# cd the test PROCESS into the private clone so no-cd script invocations
+# resolve their MAIN_ROOT here, not the shared clone.
+cd "$MAIN_ROOT"
 PROJECT_NAME="$(basename "$MAIN_ROOT")"
 
 # Fixture anchors for cases 10, 11, 19. These cases construct synthetic
@@ -133,6 +179,17 @@ cleanup() {
   # Fixture teardown (includes the hermetic HOME — must run AFTER any
   # subprocess git calls so they still see a valid GIT_CONFIG_GLOBAL).
   rm -rf -- "$TEST_TMPDIR" 2>/dev/null || true
+
+  # Per-invocation private clone (#1101). Prune its worktrees + remove the
+  # whole mktemp parent. cd out first so we never rm the cwd from under us.
+  cd / 2>/dev/null || true
+  if [ -n "${MAIN_ROOT:-}" ] && [ -d "$MAIN_ROOT" ]; then
+    git -C "$MAIN_ROOT" worktree prune 2>/dev/null || true
+  fi
+  if [ -n "${PRIVATE_CLONE_PARENT:-}" ] && [ -d "$PRIVATE_CLONE_PARENT" ] \
+     && [[ "$PRIVATE_CLONE_PARENT" == /tmp/* || "$PRIVATE_CLONE_PARENT" == "${TMPDIR%/}"/* ]]; then
+    rm -rf -- "$PRIVATE_CLONE_PARENT" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 

--- a/tests/test-port.sh
+++ b/tests/test-port.sh
@@ -178,8 +178,10 @@ rm -rf "$proj"
 # Verify PROJECT_ROOT env override + tightened regex + fail-loud guard.
 
 # 11. Fixture with default_port: 7777 — verifies PROJECT_ROOT override + configured value
-FIXTURE=/tmp/zskills-port-fixture
-rm -rf "$FIXTURE" && mkdir -p "$FIXTURE/.claude"
+# Per-invocation private fixture root (#1101): a FIXED /tmp path collides when
+# two concurrent run-alls share a clone. mktemp -d (honors $TMPDIR, which the
+# parallel runner injects per-suite) makes the fixture unique per invocation.
+FIXTURE=$(mktemp -d) && mkdir -p "$FIXTURE/.claude"
 cat > "$FIXTURE/.claude/zskills-config.json" <<JSON
 {"dev_server": {"main_repo_path": "$FIXTURE", "default_port": 7777}}
 JSON
@@ -192,8 +194,8 @@ fi
 rm -rf "$FIXTURE"
 
 # 12. Fixture WITHOUT default_port field — verifies fail-loud
-FIXTURE=/tmp/zskills-port-fixture-absent
-rm -rf "$FIXTURE" && mkdir -p "$FIXTURE/.claude"
+# Per-invocation private fixture root (#1101) — see case 11.
+FIXTURE=$(mktemp -d) && mkdir -p "$FIXTURE/.claude"
 cat > "$FIXTURE/.claude/zskills-config.json" <<JSON
 {"dev_server": {"main_repo_path": "$FIXTURE"}}
 JSON
@@ -210,8 +212,8 @@ rm -rf "$FIXTURE"
 # NOTE: main_repo_path is placed BEFORE the nested "limits" object so the (still-loose) main_repo_path
 # regex matches; default_port appears only inside "limits", so the tight [^{}]* regex must NOT match,
 # leaving DEFAULT_PORT="" and triggering fail-loud in the main-repo branch.
-FIXTURE=/tmp/zskills-port-fixture-nested
-rm -rf "$FIXTURE" && mkdir -p "$FIXTURE/.claude"
+# Per-invocation private fixture root (#1101) — see case 11.
+FIXTURE=$(mktemp -d) && mkdir -p "$FIXTURE/.claude"
 cat > "$FIXTURE/.claude/zskills-config.json" <<JSON
 {"dev_server": {"main_repo_path": "$FIXTURE", "limits": {"default_port": 9999}}}
 JSON


### PR DESCRIPTION
Closes #1101.

Two `tests/run-all.sh` invocations sharing one clone could collide (overlapping local pipelines / CI jobs sharing a checkout). Tests-only fix; CI single-run was unaffected.

## Fix
- **`tests/test-create-worktree.sh`** — was sharing `<clone>/.git/worktrees/` (resolved via `git rev-parse --git-common-dir`), so concurrent invocations raced each other's `git worktree list`/prune → `fatal: ... commondir`. Now clones the repo into a per-invocation `mktemp -d` private clone (honors the #1100 parallel runner's injected `$TMPDIR`) and operates there, so each invocation has its own git-common-dir. Assertions unchanged; cleanup trap prunes + removes the clone (guarded to /tmp/$TMPDIR).
- **`tests/test-port.sh`** — fixed `/tmp/zskills-port-fixture` fixtures replaced with unique `mktemp -d` dirs. `port.sh` reads them via env, so no production change.

## Verification
Independently verified, including **two concurrent invocations of each suite** with separate `$TMPDIR` → all passed, 0 `commondir` races, 0 leaked fixtures.

## Test plan
- [x] `bash tests/run-all.sh` — 0 failed (7626/7626); test-create-worktree 26/26, test-port 13/13.
- [x] Concurrency race mechanism confirmed removed.

Tests-only; no skill version bump.
