### PR TITLE
do: harden monitor-state test vs port squatters (#1125)

### DIFF
--- a/tests/test-monitor-state-queue-post-preservation.sh
+++ b/tests/test-monitor-state-queue-post-preservation.sh
@@ -85,17 +85,73 @@ trap cleanup EXIT INT TERM
 # Choose a base port keyed off $$ to spread across parallel test runs.
 BASE_PORT=$(( 21000 + ($$ % 500) ))
 
+# Probe /api/health once on a candidate port and confirm the responder is
+# OUR spawned process. Echoes the JSON's pid on a 200; empty string on
+# failure. Used both to gate readiness and to detect a foreign server
+# squatting on the port (the #1125 root cause): a foreign zskills_monitor
+# also answers /api/health 200, but with a DIFFERENT pid.
+_health_pid() {
+  local prt="$1" resp
+  resp=$(curl -sf -m 1 "http://127.0.0.1:$prt/api/health" 2>/dev/null) || return 1
+  printf '%s' "$resp" | python3 -c \
+    'import json,sys
+try:
+    print(json.load(sys.stdin).get("pid",""))
+except Exception:
+    pass' 2>/dev/null
+}
+
+# Start the monitor server under --main-root "$1", trying candidate ports
+# starting at "$2" and advancing until one binds cleanly to OUR process.
+#
+# A health 200 is NOT sufficient proof of readiness: a leftover/foreign
+# dashboard server may already hold the port, in which case our spawn dies
+# on EADDRINUSE while the foreign server answers the probe (#1125). We
+# therefore require the responder's reported pid to equal our spawned
+# SERVER_PID (ThreadingHTTPServer, no fork, so os.getpid() == $!), and we
+# treat a dead spawn as not-ready.
+#
+# On success: sets SERVER_PID to the live spawn, registers it in
+# TRACKED_PIDS, and prints the WORKING PORT on stdout (the caller MUST
+# capture it — the POST and the config default_port must target this
+# server, not the squatter). On exhausting all candidates: prints nothing
+# and returns 1.
 start_server() {
-  local mr="$1" prt="$2"
-  PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.server \
-    --main-root "$mr" --port "$prt" >>"$mr/server.log" 2>&1 &
-  SERVER_PID=$!
-  TRACKED_PIDS="$TRACKED_PIDS $SERVER_PID"
-  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-    if curl -sf -m 1 "http://127.0.0.1:$prt/api/health" >/dev/null 2>&1; then
+  local mr="$1" start_prt="$2"
+  local attempt prt pid
+  for attempt in 1 2 3 4 5; do
+    prt=$((start_prt + attempt - 1))
+    PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.server \
+      --main-root "$mr" --port "$prt" >>"$mr/server.log" 2>&1 &
+    SERVER_PID=$!
+    TRACKED_PIDS="$TRACKED_PIDS $SERVER_PID"
+    local _ ready=""
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        # Spawn already exited (e.g. EADDRINUSE -> _bind_or_die). Stop
+        # probing and move to the next candidate port.
+        break
+      fi
+      pid="$(_health_pid "$prt")"
+      if [ -n "$pid" ]; then
+        if [ "$pid" = "$SERVER_PID" ]; then
+          ready="yes"
+          break
+        else
+          # A foreign server answered on this port. Kill our (dead-or-soon)
+          # spawn and advance to the next candidate.
+          kill -TERM "$SERVER_PID" 2>/dev/null || true
+          break
+        fi
+      fi
+      sleep 0.25
+    done
+    if [ -n "$ready" ]; then
+      printf '%s' "$prt"
       return 0
     fi
-    sleep 0.25
+    # Reap a zombie spawn before retrying so it never leaks past cleanup.
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
   done
   return 1
 }
@@ -144,19 +200,30 @@ run_case() {
   local label="$1" seed_doc="$2" preserved_pred="$3"
 
   local MR="$TMP_ROOT/case-${label// /-}"
-  local PORT="$BASE_PORT"
-  BASE_PORT=$((BASE_PORT + 1))
+  local START_PORT="$BASE_PORT"
+  # start_server may try several candidate ports if any are squatted; budget
+  # the whole window so the next case's base never collides with a port this
+  # case ended up on.
+  BASE_PORT=$((BASE_PORT + 5))
   mkdir -p "$MR/.claude"
-  echo '{"dev_server": {"default_port": '"$PORT"'}}' > "$MR/.claude/zskills-config.json"
 
   seed_state "$MR" "$seed_doc"
   local seeded_updated_at
   seeded_updated_at=$(python3 -c "import json; print(json.load(open('$MR/.zskills/monitor-state.json')).get('updated_at',''))")
 
-  if ! start_server "$MR" "$PORT"; then
-    fail "$label: server did not start on port $PORT"
+  # start_server owns port selection: it advances past any foreign server
+  # squatting a candidate port (#1125) and echoes the WORKING port. The POST
+  # below MUST target that port so the write lands on THIS test's main-root.
+  local PORT
+  PORT=$(start_server "$MR" "$START_PORT")
+  if [ -z "$PORT" ]; then
+    fail "$label: server did not start (no free port near $START_PORT)"
     return
   fi
+  # Reflect the actual bind port in the config for consistency. The server
+  # binds via --port (which wins over config), so this is cosmetic, but keeps
+  # the on-disk config truthful for anything that reads it.
+  echo '{"dev_server": {"default_port": '"$PORT"'}}' > "$MR/.claude/zskills-config.json"
 
   # POST /api/queue with ONLY writable columns mutated; omits the
   # preserved key entirely. version "1.5" in the payload should be
@@ -272,5 +339,149 @@ echo "=== Phase 1 AC: queue-POST preserves issues.reconsider ==="
 run_case "issues.reconsider" \
   '{"version":"1.2","default_mode":"phase","updated_at":"2020-01-01T00:00:00+00:00","plans":{"drafted":[],"reviewed":[],"ready":[],"backlog":[],"discarded":[]},"issues":{"triage":[],"ready":[],"backlog":[],"reconsider":[42,99]}}' \
   'd.get("issues",{}).get("reconsider") == [42, 99]'
+
+# ---------------------------------------------------------------------------
+# Regression for #1125: a FOREIGN dashboard server squatting the candidate
+# port must NOT absorb this test's POST.
+#
+# Before the fix, start_server accepted any /api/health 200 as proof of its
+# own readiness. A leftover/foreign server on the port answered the probe,
+# our real spawn died on EADDRINUSE, and the POST was routed to the foreign
+# server — which wrote ITS OWN --main-root state, leaving our $MR at the
+# untouched seed (default_mode="phase", plans.ready=[]). The four POST-
+# dependent assertions then failed intermittently inside the full suite.
+#
+# This case forces that exact collision deterministically: it pre-binds a
+# foreign server (distinct --main-root, default_mode="foreign") on the port
+# the real server will first attempt, then drives the plans.skipped seed.
+# Post-fix, start_server rejects the foreign responder (pid mismatch),
+# advances to a free port, and the POST lands on $MR.
+#   - Pre-fix:  $MR stays at seed  -> these assertions FAIL.
+#   - Post-fix: $MR gets the POST   -> these assertions PASS,
+#               and the FOREIGN main-root is provably untouched.
+regression_foreign_squatter() {
+  local label="foreign-squatter-1125"
+
+  # The foreign server's own main-root + a marker state so we can prove the
+  # POST never reached it.
+  local FOREIGN_MR="$TMP_ROOT/foreign-${label}"
+  mkdir -p "$FOREIGN_MR/.claude"
+  seed_state "$FOREIGN_MR" \
+    '{"version":"1.2","default_mode":"foreign","updated_at":"2019-01-01T00:00:00+00:00","plans":{"drafted":[],"reviewed":[],"ready":[],"backlog":[],"discarded":[]},"issues":{"triage":[],"ready":[],"backlog":[]}}'
+
+  # Reserve a window and bind the foreign server on the FIRST port the real
+  # server will try (START_PORT). start_server (for the real server) must
+  # then skip past it.
+  local START_PORT="$BASE_PORT"
+  BASE_PORT=$((BASE_PORT + 6))
+  local FOREIGN_PORT="$START_PORT"
+
+  # Bind the foreign server directly (NOT via start_server, which would
+  # reject port reuse). Confirm it is actually answering before proceeding —
+  # otherwise the collision we are testing for would not occur and the case
+  # would be a tautology.
+  PYTHONPATH="$PKG_PARENT" python3 -m zskills_monitor.server \
+    --main-root "$FOREIGN_MR" --port "$FOREIGN_PORT" >>"$FOREIGN_MR/server.log" 2>&1 &
+  local FOREIGN_PID=$!
+  TRACKED_PIDS="$TRACKED_PIDS $FOREIGN_PID"
+  local _ foreign_up=""
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if [ "$(_health_pid "$FOREIGN_PORT")" = "$FOREIGN_PID" ]; then
+      foreign_up="yes"
+      break
+    fi
+    sleep 0.25
+  done
+  if [ -z "$foreign_up" ]; then
+    fail "$label: foreign server failed to bind port $FOREIGN_PORT (cannot exercise collision)"
+    return
+  fi
+
+  # Now run the real test case. Its main-root + seed mirror the plans.skipped
+  # AC case; the seed's default_mode is "phase" so a successful POST flipping
+  # it to "finish" is unambiguous proof the write landed HERE.
+  local MR="$TMP_ROOT/case-${label}"
+  mkdir -p "$MR/.claude"
+  seed_state "$MR" \
+    '{"version":"1.2","default_mode":"phase","updated_at":"2020-01-01T00:00:00+00:00","plans":{"drafted":[],"reviewed":[],"ready":[],"backlog":[],"discarded":[],"skipped":{"foo-plan":"already done"}},"issues":{"triage":[],"ready":[],"backlog":[]}}'
+
+  local PORT
+  PORT=$(start_server "$MR" "$START_PORT")
+  if [ -z "$PORT" ]; then
+    fail "$label: real server did not start (no free port near $START_PORT)"
+    return
+  fi
+  echo '{"dev_server": {"default_port": '"$PORT"'}}' > "$MR/.claude/zskills-config.json"
+
+  # The real server MUST have landed on a DIFFERENT port than the squatter.
+  if [ "$PORT" != "$FOREIGN_PORT" ]; then
+    pass "$label: real server advanced past foreign squatter (port $PORT != $FOREIGN_PORT)"
+  else
+    fail "$label: real server bound the squatted port $FOREIGN_PORT (should have skipped it)"
+  fi
+
+  local body
+  body='{
+    "default_mode": "finish",
+    "version": "1.5",
+    "plans": {"drafted": [], "reviewed": [], "ready": [{"slug":"new-plan"}], "backlog": [], "discarded": []},
+    "issues": {"triage": [42], "ready": [], "backlog": []}
+  }'
+  local CODE
+  CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    -H "Origin: http://127.0.0.1:$PORT" \
+    -H 'Content-Type: application/json' \
+    -d "$body" \
+    "http://127.0.0.1:$PORT/api/queue")
+  if [ "$CODE" = "200" ]; then
+    pass "$label: POST /api/queue returns 200"
+  else
+    fail "$label: POST /api/queue returned $CODE (expected 200)"
+  fi
+
+  # The write MUST have landed on OUR main-root.
+  local mine
+  mine=$(python3 - <<PY
+import json
+d = json.load(open("$MR/.zskills/monitor-state.json"))
+ready = d.get("plans",{}).get("ready") or []
+slug = ready[0].get("slug","") if ready else ""
+print("|".join([
+    "default_mode=" + str(d.get("default_mode")),
+    "plans_ready_slug=" + slug,
+]))
+PY
+)
+  if [[ "$mine" == *"default_mode=finish"* && "$mine" == *"plans_ready_slug=new-plan"* ]]; then
+    pass "$label: POST landed on OUR main-root ($mine)"
+  else
+    fail "$label: POST did NOT land on OUR main-root ($mine) — likely absorbed by foreign squatter"
+  fi
+
+  # The FOREIGN main-root MUST be untouched (proves no cross-write).
+  local theirs
+  theirs=$(python3 - <<PY
+import json
+d = json.load(open("$FOREIGN_MR/.zskills/monitor-state.json"))
+ready = d.get("plans",{}).get("ready") or []
+slug = ready[0].get("slug","") if ready else ""
+print("|".join([
+    "default_mode=" + str(d.get("default_mode")),
+    "plans_ready_slug=" + slug,
+]))
+PY
+)
+  if [[ "$theirs" == *"default_mode=foreign"* && "$theirs" == *"plans_ready_slug="* && "$theirs" != *"plans_ready_slug=new-plan"* ]]; then
+    pass "$label: foreign main-root untouched ($theirs)"
+  else
+    fail "$label: foreign main-root was mutated ($theirs) — POST leaked to squatter"
+  fi
+
+  stop_server "$MR/.zskills/dashboard-server.pid"
+}
+
+echo ""
+echo "=== Regression #1125: foreign port-squatter must not absorb the POST ==="
+regression_foreign_squatter
 
 print_summary_and_exit


