### PR TITLE
do: /session-report handoff redesign (#1114)

### DIFF
--- a/.claude/skills/session-report/SKILL.md
+++ b/.claude/skills/session-report/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   worktrees), not conversation memory — items may have been completed in
   another session.
 metadata:
-  version: "2026.06.03+7c2826"
+  version: "2026.06.05+9613e1"
 ---
 
 # /session-report — Session Intent vs. Actual State

--- a/.claude/skills/session-report/modes/handoff.md
+++ b/.claude/skills/session-report/modes/handoff.md
@@ -56,6 +56,37 @@ section pattern:
    similar). Put the full forward capture (Part 2) plus a one-line summary
    of the retrospective status buckets (Part 1) in it. Keep it skimmable —
    headers and bullets, not prose walls.
+
+   The memory file MUST end with a dedicated `## Resume protocol` section
+   in the following exact shape:
+
+   ```markdown
+   ## Resume protocol
+
+   **Next step:** <one sentence — the next thing the resuming agent should do, framed as a step, not a committed goal>
+
+   **Rule:** If the next step above is an action (anything that changes state — push, rebase, file, run, delete, edit, merge, cherry-pick, etc., as opposed to reads or asks), confirm with me in a brief plain message before executing — do not use the Ask tool (per user preference; plain conversational confirm matches the discussion-handoff posture).
+
+   **Resume context:**
+   - <branch / worktree path>
+   - <PR # / plan file path / issue #>
+   - <key file(s) or command(s) the next session needs>
+   - <gotcha(s) — anything subtle that would trip a fresh agent>
+   ```
+
+   The `**Next step:**` framing (NOT `Goal:` / `Immediate goal:`) is
+   deliberate — `Next step` is descriptive of what comes next, while
+   `Goal` reads as a committed-to-do tone that biases a fresh agent
+   toward executing without confirmation. An unanswered question of the
+   current agent (e.g. "Want me to file the issue?") goes in **Open
+   questions** in Part 2, NOT in `Next step` — promoting a question to
+   `Next step` is the exact failure mode this redesign closes.
+
+   The `**Rule:**` is principle-first: the gate is *anything that
+   changes state*; the enumeration is illustrative, not exhaustive. The
+   Ask-tool prohibition is intentional — confirmation here is a brief
+   plain conversational message, not a tool invocation.
+
 2. **Add a one-line `MEMORY.md` index pointer** linking the new file
    (`[<topic> hand-off](project_<topic>_handoff.md) — <one-line gist>`).
    Keep the index entry under ~200 chars (MEMORY.md has a size limit;
@@ -66,33 +97,59 @@ Persisting to memory — not just printing — is what makes the hand-off
 
 ## Part 4 — Ready-message
 
-Emit a single message with three parts:
+Emit a single message with two parts:
 
 1. **Work summary** — the Part-1 status buckets, terse (one bullet per
    intent item, anomalies first — same brevity discipline as the default
    report).
 
-2. **`/clear` vs. `/compact` recommendation** — apply the heuristic:
-   - Recommend **`/clear`** when everything important is *durably captured*
-     — in git, PRs, GitHub issues, or the memory file you just wrote.
-     Nothing load-bearing is context-only. `/clear` is the clean reset.
-   - Recommend **`/compact`** when something important still lives only in
-     conversation context and could not be fully externalized (e.g. a
-     subtle in-progress debugging thread, an un-externalizable judgment).
-   State which one and why in one line.
+2. **Copy-paste kickoff prompt** — a literal-`―――`-bracketed block the
+   user can paste into a fresh post-`/clear` session. It points at the
+   memory file by path and previews the next step in one line — nothing
+   else. The memory file's `## Resume protocol` section carries the
+   binding rule and resume context; the prompt MUST NOT duplicate them.
 
-3. **Copy-paste kickoff prompt** — a fenced block the user can paste into a
-   fresh post-`/clear` session. It MUST: point at the memory file by path,
-   state the immediate next goal in one sentence, and name the key
-   resume-context (branch/PR/plan/files). Keep it self-contained — assume
-   the reader has zero conversation context.
+   **Block delimitation.** The kickoff block is bracketed by literal
+   Unicode horizontal bars (`―――`, three U+2015 characters) above and
+   below — NOT markdown thematic-break syntax (`---`, `***`, `___`).
+   All three thematic-break markers render as the same `<hr>` element, a
+   block-level divider that does not provide tight visual bracketing.
+   Literal `―――` is plain text, never parsed, and hugs the content the
+   way the spec requires. **No code fence around the prompt** — the bars
+   ARE the delimiter; nesting a triple-backtick fence is redundant and
+   styles the prompt as monospace, which isn't wanted.
 
-   ````markdown
+   The bars are tight against the content inside (the label
+   `Paste below into a fresh session after /clear:` hugs the opening
+   bar with no blank line between them; the last prompt line hugs the
+   closing bar). The only blank lines are OUTSIDE the bars — one above
+   the opening bar (separating it from any closing prose above), one
+   below the closing bar (separating it from any continuing agent
+   message below), and one inside between the label and the prompt
+   content.
+
+   Concretely the emitted block looks like:
+
    ```
-   Read <memory-file-path> for the hand-off. Immediate goal: <one sentence>.
-   Resume context: branch <X>, PR #<N>, plan <path>. Start by <first step>.
+   [closing agent prose, if any]
+
+   ―――
+   Paste below into a fresh session after /clear:
+
+   Read <memory-file-path> for the hand-off. The `## Resume protocol`
+   section is binding instructions, not background.
+
+   Next step: <one-line preview matching the memory file's Next step>.
+   ―――
+
+   [agent's continuing message, if any]
    ```
-   ````
+
+   The `binding instructions, not background` sentence is load-bearing
+   — without it a fresh agent might treat the protocol section as
+   backstory rather than enforceable rules. The blank line + `Next
+   step:` on its own line is so the user can verify the goal at a
+   glance before pasting.
 
 ## Rules for handoff mode
 

--- a/skills/session-report/SKILL.md
+++ b/skills/session-report/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   worktrees), not conversation memory — items may have been completed in
   another session.
 metadata:
-  version: "2026.06.03+7c2826"
+  version: "2026.06.05+9613e1"
 ---
 
 # /session-report — Session Intent vs. Actual State

--- a/skills/session-report/modes/handoff.md
+++ b/skills/session-report/modes/handoff.md
@@ -56,6 +56,37 @@ section pattern:
    similar). Put the full forward capture (Part 2) plus a one-line summary
    of the retrospective status buckets (Part 1) in it. Keep it skimmable —
    headers and bullets, not prose walls.
+
+   The memory file MUST end with a dedicated `## Resume protocol` section
+   in the following exact shape:
+
+   ```markdown
+   ## Resume protocol
+
+   **Next step:** <one sentence — the next thing the resuming agent should do, framed as a step, not a committed goal>
+
+   **Rule:** If the next step above is an action (anything that changes state — push, rebase, file, run, delete, edit, merge, cherry-pick, etc., as opposed to reads or asks), confirm with me in a brief plain message before executing — do not use the Ask tool (per user preference; plain conversational confirm matches the discussion-handoff posture).
+
+   **Resume context:**
+   - <branch / worktree path>
+   - <PR # / plan file path / issue #>
+   - <key file(s) or command(s) the next session needs>
+   - <gotcha(s) — anything subtle that would trip a fresh agent>
+   ```
+
+   The `**Next step:**` framing (NOT `Goal:` / `Immediate goal:`) is
+   deliberate — `Next step` is descriptive of what comes next, while
+   `Goal` reads as a committed-to-do tone that biases a fresh agent
+   toward executing without confirmation. An unanswered question of the
+   current agent (e.g. "Want me to file the issue?") goes in **Open
+   questions** in Part 2, NOT in `Next step` — promoting a question to
+   `Next step` is the exact failure mode this redesign closes.
+
+   The `**Rule:**` is principle-first: the gate is *anything that
+   changes state*; the enumeration is illustrative, not exhaustive. The
+   Ask-tool prohibition is intentional — confirmation here is a brief
+   plain conversational message, not a tool invocation.
+
 2. **Add a one-line `MEMORY.md` index pointer** linking the new file
    (`[<topic> hand-off](project_<topic>_handoff.md) — <one-line gist>`).
    Keep the index entry under ~200 chars (MEMORY.md has a size limit;
@@ -66,33 +97,59 @@ Persisting to memory — not just printing — is what makes the hand-off
 
 ## Part 4 — Ready-message
 
-Emit a single message with three parts:
+Emit a single message with two parts:
 
 1. **Work summary** — the Part-1 status buckets, terse (one bullet per
    intent item, anomalies first — same brevity discipline as the default
    report).
 
-2. **`/clear` vs. `/compact` recommendation** — apply the heuristic:
-   - Recommend **`/clear`** when everything important is *durably captured*
-     — in git, PRs, GitHub issues, or the memory file you just wrote.
-     Nothing load-bearing is context-only. `/clear` is the clean reset.
-   - Recommend **`/compact`** when something important still lives only in
-     conversation context and could not be fully externalized (e.g. a
-     subtle in-progress debugging thread, an un-externalizable judgment).
-   State which one and why in one line.
+2. **Copy-paste kickoff prompt** — a literal-`―――`-bracketed block the
+   user can paste into a fresh post-`/clear` session. It points at the
+   memory file by path and previews the next step in one line — nothing
+   else. The memory file's `## Resume protocol` section carries the
+   binding rule and resume context; the prompt MUST NOT duplicate them.
 
-3. **Copy-paste kickoff prompt** — a fenced block the user can paste into a
-   fresh post-`/clear` session. It MUST: point at the memory file by path,
-   state the immediate next goal in one sentence, and name the key
-   resume-context (branch/PR/plan/files). Keep it self-contained — assume
-   the reader has zero conversation context.
+   **Block delimitation.** The kickoff block is bracketed by literal
+   Unicode horizontal bars (`―――`, three U+2015 characters) above and
+   below — NOT markdown thematic-break syntax (`---`, `***`, `___`).
+   All three thematic-break markers render as the same `<hr>` element, a
+   block-level divider that does not provide tight visual bracketing.
+   Literal `―――` is plain text, never parsed, and hugs the content the
+   way the spec requires. **No code fence around the prompt** — the bars
+   ARE the delimiter; nesting a triple-backtick fence is redundant and
+   styles the prompt as monospace, which isn't wanted.
 
-   ````markdown
+   The bars are tight against the content inside (the label
+   `Paste below into a fresh session after /clear:` hugs the opening
+   bar with no blank line between them; the last prompt line hugs the
+   closing bar). The only blank lines are OUTSIDE the bars — one above
+   the opening bar (separating it from any closing prose above), one
+   below the closing bar (separating it from any continuing agent
+   message below), and one inside between the label and the prompt
+   content.
+
+   Concretely the emitted block looks like:
+
    ```
-   Read <memory-file-path> for the hand-off. Immediate goal: <one sentence>.
-   Resume context: branch <X>, PR #<N>, plan <path>. Start by <first step>.
+   [closing agent prose, if any]
+
+   ―――
+   Paste below into a fresh session after /clear:
+
+   Read <memory-file-path> for the hand-off. The `## Resume protocol`
+   section is binding instructions, not background.
+
+   Next step: <one-line preview matching the memory file's Next step>.
+   ―――
+
+   [agent's continuing message, if any]
    ```
-   ````
+
+   The `binding instructions, not background` sentence is load-bearing
+   — without it a fresh agent might treat the protocol section as
+   backstory rather than enforceable rules. The blank line + `Next
+   step:` on its own line is so the user can verify the goal at a
+   glance before pasting.
 
 ## Rules for handoff mode
 

--- a/tests/test-skill-invariants.sh
+++ b/tests/test-skill-invariants.sh
@@ -348,6 +348,26 @@ if [ -d ".claude/skills/cleanup-merged" ]; then
     "diff -q 'skills/cleanup-merged/SKILL.md' '.claude/skills/cleanup-merged/SKILL.md' >/dev/null"
 fi
 
+# Issue #1114: /session-report handoff redesign — the 3 load-bearing prose
+# anchors that keep fresh-agent sessions from promoting unanswered
+# questions into committed actions. Each anchor closes a specific drift:
+# the binding-instructions sentence stops kickoffs from reading the
+# protocol section as backstory; the `## Resume protocol` header keeps
+# the memory file template from regressing to inline Goal: framing; and
+# the principle-first Rule substring keeps the state-changing gate from
+# being narrowed back to a fixed enumeration.
+SR_HANDOFF="skills/session-report/modes/handoff.md"
+check "session-report #1114: binding-instructions sentence (Part 4 kickoff)" \
+  "grep -q 'binding instructions, not background' '$SR_HANDOFF'"
+check "session-report #1114: '## Resume protocol' header in memory template (Part 3)" \
+  "grep -q '## Resume protocol' '$SR_HANDOFF'"
+check "session-report #1114: principle-first Rule wording (state-changing gate)" \
+  "grep -q 'anything that changes state' '$SR_HANDOFF'"
+if [ -d ".claude/skills/session-report" ]; then
+  check "mirror sync: session-report/modes/handoff.md" \
+    "diff -q 'skills/session-report/modes/handoff.md' '.claude/skills/session-report/modes/handoff.md' >/dev/null"
+fi
+
 # Tier-1 drift invariant (Phase E of 2026-05-01 recovery): every Tier-1
 # script's CURRENT blob hash must be in
 # `skills/update-zskills/references/tier1-shipped-hashes.txt`. Trivial


### PR DESCRIPTION
## Summary

Redesign `/session-report handoff`'s ready-message and memory-file template per 5 prose-only changes discussed and converged with the user.

**The bug this fixes.** Today's kickoff prompt uses `Immediate goal: do X` framing — fresh agents in the next session execute unanswered questions as if they were committed actions. Near-miss this session: a "want me to file the issue?" question got promoted to "Immediate goal: file the issue" in the kickoff, almost triggering an unintended `git push`.

**Discovery this session — the literal-bar choice.** The original spec called for `---` as the kickoff-block delimiter. In practice all CommonMark thematic-break syntax (`---`, `***`, `___`) renders as the same `<hr>` element — a block-level divider that fails to provide tight visual bracketing. Discovered after `***` reproduced `---`'s visual failure identically. Switched to literal Unicode `―――` (U+2015 HORIZONTAL BAR), which is plain text, never parsed, and hugs content tight.

## The 5 prose-only changes

1. **Block delimitation in Part 4 output** uses literal `―――` (U+2015) bars, NOT markdown thematic-break syntax. Label hugs opening bar; closing bar hugs last prompt line; blank lines only OUTSIDE the bars. No code fence around the prompt — the bars are the delimiter.
2. **Drop the `/clear` vs `/compact` recommendation** from Part 4 entirely.
3. **Memory file gets a dedicated `## Resume protocol` section** in the Part 3 template, with three fields: `Next step` (not `Goal:`), `Rule`, `Resume context`.
4. **Kickoff prompt: read-and-rule sentence + `Next step:` on its own line.** Includes the load-bearing `binding instructions, not background` sentence so fresh agents treat the protocol section as enforceable, not backstory.
5. **Rule wording is principle-first:** `anything that changes state — push, rebase, file, run, delete, edit, merge, cherry-pick, etc., as opposed to reads or asks`. Includes the Ask-tool prohibition with rationale parenthetical so a fresh agent doesn't "improve" by reaching for it.

## Test plan

- [x] `bash tests/run-all.sh` — 7640/7640 passed (was 7636; +4 pins). 3 attended-only `test-plugin-live-load.sh` skips expected.
- [x] `grep -cP '\x{2015}'` in handoff.md → 5 hits (genuine U+2015, not `---`/`***`/`___`).
- [x] `## Resume protocol` template header present in Part 3.
- [x] `binding instructions, not background` sentence present in Part 4 kickoff.
- [x] `anything that changes state` principle-first Rule wording present.
- [x] No `Immediate goal:` text used as kickoff phrase (only appears in negative-example prose).
- [x] Mirrors byte-identical (`diff` empty for both SKILL.md and handoff.md pairs).
- [x] `metadata.version` bumped to `2026.06.05+9613e1`.
- [x] 3 prose pins + 1 mirror-sync pin added to `tests/test-skill-invariants.sh` — non-tautological, fail on revert.

Closes #1114
