### PR TITLE
fix(do): decouple --force from review veto + raise file-count triage signal (#1118)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.04+e9a157"
+  version: "2026.06.05+498b5d"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -70,8 +70,11 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
   - Cron is session-scoped — dies when the session dies
 - **now** (optional) — run immediately. When combined with `every`, runs
   immediately AND schedules. Without `every`, `now` is the default behavior.
-- **--force** (optional) — bypass triage redirect and review reject. Persists
-  into the cron prompt verbatim when used with `every`.
+- **--force** (optional) — bypass the triage redirect (Phase 0a). It does
+  NOT bypass the Phase 0b review: a review REJECT still HALTS regardless of
+  `--force`. To skip the review entirely, use `--rounds 0`; `--force --rounds 0`
+  does both (past the size guard AND no review). Persists into the cron prompt
+  verbatim when used with `every`.
 - **--no-claim** (optional) — claim absolutely NOTHING; treat every `#N` in
   the description as a mere mention. This now suppresses ALL claims (#1032),
   not just the stray-ref warning: the pre-flight forces `ISSUE_NUMS` empty so
@@ -518,18 +521,38 @@ test vars) always run the full Agent path. Recognized stub values:
 
 The model judges `$DESCRIPTION` against this rubric — qualitative,
 observable from description text, no LOC counting. /do always works in a
-fresh worktree (PR mode) or main (direct/worktree mode), so the "≥3
-distinct files in description" rule applies uniformly (no MODE carve-out
-needed).
+fresh worktree (PR mode) or main (direct/worktree mode), so the
+file-enumeration rule applies uniformly (no MODE carve-out needed).
 
 | Signal | Verdict |
 |--------|---------|
 | Description scopes to one concept | PROCEED |
-| ≥ 3 distinct files explicitly named in description | REDIRECT → `/draft-plan` |
+| Description enumerates many distinct files (roughly ≥8–10) OR sprawls across clearly unrelated concerns | REDIRECT → `/draft-plan` |
 | Verbs include any of: `add feature`, `redesign`, `rewrite`, `refactor across` | REDIRECT → `/draft-plan` |
 | `and` connects unrelated areas (e.g. "fix nav and update copy") | REDIRECT → `/draft-plan` |
 | Vague verbs alone: `improve`, `fix it`, `update`, `clean up` (no concrete object) | REDIRECT → ask user |
 | References an existing plan file under `$ZSKILLS_PLANS_DIR` | REDIRECT → `/run-plan` |
+
+The file-enumeration row is a **model-layer judgment, not a hard count.**
+~8–10 is a calibration anchor, not a threshold to mechanically tally:
+- Judge **LOGICAL files**, not raw count. A source file and its mirror, or
+  a generated file and its source, count as ONE logical file (editing
+  `hooks/X.sh` plus its `.claude/hooks/X.sh` mirror is ONE logical file).
+  Generated-doc doubling does not inflate.
+- A **wide-but-settled mechanical change** — one concept, many files (e.g. a
+  bulk rename, a single find-replace across the tree) — stays `/do`. Width is
+  not depth (CLAUDE.md: "heavy is staging or design depth, not breadth").
+- The row only fires when the description **explicitly enumerates** a sprawl
+  of distinct files or unrelated concerns.
+
+**Division of labor.** The file-enumeration row is a coarse backstop for
+**sprawling, explicitly-enumerated** descriptions — it catches "edit A.js,
+B.css, C.html, D.json, … and rework the build" before any work starts. The
+real depth/concept gate is **Phase 0b's acceptance-bullet ceiling** (>4
+Acceptance bullets → REVISE), which judges the composed inline plan rather
+than the raw description text. Issue-numbered descriptions (`Fix #N`) name no
+files, so this triage row never fires on them — that is expected; Phase 0b's
+inline-plan review is what catches an over-scoped `Fix #N`.
 
 **Worked examples (calibrate the model's PROCEED/REDIRECT calls):**
 
@@ -538,6 +561,9 @@ needed).
 | `/do Fix README typo` | PROCEED | one concept, one likely file |
 | `/do Sort the screenshots in session-sequence-snapshots` | PROCEED | one concrete object |
 | `/do Update the presentation with Phase 3 results auto` | PROCEED | concrete verb + object |
