### PR TITLE
Part of #1155: zsh-safe arg/regex idiom for land-pr, do, run-plan (P0 subset)

### DIFF
--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.10+6dc07c"
+  version: "2026.06.11+0ebe97"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -281,6 +281,15 @@ fi
 # back-compat scalar (= ISSUE_NUMS[0] when non-empty, else empty).
 # claim-issue.sh rejects non-numeric input with exit 2; the `[0-9]+`
 # capture guarantees a bare integer.
+# zsh portability (#1155): on stock macOS, Claude Code snapshots zsh and
+# this fence executes under it. Without these options zsh leaves
+# $BASH_REMATCH empty after a `[[ =~ ]]` match (and indexes it 1-based),
+# so the captures below empty out AND the `${suffix#*"${BASH_REMATCH[0]}"}`
+# loop step becomes a no-op — an infinite loop on multi-ref descriptions
+# (#1155 validated rc=124). KSH_ARRAYS + BASH_REMATCH restore bash
+# semantics; the `[ -n "${BASH_REMATCH[0]-}" ] || break` guards below are a
+# belt-and-braces no-op under bash. No-op under bash (ZSH_VERSION unset).
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 ISSUE_NUMS=()
 _DO_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
 _DO_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
@@ -318,6 +327,7 @@ fi
 # filler, 5=digit capture.
 if [ "$_DO_HAS_ANCHOR" -eq 1 ]; then
   while [[ "$_DO_CHAIN_SUFFIX" =~ ^[[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
+    [ -n "${BASH_REMATCH[0]-}" ] || break
     ISSUE_NUMS+=("${BASH_REMATCH[5]}")
     _DO_CHAIN_SUFFIX="${_DO_CHAIN_SUFFIX#*"${BASH_REMATCH[0]}"}"
   done
@@ -330,6 +340,7 @@ unset _DO_HAS_ANCHOR _DO_CHAIN_SUFFIX
 # 4=kw inner, 5=optional filler, 6=digit capture.
 _DO_REMAINING="$ARGUMENTS"
 while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; do
+  [ -n "${BASH_REMATCH[0]-}" ] || break
   ISSUE_NUMS+=("${BASH_REMATCH[6]}")
   _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
 done

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.06.10+a49ae6"
+  version: "2026.06.11+e73556"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -61,6 +61,12 @@ skill's `requires.land-pr.<id>` marker — `/run-plan` PR mode passes this;
 the other 3 callers do not, preserving their no-fulfillment behavior).
 
 ```bash
+# zsh portability (#1155): on stock macOS, Claude Code snapshots zsh and
+# this fence executes under it. zsh defaults to 1-based arrays, so the
+# 0-based `${ARGS[$i]}` indexing below mis-parses every arg. KSH_ARRAYS
+# makes zsh arrays 0-based, matching bash. No-op under bash (ZSH_VERSION
+# unset). `|| true` so a future zsh without these options can't abort.
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 ARGS=( "$@" )
 BRANCH=""
 TITLE=""

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.11+6db6d0"
+  version: "2026.06.12+a8a29a"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -92,6 +92,13 @@ through multi-phase plans autonomously.
 3. Fallback: `cherry-pick`
 
 ```bash
+# zsh portability (#1155): on stock macOS, Claude Code snapshots zsh and
+# this fence executes under it. zsh leaves $BASH_REMATCH empty after a
+# `[[ =~ ]]` match unless BASH_REMATCH is set, and indexes it 1-based
+# unless KSH_ARRAYS is set — so the `${BASH_REMATCH[1]}` capture below
+# silently empties and LANDING_MODE wrongly falls to cherry-pick. No-op
+# under bash (ZSH_VERSION unset).
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 # Detect landing mode
 # Resolve repo root before any config read. $PROJECT_ROOT is never exported
 # into a SKILL.md fence (it is only set inside post-run-invariants.sh, a
@@ -199,6 +206,10 @@ verbatim to every impl/verifier/fix-agent dispatch prompt. Three-case
 decision tree (same contract as `/verify-changes`):
 
 ```bash
+# zsh portability (#1155): same $BASH_REMATCH gap as the LANDING_MODE
+# fence above — without these options the `${BASH_REMATCH[1]}` capture is
+# silently empty under zsh and FULL_TEST_CMD is lost. No-op under bash.
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 FULL_TEST_CMD=""
 if [ -f "$PROJECT_ROOT/.claude/zskills-config.json" ]; then

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.10+6dc07c"
+  version: "2026.06.11+0ebe97"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -281,6 +281,15 @@ fi
 # back-compat scalar (= ISSUE_NUMS[0] when non-empty, else empty).
 # claim-issue.sh rejects non-numeric input with exit 2; the `[0-9]+`
 # capture guarantees a bare integer.
+# zsh portability (#1155): on stock macOS, Claude Code snapshots zsh and
+# this fence executes under it. Without these options zsh leaves
+# $BASH_REMATCH empty after a `[[ =~ ]]` match (and indexes it 1-based),
+# so the captures below empty out AND the `${suffix#*"${BASH_REMATCH[0]}"}`
+# loop step becomes a no-op — an infinite loop on multi-ref descriptions
+# (#1155 validated rc=124). KSH_ARRAYS + BASH_REMATCH restore bash
+# semantics; the `[ -n "${BASH_REMATCH[0]-}" ] || break` guards below are a
+# belt-and-braces no-op under bash. No-op under bash (ZSH_VERSION unset).
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 ISSUE_NUMS=()
 _DO_ISSUE_KW='([cC][lL][oO][sS][eE][sSdD]?|[fF][iI][xX]([eE][sSdD])?|[rR][eE][sS][oO][lL][vV][eE][sSdD]?)'
 _DO_ISSUE_FILLER='([iI][sS][sS][uU][eE][sS]?:?[[:space:]]+)?'
@@ -318,6 +327,7 @@ fi
 # filler, 5=digit capture.
 if [ "$_DO_HAS_ANCHOR" -eq 1 ]; then
   while [[ "$_DO_CHAIN_SUFFIX" =~ ^[[:space:]]*[/+\&][[:space:]]*(${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER})?#([0-9]+) ]]; do
+    [ -n "${BASH_REMATCH[0]-}" ] || break
     ISSUE_NUMS+=("${BASH_REMATCH[5]}")
     _DO_CHAIN_SUFFIX="${_DO_CHAIN_SUFFIX#*"${BASH_REMATCH[0]}"}"
   done
@@ -330,6 +340,7 @@ unset _DO_HAS_ANCHOR _DO_CHAIN_SUFFIX
 # 4=kw inner, 5=optional filler, 6=digit capture.
 _DO_REMAINING="$ARGUMENTS"
 while [[ "$_DO_REMAINING" =~ ([[:space:]]*[,\;][[:space:]]*|[[:space:]](and|or|AND|OR|And|Or)[[:space:]]+)${_DO_ISSUE_KW}[[:space:]]+${_DO_ISSUE_FILLER}#([0-9]+) ]]; do
+  [ -n "${BASH_REMATCH[0]-}" ] || break
   ISSUE_NUMS+=("${BASH_REMATCH[6]}")
   _DO_REMAINING="${_DO_REMAINING#*"${BASH_REMATCH[0]}"}"
 done

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.06.10+a49ae6"
+  version: "2026.06.11+e73556"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -61,6 +61,12 @@ skill's `requires.land-pr.<id>` marker — `/run-plan` PR mode passes this;
 the other 3 callers do not, preserving their no-fulfillment behavior).
 
 ```bash
+# zsh portability (#1155): on stock macOS, Claude Code snapshots zsh and
+# this fence executes under it. zsh defaults to 1-based arrays, so the
+# 0-based `${ARGS[$i]}` indexing below mis-parses every arg. KSH_ARRAYS
+# makes zsh arrays 0-based, matching bash. No-op under bash (ZSH_VERSION
+# unset). `|| true` so a future zsh without these options can't abort.
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 ARGS=( "$@" )
 BRANCH=""
 TITLE=""

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.11+6db6d0"
+  version: "2026.06.12+a8a29a"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -92,6 +92,13 @@ through multi-phase plans autonomously.
 3. Fallback: `cherry-pick`
 
 ```bash
+# zsh portability (#1155): on stock macOS, Claude Code snapshots zsh and
+# this fence executes under it. zsh leaves $BASH_REMATCH empty after a
+# `[[ =~ ]]` match unless BASH_REMATCH is set, and indexes it 1-based
+# unless KSH_ARRAYS is set — so the `${BASH_REMATCH[1]}` capture below
+# silently empties and LANDING_MODE wrongly falls to cherry-pick. No-op
+# under bash (ZSH_VERSION unset).
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 # Detect landing mode
 # Resolve repo root before any config read. $PROJECT_ROOT is never exported
 # into a SKILL.md fence (it is only set inside post-run-invariants.sh, a
@@ -199,6 +206,10 @@ verbatim to every impl/verifier/fix-agent dispatch prompt. Three-case
 decision tree (same contract as `/verify-changes`):
 
 ```bash
+# zsh portability (#1155): same $BASH_REMATCH gap as the LANDING_MODE
+# fence above — without these options the `${BASH_REMATCH[1]}` capture is
+# silently empty under zsh and FULL_TEST_CMD is lost. No-op under bash.
+if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi
 PROJECT_ROOT="${PROJECT_ROOT:-$CLAUDE_PROJECT_DIR}"
 FULL_TEST_CMD=""
 if [ -f "$PROJECT_ROOT/.claude/zskills-config.json" ]; then


### PR DESCRIPTION
Part of #1155 (P0 subset only — the plan-scale remainder stays OPEN and is routed to /draft-plan)

## Scope
This PR fixes only the **3-fence P0 subset** of #1155. The full audit (~105 lines across ~23 skills + a conformance tripwire + a macOS-only shell-pin decision) remains open; that structural work is deferred to a plan, gated on a real-Mac shell-pin probe.

## Changes
A fence-local zsh guard `if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH 2>/dev/null || true; fi` (a strict no-op under bash) applied to exactly 3 fences, plus a `[ -n "${BASH_REMATCH[0]-}" ] || break` loop-progress guard in `/do`:
- `land-pr/SKILL.md` (~L79) — 0-based arg-index loop (broke every PR landing under zsh)
- `do/SKILL.md` (~L284) — issue-ref parser infinite-loop guard
- `run-plan/SKILL.md` (~L100 LANDING_MODE, ~L201 FULL_TEST_CMD) — silent-empty `BASH_REMATCH` captures

`.claude/skills/` mirror synced byte-identical; 3 SKILL.md version bumps.

## Test plan
- [x] bash↔zsh fence probes: identical results for each fence (correct arg parse / no hang rc≠124 / non-empty captures); guards are no-ops under bash
- [x] Conformance suite 738/738; full suite `bash tests/run-all.sh` — 7723/7723 pass
