### PR TITLE
do: test runner parallel by default (=0 for serial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ have `cd`-ed into the correct repo/worktree root; or derive it from an
 explicit `$WORKTREE_PATH` the caller passes you (never assume cwd if you
 were just handed a path).
 
+**`tests/run-all.sh` runs its suites in parallel by default** (bounded-worker
+fan-out). Set `ZSKILLS_PARALLEL=0 bash tests/run-all.sh` to force the
+byte-identical serial reference path when debugging an interleaved failure.
+
 **Never suppress errors on operations you need to verify.** Do not use
 `2>/dev/null` on commands whose success matters (git worktree remove,
 git cherry-pick, rm, mv, cp of important files). Do not use `; echo "done"`

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -17,30 +17,32 @@ TOTAL_FAIL=0
 OVERALL_EXIT=0
 
 # ──────────────────────────────────────────────────────────────────────────
-# TEST_SUITE_PARALLELIZATION Phase 4 — bounded-worker PARALLEL fan-out behind
-# the additive ZSKILLS_PARALLEL flag (default serial; byte-identical behavior
-# when unset). DESIGN CHOICE: the fan-out lives IN run-all.sh (NOT a separate
+# TEST_SUITE_PARALLELIZATION Phase 4 — bounded-worker PARALLEL fan-out is the
+# DEFAULT; ZSKILLS_PARALLEL=0 is the opt-OUT to the byte-identical serial
+# reference path. DESIGN CHOICE: the fan-out lives IN run-all.sh (NOT a separate
 # run-all-parallel.sh), per the plan + Critical Invariants — this keeps the
 # literal `run_suite "<name>" "<path>"` registry (the 23-suite self-assert
 # greps + the suite-registry lib's static parse) anchored in ONE file. The
 # registry lines below are UNCHANGED; only the dispatch behavior of run_suite
 # is mode-aware:
 #
-#   • Serial (default, ZSKILLS_PARALLEL unset/0): run_suite runs each suite
-#     inline, accumulating immediately — the original behavior, verbatim.
-#   • Parallel (ZSKILLS_PARALLEL=1): run_suite COLLECTS each (name, script)
-#     into ordered arrays instead of running it. After all the literal
-#     registration lines have executed (collecting the full set, including
-#     the conditional RUN_RACE_TESTS / RUN_E2E `if` blocks and the attended
-#     gate's branch), a driver at the bottom: (a) subtracts the Phase-3
-#     serial bucket, (b) dedupes the live-load double-registration, (c) fans
-#     the remaining POOL out at min(configured, nproc) workers, (d) runs the
-#     serial bucket OUTSIDE the pool, and (e) reports in REGISTERED order.
+#   • Parallel (default, ZSKILLS_PARALLEL unset/1): run_suite COLLECTS each
+#     (name, script) into ordered arrays instead of running it. After all the
+#     literal registration lines have executed (collecting the full set,
+#     including the conditional RUN_RACE_TESTS / RUN_E2E `if` blocks and the
+#     attended gate's branch), a driver at the bottom: (a) subtracts the
+#     Phase-3 serial bucket, (b) dedupes the live-load double-registration,
+#     (c) fans the remaining POOL out at min(configured, nproc) workers, (d)
+#     runs the serial bucket OUTSIDE the pool, and (e) reports in REGISTERED
+#     order.
+#   • Serial (opt-out, ZSKILLS_PARALLEL=0): run_suite runs each suite inline,
+#     accumulating immediately — the original behavior, verbatim. This is the
+#     escape hatch for debugging an interleaved failure.
 #
 # The pool / serial-bucket split + serial-bucket execution reuse the Phase 0
 # + Phase 3 registry helpers (is_serial_suite / serial_run_attended_live_load)
 # from tests/lib/suite-registry.sh — sourced only on the parallel path.
-ZSKILLS_PARALLEL="${ZSKILLS_PARALLEL:-0}"
+ZSKILLS_PARALLEL="${ZSKILLS_PARALLEL:-1}"
 
 # Ordered collection arrays (parallel mode). Index-aligned: REG_NAMES[i] is
 # the display name, REG_SCRIPTS[i] the script path, REG_ATTENDED[i] is 1 iff


### PR DESCRIPTION
Flip the zskills test runner to parallel-by-default.

`tests/run-all.sh` now runs the bounded-worker parallel fan-out by default (`ZSKILLS_PARALLEL` default 0→1). `ZSKILLS_PARALLEL=0` remains a working, byte-identical serial escape hatch for debugging interleaved failures — the serial code path is unchanged; only the default selector and its design comment flipped. CI's explicit `ZSKILLS_PARALLEL=1` is left in place (self-documenting). A one-line note was added to the project `CLAUDE.md`.

**Rationale:** the parallel runner was deliberately gated default-serial "until proven count-identical" (`TEST_SUITE_PARALLELIZATION_PLAN.md`). That bar is met — CI already runs parallel at the same count as serial — so the local default should follow. Previously only CI benefited; every local/agent run still ate the slow serial path.

**Verification (clean /tmp, this branch):**
- Serial (`ZSKILLS_PARALLEL=0`): Overall 7628/7628 passed, 0 failed, rc 0.
- Parallel (new default): Overall 7628/7628 passed, 0 failed, rc 0 (fan-out confirmed: pool 209, workers 12).
- Parity confirmed; `=0` still routes serial.

Commits:
1c4daf9 test: default tests/run-all.sh to parallel (ZSKILLS_PARALLEL=0 = serial escape hatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
