### PR TITLE
Fix #1166: suite-result provenance — de-dup identical test runs with provenance (4-phase plan)

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -61,6 +61,64 @@ against THAT harness's summary — what matters is asserting the suite
 ran to completion AND the final aggregated tally matches expectations,
 not just absence of visible FAILs.
 
+## Result-provenance de-duplication
+
+A `tests/run-all.sh` run now carries a **provenance** header recording the
+tree it measured (`tree`, a CONTENT-sensitive `fingerprint`, `timestamp` +
+`epoch`). When you are handed (or can locate) the implementer's captured
+results file, FIRST run `bash tests/lib/suite-result-valid.sh <file>` on it.
+
+**Reusing a provenance-validated result for the SAME tree is
+de-duplication, NOT skipping verification.** A suite is elided ONLY when you
+can affirmatively prove it unrelated to the change; an empty or uncertain
+targeted set means a FULL re-run, never "ran nothing." De-dup changes WHAT
+you execute, never that a fresh verifier independently audits the diff.
+
+- **Exit 0 (VALID — same tree, < 30 min)** → you MAY de-duplicate:
+  1. **Verify the tally on that file** — the existing
+     `Overall: N/M passed, F failed` check above (present, `N == M`,
+     `F == 0`, `N >= baseline_N`). A VALID-but-FAILING result is still a
+     verification FAIL — do not reuse a failing run.
+  2. **ALWAYS run the cross-cutting CONCERN suites**, regardless of the
+     changed area (they gate by concern, not area, so the prefix heuristic
+     below MISSES them — they are the floor):
+     `tests/test-skill-conformance.sh`, `tests/test-skills-mirror-parity.sh`,
+     `tests/test-skill-version-enforcement.sh`,
+     `tests/test-doc-viewer-catalog.sh`,
+     `tests/test-managed-md-up-to-date.sh`, `tests/test-agents-parity.sh`.
+  3. **Derive the changed-area suites on TOP of the floor.** Run
+     `git diff $(git merge-base origin/main HEAD)..HEAD --name-only`. If
+     `merge-base` fails or the changed-path set is empty while HEAD is
+     provably ahead of main → FULL re-run. Otherwise group the changed paths
+     into area families by JUDGMENT over the suite NAMING CONVENTION (e.g. a
+     `hooks/` change → `test-hooks-*` / `test-*-hook-*`; `skills/do/` →
+     `test-do-*`; `skills/fix-issues/` → `test-fix-issues-*`), enumerating
+     candidates via `list_registered_suites()` from
+     `tests/lib/suite-registry.sh` (a flat enumerator with NO area tags — this
+     is judgment, not a maintained path→suite map). **If the targeted set is
+     EMPTY or you are not confident it covers the change → run the FULL
+     suite.** Run each selected suite as `bash tests/test-<name>.sh` and
+     check its `Results: N passed, F failed` line; all (floor + targeted)
+     must pass.
+- **Exit 1 (invalid/stale/missing/empty field/git absent)** → run the FULL
+  `$FULL_TEST_CMD` as today and apply the tally check above.
+
+**FULL re-run is MANDATORY (overrides the de-dup path) when ANY of:** the
+result is invalid/stale; the diff touches `tests/`, `hooks/`,
+`scripts/_lib/`, shared skill scripts (`skills/*/scripts/`), the runner
+(`tests/run-all.sh`), ANY `skills/**/*.md` (skill bodies are behavior),
+`agents/*.md`, `.claude/agents/*.md` (the verifier.md twin lives there),
+`CLAUDE_TEMPLATE.md`, or `managed.md`; the targeted candidate set is
+EMPTY/uncertain or `merge-base` fails; or you judge the change risky.
+
+**Threat model:** a fabricated or stale results file fails at three
+independent layers — the validator (`suite-result-valid.sh`: the
+content-sensitive tree fingerprint mismatches a tree it did not measure,
+and it fails closed on empty fields / absent git), the targeted re-run plus
+the always-on concern suites (the changed area must actually pass on the
+live tree), and CI (a fresh full run on a clean clone). Provenance reuse
+NEVER accepts a result for a tree whose CONTENT was not measured.
+
 ## Scope-creep AC checks
 
 When checking AC-style "no scope creep" criteria, prefer one of:

--- a/.claude/rules/zskills/managed.md
+++ b/.claude/rules/zskills/managed.md
@@ -146,6 +146,47 @@ $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
 Then read `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` to inspect failures. Never pipe
 through `| tail`, `| head`, `| grep` -- it loses output and forces re-runs.
 
