### PR TITLE
do: fresh-plugin config seed fixes (#1136/#1137) + qe bar

### DIFF
--- a/.claude/skills/qe-audit/SKILL.md
+++ b/.claude/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.06.03+050ebb"
+  version: "2026.06.06+32a321"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -260,6 +260,7 @@ If a candidate fails any of the 3, the agent stands down. Yield 0-1 issues is a 
 - "Test could be stronger" without a current masked defect
 - Latent bugs requiring infrastructure failure or rare race conditions
 - Defense-on-defense (closure-incomplete on test-matrix gap unless runtime exposed)
+- "Closure-incomplete WHEN runtime exposed" does NOT qualify for findings against an inherently-incomplete matcher (bash tokenizer, PATH shim, any string-gate over a Turing-complete grammar) — for those surfaces only common-path breakage or observed incidence qualifies (runtime exposure is permanently true and cannot be the trigger)
 
 **Filter — DO file:**
 - Real-impact bug observable in current sessions / sprint reports / memory anchors
@@ -300,7 +301,10 @@ If a candidate fails any of the 3, the agent stands down. Yield 0-1 issues is a 
    Low with clear fix) **that passed Step 5 verification**, create issues via
    `gh issue create`. Include: summary, root cause, suggested fix/test,
    severity, which commit introduced it, and the verification command/result
