### PR TITLE
do: nudge dashboard start to run as one Bash invocation

### DIFF
--- a/.claude/skills/zskills-dashboard/SKILL.md
+++ b/.claude/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.05+f90549"
+  version: "2026.06.05+2d9c2f"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -310,6 +310,8 @@ esac
 ```
 
 ## start — launch detached server
+
+> **Run `start` as a single Bash invocation.** Resolving `$PYTHON`, the pre-flight check, and the detached launch share one shell — execute the steps below inline as one command; do NOT compile them into a helper script (e.g. `.zskills/dashboard-run.sh`).
 
 1. **Inspect existing PID file.** If present, parse `pid` and `port`
    via `BASH_REMATCH`, run liveness + identity check. On match,

--- a/skills/zskills-dashboard/SKILL.md
+++ b/skills/zskills-dashboard/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   sends SIGTERM; restart = stop+start (for code reloads). State at
   .zskills/monitor-state.json.
 metadata:
-  version: "2026.06.05+f90549"
+  version: "2026.06.05+2d9c2f"
 ---
 
 # /zskills-dashboard — Local Dashboard
@@ -310,6 +310,8 @@ esac
 ```
 
 ## start — launch detached server
+
+> **Run `start` as a single Bash invocation.** Resolving `$PYTHON`, the pre-flight check, and the detached launch share one shell — execute the steps below inline as one command; do NOT compile them into a helper script (e.g. `.zskills/dashboard-run.sh`).
 
 1. **Inspect existing PID file.** If present, parse `pid` and `port`
    via `BASH_REMATCH`, run liveness + identity check. On match,


### PR DESCRIPTION
Task: Add a one-sentence nudge to the dashboard skill's start section telling agents to run start as a single Bash invocation, not a staged helper script. Bump metadata.version + sync mirror.

Adds a one-sentence blockquote nudge under the dashboard skill's `## start` section: run the whole `start` procedure as a single Bash invocation (shared shell for $PYTHON resolve + pre-flight + detached launch) rather than compiling it into a `.zskills/dashboard-run.sh` helper. Source skill + dogfooding mirror updated in lockstep; `metadata.version` bumped. Follow-up from the Windows-dashboard cross-platform campaign (deferred item #2).

Worktree: /tmp/zskills-do-dashboard-start-nudge
Commits: b4d7e48 docs(dashboard): nudge agents to run start as one Bash invocation (no helper script)