+### Tests — result provenance / de-duplication
+
+A `tests/run-all.sh` run now carries a provenance header recording the
+tree it measured (`tree`, a CONTENT-sensitive `fingerprint`, `timestamp` +
+`epoch`). The sourced validator `tests/lib/suite-result-valid.sh <file>`
+answers "is this result still true for the current tree?" — exit 0 iff the
+recorded `tree` and content `fingerprint` match the live tree AND the result
+is under 30 minutes old; it fails closed on any empty field or absent git.
+
+**Reusing a provenance-validated result for the SAME tree is
+de-duplication, NOT skipping verification.** When a fresh verifier finds a
+result that validates for the current tree, it verifies the tally, ALWAYS
+re-runs the cross-cutting concern suites (conformance, mirror-parity,
+skill-version, catalog, managed-md, agents-parity), and additionally re-runs
+the suites covering the changed area (derived from the diff paths by
+judgment) — instead of blindly re-running everything that was just run on the
+identical tree. A suite is elided ONLY when it is provably unrelated; an
+empty or uncertain targeted set means a FULL re-run, never "ran nothing."
+
+**The safety floor is non-negotiable and is never weakened by reuse:**
+CI runs the full suite on every PR (the fresh-clone backstop); the
+post-commit committed-state gates stay in force; Layer-3 response
+validation stays in force; the fresh verifier's INDEPENDENCE is preserved
+— de-dup changes WHAT the verifier executes, never WHO; a full LOCAL run
+is mandatory before landing ANY PR that touches shared infra (`tests/`,
+`hooks/`, `scripts/_lib/`, shared skill scripts, the runner); the
+plan-completion boundary runs stay mandatory; and the two-attempt fix
+discipline is unchanged.
+
+**A full re-run is MANDATORY** when the result is invalid/stale, when the
+diff touches `tests/`, `hooks/`, `scripts/_lib/`, shared skill scripts, the
+runner, ANY `skills/**/*.md` (skill bodies are behavior), `agents/*.md`,
+`.claude/agents/*.md`, `CLAUDE_TEMPLATE.md`, or `managed.md`, when the
+targeted set is empty, or when the verifier judges the change risky.
+
+**Threat model:** a fabricated or stale results file fails at three
+independent layers — the validator (content-sensitive tree fingerprint
+mismatch), the targeted re-run plus the always-on concern suites (the
+changed area must actually pass), and CI (a fresh full run). Provenance
+reuse never accepts a result for a tree whose CONTENT was not measured.
+
 **Pre-existing test failures.** If a test fails in code you didn't touch,
 verify with `git log` that the test/source predates your changes. You may
 file a GitHub issue with the error output and mark the test `it.skip('name

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.15+85206a"
+  version: "2026.06.15+0a8beb"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -880,9 +880,15 @@ Before touching anything:
 
 3. **Classify the change type** — this determines verification intensity
    in Phase 3:
-   - **Content only** — markdown, images, presentations, documentation.
-     No tests needed.
-   - **Code** — JavaScript, CSS, HTML, model files. Tests needed.
+   - **Content only** — a diff CONFINED to `docs/`, `README*`, `CHANGELOG*`,
+     `PRESENTATION*`, and non-skill images/presentations. Runs ONLY the
+     prose-pinning subset locally (`test-skill-conformance.sh`,
+     `test-doc-viewer-catalog.sh`, `test-managed-md-up-to-date.sh`); CI still
+     runs the full suite. **EXCLUDES `skills/**/*.md` — skill bodies are
+     behavior, not docs, so any `skills/**/*.md` edit is "Code" and runs the
+     full local suite + full CI.**
+   - **Code** — JavaScript, CSS, HTML, model files, AND any `skills/**/*.md`
+     (skill bodies are behavior). Tests needed (full local suite + full CI).
    - **Mixed** — both content and code. Tests needed for code portion.
 
 4. **Plan the work** — no formal document, just mental clarity on what
@@ -1015,16 +1021,30 @@ would fail usage-error exit 2.
 
 Verification intensity matches the change type (from Phase 1):
 
-### Content-only changes (md, jpg, png, presentations)
+### Content-only changes (`docs/`, `README*`, `CHANGELOG*`, `PRESENTATION*`, non-skill images/presentations)
+
+**This class EXCLUDES `skills/**/*.md`.** Skill bodies are behavior, not
+docs — a diff touching ANY `skills/**/*.md` is NOT content-only. It routes to
+the "Code" path and runs the full local suite + full CI. Only a diff CONFINED
+to `docs/`, `README*`, `CHANGELOG*`, `PRESENTATION*`, and non-skill
+images/presentations qualifies here.
 
 - **Spot-check:** formatting, links, file organization, image references
-- **Do NOT run tests** — running 4,000+ tests for a markdown edit is
-  wasteful, and pre-existing failures would block the task unnecessarily
+- **Run ONLY the prose-pinning subset locally** — `test-skill-conformance.sh`,
+  `test-doc-viewer-catalog.sh`, and `test-managed-md-up-to-date.sh` (the
+  catalog/`docs/DocsRegistry.js` drift gate is regenerated from doc/skill
+  catalog content, so it belongs here). Do NOT run the full local suite for a
+  docs-confined edit — running 4,000+ tests for a markdown edit is wasteful,
+  and pre-existing failures would block the task unnecessarily. CI still runs
+  the full suite regardless.
 - **Dispatch a separate verification agent (worktree/direct mode).** Tell
-  the agent explicitly: "These are content-only changes (no code). Review
-  the diff for correctness and completeness — do NOT run `npm test` or
-  `npm run test:all`. Your job is: do these changes make sense? Are the
-  right files included? Anything accidentally staged? Formatting correct?"
+  the agent explicitly: "These are content-only changes (`docs/`/`README*`/
+  `CHANGELOG*`/`PRESENTATION*`, NOT any `skills/**/*.md`). Review the diff for
+  correctness and completeness — run only the prose-pinning subset
+  (`test-skill-conformance.sh`, `test-doc-viewer-catalog.sh`,
+  `test-managed-md-up-to-date.sh`), not `npm test` or `npm run test:all`. Your
+  job is: do these changes make sense? Are the right files included? Anything
+  accidentally staged? Formatting correct?"
   Do NOT invoke `/verify-changes` for content-only changes — it will run
   the full test suite regardless. Instead, dispatch a plain review agent.
 

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.11+0ebe97"
+  version: "2026.06.15+85206a"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -1070,6 +1070,21 @@ Verification intensity matches the change type (from Phase 1):
   wait for the monitor." Past failure: 6+ subagent crashes with that
   phrase across 2026-04-29 and 2026-04-30. Always foreground-Bash with
   explicit long timeout; capture to file; read the file on return.
+- **Result-provenance de-duplication (de-dup, NOT skip).** If a results file
+  already exists for the CURRENT working tree (e.g. captured moments earlier
+  on the same uncommitted tree), run `tests/lib/suite-result-valid.sh` on it
+  before re-running the full suite. On **exit 0** (the provenance header
+  validates for the current tree, < 30 min), de-duplicate — verify the tally,
+  ALWAYS run the cross-cutting concern suites (`test-skill-conformance.sh`,
+  `test-skills-mirror-parity.sh`, `test-skill-version-enforcement.sh`,
+  `test-doc-viewer-catalog.sh`, `test-managed-md-up-to-date.sh`,
+  `test-agents-parity.sh`), and re-run only the targeted suites for the
+  changed area. On **exit 1** (invalid/stale), when the targeted set is empty
+  or uncertain, or when the diff touches shared infra (`tests/`, `hooks/`,
+  `scripts/_lib/`, shared skill scripts, the runner) or any `skills/**/*.md` /
+  `agents/*.md` / `.claude/agents/*.md` / `CLAUDE_TEMPLATE.md`, run the full
+  suite. A suite is elided ONLY when provably unrelated; an empty or uncertain
+  target means a FULL re-run.
 - **If tests fail: fix them.** Do not check if failures are pre-existing.
   Do not stash, checkout old commits, or create comparison worktrees.
   If you touched code and tests fail, they're yours to fix. (See

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.12+c4f5cc"
+  version: "2026.06.15+2e2c75"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -381,6 +381,25 @@ Do not proceed until you have read the file.
 - **`$FULL_TEST_CMD` before every commit** (canonical form — maintainers: see
   `references/canonical-config-prelude.md` §1 in the zskills source) — not
   just `npm test`.
+- **Result-provenance de-duplication (de-dup, NOT skip).** The impl agent's
+  pre-commit `$FULL_TEST_CMD` run produces a STAMPED results file carrying a
+  provenance header (tree + content-sensitive fingerprint + epoch). Because
+  fix-issues uses the verifier-commits-after model (the impl agent does NOT
+  commit; the verification agent commits AFTER passing tests, above), that
+  stamped result IS reusable by the verification agent: at verify time the
+  working tree is the SAME dirty pre-commit tree the impl agent measured, so
+  `tests/lib/suite-result-valid.sh` validates it (exit 0) and the verifier
+  de-duplicates — verify the tally, ALWAYS run the cross-cutting concern
+  suites (`test-skill-conformance.sh`, `test-skills-mirror-parity.sh`,
+  `test-skill-version-enforcement.sh`, `test-doc-viewer-catalog.sh`,
+  `test-managed-md-up-to-date.sh`, `test-agents-parity.sh`), and re-run only
+  the targeted suites for the changed area. Run the FULL suite on invalid/stale
+  (exit 1), an empty/uncertain target, or a shared-infra / `skills/**/*.md` /
+  `agents/*.md` / `CLAUDE_TEMPLATE.md` diff. Honest caveat: a result captured
+  BEFORE the impl agent's LAST edit drifts in content → fingerprint mismatch →
+  exit 1 → full re-run (the predicate working, not a foreclosure). Reuse is NOT
+  foreclosed across a commit boundary — the model is identical to run-plan.
+  (fix-issues impl agents are `subagent_type: "implementer"`.)
 - **Never weaken tests** — fix the code, not the test. Do not loosen
   tolerances, skip assertions, or remove test cases.
 - **Never defer the hard parts** — finish all phases of the plan. Do not

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.12+cddf24"
+  version: "2026.06.15+a5fca0"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.15+a5fca0"
+  version: "2026.06.15+0efeca"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -692,6 +692,24 @@ Include this VERBATIM in the verifier dispatch prompt:
        2026-05-18: verifier reported "3313/3313 passed" by counting inline
        PASS lines; final tally was 3311/3313 — two regressions slipped
        (anchor `feedback_verify_by_count_not_any_fail`).
+     - **Result-provenance de-duplication (de-dup, NOT skip).** Before
+       re-running the full suite, run `tests/lib/suite-result-valid.sh` on the
+       implementer's results file. In run-plan the implementer does NOT commit
+       and the VERIFIER commits after — so at verify time the working tree is
+       the SAME dirty pre-commit tree the implementer measured, and the
+       provenance header validates (exit 0): reuse is real. On **exit 0**
+       (valid for the current tree, < 30 min), de-duplicate — verify the tally,
+       ALWAYS run the cross-cutting concern suites
+       (`test-skill-conformance.sh`, `test-skills-mirror-parity.sh`,
+       `test-skill-version-enforcement.sh`, `test-doc-viewer-catalog.sh`,
+       `test-managed-md-up-to-date.sh`, `test-agents-parity.sh`), and re-run
+       the targeted suites for the changed area. Run the **FULL suite** when
+       the result is invalid/stale (exit 1), when the targeted set is empty or
+       uncertain, or when the diff touches shared infra (`tests/`, `hooks/`,
+       `scripts/_lib/`, shared skill scripts, the runner) or any
+       `skills/**/*.md` / `agents/*.md` / `.claude/agents/*.md` /
+       `CLAUDE_TEMPLATE.md`. De-dup changes WHAT runs, never that a fresh
+       verifier independently audits the diff.
 
 2. **Additional plan-specific checks** (the verifier checks these against the
    verbatim plan text — not against a summary):

--- a/.claude/skills/run-plan/modes/execute-phase.md
+++ b/.claude/skills/run-plan/modes/execute-phase.md
@@ -443,7 +443,12 @@ else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
 
-# Orchestrator captures baseline BEFORE impl agent starts
+# Orchestrator captures baseline BEFORE impl agent starts.
+# The baseline file ALSO carries the provenance header emitted by the runner,
+# so it is a provenance-stamped result for the tree at capture time — the
+# verifier may REUSE it (via tests/lib/suite-result-valid.sh) instead of
+# re-running to refresh the baseline, killing the baseline-refresh re-run and
+# the baseline-clobber class.
 cd "$WORKTREE_PATH"
 if [ -n "$FULL_TEST_CMD" ]; then
   TEST_OUT="/tmp/zskills-tests/$(basename "$WORKTREE_PATH")"
@@ -672,7 +677,17 @@ Include this VERBATIM in the verifier dispatch prompt:
    - The **work items checklist** — verify each item was actually implemented,
      not stubbed or skipped
    - The **`"$TEST_OUT/.test-baseline.txt"` file** captured before implementation
-     started (if `FULL_TEST_CMD` is configured). The verification agent should:
+     started (if `FULL_TEST_CMD` is configured). This file ALSO carries the
+     provenance header, so it is a provenance-stamped result for the tree at
+     capture time — the verifier may treat **ANY** validating result at the
+     current tree (the baseline OR a fresh capture) as reusable: run
+     `tests/lib/suite-result-valid.sh` on the candidate; on **exit 0** reuse it
+     (verify the tally + run the cross-cutting concern suites + targeted rerun,
+     per the de-dup bullet below) instead of re-running everything to refresh
+     the baseline; on **exit 1** (e.g. the tree advanced between baseline
+     capture and verification, or > 30 min elapsed) re-run. This kills the
+     baseline-refresh re-run and the baseline-clobber class. The verification
+     agent should:
      - Read `"$TEST_OUT/.test-baseline.txt"` (baseline captured before implementation)
      - Compare against `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` (results after running tests now)
      - **New failures** (in results but not in baseline) → regressions, must

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.06.10+0b68d4"
+  version: "2026.06.15+b3eca3"
 ---
 
 # /verify-changes [<scope> | last [N]] — Verify, Test & Fix Changes
@@ -353,7 +353,22 @@ to file as below; read the file when the call returns.
 
 1. **Run the full test suite with output captured to a file** (canonical form —
    maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
-   source):
+   source).
+
+   **Result-provenance de-duplication (de-dup, NOT skip).** If a results file
+   already exists for the CURRENT working tree (e.g. one captured moments
+   earlier on the same uncommitted tree), run `tests/lib/suite-result-valid.sh`
+   on it. On **exit 0** (the provenance header validates for the current tree,
+   < 30 min), de-duplicate — verify the tally, ALWAYS run the cross-cutting
+   concern suites (`test-skill-conformance.sh`, `test-skills-mirror-parity.sh`,
+   `test-skill-version-enforcement.sh`, `test-doc-viewer-catalog.sh`,
+   `test-managed-md-up-to-date.sh`, `test-agents-parity.sh`), and re-run only
+   the targeted suites for the changed area. On **exit 1** (invalid/stale; e.g.
+   the tree advanced), when the targeted set is empty, or when the diff touches
+   shared infra (`tests/`, `hooks/`, `scripts/_lib/`, shared skill scripts, the
+   runner) or any `skills/**/*.md` / `agents/*.md` / `.claude/agents/*.md` /
+   `CLAUDE_TEMPLATE.md`, run the full suite as below. A suite is elided ONLY
+   when provably unrelated; an empty or uncertain target means a FULL re-run.
    ```bash
    if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
      export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -146,6 +146,47 @@ $FULL_TEST_CMD > "$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}" 2>&1
 Then read `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` to inspect failures. Never pipe
 through `| tail`, `| head`, `| grep` -- it loses output and forces re-runs.
 
+### Tests — result provenance / de-duplication
+
+A `tests/run-all.sh` run now carries a provenance header recording the
+tree it measured (`tree`, a CONTENT-sensitive `fingerprint`, `timestamp` +
+`epoch`). The sourced validator `tests/lib/suite-result-valid.sh <file>`
+answers "is this result still true for the current tree?" — exit 0 iff the
+recorded `tree` and content `fingerprint` match the live tree AND the result
+is under 30 minutes old; it fails closed on any empty field or absent git.
+
+**Reusing a provenance-validated result for the SAME tree is
+de-duplication, NOT skipping verification.** When a fresh verifier finds a
+result that validates for the current tree, it verifies the tally, ALWAYS
+re-runs the cross-cutting concern suites (conformance, mirror-parity,
+skill-version, catalog, managed-md, agents-parity), and additionally re-runs
+the suites covering the changed area (derived from the diff paths by
+judgment) — instead of blindly re-running everything that was just run on the
+identical tree. A suite is elided ONLY when it is provably unrelated; an
+empty or uncertain targeted set means a FULL re-run, never "ran nothing."
+
+**The safety floor is non-negotiable and is never weakened by reuse:**
+CI runs the full suite on every PR (the fresh-clone backstop); the
+post-commit committed-state gates stay in force; Layer-3 response
+validation stays in force; the fresh verifier's INDEPENDENCE is preserved
+— de-dup changes WHAT the verifier executes, never WHO; a full LOCAL run
+is mandatory before landing ANY PR that touches shared infra (`tests/`,
+`hooks/`, `scripts/_lib/`, shared skill scripts, the runner); the
+plan-completion boundary runs stay mandatory; and the two-attempt fix
+discipline is unchanged.
+
+**A full re-run is MANDATORY** when the result is invalid/stale, when the
+diff touches `tests/`, `hooks/`, `scripts/_lib/`, shared skill scripts, the
+runner, ANY `skills/**/*.md` (skill bodies are behavior), `agents/*.md`,
+`.claude/agents/*.md`, `CLAUDE_TEMPLATE.md`, or `managed.md`, when the
+targeted set is empty, or when the verifier judges the change risky.
+
+**Threat model:** a fabricated or stale results file fails at three
+independent layers — the validator (content-sensitive tree fingerprint
+mismatch), the targeted re-run plus the always-on concern suites (the
+changed area must actually pass), and CI (a fresh full run). Provenance
+reuse never accepts a result for a tree whose CONTENT was not measured.
+
 **Pre-existing test failures.** If a test fails in code you didn't touch,
 verify with `git log` that the test/source predates your changes. You may
 file a GitHub issue with the error output and mark the test `it.skip('name

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -55,6 +55,64 @@ against THAT harness's summary — what matters is asserting the suite
 ran to completion AND the final aggregated tally matches expectations,
 not just absence of visible FAILs.
 
+## Result-provenance de-duplication
+
+A `tests/run-all.sh` run now carries a **provenance** header recording the
+tree it measured (`tree`, a CONTENT-sensitive `fingerprint`, `timestamp` +
+`epoch`). When you are handed (or can locate) the implementer's captured
+results file, FIRST run `bash tests/lib/suite-result-valid.sh <file>` on it.
+
+**Reusing a provenance-validated result for the SAME tree is
+de-duplication, NOT skipping verification.** A suite is elided ONLY when you
+can affirmatively prove it unrelated to the change; an empty or uncertain
+targeted set means a FULL re-run, never "ran nothing." De-dup changes WHAT
+you execute, never that a fresh verifier independently audits the diff.
+
+- **Exit 0 (VALID — same tree, < 30 min)** → you MAY de-duplicate:
+  1. **Verify the tally on that file** — the existing
+     `Overall: N/M passed, F failed` check above (present, `N == M`,
+     `F == 0`, `N >= baseline_N`). A VALID-but-FAILING result is still a
+     verification FAIL — do not reuse a failing run.
+  2. **ALWAYS run the cross-cutting CONCERN suites**, regardless of the
+     changed area (they gate by concern, not area, so the prefix heuristic
+     below MISSES them — they are the floor):
+     `tests/test-skill-conformance.sh`, `tests/test-skills-mirror-parity.sh`,
+     `tests/test-skill-version-enforcement.sh`,
+     `tests/test-doc-viewer-catalog.sh`,
+     `tests/test-managed-md-up-to-date.sh`, `tests/test-agents-parity.sh`.
+  3. **Derive the changed-area suites on TOP of the floor.** Run
+     `git diff $(git merge-base origin/main HEAD)..HEAD --name-only`. If
+     `merge-base` fails or the changed-path set is empty while HEAD is
+     provably ahead of main → FULL re-run. Otherwise group the changed paths
+     into area families by JUDGMENT over the suite NAMING CONVENTION (e.g. a
+     `hooks/` change → `test-hooks-*` / `test-*-hook-*`; `skills/do/` →
+     `test-do-*`; `skills/fix-issues/` → `test-fix-issues-*`), enumerating
+     candidates via `list_registered_suites()` from
+     `tests/lib/suite-registry.sh` (a flat enumerator with NO area tags — this
+     is judgment, not a maintained path→suite map). **If the targeted set is
+     EMPTY or you are not confident it covers the change → run the FULL
+     suite.** Run each selected suite as `bash tests/test-<name>.sh` and
+     check its `Results: N passed, F failed` line; all (floor + targeted)
+     must pass.
+- **Exit 1 (invalid/stale/missing/empty field/git absent)** → run the FULL
+  `$FULL_TEST_CMD` as today and apply the tally check above.
+
+**FULL re-run is MANDATORY (overrides the de-dup path) when ANY of:** the
+result is invalid/stale; the diff touches `tests/`, `hooks/`,
+`scripts/_lib/`, shared skill scripts (`skills/*/scripts/`), the runner
+(`tests/run-all.sh`), ANY `skills/**/*.md` (skill bodies are behavior),
+`agents/*.md`, `.claude/agents/*.md` (the verifier.md twin lives there),
+`CLAUDE_TEMPLATE.md`, or `managed.md`; the targeted candidate set is
+EMPTY/uncertain or `merge-base` fails; or you judge the change risky.
+
+**Threat model:** a fabricated or stale results file fails at three
+independent layers — the validator (`suite-result-valid.sh`: the
+content-sensitive tree fingerprint mismatches a tree it did not measure,
+and it fails closed on empty fields / absent git), the targeted re-run plus
+the always-on concern suites (the changed area must actually pass on the
+live tree), and CI (a fresh full run on a clean clone). Provenance reuse
+NEVER accepts a result for a tree whose CONTENT was not measured.
+
 ## Scope-creep AC checks
 
 When checking AC-style "no scope creep" criteria, prefer one of:

--- a/docs/plans/SUITE_PROVENANCE_PLAN.md
+++ b/docs/plans/SUITE_PROVENANCE_PLAN.md
@@ -2,7 +2,7 @@
 issue: 1166
 title: Suite-result provenance — stamp, validate, and de-duplicate test runs without ever skipping verification
 created: 2026-06-15
-status: "active"
+status: "complete"
 ---
 
 # Plan: Suite-result provenance — stamp, validate, and de-duplicate test runs without ever skipping verification

--- a/docs/plans/SUITE_PROVENANCE_PLAN.md
+++ b/docs/plans/SUITE_PROVENANCE_PLAN.md
@@ -615,7 +615,7 @@ that would trip the deny-list.
 | 1 — STAMP (run-all.sh header) + VALIDATE helper + triplet unit suite | ✅ Done | 4fa87b9 | Suite 7776/7776; unit suite 13/13; fingerprint flip verified |
 | 2 — VERIFIER PROTOCOL: verifier.md twin + 4 dispatch templates + version bumps + mirrors | ✅ Done | 3e1e9fb | Suite 7776/7776; parity/mirror/conformance/version/managed all green |
 | 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ✅ Done | ec7c841 | Verified PASS; classifier excludes skills/**/*.md; gates green |
