### PR TITLE
Fix #1161; part of #1162: pr-monitor grace window + GH_HOST host derivation

### DIFF
--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.12+0c837a"
+  version: "2026.06.12+c4f5cc"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -404,3 +404,17 @@ Do not proceed until you have read the file.
   instead of "reset mappings to defaults" because only the title was read.
 - **Ultrathink** — use careful, thorough reasoning. Read code, understand
   what changed and why, verify correctness.
+- **Enterprise GitHub host (#1162)** — before the inline `gh issue view` /
+  `gh issue close` calls, export `GH_HOST` from the repo's actual remote so
+  `gh` targets *your* host (not the github.com default) on a GitHub
+  Enterprise repo. Source the shared helper once near the top of the
+  sprint's gh-using shell (it exports `GH_HOST` when resolvable, fail-open
+  otherwise, and respects a pre-set value):
+
+  ```bash
+  if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh" ]; then
+    . "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh"
+  else
+    . "$CLAUDE_PROJECT_DIR/.claude/skills/land-pr/scripts/gh-host.sh"
+  fi
+  ```

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.06.11+e73556"
+  version: "2026.06.12+fc7540"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -233,6 +233,18 @@ PR_STATE="not-checked"
 REASON=""
 CONFLICT_FILES_LIST=""
 CALL_ERROR_FILE=""
