### PR TITLE
fix(hooks): materialiser-sentinel path (#1132) + push-gate multi-arg flag bypass (#1133)

### DIFF
--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # block-stale-skill-version.sh — PreToolUse Bash hook.
 #
 # Denies `git commit` when a staged skill's content hash no longer matches
@@ -338,7 +338,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.3
 # Block unsafe commands that agents should never use.
 # GENERIC safety layer — works in any project with zero configuration.
 # No external dependencies — bash only.
@@ -309,7 +309,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.1
+# zskills-hook-version: 2026.06.2
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -138,7 +138,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/hooks/_lib/git-tokenwalk.sh
+++ b/hooks/_lib/git-tokenwalk.sh
@@ -127,7 +127,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # block-stale-skill-version.sh — PreToolUse Bash hook.
 #
 # Denies `git commit` when a staged skill's content hash no longer matches
@@ -338,7 +338,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/hooks/block-unmaterialised-skill.sh
+++ b/hooks/block-unmaterialised-skill.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.0
+# zskills-hook-version: 2026.06.1
 # block-unmaterialised-skill.sh — UserPromptExpansion gate (#1128).
 #
 # PLUGIN-LANE-ONLY. Registered solely in hooks/hooks.json under the
@@ -27,10 +27,13 @@
 # as zs:add-block, NOT zsbd:); the zsbd marketplace plugin is delisted, so
 # zsbd: never matches a real consumer.
 #
-# NOT materialized iff $CLAUDE_PROJECT_DIR/.claude/verifier.md is absent OR
-# its first 3 lines lack the D20(a) materialiser sentinel prefix
+# NOT materialized iff $CLAUDE_PROJECT_DIR/.claude/agents/verifier.md is absent
+# OR its first 3 lines lack the D20(a) materialiser sentinel prefix
 # `zskills-materialised:` — the SAME signal the removed PreToolUse gate used /
-# detect-install-state.sh reads.
+# detect-install-state.sh reads. The materialiser writes the sentinel to
+# .claude/agents/verifier.md (session-start-materialise.sh:296), so this gate
+# MUST read that same path; reading the bare .claude/verifier.md made the
+# "materialised -> allow" branch unreachable on a real install (#1132).
 #
 # On block: emit a single-line ASCII reason (no quotes or newlines — they
 # break the JSON envelope), exit 0. Else exit 0 with no output.
@@ -82,7 +85,10 @@ esac
 # in hook subprocesses; fall back to pwd defensively). Windows-portable: no
 # /tmp, paths via $CLAUDE_PROJECT_DIR.
 PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-ARTIFACT="$PROJ/.claude/verifier.md"
+# Canonical materialiser sentinel path — MUST match the dest the materialiser
+# writes (session-start-materialise.sh:296 -> .claude/agents/verifier.md) and
+# the path detect-install-state.sh reads. See #1132.
+ARTIFACT="$PROJ/.claude/agents/verifier.md"
 if [ -f "$ARTIFACT" ] && head -n 3 "$ARTIFACT" 2>/dev/null | grep -Eq '^(#|<!--)[[:space:]]+zskills-materialised:[[:space:]]'; then
   # Materialized -> allow.
   exit 0

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.2
+# zskills-hook-version: 2026.06.3
 # Block unsafe commands that agents should never use.
 # GENERIC safety layer — works in any project with zero configuration.
 # No external dependencies — bash only.
@@ -309,7 +309,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/hooks/block-unsafe-project.sh
+++ b/hooks/block-unsafe-project.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.1
+# zskills-hook-version: 2026.06.2
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -138,7 +138,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -1,5 +1,5 @@
 #!/bin/bash
-# zskills-hook-version: 2026.06.1
+# zskills-hook-version: 2026.06.2
 # Block unsafe commands — PROJECT-SPECIFIC enforcement layer.
 # No external dependencies — bash and git only.
 #
@@ -138,7 +138,11 @@ is_git_subcommand() {
   ((i++))
   while [[ $i -lt $n && "${TOKENS[$i]:0:1}" == "-" ]]; do
     case "${TOKENS[$i]}" in
-      -C|-c) ((i+=2)) ;;
+      # Multi-arg git GLOBAL flags taking a SEPARATE-token value: skip flag +
+      # value (2 tokens) so the subcommand isn't misread as the flag's value —
+      # the push/commit gate bypass closed by #1133 (extends the -C-only #1037).
+      # `=`-fused forms (--git-dir=DIR) are one `-`-token -> `*)` 1-token arm.
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix) ((i+=2)) ;;
       *)     ((i+=1)) ;;
     esac
   done

--- a/tests/test-block-unmaterialised-skill.sh
+++ b/tests/test-block-unmaterialised-skill.sh
@@ -36,12 +36,17 @@ echo "=== block-unmaterialised-skill.sh (#1128): UserPromptExpansion init-gate =
 
 # Make a temp project dir; if $1=="materialized", stamp a sentinel verifier.md
 # carrying the D20(a) `zskills-materialised:` prefix in its first 3 lines.