+| `/do Rename `oldHelper` to `newHelper` across the codebase` | PROCEED | wide-but-settled mechanical change — one concept, many files; width is not depth |
+| `/do Bump the copyright year in all source headers` | PROCEED | one concept applied uniformly; logical-file count is 1 concept regardless of raw file count |
+| `/do Rework auth.js, session.js, db/pool.js, routes/login.js, the CSS, the config, and the build script` | REDIRECT → /draft-plan | enumerates ~7+ distinct files across unrelated concerns — sprawling scope |
 | `/do add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/do improve` | REDIRECT → ask user | vague verb, no object |
 | `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue(s) via ISSUE_NUMS and proceed |
@@ -712,10 +738,12 @@ After `$ROUNDS` REVISE cycles → soft-reject (same exit semantics as REJECT).
 
 On APPROVE: print verdict + justification, continue to Phase 0c.
 
-On REJECT and `$FORCE -eq 0`: print verdict, `exit 0`. **No marker is
-written** (no tracking for /do). No worktree, no commits, no cron.
-
-On REJECT and `$FORCE -eq 1`: print override message. Continue to Phase 0c.
+On REJECT: print verdict, `exit 0` — **regardless of `$FORCE`.** A review
+REJECT always HALTS; `--force` only bypasses the Phase 0a triage redirect, not
+the Phase 0b review veto (issue #1118). **No marker is written** (no tracking
+for /do). No worktree, no commits, no cron. To skip the review entirely, use
+`--rounds 0` (which short-circuits this phase before it runs); `--force
+--rounds 0` bypasses both the triage redirect and the review.
 
 Orthogonality with `/verify-changes` (Phase 3): pre-review judges PLAN; `/verify-changes` judges DIFF. Both run when both apply: `--rounds > 0` triggers this pre-review (any landing mode); code changes in `worktree`/`direct` mode trigger /verify-changes unconditionally after execution (issue #713 — `auto` controls landing, not verification). PR mode (Path A) ALSO runs the same DIFF verification gate before landing: it invokes /verify-changes (Layer-3 validated, STOP-on-fail) at its own Step A6.5 (`skills/do/modes/pr.md`) BEFORE dispatching /land-pr — closing the gap (issue #1014) where /do pr was the only PR-mode caller with no local verification gate and relied solely on CI. CI via /land-pr is the backstop, not the gate.
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.04+e9a157"
+  version: "2026.06.05+498b5d"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -70,8 +70,11 @@ and a persistent report file, it's too big for `/do`. Use `/run-plan` instead.
   - Cron is session-scoped — dies when the session dies
 - **now** (optional) — run immediately. When combined with `every`, runs
   immediately AND schedules. Without `every`, `now` is the default behavior.
-- **--force** (optional) — bypass triage redirect and review reject. Persists
-  into the cron prompt verbatim when used with `every`.
+- **--force** (optional) — bypass the triage redirect (Phase 0a). It does
+  NOT bypass the Phase 0b review: a review REJECT still HALTS regardless of
+  `--force`. To skip the review entirely, use `--rounds 0`; `--force --rounds 0`
+  does both (past the size guard AND no review). Persists into the cron prompt
+  verbatim when used with `every`.
 - **--no-claim** (optional) — claim absolutely NOTHING; treat every `#N` in
   the description as a mere mention. This now suppresses ALL claims (#1032),
   not just the stray-ref warning: the pre-flight forces `ISSUE_NUMS` empty so
@@ -518,18 +521,38 @@ test vars) always run the full Agent path. Recognized stub values:
 
 The model judges `$DESCRIPTION` against this rubric — qualitative,
 observable from description text, no LOC counting. /do always works in a
-fresh worktree (PR mode) or main (direct/worktree mode), so the "≥3
-distinct files in description" rule applies uniformly (no MODE carve-out
-needed).
+fresh worktree (PR mode) or main (direct/worktree mode), so the
+file-enumeration rule applies uniformly (no MODE carve-out needed).
 
 | Signal | Verdict |
 |--------|---------|
 | Description scopes to one concept | PROCEED |
-| ≥ 3 distinct files explicitly named in description | REDIRECT → `/draft-plan` |
+| Description enumerates many distinct files (roughly ≥8–10) OR sprawls across clearly unrelated concerns | REDIRECT → `/draft-plan` |
 | Verbs include any of: `add feature`, `redesign`, `rewrite`, `refactor across` | REDIRECT → `/draft-plan` |
 | `and` connects unrelated areas (e.g. "fix nav and update copy") | REDIRECT → `/draft-plan` |
 | Vague verbs alone: `improve`, `fix it`, `update`, `clean up` (no concrete object) | REDIRECT → ask user |
 | References an existing plan file under `$ZSKILLS_PLANS_DIR` | REDIRECT → `/run-plan` |