-| 4 — POLICY PROSE: CLAUDE_TEMPLATE Tests subsection + managed.md re-render + conformance pins | ⬚ | | |
+| 4 — POLICY PROSE: CLAUDE_TEMPLATE Tests subsection + managed.md re-render + conformance pins | ✅ Done | 0701e97 | Suite 7788/7788; 12 conformance pins; managed re-render lockstep green |
 
 ---
 

--- a/docs/plans/SUITE_PROVENANCE_PLAN.md
+++ b/docs/plans/SUITE_PROVENANCE_PLAN.md
@@ -614,7 +614,7 @@ that would trip the deny-list.
 |-------|--------|--------|-------|
 | 1 — STAMP (run-all.sh header) + VALIDATE helper + triplet unit suite | ✅ Done | 4fa87b9 | Suite 7776/7776; unit suite 13/13; fingerprint flip verified |
 | 2 — VERIFIER PROTOCOL: verifier.md twin + 4 dispatch templates + version bumps + mirrors | ✅ Done | 3e1e9fb | Suite 7776/7776; parity/mirror/conformance/version/managed all green |
-| 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ✅ Done | ec7c841 | Suite 7776/7776; classifier excludes skills/**/*.md; gates green |
+| 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ✅ Done | ec7c841 | Verified PASS; classifier excludes skills/**/*.md; gates green |
 | 4 — POLICY PROSE: CLAUDE_TEMPLATE Tests subsection + managed.md re-render + conformance pins | ⬚ | | |
 
 ---

