### PR TITLE
docs: per-lane install write manifest — what gets written, what to commit

### DIFF
--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.11+b80a9b"
+  version: "2026.06.11+f62dee"
 ---
 
 # Update Z Skills Infrastructure
@@ -1309,7 +1309,9 @@ PY
     Then print the post-init footprint summary: exactly what was created
     (the `.zskills/` gitignore entry; the two `.zskills/` markers; the
     optional config + schema, only if accepted) and what A1.5 removed.
-    Exit 0.
+    End the summary with one line of commit guidance: commit the
+    `.gitignore` change (and `.claude/zskills-config.json` + its schema
+    sibling, if created); `.zskills/` stays untracked. Exit 0.
 
   **Update arm (init-done present) — A1.5 already ran; then:**
 
@@ -2405,6 +2407,11 @@ Per-skill versions:
   <name>          <metadata.version>  (new)
   <name>          <metadata.version>  (new)
   ...
+
+Commit the install: track the .claude/ files above (skills mirror, hooks,
+settings.json, rules, agents, config + schema), the scripts/ stubs, and the
+.gitignore change in git — the mirror IS the install. .zskills/ is runtime
+state; leave it untracked.
 
 Run /update-zskills to check for updates later.
 ```

--- a/docs/guides/installing-zskills.md
+++ b/docs/guides/installing-zskills.md
@@ -173,6 +173,41 @@ the plugin install you type `/zs:do`. If that translation is a recurring
 annoyance for your team, the `/update-zskills` install (bare names, matching the
 text) is the lower-friction choice.
 
+## What gets written — and what to commit
+
+Every file an install touches, and whether it belongs in git. The rule of
+thumb: everything under `.claude/` and `scripts/` is project-shared — commit
+it; everything under `.zskills/` is per-checkout runtime state — never commit
+it (and the `.gitignore` line that ignores it is itself a change you should
+commit).
+
+**Plugin install** (written by the one-time `/zs:update-zskills` init):
+
+| Path | Written when | Commit? |
+|---|---|---|
+| `.gitignore` (one `.zskills/` umbrella line) | init, always | ✅ Commit — the ignore rule belongs in the repo |
+| `.zskills/init-done`, `.zskills/setup-confirmed` | init, always | 🚫 Gitignored runtime state — never commit |
+| `.claude/zskills-config.json` | init, only if you accept the config offer | ✅ Commit — it's the project's shared settings |
+| `.claude/zskills-config.schema.json` | alongside the config | ✅ Commit — gives every teammate editor autocomplete |
+
+**`/update-zskills` install:**
+
+| Path | Written when | Commit? |
+|---|---|---|
+| `.claude/skills/` (the skills mirror) | the clone + copy step | ✅ Commit — the mirror *is* the install |
+| `.claude/hooks/` (safety hooks) | install | ✅ Commit |
+| `.claude/settings.json` (hook registrations, surgically merged) | install | ✅ Commit |
+| `.claude/rules/zskills/managed.md` (agent rules) | install; regenerated on update | ✅ Commit |
+| `.claude/agents/` (subagent definitions — `verifier.md`, `implementer.md`, plus the shipped support agents `Explore.md` and `canary-readonly.md`) | install | ✅ Commit |
+| `.claude/zskills-config.json` + `.claude/zskills-config.schema.json` | install (auto-detected) | ✅ Commit — shared project settings |
+| `scripts/` stubs (`test-all.sh`, `start-dev.sh`, `stop-dev.sh`, `post-create-worktree.sh`, `dev-port.sh`) and the four skill-version helpers | install, when missing (helpers also refresh when changed) | ✅ Commit — stubs are consumer-customizable (your edits survive updates); the version helpers are zskills-owned |
+| `.gitignore` (the `.zskills/` umbrella line, plus per-subdir runtime-state lines: `.zskills/tracking/`, `.zskills/dev-server.pid`, `.zskills/dev-server.log`) | install | ✅ Commit |
+| `.zskills/setup-confirmed` | install, written last | 🚫 Gitignored — never commit |
+
+(If the install's root-`CLAUDE.md` migration ran, it leaves a one-time
+`./CLAUDE.md.pre-zskills-migration` backup — review it, then delete it;
+don't commit it.)
+
 ## `.gitignore` guidance
 
 What to track depends on your install.

--- a/docs/guides/zskills-config.md
+++ b/docs/guides/zskills-config.md
@@ -61,9 +61,13 @@ hand-edited — see [What not to hand-edit](#what-not-to-hand-edit).
 Settings resolve through three tiers — **project > user > built-ins**:
 
 1. **Project** — `.claude/zskills-config.json` in the repo. Always wins.
+   This file (and its schema sibling) is meant to be **committed** — it's the
+   project's shared settings, and tracking it is how the whole team gets the
+   same test commands, landing mode, and timezone.
 2. **User** — `~/.claude/zskills-config.json`. Personal defaults that apply
    in any project that doesn't set its own value (e.g. your timezone, your
-   co-author trailer). Create it by hand; nothing writes it for you.
+   co-author trailer). Create it by hand; nothing writes it for you. It lives
+   outside the repo, so it's personal by construction — never committed.
 3. **Built-ins** — shipped defaults (timezone `UTC`, landing `direct`,
    output file `.test-results.txt`, port `8080`, …). This is why a
    zero-config project still works.

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.11+b80a9b"
+  version: "2026.06.11+f62dee"
 ---
 
 # Update Z Skills Infrastructure
@@ -1309,7 +1309,9 @@ PY
     Then print the post-init footprint summary: exactly what was created
     (the `.zskills/` gitignore entry; the two `.zskills/` markers; the
     optional config + schema, only if accepted) and what A1.5 removed.
-    Exit 0.
+    End the summary with one line of commit guidance: commit the
+    `.gitignore` change (and `.claude/zskills-config.json` + its schema
+    sibling, if created); `.zskills/` stays untracked. Exit 0.
 
   **Update arm (init-done present) — A1.5 already ran; then:**
 
@@ -2405,6 +2407,11 @@ Per-skill versions:
   <name>          <metadata.version>  (new)
   <name>          <metadata.version>  (new)
   ...
+
+Commit the install: track the .claude/ files above (skills mirror, hooks,
+settings.json, rules, agents, config + schema), the scripts/ stubs, and the
+.gitignore change in git — the mirror IS the install. .zskills/ is runtime
+state; leave it untracked.
 
 Run /update-zskills to check for updates later.
 ```


### PR DESCRIPTION
## Summary
User-requested clarity: every install path now states explicitly which files it writes and, per file, whether to commit or leave gitignored.

- installing-zskills.md: per-lane "What gets written — and what to commit" tables (verifier-audited row-by-row against the SKILL.md arms; 3 inaccuracies fixed during verification: full agents list incl. Explore/canary-readonly, stub-vs-helper update policy, all 4 legacy gitignore appends)
- zskills-config.md: project config+schema = commit; user-tier file lives outside the repo
- update-zskills SKILL.md: one commit-guidance line in the plugin-lane A7 footprint report + a commit block in the legacy Step G report template

## Test plan
- [x] Conformance 738/738; init oracle 59/59; catalog zero-drift; full suite 7723/7723 (headless basis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
