### PR TITLE
fix(update-zskills): resolve-repo-version.sh falls back to plugin.json when no git tag (#1124)

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.05+f3a28a"
+  version: "2026.06.05+129f56"
 ---
 
 # Update Z Skills Infrastructure
@@ -907,7 +907,10 @@ if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-con
 else
   ZSKILLS_SKIP_INIT_GATE=1 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-# Repo-level version: latest YYYY.MM.N tag in the source clone.
+# Repo-level version: latest YYYY.MM.N tag in the source clone, falling
+# back to the top-level `version` in .claude-plugin/plugin.json when there
+# is no tag (#1124) — so a tagless-but-complete clone still resolves a
+# version. Empty only when there is neither a tag nor a readable plugin.json.
 current_zskills_ver=$(bash "$ZSKILLS_SKILLS_ROOT/update-zskills/scripts/resolve-repo-version.sh" "$ZSKILLS_PATH")
 
 # Installed version: top-level `zskills_version` field in
@@ -944,13 +947,17 @@ consistency; the `Versions:` line is the audit-specific one-liner that
 also includes the per-skill delta count. Both surface the same
 underlying data.
 
-If the source clone has no tags (repo is unversioned): both lines
-still print, just with the `(unversioned)` placeholder. This surfaces
-the state instead of hiding it (CLAUDE.md surface-bugs rule). Same
-applies to a pre-Phase-5 install with no `zskills_version` field —
-print `(none)`; the install/Pull-Latest path will write the field on
-its next run via the mirror-the-tag step (see Step F.5 / Pull Latest
-step 5.7).
+If the source clone has neither a tag nor a readable
+`.claude-plugin/plugin.json` version (genuinely unversioned):
+`current_zskills_ver` is empty and both lines still print with the
+`(unversioned)` placeholder. This surfaces the state instead of hiding it
+(CLAUDE.md surface-bugs rule). Note that a tagless-but-complete clone is
+NOT unversioned — `resolve-repo-version.sh` falls back to the plugin.json
+version (#1124), so `(unversioned)` now appears only when the clone is
+truly missing both signals. Same `(none)` handling applies to a
+pre-Phase-5 install with no `zskills_version` field — print `(none)`; the
+install/Pull-Latest path will write the field on its next run via the
+mirror-the-tag step (see Step F.5 / Pull Latest step 5.7).
 
 If everything is satisfied, end with:
 ```
@@ -2168,10 +2175,14 @@ if [ -n "$new_repo_ver" ]; then
 fi
 ```
 
-If the source clone has no tags (`new_repo_ver` empty), skip silently —
-nothing authoritative to mirror. The audit will print `(unversioned)`
-on the next invocation, which surfaces the state without falsely
-recording a stale tag.
+`resolve-repo-version.sh` resolves the latest tag, falling back to the
+top-level `version` in `.claude-plugin/plugin.json` when there is no tag
+(#1124) — so on a tagless-but-complete clone `new_repo_ver` is now
+populated from plugin.json and `zskills_version` IS written. `new_repo_ver`
+is empty only when the clone has neither a tag nor a readable plugin.json
+version; in that genuinely-unversioned case, skip silently — nothing
+authoritative to mirror, and the audit will print `(unversioned)` on the
+next invocation, surfacing the state without falsely recording a value.
 
 #### Step G — Final report
 
@@ -2224,8 +2235,10 @@ printf '%s\n' "$delta_tsv" | awk -F'\t' -v show_addons="$show_addons" '
 ```
 
 `Repo version: <new_zskills_ver>` reflects the freshly mirrored
-`zskills_version` from Step F.5 (or `(unversioned)` if the source clone
-had no tags).
+`zskills_version` from Step F.5 (or `(unversioned)` only if the source
+clone had neither a tag nor a readable `.claude-plugin/plugin.json`
+version — a tagless-but-complete clone resolves the plugin.json version,
+so it is no longer `(unversioned)`).
 
 #### Step G.5 — Post-install verification (#999, cheap tier, NON-FATAL)
 
@@ -2235,11 +2248,13 @@ catches the consumer-side of the dogfood-mask (#799/#831): environment-specific
 install breakage that dev-repo tests structurally cannot see (a registered hook
 that resolves to nothing, an un-rendered `managed.md` carrying raw `{{TOKEN}}`
 template placeholders, a dropped artifact/sentinel, an accidental dual-install).
-Per the zero-false-positive bar (#1004) it NEVER flags the renderer's designed
-`<!-- TODO -->` comments for unset OPTIONAL config, nor a missing
-`zskills_version` (an untagged source clone legitimately lacks one) — a FAIL
-always means the install is genuinely broken, never that an optional setting is
-unconfigured.
+Per the zero-false-positive bar (#1004) it NEVER FAILs on the renderer's
+designed `<!-- TODO -->` comments for unset OPTIONAL config — a FAIL always
+means the install is genuinely broken. A missing `zskills_version` is now
+surfaced as a **WARN** (not FAIL): after #1124 `resolve-repo-version.sh`
+falls back to `.claude-plugin/plugin.json`, so a complete clone almost
+always yields a version and its absence is abnormal (but still not install
+breakage — hence WARN, not FAIL); when present, the version is reported.
 
 **NON-FATAL — informative only.** The install already succeeded; this
 verification reports PASS/WARN/FAIL but **does NOT undo or fail the install**.
@@ -2349,7 +2364,11 @@ date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
    fi
    ```
 
-   Skip silently if the source clone has no tags.
+   `resolve-repo-version.sh` falls back to `.claude-plugin/plugin.json`
+   when there is no tag (#1124), so `new_repo_ver` is populated on a
+   tagless-but-complete clone and `zskills_version` IS written. Skip
+   silently only when the clone has neither a tag nor a readable
+   plugin.json version (`new_repo_ver` empty).
 
 6. **Report.** Replace the prior single-line `Updated: N skills (list)`
    summary with a structured table generated from
@@ -2408,7 +2427,9 @@ date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
    ```
 
    `(unversioned)` placeholder applies to either side of the `Repo
-   version:` arrow if the corresponding tag is missing.
+   version:` arrow only if the corresponding version is missing — i.e. no
+   tag AND no readable `.claude-plugin/plugin.json` version (#1124); a
+   tagless-but-complete clone resolves the plugin.json version.
 
 7. **Post-install verification (#999, cheap tier, NON-FATAL).** Same as
    install-path **Step G.5**: run the bundled consumer verifier's cheap

--- a/.claude/skills/update-zskills/scripts/resolve-repo-version.sh
+++ b/.claude/skills/update-zskills/scripts/resolve-repo-version.sh
@@ -1,16 +1,57 @@
 #!/bin/bash
-# resolve-repo-version.sh — extract latest YYYY.MM.N tag from zskills source.
+# resolve-repo-version.sh — resolve the zskills repo version from a source clone.
+# Resolution order: latest YYYY.MM.N git tag → else the top-level `version`
+# field in <path>/.claude-plugin/plugin.json (the `zs` plugin manifest, same
+# YYYY.MM.N scheme) → else empty.
+#
 # Tag scheme is defined by RELEASING.md:44-46 (zero-indexed YYYY.MM.N).
 # If the tag scheme changes (suffixes like `-rc`, prefixes like `v`, etc.),
-# update this regex AND tests/test-skill-version-delta.sh together.
-# (refine-plan F-R15: surface the cross-file dependency.)
+# update this regex AND tests/test-update-zskills-version-surface.sh together
+# (that suite exercises resolve-repo-version.sh, incl. the #1124 plugin.json
+# fallback). (refine-plan F-R15: surface the cross-file dependency.)
+#
+# The plugin.json fallback (#1124) covers tagless-but-complete clones —
+# shallow clones, never-tagged working copies, plugin-cloned trees without
+# tags fetched — where the latest-tag pipeline yields empty even though the
+# repo's version IS available in .claude-plugin/plugin.json. Format already
+# matches (YYYY.MM.N) so no normalization is needed. Dependency-free: a
+# bash-regex extract of the manifest's TOP-LEVEL "version" key (no jq, per
+# the repo standard) — anchored to the first match in the manifest head so a
+# nested "version" key is never grabbed.
 #
 # Usage: bash resolve-repo-version.sh <zskills-source-path>
-# Stdout: latest matching tag (e.g. "2026.04.0"), or empty if none / not a git repo.
-# Exit:   0 in both cases (empty stdout signals "no version").
+# Stdout: latest matching tag, else plugin.json version (e.g. "2026.06.0"),
+#         else empty if neither is available / not a git repo.
+# Exit:   0 in all cases (empty stdout signals "no version").
 set -u
 ZSKILLS_PATH="${1:-}"
-[ -d "$ZSKILLS_PATH/.git" ] || { echo ""; exit 0; }
-git -C "$ZSKILLS_PATH" tag --list \
-  | grep -E '^[0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+$' \
-  | sort -V | tail -1
+
+# 1) git tag — latest YYYY.MM.N tag in the source clone.
+tag=""
+if [ -d "$ZSKILLS_PATH/.git" ]; then
+  tag=$(git -C "$ZSKILLS_PATH" tag --list \
+    | grep -E '^[0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+$' \
+    | sort -V | tail -1)
+fi
+if [ -n "$tag" ]; then
+  echo "$tag"
+  exit 0
+fi
+
+# 2) plugin.json fallback — top-level `version` from the `zs` plugin manifest
+#    at <path>/.claude-plugin/plugin.json. NOT block-diagram/.claude-plugin/
+#    (that is the `zsbd` addon manifest). Read only the manifest head so the
+#    FIRST "version": "..." match is the top-level key, never a nested one.
+manifest="$ZSKILLS_PATH/.claude-plugin/plugin.json"
+if [ -f "$manifest" ]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ \"version\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+      echo "${BASH_REMATCH[1]}"
+      exit 0
+    fi
+  done < <(head -n 20 "$manifest")
+fi
+
+# 3) neither — empty signals "no version".
+echo ""
+exit 0

--- a/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/.claude/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -453,11 +453,22 @@ vi_check_legacy() {
     vi_emit FAIL "legacy.config-present" ".claude/zskills-config.json missing"
   fi
 
-  # NOTE (#1004): no `legacy.version-recorded` check. A missing zskills_version
-  # is NOT install breakage — /update-zskills Step F.5 deliberately skips
-  # writing it when the source clone is untagged, so a valid install can
-  # legitimately lack it. Flagging it (even as a WARN) violated the
-  # zero-false-positive bar.
+  # (5) zskills_version recorded (#1124 — WARN, never FAIL). After #1124
+  # resolve-repo-version.sh falls back to .claude-plugin/plugin.json, so a
+  # complete clone almost always yields a version and /update-zskills writes
+  # zskills_version. Its absence is therefore abnormal — but a missing version
+  # is still NOT install breakage (the skills/hooks all work without it; only
+  # the version-skew nudge is affected). So we WARN (the carve-out rationale
+  # from #1004 — "an untagged source clone legitimately lacks one" — no longer
+  # holds now that the plugin.json fallback exists), and report the value when
+  # present. WARN keeps the zero-false-positive bar on FAILs intact.
+  local cver
+  cver="$(vi_config_version "$cfg")"
+  if [ -n "$cver" ]; then
+    vi_emit PASS "legacy.version-recorded" "zskills_version recorded: $cver"
+  else
+    vi_emit WARN "legacy.version-recorded" "zskills_version absent in .claude/zskills-config.json — after #1124 a complete clone resolves a version (git tag → .claude-plugin/plugin.json); re-run /update-zskills to record it (version-skew nudge stays disabled until then)"
+  fi
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -552,8 +563,19 @@ vi_check_plugin() {
     fi
   fi
 
-  # NOTE (#1004): no `plugin.version-recorded` check — same rationale as the
-  # legacy lane: a missing zskills_version is not install breakage.
+  # (4) zskills_version recorded (#1124 — WARN, never FAIL). Same rationale as
+  # the legacy lane: after #1124 resolve-repo-version.sh falls back to
+  # .claude-plugin/plugin.json, so a complete clone almost always yields a
+  # version. Absence is abnormal but not install breakage (only the
+  # version-skew nudge is affected) → WARN, not FAIL. The plugin seed config
+  # lives at the consumer's .claude/zskills-config.json (same path as legacy).
+  local pcver
+  pcver="$(vi_config_version "$claude/zskills-config.json")"
+  if [ -n "$pcver" ]; then
+    vi_emit PASS "plugin.version-recorded" "zskills_version recorded: $pcver"
+  else
+    vi_emit WARN "plugin.version-recorded" "zskills_version absent in .claude/zskills-config.json — after #1124 a complete clone resolves a version (git tag → .claude-plugin/plugin.json); re-run /update-zskills to record it (version-skew nudge stays disabled until then)"
+  fi
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.05+f3a28a"
+  version: "2026.06.05+129f56"
 ---
 
 # Update Z Skills Infrastructure
@@ -907,7 +907,10 @@ if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-con
 else
   ZSKILLS_SKIP_INIT_GATE=1 . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
-# Repo-level version: latest YYYY.MM.N tag in the source clone.
+# Repo-level version: latest YYYY.MM.N tag in the source clone, falling
+# back to the top-level `version` in .claude-plugin/plugin.json when there
+# is no tag (#1124) — so a tagless-but-complete clone still resolves a
+# version. Empty only when there is neither a tag nor a readable plugin.json.
 current_zskills_ver=$(bash "$ZSKILLS_SKILLS_ROOT/update-zskills/scripts/resolve-repo-version.sh" "$ZSKILLS_PATH")
 
 # Installed version: top-level `zskills_version` field in
@@ -944,13 +947,17 @@ consistency; the `Versions:` line is the audit-specific one-liner that
 also includes the per-skill delta count. Both surface the same
 underlying data.
 
-If the source clone has no tags (repo is unversioned): both lines
-still print, just with the `(unversioned)` placeholder. This surfaces
-the state instead of hiding it (CLAUDE.md surface-bugs rule). Same
-applies to a pre-Phase-5 install with no `zskills_version` field —
-print `(none)`; the install/Pull-Latest path will write the field on
-its next run via the mirror-the-tag step (see Step F.5 / Pull Latest
-step 5.7).
+If the source clone has neither a tag nor a readable
+`.claude-plugin/plugin.json` version (genuinely unversioned):
+`current_zskills_ver` is empty and both lines still print with the
+`(unversioned)` placeholder. This surfaces the state instead of hiding it
+(CLAUDE.md surface-bugs rule). Note that a tagless-but-complete clone is
+NOT unversioned — `resolve-repo-version.sh` falls back to the plugin.json
+version (#1124), so `(unversioned)` now appears only when the clone is
+truly missing both signals. Same `(none)` handling applies to a
+pre-Phase-5 install with no `zskills_version` field — print `(none)`; the
+install/Pull-Latest path will write the field on its next run via the
+mirror-the-tag step (see Step F.5 / Pull Latest step 5.7).
 
 If everything is satisfied, end with:
 ```
@@ -2168,10 +2175,14 @@ if [ -n "$new_repo_ver" ]; then
 fi
 ```
 
-If the source clone has no tags (`new_repo_ver` empty), skip silently —
-nothing authoritative to mirror. The audit will print `(unversioned)`
-on the next invocation, which surfaces the state without falsely
-recording a stale tag.
+`resolve-repo-version.sh` resolves the latest tag, falling back to the
+top-level `version` in `.claude-plugin/plugin.json` when there is no tag
+(#1124) — so on a tagless-but-complete clone `new_repo_ver` is now
+populated from plugin.json and `zskills_version` IS written. `new_repo_ver`
+is empty only when the clone has neither a tag nor a readable plugin.json
+version; in that genuinely-unversioned case, skip silently — nothing
+authoritative to mirror, and the audit will print `(unversioned)` on the
+next invocation, surfacing the state without falsely recording a value.
 
 #### Step G — Final report
 
@@ -2224,8 +2235,10 @@ printf '%s\n' "$delta_tsv" | awk -F'\t' -v show_addons="$show_addons" '
 ```
 
 `Repo version: <new_zskills_ver>` reflects the freshly mirrored
-`zskills_version` from Step F.5 (or `(unversioned)` if the source clone
-had no tags).
+`zskills_version` from Step F.5 (or `(unversioned)` only if the source
+clone had neither a tag nor a readable `.claude-plugin/plugin.json`
+version — a tagless-but-complete clone resolves the plugin.json version,
+so it is no longer `(unversioned)`).
 
 #### Step G.5 — Post-install verification (#999, cheap tier, NON-FATAL)
 
@@ -2235,11 +2248,13 @@ catches the consumer-side of the dogfood-mask (#799/#831): environment-specific
 install breakage that dev-repo tests structurally cannot see (a registered hook
 that resolves to nothing, an un-rendered `managed.md` carrying raw `{{TOKEN}}`
 template placeholders, a dropped artifact/sentinel, an accidental dual-install).
-Per the zero-false-positive bar (#1004) it NEVER flags the renderer's designed
-`<!-- TODO -->` comments for unset OPTIONAL config, nor a missing
-`zskills_version` (an untagged source clone legitimately lacks one) — a FAIL
-always means the install is genuinely broken, never that an optional setting is
-unconfigured.
+Per the zero-false-positive bar (#1004) it NEVER FAILs on the renderer's
+designed `<!-- TODO -->` comments for unset OPTIONAL config — a FAIL always
+means the install is genuinely broken. A missing `zskills_version` is now
+surfaced as a **WARN** (not FAIL): after #1124 `resolve-repo-version.sh`
+falls back to `.claude-plugin/plugin.json`, so a complete clone almost
+always yields a version and its absence is abnormal (but still not install
+breakage — hence WARN, not FAIL); when present, the version is reported.
 
 **NON-FATAL — informative only.** The install already succeeded; this
 verification reports PASS/WARN/FAIL but **does NOT undo or fail the install**.
@@ -2349,7 +2364,11 @@ date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
    fi
    ```
 
-   Skip silently if the source clone has no tags.
+   `resolve-repo-version.sh` falls back to `.claude-plugin/plugin.json`
+   when there is no tag (#1124), so `new_repo_ver` is populated on a
+   tagless-but-complete clone and `zskills_version` IS written. Skip
+   silently only when the clone has neither a tag nor a readable
+   plugin.json version (`new_repo_ver` empty).
 
 6. **Report.** Replace the prior single-line `Updated: N skills (list)`
    summary with a structured table generated from
@@ -2408,7 +2427,9 @@ date -Iseconds > "$CLAUDE_PROJECT_DIR/.zskills/setup-confirmed"
    ```
 
    `(unversioned)` placeholder applies to either side of the `Repo
-   version:` arrow if the corresponding tag is missing.
+   version:` arrow only if the corresponding version is missing — i.e. no
+   tag AND no readable `.claude-plugin/plugin.json` version (#1124); a
+   tagless-but-complete clone resolves the plugin.json version.
 
 7. **Post-install verification (#999, cheap tier, NON-FATAL).** Same as
    install-path **Step G.5**: run the bundled consumer verifier's cheap

--- a/skills/update-zskills/scripts/resolve-repo-version.sh
+++ b/skills/update-zskills/scripts/resolve-repo-version.sh
@@ -1,16 +1,57 @@
 #!/bin/bash
-# resolve-repo-version.sh — extract latest YYYY.MM.N tag from zskills source.
+# resolve-repo-version.sh — resolve the zskills repo version from a source clone.
+# Resolution order: latest YYYY.MM.N git tag → else the top-level `version`
+# field in <path>/.claude-plugin/plugin.json (the `zs` plugin manifest, same
+# YYYY.MM.N scheme) → else empty.
+#
 # Tag scheme is defined by RELEASING.md:44-46 (zero-indexed YYYY.MM.N).
 # If the tag scheme changes (suffixes like `-rc`, prefixes like `v`, etc.),
-# update this regex AND tests/test-skill-version-delta.sh together.
-# (refine-plan F-R15: surface the cross-file dependency.)
+# update this regex AND tests/test-update-zskills-version-surface.sh together
+# (that suite exercises resolve-repo-version.sh, incl. the #1124 plugin.json
+# fallback). (refine-plan F-R15: surface the cross-file dependency.)
+#
+# The plugin.json fallback (#1124) covers tagless-but-complete clones —
+# shallow clones, never-tagged working copies, plugin-cloned trees without
+# tags fetched — where the latest-tag pipeline yields empty even though the
+# repo's version IS available in .claude-plugin/plugin.json. Format already
+# matches (YYYY.MM.N) so no normalization is needed. Dependency-free: a
+# bash-regex extract of the manifest's TOP-LEVEL "version" key (no jq, per
+# the repo standard) — anchored to the first match in the manifest head so a
+# nested "version" key is never grabbed.
 #
 # Usage: bash resolve-repo-version.sh <zskills-source-path>
-# Stdout: latest matching tag (e.g. "2026.04.0"), or empty if none / not a git repo.
-# Exit:   0 in both cases (empty stdout signals "no version").
+# Stdout: latest matching tag, else plugin.json version (e.g. "2026.06.0"),
+#         else empty if neither is available / not a git repo.
+# Exit:   0 in all cases (empty stdout signals "no version").
 set -u
 ZSKILLS_PATH="${1:-}"
-[ -d "$ZSKILLS_PATH/.git" ] || { echo ""; exit 0; }
-git -C "$ZSKILLS_PATH" tag --list \
-  | grep -E '^[0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+$' \
-  | sort -V | tail -1
+
+# 1) git tag — latest YYYY.MM.N tag in the source clone.
+tag=""
+if [ -d "$ZSKILLS_PATH/.git" ]; then
+  tag=$(git -C "$ZSKILLS_PATH" tag --list \
+    | grep -E '^[0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+$' \
+    | sort -V | tail -1)
+fi
+if [ -n "$tag" ]; then
+  echo "$tag"
+  exit 0
+fi
+
+# 2) plugin.json fallback — top-level `version` from the `zs` plugin manifest
+#    at <path>/.claude-plugin/plugin.json. NOT block-diagram/.claude-plugin/
+#    (that is the `zsbd` addon manifest). Read only the manifest head so the
+#    FIRST "version": "..." match is the top-level key, never a nested one.
+manifest="$ZSKILLS_PATH/.claude-plugin/plugin.json"
+if [ -f "$manifest" ]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ \"version\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+      echo "${BASH_REMATCH[1]}"
+      exit 0
+    fi
+  done < <(head -n 20 "$manifest")
+fi
+
+# 3) neither — empty signals "no version".
+echo ""
+exit 0

--- a/skills/update-zskills/verifiers/verify-install-lib.sh
+++ b/skills/update-zskills/verifiers/verify-install-lib.sh
@@ -453,11 +453,22 @@ vi_check_legacy() {
     vi_emit FAIL "legacy.config-present" ".claude/zskills-config.json missing"
   fi
 
-  # NOTE (#1004): no `legacy.version-recorded` check. A missing zskills_version
-  # is NOT install breakage — /update-zskills Step F.5 deliberately skips
-  # writing it when the source clone is untagged, so a valid install can
-  # legitimately lack it. Flagging it (even as a WARN) violated the
-  # zero-false-positive bar.
+  # (5) zskills_version recorded (#1124 — WARN, never FAIL). After #1124
+  # resolve-repo-version.sh falls back to .claude-plugin/plugin.json, so a
+  # complete clone almost always yields a version and /update-zskills writes
+  # zskills_version. Its absence is therefore abnormal — but a missing version
+  # is still NOT install breakage (the skills/hooks all work without it; only
+  # the version-skew nudge is affected). So we WARN (the carve-out rationale
+  # from #1004 — "an untagged source clone legitimately lacks one" — no longer
+  # holds now that the plugin.json fallback exists), and report the value when
+  # present. WARN keeps the zero-false-positive bar on FAILs intact.
+  local cver
+  cver="$(vi_config_version "$cfg")"
+  if [ -n "$cver" ]; then
+    vi_emit PASS "legacy.version-recorded" "zskills_version recorded: $cver"
+  else
+    vi_emit WARN "legacy.version-recorded" "zskills_version absent in .claude/zskills-config.json — after #1124 a complete clone resolves a version (git tag → .claude-plugin/plugin.json); re-run /update-zskills to record it (version-skew nudge stays disabled until then)"
+  fi
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -552,8 +563,19 @@ vi_check_plugin() {
     fi
   fi
 
-  # NOTE (#1004): no `plugin.version-recorded` check — same rationale as the
-  # legacy lane: a missing zskills_version is not install breakage.
+  # (4) zskills_version recorded (#1124 — WARN, never FAIL). Same rationale as
+  # the legacy lane: after #1124 resolve-repo-version.sh falls back to
+  # .claude-plugin/plugin.json, so a complete clone almost always yields a
+  # version. Absence is abnormal but not install breakage (only the
+  # version-skew nudge is affected) → WARN, not FAIL. The plugin seed config
+  # lives at the consumer's .claude/zskills-config.json (same path as legacy).
+  local pcver
+  pcver="$(vi_config_version "$claude/zskills-config.json")"
+  if [ -n "$pcver" ]; then
+    vi_emit PASS "plugin.version-recorded" "zskills_version recorded: $pcver"
+  else
+    vi_emit WARN "plugin.version-recorded" "zskills_version absent in .claude/zskills-config.json — after #1124 a complete clone resolves a version (git tag → .claude-plugin/plugin.json); re-run /update-zskills to record it (version-skew nudge stays disabled until then)"
+  fi
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/tests/test-update-zskills-version-surface.sh
+++ b/tests/test-update-zskills-version-surface.sh
@@ -254,9 +254,48 @@ cat > "$T3/consumer/.claude/zskills-config.json" <<'EOF'
 EOF
 OUT=$(render_site_a_line "$T3/source" "$T3/consumer")
 if echo "$OUT" | grep -q '(unversioned)'; then
-  pass "Site A (unversioned) for tagless source"
+  pass "Site A (unversioned) for tagless source with NO plugin.json"
 else
   fail "Site A (unversioned)" "got: $OUT"
+fi
+
+# ----------------------------------------------------------------------
+# Test 3b (#1124): tagless source WITH a .claude-plugin/plugin.json →
+# resolve-repo-version.sh falls back to the plugin.json version, so the
+# Repo version is the plugin.json value, NOT (unversioned).
+# ----------------------------------------------------------------------
+echo ""
+echo "=== Test 3b (#1124): tagless source WITH plugin.json → plugin.json version ==="
+T3B=$(mktemp -d /tmp/zskills-test-vsurf-XXXXXX)
+mkdir -p "$T3B/source/skills" "$T3B/source/scripts" "$T3B/source/.claude-plugin"
+cp "$GET_HELPER" "$T3B/source/scripts/frontmatter-get.sh"
+write_skill "$T3B/source/skills/run-plan" run-plan "2026.05.02+aaaaaa"
+cat > "$T3B/source/.claude-plugin/plugin.json" <<'EOF'
+{
+  "name": "zs",
+  "displayName": "Z Skills",
+  "version": "2026.06.0",
+  "hooks": { "version": "nested-must-not-be-picked" }
+}
+EOF
+( cd "$T3B/source" && git init -q && git config user.email t@e && git config user.name t \
+  && git add -A && git commit -q -m init )
+# NO tag created — exercise the plugin.json fallback path.
+mkdir -p "$T3B/consumer/.claude/skills"
+cat > "$T3B/consumer/.claude/zskills-config.json" <<'EOF'
+{ "project_name": "acme" }
+EOF
+RV=$(bash "$RESOLVE" "$T3B/source")
+if [ "$RV" = "2026.06.0" ]; then
+  pass "resolve-repo-version.sh tagless+plugin.json → plugin.json version (2026.06.0), nested key not picked"
+else
+  fail "resolve tagless+plugin.json" "expected 2026.06.0 got '$RV'"
+fi
+OUT=$(render_site_a_line "$T3B/source" "$T3B/consumer")
+if echo "$OUT" | grep -q 'Repo version: (none) → 2026.06.0' && ! echo "$OUT" | grep -q '(unversioned)'; then
+  pass "Site A: tagless-but-complete clone shows plugin.json version, NOT (unversioned)"
+else
+  fail "Site A tagless+plugin.json" "got: $OUT"
 fi
 
 # ----------------------------------------------------------------------

--- a/tests/test-verify-install.sh
+++ b/tests/test-verify-install.sh
@@ -15,12 +15,16 @@
 #   - good legacy + UNSET optional config  → 0 FAIL  (#1004 — the renderer's
 #       designed `<!-- TODO -->` placeholders for unset OPTIONAL config must
 #       NOT be flagged; this is the recurrence-proof case PR #1003 missed)
-#   - good legacy + NO zskills_version     → 0 FAIL / 0 WARN  (#1004 — Step F.5
-#       legitimately skips writing it on an untagged source clone)
+#   - good legacy + NO zskills_version     → 0 FAIL + legacy.version-recorded
+#       WARN  (#1124 — after the plugin.json fallback a missing version is
+#       abnormal but not breakage; WARN, never FAIL)
+#   - good legacy + zskills_version present → legacy.version-recorded PASS
 #   - broken legacy (hook file gone)       → FAIL
 #   - broken legacy (raw {{TOKEN}})        → FAIL  (renderer never ran)
 #   - good plugin layout                   → no FAIL
-#   - good plugin + NO zskills_version     → 0 FAIL / 0 WARN  (#1004)
+#   - good plugin + NO zskills_version     → 0 FAIL + plugin.version-recorded
+#       WARN  (#1124)
+#   - good plugin + zskills_version present → plugin.version-recorded PASS
 #   - broken plugin (sentinel dropped)     → FAIL
 #   - broken plugin (artifact dropped)     → FAIL
 #   - dual install                         → FAIL
@@ -224,28 +228,48 @@ else
   pass "3b. valid legacy unset-optional → managed.md check does not FAIL on <!-- TODO --> placeholders"
 fi
 
-# ── LEGACY valid + NO zskills_version (#1004): an untagged source clone ───────
-# legitimately leaves zskills_version unset (Step F.5 skips writing it). This
-# must produce 0 FAIL AND 0 WARN — absence of a version is NOT install
-# breakage, and must not even alarm with a WARN.
+# ── LEGACY valid + NO zskills_version (#1124): after the plugin.json fallback ─
+# a complete clone almost always resolves a version (git tag → .claude-plugin/
+# plugin.json), so a missing zskills_version is abnormal — surfaced as a WARN
+# (never FAIL: it is not install breakage, only the version-skew nudge stays
+# off). So this case must produce 0 FAIL but exactly the legacy.version-recorded
+# WARN.
 LNV="$(make_legacy_good 4)"
 cat > "$LNV/.claude/zskills-config.json" <<'JSON'
 { "project_name": "acme" }
 JSON
-# A real legacy install lives in a git repo — init the fixture so the new
-# lane-agnostic env.git-repo check (#1119) PASSes, keeping this case at 0 WARN.
+# A real legacy install lives in a git repo — init the fixture so the
+# lane-agnostic env.git-repo check (#1119) PASSes, isolating the version WARN.
 git_init_fixture "$LNV"
 OUT="$TMP/out-legacy-no-version.txt"
 run_cheap_capture "$LNV" "$OUT"
-if [ "$VI_FAIL" -eq 0 ] && [ "$VI_WARN" -eq 0 ]; then
-  pass "3c. valid legacy install with NO zskills_version → 0 FAIL / 0 WARN (no version-recorded check)"
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "3c. valid legacy install with NO zskills_version → 0 FAIL (missing version is WARN, never FAIL)"
 else
-  fail "3c. valid legacy no-version" "expected 0 FAIL / 0 WARN; FAIL=$(grep '^FAIL' "$OUT") WARN=$(grep '^WARN' "$OUT")"
+  fail "3c. valid legacy no-version" "expected 0 FAIL; FAIL=$(grep '^FAIL' "$OUT")"
 fi
-if has_warn_id "$OUT" "legacy.version-recorded" || has_fail_id "$OUT" "legacy.version-recorded"; then
-  fail "3d. legacy version-recorded removed" "legacy.version-recorded check still present — should be cut per #1004"
+if has_warn_id "$OUT" "legacy.version-recorded"; then
+  pass "3d. legacy.version-recorded → WARN when zskills_version absent (#1124 plugin.json fallback makes absence abnormal)"
 else
-  pass "3d. legacy.version-recorded check removed (no false-positive WARN on untagged clone)"
+  fail "3d. legacy version-recorded WARN" "expected WARN on legacy.version-recorded; records=$(grep -E '^(WARN|FAIL)' "$OUT")"
+fi
+
+# ── LEGACY valid + zskills_version PRESENT (#1124): the recorded version is ───
+# reported as a PASS on legacy.version-recorded, with NO WARN on that id. Uses
+# the good-install fixture (its config carries zskills_version: 2026.06.0).
+LVV="$(make_legacy_good 4b)"
+git_init_fixture "$LVV"
+OUT="$TMP/out-legacy-version-present.txt"
+run_cheap_capture "$LVV" "$OUT"
+if grep -q '^PASS	legacy.version-recorded	zskills_version recorded: 2026.06.0' "$OUT"; then
+  pass "3d2. legacy.version-recorded → PASS reporting the recorded version when present"
+else
+  fail "3d2. legacy version-recorded PASS" "expected PASS reporting 2026.06.0; records=$(grep version-recorded "$OUT")"
+fi
+if has_warn_id "$OUT" "legacy.version-recorded"; then
+  fail "3d3. legacy version-recorded no WARN when present" "unexpected WARN: $(grep version-recorded "$OUT")"
+else
+  pass "3d3. legacy.version-recorded → no WARN when zskills_version present"
 fi
 
 # ── LEGACY broken (B): a raw, UN-substituted {{TOKEN}} in managed.md → FAIL ───
@@ -399,9 +423,10 @@ else
   fail "4b. good plugin lane detect" "lane.detect not 'plugin': $(grep lane.detect "$OUT")"
 fi
 
-# ── PLUGIN valid + NO zskills_version (#1004): plugin seed config has no tag ──
-# A valid mirror-less plugin install whose seed config carries no zskills_version
-# must produce 0 FAIL AND 0 WARN — same zero-false-positive bar as legacy.
+# ── PLUGIN valid + NO zskills_version (#1124): same as legacy — after the ─────
+# plugin.json fallback, a missing zskills_version is abnormal → WARN (never
+# FAIL). The case must produce 0 FAIL but exactly the plugin.version-recorded
+# WARN.
 PNV="$(make_plugin_good 5)"
 cat > "$PNV/.claude/zskills-config.json" <<'JSON'
 { "project_name": "acme" }
@@ -410,15 +435,32 @@ JSON
 git_init_fixture "$PNV"
 OUT="$TMP/out-plugin-no-version.txt"
 run_cheap_capture "$PNV" "$OUT"
-if [ "$VI_FAIL" -eq 0 ] && [ "$VI_WARN" -eq 0 ]; then
-  pass "4c. valid plugin install with NO zskills_version → 0 FAIL / 0 WARN (no version-recorded check)"
+if [ "$VI_FAIL" -eq 0 ]; then
+  pass "4c. valid plugin install with NO zskills_version → 0 FAIL (missing version is WARN, never FAIL)"
 else
-  fail "4c. valid plugin no-version" "expected 0 FAIL / 0 WARN; FAIL=$(grep '^FAIL' "$OUT") WARN=$(grep '^WARN' "$OUT")"
+  fail "4c. valid plugin no-version" "expected 0 FAIL; FAIL=$(grep '^FAIL' "$OUT")"
 fi
-if has_warn_id "$OUT" "plugin.version-recorded" || has_fail_id "$OUT" "plugin.version-recorded"; then
-  fail "4d. plugin version-recorded removed" "plugin.version-recorded check still present — should be cut per #1004"
+if has_warn_id "$OUT" "plugin.version-recorded"; then
+  pass "4d. plugin.version-recorded → WARN when zskills_version absent (#1124)"
 else
-  pass "4d. plugin.version-recorded check removed (no false-positive WARN on untagged seed config)"
+  fail "4d. plugin version-recorded WARN" "expected WARN on plugin.version-recorded; records=$(grep -E '^(WARN|FAIL)' "$OUT")"
+fi
+
+# ── PLUGIN valid + zskills_version PRESENT (#1124): reported as PASS, no WARN. ─
+# Uses the good-plugin fixture (config carries zskills_version: 2026.06.0).
+PVV="$(make_plugin_good 5b)"
+git_init_fixture "$PVV"
+OUT="$TMP/out-plugin-version-present.txt"
+run_cheap_capture "$PVV" "$OUT"
+if grep -q '^PASS	plugin.version-recorded	zskills_version recorded: 2026.06.0' "$OUT"; then
+  pass "4d2. plugin.version-recorded → PASS reporting the recorded version when present"
+else
+  fail "4d2. plugin version-recorded PASS" "expected PASS reporting 2026.06.0; records=$(grep version-recorded "$OUT")"
+fi
+if has_warn_id "$OUT" "plugin.version-recorded"; then
+  fail "4d3. plugin version-recorded no WARN when present" "unexpected WARN: $(grep version-recorded "$OUT")"
+else
+  pass "4d3. plugin.version-recorded → no WARN when zskills_version present"
 fi
 
 # ── PLUGIN broken (A): strip a sentinel from one artifact → FAIL ─────────────


### PR DESCRIPTION
Closes #1124.

`zskills_version` mirrored into `.claude/zskills-config.json` came only from the latest git tag, so tagless-but-complete clones (shallow, never-tagged, plugin-cloned-without-tags) left it empty even after a successful `/update-zskills` — silently disabling the installed-vs-source version-skew nudge. The repo's version is available tag-free in `.claude-plugin/plugin.json`.

## Fix
- `resolve-repo-version.sh` resolution order is now **git tag → root `.claude-plugin/plugin.json` `version` → empty**. Dependency-free (no jq): bash-regex extract of the TOP-LEVEL `"version"` from the `zs` manifest head (first-match, anchored so a nested key isn't grabbed). Empty-signals-no-version exit-0 contract preserved for the truly-tagless-and-manifestless case. Header comment documents the fallback (and corrects a stale test cross-reference).
- **verify-install**: the "untagged clone legitimately lacks a version" carve-out no longer holds — now **WARNs** (never FAILs) on absent `zskills_version` and reports it when present (both lanes).
- SKILL.md empty-on-untagged prose flipped at the affected sites.

## Verification
Exercised in scratch clones: tagless+plugin.json → plugin.json version; tagged → tag wins; tagless+no-manifest → empty. Test deviation: the issue's cross-ref to `test-skill-version-delta.sh` was stale (it doesn't exercise this script); new assertions live in `test-update-zskills-version-surface.sh` (3b, incl. nested-key-not-picked) + `test-verify-install.sh` (WARN/PASS cases).

## Test plan
- [x] `bash tests/run-all.sh` — all #1124 suites green: version-surface 40/40, verify-install 43/43, version-delta 12/12, conformance 68/68.
- [x] Mirrors byte-identical; `metadata.version` bumped (`2026.06.05+129f56`).

Note: a pre-existing flaky dashboard suite (`test-monitor-state-queue-post-preservation.sh`) is unrelated to this change (zero dashboard code touched) — tracked separately in #1125.
