### PR TITLE
Fix #1163: worktree-bootstrap stub/doc guidance (npm prepare; no node_modules symlink)

### DIFF
--- a/.claude/skills/create-worktree/SKILL.md
+++ b/.claude/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills/tracked / .zskills/worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.06.11+ec2b25"
+  version: "2026.06.12+e32c6d"
 ---
 
 # /create-worktree — Unified Worktree Creation
@@ -100,6 +100,15 @@ Codes 2/3/4 propagate from `.claude/skills/create-worktree/scripts/worktree-add-
 - `.zskills/worktreepurpose` is written iff `--purpose` was given.
 - Both files are untracked and not safe to commit — `.claude/skills/commit/scripts/land-phase.sh`
   refuses to clean up a worktree that has git-tracked copies of either.
+- The consumer `scripts/post-create-worktree.sh` stub runs LAST (the worktree
+  path is `$1`). This is THE place for per-project worktree bootstrap —
+  dependency install and git-hook setup (e.g. `npm i && npm run prepare`) so a
+  fresh worktree is commit-ready. A fresh worktree has no installed deps and no
+  installed hooks, so do the bootstrap in the stub rather than baking install
+  commands into agent dispatch prompts. **Never symlink `node_modules` from the
+  main repo** — a shared `node_modules` shares build-tool caches (vite / webpack
+  / esbuild) across worktrees and serves stale output; do a real install into
+  the worktree. See the stub's inline comments for the template.
 
 ## Pointer
 

--- a/.claude/skills/update-zskills/SKILL.md
+++ b/.claude/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.11+0c10da"
+  version: "2026.06.12+a14fcd"
 ---
 
 # Update Z Skills Infrastructure

--- a/.claude/skills/update-zskills/stubs/post-create-worktree.sh
+++ b/.claude/skills/update-zskills/stubs/post-create-worktree.sh
@@ -1,7 +1,38 @@
 #!/bin/bash
 # post-create-worktree.sh -- runs after a /create-worktree
 # invocation succeeds. Replace this no-op with your own setup
-# logic (cp .env.local, npm install, seed restore, etc.).
+# logic (cp .env.local, dependency install, seed restore, etc.).
+#
+# THIS IS THE place for per-project worktree bootstrap. A fresh
+# worktree is a clean checkout: it has NO node_modules, NO
+# generated dependency dirs, and NO git hooks installed (e.g. a
+# husky `.husky/_/` dir is absent until the project's prepare
+# step runs). If your project's git hooks aren't installed, every
+# `git commit` in the worktree fails. Bootstrap them HERE, once,
+# instead of baking install commands into agent dispatch prompts.
+#
+# Canonical npm shape (customize to YOUR project's commands):
+#
+#     set -euo pipefail
+#     WT_PATH="$1"
+#     cd "$WT_PATH"
+#     npm i              # install deps INTO the worktree
+#     npm run prepare    # install git hooks (husky etc.)
+#
+# Use whatever your project actually uses: `pnpm install`,
+# `yarn install`, `bundle install`, `poetry install`, a Makefile
+# target, etc. The point is to make the worktree commit-ready.
+#
+# DO NOT symlink node_modules from the main repo, e.g.
+#     ln -s ../main-repo/node_modules node_modules   # <-- DON'T
+# A symlinked node_modules shares build-tool state (vite / webpack
+# / esbuild caches, .vite, .cache dirs) between worktrees, which
+# causes stale-cache corruption: the worktree builds against the
+# main repo's cached modules and serves wrong output. Always do a
+# real install into the worktree (it's slower but correct). If
+# install time is the concern, prefer your package manager's own
+# cache/store (npm/pnpm/yarn keep a shared global cache that is
+# safe to share) over symlinking the project-local node_modules.
 #
 # Arguments (positional):
 #   $1  WT_PATH       absolute worktree path

--- a/docs/guides/installing-zskills.md
+++ b/docs/guides/installing-zskills.md
@@ -208,6 +208,29 @@ commit).
 `./CLAUDE.md.pre-zskills-migration` backup — review it, then delete it;
 don't commit it.)
 
+## Per-project worktree bootstrap
+
+zskills runs agent work in throwaway git worktrees (a fresh checkout per
+task). A fresh worktree has **no installed dependencies and no installed
+git hooks** — so if your project installs commit-time hooks (husky, a
+`prepare` script, etc.), every `git commit` in a fresh worktree fails until
+those hooks exist.
+
+`scripts/post-create-worktree.sh` is **THE place** for per-project worktree
+bootstrap. It's a consumer-customizable stub that `/create-worktree` runs
+once, right after a worktree is created, with the worktree path as `$1`.
+Put your dependency install and hook setup there — the canonical npm shape
+is `npm i && npm run prepare` (use your project's actual commands) — so a
+new worktree is commit-ready without baking install steps into agent
+dispatch prompts.
+
+**Do not symlink `node_modules` from the main repo into the worktree.**
+A shared `node_modules` shares build-tool caches (vite / webpack / esbuild
+`.vite`, `.cache`) across worktrees and causes stale-cache corruption. Do a
+real install into the worktree; rely on your package manager's shared global
+cache for speed instead of a project-local symlink. See the stub's inline
+comments for the full template.
+
 ## `.gitignore` guidance
 
 What to track depends on your install.

--- a/skills/create-worktree/SKILL.md
+++ b/skills/create-worktree/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   and sanitised .zskills/tracked / .zskills/worktreepurpose writes. Prints the
   worktree path on stdout.
 metadata:
-  version: "2026.06.11+ec2b25"
+  version: "2026.06.12+e32c6d"
 ---
 
 # /create-worktree — Unified Worktree Creation
@@ -100,6 +100,15 @@ Codes 2/3/4 propagate from `.claude/skills/create-worktree/scripts/worktree-add-
 - `.zskills/worktreepurpose` is written iff `--purpose` was given.
 - Both files are untracked and not safe to commit — `.claude/skills/commit/scripts/land-phase.sh`
   refuses to clean up a worktree that has git-tracked copies of either.