--- a/docs/plans/SUITE_PROVENANCE_PLAN.md
+++ b/docs/plans/SUITE_PROVENANCE_PLAN.md
@@ -612,7 +612,7 @@ that would trip the deny-list.
 
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
-| 1 — STAMP (run-all.sh header) + VALIDATE helper + triplet unit suite | ⬚ | | |
+| 1 — STAMP (run-all.sh header) + VALIDATE helper + triplet unit suite | ✅ Done | 4fa87b9 | Suite 7776/7776; unit suite 13/13; fingerprint flip verified |
 | 2 — VERIFIER PROTOCOL: verifier.md twin + 4 dispatch templates + version bumps + mirrors | ⬚ | | |
 | 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ⬚ | | |
 | 4 — POLICY PROSE: CLAUDE_TEMPLATE Tests subsection + managed.md re-render + conformance pins | ⬚ | | |

--- a/docs/plans/SUITE_PROVENANCE_PLAN.md
+++ b/docs/plans/SUITE_PROVENANCE_PLAN.md
@@ -614,7 +614,7 @@ that would trip the deny-list.
 |-------|--------|--------|-------|
 | 1 — STAMP (run-all.sh header) + VALIDATE helper + triplet unit suite | ✅ Done | 4fa87b9 | Suite 7776/7776; unit suite 13/13; fingerprint flip verified |
 | 2 — VERIFIER PROTOCOL: verifier.md twin + 4 dispatch templates + version bumps + mirrors | ✅ Done | 3e1e9fb | Suite 7776/7776; parity/mirror/conformance/version/managed all green |
-| 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ⬚ | | |
+| 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ✅ Done | ec7c841 | Suite 7776/7776; classifier excludes skills/**/*.md; gates green |
 | 4 — POLICY PROSE: CLAUDE_TEMPLATE Tests subsection + managed.md re-render + conformance pins | ⬚ | | |
 
 ---

--- a/docs/plans/SUITE_PROVENANCE_PLAN.md
+++ b/docs/plans/SUITE_PROVENANCE_PLAN.md
@@ -613,7 +613,7 @@ that would trip the deny-list.
 | Phase | Status | Commit | Notes |
 |-------|--------|--------|-------|
 | 1 — STAMP (run-all.sh header) + VALIDATE helper + triplet unit suite | ✅ Done | 4fa87b9 | Suite 7776/7776; unit suite 13/13; fingerprint flip verified |
-| 2 — VERIFIER PROTOCOL: verifier.md twin + 4 dispatch templates + version bumps + mirrors | ⬚ | | |
+| 2 — VERIFIER PROTOCOL: verifier.md twin + 4 dispatch templates + version bumps + mirrors | ✅ Done | 3e1e9fb | Suite 7776/7776; parity/mirror/conformance/version/managed all green |
 | 3 — ORCHESTRATOR baseline reuse + DOCS-ONLY classifier refinement | ⬚ | | |
 | 4 — POLICY PROSE: CLAUDE_TEMPLATE Tests subsection + managed.md re-render + conformance pins | ⬚ | | |
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.15+85206a"
+  version: "2026.06.15+0a8beb"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -880,9 +880,15 @@ Before touching anything:
 
 3. **Classify the change type** — this determines verification intensity
    in Phase 3:
-   - **Content only** — markdown, images, presentations, documentation.
-     No tests needed.
-   - **Code** — JavaScript, CSS, HTML, model files. Tests needed.
+   - **Content only** — a diff CONFINED to `docs/`, `README*`, `CHANGELOG*`,
+     `PRESENTATION*`, and non-skill images/presentations. Runs ONLY the
+     prose-pinning subset locally (`test-skill-conformance.sh`,
+     `test-doc-viewer-catalog.sh`, `test-managed-md-up-to-date.sh`); CI still
+     runs the full suite. **EXCLUDES `skills/**/*.md` — skill bodies are
+     behavior, not docs, so any `skills/**/*.md` edit is "Code" and runs the
+     full local suite + full CI.**
+   - **Code** — JavaScript, CSS, HTML, model files, AND any `skills/**/*.md`
+     (skill bodies are behavior). Tests needed (full local suite + full CI).
    - **Mixed** — both content and code. Tests needed for code portion.
 
 4. **Plan the work** — no formal document, just mental clarity on what
@@ -1015,16 +1021,30 @@ would fail usage-error exit 2.
 
 Verification intensity matches the change type (from Phase 1):
 
-### Content-only changes (md, jpg, png, presentations)
+### Content-only changes (`docs/`, `README*`, `CHANGELOG*`, `PRESENTATION*`, non-skill images/presentations)
+
+**This class EXCLUDES `skills/**/*.md`.** Skill bodies are behavior, not
+docs — a diff touching ANY `skills/**/*.md` is NOT content-only. It routes to
+the "Code" path and runs the full local suite + full CI. Only a diff CONFINED
+to `docs/`, `README*`, `CHANGELOG*`, `PRESENTATION*`, and non-skill
+images/presentations qualifies here.
 
 - **Spot-check:** formatting, links, file organization, image references
-- **Do NOT run tests** — running 4,000+ tests for a markdown edit is
-  wasteful, and pre-existing failures would block the task unnecessarily
+- **Run ONLY the prose-pinning subset locally** — `test-skill-conformance.sh`,
+  `test-doc-viewer-catalog.sh`, and `test-managed-md-up-to-date.sh` (the
+  catalog/`docs/DocsRegistry.js` drift gate is regenerated from doc/skill
+  catalog content, so it belongs here). Do NOT run the full local suite for a
+  docs-confined edit — running 4,000+ tests for a markdown edit is wasteful,
+  and pre-existing failures would block the task unnecessarily. CI still runs
+  the full suite regardless.
 - **Dispatch a separate verification agent (worktree/direct mode).** Tell
-  the agent explicitly: "These are content-only changes (no code). Review
-  the diff for correctness and completeness — do NOT run `npm test` or
-  `npm run test:all`. Your job is: do these changes make sense? Are the
-  right files included? Anything accidentally staged? Formatting correct?"
+  the agent explicitly: "These are content-only changes (`docs/`/`README*`/
+  `CHANGELOG*`/`PRESENTATION*`, NOT any `skills/**/*.md`). Review the diff for
+  correctness and completeness — run only the prose-pinning subset
+  (`test-skill-conformance.sh`, `test-doc-viewer-catalog.sh`,
+  `test-managed-md-up-to-date.sh`), not `npm test` or `npm run test:all`. Your
+  job is: do these changes make sense? Are the right files included? Anything
+  accidentally staged? Formatting correct?"
   Do NOT invoke `/verify-changes` for content-only changes — it will run
   the full test suite regardless. Instead, dispatch a plain review agent.
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.11+0ebe97"
+  version: "2026.06.15+85206a"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -1070,6 +1070,21 @@ Verification intensity matches the change type (from Phase 1):
   wait for the monitor." Past failure: 6+ subagent crashes with that
   phrase across 2026-04-29 and 2026-04-30. Always foreground-Bash with
   explicit long timeout; capture to file; read the file on return.
+- **Result-provenance de-duplication (de-dup, NOT skip).** If a results file
+  already exists for the CURRENT working tree (e.g. captured moments earlier
+  on the same uncommitted tree), run `tests/lib/suite-result-valid.sh` on it
+  before re-running the full suite. On **exit 0** (the provenance header
+  validates for the current tree, < 30 min), de-duplicate — verify the tally,
+  ALWAYS run the cross-cutting concern suites (`test-skill-conformance.sh`,
+  `test-skills-mirror-parity.sh`, `test-skill-version-enforcement.sh`,
+  `test-doc-viewer-catalog.sh`, `test-managed-md-up-to-date.sh`,
+  `test-agents-parity.sh`), and re-run only the targeted suites for the
+  changed area. On **exit 1** (invalid/stale), when the targeted set is empty
+  or uncertain, or when the diff touches shared infra (`tests/`, `hooks/`,
+  `scripts/_lib/`, shared skill scripts, the runner) or any `skills/**/*.md` /
+  `agents/*.md` / `.claude/agents/*.md` / `CLAUDE_TEMPLATE.md`, run the full
+  suite. A suite is elided ONLY when provably unrelated; an empty or uncertain
+  target means a FULL re-run.
 - **If tests fail: fix them.** Do not check if failures are pre-existing.
   Do not stash, checkout old commits, or create comparison worktrees.
   If you touched code and tests fail, they're yours to fix. (See

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.12+c4f5cc"
+  version: "2026.06.15+2e2c75"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -381,6 +381,25 @@ Do not proceed until you have read the file.
 - **`$FULL_TEST_CMD` before every commit** (canonical form — maintainers: see
   `references/canonical-config-prelude.md` §1 in the zskills source) — not
   just `npm test`.