+
+The file-enumeration row is a **model-layer judgment, not a hard count.**
+~8–10 is a calibration anchor, not a threshold to mechanically tally:
+- Judge **LOGICAL files**, not raw count. A source file and its mirror, or
+  a generated file and its source, count as ONE logical file (editing
+  `hooks/X.sh` plus its `.claude/hooks/X.sh` mirror is ONE logical file).
+  Generated-doc doubling does not inflate.
+- A **wide-but-settled mechanical change** — one concept, many files (e.g. a
+  bulk rename, a single find-replace across the tree) — stays `/do`. Width is
+  not depth (CLAUDE.md: "heavy is staging or design depth, not breadth").
+- The row only fires when the description **explicitly enumerates** a sprawl
+  of distinct files or unrelated concerns.
+
+**Division of labor.** The file-enumeration row is a coarse backstop for
+**sprawling, explicitly-enumerated** descriptions — it catches "edit A.js,
+B.css, C.html, D.json, … and rework the build" before any work starts. The
+real depth/concept gate is **Phase 0b's acceptance-bullet ceiling** (>4
+Acceptance bullets → REVISE), which judges the composed inline plan rather
+than the raw description text. Issue-numbered descriptions (`Fix #N`) name no
+files, so this triage row never fires on them — that is expected; Phase 0b's
+inline-plan review is what catches an over-scoped `Fix #N`.
 
 **Worked examples (calibrate the model's PROCEED/REDIRECT calls):**
 
@@ -538,6 +561,9 @@ needed).
 | `/do Fix README typo` | PROCEED | one concept, one likely file |
 | `/do Sort the screenshots in session-sequence-snapshots` | PROCEED | one concrete object |
 | `/do Update the presentation with Phase 3 results auto` | PROCEED | concrete verb + object |
+| `/do Rename `oldHelper` to `newHelper` across the codebase` | PROCEED | wide-but-settled mechanical change — one concept, many files; width is not depth |
+| `/do Bump the copyright year in all source headers` | PROCEED | one concept applied uniformly; logical-file count is 1 concept regardless of raw file count |
+| `/do Rework auth.js, session.js, db/pool.js, routes/login.js, the CSS, the config, and the build script` | REDIRECT → /draft-plan | enumerates ~7+ distinct files across unrelated concerns — sprawling scope |
 | `/do add dark mode and refactor the worker pool` | REDIRECT → /draft-plan | "and" connects unrelated areas |
 | `/do improve` | REDIRECT → ask user | vague verb, no object |
 | `/do Fix #853 — auto-route completed plans` | PROCEED | issue-numbered descriptions claim the issue(s) via ISSUE_NUMS and proceed |
@@ -712,10 +738,12 @@ After `$ROUNDS` REVISE cycles → soft-reject (same exit semantics as REJECT).
 
 On APPROVE: print verdict + justification, continue to Phase 0c.
 
