### PR TITLE
Fix #1164: claim-plan/claim-issue arg aliases + named test-cmd candidate

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.10+27ecdf"
+  version: "2026.06.12+0c837a"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/.claude/skills/fix-issues/scripts/claim-issue.sh
+++ b/.claude/skills/fix-issues/scripts/claim-issue.sh
@@ -7,8 +7,16 @@
 # (NEVER $PWD — the per-issue dispatch fence in /fix-issues runs from a
 # sprint worktree, so $PWD points at the wrong root at acquire time).
 #
+# Arg-spelling alias (#1164): the pipeline-id flag is accepted under BOTH
+# spellings --pipeline-id and --require-pipeline on the acquire AND release
+# verbs. They are pure aliases — same value, no behavior change — so a
+# caller that mixes spellings across verbs (the historical
+# acquire=--pipeline-id, release=--require-pipeline asymmetry) no longer
+# hits an "unknown arg" usage error.
+#
 # Subcommands:
 #   acquire <N> --pipeline-id <id> --sprint-id <id>
+#     (--require-pipeline accepted as an alias for --pipeline-id)
 #     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
 #               claim — the stored pipeline_id matches --pipeline-id).
 #     Exit 2  — usage error.
@@ -17,6 +25,7 @@
 #     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
 #               (EACCES/ENOSPC/EDQUOT/EROFS/...).
 #   release <N> [--require-pipeline <id>]
+#     (--pipeline-id accepted as an alias for --require-pipeline)
 #     Exit 0  — released (or already absent — idempotent).
 #     Exit 2  — usage error.
 #     Exit 12 — release pipeline-id mismatch (claim left intact).
@@ -166,7 +175,10 @@ cmd_acquire() {
   n="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      # --require-pipeline accepted as an alias for --pipeline-id (#1164):
+      # release spells the same value --require-pipeline, so accept both
+      # spellings on every verb. Pure alias — no behavior change.
+      --pipeline-id|--require-pipeline) pipeline_id="${2:-}"; shift 2 ;;
       --sprint-id)   sprint_id="${2:-}"; shift 2 ;;
       *) echo "fix-issues claim-issue.sh acquire: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -270,7 +282,10 @@ cmd_release() {
   n="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --require-pipeline) require_pipeline="${2:-}"; shift 2 ;;
+      # --pipeline-id accepted as an alias for --require-pipeline (#1164):
+      # acquire spells the same value --pipeline-id, so accept both
+      # spellings on every verb. Pure alias — no behavior change.
+      --require-pipeline|--pipeline-id) require_pipeline="${2:-}"; shift 2 ;;
       *) echo "fix-issues claim-issue.sh release: unknown arg '$1'" >&2; return 2 ;;
     esac
   done

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.12+a8a29a"
+  version: "2026.06.12+cddf24"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -225,17 +225,63 @@ if [ -n "$FULL_TEST_CMD" ]; then
 else
   # Check for test infra (same list as preflight hook-placeholder gate):
   # package.json with a "test" script, vitest/jest/pytest configs,
-  # Makefile, tests/*.sh, tests/*.py, tests/*.js.
+  # Makefile, tests/*.sh, tests/*.py, tests/*.js. When infra is found,
+  # also record a concrete CANDIDATE command (#1164) so the Case-2 refusal
+  # can NAME a next step instead of dead-ending — "test infra detected but
+  # empty" with no concrete command left an overnight /run-plan stuck.
   TEST_INFRA_DETECTED=0