### PR DESCRIPTION
Closes #1125.

`tests/test-monitor-state-queue-post-preservation.sh` intermittently failed its first sub-block (`plans.skipped`, 4 assertions) while structurally-identical later sub-blocks passed.

**Root cause (proven via `/investigate` with a deterministic repro):** `start_server()` trusted a bare `curl /api/health` 200 as proof its server was up, without verifying the responder's identity. The port is `BASE_PORT=$(( 21000 + ($$ % 500) ))` (21000–21499, first sub-block uses the base). When that port is held by a leftover/foreign dashboard server (happens inside the full suite, not clean standalone runs — hence intermittent), the real server dies on `EADDRINUSE` but the health probe passes against the **foreign** server; the POST lands on the foreign `--main-root` and the test's `$MR` file stays at the untouched seed (`default_mode=phase`, the exact reporter FAIL value). Test-harness bug only — `server.py` is correct (production `_bind_or_die` fails loudly on a busy port) and is **not** touched.

**Fix (test-file-only):** `start_server` now parses the `/api/health` `pid` (server.py:916) and requires it == the spawned `$SERVER_PID` (+`kill -0` liveness); on a foreign responder / dead spawn it retries the next free port and hands the working port back to `run_case` so the POST always targets this test's server. All spawned servers are reaped via the existing `TRACKED_PIDS`/cleanup trap.

**Regression test:** new `regression_foreign_squatter` case pre-binds a foreign server (distinct `--main-root`) to the port and asserts the POST lands on the test's own `$MR` (not the foreign root). Proven to FAIL against the pre-fix harness (22 passed / 3 failed) and PASS after.

**Verification:** full suite `bash tests/run-all.sh` → Overall 7664/7664 passed, 0 failed. Target test looped 20× → 20/20 (`25 passed, 0 failed` each). No existing assertions weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
