### PR TITLE
do: ship-to-prod PAT push fix + write-probe preflight

### DIFF
--- a/.claude/zskills-config.json
+++ b/.claude/zskills-config.json
@@ -11,7 +11,7 @@
     "dashboard_completed_limit": 500
   },
   "commit": {
-    "co_author": "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+    "co_author": "Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
   },
   "logging": {
     "enabled": true,

--- a/.github/workflows/ship-to-prod.yml
+++ b/.github/workflows/ship-to-prod.yml
@@ -42,10 +42,14 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Pre-flight — verify PROD_PUSH_TOKEN is valid
-        # Runs before any state-changing work so an expired/missing PAT
-        # fails the workflow in seconds, with zero cleanup required. Also
-        # runs on dry-run so you can catch a dead token without shipping.
+      - name: Pre-flight — verify PROD_PUSH_TOKEN can WRITE to prod
+        # A real write-probe, not a read. The old `git ls-remote` proved only a READ,
+        # which works for ANY identity on a public repo (even github-actions[bot]) — so
+        # it went green while the real push later 403'd. This probe pushes a throwaway
+        # ref to prod using the PAT via the SAME explicit auth header the real push uses,
+        # then deletes it. Runs on dry-run too: a dry-run now makes exactly ONE reversible
+        # write (this probe ref, pushed-then-deleted, pointing at prod's existing main SHA
+        # — no content change) and otherwise still writes nothing.
         env:
           PROD_PUSH_TOKEN: ${{ secrets.PROD_PUSH_TOKEN }}
         run: |
@@ -53,11 +57,22 @@ jobs:
             echo "::error::PROD_PUSH_TOKEN secret is not set. See RELEASING.md for one-time setup."
             exit 1
           fi
-          if ! git ls-remote --heads "https://x-access-token:${PROD_PUSH_TOKEN}@github.com/zeveck/zskills.git" >/dev/null 2>&1; then
-            echo "::error::PROD_PUSH_TOKEN auth failed against zeveck/zskills. Rotate the PAT (RELEASING.md → 'One-time setup') and re-run."
-            exit 1
+          AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$PROD_PUSH_TOKEN" | base64 -w0)"
+          echo "::add-mask::$AUTH"
+          PROD_URL="https://github.com/zeveck/zskills.git"
+          PROBE="refs/heads/__ship-preflight-probe-${{ github.run_id }}"
+          if ! git -c "http.https://github.com/.extraheader=$AUTH" fetch "$PROD_URL" main 2>fetch-err.log; then
+            echo "::error::Could not reach zeveck/zskills with PROD_PUSH_TOKEN:"; cat fetch-err.log; exit 1
           fi
-          echo "::notice::PAT auth OK."
+          PROD_MAIN=$(git rev-parse FETCH_HEAD)
+          if ! git -c "http.https://github.com/.extraheader=$AUTH" push "$PROD_URL" "$PROD_MAIN:$PROBE" 2>probe-err.log; then
+            echo "::error::PROD_PUSH_TOKEN cannot WRITE to zeveck/zskills (the real push would fail the same way). Rotate/repair the PAT — RELEASING.md 'One-time setup' — and re-run."
+            cat probe-err.log; exit 1
+          fi
+          if ! git -c "http.https://github.com/.extraheader=$AUTH" push "$PROD_URL" ":$PROBE" 2>cleanup-err.log; then
+            echo "::warning::Probe ref cleanup failed; delete $PROBE on zeveck/zskills manually."; cat cleanup-err.log
+          fi
+          echo "::notice::PAT write-access to prod confirmed."
 
       - name: Capture dev SHA being released
         id: dev_sha
@@ -103,14 +118,21 @@ jobs:
 
       - name: Push to prod (prod-first, so dev stays clean on failure)
         if: ${{ inputs.dry-run == false }}
+        env:
+          PROD_PUSH_TOKEN: ${{ secrets.PROD_PUSH_TOKEN }}
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           PROD_SHA="${{ steps.prod_commit.outputs.sha }}"
-          # 1) Push transformed commit to prod's main. Fast-forward — we
-          #    built on prod/main as parent in the commit-tree step above.
-          git push prod "${PROD_SHA}:refs/heads/main"
-          # 2) Push the same tag to prod, pointing at the transformed commit.
-          git push prod "${PROD_SHA}:refs/tags/${TAG}"
+          # actions/checkout installs a global http.https://github.com/.extraheader
+          # carrying the GITHUB_TOKEN (github-actions[bot]). Left in place it OVERRIDES
+          # the PAT and the push authenticates as the bot, which has no write access to
+          # the separate prod repo -> 403. Force the correct identity by setting the
+          # extraheader to the PAT (the same mechanism checkout uses, with our token).
+          AUTH="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$PROD_PUSH_TOKEN" | base64 -w0)"
+          echo "::add-mask::$AUTH"
+          PROD_URL="https://github.com/zeveck/zskills.git"
+          git -c "http.https://github.com/.extraheader=$AUTH" push "$PROD_URL" "${PROD_SHA}:refs/heads/main"
+          git -c "http.https://github.com/.extraheader=$AUTH" push "$PROD_URL" "${PROD_SHA}:refs/tags/${TAG}"
 
       - name: Tag dev + create Release (only after prod succeeded)
         if: ${{ inputs.dry-run == false }}