+- **Result-provenance de-duplication (de-dup, NOT skip).** The impl agent's
+  pre-commit `$FULL_TEST_CMD` run produces a STAMPED results file carrying a
+  provenance header (tree + content-sensitive fingerprint + epoch). Because
+  fix-issues uses the verifier-commits-after model (the impl agent does NOT
+  commit; the verification agent commits AFTER passing tests, above), that
+  stamped result IS reusable by the verification agent: at verify time the
+  working tree is the SAME dirty pre-commit tree the impl agent measured, so
+  `tests/lib/suite-result-valid.sh` validates it (exit 0) and the verifier
+  de-duplicates — verify the tally, ALWAYS run the cross-cutting concern
+  suites (`test-skill-conformance.sh`, `test-skills-mirror-parity.sh`,
+  `test-skill-version-enforcement.sh`, `test-doc-viewer-catalog.sh`,
+  `test-managed-md-up-to-date.sh`, `test-agents-parity.sh`), and re-run only
+  the targeted suites for the changed area. Run the FULL suite on invalid/stale
+  (exit 1), an empty/uncertain target, or a shared-infra / `skills/**/*.md` /
+  `agents/*.md` / `CLAUDE_TEMPLATE.md` diff. Honest caveat: a result captured
+  BEFORE the impl agent's LAST edit drifts in content → fingerprint mismatch →
+  exit 1 → full re-run (the predicate working, not a foreclosure). Reuse is NOT
+  foreclosed across a commit boundary — the model is identical to run-plan.
+  (fix-issues impl agents are `subagent_type: "implementer"`.)
 - **Never weaken tests** — fix the code, not the test. Do not loosen
   tolerances, skip assertions, or remove test cases.
 - **Never defer the hard parts** — finish all phases of the plan. Do not

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.12+cddf24"
+  version: "2026.06.15+a5fca0"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.15+a5fca0"
+  version: "2026.06.15+0efeca"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -692,6 +692,24 @@ Include this VERBATIM in the verifier dispatch prompt:
        2026-05-18: verifier reported "3313/3313 passed" by counting inline
        PASS lines; final tally was 3311/3313 — two regressions slipped
        (anchor `feedback_verify_by_count_not_any_fail`).
+     - **Result-provenance de-duplication (de-dup, NOT skip).** Before
+       re-running the full suite, run `tests/lib/suite-result-valid.sh` on the
+       implementer's results file. In run-plan the implementer does NOT commit
+       and the VERIFIER commits after — so at verify time the working tree is
+       the SAME dirty pre-commit tree the implementer measured, and the
+       provenance header validates (exit 0): reuse is real. On **exit 0**
+       (valid for the current tree, < 30 min), de-duplicate — verify the tally,
+       ALWAYS run the cross-cutting concern suites
+       (`test-skill-conformance.sh`, `test-skills-mirror-parity.sh`,
+       `test-skill-version-enforcement.sh`, `test-doc-viewer-catalog.sh`,
+       `test-managed-md-up-to-date.sh`, `test-agents-parity.sh`), and re-run
+       the targeted suites for the changed area. Run the **FULL suite** when
+       the result is invalid/stale (exit 1), when the targeted set is empty or
+       uncertain, or when the diff touches shared infra (`tests/`, `hooks/`,
+       `scripts/_lib/`, shared skill scripts, the runner) or any
+       `skills/**/*.md` / `agents/*.md` / `.claude/agents/*.md` /
+       `CLAUDE_TEMPLATE.md`. De-dup changes WHAT runs, never that a fresh
+       verifier independently audits the diff.
 
 2. **Additional plan-specific checks** (the verifier checks these against the
    verbatim plan text — not against a summary):

--- a/skills/run-plan/modes/execute-phase.md
+++ b/skills/run-plan/modes/execute-phase.md
@@ -443,7 +443,12 @@ else
   . "$CLAUDE_PROJECT_DIR/.claude/skills/update-zskills/scripts/zskills-resolve-config.sh"
 fi
 
-# Orchestrator captures baseline BEFORE impl agent starts
+# Orchestrator captures baseline BEFORE impl agent starts.
+# The baseline file ALSO carries the provenance header emitted by the runner,
+# so it is a provenance-stamped result for the tree at capture time — the
+# verifier may REUSE it (via tests/lib/suite-result-valid.sh) instead of
+# re-running to refresh the baseline, killing the baseline-refresh re-run and
+# the baseline-clobber class.
 cd "$WORKTREE_PATH"
 if [ -n "$FULL_TEST_CMD" ]; then
   TEST_OUT="/tmp/zskills-tests/$(basename "$WORKTREE_PATH")"
@@ -672,7 +677,17 @@ Include this VERBATIM in the verifier dispatch prompt:
    - The **work items checklist** — verify each item was actually implemented,
      not stubbed or skipped
    - The **`"$TEST_OUT/.test-baseline.txt"` file** captured before implementation
-     started (if `FULL_TEST_CMD` is configured). The verification agent should:
+     started (if `FULL_TEST_CMD` is configured). This file ALSO carries the
+     provenance header, so it is a provenance-stamped result for the tree at
+     capture time — the verifier may treat **ANY** validating result at the
+     current tree (the baseline OR a fresh capture) as reusable: run
+     `tests/lib/suite-result-valid.sh` on the candidate; on **exit 0** reuse it
+     (verify the tally + run the cross-cutting concern suites + targeted rerun,
+     per the de-dup bullet below) instead of re-running everything to refresh
+     the baseline; on **exit 1** (e.g. the tree advanced between baseline
+     capture and verification, or > 30 min elapsed) re-run. This kills the
+     baseline-refresh re-run and the baseline-clobber class. The verification
+     agent should:
      - Read `"$TEST_OUT/.test-baseline.txt"` (baseline captured before implementation)
      - Compare against `"$TEST_OUT/${TEST_OUTPUT_FILE:-.test-results.txt}"` (results after running tests now)
      - **New failures** (in results but not in baseline) → regressions, must

--- a/skills/verify-changes/SKILL.md
+++ b/skills/verify-changes/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   playwright-cli, fix problems, re-verify until clean, then report with
   recommendations.
 metadata:
-  version: "2026.06.10+0b68d4"
+  version: "2026.06.15+b3eca3"
 ---
 
 # /verify-changes [<scope> | last [N]] — Verify, Test & Fix Changes