-   from Step 5.
+   from Step 5. Before filing each finding, RE-APPLY TIGHT-BAR Q2 ("real
+   user/agent plausibly hits this within ~1 month?") to the finding yourself
+   — delegating the bar to the finding agents does NOT re-assert it at your own
+   filing step, and a finding that fails Q2 here is dropped, not filed.
 
    **Issue body format — every filed issue MUST include near the top:**
 

--- a/hooks/session-start-materialise.sh
+++ b/hooks/session-start-materialise.sh
@@ -358,6 +358,9 @@ cfg = {
         "auto_fix": True,
         "max_fix_attempts": 2,
     },
+    "agents": {
+        "min_model": "auto",
+    },
     "output": {
         "plans_dir": "docs/plans",
         "issues_dir": "docs/issues",
@@ -385,6 +388,31 @@ PY
   else
     rm -f "$config_tmp"
     echo "zskills: failed to seed default zskills-config.json — managed.md will NOT be rendered" >&2
+  fi
+fi
+
+# ── Stamp zskills_version into the config (#1137, plugin-lane heal) ───────
+# On the plugin lane, /update-zskills Step F.5 (the only writer of
+# `zskills_version`) is unreachable, so the field is never recorded and
+# verify-install WARNs permanently. Mirror Step F.5 here: resolve the version
+# the SAME way (latest git tag, falling back to .claude-plugin/plugin.json's
+# `version` per #1124) and write it idempotently — only when absent OR when it
+# differs from the resolved value. Skip silently on an empty resolve (a
+# genuinely unversioned clone), matching Step F.5. Runs after the config is
+# ensured to exist, so it heals both fresh AND already-installed consumers.
+if [ -f "$CONFIG" ] && [ -f "$PLUGIN/skills/update-zskills/scripts/resolve-repo-version.sh" ]; then
+  resolved_ver="$(bash "$PLUGIN/skills/update-zskills/scripts/resolve-repo-version.sh" "$PLUGIN" 2>/dev/null || true)"
+  if [ -n "$resolved_ver" ]; then
+    current_ver="$("$PYTHON" -c 'import json,sys
+try:
+    print(json.load(open(sys.argv[1])).get("zskills_version", ""))
+except Exception:
+    print("")' "$CONFIG" 2>/dev/null || echo "")"
+    if [ "$current_ver" != "$resolved_ver" ]; then
+      bash "$PLUGIN/skills/update-zskills/scripts/json-set-string-field.sh" \
+        "$CONFIG" zskills_version "$resolved_ver" \
+        || echo "zskills: failed to stamp zskills_version into config" >&2
+    fi
   fi
 fi
 

--- a/skills/qe-audit/SKILL.md
+++ b/skills/qe-audit/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   bash/stress-test features to find bugs. Files GitHub issues for
   findings. Recurring via every SCHEDULE; stop/next manage it.
 metadata:
-  version: "2026.06.03+050ebb"
+  version: "2026.06.06+32a321"
 ---
 
 # /qe-audit [bash [area]] [every SCHEDULE] [now] | stop | next — Quality Engineering Audit
@@ -260,6 +260,7 @@ If a candidate fails any of the 3, the agent stands down. Yield 0-1 issues is a 
 - "Test could be stronger" without a current masked defect
 - Latent bugs requiring infrastructure failure or rare race conditions
 - Defense-on-defense (closure-incomplete on test-matrix gap unless runtime exposed)
+- "Closure-incomplete WHEN runtime exposed" does NOT qualify for findings against an inherently-incomplete matcher (bash tokenizer, PATH shim, any string-gate over a Turing-complete grammar) — for those surfaces only common-path breakage or observed incidence qualifies (runtime exposure is permanently true and cannot be the trigger)
 
 **Filter — DO file:**
 - Real-impact bug observable in current sessions / sprint reports / memory anchors
@@ -300,7 +301,10 @@ If a candidate fails any of the 3, the agent stands down. Yield 0-1 issues is a 
    Low with clear fix) **that passed Step 5 verification**, create issues via
    `gh issue create`. Include: summary, root cause, suggested fix/test,
    severity, which commit introduced it, and the verification command/result
-   from Step 5.
+   from Step 5. Before filing each finding, RE-APPLY TIGHT-BAR Q2 ("real
+   user/agent plausibly hits this within ~1 month?") to the finding yourself
+   — delegating the bar to the finding agents does NOT re-assert it at your own
+   filing step, and a finding that fails Q2 here is dropped, not filed.
 
    **Issue body format — every filed issue MUST include near the top:**
 

--- a/tests/test-sessionstart-materialise.sh
+++ b/tests/test-sessionstart-materialise.sh
@@ -206,6 +206,37 @@ else
   fail "13b. seeded config output check skipped: no config file"
 fi
 
+# 13c. Seeded config carries agents.min_model (#1136). Absence used to make
+# block-agents.sh exit 0 with NO enforcement, silently disabling the
+# never-Haiku floor on fresh plugin installs. The schema default is "auto".
+if [ -f "$SEED_CFG" ]; then
+  seed_min_model=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("agents",{}).get("min_model",""))' "$SEED_CFG" 2>/dev/null)
+  if [ "$seed_min_model" = "auto" ]; then
+    pass "13c. seeded config carries agents.min_model=auto (#1136)"
+  else
+    fail "13c. seeded config agents.min_model wrong: '$seed_min_model' (expected auto)"
+  fi
+else
+  fail "13c. seeded agents.min_model check skipped: no config file"
+fi
+
+# 13d. Materialiser stamps zskills_version into the config (#1137). On the
+# plugin lane /update-zskills Step F.5 is unreachable, so this is the only
+# writer. The test sets CLAUDE_PLUGIN_ROOT=$REPO_ROOT, which has a
+# .claude-plugin/plugin.json, so resolve-repo-version.sh returns a non-empty
+# value (latest tag, else plugin.json version) and the field IS written.
+if [ -f "$SEED_CFG" ]; then
+  seed_zver=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("zskills_version",""))' "$SEED_CFG" 2>/dev/null)
+  expected_zver=$(bash "$REPO_ROOT/skills/update-zskills/scripts/resolve-repo-version.sh" "$REPO_ROOT" 2>/dev/null || echo "")
+  if [ -n "$seed_zver" ] && [ "$seed_zver" = "$expected_zver" ]; then
+    pass "13d. materialiser stamped zskills_version=$seed_zver (#1137)"
+  else
+    fail "13d. zskills_version wrong: stamped='$seed_zver' expected='$expected_zver'"
+  fi
+else
+  fail "13d. zskills_version check skipped: no config file"
+fi
+
 # 14. All 5 artifacts materialised now that the render gate passes.
 if [ -f "$SEED/.claude/agents/verifier.md" ] \
    && [ -f "$SEED/.claude/agents/implementer.md" ] \
@@ -239,8 +270,12 @@ fi
 echo ""
 echo "=== Config seeding: existing config is NEVER clobbered ==="
 
-# A project that already has a config (any values) must keep it verbatim —
-# the materialiser only seeds when ABSENT.
+# A project that already has a config (any values) must keep its CHOSEN values
+# verbatim — the materialiser only SEEDS when ABSENT. The one permitted
+# additive change is the orthogonal zskills_version stamp (#1137), which heals
+# an already-installed plugin consumer each session; it never rewrites the
+# consumer's chosen execution/commit/etc. values. So we assert the consumer's
+# choices are preserved AND the only delta is the additive zskills_version.
 KEEP="$TMP/keepproj"
 mkdir -p "$KEEP/.claude"
 cp "$REPO_ROOT/CLAUDE_TEMPLATE.md" "$KEEP/"