--- a/PRESENTATION.html
+++ b/PRESENTATION.html
@@ -268,7 +268,6 @@
 <nav>
   <span class="logo">Z Skills</span>
   <a href="#skills">23 Skills</a>
-  <a href="#quickstart">Typical Workflow</a>
   <a href="#workflows">Workflows</a>
   <a href="#schedulable">Schedulable</a>
   <a href="#patterns">Patterns</a>
@@ -410,40 +409,6 @@
       </div>
 
 
-</section>
-
-<!-- TYPICAL WORKFLOW -->
-<section id="quickstart" class="fade-in">
-  <h2>Typical Workflow</h2>
-
-  <table>
-    <tr><th>Command</th><th>What It Does</th><th>When</th></tr>
-    <tr>
-      <td><code>/briefing</code></td>
-      <td>See what happened, what needs attention, what's in flight</td>
-      <td>Start of session</td>
-    </tr>
-    <tr>
-      <td><code>/draft-plan plans/FOO.md</code></td>
-      <td>Research, draft, and refine a plan through adversarial review</td>
-      <td>Starting a feature</td>
-    </tr>
-    <tr>
-      <td><code>/run-plan plans/FOO.md finish auto</code></td>
-      <td>Execute all remaining phases autonomously</td>
-      <td>Implementing</td>
-    </tr>
-    <tr>
-      <td><code>/verify-changes</code></td>
-      <td>Audit diffs, run tests, manual-test UI, fix issues</td>
-      <td>Before committing</td>
-    </tr>
-    <tr>
-      <td><code>/commit</code></td>
-      <td>Stage with dependency tracing, protect other agents' work</td>
-      <td>Landing code</td>
-    </tr>
-  </table>
 </section>
 
 <!-- THE FOUR WORKFLOWS -->

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -125,9 +125,16 @@ creating the release — no extra setup needed for that side.
 On dispatch, it:
 
 1. Checks out the current dev HEAD (full history, so it can enumerate tags).