-  [ -f "$PROJECT_ROOT/package.json" ] && grep -q '"test"[[:space:]]*:' "$PROJECT_ROOT/package.json" && TEST_INFRA_DETECTED=1
-  ls "$PROJECT_ROOT"/vitest.config.* "$PROJECT_ROOT"/jest.config.* "$PROJECT_ROOT"/pytest.ini \
-     "$PROJECT_ROOT"/.mocharc.* "$PROJECT_ROOT"/Makefile 2>/dev/null | grep -q . && TEST_INFRA_DETECTED=1
-  ls "$PROJECT_ROOT/tests"/*.sh "$PROJECT_ROOT/tests"/*.py "$PROJECT_ROOT/tests"/*.js 2>/dev/null | grep -q . && TEST_INFRA_DETECTED=1
+  TEST_CMD_CANDIDATE=""
+  if [ -f "$PROJECT_ROOT/package.json" ] && grep -q '"test"[[:space:]]*:' "$PROJECT_ROOT/package.json"; then
+    TEST_INFRA_DETECTED=1
+    [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npm test"
+  fi
+  if ls "$PROJECT_ROOT"/vitest.config.* 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npx vitest run"
+  fi
+  if ls "$PROJECT_ROOT"/jest.config.* "$PROJECT_ROOT"/.mocharc.* 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npm test"
+  fi
+  if [ -f "$PROJECT_ROOT/pytest.ini" ]; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="pytest"
+  fi
+  if [ -f "$PROJECT_ROOT/Makefile" ] && grep -q '^test:' "$PROJECT_ROOT/Makefile"; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="make test"
+  fi
+  if ls "$PROJECT_ROOT/tests"/*.sh 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1
+    if [ -z "$TEST_CMD_CANDIDATE" ]; then
+      if [ -f "$PROJECT_ROOT/tests/run-all.sh" ]; then
+        TEST_CMD_CANDIDATE="bash tests/run-all.sh"
+      else
+        TEST_CMD_CANDIDATE="bash tests/*.sh"
+      fi
+    fi
+  fi
+  if ls "$PROJECT_ROOT/tests"/*.py 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="pytest"
+  fi
+  if ls "$PROJECT_ROOT/tests"/*.js 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npm test"
+  fi
 
   if [ "$TEST_INFRA_DETECTED" -eq 1 ]; then
-    # Case 2: tests exist but no command — misconfigured. Refuse.
+    # Case 2: tests exist but no command configured. NAME the detected
+    # candidate (#1164) so the user has a concrete next step — the bare
+    # "empty" message previously dead-ended an overnight /run-plan.
     echo "ERROR: /run-plan: test infra detected but testing.full_cmd is empty." >&2
-    echo "  Run /update-zskills to configure, or edit .claude/zskills-config.json." >&2
+    echo "  Detected test infra; a likely command is: ${TEST_CMD_CANDIDATE}" >&2
+    echo "  Set it in .claude/zskills-config.json under testing.full_cmd, e.g.:" >&2
+    echo "      \"testing\": { \"full_cmd\": \"${TEST_CMD_CANDIDATE}\" }" >&2
+    echo "  Or run /update-zskills to configure interactively. Verify the" >&2
+    echo "  candidate matches your project before using it." >&2
+    # Interactive auto-write offer (#1164): the auto-write is intentionally
+    # NOT performed here — this resolution runs in a non-interactive,
+    # config-read-only fence with no consent/prompt affordance to hook
+    # into, and writing config without explicit consent is forbidden. When
+    # /run-plan is driven interactively, the orchestrator SHOULD offer to
+    # write testing.full_cmd=${TEST_CMD_CANDIDATE} (project tier) on the
+    # user's confirmation before re-running. A standalone consented
+    # auto-write affordance is tracked as a smaller follow-up.
     exit 1
   else
     # Case 3: no test infra, no command — docs-only/greenfield. Skip test gate.

--- a/.claude/skills/run-plan/scripts/claim-plan.sh
+++ b/.claude/skills/run-plan/scripts/claim-plan.sh
@@ -11,8 +11,16 @@
 # (NEVER $PWD — /run-plan PR-mode dispatches run from a worktree so $PWD
 # points at the wrong root; DA4.1 / DA7 invariant).
 #
+# Arg-spelling alias (#1164): the pipeline-id flag is accepted under BOTH
+# spellings --pipeline-id and --require-pipeline on EVERY verb
+# (acquire/release/set-phase). They are pure aliases — same value, no
+# behavior change — so a caller that mixes spellings across verbs (the
+# historical acquire=--pipeline-id, release=--require-pipeline asymmetry)
+# no longer hits an "unknown arg" usage error.
+#
 # Subcommands:
 #   acquire <slug> --pipeline-id <id> [--dispatch-mode <mode>]
+#     (--require-pipeline accepted as an alias for --pipeline-id)
 #     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
 #               claim — the stored pipeline_id matches --pipeline-id).
 #     Exit 2  — usage error (bad slug, missing flags, invalid dispatch-mode).
@@ -30,6 +38,7 @@
 #     Sibling to #858 (the wrapper-lifetime batch_mode signal); this
 #     field covers the claim's full duration.
 #   release <slug> --require-pipeline <id>
+#     (--pipeline-id accepted as an alias for --require-pipeline)
 #     Exit 0  — released (or already absent — idempotent).
 #     Exit 2  — usage error.
 #     Exit 12 — release pipeline-id mismatch (claim left intact).
@@ -233,7 +242,10 @@ cmd_acquire() {
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      # --require-pipeline is an accepted alias for --pipeline-id (#1164):
+      # release/set-phase spell the same value --require-pipeline, so accept
+      # both spellings on every verb. Pure alias — no behavior change.
+      --pipeline-id|--require-pipeline) pipeline_id="${2:-}"; shift 2 ;;
       --dispatch-mode) dispatch_mode="${2:-}"; shift 2 ;;
       *) echo "run-plan claim-plan.sh acquire: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -426,7 +438,10 @@ cmd_release() {
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --require-pipeline) require_pipeline="${2:-}"; shift 2 ;;
+      # --pipeline-id is an accepted alias for --require-pipeline (#1164):
+      # acquire spells the same value --pipeline-id, so accept both
+      # spellings on every verb. Pure alias — no behavior change.
+      --require-pipeline|--pipeline-id) require_pipeline="${2:-}"; shift 2 ;;
       *) echo "run-plan claim-plan.sh release: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -481,7 +496,8 @@ cmd_set_phase() {
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --require-pipeline) require_pipeline="${2:-}"; shift 2 ;;
+      # --pipeline-id alias accepted for symmetry (#1164).
+      --require-pipeline|--pipeline-id) require_pipeline="${2:-}"; shift 2 ;;
       --current-phase)    current_phase="${2:-}"; current_phase_set=1; shift 2 ;;
       *) echo "run-plan claim-plan.sh set-phase: unknown arg '$1'" >&2; return 2 ;;
     esac

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.10+27ecdf"
+  version: "2026.06.12+0c837a"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint

--- a/skills/fix-issues/scripts/claim-issue.sh
+++ b/skills/fix-issues/scripts/claim-issue.sh
@@ -7,8 +7,16 @@
 # (NEVER $PWD — the per-issue dispatch fence in /fix-issues runs from a
 # sprint worktree, so $PWD points at the wrong root at acquire time).
 #
+# Arg-spelling alias (#1164): the pipeline-id flag is accepted under BOTH
+# spellings --pipeline-id and --require-pipeline on the acquire AND release
+# verbs. They are pure aliases — same value, no behavior change — so a
+# caller that mixes spellings across verbs (the historical
+# acquire=--pipeline-id, release=--require-pipeline asymmetry) no longer
+# hits an "unknown arg" usage error.
+#
 # Subcommands:
 #   acquire <N> --pipeline-id <id> --sprint-id <id>
+#     (--require-pipeline accepted as an alias for --pipeline-id)
 #     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
 #               claim — the stored pipeline_id matches --pipeline-id).
 #     Exit 2  — usage error.
@@ -17,6 +25,7 @@
 #     Exit 11 — non-EEXIST mkdir failure / fs error / atomic-write failure
 #               (EACCES/ENOSPC/EDQUOT/EROFS/...).
 #   release <N> [--require-pipeline <id>]
+#     (--pipeline-id accepted as an alias for --require-pipeline)
 #     Exit 0  — released (or already absent — idempotent).
 #     Exit 2  — usage error.
 #     Exit 12 — release pipeline-id mismatch (claim left intact).
@@ -166,7 +175,10 @@ cmd_acquire() {
   n="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      # --require-pipeline accepted as an alias for --pipeline-id (#1164):
+      # release spells the same value --require-pipeline, so accept both
+      # spellings on every verb. Pure alias — no behavior change.
+      --pipeline-id|--require-pipeline) pipeline_id="${2:-}"; shift 2 ;;
       --sprint-id)   sprint_id="${2:-}"; shift 2 ;;
       *) echo "fix-issues claim-issue.sh acquire: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -270,7 +282,10 @@ cmd_release() {
   n="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --require-pipeline) require_pipeline="${2:-}"; shift 2 ;;
+      # --pipeline-id accepted as an alias for --require-pipeline (#1164):
+      # acquire spells the same value --pipeline-id, so accept both
+      # spellings on every verb. Pure alias — no behavior change.
+      --require-pipeline|--pipeline-id) require_pipeline="${2:-}"; shift 2 ;;
       *) echo "fix-issues claim-issue.sh release: unknown arg '$1'" >&2; return 2 ;;
     esac
   done

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.12+a8a29a"
+  version: "2026.06.12+cddf24"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -225,17 +225,63 @@ if [ -n "$FULL_TEST_CMD" ]; then
 else
   # Check for test infra (same list as preflight hook-placeholder gate):
   # package.json with a "test" script, vitest/jest/pytest configs,
-  # Makefile, tests/*.sh, tests/*.py, tests/*.js.
+  # Makefile, tests/*.sh, tests/*.py, tests/*.js. When infra is found,
+  # also record a concrete CANDIDATE command (#1164) so the Case-2 refusal
+  # can NAME a next step instead of dead-ending — "test infra detected but
+  # empty" with no concrete command left an overnight /run-plan stuck.
   TEST_INFRA_DETECTED=0
-  [ -f "$PROJECT_ROOT/package.json" ] && grep -q '"test"[[:space:]]*:' "$PROJECT_ROOT/package.json" && TEST_INFRA_DETECTED=1
-  ls "$PROJECT_ROOT"/vitest.config.* "$PROJECT_ROOT"/jest.config.* "$PROJECT_ROOT"/pytest.ini \
-     "$PROJECT_ROOT"/.mocharc.* "$PROJECT_ROOT"/Makefile 2>/dev/null | grep -q . && TEST_INFRA_DETECTED=1
-  ls "$PROJECT_ROOT/tests"/*.sh "$PROJECT_ROOT/tests"/*.py "$PROJECT_ROOT/tests"/*.js 2>/dev/null | grep -q . && TEST_INFRA_DETECTED=1
+  TEST_CMD_CANDIDATE=""
+  if [ -f "$PROJECT_ROOT/package.json" ] && grep -q '"test"[[:space:]]*:' "$PROJECT_ROOT/package.json"; then
+    TEST_INFRA_DETECTED=1
+    [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npm test"
+  fi
+  if ls "$PROJECT_ROOT"/vitest.config.* 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npx vitest run"
+  fi
+  if ls "$PROJECT_ROOT"/jest.config.* "$PROJECT_ROOT"/.mocharc.* 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npm test"
+  fi
+  if [ -f "$PROJECT_ROOT/pytest.ini" ]; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="pytest"
+  fi
+  if [ -f "$PROJECT_ROOT/Makefile" ] && grep -q '^test:' "$PROJECT_ROOT/Makefile"; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="make test"
+  fi
+  if ls "$PROJECT_ROOT/tests"/*.sh 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1
+    if [ -z "$TEST_CMD_CANDIDATE" ]; then
+      if [ -f "$PROJECT_ROOT/tests/run-all.sh" ]; then
+        TEST_CMD_CANDIDATE="bash tests/run-all.sh"
+      else
+        TEST_CMD_CANDIDATE="bash tests/*.sh"
+      fi
+    fi
+  fi
+  if ls "$PROJECT_ROOT/tests"/*.py 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="pytest"
+  fi
+  if ls "$PROJECT_ROOT/tests"/*.js 2>/dev/null | grep -q .; then
+    TEST_INFRA_DETECTED=1; [ -z "$TEST_CMD_CANDIDATE" ] && TEST_CMD_CANDIDATE="npm test"
+  fi
 
   if [ "$TEST_INFRA_DETECTED" -eq 1 ]; then
-    # Case 2: tests exist but no command — misconfigured. Refuse.
+    # Case 2: tests exist but no command configured. NAME the detected
+    # candidate (#1164) so the user has a concrete next step — the bare
+    # "empty" message previously dead-ended an overnight /run-plan.
     echo "ERROR: /run-plan: test infra detected but testing.full_cmd is empty." >&2
-    echo "  Run /update-zskills to configure, or edit .claude/zskills-config.json." >&2
+    echo "  Detected test infra; a likely command is: ${TEST_CMD_CANDIDATE}" >&2
+    echo "  Set it in .claude/zskills-config.json under testing.full_cmd, e.g.:" >&2
+    echo "      \"testing\": { \"full_cmd\": \"${TEST_CMD_CANDIDATE}\" }" >&2
+    echo "  Or run /update-zskills to configure interactively. Verify the" >&2
+    echo "  candidate matches your project before using it." >&2
+    # Interactive auto-write offer (#1164): the auto-write is intentionally
+    # NOT performed here — this resolution runs in a non-interactive,
+    # config-read-only fence with no consent/prompt affordance to hook
+    # into, and writing config without explicit consent is forbidden. When
+    # /run-plan is driven interactively, the orchestrator SHOULD offer to
+    # write testing.full_cmd=${TEST_CMD_CANDIDATE} (project tier) on the
+    # user's confirmation before re-running. A standalone consented
+    # auto-write affordance is tracked as a smaller follow-up.
     exit 1
   else
     # Case 3: no test infra, no command — docs-only/greenfield. Skip test gate.

--- a/skills/run-plan/scripts/claim-plan.sh
+++ b/skills/run-plan/scripts/claim-plan.sh
@@ -11,8 +11,16 @@
 # (NEVER $PWD — /run-plan PR-mode dispatches run from a worktree so $PWD
 # points at the wrong root; DA4.1 / DA7 invariant).
 #
+# Arg-spelling alias (#1164): the pipeline-id flag is accepted under BOTH
+# spellings --pipeline-id and --require-pipeline on EVERY verb
+# (acquire/release/set-phase). They are pure aliases — same value, no
+# behavior change — so a caller that mixes spellings across verbs (the
+# historical acquire=--pipeline-id, release=--require-pipeline asymmetry)
+# no longer hits an "unknown arg" usage error.
+#
 # Subcommands:
 #   acquire <slug> --pipeline-id <id> [--dispatch-mode <mode>]
+#     (--require-pipeline accepted as an alias for --pipeline-id)
 #     Exit 0  — acquired-fresh OR self-re-entry (caller already owns this
 #               claim — the stored pipeline_id matches --pipeline-id).
 #     Exit 2  — usage error (bad slug, missing flags, invalid dispatch-mode).
@@ -30,6 +38,7 @@
 #     Sibling to #858 (the wrapper-lifetime batch_mode signal); this
 #     field covers the claim's full duration.
 #   release <slug> --require-pipeline <id>
+#     (--pipeline-id accepted as an alias for --require-pipeline)
 #     Exit 0  — released (or already absent — idempotent).
 #     Exit 2  — usage error.
 #     Exit 12 — release pipeline-id mismatch (claim left intact).
@@ -233,7 +242,10 @@ cmd_acquire() {
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --pipeline-id) pipeline_id="${2:-}"; shift 2 ;;
+      # --require-pipeline is an accepted alias for --pipeline-id (#1164):
+      # release/set-phase spell the same value --require-pipeline, so accept
+      # both spellings on every verb. Pure alias — no behavior change.
+      --pipeline-id|--require-pipeline) pipeline_id="${2:-}"; shift 2 ;;
       --dispatch-mode) dispatch_mode="${2:-}"; shift 2 ;;
       *) echo "run-plan claim-plan.sh acquire: unknown arg '$1'" >&2; return 2 ;;
     esac
@@ -426,7 +438,10 @@ cmd_release() {
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --require-pipeline) require_pipeline="${2:-}"; shift 2 ;;
+      # --pipeline-id is an accepted alias for --require-pipeline (#1164):
+      # acquire spells the same value --pipeline-id, so accept both
+      # spellings on every verb. Pure alias — no behavior change.
+      --require-pipeline|--pipeline-id) require_pipeline="${2:-}"; shift 2 ;;
       *) echo "run-plan claim-plan.sh release: unknown arg '$1'" >&2; return 2 ;;
     esac
   done
@@ -481,7 +496,8 @@ cmd_set_phase() {
   raw_slug="$1"; shift
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --require-pipeline) require_pipeline="${2:-}"; shift 2 ;;
+      # --pipeline-id alias accepted for symmetry (#1164).
+      --require-pipeline|--pipeline-id) require_pipeline="${2:-}"; shift 2 ;;
       --current-phase)    current_phase="${2:-}"; current_phase_set=1; shift 2 ;;
       *) echo "run-plan claim-plan.sh set-phase: unknown arg '$1'" >&2; return 2 ;;
     esac

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -281,6 +281,7 @@ run_suite "test-fix-issues-claim-race-baseline.sh" "tests/test-fix-issues-claim-
 run_suite "test-fix-issues-claim-conformance.sh" "tests/test-fix-issues-claim-conformance.sh"
 run_suite "test-fix-issues-claim-regression-single.sh" "tests/test-fix-issues-claim-regression-single.sh"
 run_suite "test-plan-claim-script.sh" "tests/test-plan-claim-script.sh"
+run_suite "test-run-plan-test-cmd-candidate.sh" "tests/test-run-plan-test-cmd-candidate.sh"
 run_suite "test-plan-claim-race-baseline.sh" "tests/test-plan-claim-race-baseline.sh"
 run_suite "test-plan-claim-hook-deny.sh" "tests/test-plan-claim-hook-deny.sh"
 run_suite "test-plan-claim-main-root-anchor.sh" "tests/test-plan-claim-main-root-anchor.sh"

--- a/tests/test-fix-issues-claim-script.sh
+++ b/tests/test-fix-issues-claim-script.sh
@@ -554,6 +554,57 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# Test 14: Arg-spelling alias (#1164) — --pipeline-id and
+# --require-pipeline are interchangeable on BOTH acquire AND release.
+#   14a. acquire accepts --require-pipeline (the release spelling).
+#   14b. release accepts --pipeline-id (the acquire spelling) and matches.
+#   14c. mismatched value via the alias spelling is still refused (12).
+# ───────────────────────────────────────────────────────────────────────
+t14_root="$SCRATCH_ROOT/t14"
+make_repo "$t14_root"
+(
+  cd "$t14_root" || exit 1
+  # 14a: acquire with --require-pipeline alias.
+  out=$(bash "$CLAIM_SH" acquire 800 --require-pipeline pipe-A --sprint-id sprint-A 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL_REASON acquire --require-pipeline alias returned $rc, out: $out"
+    exit 1
+  fi
+  cf="$t14_root/.zskills/claims/issue-800/claim.json"
+  if [ ! -f "$cf" ]; then
+    echo "FAIL_REASON claim.json not written after --require-pipeline acquire"
+    exit 1
+  fi
+  pipe=$("${ZSKILLS_PYTHON:-python3}" -c "import json; print(json.load(open('$cf'))['pipeline_id'])")
+  if [ "$pipe" != "pipe-A" ]; then
+    echo "FAIL_REASON pipeline_id=$pipe, expected pipe-A"
+    exit 1
+  fi
+  # 14b: release with --pipeline-id alias, matching value -> rc 0, removed.
+  out=$(bash "$CLAIM_SH" release 800 --pipeline-id pipe-A 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ] || [ -d "$t14_root/.zskills/claims/issue-800" ]; then
+    echo "FAIL_REASON release --pipeline-id alias rc=$rc, dir still present? $([ -d "$t14_root/.zskills/claims/issue-800" ] && echo yes || echo no); out: $out"
+    exit 1
+  fi
+  # 14c: mismatched value via alias spelling -> still refused (12), intact.
+  bash "$CLAIM_SH" acquire 801 --pipeline-id pipe-A --sprint-id sprint-A >/dev/null
+  out=$(bash "$CLAIM_SH" release 801 --pipeline-id pipe-WRONG 2>&1)
+  rc=$?
+  if [ "$rc" -ne 12 ] || [ ! -d "$t14_root/.zskills/claims/issue-801" ]; then
+    echo "FAIL_REASON mismatch via alias rc=$rc (expected 12), dir present? $([ -d "$t14_root/.zskills/claims/issue-801" ] && echo yes || echo no); out: $out"
+    exit 1
+  fi
+  exit 0
+)
+if [ "$?" -eq 0 ]; then
+  pass "arg-spelling alias: --pipeline-id/--require-pipeline interchangeable on acquire+release; mismatch still refused (#1164)"
+else
+  fail "arg-spelling alias (#1164)" "see FAIL_REASON above"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/test-plan-claim-script.sh
+++ b/tests/test-plan-claim-script.sh
@@ -340,6 +340,62 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# 26. Arg-spelling alias (#1164): --pipeline-id and --require-pipeline are
+# interchangeable on BOTH acquire AND release.
+#   26a. acquire accepts --require-pipeline (the release spelling).
+#   26b. release accepts --pipeline-id (the acquire spelling) and matches.
+#   26c. cross-spelling round-trip: acquire --require-pipeline X then
+#        release --pipeline-id X succeeds; mismatched value still refused.
+# ───────────────────────────────────────────────────────────────────────
+REPO_ALIAS="$SCRATCH_ROOT/r_alias"
+make_repo "$REPO_ALIAS" || { echo "FATAL repo init"; exit 1; }
+
+# 26a. acquire with --require-pipeline (alias for --pipeline-id).
+(cd "$REPO_ALIAS" && bash "$CLAIM_SH" acquire aliasacq --require-pipeline "run-plan.alias") 2>/dev/null
+rc_acq_alias=$?
+ALIAS_FILE="$REPO_ALIAS/.zskills/claims/plan-aliasacq/claim.json"
+ALIAS_PIPE=""
+[ -f "$ALIAS_FILE" ] && ALIAS_PIPE=$("$PYTHON" -c "import json; print(json.load(open('$ALIAS_FILE'))['pipeline_id'])")
+if [ "$rc_acq_alias" -eq 0 ] && [ "$ALIAS_PIPE" = "run-plan.alias" ]; then
+  pass "acquire accepts --require-pipeline alias (rc=0, pipeline_id persisted) (#1164)"
+else
+  fail "acquire --require-pipeline alias" "rc=$rc_acq_alias pipeline_id=<$ALIAS_PIPE>"
+fi
+
+# 26b. release with --pipeline-id (alias for --require-pipeline), matching
+# value — must succeed and remove the claim dir.
+(cd "$REPO_ALIAS" && bash "$CLAIM_SH" release aliasacq --pipeline-id "run-plan.alias") 2>/dev/null
+rc_rel_alias=$?
+if [ "$rc_rel_alias" -eq 0 ] && [ ! -d "$REPO_ALIAS/.zskills/claims/plan-aliasacq" ]; then
+  pass "release accepts --pipeline-id alias and matches (rc=0, claim removed) (#1164)"
+else
+  fail "release --pipeline-id alias" "rc=$rc_rel_alias dir=$([ -d "$REPO_ALIAS/.zskills/claims/plan-aliasacq" ] && echo yes || echo no)"
+fi
+
+# 26c. The alias is a pure value-passthrough: a MISMATCHED value supplied
+# via the alias spelling is still refused with exit 12 (no behavior
+# change — the alias only changes the accepted flag name, not the check).
+(cd "$REPO_ALIAS" && bash "$CLAIM_SH" acquire aliasmm --pipeline-id "run-plan.right") 2>/dev/null
+(cd "$REPO_ALIAS" && bash "$CLAIM_SH" release aliasmm --pipeline-id "run-plan.wrong") 2>/dev/null
+rc_rel_mm=$?
+if [ "$rc_rel_mm" -eq 12 ] && [ -d "$REPO_ALIAS/.zskills/claims/plan-aliasmm" ]; then
+  pass "release --pipeline-id alias still refuses mismatched value (rc=12, claim intact) (#1164)"
+else
+  fail "release --pipeline-id alias mismatch" "rc=$rc_rel_mm dir=$([ -d "$REPO_ALIAS/.zskills/claims/plan-aliasmm" ] && echo yes || echo no)"
+fi
+
+# 26d. set-phase also accepts --pipeline-id as an alias for
+# --require-pipeline (full-verb symmetry).
+(cd "$REPO_ALIAS" && bash "$CLAIM_SH" set-phase aliasmm --pipeline-id "run-plan.right" --current-phase "Phase 2 — aliased") 2>/dev/null
+rc_sp_alias=$?
+SP_ALIAS_PHASE=$("$PYTHON" -c "import json; print(json.load(open('$REPO_ALIAS/.zskills/claims/plan-aliasmm/claim.json'))['current_phase'])" 2>/dev/null)
+if [ "$rc_sp_alias" -eq 0 ] && [ "$SP_ALIAS_PHASE" = "Phase 2 — aliased" ]; then
+  pass "set-phase accepts --pipeline-id alias (rc=0, phase updated) (#1164)"
+else
+  fail "set-phase --pipeline-id alias" "rc=$rc_sp_alias phase=<$SP_ALIAS_PHASE>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""

--- a/tests/test-run-plan-test-cmd-candidate.sh
+++ b/tests/test-run-plan-test-cmd-candidate.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# tests/test-run-plan-test-cmd-candidate.sh — #1164.
+#
+# Behavioral regression for the /run-plan FULL_TEST_CMD three-case
+# resolution fence in skills/run-plan/SKILL.md. The Case-2 refusal ("test
+# infra detected but testing.full_cmd is empty") previously dead-ended an
+# overnight /run-plan with no concrete next step. The fix NAMES a detected
+# candidate command in the refusal so the user can set testing.full_cmd.
+#
+# This test EXTRACTS the resolution fence from the SKILL.md and RUNS it
+# against fixture project roots, asserting:
+#   - Case 1 (config set): TEST_MODE=config, no refusal.
+#   - Case 2 (infra, no cmd): exit 1, refusal NAMES a concrete candidate.
+#   - Case 3 (no infra): TEST_MODE=skipped, exit 0, no refusal.
+#   - Candidate selection: package.json "test" -> "npm test";
+#     tests/run-all.sh -> "bash tests/run-all.sh"; pytest.ini -> "pytest".
+#
+# The fence is extracted between two stable landmarks so a SKILL.md edit
+# that drops the candidate naming makes this test fail loudly.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/run-plan/SKILL.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+SCRATCH_ROOT="/tmp/test-run-plan-test-cmd-candidate-$$"
+cleanup() {
+  [ -n "${TEST_KEEP_SCRATCH:-}" ] && { echo "TEST_KEEP_SCRATCH set — leaving $SCRATCH_ROOT" >&2; return; }
+  [ -d "$SCRATCH_ROOT" ] && rm -rf "$SCRATCH_ROOT"
+}
+trap cleanup EXIT INT TERM
+mkdir -p "$SCRATCH_ROOT"
+
+[ -f "$SKILL_MD" ] || { echo "FATAL: SKILL.md not found at $SKILL_MD" >&2; exit 1; }
+
+# ───────────────────────────────────────────────────────────────────────
+# Extract the resolution fence. Landmarks:
+#   START: the line `FULL_TEST_CMD=""`
+#   END:   the closing ``` that terminates that bash fence.
+# We capture from the first `FULL_TEST_CMD=""` line through the next bare
+# ``` fence-close. This is the body of the three-case decision tree.
+# ───────────────────────────────────────────────────────────────────────
+FENCE="$SCRATCH_ROOT/fence.sh"
+awk '
+  /^FULL_TEST_CMD=""$/ { capture=1 }
+  capture && /^```[[:space:]]*$/ { exit }
+  capture { print }
+' "$SKILL_MD" > "$FENCE"
+
+if ! grep -q 'TEST_INFRA_DETECTED' "$FENCE"; then
+  fail "fence extraction" "extracted fence missing TEST_INFRA_DETECTED — landmark drift?"
+  echo ""
+  printf '\033[31mResults: %d passed, %d failed\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT"
+  exit 1
+fi
+pass "extracted resolution fence from SKILL.md"
+
+# Run the fence against a given PROJECT_ROOT. Captures combined stdout+stderr
+# to $OUT_FILE and the exit code to $RC. The fence reads PROJECT_ROOT and
+# emits TEST_MODE / refusal text; we echo TEST_MODE at the end for Case 1/3.
+run_fence() {
+  local proj="$1"
+  RC=0
+  OUT=$(
+    PROJECT_ROOT="$proj" CLAUDE_PROJECT_DIR="$proj" bash -c "
+      $(cat "$FENCE")
+      echo \"TEST_MODE_RESULT=\${TEST_MODE:-<unset>}\"
+    " 2>&1
+  ) || RC=$?
+}
+
+# ───────────────────────────────────────────────────────────────────────
+# Case 1: config sets testing.full_cmd -> TEST_MODE=config, rc 0.
+# ───────────────────────────────────────────────────────────────────────
+P1="$SCRATCH_ROOT/case1"
+mkdir -p "$P1/.claude"
+cat > "$P1/.claude/zskills-config.json" <<'JSON'
+{ "testing": { "full_cmd": "bash tests/run-all.sh" } }
+JSON
+run_fence "$P1"
+if [ "$RC" -eq 0 ] && echo "$OUT" | grep -q 'TEST_MODE_RESULT=config'; then
+  pass "Case 1: config set -> TEST_MODE=config, rc 0"
+else
+  fail "Case 1" "rc=$RC out=<$OUT>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Case 3: no infra, no config -> TEST_MODE=skipped, rc 0.
+# ───────────────────────────────────────────────────────────────────────
+P3="$SCRATCH_ROOT/case3"
+mkdir -p "$P3"
+run_fence "$P3"
+if [ "$RC" -eq 0 ] && echo "$OUT" | grep -q 'TEST_MODE_RESULT=skipped'; then
+  pass "Case 3: no infra -> TEST_MODE=skipped, rc 0"
+else
+  fail "Case 3" "rc=$RC out=<$OUT>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Case 2a: package.json with a "test" script -> rc 1, refusal NAMES
+# "npm test".
+# ───────────────────────────────────────────────────────────────────────
+P2a="$SCRATCH_ROOT/case2a"
+mkdir -p "$P2a"
+cat > "$P2a/package.json" <<'JSON'
+{ "scripts": { "test": "vitest run" } }
+JSON
+run_fence "$P2a"
+if [ "$RC" -eq 1 ] \
+   && echo "$OUT" | grep -q 'test infra detected but testing.full_cmd is empty' \
+   && echo "$OUT" | grep -q 'a likely command is: npm test'; then
+  pass "Case 2a: package.json test script -> rc 1, refusal names 'npm test' (#1164)"
+else
+  fail "Case 2a candidate naming" "rc=$RC out=<$OUT>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Case 2b: tests/run-all.sh -> rc 1, refusal NAMES "bash tests/run-all.sh".
+# ───────────────────────────────────────────────────────────────────────
+P2b="$SCRATCH_ROOT/case2b"
+mkdir -p "$P2b/tests"
+echo '#!/bin/bash' > "$P2b/tests/run-all.sh"
+run_fence "$P2b"
+if [ "$RC" -eq 1 ] \
+   && echo "$OUT" | grep -q 'a likely command is: bash tests/run-all.sh'; then
+  pass "Case 2b: tests/run-all.sh -> refusal names 'bash tests/run-all.sh' (#1164)"
+else
+  fail "Case 2b candidate naming" "rc=$RC out=<$OUT>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Case 2c: pytest.ini -> rc 1, refusal NAMES "pytest".
+# ───────────────────────────────────────────────────────────────────────
+P2c="$SCRATCH_ROOT/case2c"
+mkdir -p "$P2c"
+echo '[pytest]' > "$P2c/pytest.ini"
+run_fence "$P2c"
+if [ "$RC" -eq 1 ] && echo "$OUT" | grep -q 'a likely command is: pytest'; then
+  pass "Case 2c: pytest.ini -> refusal names 'pytest' (#1164)"
+else
+  fail "Case 2c candidate naming" "rc=$RC out=<$OUT>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Case 2d: the refusal also points at testing.full_cmd in the config and
+# names the candidate inside the JSON example (concrete, copy-pasteable).
+# ───────────────────────────────────────────────────────────────────────
+if echo "$OUT" | grep -q '"full_cmd": "pytest"' \
+   && echo "$OUT" | grep -q 'testing.full_cmd'; then
+  pass "Case 2: refusal shows a copy-pasteable testing.full_cmd JSON example (#1164)"
+else
+  fail "Case 2 JSON example" "out=<$OUT>"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '\033[32mResults: %d passed, 0 failed (%d total)\033[0m\n' "$PASS_COUNT" "$TOTAL"
+  exit 0
+else
+  printf '\033[31mResults: %d passed, %d failed (%d total)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$TOTAL"
+  exit 1
+fi

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -350,6 +350,13 @@ check_fixed run-plan "test-cmd: config.full_cmd read" 'full_cmd'
 check_fixed run-plan "test-cmd: TEST_MODE=config"     'TEST_MODE="config"'
 check_fixed run-plan "test-cmd: TEST_MODE=skipped"    'TEST_MODE="skipped"'
 check_fixed run-plan "test-cmd: misconfig refusal"    'test infra detected but testing.full_cmd is empty'
+# #1164: the Case-2 refusal must NAME the detected candidate — a bare
+# "empty" message dead-ended an overnight /run-plan. The detection block
+# records TEST_CMD_CANDIDATE and the refusal echoes it as a concrete next
+# step. Tripwire: any refactor that drops the candidate capture or stops
+# naming it in the refusal regresses the fix.
+check_fixed run-plan "test-cmd: refusal records candidate" 'TEST_CMD_CANDIDATE='
+check_fixed run-plan "test-cmd: refusal names candidate"   'a likely command is: ${TEST_CMD_CANDIDATE}'
 check       run-plan "test-cmd: no raw npm run test:all in exec paths" \
   '^[[:space:]]*>?[[:space:]]*\$FULL_TEST_CMD'
 # Same contract for /verify-changes.


### PR DESCRIPTION
Fixes #1164

## Changes
Two evaluator paper cuts:
1. **Arg asymmetry** — `claim-plan.sh` `acquire` took `--pipeline-id` but `release` wanted `--require-pipeline`. Both verbs (acquire/release/set-phase) now accept BOTH spellings (pure alias, no behavior change). Same trivial asymmetry fixed in the sibling `claim-issue.sh`. The ownership/mismatch check is untouched (mismatched value via either spelling is still refused).
2. **Dead-end refusal** — the Case-2 "test infra detected but `testing.full_cmd` is empty" message blocked an overnight `/run-plan` with no path forward. It now detects and **names** the concrete candidate (`npm test` / `bash tests/run-all.sh` / `pytest` / …) and prints a copy-pasteable `testing.full_cmd` JSON example. (Interactive consented auto-write left as a follow-up — no consent affordance in the read-only resolution fence.)

## Test plan
- [x] New `tests/test-run-plan-test-cmd-candidate.sh` (extracts + runs the fence) + extended claim-script alias tests
- [x] Full suite `bash tests/run-all.sh` — 7752/7752