@@ -257,16 +292,36 @@ cat > "$KEEP/.claude/zskills-config.json" <<'KEEPCFG'
   }
 }
 KEEPCFG
-KEEP_BEFORE=$(cat "$KEEP/.claude/zskills-config.json")
 
 env CLAUDE_PROJECT_DIR="$KEEP" CLAUDE_PLUGIN_ROOT="$REPO_ROOT" \
   bash "$REPO_ROOT/$MAT" 2>/dev/null
 
-KEEP_AFTER=$(cat "$KEEP/.claude/zskills-config.json")
-if [ "$KEEP_BEFORE" = "$KEEP_AFTER" ]; then
-  pass "17. existing config left byte-identical (never clobbered)"
+# The consumer's chosen values must be preserved verbatim; the ONLY allowed
+# delta is the additive zskills_version stamp.
+keep_preserved=$(python3 - "$KEEP/.claude/zskills-config.json" "$REPO_ROOT" <<'PY'
+import json, subprocess, sys
+cfg = json.load(open(sys.argv[1]))
+repo = sys.argv[2]
+expected_zver = subprocess.run(
+    ["bash", repo + "/skills/update-zskills/scripts/resolve-repo-version.sh", repo],
+    capture_output=True, text=True).stdout.strip()
+ok = (
+    cfg.get("$schema") == "./zskills-config.schema.json"
+    and cfg.get("project_name") == "my-existing-project"
+    and cfg.get("execution", {}).get("landing") == "cherry-pick"
+    and cfg.get("execution", {}).get("main_protected") is False
+    and cfg.get("execution", {}).get("branch_prefix") == "feat/"
+    # The ONLY new key permitted is zskills_version, set to the resolved value.
+    and cfg.get("zskills_version") == expected_zver
+    and set(cfg.keys()) - {"zskills_version"} == {"$schema", "project_name", "execution"}
+)
+print("ok" if ok else "bad:" + json.dumps(cfg))
+PY
+)
+if [ "$keep_preserved" = "ok" ]; then
+  pass "17. existing config: chosen values preserved; only additive zskills_version stamped"
 else
-  fail "17. existing config was modified by the materialiser"
+  fail "17. existing config clobbered or stamped wrong ($keep_preserved)"
 fi
 # 18. And no spurious seed notice for the existing-config case.
 if [ ! -f "$KEEP/.zskills/config-seeded-notice" ]; then


### PR DESCRIPTION
## Summary
Fixes two fresh-plugin-install config-seed gaps + tightens the qe-audit triage bar. All small, low-risk config-seed/prose changes surfaced this session.

### #1136 — seed `agents.min_model`
The SessionStart materialiser's seeded config omitted the `agents` block, so `block-agents.sh` exited 0 with **no enforcement** — the never-Haiku floor was silently off on every fresh plugin install. Seed now includes `"agents": {"min_model": "auto"}` (schema default + this repo's own value).

### #1137 — stamp `zskills_version`
On the plugin lane, `/update-zskills` Step F.5 (the only writer of `zskills_version`) is unreachable, and the materialiser never stamped it — so the field was **never recorded** and verify-install WARNed permanently. The materialiser now stamps `zskills_version` from the plugin root via `resolve-repo-version.sh` (the Step-F.5 resolver), idempotently when absent/stale — healing fresh AND already-installed plugin consumers each session.

### qe-audit triage bar
Added a do-NOT-file carve-out for **inherently-incomplete matchers** (the seam #1135 slipped through) + a Step-6 sentence telling the orchestrator to re-apply TIGHT-BAR Q2 to each finding before filing. Skill `metadata.version` bumped.

## Verification
Independent verifier: full suite **7680/7680**; the assertion-#17 rewrite confirmed **legitimate + stricter** (the additive `zskills_version` stamp invalidates the old byte-identity no-clobber check; the new form pins each chosen value and asserts the only delta is `zskills_version`); #1137 idempotency sound (writes only when absent/differs, skips on empty resolve); scope clean (4 files).

Closes #1136
Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