+# The sentinel MUST be written to the CANONICAL path the materialiser uses
+# (.claude/agents/verifier.md, session-start-materialise.sh:296) — the path the
+# gate reads. Writing the bare .claude/verifier.md here is what masked #1132:
+# both fixture and (buggy) gate agreed on a path nothing real ever writes, so
+# the suite passed while every real install stayed permanently blocked.
 bm_make_proj() {
   local kind="$1" dir
   dir=$(mktemp -d)
-  mkdir -p "$dir/.claude"
+  mkdir -p "$dir/.claude/agents"
   if [ "$kind" = "materialized" ]; then
-    printf '# zskills-materialised: 2026.06.0\n# verifier.md\n\nbody\n' > "$dir/.claude/verifier.md"
+    printf '# zskills-materialised: 2026.06.0\n# verifier.md\n\nbody\n' > "$dir/.claude/agents/verifier.md"
   fi
   echo "$dir"
 }
@@ -87,6 +92,18 @@ bm_expect_allow "$BM_PROJ_NOTMAT" "zs:update-zskills" "zs:update-zskills (the cu
 
 # ALLOW: a zs:<skill> command when artifacts PRESENT (materialized).
 bm_expect_allow "$BM_PROJ_MAT" "zs:do" "zs:do, materialized"
+
+# DENY (#1132 regression): a sentinel written ONLY at the bare
+# .claude/verifier.md (the path the buggy gate read) with the canonical
+# .claude/agents/verifier.md ABSENT must STILL be treated as NOT materialized.
+# The materialiser only ever writes .claude/agents/verifier.md, so honoring the
+# bare path would let the broken pre-#1132 gate's masking fixture pass while
+# real installs stay blocked. If this case ALLOWs, the path regressed.
+BM_PROJ_WRONGPATH="$(mktemp -d)"
+mkdir -p "$BM_PROJ_WRONGPATH/.claude"
+printf '# zskills-materialised: 2026.06.0\n# verifier.md\n\nbody\n' > "$BM_PROJ_WRONGPATH/.claude/verifier.md"
+bm_expect_deny "$BM_PROJ_WRONGPATH" "zs:do" "zs:do, sentinel at WRONG bare path only (#1132)"
+rm -rf "$BM_PROJ_WRONGPATH"
 
 # ALLOW: a non-zskills command never matches (no ^zs: prefix), even when NOT
 # materialized.

--- a/tests/test-hooks-block-unsafe.sh
+++ b/tests/test-hooks-block-unsafe.sh
@@ -621,6 +621,31 @@ expect_allow "git -C /tmp/wt push --force-with-lease origin feat/x (worktree —
 expect_allow "git -C /tmp/wt push origin feat/x (worktree — #1037)" "git -C /tmp/wt push origin feat/x"
 expect_allow "cd /tmp/wt && git push --force-with-lease origin feat/x (cd form parity — #1037)" "cd /tmp/wt && git push --force-with-lease origin feat/x"
 
+# Issue #1133: the #1037 fix only taught is_git_subcommand's flag-skip loop
+# about `-C`/`-c`. Every OTHER multi-arg git GLOBAL flag with a SPACE-separated
+# value (`--git-dir <dir>`, `--work-tree <dir>`, `--namespace <ns>`,
+# `--exec-path <path>`, `--super-prefix <pfx>`) still fell through as a 1-token
+# flag, so its value was read as the subcommand and the push gate never fired —
+# a silent bypass of the same class. The `=`-fused form (`--git-dir=DIR`) is a
+# single `-`-prefixed token and was always handled correctly; only the
+# space-separated form bypassed.
+#
+# (a) SECURITY: every space-separated multi-arg flag form pushing to main must
+# DENY (fail-closed, no config = main_protected default). Pre-fix: silently
+# ALLOWED.
+expect_deny "git --git-dir /tmp/wt/.git push origin main (space form — #1133)" "git --git-dir /tmp/wt/.git push origin main"
+expect_deny "git --work-tree /tmp/wt push origin main (space form — #1133)" "git --work-tree /tmp/wt push origin main"
+expect_deny "git --namespace foo push origin main (space form — #1133)" "git --namespace foo push origin main"
+expect_deny "git --exec-path /tmp/wt push origin main (space form — #1133)" "git --exec-path /tmp/wt push origin main"
+expect_deny "git --super-prefix p/ push origin main (space form — #1133)" "git --super-prefix p/ push origin main"
+# The =-fused forms were already denied (single token) — pin that they stay so.
+expect_deny "git --git-dir=/tmp/wt/.git push origin main (fused form — #1133)" "git --git-dir=/tmp/wt/.git push origin main"
+# (b) ALLOWED: the same flags pushing a FEATURE branch must still ALLOW (the
+# value-token consumption must not over-block a legit feature push).
+expect_allow "git --git-dir /tmp/wt/.git push origin feat/x (space form — #1133)" "git --git-dir /tmp/wt/.git push origin feat/x"
+expect_allow "git --work-tree /tmp/wt push origin feat/x (space form — #1133)" "git --work-tree /tmp/wt push origin feat/x"
+expect_allow "git --namespace foo push origin feat/x (space form — #1133)" "git --namespace foo push origin feat/x"
+
 echo ""
 echo "=== Push: main-push block reads execution.main_protected from config ==="
 