-2. **Pre-flight:** `git ls-remote`s the prod repo with `PROD_PUSH_TOKEN`
-   to validate the PAT. Fails the workflow in seconds if the token is
-   missing or expired — **zero state change required**, just rotate and
+2. **Pre-flight write-probe:** pushes a throwaway ref to the prod repo with
+   `PROD_PUSH_TOKEN` (via the same explicit auth header the real push uses),
+   then deletes it. This genuinely validates **write** access — a plain
+   `git ls-remote` read would pass for ANY identity on a public repo (even
+   `github-actions[bot]`, which can't write to prod), so it went green while
+   the real push later 403'd. The probe pushes its ref at prod's existing
+   `main` SHA (no content change) and deletes it again, so the only state
+   change is reversible and self-cleaning. Runs on dry-run too, so you can
+   catch a dead/under-permissioned token before shipping. Fails the workflow
+   in seconds if the token is missing, expired, or read-only — rotate and
    re-run.
 3. Runs `bash tests/run-all.sh` as a gate. Any red test aborts.
 4. Computes the next tag as `YYYY.MM.N` where `N` is the count of existing
@@ -155,7 +162,10 @@ workflow.
 If you changed `scripts/build-prod.sh` and want to verify the transforms
 without actually shipping: click Run workflow, check **Dry run**, run. The
 workflow will build the prod tree and show the file diff in the run
-summary, but will not push anything or tag anything.
+summary. It publishes no release commit and no tag — the ONE exception is
+the pre-flight write-probe, which makes a single reversible push-then-delete
+of a throwaway ref to prod (pointing at prod's existing `main` SHA, no
+content change) to confirm write access. Nothing else is pushed.
 
 ## Adding new transforms
 

--- a/tests/test-plugin-ref-consistency.sh
+++ b/tests/test-plugin-ref-consistency.sh
@@ -7,8 +7,8 @@
 # THE publisher is the "🚀 Ship to Prod" button:
 #   .github/workflows/ship-to-prod.yml → scripts/build-prod.sh
 #   → push to prod's BARE `main` branch + a BARE `<version>` tag
-#     (ship-to-prod.yml: `git push prod "${PROD_SHA}:refs/heads/main"` and
-#      `git push prod "${PROD_SHA}:refs/tags/${TAG}"`).
+#     (ship-to-prod.yml pushes "${PROD_SHA}:refs/heads/main" and
+#      "${PROD_SHA}:refs/tags/${TAG}", via an explicit PAT extraheader).
 #
 # Consumers resolve:
 #   - .claude-plugin/marketplace.json's `zs` source.ref — the moving window
@@ -60,11 +60,17 @@ for f in "$WF" "$MP" "$DOC"; do
   fi
 done
 
-# ── Parse the two `git push prod ...` refspec lines out of the WORKFLOW ─────
-# Heads refspec: git push prod "${PROD_SHA}:refs/heads/main"
-# Tags  refspec: git push prod "${PROD_SHA}:refs/tags/${TAG}"
-HEADS_LINE="$(grep -E 'git push prod .*:refs/heads/' "$WF" | head -1)"
-TAGS_LINE="$(grep -E 'git push prod .*:refs/tags/' "$WF" | head -1)"
+# ── Parse the two `git ... push ...` refspec lines out of the WORKFLOW ─────
+# The real-push step issues (with an explicit PAT extraheader to override the
+# checkout-installed GITHUB_TOKEN header — see the workflow comment):
+#   git -c "http.https://github.com/.extraheader=$AUTH" push "$PROD_URL" "${PROD_SHA}:refs/heads/main"
+#   git -c "http.https://github.com/.extraheader=$AUTH" push "$PROD_URL" "${PROD_SHA}:refs/tags/${TAG}"
+# Match on `push ... :refs/heads/` / `:refs/tags/` (NOT pinned to a remote
+# alias) so the same bare-ref invariant is validated regardless of whether the
+# push targets the `prod` remote alias or an explicit "$PROD_URL". Exclude the
+# pre-flight write-probe's throwaway ref (refs/heads/__ship-preflight-probe-).
+HEADS_LINE="$(grep -E 'push .*:refs/heads/' "$WF" | grep -v '__ship-preflight-probe' | head -1)"
+TAGS_LINE="$(grep -E 'push .*:refs/tags/' "$WF" | head -1)"
 
 if [ -n "$HEADS_LINE" ]; then
   pass "workflow has a heads-refspec push line"


### PR DESCRIPTION
Task: Fix the Ship-to-Prod workflow so the prod push uses the PROD_PUSH_TOKEN PAT instead of github-actions[bot] (today's real ship 403'd — actions/checkout's global GITHUB_TOKEN extraheader overrode the PAT on push). The push step now forces the PAT via an explicit extraheader override; the pre-flight is now a real WRITE-probe (push+delete a throwaway ref) so a dry-run actually validates write access instead of giving false confidence. Plus: RELEASING.md doc sync, remove the "Typical Workflow" section from PRESENTATION.html, and bump the commit co-author to Opus 4.8.

Verification: independent clean full-suite run 7628/7628 (740s, quiet box); independent diff review PASS — the one adapted test (test-plugin-ref-consistency.sh, broken by the new push-line shape) is a faithful adaptation, NOT a weakening (all 12 cross-lane invariant assertions still bite).

Worktree: /tmp/zskills-do-ship-to-prod-pat-fix
Commits: 36b3e04 fix(ship-to-prod): push to prod with the PAT (override checkout extraheader) + write-probe preflight; rm PRESENTATION Typical Workflow; co-author -> Opus 4.8