@@ -353,7 +353,22 @@ to file as below; read the file when the call returns.
 
 1. **Run the full test suite with output captured to a file** (canonical form —
    maintainers: see `references/canonical-config-prelude.md` §1 in the zskills
-   source):
+   source).
+
+   **Result-provenance de-duplication (de-dup, NOT skip).** If a results file
+   already exists for the CURRENT working tree (e.g. one captured moments
+   earlier on the same uncommitted tree), run `tests/lib/suite-result-valid.sh`
+   on it. On **exit 0** (the provenance header validates for the current tree,
+   < 30 min), de-duplicate — verify the tally, ALWAYS run the cross-cutting
+   concern suites (`test-skill-conformance.sh`, `test-skills-mirror-parity.sh`,
+   `test-skill-version-enforcement.sh`, `test-doc-viewer-catalog.sh`,
+   `test-managed-md-up-to-date.sh`, `test-agents-parity.sh`), and re-run only
+   the targeted suites for the changed area. On **exit 1** (invalid/stale; e.g.
+   the tree advanced), when the targeted set is empty, or when the diff touches
+   shared infra (`tests/`, `hooks/`, `scripts/_lib/`, shared skill scripts, the
+   runner) or any `skills/**/*.md` / `agents/*.md` / `.claude/agents/*.md` /
+   `CLAUDE_TEMPLATE.md`, run the full suite as below. A suite is elided ONLY
+   when provably unrelated; an empty or uncertain target means a FULL re-run.
    ```bash
    if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
      export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"

--- a/tests/lib/suite-result-valid.sh
+++ b/tests/lib/suite-result-valid.sh
@@ -1,0 +1,130 @@
+# tests/lib/suite-result-valid.sh — provenance-result validator for a
+# tests/run-all.sh output file (SUITE_PROVENANCE Phase 1, #1166).
+#
+# SOURCEABLE LIBRARY, NOT A SUITE. Do NOT register in run-all.sh as a
+# `run_suite`. `tests/test-suite-result-valid.sh` is the registered self-test
+# that exercises this function.
+#
+# Answers ONLY "is this result still TRUE for the current tree?" — NOT "did it
+# pass?". The pass signal (every suite passed) is the bottom
+# `Overall: N/M passed, F failed` line, checked SEPARATELY by the verifier; a
+# result can be VALID (right tree, fresh) and FAILING. Keep the two concerns
+# distinct.
+#
+# suite_result_valid <file>
+#   exit 0 (valid) IFF ALL clauses hold; exit 1 otherwise:
+#     0. Fields present + non-empty (fail closed). <file> exists, its first
+#        non-blank line is `zskills-suite-provenance: v1`, and it carries
+#        NON-EMPTY tree=/fingerprint=/timestamp=/epoch= header lines. Empty is
+#        MALFORMED, not a wildcard — checked BEFORE any live comparison so an
+#        empty recorded value can never `""==""`-match an empty live value when
+#        git is unavailable.
+#     1. git available + HEAD resolvable. `git -C "$REPO_ROOT" rev-parse HEAD`
+#        succeeds (non-empty, exit 0). Absent git / not a repo / unborn HEAD →
+#        exit 1 (cannot prove "same tree").
+#     2. tree + fingerprint match the CURRENT tree. Recorded `tree` == live
+#        HEAD AND recorded `fingerprint` == the live content-sensitive
+#        fingerprint (the EXACT formula run-all.sh emits — same `git diff HEAD`
+#        + untracked roll-up).
+#     3. Age < 30 minutes. (now_epoch - recorded_epoch) < 1800, where
+#        now_epoch=$(date -u +%s) and recorded_epoch is read DIRECTLY from the
+#        header (a plain integer — NO ISO re-parse, portable across GNU/BSD
+#        date). A negative/future delta → invalid (defensive).
+#
+# Pure bash + git/date math — NO jq, NO Python (the fields are simple
+# grep-able lines).
+#
+# REPO_ROOT: if the caller has already exported it (run-all.sh does), it is
+# used; otherwise self-locate from this lib's path. zsh leaves
+# ${BASH_SOURCE[0]} unset, so fall back to $0 (#1149 idiom). All live git
+# calls use `git -C "$REPO_ROOT" …` — the validator must NOT assume the
+# caller's cwd is the repo root.
+if [ -z "${REPO_ROOT:-}" ]; then
+  _srv_self="${BASH_SOURCE[0]:-$0}"
+  _srv_dir="$(cd "$(dirname "$_srv_self")" && pwd)"
+  REPO_ROOT="$(cd "$_srv_dir/../.." && pwd)"
+fi
+
+# Recompute the live content-sensitive fingerprint. MUST be byte-identical to
+# the formula tests/run-all.sh emits (any divergence makes a freshly-captured
+# header fail its own validator).
+_suite_result_live_fingerprint() {
+  {
+    git -C "$REPO_ROOT" rev-parse HEAD
+    git -C "$REPO_ROOT" diff HEAD
+    git -C "$REPO_ROOT" ls-files --others --exclude-standard -z \
+      | while IFS= read -r -d '' f; do
+          printf '%s\0' "$f"
+          git -C "$REPO_ROOT" hash-object "$REPO_ROOT/$f"
+        done
+  } 2>/dev/null | git -C "$REPO_ROOT" hash-object --stdin 2>/dev/null
+}
+
+# Extract a `key=value` header field's VALUE from the first ~10 lines.
+# Echoes the raw value (may be empty). Returns the value verbatim after the
+# first `=`.
+_suite_result_field() {
+  local file="$1" key="$2"
+  head -n 10 "$file" | grep -m1 -E "^${key}=" | sed -E "s/^${key}=//"
+}
+
+suite_result_valid() {
+  local file="$1"
+
+  # ── Clause 0: file exists, marker present, fields present + non-empty ──────
+  [ -n "$file" ] || return 1
+  [ -f "$file" ] || return 1
+
+  # First NON-BLANK line must be the format-version marker.
+  local first_nonblank
+  first_nonblank="$(grep -m1 -E '[^[:space:]]' "$file")"
+  [ "$first_nonblank" = "zskills-suite-provenance: v1" ] || return 1
+
+  local rec_tree rec_fp rec_ts rec_epoch
+  rec_tree="$(_suite_result_field "$file" tree)"
+  rec_fp="$(_suite_result_field "$file" fingerprint)"
+  rec_ts="$(_suite_result_field "$file" timestamp)"
+  rec_epoch="$(_suite_result_field "$file" epoch)"
+
+  # Missing OR empty field → malformed → fail closed (BEFORE any live compare).
+  [ -n "$rec_tree" ]  || return 1
+  [ -n "$rec_fp" ]    || return 1
+  [ -n "$rec_ts" ]    || return 1
+  [ -n "$rec_epoch" ] || return 1
+
+  # epoch must be a plain integer (a non-integer would break clause 3 math).
+  case "$rec_epoch" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+
+  # ── Clause 1: git available + HEAD resolvable ─────────────────────────────
+  local live_tree
+  live_tree="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)" || return 1
+  [ -n "$live_tree" ] || return 1
+
+  # ── Clause 2: tree + fingerprint match the CURRENT tree ───────────────────
+  [ "$rec_tree" = "$live_tree" ] || return 1
+  local live_fp
+  live_fp="$(_suite_result_live_fingerprint)"
+  [ -n "$live_fp" ] || return 1
+  [ "$rec_fp" = "$live_fp" ] || return 1
+
+  # ── Clause 3: age < 30 minutes (epoch integer subtraction; defensive on
+  # negative/future delta) ──────────────────────────────────────────────────
+  local now_epoch delta
+  now_epoch="$(date -u +%s)"
+  delta=$(( now_epoch - rec_epoch ))
+  [ "$delta" -ge 0 ] || return 1      # future/negative → invalid (defensive)
+  [ "$delta" -lt 1800 ] || return 1   # >= 30 min → stale
+
+  return 0
+}
+
+# Runnable directly: `bash tests/lib/suite-result-valid.sh <file>` → exit 0/1.
+# (The self-test invokes it both ways; when sourced, only the function is
+# defined.) Guard on BASH_SOURCE vs $0 so a `bash <lib> <file>` invocation
+# runs the predicate while a `. <lib>` source does not.
+if [ "${BASH_SOURCE[0]:-$0}" = "${0}" ]; then
+  suite_result_valid "$1"
+  exit $?
+fi

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -17,6 +17,44 @@ TOTAL_FAIL=0
 OVERALL_EXIT=0
 
 # ──────────────────────────────────────────────────────────────────────────
+# SUITE_PROVENANCE Phase 1 (#1166) — provenance header. Emitted ONCE by the
+# MAIN process to stdout, BEFORE any suite output, in BOTH parallel (default)
+# and serial (ZSKILLS_PARALLEL=0) modes. The caller's `> file` redirect
+# captures it as the result file's header; the sourced validator
+# tests/lib/suite-result-valid.sh later answers "is this result still TRUE for
+# the current tree?". run-all.sh does NOT `cd` (REPO_ROOT is exported above but
+# there is zero `cd`), so EVERY git call MUST pass `-C "$REPO_ROOT"` — a bare
+# `git rev-parse` would read the caller's cwd. The bottom `Overall:` tally is
+# UNTOUCHED. On git-absent each field is emitted EMPTY (fail-safe); the
+# validator treats an empty tree/fingerprint/epoch as malformed → full re-run.
+PROV_TREE="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || true)"
+# CONTENT-sensitive fingerprint: committed HEAD + ALL tracked changes
+# (git diff HEAD covers staged+unstaged CONTENT) + the CONTENT of every
+# untracked-not-ignored file (--exclude-standard honors .gitignore). This
+# hashes file CONTENT, not just changed PATHS, so it FLIPS on a content-only
+# edit to an already-modified file (which a porcelain formula would miss).
+PROV_FINGERPRINT="$(
+  {
+    git -C "$REPO_ROOT" rev-parse HEAD
+    git -C "$REPO_ROOT" diff HEAD
+    git -C "$REPO_ROOT" ls-files --others --exclude-standard -z \
+      | while IFS= read -r -d '' f; do
+          printf '%s\0' "$f"
+          git -C "$REPO_ROOT" hash-object "$REPO_ROOT/$f"
+        done
+  } 2>/dev/null | git -C "$REPO_ROOT" hash-object --stdin 2>/dev/null || true
+)"
+PROV_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PROV_EPOCH="$(date -u +%s)"
+PROV_COMMAND="tests/run-all.sh"
+echo "zskills-suite-provenance: v1"
+echo "tree=$PROV_TREE"
+echo "fingerprint=$PROV_FINGERPRINT"
+echo "timestamp=$PROV_TIMESTAMP"
+echo "epoch=$PROV_EPOCH"
+echo "command=$PROV_COMMAND"
+
+# ──────────────────────────────────────────────────────────────────────────
 # TEST_SUITE_PARALLELIZATION Phase 4 — bounded-worker PARALLEL fan-out is the
 # DEFAULT; ZSKILLS_PARALLEL=0 is the opt-OUT to the byte-identical serial
 # reference path. DESIGN CHOICE: the fan-out lives IN run-all.sh (NOT a separate
@@ -233,6 +271,10 @@ run_suite "test-extract-fence-lib.sh" "tests/test-extract-fence-lib.sh"
 # are intentionally NOT registered; these two ARE the registered self-tests.
 run_suite "test-parse-results.sh" "tests/test-parse-results.sh"
 run_suite "test-suite-registry.sh" "tests/test-suite-registry.sh"
+# SUITE_PROVENANCE Phase 1 (#1166) — self-test for the sourceable validator
+# lib tests/lib/suite-result-valid.sh (which is NOT registered as a run_suite,
+# same as parse-results.sh / suite-registry.sh above).
+run_suite "test-suite-result-valid.sh" "tests/test-suite-result-valid.sh"
 run_suite "test-land-pr-tracking-copy.sh" "tests/test-land-pr-tracking-copy.sh"
 run_suite "test-landed-schema.sh" "tests/test-landed-schema.sh"
 run_suite "test-landed-status-vocabulary.sh" "tests/test-landed-status-vocabulary.sh"

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -872,6 +872,60 @@ else
 fi
 
 echo ""
+echo "=== Suite-result provenance (#1166) ==="
+# Phase 4 of SUITE_PROVENANCE_PLAN — pin the new result-provenance de-dup
+# protocol prose across every surface it lands in, plus the validator helper
+# and its registered self-test. The protocol is de-dup-WITH-provenance, never
+# "skip verification": each de-dup surface references the validator helper by
+# name (`suite-result-valid.sh`), and the central surfaces (agents/verifier.md
+# + CLAUDE_TEMPLATE.md) ALSO carry a safety-floor token so a floor-eroding edit
+# that keeps the anchor but drops the floor is caught (R1-4 backstop).
+#
+# A single `grep -qF` per file is SUFFICIENT for the verifier.md de-dup token:
+# tests/test-agents-parity.sh guarantees the agents/verifier.md ↔
+# .claude/agents/verifier.md de-dup prose is byte-identical transitively, so
+# the token does NOT also need appending to the _pin loop above (avoid the
+# double-pin).
+for _prov_surface in \
+  "agents/verifier.md" \
+  ".claude/agents/verifier.md" \
+  "skills/run-plan/modes/execute-phase.md" \
+  "skills/verify-changes/SKILL.md" \
+  "skills/do/SKILL.md" \
+  "skills/fix-issues/SKILL.md" \
+  "CLAUDE_TEMPLATE.md" \
+  ".claude/rules/zskills/managed.md"; do
+  if grep -qF 'suite-result-valid.sh' "$REPO_ROOT/$_prov_surface" 2>/dev/null; then
+    pass "[$_prov_surface] provenance de-dup anchor: suite-result-valid.sh"
+  else
+    fail "[$_prov_surface] provenance de-dup anchor: suite-result-valid.sh" "de-dup protocol prose missing (Phase 4 #1166)"
+  fi
+done
+# Safety-floor backstop — the always-on cross-cutting concern suites must be
+# named in the central verifier surface and the policy template so a de-dup
+# edit cannot quietly erode the floor (de-dup changes WHAT runs, never WHO,
+# and the cross-cutting gates ALWAYS run).
+for _floor_surface in "agents/verifier.md" "CLAUDE_TEMPLATE.md"; do
+  if grep -qF 'cross-cutting' "$REPO_ROOT/$_floor_surface" 2>/dev/null; then
+    pass "[$_floor_surface] provenance safety-floor token: cross-cutting"
+  else
+    fail "[$_floor_surface] provenance safety-floor token: cross-cutting" "safety-floor (always-on cross-cutting suites) prose missing (Phase 4 #1166)"
+  fi
+done
+# Validator helper + its registered self-test exist (tests/lib/ is repo-only,
+# never mirrored — Settled decision 10, so no mirror-parity pin).
+if [ -f "$REPO_ROOT/tests/lib/suite-result-valid.sh" ]; then
+  pass "[tests/lib/suite-result-valid.sh] validator helper exists"
+else
+  fail "[tests/lib/suite-result-valid.sh] validator helper exists" "provenance validator lib missing (Phase 1 #1166)"
+fi
+if [ -f "$REPO_ROOT/tests/test-suite-result-valid.sh" ]; then
+  pass "[tests/test-suite-result-valid.sh] registered self-test exists"
+else
+  fail "[tests/test-suite-result-valid.sh] registered self-test exists" "provenance validator self-test missing (Phase 1 #1166)"
+fi
+
+echo ""
 echo "=== Cross-skill PR-landing tripwires (PR_LANDING_UNIFICATION Phase 6 WI 6.1) ==="
 # Drift-prevention assertions catching any future re-introduction of inline
 # PR-landing primitives outside /land-pr. Each historical drift bug below

--- a/tests/test-suite-result-valid.sh
+++ b/tests/test-suite-result-valid.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+# Tests for the provenance-result validator tests/lib/suite-result-valid.sh
+# (SUITE_PROVENANCE Phase 1, #1166).
+#
+# The validator answers ONLY "is this result still TRUE for the current tree?"
+# (non-empty fields + tree + CONTENT-fingerprint + age < 30min), NOT "did it
+# pass?". Each fixture synthesizes a provenance header from LIVE values via the
+# lib's OWN fingerprint formula (so the round-trip is self-consistent on any
+# platform), then asserts the validator's exit code.
+#
+# Content-drift cases run against a `mktemp -d` SCRATCH git repo (the test must
+# never mutate the worktree it runs in): the header is captured with REPO_ROOT
+# pointed at the scratch repo, then the scratch tree's CONTENT is mutated, then
+# the validator is re-run with the SAME REPO_ROOT — proving the
+# content-sensitive fingerprint flips on a content-only change (the
+# R1-1/DA1 regression the porcelain-path formula missed).
+#
+# Cases:
+#   VALID                     — live tree/fingerprint, epoch=now            → 0
+#   INVALID-tree              — fabricated tree SHA                          → 1
+#   INVALID-fingerprint       — wrong fingerprint hash                       → 1
+#   CONTENT-DRIFT             — same paths, different tracked CONTENT        → 1
+#   UNTRACKED-CONTENT-DRIFT   — untracked file CONTENT changes              → 1
+#   CLEAN-STABLE              — header from a clean tree validates again     → 0
+#   STALE                     — epoch 31 min old                            → 1
+#   FRESH-boundary            — epoch ~29 min old                           → 0
+#   MISSING-file              — nonexistent path                            → 1
+#   MISSING-header            — file with no provenance marker              → 1
+#   GARBLED-header            — marker present but a field missing           → 1
+#   EMPTY-FIELD               — header with an EMPTY tree=/fingerprint=/epoch= → 1
+#   FUTURE-epoch              — epoch greater than now                       → 1
+#
+# Run from repo root: bash tests/test-suite-result-valid.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/tests/lib/suite-result-valid.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf '\033[32m  PASS\033[0m %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '\033[31m  FAIL\033[0m %s — %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+summary_and_exit() {
+  echo ""
+  echo "---"
+  local total=$((PASS_COUNT + FAIL_COUNT))
+  if [ "$FAIL_COUNT" -eq 0 ]; then
+    printf '\033[32mResults: %d passed, 0 failed (of %d)\033[0m\n' "$PASS_COUNT" "$total"
+    exit 0
+  else
+    printf '\033[31mResults: %d passed, %d failed (of %d)\033[0m\n' "$PASS_COUNT" "$FAIL_COUNT" "$total"
+    exit 1
+  fi
+}
+
+if [ ! -f "$LIB" ]; then
+  fail "validator lib exists" "$LIB missing"
+  summary_and_exit
+fi
+
+# Validate <file> against a given REPO_ROOT; echo the exit code. Runs in a
+# subshell with REPO_ROOT exported so the lib's live git calls target the
+# chosen repo, and unsets the function so each call re-sources cleanly.
+validate_against() {
+  local repo="$1" file="$2"
+  ( export REPO_ROOT="$repo"; bash "$LIB" "$file"; echo "RC=$?" ) 2>/dev/null \
+    | grep -oE 'RC=[0-9]+' | sed 's/RC=//'
+}
+
+# Compute the live content-sensitive fingerprint of a repo via the SAME formula
+# the lib uses (so headers are self-consistent). Mirrors run-all.sh verbatim.
+live_fingerprint() {
+  local repo="$1"
+  {
+    git -C "$repo" rev-parse HEAD
+    git -C "$repo" diff HEAD
+    git -C "$repo" ls-files --others --exclude-standard -z \
+      | while IFS= read -r -d '' f; do
+          printf '%s\0' "$f"
+          git -C "$repo" hash-object "$repo/$f"
+        done
+  } 2>/dev/null | git -C "$repo" hash-object --stdin 2>/dev/null
+}
+
+# Write a provenance header to <file>. Args: file tree fingerprint epoch.
+# timestamp is derived from epoch-of-now (forensic-only; the validator never
+# parses it, only requires non-empty).
+write_header() {
+  local file="$1" tree="$2" fp="$3" epoch="$4"
+  {
+    echo "zskills-suite-provenance: v1"
+    echo "tree=$tree"
+    echo "fingerprint=$fp"
+    echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "epoch=$epoch"
+    echo "command=tests/run-all.sh"
+  } > "$file"
+}
+
+now_epoch() { date -u +%s; }
+
+# ── Scratch repos / fixtures (all under mktemp; never a hardcoded /tmp path) ──
+SCRATCH="$(mktemp -d)"
+FIXT="$(mktemp -d)"
+cleanup() { rm -rf "$SCRATCH" "$FIXT"; }
+trap cleanup EXIT INT TERM
+
+# A scratch git repo with one committed tracked file.
+DRIFT_REPO="$SCRATCH/drift"
+mkdir -p "$DRIFT_REPO"
+git -C "$DRIFT_REPO" init -q
+git -C "$DRIFT_REPO" config user.email t@t
+git -C "$DRIFT_REPO" config user.name t
+printf 'original\n' > "$DRIFT_REPO/f.txt"
+git -C "$DRIFT_REPO" add f.txt
+git -C "$DRIFT_REPO" commit -qm init
+DRIFT_HEAD="$(git -C "$DRIFT_REPO" rev-parse HEAD)"
+
+# ── Case VALID: live tree/fingerprint of the scratch repo, epoch=now → 0 ─────
+echo "=== Case VALID: live tree/fingerprint, epoch=now → exit 0 ==="
+F="$FIXT/valid.txt"
+write_header "$F" "$DRIFT_HEAD" "$(live_fingerprint "$DRIFT_REPO")" "$(now_epoch)"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "0" ] && pass "VALID → exit 0" || fail "VALID" "expected 0 got '$RC'"
+
+# ── Case INVALID-tree: fabricated tree SHA → 1 ───────────────────────────────
+echo "=== Case INVALID-tree: fabricated tree SHA → exit 1 ==="
+F="$FIXT/invtree.txt"
+write_header "$F" "0000000000000000000000000000000000000000" "$(live_fingerprint "$DRIFT_REPO")" "$(now_epoch)"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "1" ] && pass "INVALID-tree → exit 1" || fail "INVALID-tree" "expected 1 got '$RC'"
+
+# ── Case INVALID-fingerprint: wrong fingerprint hash → 1 ─────────────────────
+echo "=== Case INVALID-fingerprint: wrong fingerprint → exit 1 ==="
+F="$FIXT/invfp.txt"
+write_header "$F" "$DRIFT_HEAD" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" "$(now_epoch)"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "1" ] && pass "INVALID-fingerprint → exit 1" || fail "INVALID-fingerprint" "expected 1 got '$RC'"
+
+# ── Case CONTENT-DRIFT: capture fingerprint, mutate tracked CONTENT (same
+# path/status), re-validate → fingerprint flips → 1 (the porcelain formula
+# would COLLIDE here). ───────────────────────────────────────────────────────
+echo "=== Case CONTENT-DRIFT: same paths, different tracked content → exit 1 ==="
+# Make the tracked file dirty first (so both before/after are ` M f.txt`).
+printf 'CONTENT_X\n' > "$DRIFT_REPO/f.txt"
+F="$FIXT/drift.txt"
+write_header "$F" "$DRIFT_HEAD" "$(live_fingerprint "$DRIFT_REPO")" "$(now_epoch)"
+# Sanity: it validates BEFORE the content drift.
+RC_BEFORE="$(validate_against "$DRIFT_REPO" "$F")"
+# Now change CONTENT only (path + porcelain status ` M f.txt` unchanged).
+printf 'CONTENT_Y_different\n' > "$DRIFT_REPO/f.txt"
+RC_AFTER="$(validate_against "$DRIFT_REPO" "$F")"
+if [ "$RC_BEFORE" = "0" ] && [ "$RC_AFTER" = "1" ]; then
+  pass "CONTENT-DRIFT → valid before drift (0), invalid after content-only change (1)"
+else
+  fail "CONTENT-DRIFT" "before='$RC_BEFORE' (want 0) after='$RC_AFTER' (want 1)"
+fi
+
+# ── Case UNTRACKED-CONTENT-DRIFT: untracked-not-ignored file CONTENT changes
+# → fingerprint flips → 1. ────────────────────────────────────────────────────
+echo "=== Case UNTRACKED-CONTENT-DRIFT: untracked file content changes → exit 1 ==="
+# Reset the tracked file to its committed content; add an untracked file.
+git -C "$DRIFT_REPO" checkout -q -- f.txt
+printf 'untracked_A\n' > "$DRIFT_REPO/u.txt"
+F="$FIXT/udrift.txt"
+write_header "$F" "$DRIFT_HEAD" "$(live_fingerprint "$DRIFT_REPO")" "$(now_epoch)"
+RC_BEFORE="$(validate_against "$DRIFT_REPO" "$F")"
+printf 'untracked_B_different\n' > "$DRIFT_REPO/u.txt"
+RC_AFTER="$(validate_against "$DRIFT_REPO" "$F")"
+if [ "$RC_BEFORE" = "0" ] && [ "$RC_AFTER" = "1" ]; then
+  pass "UNTRACKED-CONTENT-DRIFT → valid before (0), invalid after content change (1)"
+else
+  fail "UNTRACKED-CONTENT-DRIFT" "before='$RC_BEFORE' (want 0) after='$RC_AFTER' (want 1)"
+fi
+rm -f "$DRIFT_REPO/u.txt"
+
+# ── Case CLEAN-STABLE: two fingerprints of an unchanged clean tree are equal;
+# a header from the first validates against the second → 0. ───────────────────
+echo "=== Case CLEAN-STABLE: clean-tree fingerprint stable → exit 0 ==="
+CLEAN_REPO="$SCRATCH/clean"
+mkdir -p "$CLEAN_REPO"
+git -C "$CLEAN_REPO" init -q
+git -C "$CLEAN_REPO" config user.email t@t
+git -C "$CLEAN_REPO" config user.name t
+printf 'stable\n' > "$CLEAN_REPO/g.txt"
+git -C "$CLEAN_REPO" add g.txt
+git -C "$CLEAN_REPO" commit -qm init
+CLEAN_HEAD="$(git -C "$CLEAN_REPO" rev-parse HEAD)"
+FP1="$(live_fingerprint "$CLEAN_REPO")"
+FP2="$(live_fingerprint "$CLEAN_REPO")"
+F="$FIXT/clean.txt"
+write_header "$F" "$CLEAN_HEAD" "$FP1" "$(now_epoch)"
+RC="$(validate_against "$CLEAN_REPO" "$F")"
+if [ "$FP1" = "$FP2" ] && [ "$RC" = "0" ]; then
+  pass "CLEAN-STABLE → fingerprint stable across calls, header validates (0)"
+else
+  fail "CLEAN-STABLE" "fp1='$FP1' fp2='$FP2' rc='$RC' (want equal fps + rc 0)"
+fi
+
+# ── Case STALE: epoch 31 min old → 1 (epoch arithmetic; portable). ───────────
+echo "=== Case STALE: epoch 31 min old → exit 1 ==="
+F="$FIXT/stale.txt"
+write_header "$F" "$DRIFT_HEAD" "$(live_fingerprint "$DRIFT_REPO")" "$(( $(now_epoch) - 1860 ))"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "1" ] && pass "STALE (31 min) → exit 1" || fail "STALE" "expected 1 got '$RC'"
+
+# ── Case FRESH-boundary: epoch ~29 min old → 0. ──────────────────────────────
+echo "=== Case FRESH-boundary: epoch ~29 min old → exit 0 ==="
+F="$FIXT/fresh.txt"
+write_header "$F" "$DRIFT_HEAD" "$(live_fingerprint "$DRIFT_REPO")" "$(( $(now_epoch) - 1740 ))"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "0" ] && pass "FRESH-boundary (29 min) → exit 0" || fail "FRESH-boundary" "expected 0 got '$RC'"
+
+# ── Case MISSING-file: nonexistent path → 1. ─────────────────────────────────
+echo "=== Case MISSING-file: nonexistent path → exit 1 ==="
+RC="$(validate_against "$DRIFT_REPO" "$FIXT/does-not-exist.txt")"
+[ "$RC" = "1" ] && pass "MISSING-file → exit 1" || fail "MISSING-file" "expected 1 got '$RC'"
+
+# ── Case MISSING-header: file with no provenance marker → 1. ─────────────────
+echo "=== Case MISSING-header: no provenance marker → exit 1 ==="
+F="$FIXT/nomarker.txt"
+{ echo "Tests: foo"; echo "Results: 3 passed, 0 failed"; echo "Overall: 3/3 passed, 0 failed"; } > "$F"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "1" ] && pass "MISSING-header → exit 1" || fail "MISSING-header" "expected 1 got '$RC'"
+
+# ── Case GARBLED-header: marker present but a field missing → 1. ──────────────
+echo "=== Case GARBLED-header: marker present, fingerprint field missing → exit 1 ==="
+F="$FIXT/garbled.txt"
+{
+  echo "zskills-suite-provenance: v1"
+  echo "tree=$DRIFT_HEAD"
+  # fingerprint= line deliberately OMITTED
+  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "epoch=$(now_epoch)"
+  echo "command=tests/run-all.sh"
+} > "$F"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "1" ] && pass "GARBLED-header (missing field) → exit 1" || fail "GARBLED-header" "expected 1 got '$RC'"
+
+# ── Case EMPTY-FIELD: header with EMPTY tree=/fingerprint=/epoch= → 1
+# (clause 0; empty NEVER equals empty-as-valid — the DA3 fail-OPEN case). ──────
+echo "=== Case EMPTY-FIELD: empty tree=/fingerprint=/epoch= → exit 1 ==="
+EMPTY_FAILS=0
+for fieldset in "tree" "fingerprint" "epoch"; do
+  F="$FIXT/empty-$fieldset.txt"
+  TREE_V="$DRIFT_HEAD"; FP_V="$(live_fingerprint "$DRIFT_REPO")"; EP_V="$(now_epoch)"
+  case "$fieldset" in
+    tree) TREE_V="" ;;
+    fingerprint) FP_V="" ;;
+    epoch) EP_V="" ;;
+  esac
+  write_header "$F" "$TREE_V" "$FP_V" "$EP_V"
+  RC="$(validate_against "$DRIFT_REPO" "$F")"
+  [ "$RC" = "1" ] && EMPTY_FAILS=$((EMPTY_FAILS + 1)) \
+    || fail "EMPTY-FIELD ($fieldset)" "expected 1 got '$RC'"
+done
+[ "$EMPTY_FAILS" = "3" ] && pass "EMPTY-FIELD (tree/fingerprint/epoch each empty) → exit 1"
+
+# ── Case FUTURE-epoch: epoch greater than now → 1 (defensive). ───────────────
+echo "=== Case FUTURE-epoch: epoch greater than now → exit 1 ==="
+F="$FIXT/future.txt"
+write_header "$F" "$DRIFT_HEAD" "$(live_fingerprint "$DRIFT_REPO")" "$(( $(now_epoch) + 600 ))"
+RC="$(validate_against "$DRIFT_REPO" "$F")"
+[ "$RC" = "1" ] && pass "FUTURE-epoch → exit 1" || fail "FUTURE-epoch" "expected 1 got '$RC'"
+
+summary_and_exit


### PR DESCRIPTION
## Summary

Executes `docs/plans/SUITE_PROVENANCE_PLAN.md` (#1166) — suite-result provenance to **de-duplicate identical full-suite test runs without reducing verification** ("de-dup WITH provenance, never verify less"). All 4 phases, each independently verified; full suite green at every boundary.

Closes #1166.

## What shipped (the 5 surfaces)

- **Phase 1 — stamp + validator.** `tests/run-all.sh` emits a provenance header (content-sensitive tree fingerprint, not the issue's content-blind `git status --porcelain` formula — that bug is corrected here); `tests/lib/suite-result-valid.sh` validates tree+content-fingerprint+age<30min, fail-closed; `tests/test-suite-result-valid.sh` (13 cases incl. content-drift / untracked-drift / empty-field). Triplet-registered.
- **Phase 2 — verifier protocol.** De-dup subsection in the parity-locked `verifier.md` twins + the 4 verifier-dispatch skills: reuse a validating result → verify tally + targeted re-run; ALWAYS run the cross-cutting concern suites; FULL re-run on invalid/stale or any touch of tests/, hooks/, scripts/_lib, runner, `skills/**/*.md`, `agents/*.md`. Independence preserved (WHAT executes, never WHO). Version bumps + mirrors.
- **Phase 3 — orchestrator baseline reuse + `/do` docs-only classifier** refined to exclude `skills/**/*.md` (skill bodies are behavior).
- **Phase 4 — policy prose + conformance pins.** Additive CLAUDE_TEMPLATE/managed "Tests — result provenance / de-duplication" subsection (safety floor + threat model verbatim) + 12 conformance pins (proven non-vacuous).

## Verification

- Drafted via `/draft-plan` (2 adversarial rounds; corrected the issue's own latent content-blind-hash bug + a cross-cutting-suite-miss).
- Each phase implemented + independently verified (fresh verifier); final cross-phase overall verification PASS.
- Full suite: **7788/7788 passed, 0 failed**. Validator round-trips on the final tree. Scope held to exactly the issue's 5 surfaces.

## Test plan

- [x] `bash tests/run-all.sh` green (7788/7788) on the final combined state
- [x] New unit suite `test-suite-result-valid.sh` 13/13; conformance pins green; managed↔template render lockstep green
- [x] Threat-model core independently confirmed: fingerprint flips on same-path/different-content