+
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin ONCE, up
+# front, so every inline `gh` call in this skill (Step 2 resume `gh pr
+# view`, Step 6b/6c auto-rebase `gh pr view --json mergeStateStatus`) and
+# the gh-using scripts target the repo's ACTUAL host, not the github.com
+# default. gh-host.sh is sourced (exports GH_HOST when resolvable;
+# fail-open otherwise) and respects a pre-set GH_HOST.
+if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/land-pr/scripts/gh-host.sh"
+fi
 ```
 
 ### Step 2 — Resume-mode short-circuit (`--pr <num>`)

--- a/.claude/skills/land-pr/scripts/gh-host.sh
+++ b/.claude/skills/land-pr/scripts/gh-host.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# gh-host.sh — resolve the GitHub host from `origin` and export GH_HOST.
+#
+# Owner: /land-pr (skills/land-pr). Shared by the gh-using land-pr scripts
+# (pr-monitor.sh, pr-merge.sh, pr-push-and-create.sh) and recommended for
+# any gh call in the land-pr / commit / fix-issues flows.
+#
+# WHY (issue #1162): `gh` defaults every subcommand to github.com unless
+# told otherwise. On an enterprise-GitHub repo whose `origin` points at
+# (e.g.) github.example.com, a bare `gh auth status` / branch-protection
+# query answers for github.com — a false "authed, no protection" green-
+# light that has merged a PR overnight on the wrong host. `gh` honors the
+# `GH_HOST` environment variable GLOBALLY for ALL subcommands, so the
+# robust, minimal fix is to derive the host ONCE from the repo's actual
+# remote and export it — no need to thread `--hostname` through every call.
+#
+# USAGE — source it (so the export reaches the caller's gh invocations):
+#   . "$(dirname "$0")/gh-host.sh"     # or via $ZSKILLS_SKILLS_ROOT
+# After sourcing, $GH_HOST is exported (when a host could be resolved).
+#
+# BEHAVIOR:
+#   - Parses `git remote get-url origin` and extracts the host from the
+#     common URL shapes:
+#       * SSH scp-like:  git@HOST:owner/repo.git
+#       * SSH URL:       ssh://git@HOST[:port]/owner/repo.git
+#       * HTTPS/HTTP:    https://HOST/owner/repo(.git)  (strips userinfo)
+#   - github.com remotes resolve to host `github.com` (no behavior change).
+#   - If GH_HOST is ALREADY set in the environment, it is respected and
+#     NOT overwritten (explicit caller override wins).
+#   - If origin is absent / unparseable, GH_HOST is left UNSET (gh keeps
+#     its own default) — fail-open, never abort the caller.
+#
+# This script is SOURCED, so it must not `exit` on the no-resolve path and
+# must not leave `set -e`/`set -u` side effects in the caller.
+
+# Honor an explicit caller-provided GH_HOST — do not clobber it.
+if [ -n "${GH_HOST:-}" ]; then
+  : # already set; respect it
+else
+  _zsk_ghhost_url=""
+  _zsk_ghhost_host=""
+  # `git remote get-url origin` — tolerate absence (no remote, not a repo).
+  _zsk_ghhost_url=$(git remote get-url origin 2>/dev/null || true)
+
+  if [ -n "$_zsk_ghhost_url" ]; then
+    case "$_zsk_ghhost_url" in
+      ssh://*|git+ssh://*)
+        # ssh://[user@]HOST[:port]/path  → strip scheme, userinfo, port, path
+        _zsk_ghhost_host="${_zsk_ghhost_url#*://}"   # drop scheme
+        _zsk_ghhost_host="${_zsk_ghhost_host#*@}"    # drop userinfo
+        _zsk_ghhost_host="${_zsk_ghhost_host%%/*}"   # drop /path
+        _zsk_ghhost_host="${_zsk_ghhost_host%%:*}"   # drop :port
+        ;;
+      http://*|https://*)
+        # http(s)://[user[:pass]@]HOST[:port]/path
+        _zsk_ghhost_host="${_zsk_ghhost_url#*://}"   # drop scheme
+        _zsk_ghhost_host="${_zsk_ghhost_host#*@}"    # drop userinfo
+        _zsk_ghhost_host="${_zsk_ghhost_host%%/*}"   # drop /path
+        _zsk_ghhost_host="${_zsk_ghhost_host%%:*}"   # drop :port
+        ;;
+      *@*:*)
+        # scp-like: [user@]HOST:owner/repo(.git)
+        _zsk_ghhost_host="${_zsk_ghhost_url#*@}"     # drop user@
+        _zsk_ghhost_host="${_zsk_ghhost_host%%:*}"   # drop :owner/repo
+        ;;
+      *)
+        _zsk_ghhost_host=""
+        ;;
+    esac
+  fi
+
+  if [ -n "$_zsk_ghhost_host" ]; then
+    export GH_HOST="$_zsk_ghhost_host"
+  fi
+
+  unset _zsk_ghhost_url _zsk_ghhost_host
+fi

--- a/.claude/skills/land-pr/scripts/pr-merge.sh
+++ b/.claude/skills/land-pr/scripts/pr-merge.sh
@@ -80,6 +80,11 @@ case "$CI_STATUS" in
     ;;
 esac
 
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin so gh
+# talks to the repo's ACTUAL host, not the github.com default. Sourced —
+# exports GH_HOST when resolvable; fail-open otherwise.
+. "$(dirname "${BASH_SOURCE[0]}")/gh-host.sh"
+
 # Step 3 — Request auto-merge with squash.
 STDERR_LOG="/tmp/land-pr-merge-stderr-$PR_NUMBER-$$.log"
 

--- a/.claude/skills/land-pr/scripts/pr-monitor.sh
+++ b/.claude/skills/land-pr/scripts/pr-monitor.sh
@@ -65,6 +65,12 @@ fi
 
 STDERR_LOG="$LOG_OUT.stderr"
 
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin so every
+# gh call below (auth status, pr checks, run view) targets the repo's
+# ACTUAL host, not the github.com default. Sourced — exports GH_HOST when
+# resolvable; fail-open otherwise.
+. "$(dirname "${BASH_SOURCE[0]}")/gh-host.sh"
+
 # Pre-flight: gh auth must work before we try to query.
 if ! gh auth status >"$STDERR_LOG" 2>&1; then
   echo "ERROR: pr-monitor.sh: gh auth status failed — see $STDERR_LOG" >&2
@@ -72,9 +78,22 @@ if ! gh auth status >"$STDERR_LOG" 2>&1; then
   exit 20
 fi
 
-# Step 1 — Pre-check loop. Up to 3 attempts × 10s for checks to register.
+# Step 1 — Registration grace window (#1161). GitHub lags a few seconds-
+# to-tens-of-seconds after a push before the first check run is REGISTERED
+# on the PR. Pre-fix this loop ran only 3×10s (≤30s) and then emitted
+# `none` — indistinguishable from a repo that has NO checks configured.
+# Callers (/land-pr Step 6, rows 6-10) treat `none` as "safe to merge", so
+# a green-light could fire BEFORE CI even started — the documented
+# premature merge. The window is now longer and configurable; zero checks
+# registered yet maps to `pending` (NOT `none`/`pass`) below — see Step 2.
+#   PR_MONITOR_REGISTER_ATTEMPTS — poll count   (default 6)
+#   PR_MONITOR_REGISTER_SLEEP    — seconds/poll (default 10; test seam → 0)
+REGISTER_ATTEMPTS="${PR_MONITOR_REGISTER_ATTEMPTS:-6}"
+REGISTER_SLEEP="${PR_MONITOR_REGISTER_SLEEP:-10}"
 CHECK_COUNT=0
-for _i in 1 2 3; do
+_attempt=0
+while [ "$_attempt" -lt "$REGISTER_ATTEMPTS" ]; do
+  _attempt=$((_attempt + 1))
   PR_CHECKS_JSON=""
   if PR_CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --json name 2>"$STDERR_LOG"); then
     # `gh pr checks --json name` returns a JSON array. Detect "non-empty
@@ -84,11 +103,61 @@ for _i in 1 2 3; do
       break
     fi
   fi
-  sleep 10
+  # Don't sleep after the last attempt.
+  if [ "$_attempt" -lt "$REGISTER_ATTEMPTS" ]; then
+    sleep "$REGISTER_SLEEP"
+  fi
 done
 
-# Step 2 — No checks ever registered. Emit none and exit cleanly.
+# Step 2 — Zero checks registered after the grace window. We must NOT
+# conflate two cases (#1161):
+#   (a) checks are CONFIGURED but haven't registered yet (GitHub lag) —
+#       a merge here is premature; map to `pending` so the caller waits.
+#   (b) the repo genuinely has NO required checks — `none` is correct.
+# Distinguish via branch protection: query the PR's base branch for
+# required status checks. If any are required → case (a), emit `pending`.
+# Otherwise → case (b), emit `none`. The query is best-effort: if it
+# fails or we can't resolve the base branch, we FAIL SAFE to `pending`
+# (never auto-merge on uncertainty), since a stuck-`pending` only costs a
+# manual nudge whereas a false `none` is the premature-merge bug.
 if [ "$CHECK_COUNT" -eq 0 ]; then
+  BASE_BRANCH=""
+  BASE_JSON=""
+  if BASE_JSON=$(gh pr view "$PR_NUMBER" --json baseRefName 2>"$STDERR_LOG"); then
+    if [[ "$BASE_JSON" =~ \"baseRefName\":[[:space:]]*\"([^\"]+)\" ]]; then
+      BASE_BRANCH="${BASH_REMATCH[1]}"
+    fi
+  fi
+
+  if [ -z "$BASE_BRANCH" ]; then
+    # Couldn't resolve the base branch — fail safe to pending.
+    echo "CI_STATUS=pending"
+    echo "CI_LOG_FILE="
+    exit 0
+  fi
+
+  # Query required status checks on the base branch. 200 with a non-empty
+  # `contexts`/`checks` array ⇒ checks ARE required (case a → pending).
+  # 404 (no protection) or empty contexts ⇒ no required checks (case b →
+  # none). `gh api` resolves {owner}/{repo} from the current repo.
+  REQ_JSON=""
+  set +e
+  REQ_JSON=$(gh api \
+    "repos/{owner}/{repo}/branches/$BASE_BRANCH/protection/required_status_checks" \
+    2>"$STDERR_LOG")
+  REQ_RC=$?
+  # Leave errexit OFF (its state on entry to this block) — every path here
+  # exits explicitly; matches the script's lazy errexit management.
+  set +e
+
+  if [ "$REQ_RC" -eq 0 ] && [[ "$REQ_JSON" =~ \"(contexts|checks)\":[[:space:]]*\[[[:space:]]*[^][:space:]] ]]; then
+    # Required checks ARE configured but none registered yet → lag.
+    echo "CI_STATUS=pending"
+    echo "CI_LOG_FILE="
+    exit 0
+  fi
+
+  # No required checks configured (404 / empty contexts) → genuine no-CI.
   echo "CI_STATUS=none"
   echo "CI_LOG_FILE="
   exit 0

--- a/.claude/skills/land-pr/scripts/pr-push-and-create.sh
+++ b/.claude/skills/land-pr/scripts/pr-push-and-create.sh
@@ -70,6 +70,11 @@ fi
 BRANCH_SLUG="${BRANCH//\//-}"
 STDERR_LOG="/tmp/land-pr-push-create-stderr-$BRANCH_SLUG-$$.log"
 
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin so gh
+# talks to the repo's ACTUAL host, not the github.com default. Sourced —
+# exports GH_HOST when resolvable; fail-open otherwise.
+. "$(dirname "${BASH_SOURCE[0]}")/gh-host.sh"
+
 # Step 1 — Detect existing PR via bash regex on `gh pr list --json`.
 PR_LIST_JSON=""
 if ! PR_LIST_JSON=$(gh pr list --head "$BRANCH" --base "$BASE" --json number,url 2>"$STDERR_LOG"); then

--- a/docs/guides/installing-zskills.md
+++ b/docs/guides/installing-zskills.md
@@ -57,6 +57,29 @@ state are blocked (read-only skills work immediately).
 > plugin clones over **HTTPS**. Tell Claude *"configure git to use HTTPS instead
 > of SSH so the install works"* and re-run `/plugin install zs@zskills`.
 
+### Enterprise GitHub (GitHub Enterprise Server / `github.example.com`)
+
+zskills works against an enterprise GitHub host, with two things to know:
+
+- **Marketplace add over SSH.** `/plugin marketplace add zeveck/zskills`
+  resolves `zeveck/zskills` against **github.com**. If your zskills source
+  lives on an enterprise host (or your network can only reach GitHub over
+  SSH), pass an explicit **git URL** instead of the `owner/repo` shorthand,
+  e.g. `/plugin marketplace add git@github.example.com:org/zskills.git` (or
+  the HTTPS form). The SSH URL also sidesteps the HTTPS-can't-prompt-for-
+  credentials problem on a credential-gated enterprise remote.
+
+- **`GH_HOST` is derived automatically for landing/commit flows.** The
+  land-pr / commit / fix-issues scripts that call `gh` (auth status, branch
+  protection, PR create/merge/checks) resolve the target host from your
+  repo's `origin` remote and export **`GH_HOST`** for the duration of the
+  call — so `gh` talks to *your* host, not the github.com default. This
+  prevents the false "authenticated, no branch protection" green-light that
+  could otherwise auto-merge a PR against the wrong host. You normally need
+  to do nothing; an explicitly pre-set `GH_HOST` in your environment is
+  always respected and not overridden. (Make sure you are `gh auth login`'d
+  to that enterprise host so the `gh` calls succeed.)
+
 **The plugin writes nothing into your project by itself.** Skills, hooks, the
 verifier/implementer agents, and the agent rules all live in (and run from)
 the plugin's own tree — `git status` in your project stays clean across

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.12+0c837a"
+  version: "2026.06.12+c4f5cc"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -404,3 +404,17 @@ Do not proceed until you have read the file.
   instead of "reset mappings to defaults" because only the title was read.
 - **Ultrathink** — use careful, thorough reasoning. Read code, understand
   what changed and why, verify correctness.
+- **Enterprise GitHub host (#1162)** — before the inline `gh issue view` /
+  `gh issue close` calls, export `GH_HOST` from the repo's actual remote so
+  `gh` targets *your* host (not the github.com default) on a GitHub
+  Enterprise repo. Source the shared helper once near the top of the
+  sprint's gh-using shell (it exports `GH_HOST` when resolvable, fail-open
+  otherwise, and respects a pre-set value):
+
+  ```bash
+  if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh" ]; then
+    . "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh"
+  else
+    . "$CLAUDE_PROJECT_DIR/.claude/skills/land-pr/scripts/gh-host.sh"
+  fi
+  ```

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
 argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.06.11+e73556"
+  version: "2026.06.12+fc7540"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -233,6 +233,18 @@ PR_STATE="not-checked"
 REASON=""
 CONFLICT_FILES_LIST=""
 CALL_ERROR_FILE=""
+
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin ONCE, up
+# front, so every inline `gh` call in this skill (Step 2 resume `gh pr
+# view`, Step 6b/6c auto-rebase `gh pr view --json mergeStateStatus`) and
+# the gh-using scripts target the repo's ACTUAL host, not the github.com
+# default. gh-host.sh is sourced (exports GH_HOST when resolvable;
+# fail-open otherwise) and respects a pre-set GH_HOST.
+if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh" ]; then
+  . "${CLAUDE_PLUGIN_ROOT}/skills/land-pr/scripts/gh-host.sh"
+else
+  . "$CLAUDE_PROJECT_DIR/.claude/skills/land-pr/scripts/gh-host.sh"
+fi
 ```
 
 ### Step 2 — Resume-mode short-circuit (`--pr <num>`)

--- a/skills/land-pr/scripts/gh-host.sh
+++ b/skills/land-pr/scripts/gh-host.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# gh-host.sh — resolve the GitHub host from `origin` and export GH_HOST.
+#
+# Owner: /land-pr (skills/land-pr). Shared by the gh-using land-pr scripts
+# (pr-monitor.sh, pr-merge.sh, pr-push-and-create.sh) and recommended for
+# any gh call in the land-pr / commit / fix-issues flows.
+#
+# WHY (issue #1162): `gh` defaults every subcommand to github.com unless
+# told otherwise. On an enterprise-GitHub repo whose `origin` points at
+# (e.g.) github.example.com, a bare `gh auth status` / branch-protection
+# query answers for github.com — a false "authed, no protection" green-
+# light that has merged a PR overnight on the wrong host. `gh` honors the
+# `GH_HOST` environment variable GLOBALLY for ALL subcommands, so the
+# robust, minimal fix is to derive the host ONCE from the repo's actual
+# remote and export it — no need to thread `--hostname` through every call.
+#
+# USAGE — source it (so the export reaches the caller's gh invocations):
+#   . "$(dirname "$0")/gh-host.sh"     # or via $ZSKILLS_SKILLS_ROOT
+# After sourcing, $GH_HOST is exported (when a host could be resolved).
+#
+# BEHAVIOR:
+#   - Parses `git remote get-url origin` and extracts the host from the
+#     common URL shapes:
+#       * SSH scp-like:  git@HOST:owner/repo.git
+#       * SSH URL:       ssh://git@HOST[:port]/owner/repo.git
+#       * HTTPS/HTTP:    https://HOST/owner/repo(.git)  (strips userinfo)
+#   - github.com remotes resolve to host `github.com` (no behavior change).
+#   - If GH_HOST is ALREADY set in the environment, it is respected and
+#     NOT overwritten (explicit caller override wins).
+#   - If origin is absent / unparseable, GH_HOST is left UNSET (gh keeps
+#     its own default) — fail-open, never abort the caller.
+#
+# This script is SOURCED, so it must not `exit` on the no-resolve path and
+# must not leave `set -e`/`set -u` side effects in the caller.
+
+# Honor an explicit caller-provided GH_HOST — do not clobber it.
+if [ -n "${GH_HOST:-}" ]; then
+  : # already set; respect it
+else
+  _zsk_ghhost_url=""
+  _zsk_ghhost_host=""
+  # `git remote get-url origin` — tolerate absence (no remote, not a repo).
+  _zsk_ghhost_url=$(git remote get-url origin 2>/dev/null || true)
+
+  if [ -n "$_zsk_ghhost_url" ]; then
+    case "$_zsk_ghhost_url" in
+      ssh://*|git+ssh://*)
+        # ssh://[user@]HOST[:port]/path  → strip scheme, userinfo, port, path
+        _zsk_ghhost_host="${_zsk_ghhost_url#*://}"   # drop scheme
+        _zsk_ghhost_host="${_zsk_ghhost_host#*@}"    # drop userinfo
+        _zsk_ghhost_host="${_zsk_ghhost_host%%/*}"   # drop /path
+        _zsk_ghhost_host="${_zsk_ghhost_host%%:*}"   # drop :port
+        ;;
+      http://*|https://*)
+        # http(s)://[user[:pass]@]HOST[:port]/path
+        _zsk_ghhost_host="${_zsk_ghhost_url#*://}"   # drop scheme
+        _zsk_ghhost_host="${_zsk_ghhost_host#*@}"    # drop userinfo
+        _zsk_ghhost_host="${_zsk_ghhost_host%%/*}"   # drop /path
+        _zsk_ghhost_host="${_zsk_ghhost_host%%:*}"   # drop :port
+        ;;
+      *@*:*)
+        # scp-like: [user@]HOST:owner/repo(.git)
+        _zsk_ghhost_host="${_zsk_ghhost_url#*@}"     # drop user@
+        _zsk_ghhost_host="${_zsk_ghhost_host%%:*}"   # drop :owner/repo
+        ;;
+      *)
+        _zsk_ghhost_host=""
+        ;;
+    esac
+  fi
+
+  if [ -n "$_zsk_ghhost_host" ]; then
+    export GH_HOST="$_zsk_ghhost_host"
+  fi
+
+  unset _zsk_ghhost_url _zsk_ghhost_host
+fi

--- a/skills/land-pr/scripts/pr-merge.sh
+++ b/skills/land-pr/scripts/pr-merge.sh
@@ -80,6 +80,11 @@ case "$CI_STATUS" in
     ;;
 esac
 
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin so gh
+# talks to the repo's ACTUAL host, not the github.com default. Sourced —
+# exports GH_HOST when resolvable; fail-open otherwise.
+. "$(dirname "${BASH_SOURCE[0]}")/gh-host.sh"
+
 # Step 3 — Request auto-merge with squash.
 STDERR_LOG="/tmp/land-pr-merge-stderr-$PR_NUMBER-$$.log"
 

--- a/skills/land-pr/scripts/pr-monitor.sh
+++ b/skills/land-pr/scripts/pr-monitor.sh
@@ -65,6 +65,12 @@ fi
 
 STDERR_LOG="$LOG_OUT.stderr"
 
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin so every
+# gh call below (auth status, pr checks, run view) targets the repo's
+# ACTUAL host, not the github.com default. Sourced — exports GH_HOST when
+# resolvable; fail-open otherwise.
+. "$(dirname "${BASH_SOURCE[0]}")/gh-host.sh"
+
 # Pre-flight: gh auth must work before we try to query.
 if ! gh auth status >"$STDERR_LOG" 2>&1; then
   echo "ERROR: pr-monitor.sh: gh auth status failed — see $STDERR_LOG" >&2
@@ -72,9 +78,22 @@ if ! gh auth status >"$STDERR_LOG" 2>&1; then
   exit 20
 fi
 
-# Step 1 — Pre-check loop. Up to 3 attempts × 10s for checks to register.
+# Step 1 — Registration grace window (#1161). GitHub lags a few seconds-
+# to-tens-of-seconds after a push before the first check run is REGISTERED
+# on the PR. Pre-fix this loop ran only 3×10s (≤30s) and then emitted
+# `none` — indistinguishable from a repo that has NO checks configured.
+# Callers (/land-pr Step 6, rows 6-10) treat `none` as "safe to merge", so
+# a green-light could fire BEFORE CI even started — the documented
+# premature merge. The window is now longer and configurable; zero checks
+# registered yet maps to `pending` (NOT `none`/`pass`) below — see Step 2.
+#   PR_MONITOR_REGISTER_ATTEMPTS — poll count   (default 6)
+#   PR_MONITOR_REGISTER_SLEEP    — seconds/poll (default 10; test seam → 0)
+REGISTER_ATTEMPTS="${PR_MONITOR_REGISTER_ATTEMPTS:-6}"
+REGISTER_SLEEP="${PR_MONITOR_REGISTER_SLEEP:-10}"
 CHECK_COUNT=0
-for _i in 1 2 3; do
+_attempt=0
+while [ "$_attempt" -lt "$REGISTER_ATTEMPTS" ]; do
+  _attempt=$((_attempt + 1))
   PR_CHECKS_JSON=""
   if PR_CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --json name 2>"$STDERR_LOG"); then
     # `gh pr checks --json name` returns a JSON array. Detect "non-empty
@@ -84,11 +103,61 @@ for _i in 1 2 3; do
       break
     fi
   fi
-  sleep 10
+  # Don't sleep after the last attempt.
+  if [ "$_attempt" -lt "$REGISTER_ATTEMPTS" ]; then
+    sleep "$REGISTER_SLEEP"
+  fi
 done
 
-# Step 2 — No checks ever registered. Emit none and exit cleanly.
+# Step 2 — Zero checks registered after the grace window. We must NOT
+# conflate two cases (#1161):
+#   (a) checks are CONFIGURED but haven't registered yet (GitHub lag) —
+#       a merge here is premature; map to `pending` so the caller waits.
+#   (b) the repo genuinely has NO required checks — `none` is correct.
+# Distinguish via branch protection: query the PR's base branch for
+# required status checks. If any are required → case (a), emit `pending`.
+# Otherwise → case (b), emit `none`. The query is best-effort: if it
+# fails or we can't resolve the base branch, we FAIL SAFE to `pending`
+# (never auto-merge on uncertainty), since a stuck-`pending` only costs a
+# manual nudge whereas a false `none` is the premature-merge bug.
 if [ "$CHECK_COUNT" -eq 0 ]; then
+  BASE_BRANCH=""
+  BASE_JSON=""
+  if BASE_JSON=$(gh pr view "$PR_NUMBER" --json baseRefName 2>"$STDERR_LOG"); then
+    if [[ "$BASE_JSON" =~ \"baseRefName\":[[:space:]]*\"([^\"]+)\" ]]; then
+      BASE_BRANCH="${BASH_REMATCH[1]}"
+    fi
+  fi
+
+  if [ -z "$BASE_BRANCH" ]; then
+    # Couldn't resolve the base branch — fail safe to pending.
+    echo "CI_STATUS=pending"
+    echo "CI_LOG_FILE="
+    exit 0
+  fi
+
+  # Query required status checks on the base branch. 200 with a non-empty
+  # `contexts`/`checks` array ⇒ checks ARE required (case a → pending).
+  # 404 (no protection) or empty contexts ⇒ no required checks (case b →
+  # none). `gh api` resolves {owner}/{repo} from the current repo.
+  REQ_JSON=""
+  set +e
+  REQ_JSON=$(gh api \
+    "repos/{owner}/{repo}/branches/$BASE_BRANCH/protection/required_status_checks" \
+    2>"$STDERR_LOG")
+  REQ_RC=$?
+  # Leave errexit OFF (its state on entry to this block) — every path here
+  # exits explicitly; matches the script's lazy errexit management.
+  set +e
+
+  if [ "$REQ_RC" -eq 0 ] && [[ "$REQ_JSON" =~ \"(contexts|checks)\":[[:space:]]*\[[[:space:]]*[^][:space:]] ]]; then
+    # Required checks ARE configured but none registered yet → lag.
+    echo "CI_STATUS=pending"
+    echo "CI_LOG_FILE="
+    exit 0
+  fi
+
+  # No required checks configured (404 / empty contexts) → genuine no-CI.
   echo "CI_STATUS=none"
   echo "CI_LOG_FILE="
   exit 0

--- a/skills/land-pr/scripts/pr-push-and-create.sh
+++ b/skills/land-pr/scripts/pr-push-and-create.sh
@@ -70,6 +70,11 @@ fi
 BRANCH_SLUG="${BRANCH//\//-}"
 STDERR_LOG="/tmp/land-pr-push-create-stderr-$BRANCH_SLUG-$$.log"
 
+# Enterprise-host awareness (#1162): resolve GH_HOST from origin so gh
+# talks to the repo's ACTUAL host, not the github.com default. Sourced —
+# exports GH_HOST when resolvable; fail-open otherwise.
+. "$(dirname "${BASH_SOURCE[0]}")/gh-host.sh"
+
 # Step 1 — Detect existing PR via bash regex on `gh pr list --json`.
 PR_LIST_JSON=""
 if ! PR_LIST_JSON=$(gh pr list --head "$BRANCH" --base "$BASE" --json number,url 2>"$STDERR_LOG"); then

--- a/tests/mocks/mock-gh.sh
+++ b/tests/mocks/mock-gh.sh
@@ -50,6 +50,15 @@ case "$ARG1" in
     ;;
 esac
 
+# Sanitize path separators in the key — `gh api repos/{owner}/{repo}/...`
+# yields an ARG2 containing slashes, which would otherwise produce a
+# slash-bearing state-file path. Replace `/` and `{`/`}` with `_` so the
+# key is a safe flat filename. (No pre-existing key contains these chars,
+# so this is backward-compatible.)
+KEY="${KEY//\//_}"
+KEY="${KEY//\{/_}"
+KEY="${KEY//\}/_}"
+
 COUNT_FILE="$STATE_DIR/$KEY.count"
 PREV_COUNT=0
 if [ -f "$COUNT_FILE" ]; then

--- a/tests/test-land-pr-scripts.sh
+++ b/tests/test-land-pr-scripts.sh
@@ -405,6 +405,167 @@ fi
 cleanup_fixture "$F"
 
 # ----------------------------------------------------------------------
+# Issue #1161 — registration grace window. pr-monitor.sh must NOT emit
+# CI_STATUS=none when checks haven't REGISTERED yet but the base branch
+# REQUIRES status checks (GitHub lag right after push). Mapping zero-
+# checks-yet to `none` green-lit a premature merge (rows 6-10 treat `none`
+# as mergeable). Required-checks-configured + zero-registered → `pending`.
+#
+# Sequence (PR_MONITOR_REGISTER_SLEEP=0 → no wall-clock wait):
+#   auth_status                  → 0
+#   pr_checks 1..6 (all attempts)→ stdout="[]" (empty array, never registers)
+#   pr_view (baseRefName)        → stdout={"baseRefName":"main"}
+#   api_..._required_status_checks → 200 with non-empty contexts
+# Expect: CI_STATUS=pending (NOT none/pass).
+# ----------------------------------------------------------------------
+# The sanitized mock key for the branch-protection api call (mirrors
+# mock-gh.sh's `/`,`{`,`}` → `_` transform).
+api_key_for() {
+  local key="api_repos/{owner}/{repo}/branches/$1/protection/required_status_checks"
+  key="${key//\//_}"; key="${key//\{/_}"; key="${key//\}/_}"
+  printf '%s' "$key"
+}
+
+F=$(new_fixture issue1161_required_lag)
+mkdir -p "$F/work"
+prep_gh "$F/state-gh" auth_status 1 exit 0
+# All 6 registration attempts return an empty array → never registers.
+for n in 1 2 3 4 5 6; do prep_gh "$F/state-gh" pr_checks "$n" stdout '[]'; done
+prep_gh "$F/state-gh" pr_view 1 stdout '{"baseRefName":"main"}'
+PROT_KEY=$(api_key_for main)
+prep_gh "$F/state-gh" "$PROT_KEY" 1 stdout '{"contexts":["build"],"checks":[{"context":"build"}]}'
+prep_gh "$F/state-gh" "$PROT_KEY" 1 exit 0
+SUT_OUT_FILE="$F/sut.stdout"; SUT_ERR_FILE="$F/sut.stderr"
+set +e
+PATH="$F/bin:$PATH" \
+  MOCK_GH_STATE_DIR="$F/state-gh" \
+  MOCK_GIT_STATE_DIR="$F/state-git" \
+  PR_MONITOR_REGISTER_SLEEP=0 \
+  bash "$SCRIPTS_DIR/pr-monitor.sh" --pr 42 --timeout 1 --log-out "$F/work/ci.log" \
+  >"$SUT_OUT_FILE" 2>"$SUT_ERR_FILE"
+SUT_RC=$?
+set -e
+SUT_OUT=$(cat "$SUT_OUT_FILE")
+if [ "$SUT_RC" -eq 0 ] \
+   && [[ "$SUT_OUT" == *"CI_STATUS=pending"* ]] \
+   && [[ "$SUT_OUT" != *"CI_STATUS=none"* ]]; then
+  pass "[issue1161] required-checks-configured + zero-registered → CI_STATUS=pending (not none)"
+else
+  fail "[issue1161] required-checks lag → pending" "rc=$SUT_RC out=$SUT_OUT err=$SUT_ERR"
+fi
+cleanup_fixture "$F"
+
+# Companion: genuinely no required checks configured (404 / empty
+# contexts) → CI_STATUS=none is STILL correct (no behavior regression for
+# real no-CI repos). The api call returns rc!=0 (404) OR empty contexts.
+F=$(new_fixture issue1161_no_checks)
+mkdir -p "$F/work"
+prep_gh "$F/state-gh" auth_status 1 exit 0
+for n in 1 2 3 4 5 6; do prep_gh "$F/state-gh" pr_checks "$n" stdout '[]'; done
+prep_gh "$F/state-gh" pr_view 1 stdout '{"baseRefName":"main"}'
+PROT_KEY=$(api_key_for main)
+# 404: no branch protection → gh api exits non-zero with an error body.
+prep_gh "$F/state-gh" "$PROT_KEY" 1 stderr 'gh: Branch not protected (HTTP 404)'
+prep_gh "$F/state-gh" "$PROT_KEY" 1 exit 1
+SUT_OUT_FILE="$F/sut.stdout"; SUT_ERR_FILE="$F/sut.stderr"
+set +e
+PATH="$F/bin:$PATH" \
+  MOCK_GH_STATE_DIR="$F/state-gh" \
+  MOCK_GIT_STATE_DIR="$F/state-git" \
+  PR_MONITOR_REGISTER_SLEEP=0 \
+  bash "$SCRIPTS_DIR/pr-monitor.sh" --pr 42 --timeout 1 --log-out "$F/work/ci.log" \
+  >"$SUT_OUT_FILE" 2>"$SUT_ERR_FILE"
+SUT_RC=$?
+set -e
+SUT_OUT=$(cat "$SUT_OUT_FILE")
+if [ "$SUT_RC" -eq 0 ] \
+   && [[ "$SUT_OUT" == *"CI_STATUS=none"* ]]; then
+  pass "[issue1161] no required checks (404) → CI_STATUS=none (no regression)"
+else
+  fail "[issue1161] no-required-checks → none" "rc=$SUT_RC out=$SUT_OUT err=$SUT_ERR"
+fi
+cleanup_fixture "$F"
+
+# Companion: base branch unresolvable (gh pr view fails) → fail SAFE to
+# pending (never none on uncertainty — a stuck pending costs a manual
+# nudge; a false none is the premature-merge bug).
+F=$(new_fixture issue1161_base_unknown)
+mkdir -p "$F/work"
+prep_gh "$F/state-gh" auth_status 1 exit 0
+for n in 1 2 3 4 5 6; do prep_gh "$F/state-gh" pr_checks "$n" stdout '[]'; done
+prep_gh "$F/state-gh" pr_view 1 exit 1
+prep_gh "$F/state-gh" pr_view 1 stderr 'gh: could not resolve PR'
+SUT_OUT_FILE="$F/sut.stdout"; SUT_ERR_FILE="$F/sut.stderr"
+set +e
+PATH="$F/bin:$PATH" \
+  MOCK_GH_STATE_DIR="$F/state-gh" \
+  MOCK_GIT_STATE_DIR="$F/state-git" \
+  PR_MONITOR_REGISTER_SLEEP=0 \
+  bash "$SCRIPTS_DIR/pr-monitor.sh" --pr 42 --timeout 1 --log-out "$F/work/ci.log" \
+  >"$SUT_OUT_FILE" 2>"$SUT_ERR_FILE"
+SUT_RC=$?
+set -e
+SUT_OUT=$(cat "$SUT_OUT_FILE")
+if [ "$SUT_RC" -eq 0 ] \
+   && [[ "$SUT_OUT" == *"CI_STATUS=pending"* ]]; then
+  pass "[issue1161] base-branch unresolvable → fail-safe CI_STATUS=pending"
+else
+  fail "[issue1161] base-unknown fail-safe pending" "rc=$SUT_RC out=$SUT_OUT err=$SUT_ERR"
+fi
+cleanup_fixture "$F"
+
+# ----------------------------------------------------------------------
+# Issue #1162 — gh-host.sh resolves GH_HOST from origin URL shapes.
+# Direct unit test of the sourceable helper (no gh involved).
+# ----------------------------------------------------------------------
+ghhost_resolves() {
+  local label="$1" url="$2" expect="$3"
+  local F; F=$(new_fixture "ghhost-$label")
+  # mock-git returns the canned origin URL for `git remote get-url origin`.
+  prep_git "$F/state-git" remote 1 stdout "$url"
+  local out
+  out=$(PATH="$F/bin:$PATH" MOCK_GIT_STATE_DIR="$F/state-git" \
+        bash -c '. "'"$SCRIPTS_DIR"'/gh-host.sh"; printf "%s" "${GH_HOST:-<unset>}"')
+  if [ "$out" = "$expect" ]; then
+    pass "[issue1162] gh-host $label ($url) → GH_HOST=$expect"
+  else
+    fail "[issue1162] gh-host $label" "url=$url got='$out' expected='$expect'"
+  fi
+  cleanup_fixture "$F"
+}
+ghhost_resolves scp-enterprise 'git@github.example.com:org/repo.git' 'github.example.com'
+ghhost_resolves https-enterprise 'https://github.example.com/org/repo.git' 'github.example.com'
+ghhost_resolves https-userinfo 'https://user@github.example.com/org/repo.git' 'github.example.com'
+ghhost_resolves ssh-url 'ssh://git@github.example.com:22/org/repo.git' 'github.example.com'
+ghhost_resolves dotcom-scp 'git@github.com:org/repo.git' 'github.com'
+ghhost_resolves dotcom-https 'https://github.com/org/repo.git' 'github.com'
+
+# Origin absent → GH_HOST stays unset (fail-open; gh keeps its default).
+F=$(new_fixture ghhost-no-origin)
+prep_git "$F/state-git" remote 1 exit 1
+prep_git "$F/state-git" remote 1 stderr "error: No such remote 'origin'"
+out=$(PATH="$F/bin:$PATH" MOCK_GIT_STATE_DIR="$F/state-git" \
+      bash -c '. "'"$SCRIPTS_DIR"'/gh-host.sh"; printf "%s" "${GH_HOST:-<unset>}"')
+if [ "$out" = "<unset>" ]; then
+  pass "[issue1162] gh-host no-origin → GH_HOST unset (fail-open)"
+else
+  fail "[issue1162] gh-host no-origin" "got='$out' expected='<unset>'"
+fi
+cleanup_fixture "$F"
+
+# Explicit caller-provided GH_HOST is respected (not clobbered).
+F=$(new_fixture ghhost-respect-existing)
+prep_git "$F/state-git" remote 1 stdout 'git@github.com:org/repo.git'
+out=$(PATH="$F/bin:$PATH" MOCK_GIT_STATE_DIR="$F/state-git" GH_HOST='preset.example.com' \
+      bash -c '. "'"$SCRIPTS_DIR"'/gh-host.sh"; printf "%s" "${GH_HOST:-<unset>}"')
+if [ "$out" = "preset.example.com" ]; then
+  pass "[issue1162] gh-host respects pre-set GH_HOST (no clobber)"
+else
+  fail "[issue1162] gh-host respects pre-set GH_HOST" "got='$out' expected='preset.example.com'"
+fi
+cleanup_fixture "$F"
+
+# ----------------------------------------------------------------------
 # Failure mode #9 — auto-merge-disabled-on-repo (benign, exit 0)
 # ----------------------------------------------------------------------
 F=$(new_fixture mode9)


### PR DESCRIPTION
Fixes #1161
Part of #1162 (items 1 + 2 only — item 3 glab/gh shim stays open as a design item)

## Changes
- **#1161** — `pr-monitor.sh` could report `none`/`pass` when GitHub simply hadn't *registered* checks yet (lag right after push), green-lighting an auto-merge before CI started (an actual premature merge in the eval corpus). Now: a grace window re-polls until ≥1 check is registered OR a definitive no-checks signal (base-branch `required_status_checks`); zero-registered-with-required-checks → `pending` (never `none`/`pass`); genuinely-no-CI → `none` (unchanged). Output contract preserved.
- **#1162 item 1** — new `gh-host.sh` parses `git remote get-url origin` → exports `GH_HOST` (gh honors it globally), sourced by the land-pr gh-using scripts + land-pr/fix-issues inline gh calls. github.com → github.com (no change); enterprise/ssh origins → that host. So gh auth / branch-protection checks hit the repo's actual host, not github.com defaults.
- **#1162 item 2** — `installing-zskills.md` enterprise note (SSH marketplace-add URL + GH_HOST behavior).
- **#1162 item 3** (glab/gh shim) — NOT implemented; it is a larger design item. #1162 stays open for it.

(commit/fix-issues scripts have no real gh calls — they reach gh transitively via /land-pr — so they needed no edits.)

## Test plan
- [x] `tests/test-land-pr-scripts.sh` +12 (3 grace-window incl. zero-checks→pending negative assertion; 9 gh-host incl. enterprise/ssh/no-origin)
- [x] Full suite `bash tests/run-all.sh` — 7749/7749