--- a/tests/test-hooks-worktree-cd.sh
+++ b/tests/test-hooks-worktree-cd.sh
@@ -258,6 +258,26 @@ setup_project_test_on_main
 expect_project_allow "PR10/XCC14: git -C path diff on main" "git -C /tmp diff"
 teardown_project_test
 
+# XCC15 (#1133) — SPACE-separated multi-arg git GLOBAL flags before a commit
+# must skip the value token so `commit` is recognized as the subcommand → DENY
+# on main. Pre-#1133 the flag-skip loop only knew `-C`/`-c`, so the value was
+# misread as the subcommand and the commit gate never fired. The fused form
+# (XCC12) was always handled; these pin the space form.
+setup_project_test_on_main
+expect_project_deny "PR10/XCC15: git --git-dir <dir> commit on main (#1133)" "git --git-dir /x/.git commit -m msg"
+teardown_project_test
+setup_project_test_on_main
+expect_project_deny "PR10/XCC16: git --work-tree <dir> commit on main (#1133)" "git --work-tree /y commit -m msg"
+teardown_project_test
+setup_project_test_on_main
+expect_project_deny "PR10/XCC17: git --namespace <ns> commit on main (#1133)" "git --namespace foo commit -m msg"
+teardown_project_test
+# XCC18 (#1133) — space-form flag before a NON-mutating subcommand → ALLOW
+# (the value token must not be misread as a mutating subcommand).
+setup_project_test_on_main
+expect_project_allow "PR10/XCC18: git --git-dir <dir> log on main (#1133)" "git --git-dir /x/.git log"
+teardown_project_test
+
 # JSON quote-injection (round-1 DA-H-1): `git "commit" -m "x"` should still
 # DENY — the helper unwraps one quote layer on the subcommand token.
 setup_project_test_on_main


### PR DESCRIPTION
## Summary

Fixes two hook bugs surfaced by QE audit, both verified with re-run falsifying traces.

### #1132 (Critical) — materialiser-sentinel path mismatch
`hooks/block-unmaterialised-skill.sh` read the bare `$CLAUDE_PROJECT_DIR/.claude/verifier.md` to detect "materialised", but the SessionStart materialiser writes the sentinel to `.claude/agents/verifier.md` (`session-start-materialise.sh:296`). The gate's "materialised → allow" branch was therefore **unreachable on a real plugin install** — every `/zs:*` (except `/zs:update-zskills`) stayed permanently blocked even after a correct install + restart. The unit fixture stamped the *same wrong path*, so 6/6 passed while the real install was broken.

**Fix:** gate reads the canonical `.claude/agents/verifier.md`; fixture corrected; new regression case pins that a sentinel at the wrong bare path is still treated as NOT-materialised (deny).

### #1133 (High) — push/commit gate bypass via space-separated git global flags
`is_git_subcommand`'s flag-skip loop only consumed `-C`/`-c` as 2-token (flag+value) global flags. Space-separated `--git-dir DIR`, `--work-tree DIR`, `--namespace NS`, `--exec-path PATH`, `--super-prefix PFX` fell through as 1-token, so the value was misread as the subcommand and the `main_protected` push/commit gate never fired — same defect class as the original `-C` gap (#1037), which #1044's audit missed. (`=`-fused forms were always denied.)

**Fix:** extended the canonical arm in the source-of-truth `hooks/_lib/git-tokenwalk.sh` and propagated byte-identically to every inlined copy + `.claude/hooks/` mirrors. Hook-version stamps bumped on all changed registered hooks.

## Verification
- Independent verifier: full suite **7682/7682** (1 attended live-load skip), helper-drift **48/48**, source↔mirror byte-identical for all 3 pairs.
- #1133 falsifying matrix re-run live: all 5 space-form flags + fused + `-C` + bare now **DENY** push-to-main; feature-branch pushes still **ALLOW** (no over-block).
- #1132: `block-unmaterialised-skill.sh` reads `.claude/agents/verifier.md`; regression case passes; no other reader/writer of the bare path.
- No assertions weakened; +12 new assertions; scope = 12 files (hooks + 3 test suites).

Closes #1132
Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
