### PR TITLE
do: casual plugin first-run UX (#1119)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.05+bcc9c7"
+  version: "2026.06.05+4e7652"
 ---
 
 # Update Z Skills Infrastructure
@@ -2271,6 +2271,18 @@ Report the verifier's per-check output and overall result as a final block of
 the success message. On WARN-only, note it's informative; on FAIL, tell the
 user the install succeeded but verification flagged an environment issue.
 
+**Write the `setup-confirmed` marker (#1119).** A successful install means the
+consumer has now run `/update-zskills` — record that so the plugin SessionStart
+greeting (`👋 zskills installed. Run /update-zskills …`) goes silent from the
+next session on. Write a one-line ISO timestamp to `.zskills/setup-confirmed`
+(`.zskills/` is gitignored — per-checkout local state). Do this LAST, after the
+verifier ran, so the marker means "install completed AND was verified":
+
+```bash
+mkdir -p "$CLAUDE_PROJECT_DIR/.zskills"
+date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
+```
+
 ### Pull Latest and Update (already-installed path)
 
 1. **Pull latest from upstream.** Find the `zskills/` clone (Step 0) and
@@ -2415,6 +2427,16 @@ user the install succeeded but verification flagged an environment issue.
      bash "$VERIFY_INSTALL" --project-dir "$CLAUDE_PROJECT_DIR" || \
        echo "(post-install verification reported a FAIL above — the update still succeeded; review and fix your environment, then re-run /update-zskills to re-verify)"
    fi
+   ```
+
+8. **Write the `setup-confirmed` marker (#1119).** Same as install-path
+   Step G.5: a successful update is also a run of `/update-zskills`, so record
+   it to silence the plugin SessionStart greeting. Write a one-line ISO
+   timestamp to `.zskills/setup-confirmed` (gitignored, per-checkout state):
+
+   ```bash
+   mkdir -p "$CLAUDE_PROJECT_DIR/.zskills"
+   date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
    ```
 
 ---

--- a/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -557,15 +557,76 @@ vi_check_plugin() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
+# Environment checks (lane-agnostic — #1119).
+#
+# vi_check_env <project_dir> — REPORT (never gate) the host tooling a zskills
+# consumer needs. Runs unconditionally at the top of vi_run_cheap, regardless
+# of detected lane, so a fresh casual plugin consumer learns their environment
+# is missing git/gh BEFORE the lane-specific structural checks.
+#
+#   git binary present  → FAIL if absent (zskills' worktree/commit/cherry-pick
+#                         machinery is unusable without git).
+#   git repo            → WARN (+ "run git init") if $proj is not a git work
+#                         tree. Reported with `git -C "$proj" rev-parse` so the
+#                         check is anchored to the project dir, not cwd.
+#   gh present          → WARN if absent (PR-mode landing + /fix-issues need it,
+#                         but cherry-pick/direct lanes work without it).
+#   python              → already covered (VI_PY / the resolver). A missing
+#                         interpreter would have FAILed earlier checks; we
+#                         report it here too for a complete env picture.
+# ───────────────────────────────────────────────────────────────────────────
+vi_check_env() {
+  local proj="$1"
+
+  # git binary.
+  if command -v git >/dev/null 2>&1; then
+    vi_emit PASS "env.git-binary" "git is installed"
+  else
+    vi_emit FAIL "env.git-binary" "git not found on PATH — zskills needs git (worktrees, commits, cherry-picks). Install git."
+  fi
+
+  # git repo (project dir is a work tree). Only meaningful when git exists;
+  # use git -C "$proj" so the check is anchored to the project, not cwd.
+  if command -v git >/dev/null 2>&1; then
+    if git -C "$proj" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      vi_emit PASS "env.git-repo" "$proj is a git repository"
+    else
+      vi_emit WARN "env.git-repo" "$proj is not a git repository — run 'git init' here so zskills' commit/worktree machinery works"
+    fi
+  fi
+
+  # gh CLI.
+  if command -v gh >/dev/null 2>&1; then
+    vi_emit PASS "env.gh" "gh (GitHub CLI) is installed"
+  else
+    vi_emit WARN "env.gh" "gh (GitHub CLI) not found — PR-mode landing and /fix-issues need it; cherry-pick/direct lanes do not"
+  fi
+
+  # python (already resolved into VI_PY by the resolver at load time).
+  if [ -n "$VI_PY" ]; then
+    vi_emit PASS "env.python" "Python 3 resolved ($VI_PY)"
+  else
+    vi_emit FAIL "env.python" "no working Python 3 found — zskills hooks/scripts need it (set ZSKILLS_PYTHON)"
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
 # Dispatch by detected lane.
 #
 # vi_run_cheap <project_dir> — detect the lane and run the cheap structural
 # tier for it. Emits per-check records and leaves VI_PASS/WARN/FAIL populated.
 # A `dual` lane is flagged FAIL (unsupported client state) but still runs the
 # legacy checks so the consumer sees the full picture. `none` is a FAIL.
+#
+# vi_check_env runs FIRST, unconditionally (lane-agnostic), so the host-tooling
+# report (git/gh/python) is always present regardless of detected lane (#1119).
 # ───────────────────────────────────────────────────────────────────────────
 vi_run_cheap() {
   local proj="$1"
+
+  # Lane-agnostic environment report (#1119) — always runs first.
+  vi_check_env "$proj"
+
   local lane
   lane="$(vi_detect_lane "$proj")"
   vi_emit "$([ "$lane" = none ] && echo FAIL || echo PASS)" "lane.detect" "detected lane: $lane"

--- a/README.md
+++ b/README.md
@@ -90,11 +90,29 @@ From inside a Claude Code session in your project:
 /plugin install zs@zskills
 ```
 
+Then **restart Claude Code (or `/clear`) so we can finish setup** — the
+SessionStart hook materialises zskills' consumer-side artifacts on the next
+session start (plugins cannot write at install time). Finally, run:
+
+```
+/update-zskills
+```
+
+to confirm the install and check your environment (it reports whether git,
+Python, and gh are present). `/update-zskills` is the post-install step on
+**every** lane — plugin and `/update-zskills` alike. Until you run it, a one
+line greeting on startup reminds you.
+
 The `zs` plugin bundles the block-diagram add-on skills, so a single install
 gives you everything. (The block-diagram add-on currently ships inside `zs`
 and will move to its own separately-installable plugin in a future repo.) See
 [`docs/guides/installing-zskills.md`](docs/guides/installing-zskills.md) for what gets
 materialised, version pinning, and the bare-slash prose tradeoff.
+
+> **zskills needs git and bash.** Its worktree, commit, and cherry-pick
+> machinery is built on `git`, and its hooks and helper scripts run under
+> `bash`. `/update-zskills` reports whether git (and gh, for PR-mode landing)
+> are present; bash is assumed by every shipped script.
 
 ### `/update-zskills` lane (quick start)
 

--- a/hooks/session-start-materialise.sh
+++ b/hooks/session-start-materialise.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# zskills-hook-version: 2026.06.6
+# zskills-hook-version: 2026.06.7
 # session-start-materialise.sh — W2.1 SessionStart materialiser (D11, D20, D27).
 #
 # Plugins cannot write to the consumer repo at install time (research §10),
@@ -314,8 +314,9 @@ done
 # gated on [ -f "$CONFIG" ]. A fresh plugin install therefore used to leave
 # the consumer with NO config and NO managed.md — silently. Seed a default
 # headless config here so the render gate passes and all 5 artifacts
-# materialise. The preset is locked-main-pr (landing=pr, main_protected=true)
-# — the safe default for a fresh consumer.
+# materialise. The seed defaults to landing=direct, main_protected=false —
+# the lowest-friction default for a casual plugin consumer (concurrency-1,
+# fresh container). Sophisticated forks opt into locked-main-pr explicitly.
 #
 # Idempotent: ONLY create when the config is absent. An existing config (any
 # values) is NEVER clobbered. We track whether we seeded this run so the
@@ -332,8 +333,8 @@ cfg = {
     "project_name": os.environ["PROJECT_NAME"],
     "timezone": "UTC",
     "execution": {
-        "landing": "pr",
-        "main_protected": True,
+        "landing": "direct",
+        "main_protected": False,
         "branch_prefix": "feat/",
     },
     "commit": {
@@ -437,8 +438,23 @@ fi
 # consumer to review the generated config (test commands + landing mode).
 if [ "$CONFIG_SEEDED" -eq 1 ] && [ ! -f "$PROJ/.zskills/config-seeded-notice" ]; then
   mkdir -p "$PROJ/.zskills"
-  echo "zskills: created a default .claude/zskills-config.json (locked-main-pr: landing=pr, main_protected=true). Review it — especially testing.unit_cmd/full_cmd and execution.landing — and adjust for this project." >&2
+  echo "zskills: created a default .claude/zskills-config.json (landing=direct, main_protected=false). Review it — especially testing.unit_cmd/full_cmd and execution.landing — and adjust for this project." >&2
   touch "$PROJ/.zskills/config-seeded-notice"
+fi
+
+# ── SessionStart greeting (systemMessage on stdout) ───────────────────────
+# Nudge a fresh plugin consumer toward /update-zskills. We only reach here on
+# the fresh|plugin flow (update-zskills/dual already early-exited, so those
+# lanes stay silent). Emit a JSON `systemMessage` on STDOUT — Claude Code
+# renders it on startup + /clear — when the config exists (so we are past the
+# seed point) AND the .zskills/setup-confirmed marker is ABSENT (they have not
+# run /update-zskills yet). It persists every session until that marker exists.
+#
+# stdout must be ONLY this JSON (stderr stays for diagnostics). The emit is
+# guarded with `|| true` because the script runs under `set -euo pipefail` and
+# a Python miss here must not abort. It is the LAST thing before `exit 0`.
+if [ -f "$CONFIG" ] && [ ! -f "$PROJ/.zskills/setup-confirmed" ]; then
+  "$PYTHON" -c 'import json,sys; sys.stdout.write(json.dumps({"systemMessage": "\U0001F44B zskills installed. Run /update-zskills to finish setup and check your environment'"'"'s ready."}))' 2>/dev/null || true
 fi
 
 exit 0

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.05+bcc9c7"
+  version: "2026.06.05+4e7652"
 ---
 
 # Update Z Skills Infrastructure
@@ -2271,6 +2271,18 @@ Report the verifier's per-check output and overall result as a final block of
 the success message. On WARN-only, note it's informative; on FAIL, tell the
 user the install succeeded but verification flagged an environment issue.
 
+**Write the `setup-confirmed` marker (#1119).** A successful install means the
+consumer has now run `/update-zskills` — record that so the plugin SessionStart
+greeting (`👋 zskills installed. Run /update-zskills …`) goes silent from the
+next session on. Write a one-line ISO timestamp to `.zskills/setup-confirmed`
+(`.zskills/` is gitignored — per-checkout local state). Do this LAST, after the
+verifier ran, so the marker means "install completed AND was verified":
+
+```bash
+mkdir -p "$CLAUDE_PROJECT_DIR/.zskills"
+date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
+```
+
 ### Pull Latest and Update (already-installed path)
 
 1. **Pull latest from upstream.** Find the `zskills/` clone (Step 0) and
@@ -2415,6 +2427,16 @@ user the install succeeded but verification flagged an environment issue.
      bash "$VERIFY_INSTALL" --project-dir "$CLAUDE_PROJECT_DIR" || \
        echo "(post-install verification reported a FAIL above — the update still succeeded; review and fix your environment, then re-run /update-zskills to re-verify)"
    fi
+   ```
+
+8. **Write the `setup-confirmed` marker (#1119).** Same as install-path
+   Step G.5: a successful update is also a run of `/update-zskills`, so record
+   it to silence the plugin SessionStart greeting. Write a one-line ISO
+   timestamp to `.zskills/setup-confirmed` (gitignored, per-checkout state):
+
+   ```bash
+   mkdir -p "$CLAUDE_PROJECT_DIR/.zskills"
+   date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
    ```
 
 ---

--- a/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -557,15 +557,76 @@ vi_check_plugin() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
+# Environment checks (lane-agnostic — #1119).
+#
+# vi_check_env <project_dir> — REPORT (never gate) the host tooling a zskills
+# consumer needs. Runs unconditionally at the top of vi_run_cheap, regardless
+# of detected lane, so a fresh casual plugin consumer learns their environment
+# is missing git/gh BEFORE the lane-specific structural checks.
+#
+#   git binary present  → FAIL if absent (zskills' worktree/commit/cherry-pick
+#                         machinery is unusable without git).
+#   git repo            → WARN (+ "run git init") if $proj is not a git work
+#                         tree. Reported with `git -C "$proj" rev-parse` so the
+#                         check is anchored to the project dir, not cwd.
+#   gh present          → WARN if absent (PR-mode landing + /fix-issues need it,
+#                         but cherry-pick/direct lanes work without it).
+#   python              → already covered (VI_PY / the resolver). A missing
+#                         interpreter would have FAILed earlier checks; we
+#                         report it here too for a complete env picture.
+# ───────────────────────────────────────────────────────────────────────────
+vi_check_env() {
+  local proj="$1"
+
+  # git binary.
+  if command -v git >/dev/null 2>&1; then
+    vi_emit PASS "env.git-binary" "git is installed"
+  else
+    vi_emit FAIL "env.git-binary" "git not found on PATH — zskills needs git (worktrees, commits, cherry-picks). Install git."
+  fi
+
+  # git repo (project dir is a work tree). Only meaningful when git exists;
+  # use git -C "$proj" so the check is anchored to the project, not cwd.
+  if command -v git >/dev/null 2>&1; then
+    if git -C "$proj" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      vi_emit PASS "env.git-repo" "$proj is a git repository"
+    else
+      vi_emit WARN "env.git-repo" "$proj is not a git repository — run 'git init' here so zskills' commit/worktree machinery works"
+    fi
+  fi
+
+  # gh CLI.
+  if command -v gh >/dev/null 2>&1; then
+    vi_emit PASS "env.gh" "gh (GitHub CLI) is installed"
+  else
+    vi_emit WARN "env.gh" "gh (GitHub CLI) not found — PR-mode landing and /fix-issues need it; cherry-pick/direct lanes do not"
+  fi
+
+  # python (already resolved into VI_PY by the resolver at load time).
+  if [ -n "$VI_PY" ]; then
+    vi_emit PASS "env.python" "Python 3 resolved ($VI_PY)"
+  else
+    vi_emit FAIL "env.python" "no working Python 3 found — zskills hooks/scripts need it (set ZSKILLS_PYTHON)"
+  fi
+}
+
+# ───────────────────────────────────────────────────────────────────────────
 # Dispatch by detected lane.
 #
 # vi_run_cheap <project_dir> — detect the lane and run the cheap structural
 # tier for it. Emits per-check records and leaves VI_PASS/WARN/FAIL populated.
 # A `dual` lane is flagged FAIL (unsupported client state) but still runs the
 # legacy checks so the consumer sees the full picture. `none` is a FAIL.
+#
+# vi_check_env runs FIRST, unconditionally (lane-agnostic), so the host-tooling
+# report (git/gh/python) is always present regardless of detected lane (#1119).
 # ───────────────────────────────────────────────────────────────────────────
 vi_run_cheap() {
   local proj="$1"
+
+  # Lane-agnostic environment report (#1119) — always runs first.
+  vi_check_env "$proj"
+
   local lane
   lane="$(vi_detect_lane "$proj")"
   vi_emit "$([ "$lane" = none ] && echo FAIL || echo PASS)" "lane.detect" "detected lane: $lane"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -374,6 +374,8 @@ run_suite "test-sessionstart-materialise-overwrite-guard.sh" "tests/test-session
 run_suite "test-sessionstart-dual-install-detect.sh" "tests/test-sessionstart-dual-install-detect.sh"
 # #1080 — UserPromptSubmit restart nudge (post-/reload-plugins half-install).
 run_suite "test-nudge-restart-to-materialise.sh" "tests/test-nudge-restart-to-materialise.sh"
+# #1119 — SessionStart greeting (systemMessage on stdout) toward /update-zskills.
+run_suite "test-sessionstart-greeting.sh" "tests/test-sessionstart-greeting.sh"
 run_suite "test-synthetic-consumer-install.sh" "tests/test-synthetic-consumer-install.sh"
 run_suite "test-verify-install.sh" "tests/test-verify-install.sh"
 run_suite "test-render-managed-rules-correctness.sh" "tests/test-render-managed-rules-correctness.sh"

--- a/tests/test-sessionstart-greeting.sh
+++ b/tests/test-sessionstart-greeting.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# tests/test-sessionstart-greeting.sh
+#
+# #1119 — the SessionStart greeting. The materialiser emits a user-visible
+# `systemMessage` JSON on STDOUT nudging a fresh plugin consumer toward
+# /update-zskills. It fires on every SessionStart where the seeded config
+# exists AND the `.zskills/setup-confirmed` marker is ABSENT (they have not
+# run /update-zskills yet), and goes silent once that marker appears.
+#
+# Critical contract points:
+#   - stdout carries ONLY the greeting JSON (stderr stays for diagnostics).
+#   - The greeting fires on the fresh|plugin flow only — the early-exit
+#     update-zskills/dual lanes stay SILENT on stdout (they only nag stderr).
+#
+# Cases:
+#   (a) fresh + no setup-confirmed marker -> valid JSON with a non-empty
+#       systemMessage on stdout.
+#   (b) setup-confirmed marker present    -> no stdout.
+#   (c) lane == update-zskills            -> no stdout (early exit, silent).
+#   (d) lane == dual                      -> no stdout (early exit, silent).
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+MAT="hooks/session-start-materialise.sh"
+
+# Resolve a working Python 3 for the JSON-shape assertions.
+PY=""
+for cand in "${ZSKILLS_PYTHON:-}" python3 python; do
+  [ -n "$cand" ] || continue
+  command -v "$cand" >/dev/null 2>&1 || continue
+  if "$cand" -c 'import sys; sys.exit(0 if sys.version_info[0]==3 else 1)' >/dev/null 2>&1; then
+    PY="$(command -v "$cand")"; break
+  fi
+done
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# base_fixture <proj> — a fresh project with a root CLAUDE_TEMPLATE.md so the
+# materialiser can seed a config + render managed.md (no pre-existing .claude
+# artifacts → lane=fresh).
+base_fixture() {
+  local p="$1"
+  mkdir -p "$p"
+  cp "$REPO_ROOT/CLAUDE_TEMPLATE.md" "$p/"
+}
+# Write an update-zskills-installed (UN-sentinelled) skill mirror.
+write_unsentinelled_skill() {
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' '---' 'name: x' '---' 'body' > "$1"
+}
+write_sentinelled_hook() {
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' '#!/usr/bin/env bash' '# zskills-materialised: 2026.05.0' 'echo hi' > "$1"
+}
+
+# run_mat <proj> <stderr-path> — runs the materialiser, captures stdout via the
+# surrounding command substitution and stderr into the given file.
+run_mat() {
+  env CLAUDE_PROJECT_DIR="$1" CLAUDE_PLUGIN_ROOT="$REPO_ROOT" bash "$REPO_ROOT/$MAT" 2>"$2"
+}
+
+GREET_MARK="Run /update-zskills"
+
+echo "=== SessionStart greeting (#1119) ==="
+
+# ── (a) fresh + no setup-confirmed marker -> greeting JSON on stdout ──────────
+PA="$TMP/proj_a"
+base_fixture "$PA"
+ERRA="$TMP/err_a"
+OUT_A="$(run_mat "$PA" "$ERRA")"
+
+if [ -z "$PY" ]; then
+  fail "a. no Python 3 available to validate greeting JSON"
+else
+  A_RESULT="$(ZS_OUT="$OUT_A" GREET_MARK="$GREET_MARK" "$PY" - <<'PYCHK'
+import os, json
+raw = os.environ.get("ZS_OUT", "")
+try:
+    d = json.loads(raw)
+except Exception as e:
+    print("NOTJSON:%s" % e); raise SystemExit(0)
+sm = d.get("systemMessage")
+if not isinstance(sm, str) or not sm.strip():
+    print("NOSYSMSG"); raise SystemExit(0)
+if os.environ["GREET_MARK"] not in sm:
+    print("MARKMISSING"); raise SystemExit(0)
+print("OK")
+PYCHK
+)"
+  case "$A_RESULT" in
+    OK)
+      pass "a. fresh + no marker: valid JSON with non-empty systemMessage carrying the /update-zskills nudge on stdout" ;;
+    NOTJSON:*)
+      fail "a. greeting stdout is not valid JSON ($A_RESULT)"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    NOSYSMSG)
+      fail "a. greeting JSON has no non-empty top-level systemMessage"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    MARKMISSING)
+      fail "a. systemMessage present but missing the nudge text (\"$GREET_MARK\")"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+    *)
+      fail "a. unexpected JSON-check result: $A_RESULT"
+      printf '      stdout: %s\n' "$OUT_A" ;;
+  esac
+fi
+
+# ── (b) setup-confirmed marker present -> silent ─────────────────────────────
+# Re-run against the SAME $PA after writing the marker. The config now exists
+# (seeded in case a), so the ONLY thing silencing the greeting is the marker.
+mkdir -p "$PA/.zskills"
+date -Iseconds > "$PA/.zskills/setup-confirmed"
+ERRB="$TMP/err_b"
+OUT_B="$(run_mat "$PA" "$ERRB")"
+if [ -z "$OUT_B" ]; then
+  pass "b. setup-confirmed marker present: no greeting on stdout (silent)"
+else
+  fail "b. marker present: greeting still emitted"
+  printf '      stdout: %s\n' "$OUT_B"
+fi
+
+# ── (c) lane == update-zskills -> silent (early exit) ────────────────────────
+PC="$TMP/proj_c"
+base_fixture "$PC"
+write_unsentinelled_skill "$PC/.claude/skills/update-zskills/SKILL.md"
+ERRC="$TMP/err_c"
+OUT_C="$(run_mat "$PC" "$ERRC")"
+if [ -z "$OUT_C" ]; then
+  pass "c. lane==update-zskills: no greeting on stdout (early exit, silent)"
+else
+  fail "c. lane==update-zskills: greeting unexpectedly emitted"
+  printf '      stdout: %s\n' "$OUT_C"
+fi
+# The stderr dual/early-exit nag should still be present (sanity: it IS the
+# update-zskills lane, not a no-op).
+if grep -q "switch-install-path.sh" "$ERRC"; then
+  pass "c2. lane==update-zskills: stderr nag still emitted (greeting did not displace it)"
+else
+  fail "c2. lane==update-zskills: expected stderr nag missing"
+fi
+
+# ── (d) lane == dual -> silent (early exit) ──────────────────────────────────
+# Dual = a sentinelled plugin artifact AND an un-sentinelled zskills mirror.
+PD="$TMP/proj_d"
+base_fixture "$PD"
+write_unsentinelled_skill "$PD/.claude/skills/update-zskills/SKILL.md"
+write_sentinelled_hook "$PD/.claude/hooks/inject-bash-timeout.sh"
+ERRD="$TMP/err_d"
+OUT_D="$(run_mat "$PD" "$ERRD")"
+if [ -z "$OUT_D" ]; then
+  pass "d. lane==dual: no greeting on stdout (early exit, silent)"
+else
+  fail "d. lane==dual: greeting unexpectedly emitted"
+  printf '      stdout: %s\n' "$OUT_D"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'Results: %d passed, %d failed (of %d)\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+exit "$FAIL_COUNT"

--- a/tests/test-sessionstart-materialise.sh
+++ b/tests/test-sessionstart-materialise.sh
@@ -148,9 +148,10 @@ echo ""
 echo "=== Config seeding: fresh project with NO config ==="
 
 # A truly fresh plugin install has NO .claude/zskills-config.json. The
-# materialiser must seed a default (locked-main-pr) config, then the render
-# gate passes and all 5 artifacts materialise. Previously this case left the
-# consumer with no config and no managed.md, silently.
+# materialiser must seed a default (landing=direct, main_protected=false —
+# the casual plugin default, #1119) config, then the render gate passes and
+# all 5 artifacts materialise. Previously this case left the consumer with no
+# config and no managed.md, silently.
 SEED="$TMP/seedproj"
 mkdir -p "$SEED"
 # Provide the template at the project root so the renderer has something to
@@ -170,13 +171,15 @@ else
   fail "12. fresh project: config NOT seeded"
 fi
 
-# 13. Seeded preset is locked-main-pr (landing=pr, main_protected=true).
+# 13. Seeded default is the casual plugin default (landing=direct,
+# main_protected=false) — #1119. A concurrency-1 plugin consumer gets the
+# lowest-friction defaults; sophisticated forks opt into locked-main-pr.
 if [ -f "$SEED_CFG" ]; then
   seed_landing=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["execution"]["landing"])' "$SEED_CFG" 2>/dev/null)
   seed_prot=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["execution"]["main_protected"])' "$SEED_CFG" 2>/dev/null)
   seed_name=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["project_name"])' "$SEED_CFG" 2>/dev/null)
-  if [ "$seed_landing" = "pr" ] && [ "$seed_prot" = "True" ] && [ "$seed_name" = "seedproj" ]; then
-    pass "13. seeded config is locked-main-pr (landing=pr, main_protected=true, project_name=seedproj)"
+  if [ "$seed_landing" = "direct" ] && [ "$seed_prot" = "False" ] && [ "$seed_name" = "seedproj" ]; then
+    pass "13. seeded config is the casual default (landing=direct, main_protected=false, project_name=seedproj)"
   else
     fail "13. seeded config wrong: landing=$seed_landing main_protected=$seed_prot project_name=$seed_name"
   fi

--- a/tests/test-verify-install.sh
+++ b/tests/test-verify-install.sh
@@ -65,6 +65,18 @@ run_cheap_capture() {
   vi_run_cheap "$proj" > "$out"
 }
 
+# git_init_fixture <dir> — make a synthetic fixture a real git repo so the
+# lane-agnostic env check (vi_check_env, #1119) sees a work tree and emits the
+# env.git-repo PASS instead of a WARN. A REAL zskills install always sits in a
+# git repo; the synthetic $TMP fixtures are not repos by default, so the
+# zero-WARN assertions (3c/4c) require this. We do NOT weaken those assertions —
+# we make the fixture match reality.
+git_init_fixture() {
+  git -C "$1" init -q >/dev/null 2>&1
+  git -C "$1" config user.email t@t >/dev/null 2>&1 || true
+  git -C "$1" config user.name t >/dev/null 2>&1 || true
+}
+
 # Count FAIL records in a captured output file.
 count_fail() { grep -c '^FAIL' "$1" 2>/dev/null || echo 0; }
 # Does the captured output contain a FAIL whose id matches $2?
@@ -220,6 +232,9 @@ LNV="$(make_legacy_good 4)"
 cat > "$LNV/.claude/zskills-config.json" <<'JSON'
 { "project_name": "acme" }
 JSON
+# A real legacy install lives in a git repo — init the fixture so the new
+# lane-agnostic env.git-repo check (#1119) PASSes, keeping this case at 0 WARN.
+git_init_fixture "$LNV"
 OUT="$TMP/out-legacy-no-version.txt"
 run_cheap_capture "$LNV" "$OUT"
 if [ "$VI_FAIL" -eq 0 ] && [ "$VI_WARN" -eq 0 ]; then
@@ -391,6 +406,8 @@ PNV="$(make_plugin_good 5)"
 cat > "$PNV/.claude/zskills-config.json" <<'JSON'
 { "project_name": "acme" }
 JSON
+# Real plugin install lives in a git repo — init so env.git-repo (#1119) PASSes.
+git_init_fixture "$PNV"
 OUT="$TMP/out-plugin-no-version.txt"
 run_cheap_capture "$PNV" "$OUT"
 if [ "$VI_FAIL" -eq 0 ] && [ "$VI_WARN" -eq 0 ]; then
@@ -606,6 +623,69 @@ if printf '%s\n' "$DEEP_OUT" | grep -q 'heavy tier' \
 else
   fail "10. --deep opt-in" "expected heavy-tier section + Overall: PASS on a good install"
 fi
+
+# ── vi_check_env (#1119): lane-agnostic environment report ───────────────────
+# Positive coverage for the new env checks. They run unconditionally in
+# vi_run_cheap; here we drive vi_check_env directly with a controlled PATH to
+# assert each branch: git-binary FAIL when git is absent, git-repo WARN on a
+# non-repo dir, gh WARN when gh is absent. Each runs in a `( ... )` subshell so
+# the manipulated PATH and the lib's vi_emit counter mutations are scoped.
+
+# (11a) git binary absent → env.git-binary FAIL. Build a PATH stub dir that
+# carries everything EXCEPT git (so `command -v git` misses but the rest of the
+# check function still works), then re-source the lib so VI_PY re-resolves under
+# the stubbed PATH.
+ENVTMP="$TMP/envcheck"
+mkdir -p "$ENVTMP/proj"
+git_init_fixture "$ENVTMP/proj"
+# 11a — git absent.
+( STUB="$TMP/nogit-bin"; mkdir -p "$STUB"
+  for t in bash sed grep head printf cat dirname basename env python3 gh; do
+    p="$(command -v "$t" 2>/dev/null)"; [ -n "$p" ] && ln -sf "$p" "$STUB/$t"
+  done
+  PATH="$STUB"
+  out11a="$TMP/env-nogit.txt"
+  vi_reset; vi_check_env "$ENVTMP/proj" > "$out11a" 2>/dev/null
+  if grep -q '^FAIL	env.git-binary	' "$out11a"; then
+    pass "11a. vi_check_env: git binary absent → env.git-binary FAIL"
+  else
+    fail "11a. env git absent" "expected env.git-binary FAIL; got $(cat "$out11a")"
+  fi
+)
+
+# (11b) project dir is NOT a git repo → env.git-repo WARN (with git present).
+out11b="$TMP/env-nonrepo.txt"
+NONREPO="$TMP/env-nonrepo-dir"; mkdir -p "$NONREPO"
+vi_reset; vi_check_env "$NONREPO" > "$out11b" 2>/dev/null
+if grep -q '^WARN	env.git-repo	' "$out11b"; then
+  pass "11b. vi_check_env: non-repo project dir → env.git-repo WARN"
+else
+  fail "11b. env non-repo" "expected env.git-repo WARN; got $(cat "$out11b")"
+fi
+# And a real git repo PASSes env.git-repo (the inverse — proves the WARN is
+# conditional, not unconditional).
+out11b2="$TMP/env-repo.txt"
+vi_reset; vi_check_env "$ENVTMP/proj" > "$out11b2" 2>/dev/null
+if grep -q '^PASS	env.git-repo	' "$out11b2"; then
+  pass "11b2. vi_check_env: git-repo project dir → env.git-repo PASS"
+else
+  fail "11b2. env repo" "expected env.git-repo PASS; got $(cat "$out11b2")"
+fi
+
+# (11c) gh absent → env.gh WARN (git still present, so no git FAIL).
+( STUB="$TMP/nogh-bin"; mkdir -p "$STUB"
+  for t in bash sed grep head printf cat dirname basename env python3 git; do
+    p="$(command -v "$t" 2>/dev/null)"; [ -n "$p" ] && ln -sf "$p" "$STUB/$t"
+  done
+  PATH="$STUB"
+  out11c="$TMP/env-nogh.txt"
+  vi_reset; vi_check_env "$ENVTMP/proj" > "$out11c" 2>/dev/null
+  if grep -q '^WARN	env.gh	' "$out11c" && ! grep -q '^FAIL	env.git-binary	' "$out11c"; then
+    pass "11c. vi_check_env: gh absent → env.gh WARN (git still PASSes)"
+  else
+    fail "11c. env gh absent" "expected env.gh WARN + no git-binary FAIL; got $(cat "$out11c")"
+  fi
+)
 
 echo ""
 TOTAL=$((PASS_COUNT + FAIL_COUNT))


### PR DESCRIPTION
Closes #1119.

Casual plugin first-run UX — the soft/report half (the hard-block init-gate is a separate follow-up):

- **Plugin seed default → `direct`** (`main_protected: false`). Concurrency-1 casual users gain nothing from worktrees/PR and faceplant on locked-main-pr; `direct` is lowest-friction. (Conformance #13 + test #15 updated.)
- **SessionStart greeting** — `systemMessage` JSON on stdout (today the materialiser only used invisible stderr): `👋 zskills installed. Run /update-zskills to finish setup and check your environment's ready.` Emitted while config exists but `.zskills/setup-confirmed` is absent; silent once `/update-zskills` writes it. New `tests/test-sessionstart-greeting.sh`.
- **`.zskills/setup-confirmed` marker** written by `/update-zskills` at install AND update verify completion (not bare-call/bare-preset).
- **`verify-install` env checks** — lane-agnostic `vi_check_env` reports git-binary (FAIL) / git-repo (WARN) / gh (WARN); python already covered. Test fixtures git-init'd (assertions not weakened).
- **Docs** — README plugin-install block now says restart/`/clear` then `/update-zskills`; "/update-zskills on every lane"; "needs git + bash".

Verified: full suite 7647/7647, diff scoped to 10 files, source/.claude mirrors byte-identical, metadata.version bumped. Plugin-scope greeting *rendering* is verified manually by the author (not CI-testable).

Commits:
c6575f8 feat(plugin): casual first-run UX — direct seed default + SessionStart greeting + env checks