+- The consumer `scripts/post-create-worktree.sh` stub runs LAST (the worktree
+  path is `$1`). This is THE place for per-project worktree bootstrap —
+  dependency install and git-hook setup (e.g. `npm i && npm run prepare`) so a
+  fresh worktree is commit-ready. A fresh worktree has no installed deps and no
+  installed hooks, so do the bootstrap in the stub rather than baking install
+  commands into agent dispatch prompts. **Never symlink `node_modules` from the
+  main repo** — a shared `node_modules` shares build-tool caches (vite / webpack
+  / esbuild) across worktrees and serves stale output; do a real install into
+  the worktree. See the stub's inline comments for the template.
 
 ## Pointer
 

--- a/skills/update-zskills/SKILL.md
+++ b/skills/update-zskills/SKILL.md
@@ -3,7 +3,7 @@ name: update-zskills
 argument-hint: "[install] [locked-main-pr|direct|cherry-pick]"
 description: Install or update Z Skills supporting infrastructure (CLAUDE.md rules, hooks, scripts)
 metadata:
-  version: "2026.06.11+0c10da"
+  version: "2026.06.12+a14fcd"
 ---
 
 # Update Z Skills Infrastructure

--- a/skills/update-zskills/stubs/post-create-worktree.sh
+++ b/skills/update-zskills/stubs/post-create-worktree.sh
@@ -1,7 +1,38 @@
 #!/bin/bash
 # post-create-worktree.sh -- runs after a /create-worktree
 # invocation succeeds. Replace this no-op with your own setup
-# logic (cp .env.local, npm install, seed restore, etc.).
+# logic (cp .env.local, dependency install, seed restore, etc.).
+#
+# THIS IS THE place for per-project worktree bootstrap. A fresh
+# worktree is a clean checkout: it has NO node_modules, NO
+# generated dependency dirs, and NO git hooks installed (e.g. a
+# husky `.husky/_/` dir is absent until the project's prepare
+# step runs). If your project's git hooks aren't installed, every
+# `git commit` in the worktree fails. Bootstrap them HERE, once,
+# instead of baking install commands into agent dispatch prompts.
+#
+# Canonical npm shape (customize to YOUR project's commands):
+#
+#     set -euo pipefail
+#     WT_PATH="$1"
+#     cd "$WT_PATH"
+#     npm i              # install deps INTO the worktree
+#     npm run prepare    # install git hooks (husky etc.)
+#
+# Use whatever your project actually uses: `pnpm install`,
+# `yarn install`, `bundle install`, `poetry install`, a Makefile
+# target, etc. The point is to make the worktree commit-ready.
+#
+# DO NOT symlink node_modules from the main repo, e.g.
+#     ln -s ../main-repo/node_modules node_modules   # <-- DON'T
+# A symlinked node_modules shares build-tool state (vite / webpack
+# / esbuild caches, .vite, .cache dirs) between worktrees, which
+# causes stale-cache corruption: the worktree builds against the
+# main repo's cached modules and serves wrong output. Always do a
+# real install into the worktree (it's slower but correct). If
+# install time is the concern, prefer your package manager's own
+# cache/store (npm/pnpm/yarn keep a shared global cache that is
+# safe to share) over symlinking the project-local node_modules.
 #
 # Arguments (positional):
 #   $1  WT_PATH       absolute worktree path


### PR DESCRIPTION
Fixes #1163

## Changes
The evaluator's highest-frequency tax (8+ incidents): fresh worktrees lack the project's husky/install bootstrap → every commit fails; agents invented `npx husky install` + `ln -s node_modules`, and the symlink corrupted vite/build caches. The consumer hook point already existed (`post-create-worktree.sh`) but lacked guidance.

- `skills/update-zskills/stubs/post-create-worktree.sh` — stub comments now show the canonical `npm i && npm run prepare` shape (generic; customize per project) and an explicit **DO-NOT-symlink-`node_modules`** warning with the stale-build-cache rationale. Stays a no-op stub.
- `skills/create-worktree/SKILL.md` — bullet naming the stub as THE bootstrap hook point + no-symlink warning.
- `docs/guides/installing-zskills.md` — new per-project-worktree-bootstrap section.

A repo-wide sweep confirmed there were **no** pre-existing symlink/husky suggestions to remove — the pattern was agent-invented; this adds guidance so they stop.

## Test plan
- [x] `tests/test-skill-conformance.sh` 738/738 (hardcode discipline clean), invariants 119/119
- [x] Full suite `bash tests/run-all.sh` — 7738/7738