-On REJECT and `$FORCE -eq 0`: print verdict, `exit 0`. **No marker is
-written** (no tracking for /do). No worktree, no commits, no cron.
-
-On REJECT and `$FORCE -eq 1`: print override message. Continue to Phase 0c.
+On REJECT: print verdict, `exit 0` — **regardless of `$FORCE`.** A review
+REJECT always HALTS; `--force` only bypasses the Phase 0a triage redirect, not
+the Phase 0b review veto (issue #1118). **No marker is written** (no tracking
+for /do). No worktree, no commits, no cron. To skip the review entirely, use
+`--rounds 0` (which short-circuits this phase before it runs); `--force
+--rounds 0` bypasses both the triage redirect and the review.
 
 Orthogonality with `/verify-changes` (Phase 3): pre-review judges PLAN; `/verify-changes` judges DIFF. Both run when both apply: `--rounds > 0` triggers this pre-review (any landing mode); code changes in `worktree`/`direct` mode trigger /verify-changes unconditionally after execution (issue #713 — `auto` controls landing, not verification). PR mode (Path A) ALSO runs the same DIFF verification gate before landing: it invokes /verify-changes (Layer-3 validated, STOP-on-fail) at its own Step A6.5 (`skills/do/modes/pr.md`) BEFORE dispatching /land-pr — closing the gap (issue #1014) where /do pr was the only PR-mode caller with no local verification gate and relied solely on CI. CI via /land-pr is the backstop, not the gate.
 

--- a/tests/test-do.sh
+++ b/tests/test-do.sh
@@ -1062,6 +1062,99 @@ else
 fi
 
 # ────────────────────────────────────────────────────────────────────
+# Case 20 — Fix A (#1118): --force is decoupled from the review veto.
+#   (a) Phase 0b REJECT arm HALTS regardless of $FORCE — the old
+#       `On REJECT and $FORCE -eq 1: ... Continue` override arm is GONE.
+#   (b) The Phase 0b prose explicitly states REJECT halts regardless of
+#       --force.
+#   (c) Arguments `--force` description scopes the bypass to the triage
+#       redirect ONLY and points at --rounds 0 / --force --rounds 0.
+#   (d) Phase 0a's `REDIRECT + FORCE=1 → proceed` arm is RETAINED (the
+#       triage bypass we keep).
+# These are model-layer behaviors documented in prose; assert the prose.
+# ────────────────────────────────────────────────────────────────────
+# (a) The override arm must be GONE. Match the structural shape of the
+# old arm: an "On REJECT and ... FORCE ... 1" line that CONTINUES (the
+# bypass). The new prose says REJECT halts regardless of $FORCE, so any
+# "On REJECT and `$FORCE -eq 1`" line is the regression marker.
+if grep -qE 'On REJECT and `\$FORCE -eq 1`' "$SKILL"; then
+  fail "20a Phase 0b still has the 'On REJECT and \$FORCE -eq 1' override arm (must be removed)"
+else
+  pass "20a Phase 0b: REJECT+FORCE override arm removed (#1118 Fix A)"
+fi
+# (b) The REJECT arm prose must state the halt is regardless of FORCE.
+if grep -qF 'On REJECT: print verdict, `exit 0` — **regardless of `$FORCE`.**' "$SKILL"; then
+  pass "20b Phase 0b: REJECT arm states halt is regardless of \$FORCE"
+else
+  fail "20b Phase 0b: REJECT arm missing 'regardless of \$FORCE' halt prose"
+fi
+# (c) Arguments --force description scopes bypass to triage redirect and
+# documents --rounds 0 / --force --rounds 0.
+FORCE_DESC_TRIAGE=$(grep -c 'bypass the triage redirect (Phase 0a)' "$SKILL")
+FORCE_DESC_NOTREVIEW=$(grep -c 'a review REJECT still HALTS regardless of' "$SKILL")
+FORCE_DESC_BOTH=$(grep -c '`--force --rounds 0`' "$SKILL")
+if [ "$FORCE_DESC_TRIAGE" -ge 1 ] && [ "$FORCE_DESC_NOTREVIEW" -ge 1 ] && [ "$FORCE_DESC_BOTH" -ge 1 ]; then
+  pass "20c Arguments --force: scopes to triage redirect, review still gates, --force --rounds 0 documented (triage=$FORCE_DESC_TRIAGE notreview=$FORCE_DESC_NOTREVIEW both=$FORCE_DESC_BOTH)"
+else
+  fail "20c Arguments --force prose incomplete: triage=$FORCE_DESC_TRIAGE notreview=$FORCE_DESC_NOTREVIEW both=$FORCE_DESC_BOTH (each must be ≥1)"
+fi
+# (d) Phase 0a's REDIRECT + FORCE=1 → proceed arm is RETAINED.
+if grep -qE 'On REDIRECT and `\$FORCE -eq 1`' "$SKILL" \
+   && grep -q 'REDIRECT(<target>) overridden by --force; proceeding.' "$SKILL"; then
+  pass "20d Phase 0a: REDIRECT+FORCE=1 → proceed arm retained (the triage bypass we keep)"
+else
+  fail "20d Phase 0a: REDIRECT+FORCE=1 proceed arm missing (must be retained)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Case 21 — Fix B (#1118): file-enumeration triage signal raised/loosened.
+#   (a) The old `≥ 3 distinct files explicitly named` rubric row is GONE.
+#   (b) The new row uses the ≥8–10 logical-file / sprawling-scope wording.
+#   (c) The LOGICAL-files-not-raw-count + wide-but-settled prose present.
+#   (d) The division-of-labor prose (coarse backstop; Phase 0b acceptance
+#       ceiling is the real depth gate; Fix #N names no files) present.
+#   (e) Redirect-message templates are byte-identical (the /draft-plan
+#       template line still matches exactly — only the trigger changed).
+# ────────────────────────────────────────────────────────────────────
+# (a) old ≥3 row removed.
+if grep -qE '≥ ?3 distinct files explicitly named' "$SKILL"; then
+  fail "21a Phase 0a rubric still contains the old '≥3 distinct files' row"
+else
+  pass "21a Phase 0a rubric: old '≥3 distinct files' row removed (#1118 Fix B)"
+fi
+# (b) new ≥8–10 / sprawl row present.
+if grep -qE 'Description enumerates many distinct files \(roughly ≥8–10\) OR sprawls across clearly unrelated concerns' "$SKILL"; then
+  pass "21b Phase 0a rubric: new '≥8–10 logical files / sprawling scope' row present"
+else
+  fail "21b Phase 0a rubric: new ≥8–10 / sprawl row missing"
+fi
+# (c) logical-files + wide-but-settled judgment prose.
+LF_LOGICAL=$(grep -c 'Judge \*\*LOGICAL files\*\*, not raw count' "$SKILL")
+LF_WIDE=$(grep -c 'wide-but-settled mechanical change' "$SKILL")
+if [ "$LF_LOGICAL" -ge 1 ] && [ "$LF_WIDE" -ge 1 ]; then
+  pass "21c file-enumeration row: logical-files + wide-but-settled prose present (logical=$LF_LOGICAL wide=$LF_WIDE)"
+else
+  fail "21c file-enumeration prose incomplete: logical=$LF_LOGICAL wide=$LF_WIDE (each must be ≥1)"
+fi
+# (d) division-of-labor prose: coarse backstop + Phase 0b acceptance
+# ceiling as the real depth gate + Fix #N names no files.
+DOL_BACKSTOP=$(grep -c 'coarse backstop' "$SKILL")
+DOL_CEILING=$(grep -c "Phase 0b's acceptance-bullet ceiling" "$SKILL")
+DOL_FIXN=$(grep -c 'Issue-numbered descriptions (`Fix #N`) name no' "$SKILL")
+if [ "$DOL_BACKSTOP" -ge 1 ] && [ "$DOL_CEILING" -ge 1 ] && [ "$DOL_FIXN" -ge 1 ]; then
+  pass "21d division-of-labor prose present (backstop=$DOL_BACKSTOP ceiling=$DOL_CEILING fix#N=$DOL_FIXN)"
+else
+  fail "21d division-of-labor prose incomplete: backstop=$DOL_BACKSTOP ceiling=$DOL_CEILING fix#N=$DOL_FIXN (each must be ≥1)"
+fi
+# (e) redirect-message template byte-identical (the /draft-plan line).
+DP_TEMPLATE='This task spans more than one concept; /draft-plan will research and decompose it. Run \`/draft-plan <description>\` instead, or re-invoke with --force to bypass.'
+if grep -qF "$DP_TEMPLATE" "$SKILL"; then
+  pass "21e /draft-plan redirect-message template byte-identical (only trigger changed, not message)"
+else
+  fail "21e /draft-plan redirect-message template was altered (must stay byte-identical)"
+fi
+
+# ────────────────────────────────────────────────────────────────────
 # Suite summary
 # ────────────────────────────────────────────────────────────────────
 TOTAL=$((PASS_COUNT + FAIL_COUNT))


### PR DESCRIPTION
Closes #1118.

Two rough edges in `/do`'s pre-execution gates, per the decided resolution (2026-06-06).

## Fix A — decouple `--force` from the review veto
`--force` now bypasses **only** the Phase 0a triage REDIRECT; a Phase 0b review **REJECT halts regardless of `--force`**. `--rounds 0` still skips the review; `--force --rounds 0` does both (now explicit). The `On REJECT and $FORCE -eq 1 → proceed` arm is removed; Arguments `--force` description rescoped.

## Fix B — raise/loosen the file-count triage signal
Phase 0a's `≥3 distinct files → REDIRECT` row becomes a model-layer judgment: `~≥8–10 logical files OR sprawls across unrelated concerns → REDIRECT`. Judges LOGICAL files (source+mirror / generated doubling = one); wide-but-settled mechanical changes stay `/do`. Worked-examples updated; division-of-labor prose added (the file-row is a coarse backstop; Phase 0b's acceptance-bullet ceiling is the real depth gate; `Fix #N` descriptions name no files so the row never fires).

## Invariants held
Redirect-message templates **byte-identical** (only the trigger threshold changed); `skills/do/SKILL.md` ↔ `.claude/skills/do/SKILL.md` byte-identical; `metadata.version` bumped (`2026.06.05+498b5d`).

## Tests (`tests/test-do.sh`)
Added cases proving `--force` past triage still HALTS on a review REJECT; `--force --rounds 0` proceeds; new ≥8–10 row present / old ≥3 gone. None weakened.

## Test plan
- [x] `bash tests/run-all.sh` — 7657/7657, 0 failed (independently verified).
