### PR TITLE
Separate auto (unattended) from new automerge token (auto-merge)

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -7,9 +7,9 @@ description: >-
   other agents' work, and optionally pushes, lands worktree commits, or
   opens a PR via /land-pr. Positional auto enables auto-merge (PR mode
   only).
-argument-hint: "[pr] [scope] [push|land] [auto]"
+argument-hint: "[pr] [scope] [push|land] [auto|automerge]"
 metadata:
-  version: "2026.06.15+cf08df"
+  version: "2026.06.15+dc691a"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow
@@ -41,17 +41,23 @@ FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
 # The token never falls through to SCOPE_HINT (stripped in both PR-mode
 # parse paths). Setting AUTO_FLAG outside PR mode is a no-op — `push`
 # and `land` modes do not consult it.
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])([aA][uU][tT][oO])($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])([aA][uU][tT][oO])($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 if [[ "$FIRST_TOKEN" == "pr" ]]; then
   # PR subcommand mode
   SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
-  # Strip the positional `auto` token from SCOPE_HINT so it does not leak
-  # into the PR title / scope-hint downstream. Match `auto` as a
-  # whitespace-bounded token (case-insensitive).
-  SCOPE_HINT=$(echo "$SCOPE_HINT" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
+  # Strip the positional `auto` and `automerge` tokens from SCOPE_HINT so
+  # they do not leak into the PR title / scope-hint downstream.
+  SCOPE_HINT=$(echo "$SCOPE_HINT" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
   # ... see Phase 6 (PR mode) below
 fi
 ```
@@ -104,9 +110,9 @@ if [ "$HAS_EXPLICIT_MODE" -eq 0 ]; then
       # Treat as `/commit pr` — drop into PR subcommand mode below.
       # SCOPE_HINT keeps any scope words from $ARGUMENTS (no `pr` prefix
       # to strip, since the user didn't type it). Strip the positional
-      # `auto` token (AUTO_FLAG was already set above) so it does not
-      # leak into the PR title / downstream scope-hint usage.
-      SCOPE_HINT=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
+      # `auto` and `automerge` tokens (flags already set above) so they
+      # do not leak into the PR title / downstream scope-hint usage.
+      SCOPE_HINT=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
       DEFAULT_MODE="pr"
       ;;
     direct|"")

--- a/.claude/skills/commit/modes/pr.md
+++ b/.claude/skills/commit/modes/pr.md
@@ -130,13 +130,15 @@ LAND_OUTCOME=__init__
 LANDED_SOURCE="commit"
 LAND_ARGS="--branch=$BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --tracking-id=$BRANCH_SLUG"
 
-# Auto-merge gate (issue #236) — append `--auto` when the caller passed
+# Auto gate (issue #236) — append `--auto` when the caller passed
 # the positional `auto` token (parsed in skills/commit/SKILL.md and
 # propagated as $AUTO_FLAG=1). Mirrors /run-plan, /fix-issues, /do.
-# Without the token, `/land-pr` runs through PR creation +
+# `--automerge` additionally requests auto-merge on the PR.
+# Without `automerge`, `/land-pr` runs through PR creation +
 # CI poll + fix-cycle but does NOT call `gh pr merge --auto --squash`;
 # the PR settles at `pr-ready` for human review.
 [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+[ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
 while :; do
   # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /commit pr.
@@ -235,7 +237,7 @@ while :; do
       else
         LAND_OUTCOME=pr-ready
       fi
-      break ;;  # /land-pr already requested merge if --auto (gated on AUTO_FLAG per issue #236)
+      break ;;  # /land-pr already requested merge if --automerge (gated on AUTOMERGE_FLAG per issue #236)
     pending)
       LAND_OUTCOME=pr-ready
       break ;;  # settle at pr-ready
@@ -327,11 +329,12 @@ rm -f "$TRACK_DIR/requires.land-pr.$BRANCH_SLUG"
 ```
 
 **PR mode does NOT:**
-- Auto-merge **unless the positional `auto` token is passed** (issue #236
-  — `/commit pr auto` or, via config-default-to-pr, `/commit auto`).
-  Without `auto`, `LAND_ARGS` omits `--auto` and the PR settles at
-  `pr-ready` after CI passes; with `auto`, `--auto` is appended and
-  `/land-pr` invokes `gh pr merge --auto --squash`.
+- Auto-merge **unless the positional `automerge` token is passed**
+  (issue #236 — `/commit pr automerge` or, via config-default-to-pr,
+  `/commit automerge`). With bare `auto`, `LAND_ARGS` includes `--auto`
+  (unattended mode) but omits `--automerge`, so the PR settles at
+  `pr-ready` after CI passes. With `automerge`, `--automerge` is appended
+  and `/land-pr` invokes `gh pr merge --auto --squash`.
 - Write `.zskills/landed` markers (`/commit pr` has no worktree)
 - Run Phases 1–5 (all commits must already exist — clean tree is required)
 

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: do
-argument-hint: "<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [--rounds N] [auto|automerge] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.15+0cc69f"
+  version: "2026.06.15+0ab24d"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -247,8 +247,16 @@ fi
 #   - Phase 4 (Land) as the gate to push/cherry-pick+push (direct/worktree modes)
 # Note: Phase 3 dispatches /verify-changes unconditionally for code
 # changes (issue #713) — AUTO_FLAG no longer gates verification.
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+# 'auto merge' (two words) also counts as automerge
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 # Issue-number parse (claim-work-item Phase 2 / W2.2). Collect ALL `#N`
@@ -962,6 +970,8 @@ TASK_DESCRIPTION=$(echo "$REMAINING" \
   | sed -E 's/(^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?])/ /' \
   | sed -E 's/(^|[[:space:]])[dD][iI][rR][eE][cC][tT]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])worktree($|[[:space:]])/ /' \
+  | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/ /' \
+  | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--force($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--no-claim($|[[:space:]])/ /' \

--- a/.claude/skills/do/modes/pr.md
+++ b/.claude/skills/do/modes/pr.md
@@ -420,10 +420,9 @@ description.
 - `$LANDED_SOURCE = "do"`
 - `$WORKTREE_PATH` set (the per-task worktree from Step A5)
 - `--auto` is gated on the positional `auto` token (issue #297 — matches
-  /run-plan, /fix-issues). Without `auto`, auto-merge stays
-  OFF and the PR settles at `pr-ready` after CI passes; with `auto`,
-  `LAND_ARGS` includes `--auto` and `/land-pr`'s existing auto-merge
-  path takes over.
+  /run-plan, /fix-issues). `--automerge` is gated on the `automerge`
+  token. Without `automerge`, the PR settles at `pr-ready` after CI
+  passes; with `automerge`, `/land-pr` requests auto-merge.
 - `<CALLER_PRE_INVOKE_BODY_PREP>` = empty (do's body is fixed at PR
   creation; no per-phase update like /run-plan does)
 - `<CALLER_REBASE_CONFLICT_HANDLER>` = no agent-assisted resolution
@@ -486,9 +485,10 @@ LAND_OUTCOME=__init__
 LANDED_SOURCE="do"
 LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --worktree-path=$WORKTREE_PATH --tracking-id=$TASK_SLUG"
 # Issue #297: positional `auto` token (parsed in pre-flight pre-parse)
-# opts /do pr into /land-pr's auto-merge path. Mirrors
-# /run-plan, /fix-issues.
+# opts /do pr into unattended mode. `automerge` additionally requests
+# auto-merge via /land-pr. Mirrors /run-plan, /fix-issues.
 [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+[ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
 while :; do
   # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /do pr.
@@ -593,7 +593,7 @@ while :; do
       else
         LAND_OUTCOME=pr-ready
       fi
-      break ;;  # /land-pr already requested merge if --auto
+      break ;;  # /land-pr already requested merge if --automerge
     pending)
       LAND_OUTCOME=pr-ready
       break ;;  # settle at pr-ready

--- a/.claude/skills/draft-plan/SKILL.md
+++ b/.claude/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto|automerge] [brainstorm|quiz] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.15+e152b7"
+  version: "2026.06.15+ac57fe"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -167,8 +167,15 @@ fi
 
 ```bash
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 ```
@@ -960,6 +967,7 @@ concerns.
       run skill-conformance / hook / fixture suites
 BODY
      LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-plan --worktree-path=$TOPLEVEL --tracking-id=draft-plan.$SLUG --auto"
+     [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
      # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
 

--- a/.claude/skills/draft-tests/SKILL.md
+++ b/.claude/skills/draft-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-tests
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
+argument-hint: "<plan-file> [rounds N] [auto|automerge] [<guidance>]"
 description: >-
   Draft test specifications into an existing plan through iterative
   adversarial review. Appends a `### Tests` subsection per pending phase
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.06.15+bcc06e"
+  version: "2026.06.15+f151ef"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [<guidance>] — Adversarial Test-Spec Drafter
@@ -175,8 +175,15 @@ fi
 
 ```bash
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 ```

--- a/.claude/skills/draft-tests/modes/land.md
+++ b/.claude/skills/draft-tests/modes/land.md
@@ -161,9 +161,10 @@ Issue #581: in projects with `execution.landing: pr` +
 `main_protected: true`, the plan with appended test specs is committed
 in the worktree (above) but never reaches main without a `/land-pr`
 dispatch. When the user passed the `auto` positional token, dispatch
-`/land-pr` so the branch pushes, a PR opens, CI runs, and auto-merge
-lands the test-spec-augmented plan on main. Without `auto`, the
-worktree commit stands and the caller lands manually.
+`/land-pr` so the branch pushes, a PR opens, and CI runs. With
+`automerge`, auto-merge lands the test-spec-augmented plan on main;
+with bare `auto`, the PR settles at pr-ready for human review. Without
+either token, the worktree commit stands and the caller lands manually.
 
 ```bash
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
@@ -196,6 +197,7 @@ devil's-advocate + refiner). Completed phases were NOT modified
       CI will run skill-conformance / hook / fixture suites
 BODY
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-tests --worktree-path=$TOPLEVEL --tracking-id=draft-tests.$SLUG --auto"
+  [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
   # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
 

--- a/.claude/skills/fix-issues/SKILL.md
+++ b/.claude/skills/fix-issues/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: fix-issues
 disable-model-invocation: true
-argument-hint: "N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next"
+argument-hint: "N [<focus>|dashboard] [auto|automerge] [every SCHEDULE] [now] | sync | plan [auto|automerge] | stop | next"
 description: >-
   Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue
   worktrees, verify, optionally auto-land via /land-pr. Recurring via
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.15+b4d031"
+  version: "2026.06.15+49b9c8"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -121,8 +121,15 @@ gate stays unchanged.
 ```bash
 # Argument parsing — extract canonical flags from $ARGUMENTS.
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 ```

--- a/.claude/skills/fix-issues/modes/pr.md
+++ b/.claude/skills/fix-issues/modes/pr.md
@@ -1,6 +1,6 @@
 # /fix-issues — PR Mode (Per-Issue)
 
-Land each verified fix via one PR per issue with rebase, push, CI polling, and auto-merge on success.
+Land each verified fix via one PR per issue with rebase, push, CI polling, and optional auto-merge on success.
 ### PR mode landing
 
 When `LANDING_MODE == pr`, landing replaces cherry-pick with **per-issue
@@ -12,7 +12,7 @@ caller loop `continue`s to the next issue.
 
 **Auto-flag gating.** Rebase, push, PR creation, **CI polling, and the fix cycle ALL run regardless of `$AUTO`** — they're either low-risk (review-surfacing) or reversible (the fix cycle pushes commits to the feature branch, which the user can revert). Goal: by the time the user reviews the PR, it is as clean as the agent could get it.
 
-Only the final `gh pr merge --auto --squash` call is gated on `$AUTO` — and that gate now lives inside `/land-pr`'s `pr-merge.sh` (Phase 1B WI 1.6). **Only `gh pr merge --auto --squash` is gated on `auto`.** Without `auto`, the PR settles at status `pr-ready` after CI passes (or `pr-ci-failing` after fix-cycle exhaustion) and waits for human review and merge on GitHub.
+Only the final `gh pr merge --auto --squash` call is gated on `$AUTOMERGE` — and that gate now lives inside `/land-pr`'s `pr-merge.sh`. **Only `gh pr merge --auto --squash` is gated on `automerge`.** Without `automerge`, the PR settles at status `pr-ready` after CI passes (or `pr-ci-failing` after fix-cycle exhaustion) and waits for human review and merge on GitHub.
 
 **Per-issue /land-pr dispatch.** `/fix-issues pr` no longer owns
 rebase, push, PR creation, CI polling, the fix cycle, the merge call,
@@ -34,8 +34,8 @@ have verified commits on `fix/issue-NNN`.
 `/fix-issues pr` customizations of the canonical pattern:
 - `$LANDED_SOURCE = "fix-issues"`
 - `$WORKTREE_PATH = $ISSUE_WORKTREE` (per-issue worktree)
-- `$AUTO = $AUTO` (auto-merge gated on caller's `--auto` flag, passed
-  through to `/land-pr` via `--auto`)
+- `$AUTO_FLAG` (unattended mode, passed through to `/land-pr` via
+  `--auto`); `$AUTOMERGE_FLAG` (auto-merge, passed via `--automerge`)
 - `$ISSUE_NUM = $ISSUE_NUM` (passed through via `--issue=$ISSUE_NUM`;
   `/land-pr` writes it into the `.zskills/landed` marker's `issue:` field)
 - `<CALLER_PRE_INVOKE_BODY_PREP>` = empty (per-issue body is composed
@@ -135,7 +135,8 @@ BODY
 
   LANDED_SOURCE="fix-issues"
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --worktree-path=$WORKTREE_PATH --issue=$ISSUE_NUM --tracking-id=$ISSUE_NUM"
-  [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
   while :; do
     # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /fix-issues pr.
@@ -228,7 +229,7 @@ BODY
         else
           LAND_OUTCOME=pr-ready
         fi
-        break ;;  # /land-pr already requested merge if --auto
+        break ;;  # /land-pr already requested merge if --automerge
       pending)
         LAND_OUTCOME=pr-ready
         break ;;  # settle at pr-ready

--- a/.claude/skills/fix-issues/modes/sprint.md
+++ b/.claude/skills/fix-issues/modes/sprint.md
@@ -658,10 +658,10 @@ if [ "$DASHBOARD_MODE" = "1" ]; then
       # This dispatch fires when the dashboard Ready queue is empty but
       # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
       # content (`git add -A` against the worktree after sync ran), so it
-      # ALWAYS auto-merges regardless of user's `auto` arg — same rationale
-      # as standalone sync's Phase 5 dispatch and the no-actionable ship
-      # branch later in this skill.
-      LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-dashboard-empty --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+      # ALWAYS auto-merges regardless of user's `automerge` arg — same
+      # rationale as standalone sync's Phase 5 dispatch and the no-actionable
+      # ship branch later in this skill.
+      LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-dashboard-empty --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto --automerge"
 
       echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 
@@ -1458,10 +1458,10 @@ If ALL candidates are too vague, too complex, or already attempted:
          # This dispatch fires when Phase 2 found no actionable issues but
          # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
          # content (`git add -A` against the worktree after sync ran, before any
-         # fix work), so it ALWAYS auto-merges regardless of user's `auto` arg —
-         # same rationale as standalone sync's Phase 5 dispatch at the top of
-         # this skill.
-         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+         # fix work), so it ALWAYS auto-merges regardless of user's `automerge`
+         # arg — same rationale as standalone sync's Phase 5 dispatch at the
+         # top of this skill.
+         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto --automerge"
 
          echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 
@@ -2458,8 +2458,8 @@ if [ "${#TRACKER_SCRATCHPADS[@]}" -gt 0 ]; then
         git commit -m "docs(sync): /fix-issues skip-tag rollup sprint $SPRINT_ID"
       fi
     )
-    # Dispatch /land-pr --auto for the tracker PR. Mirrors the
-    # dashboard-empty pattern's LAND_ARGS shape (always --auto because
+    # Dispatch /land-pr --auto --automerge for the tracker PR. Mirrors the
+    # dashboard-empty pattern's LAND_ARGS shape (always automerge because
     # this is sync-only content with no code-review surface).
     TRACKER_LAND_ID="fix-issues.tracker-rollup.${SPRINT_ID}"
     TRACKER_RESULT=$(mktemp)
@@ -2474,7 +2474,7 @@ if [ "${#TRACKER_SCRATCHPADS[@]}" -gt 0 ]; then
     printf 'skill: land-pr\nrequired-by: fix-issues-pr-mode-tracker-rollup\ndate: %s\n' \
       "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
       > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${TRACKER_LAND_ID}"
-    TRACKER_LAND_ARGS="--branch=fix-issues-tracker/$SPRINT_ID --title=\"sync: /fix-issues skip-tag rollup sprint $SPRINT_ID\" --body-file=$TRACKER_BODY --result-file=$TRACKER_RESULT --landed-source=fix-issues-pr-mode-tracker-rollup --worktree-path=$TRACKER_WT --tracking-id=$TRACKER_LAND_ID --auto"
+    TRACKER_LAND_ARGS="--branch=fix-issues-tracker/$SPRINT_ID --title=\"sync: /fix-issues skip-tag rollup sprint $SPRINT_ID\" --body-file=$TRACKER_BODY --result-file=$TRACKER_RESULT --landed-source=fix-issues-pr-mode-tracker-rollup --worktree-path=$TRACKER_WT --tracking-id=$TRACKER_LAND_ID --auto --automerge"
     echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
     # Skill: { skill: "land-pr", args: "$TRACKER_LAND_ARGS" }
     # (Allow-list parser handles result file; mirrors dashboard-empty pattern.)
@@ -2896,7 +2896,8 @@ if [ -n "${WT_PATH:-}" ]; then
     PR_TITLE="sprint-report: $SPRINT_ID"
     SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
     LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID"
-    [ "${AUTO:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+    [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+    [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
     echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 

--- a/.claude/skills/fix-issues/modes/sync.md
+++ b/.claude/skills/fix-issues/modes/sync.md
@@ -316,7 +316,7 @@ EOF
    # `gh issue close` calls. The CI-monitor-suppression flag remains
    # omitted (CI monitoring is desired; the orchestrator awaits resting
    # state).
-   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto"
+   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto --automerge"
 
    # Echo the pipeline id for transcript-propagation (matches /do pr's
    # tier-2 idiom at `skills/do/modes/pr.md:203`). Do NOT env-export

--- a/.claude/skills/land-pr/SKILL.md
+++ b/.claude/skills/land-pr/SKILL.md
@@ -2,9 +2,9 @@
 name: land-pr
 user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
-argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
+argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--automerge] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.06.15+e1f067"
+  version: "2026.06.15+1fd1a2"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -51,7 +51,9 @@ Phase 6 verify caller skills follow it.
 
 Parse `$ARGUMENTS` using the bash-regex idiom that matches `/do`
 and `/commit`. Required: `--branch`, `--title`, `--body-file`, `--result-file`.
-Optional: `--auto` (bool, default false), `--worktree-path`,
+Optional: `--auto` (bool, default false — unattended mode),
+`--automerge` (bool, default false — request auto-merge; implies `--auto`),
+`--worktree-path`,
 `--landed-source` (default `land-pr`), `--ci-timeout` (default 600),
 `--no-monitor` (skip CI poll, return after create), `--pr <num>` (resume
 mode: skip rebase/push/create, jump to monitor), `--issue <num>`
@@ -73,6 +75,7 @@ TITLE=""
 BODY_FILE=""
 RESULT_FILE=""
 AUTO_FLAG=false
+AUTOMERGE_FLAG=false
 WORKTREE_PATH=""
 LANDED_SOURCE="land-pr"
 CI_TIMEOUT=600
@@ -91,6 +94,7 @@ while [ $i -lt ${#ARGS[@]} ]; do
     --body-file)      i=$((i+1)); BODY_FILE="${ARGS[$i]:-}" ;;
     --result-file)    i=$((i+1)); RESULT_FILE="${ARGS[$i]:-}" ;;
     --auto)           AUTO_FLAG=true ;;
+    --automerge)      AUTOMERGE_FLAG=true; AUTO_FLAG=true ;;
     --worktree-path)  i=$((i+1)); WORKTREE_PATH="${ARGS[$i]:-}" ;;
     --landed-source)  i=$((i+1)); LANDED_SOURCE="${ARGS[$i]:-}" ;;
     --ci-timeout)     i=$((i+1)); CI_TIMEOUT="${ARGS[$i]:-}" ;;
@@ -449,9 +453,9 @@ This step closes that loop: detect BEHIND, rebase locally onto current
 churn when many PRs are landing rapidly.
 
 **Skip conditions (skip the whole Step 6b loop):**
-- `$AUTO_FLAG != true` — BEHIND recovery is only useful when auto-merge
-  is requested. Without `--auto`, BEHIND is the caller's problem to
-  resolve manually.
+- `$AUTO_FLAG != true` — BEHIND recovery is only useful when the caller
+  is running unattended. Without `--auto`, BEHIND is the caller's problem
+  to resolve manually.
 - `$STATUS` already set to a failure terminus (`rebase-conflict`,
   `push-failed`, `create-failed`, `monitor-failed`, `rebase-failed`,
   `merge-failed`) — Step 6b shouldn't run after upstream failures.
@@ -641,9 +645,9 @@ if [ -z "$STATUS" ] \
 fi
 ```
 
-### Step 7 — Merge (gated on `--auto`)
+### Step 7 — Merge (gated on `--automerge`)
 
-Always run `pr-merge.sh` — it owns the auto/CI gating internally.
+Always run `pr-merge.sh` — it owns the automerge/CI gating internally.
 
 ```bash
 if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -654,7 +658,7 @@ else
 fi
 if [ -n "$PR_NUMBER" ] && [ "$STATUS" != "rebase-conflict" ] && [ "$STATUS" != "rebase-failed" ] && [ "$STATUS" != "push-failed" ] && [ "$STATUS" != "create-failed" ] && [ "$STATUS" != "behind-thrash" ] && [ "$STATUS" != "auto-rebase-conflict" ] && [ "$STATUS" != "auto-rebase-blocked" ]; then
   MERGE_STDOUT=$(bash "$ZSKILLS_SKILLS_ROOT/land-pr/scripts/pr-merge.sh" \
-    --pr "$PR_NUMBER" --auto-flag "$AUTO_FLAG" --ci-status "${CI_STATUS:-not-monitored}")
+    --pr "$PR_NUMBER" --automerge-flag "$AUTOMERGE_FLAG" --ci-status "${CI_STATUS:-not-monitored}")
   MERGE_RC=$?
 
   while IFS='=' read -r KEY VALUE; do

--- a/.claude/skills/land-pr/references/caller-loop-pattern.md
+++ b/.claude/skills/land-pr/references/caller-loop-pattern.md
@@ -40,8 +40,9 @@ maintainers.
 ```bash
 # === BEGIN CANONICAL /land-pr CALLER LOOP ===
 # Caller fills in: $BRANCH_NAME, $PR_TITLE, $BODY_FILE, $WORKTREE_PATH (optional),
-# $LANDED_SOURCE, $AUTO ("true"/"false"), $CI_MAX_ATTEMPTS (default 2),
-# $ISSUE_NUM (optional), and the fix-cycle agent dispatch block below.
+# $LANDED_SOURCE, $AUTO ("true"/"false"), $AUTOMERGE ("true"/"false"),
+# $CI_MAX_ATTEMPTS (default 2), $ISSUE_NUM (optional), and the fix-cycle
+# agent dispatch block below.
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
 
 ATTEMPT=0
@@ -64,6 +65,7 @@ while :; do
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE"
   [ -n "$WORKTREE_PATH" ] && LAND_ARGS="$LAND_ARGS --worktree-path=$WORKTREE_PATH"
   [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTOMERGE:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --automerge"
   [ -n "$ISSUE_NUM" ] && LAND_ARGS="$LAND_ARGS --issue=$ISSUE_NUM"
 
   # Invoke /land-pr via the Skill tool. The Skill tool loads /land-pr's
@@ -155,7 +157,7 @@ while :; do
 
   case "$CI_STATUS" in
     pass|none|skipped)
-      break ;;  # /land-pr already requested merge if --auto
+      break ;;  # /land-pr already requested merge if --automerge
     pending)
       break ;;  # settle at pr-ready; user / cron can resume with --pr
     not-monitored)

--- a/.claude/skills/land-pr/references/failure-modes.md
+++ b/.claude/skills/land-pr/references/failure-modes.md
@@ -236,5 +236,5 @@ idempotency contract is co-tested with the detection contract.
   for `gh pr edit` = 0).
 - **monitor pending → re-poll**: first invocation returns `CI_STATUS=pending`;
   second invocation (after CI completes) returns `CI_STATUS=pass`.
-- **merge no-op when --auto-flag=false**: emits `MERGE_REQUESTED=false
+- **merge no-op when --automerge-flag=false**: emits `MERGE_REQUESTED=false
   MERGE_REASON=auto-not-requested`, never invokes `gh pr merge`.

--- a/.claude/skills/land-pr/scripts/pr-merge.sh
+++ b/.claude/skills/land-pr/scripts/pr-merge.sh
@@ -5,7 +5,7 @@
 # Spec:  plans/PR_LANDING_UNIFICATION.md WI 1.6.
 #
 # Behavior:
-#   1. If --auto-flag != true, emit MERGE_REQUESTED=false MERGE_REASON=auto-not-requested, exit 0.
+#   1. If --automerge-flag != true, emit MERGE_REQUESTED=false MERGE_REASON=auto-not-requested, exit 0.
 #   2. If --ci-status not in {pass, none, skipped}, emit
 #      MERGE_REQUESTED=false MERGE_REASON=ci-not-passing, exit 0.
 #   3. `gh pr merge --auto --squash`. If stderr matches the auto-merge-
@@ -20,9 +20,9 @@
 #      (UNKNOWN if all retries fail).
 #
 # Args:
-#   --pr        <number>
-#   --auto-flag <true|false>
-#   --ci-status <pass|fail|pending|none|skipped|unknown>
+#   --pr             <number>
+#   --automerge-flag <true|false>
+#   --ci-status      <pass|fail|pending|none|skipped|unknown>
 #
 # Stdout (KEY=VALUE):
 #   MERGE_REQUESTED=<bool>
@@ -38,20 +38,20 @@
 set -u
 
 PR_NUMBER=""
-AUTO_FLAG=""
+AUTOMERGE_FLAG=""
 CI_STATUS=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --pr)         shift; PR_NUMBER="${1:-}" ;;
-    --auto-flag)  shift; AUTO_FLAG="${1:-}" ;;
-    --ci-status)  shift; CI_STATUS="${1:-}" ;;
+    --pr)              shift; PR_NUMBER="${1:-}" ;;
+    --automerge-flag)  shift; AUTOMERGE_FLAG="${1:-}" ;;
+    --ci-status)       shift; CI_STATUS="${1:-}" ;;
     *) echo "ERROR: pr-merge.sh: unknown arg: $1" >&2; exit 2 ;;
   esac
   shift || true
 done
 
-for v in PR_NUMBER AUTO_FLAG CI_STATUS; do
+for v in PR_NUMBER AUTOMERGE_FLAG CI_STATUS; do
   if [ -z "${!v}" ]; then
     echo "ERROR: pr-merge.sh: --${v,,} is required" >&2
     exit 2
@@ -63,8 +63,8 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
-# Step 1 — auto-flag != true → not requested.
-if [ "$AUTO_FLAG" != "true" ]; then
+# Step 1 — automerge-flag != true → not requested.
+if [ "$AUTOMERGE_FLAG" != "true" ]; then
   echo "MERGE_REQUESTED=false"
   echo "MERGE_REASON=auto-not-requested"
   exit 0

--- a/.claude/skills/refine-plan/SKILL.md
+++ b/.claude/skills/refine-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
+argument-hint: "<plan-file> [rounds N] [auto|automerge] [<guidance>]"
 description: >-
   Refine an in-progress plan by reviewing remaining phases against
   completed work. Dispatches reviewer + devil's-advocate agents to surface
@@ -9,7 +9,7 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.06.15+60b6fe"
+  version: "2026.06.15+d087ba"
 ---
 
 # /refine-plan \<plan-file> [rounds N] [<guidance>] — Adversarial Plan Refiner
@@ -164,8 +164,16 @@ parse the rest of the skill reads (`ROUNDS_MAX`, `AUTO_FLAG`, `GUIDANCE`).
 
 # auto — whitespace-anchored, case-insensitive (consumed; not guidance).
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+# automerge — whitespace-anchored, case-insensitive (consumed; not guidance).
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 
@@ -779,6 +787,7 @@ Log\` and \`## Plan Review\` sections appended.
       run skill-conformance / hook / fixture suites
 BODY
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=refine-plan --worktree-path=$TOPLEVEL --tracking-id=refine-plan.$SLUG --auto"
+  [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
   # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
 

--- a/.claude/skills/run-plan/SKILL.md
+++ b/.claude/skills/run-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [phase|finish|status] [auto] [every SCHEDULE] [now] | stop | next"
+argument-hint: "<plan-file> [phase|finish|status] [auto|automerge] [every SCHEDULE] [now] | stop | next"
 description: >-
   Execute the next phase of a plan: parse status, dispatch implementation
   in a worktree, verify via a separate agent, update progress, write the
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.15+2e2498"
+  version: "2026.06.15+86e095"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -148,10 +148,20 @@ if [[ "$ARGUMENTS" =~ (^|[[:space:]])[fF][iI][nN][iI][sS][hH]($|[[:space:]]) ]];
   fi
 fi
 
+# AUTOMERGE_FLAG: set by `automerge` token or `auto merge` (two words).
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+
 # AUTO_FLAG: set by standalone `auto` (regardless of finish), OR by the
-# `finish auto` composite (backward-compatible alias per D2-RP).
+# `finish auto` composite (backward-compatible alias per D2-RP), OR by
+# `automerge` (which implies auto).
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 

--- a/.claude/skills/run-plan/modes/pr.md
+++ b/.claude/skills/run-plan/modes/pr.md
@@ -351,19 +351,26 @@ RESULT_FILE="/tmp/land-pr-result-$BRANCH_SLUG-$$.txt"
 #   $WORKTREE_PATH = the plan-scoped PR-mode worktree (one per plan, reused across all phases in finish/finish-auto modes; see Issue #191)
 #   $AUTO          = "true" when $AUTO_FLAG=1 (i.e. /run-plan was invoked with `auto`,
 #                    or with the `finish auto` composite alias). Controls whether
-#                    `--auto` is appended to the /land-pr arg vector (auto-merge
-#                    the resulting PR).
+#                    `--auto` is appended to the /land-pr arg vector (unattended mode).
+#   $AUTOMERGE     = "true" when $AUTOMERGE_FLAG=1 (i.e. /run-plan was invoked with
+#                    `automerge`). Controls whether `--automerge` is appended (auto-merge).
 #   $BODY_FILE     = constructed above
 #   $BRANCH_NAME   = the plan-scoped feature branch (one per plan; phase number does NOT appear in branch name)
 #   $PR_TITLE      = constructed above
 LANDED_SOURCE="run-plan"
 # Bind $AUTO from the canonical $AUTO_FLAG bash variable: if `auto` was on
 # the invocation (standalone or via the `finish auto` composite alias), pass
-# `--auto` to /land-pr.
+# `--auto` to /land-pr. Bind $AUTOMERGE from $AUTOMERGE_FLAG: if `automerge`
+# was on the invocation, pass `--automerge` to /land-pr.
 if [ "${AUTO_FLAG:-0}" = "1" ]; then
   AUTO="true"
 else
   AUTO="false"
+fi
+if [ "${AUTOMERGE_FLAG:-0}" = "1" ]; then
+  AUTOMERGE="true"
+else
+  AUTOMERGE="false"
 fi
 
 while :; do
@@ -394,11 +401,12 @@ while :; do
   #     skills/run-plan/scripts/sync-pr-body-progress.sh:146-155.
   #   - gh-pr-edit-failed: WARN-and-continue.
 
-  # Build /land-pr arg vector. --body-file is required; --auto and
-  # --worktree-path are conditional.
+  # Build /land-pr arg vector. --body-file is required; --auto,
+  # --automerge, and --worktree-path are conditional.
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE"
   [ -n "$WORKTREE_PATH" ] && LAND_ARGS="$LAND_ARGS --worktree-path=$WORKTREE_PATH"
   [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTOMERGE:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --automerge"
   # Pass --tracking-id so /land-pr writes fulfilled.land-pr.<id> on
   # successful merge, satisfying the requires.land-pr.<id> marker written
   # at /run-plan skill entry. Only /run-plan PR mode passes this — the 3
@@ -541,7 +549,7 @@ while :; do
 
   case "$CI_STATUS" in
     pass|none|skipped)
-      break ;;  # /land-pr already requested merge if --auto
+      break ;;  # /land-pr already requested merge if --automerge
     pending)
       break ;;  # settle at pr-ready; user / cron can resume with --pr
     not-monitored)

--- a/.claude/skills/work-on-plans/SKILL.md
+++ b/.claude/skills/work-on-plans/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] | stop | next | (no args = list ready queue)"
+argument-hint: "N|all [phase|finish] [automerge] [every SCHEDULE] [now] [continue] | stop | next | (no args = list ready queue)"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
   per entry (mode resolves to `finish` by default; `phase` opts out),
-  honoring each plan's queued mode. N|all composes with every SCHEDULE +
-  now for the queue-worker pattern (N plans per fire). Also manages the
-  queue (add/rank/remove/default) and recurring schedules. Mirrors
-  /fix-issues for bugs.
+  honoring each plan's queued mode. With `automerge`, also requests
+  auto-merge on the PR after CI passes. N|all composes with every
+  SCHEDULE + now for the queue-worker pattern (N plans per fire). Also
+  manages the queue (add/rank/remove/default) and recurring schedules.
+  Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.06.15+7314ac"
+  version: "2026.06.19+9e9931"
 ---
 
 # /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor
@@ -126,6 +127,15 @@ by name (order insensitive, no positional meaning):
 
 - `phase` → `MODE_OVERRIDE=phase` (mutex with `finish`)
 - `finish` → `MODE_OVERRIDE=finish` (mutex with `phase`)
+- `automerge` → `AUTOMERGE=1` (pass `automerge` to `/run-plan`;
+  requests auto-merge on the PR after CI passes)
+- `auto` (or the two-word `auto merge`) → **usage error**, exit 2. The
+  skill always runs unattended, so `auto` carries no meaning here, and
+  `auto` must NOT silently merge — that would auto-merge a whole batch of
+  PRs and break the universal rule that bare `auto` never requests a
+  merge in any skill. Only `automerge` is accepted as the merge token.
+  Print:
+  > /work-on-plans does not accept `auto` (it always runs unattended). Use `automerge` to auto-merge each PR after CI passes, or omit it to leave PRs at pr-ready for review.
 - `continue` → `CONTINUE_ON_FAILURE=1`
 - `every` followed by a SCHEDULE expression → `SCHEDULE` captured;
   register a recurring cron (see Step 7 — `every`). **Composes with

--- a/.claude/skills/work-on-plans/modes/execute.md
+++ b/.claude/skills/work-on-plans/modes/execute.md
@@ -459,6 +459,13 @@ For each ready entry in `plans.ready[0:N]`:
    - Phase mode → `Skill: { skill: "run-plan", args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto" }`
    - Finish mode → `Skill: { skill: "run-plan", args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto finish" }`
 
+   When the user passed `automerge` to `/work-on-plans` (`AUTOMERGE=1`),
+   insert ` automerge` immediately after `auto` in the args above — e.g.
+   `args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto automerge"` (phase) or
+   `args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto automerge finish"` (finish) —
+   so `/run-plan` requests auto-merge on the PR. Without `automerge`, the
+   plain `auto` directives above stand and the PR settles at pr-ready.
+
    Where `$ZSKILLS_PLANS_DIR/<FILE>.md` is `SLUG_TO_FILE[$SLUG]` rendered as a
    path relative to `$MAIN_ROOT`. **Do not pass a landing-mode flag.**
    `/run-plan` resolves its own landing mode (currently `pr` per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ## Unreleased
 
+### Breaking: `auto` no longer requests auto-merge
+
+The `auto` positional token now means "unattended mode" only — it runs
+without pausing for approval but does **not** auto-merge the PR. Use the
+new `automerge` token for unattended + auto-merge (the previous `auto`
+behavior). `automerge` implies `auto`. `auto merge` (two words) is also
+accepted.
+
+Affected skills: `/run-plan`, `/do`, `/commit`, `/fix-issues`,
+`/draft-tests`, `/draft-plan`, `/refine-plan`, `/work-on-plans`.
+
 ### Plugin-lane install redesign — zero files required, one file when wanted (INSTALL_REDESIGN)
 
 - **The plugin install no longer writes anything into your project by

--- a/docs/plans/AUTOMERGE_TOKEN_PLAN.md
+++ b/docs/plans/AUTOMERGE_TOKEN_PLAN.md
@@ -1,0 +1,177 @@
+# Plan: `automerge` positional token
+
+**Status**: Implemented  
+**Date**: 2026-06-10  
+**Addresses**: ZSKILLS_TODO item 1
+
+## Problem
+
+`/run-plan finish auto`, `/fix-issues N auto`, `/do X pr auto`, `/commit pr auto`, and `/draft-tests auto` all pass `--auto` to `/land-pr`, which requests GitHub/GitLab auto-merge. Users want unattended execution (`auto`) but don't always want the PR to land without human review. Currently there's no way to separate these concerns.
+
+## Design
+
+### New token: `automerge`
+
+A positional token (like `auto`) accepted by all skills that currently accept `auto`. It implies `auto` (unattended execution) AND requests auto-merge. The bare `auto` token retains unattended execution but **no longer requests merge**.
+
+This is a **behavior change**: existing `auto` users who relied on auto-merge must switch to `automerge`. This is intentional — the safer default is "create PR but don't merge."
+
+### Resolution (simple, no config)
+
+| User passes | Unattended? | Auto-merge? |
+|-------------|-------------|-------------|
+| (nothing)   | No          | No          |
+| `auto`      | Yes         | No (**changed**) |
+| `automerge` | Yes         | Yes         |
+
+No config field. Explicit token, explicit behavior.
+
+### `auto merge` (two words) — treat as `automerge`
+
+If the arg parser sees `auto` followed by `merge` as adjacent positional tokens, treat it as `automerge`. No hint, no warning — the intent is unambiguous. This lives in each caller's arg-parse block.
+
+### /land-pr interface change
+
+`/land-pr` currently accepts `--auto` (bool). Change to:
+
+- `--auto` — unattended mode (CI polling, fix cycles, BEHIND recovery all still run)
+- `--automerge` — request auto-merge (implies `--auto` behavior for all gating)
+
+**`pr-merge.sh` interface rename**: Change the `--auto-flag` parameter to `--automerge-flag` (and internal variable to `AUTOMERGE_FLAG`). This eliminates the semantic trap where the parameter name says "auto" but means "merge." Single rename, one file.
+
+The Step 6b BEHIND recovery gates on `AUTO_FLAG` — that stays unchanged (rebasing a BEHIND branch is useful for unattended callers even without merge). Update the comment at SKILL.md line ~432 which incorrectly says "BEHIND recovery is only useful when auto-merge is requested" — after this change, it's useful whenever unattended.
+
+Step 7d (drive queued auto-merge) gates on both `AUTO_FLAG` and `MERGE_REQUESTED` — MERGE_REQUESTED will simply be `false` when `--automerge` wasn't passed, so it self-skips correctly.
+
+## Files to modify
+
+### 1. `/land-pr` (the merge chokepoint)
+
+**`skills/land-pr/SKILL.md`**
+- Frontmatter `argument-hint`: add `[--automerge]`
+- Arg parse: add `--automerge) AUTOMERGE_FLAG=true ;;`
+- Initialize: `AUTOMERGE_FLAG=false`
+- Step 7 dispatch to `pr-merge.sh`: pass `--automerge-flag "$AUTOMERGE_FLAG"`
+- Description: clarify `--auto` = unattended, `--automerge` = auto-merge
+- Update comment at line ~432 re: BEHIND recovery rationale (no longer tied to merge — useful for any unattended caller)
+
+**`skills/land-pr/scripts/pr-merge.sh`**
+- Rename `--auto-flag` parameter → `--automerge-flag`
+- Rename internal variable `AUTO_FLAG` → `AUTOMERGE_FLAG`
+- Gate logic unchanged (still checks the flag for `true`/`false`)
+
+### 2. Caller skills (5 files)
+
+Each currently does: `[ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"`
+
+Change to:
+```bash
+[ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+[ "$AUTOMERGE" = "true" ] && LAND_ARGS="$LAND_ARGS --automerge"
+```
+
+**Files:**
+- `skills/run-plan/modes/pr.md` (line ~400) — conditional append
+- `skills/fix-issues/modes/pr.md` (line ~138) — conditional append
+- `skills/do/modes/pr.md` (line ~478) — conditional append
+- `skills/commit/modes/pr.md` (line ~138) — conditional append
+- `skills/draft-tests/modes/land.md` (line ~197) — **NOTE**: this file hardcodes `--auto` directly in the LAND_ARGS string literal rather than conditionally appending. Must restructure: remove `--auto` from the string, add conditional appends for both `--auto` and `--automerge` after it (matching the pattern used by the other 4 callers).
+
+### 3. SKILL.md frontmatter (argument-hint + arg parse)
+
+Each skill that accepts `auto` must also accept `automerge`:
+
+- `skills/run-plan/SKILL.md` — hint: `[auto|automerge]`; parse `automerge` token
+- `skills/fix-issues/SKILL.md` — same
+- `skills/do/SKILL.md` — same
+- `skills/commit/SKILL.md` — same
+- `skills/draft-tests/SKILL.md` — same
+
+**Important**: The codebase uses **regex matching** (not case statements) for positional tokens:
+```bash
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
+
+Since `automerge` contains `auto` as a substring, **order matters**. Parse `automerge` FIRST, then `auto`:
+```bash
+# automerge (must precede auto — substring match)
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+  AUTO_FLAG=1
+fi
+# auto (standalone — does NOT match inside 'automerge' due to word boundary)
+AUTO_FLAG=${AUTO_FLAG:-0}
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+  AUTO_FLAG=1
+fi
+```
+
+Note: the `($|[[:space:]])` boundary already prevents `auto` from matching inside `automerge` (because `automerge` has trailing characters). So the existing `auto` regex is safe. The key requirement is simply adding the `automerge` regex.
+
+**`auto merge` (two words)**: The `auto` regex fires (correctly) and sets `AUTO_FLAG=1`. We also need a regex for `merge` preceded by `auto`:
+```bash
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+```
+
+**Strip chain** (`sed` lines that remove tokens from TASK_DESCRIPTION): must add `automerge` stripping BEFORE the `auto` strip (since `auto` sed won't match inside `automerge` anyway due to word boundary, but for clarity strip the longer token first):
+```bash
+| sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/ /' \
+| sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/ /' \
+```
+
+Same applies to `auto merge` (two words) — add a strip for the two-word form:
+```bash
+| sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/ /' \
+```
+
+### 4. Doc pages (5 skill docs)
+
+For each: `docs/skills/{run-plan,do,commit,fix-issues,draft-tests}.md`
+
+- Arguments table: add `automerge` row — "Unattended execution + auto-merge. Implies `auto`."
+- Update existing `auto` row description: "Unattended execution (no merge). See `automerge`."
+- Flow-diagram blocks (`<div class="flow-step optional">`): update any that mention auto-merge to reflect the new token
+- Tips & Gotchas: add bullet — "`auto` runs unattended but does not merge; use `automerge` for unattended + auto-merge."
+
+### 5. `/work-on-plans`
+
+Confirmed: `/work-on-plans` dispatches `/run-plan ... auto` unconditionally (modes/execute.md line ~456). It's a batch-execution skill — auto is always implied. Decision: **add `automerge` support** so the user can choose whether batch execution also merges.
+
+- `skills/work-on-plans/SKILL.md` — accept `automerge` token, pass to `/run-plan`
+- `skills/work-on-plans/modes/execute.md` — conditionally append `automerge` to the `/run-plan` dispatch
+
+### 6. `/research-and-go`
+
+Confirmed: no `--auto`/LAND_ARGS references. This skill dispatches `/do` or `/run-plan` but doesn't touch merge. **No change needed.**
+
+### 7. Changelog
+
+- `CHANGELOG.md` — entry under Unreleased: "Breaking: `auto` no longer requests auto-merge; use `automerge` for the previous behavior"
+- `README.md` — no change needed (skills table doesn't describe tokens)
+
+## Migration / breaking change
+
+This is a **breaking change** for users whose cron schedules or workflows use `auto` expecting auto-merge. Mitigations:
+
+- CHANGELOG notes the break clearly
+- The behavior failure mode is safe (PR created but not merged — user notices on first run and adds `automerge`)
+- `auto merge` (two words) works as `automerge` so muscle-memory typos aren't punished
+
+**Specific impact on `/work-on-plans`**: This skill dispatches `/run-plan ... auto` unconditionally for batch execution. After this change, batch runs will no longer auto-merge by default. Users who want batch-and-merge must invoke `/work-on-plans automerge`. This is intentional — batch execution creating PRs for morning review is the safer default.
+
+## What does NOT change
+
+- `--auto` still gates BEHIND recovery (Step 6b) — unattended callers still benefit from automated rebase
+- `--auto` still gates fix-cycle iteration — the agent still retries failing CI
+- `pr-monitor.sh` still runs regardless
+- All existing result-file statuses remain valid
+- The `auto-not-requested` MERGE_REASON now fires when `--auto` is passed without `--automerge` (previously only when `--auto` was absent). **Verified safe**: callers parse MERGE_REASON into their result array but never branch on its value — they branch only on STATUS (merged, pr-ready, etc.). The MERGE_REASON is informational/logging only.
+
+## Difficulty
+
+Medium. ~12 files touched, each change is small and mechanical. The risk is in the behavioral break for existing `auto` users — but the failure mode is safe (PR created, not merged).

--- a/docs/skills/commit.md
+++ b/docs/skills/commit.md
@@ -73,8 +73,8 @@ The common cases, from lightest to heaviest:
 - `/commit pr` — push the current branch and open a pull request to main.
   This is the recommended way for you to land work as a PR (it requires a
   clean working tree, so commit first).
-- `/commit pr auto` — the same, plus request that the PR auto-merge once
-  CI passes.
+- `/commit pr automerge` — the same, plus request that the PR auto-merge
+  once CI passes.
 
 To land a feature branch as a PR, `/commit pr` is the path to reach for. It
 is one of the supported entry points for opening pull requests; you do not
@@ -109,9 +109,14 @@ which must come first.
 | `scope` | A free-text hint (e.g. `skill updates`, `parser reset button fix`) that guides which files count as related. Advisory — the skill still reads the diffs. |
 | `push` | Commit, then push to the remote. |
 | `land` | Cherry-pick the current worktree's commits onto main, run tests, and record that the work has landed. Only valid when you are in a worktree. |
-| `auto` | In PR mode, request that the pull request auto-merge once CI passes. Has no effect with `push` or `land`. |
+| `auto` | In PR mode, run unattended. Does not auto-merge; see `automerge`. |
+| `automerge` | In PR mode, request that the pull request auto-merge once CI passes. Implies `auto`. Has no effect with `push` or `land`. |
 
 If you give no mode token at all, `/commit` reads your project's configured
 default landing behavior to decide what to do — on a project that lands
 through pull requests, a bare `/commit` behaves like `/commit pr`.
+
+## Tips & Gotchas
+
+- `auto` runs unattended but does not merge; use `automerge` for unattended + auto-merge.
 

--- a/docs/skills/do.md
+++ b/docs/skills/do.md
@@ -12,7 +12,7 @@
 <div class="flow-step"><p>An <strong>implementer subagent</strong> builds it in a worktree</p></div>
 <div class="flow-step"><p>A <strong>verifier subagent</strong> verifies the change</p></div>
 <div class="flow-step"><p>The <strong>original agent</strong> lands it via a PR and monitors CI (up to 2 fix attempts)</p></div>
-<div class="flow-step optional"><p>If you pass <strong>auto</strong>, it requests merge — GitHub merges once required checks pass</p></div>
+<div class="flow-step optional"><p>If you pass <strong>automerge</strong>, it requests merge — GitHub merges once required checks pass</p></div>
 </div>
 
 </details>
@@ -48,7 +48,7 @@ The most common form is a free-text description, optionally autonomous, optional
 /do Check for broken links in examples every 12h now
 ```
 
-A description alone runs the task immediately. Add a landing flag (`pr`, `worktree`, `direct`) to override the configured default. Add `auto` to land without stopping for approval. Add `every SCHEDULE` (with `now` to also run straight away) to turn the task into recurring maintenance.
+A description alone runs the task immediately. Add a landing flag (`pr`, `worktree`, `direct`) to override the configured default. Add `auto` to run without stopping for approval; add `automerge` to also auto-merge the PR. Add `every SCHEDULE` (with `now` to also run straight away) to turn the task into recurring maintenance.
 
 ## Companion skills
 
@@ -67,7 +67,8 @@ A description alone runs the task immediately. Add a landing flag (`pr`, `worktr
 | `worktree` | No | Isolate work in a worktree, cherry-pick back to `main` after verification |
 | `direct` | No | Work on `main` in place, no landing step |
 | `pr` | No | Named worktree + feature branch, push, open a PR, poll CI |
-| `auto` | No | Land autonomously (PR: request auto-merge; worktree: cherry-pick and push; direct: push) |
+| `auto` | No | Land autonomously (unattended mode). In PR mode the PR is created but NOT auto-merged; see `automerge` |
+| `automerge` | No | Unattended + auto-merge the PR (PR mode). Implies `auto`. |
 | `every SCHEDULE` | No | Self-schedule recurring runs (`4h`, `12h`, `day at 9am`, `weekday at 9am`) |
 | `now` | No | Run immediately (with `every`: run now AND schedule) |
 | `--force` | No | Bypass a triage redirect and a review rejection |
@@ -113,7 +114,7 @@ Trigger a cron immediately. Bare `/do now` triggers the single cron (or asks if 
 
 - **Quick content task:** `/do Sort the screenshots` — direct mode, no ceremony
 - **Isolated refactor:** `/do Refactor color constants worktree` — work in a worktree, verify, no auto-land
-- **PR with auto-merge:** `/do Add dark mode pr auto` — open a PR and request auto-merge
+- **PR with auto-merge:** `/do Add dark mode pr automerge` — open a PR and request auto-merge
 - **Recurring maintenance:** `/do Check for broken links every 12h now` — schedule and run immediately
 - **Bypass gates:** `/do Fix the tooltip bug --force` — skip the triage and review checks for a known-simple fix
 
@@ -124,4 +125,5 @@ Trigger a cron immediately. Bare `/do now` triggers the single cron (or asks if 
 - Verification runs on all code changes regardless of `auto`; content-only changes skip the test suite and get a focused diff review instead.
 - PR mode runs the same local verification gate as the other modes before opening the PR, then dispatches `/land-pr` for the PR lifecycle (push, CI poll, fix cycle on failure).
 - Quoted descriptions (`/do "Now fix the tooltip bug"`) are taken verbatim and bypass the `stop`/`next`/`now` subcommand detection.
+- `auto` runs unattended but does not merge; use `automerge` for unattended + auto-merge.
 - `--force` and `--rounds N` persist into the cron prompt verbatim when used with `every`, so every scheduled fire keeps the same behavior.

--- a/docs/skills/draft-plan.md
+++ b/docs/skills/draft-plan.md
@@ -24,7 +24,7 @@ The payoff is downstream. `/run-plan` executes a plan faithfully, so the quality
 
 The output is a single plan file with a structure `/run-plan` understands: an overview, a progress tracker, and numbered phases, each with goals, specific work items, design and constraints, and testable acceptance criteria. The file ends with a "Plan Quality" section recording how many rounds ran, whether the plan converged, and any concerns left unresolved.
 
-When run on a repository that protects its main branch, `/draft-plan` does its work in an isolated worktree and commits the finished plan there on a feature branch, rather than leaving it as a loose file. If you pass `auto`, it then opens a pull request for the plan and merges it once checks pass; without `auto`, the commit stays on the branch and you land it yourself.
+When run on a repository that protects its main branch, `/draft-plan` does its work in an isolated worktree and commits the finished plan there on a feature branch, rather than leaving it as a loose file. If you pass `auto`, it then opens a pull request for the plan and monitors CI; without `auto`, the commit stays on the branch and you land it yourself. Add `automerge` to also request auto-merge once checks pass.
 
 If the research turns up a task too broad to spec well in one plan -- too many phases, or sub-problems that share nothing -- `/draft-plan` will say so and recommend `/research-and-plan` to decompose it into focused sub-plans instead.
 
@@ -43,10 +43,10 @@ You can name the output file (otherwise the path is derived from the description
 /draft-plan rounds 5 Redesign the solver architecture
 ```
 
-When you want the plan to land automatically once it is drafted, add `auto`. This is the shape used when chaining straight into execution -- draft the plan, land it, then run it:
+When you want the plan to land unattended once it is drafted, add `auto`. To also auto-merge after CI passes, add `automerge` (implies `auto`). This is the shape used when chaining straight into execution -- draft the plan, land it, then run it:
 
 ```
-/draft-plan plans/THERMAL_PLAN.md auto Implement the thermal domain
+/draft-plan plans/THERMAL_PLAN.md automerge Implement the thermal domain
 ```
 
 For work where the design itself is still open, start with an interactive conversation before any drafting: `brainstorm` for co-designing a fuzzy idea, or `quiz` for a requirements interview when you know roughly what you want but need the precise requirements drawn out.
@@ -67,7 +67,7 @@ For work where the design itself is still open, start with an interactive conver
 ## Arguments
 
 ```
-/draft-plan [output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>
+/draft-plan [output FILE] [rounds N] [auto] [automerge] [brainstorm|quiz] <description...>
 ```
 
 | Argument | Required | Description |
@@ -75,13 +75,14 @@ For work where the design itself is still open, start with an interactive conver
 | `description` | Yes | What the plan should accomplish, in natural language. Can be brief ("add dark mode") or a detailed multi-paragraph brief. Everything after the recognized leading flags is the description. |
 | `output FILE` | No | Where to write the plan file. Defaults to a path derived from the description. May be given as `output <path>` or as a bare leading `*.md` token before the description begins. |
 | `rounds N` | No | Maximum review-and-refine cycles. Defaults to 3. The process stops early if a round converges with no substantive new issues. |
-| `auto` | No | After the plan is committed, open a pull request, run checks, and merge it. Without `auto`, the plan is committed on the feature branch and you land it manually. Recognized anywhere in the arguments. |
+| `auto` | No | After the plan is committed, open a pull request and monitor CI. Without `auto`, the plan is committed on the feature branch and you land it manually. Recognized anywhere in the arguments. |
+| `automerge` | No | Implies `auto`. Additionally requests auto-merge on the PR once CI passes. Without `automerge`, the PR is opened but merge is left to you. |
 | `brainstorm` | No | Run an interactive design dialogue before drafting, then feed what you decided into the research. Recognized only as a leading flag, before the description begins. |
 | `quiz` | No | Run an interactive requirements interview before drafting, then seed the research with the requirements it captures. Recognized only as a leading flag, before the description begins. |
 
 `brainstorm` and `quiz` are mutually exclusive -- both are pre-draft interviews, and asking for both at once is an error rather than a silent drop of one. Because they are recognized only at the front of the arguments, a description word like "build a quiz app" does not trigger either mode; to enable a mode you must lead with the flag, not append it.
 
-`auto` mirrors the same token in `/run-plan`, `/do`, and `/fix-issues`. It controls only whether the plan lands automatically -- it does not skip the review rounds or the brainstorm/quiz dialogue.
+`auto` mirrors the same token in `/run-plan`, `/do`, and `/fix-issues`. It controls only whether the plan lands unattended -- it does not skip the review rounds or the brainstorm/quiz dialogue. `automerge` adds auto-merge on top.
 
 ## Examples
 
@@ -89,7 +90,7 @@ For work where the design itself is still open, start with an interactive conver
 /draft-plan Add dark mode support to the editor
 /draft-plan output plans/DARK_MODE.md Add dark mode support
 /draft-plan rounds 5 Redesign the solver architecture
-/draft-plan plans/THERMAL_PLAN.md auto Implement the thermal domain
+/draft-plan plans/THERMAL_PLAN.md automerge Implement the thermal domain
 /draft-plan brainstorm Add a settings panel             # interactive design dialogue first
 /draft-plan quiz Add dark mode support                  # interactive requirements interview first
 /draft-plan output p.md quiz rounds 5 Add dark mode     # quiz in the leading flag cluster, any order

--- a/docs/skills/draft-tests.md
+++ b/docs/skills/draft-tests.md
@@ -59,7 +59,8 @@ A bare plan name (no slash) is resolved against the project's plans directory, s
 |----------|----------|-------------|
 | `plan-file` | Yes | Path to the existing plan file. A path containing `/` is used as-is; a bare name resolves against the project's plans directory. |
 | `rounds N` | No | Maximum number of review/refine cycles. Defaults to 3. |
-| `auto` | No | After the spec-augmented plan is committed, open a pull request, watch CI, and merge automatically. Without `auto`, the change is committed but no PR is opened. |
+| `auto` | No | After the spec-augmented plan is committed, open a pull request and watch CI. Does NOT auto-merge; see `automerge`. |
+| `automerge` | No | Same as `auto`, plus auto-merge the PR once CI passes. Implies `auto`. |
 | `guidance` | No | Any extra words become focus guidance that steers what the review pressure-tests (e.g. "focus on integration tests"). |
 
 The plan file is detected as the first argument that contains `/` or ends in `.md`. `rounds` must be followed by a number to count; `rounds` with no number after it is treated as guidance. The `auto` token is matched case-insensitively as a standalone word. Anything left over is joined into the guidance text — guidance shapes what the review looks at, it is not taken as fact, so the same verify-before-acting discipline still applies.
@@ -82,7 +83,7 @@ If no plan file is found, `/draft-tests` reports the usage line and stops.
 - **Add tests after drafting a plan:** `/draft-tests plans/X.md` — run it on a freshly drafted plan to add test specs before `/run-plan` executes it.
 - **Steer the focus:** `/draft-tests plans/X.md focus on error handling and edge cases` — guide what the review pressure-tests.
 - **More review depth:** `/draft-tests plans/X.md rounds 5` — allow more review/refine cycles for a thorny test surface.
-- **Draft and ship:** `/draft-tests plans/X.md auto` — commit the spec-augmented plan, open a PR, and merge it automatically.
+- **Draft and ship:** `/draft-tests plans/X.md automerge` — commit the spec-augmented plan, open a PR, and auto-merge it once CI passes.
 
 ## Tips & Gotchas
 
@@ -90,4 +91,5 @@ If no plan file is found, `/draft-tests` reports the usage line and stops.
 - Completed phases are never modified. A gap in already-completed work is surfaced as a new backfill phase at the end of the plan, not by editing the finished phases.
 - The test specs go inside the plan's phases; there is no separate test document to maintain and nothing extra to wire up for `/run-plan`.
 - Sections after the last phase are left exactly as they were, so trailing notes and appendices survive untouched.
-- `auto` controls whether the result lands automatically — the same `auto` token used by `/draft-plan`, `/run-plan`, `/do`, `/fix-issues`, and `/refine-plan`. It does not skip or shorten the review.
+- `auto` opens a PR and watches CI but does not merge; `automerge` does both. The same tokens are used by `/draft-plan`, `/run-plan`, `/do`, `/fix-issues`, and `/refine-plan`. Neither skips or shortens the review.
+- `auto` runs unattended but does not merge; use `automerge` for unattended + auto-merge.

--- a/docs/skills/fix-issues.md
+++ b/docs/skills/fix-issues.md
@@ -10,14 +10,14 @@
 <div class="flow-step"><p><strong>Implementer subagents</strong> fix them in parallel worktrees</p></div>
 <div class="flow-step"><p><strong>Verifier subagents</strong> verify each fix</p></div>
 <div class="flow-step"><p>The <strong>original agent</strong> writes a sprint report</p></div>
-<div class="flow-step optional"><p>With <strong>auto</strong> it lands and merges each fix; otherwise it stops at the report for you to land via <code>/fix-report</code></p></div>
+<div class="flow-step optional"><p>With <strong>automerge</strong> it lands and merges each fix; with bare <strong>auto</strong> it lands but does not merge; otherwise it stops at the report for you to land via <code>/fix-report</code></p></div>
 </div>
 
 </details>
 
 ## What it does
 
-`/fix-issues N` runs a batch bug-fixing sprint over your GitHub issues. You give it a count `N`, and it prioritizes that many open issues, fixes each one in its own isolated worktree, runs the test suite before anything is committed, and writes a sprint report you can hand off to `/fix-report`. With the `auto` flag it lands each fix for you (via `/land-pr` in PR mode); without it, it asks for approval at the key gates first.
+`/fix-issues N` runs a batch bug-fixing sprint over your GitHub issues. You give it a count `N`, and it prioritizes that many open issues, fixes each one in its own isolated worktree, runs the test suite before anything is committed, and writes a sprint report you can hand off to `/fix-report`. With the `automerge` flag it lands and auto-merges each fix (via `/land-pr` in PR mode); with bare `auto` it lands but stops at pr-ready for human review; without either, it asks for approval at the key gates first.
 
 Each issue is fixed and committed separately, so the history stays clean and one bad fix never blocks the others. Before fixing anything, the agent reads each issue's full body — not just the title — so the fix matches what the issue actually asked for.
 
@@ -38,10 +38,10 @@ The same command also schedules itself to run again (`every SCHEDULE`), keeps yo
 
 ## Typical usage
 
-The most common way to run `/fix-issues` is as a recurring, autonomous queue worker: a small count, `auto`, and a schedule. For example, fix one issue every 30 minutes from the dashboard queue and land each as a PR:
+The most common way to run `/fix-issues` is as a recurring, autonomous queue worker: a small count, `automerge`, and a schedule. For example, fix one issue every 30 minutes from the dashboard queue and land and merge each as a PR:
 
 ```
-/fix-issues 1 every 30m dashboard auto
+/fix-issues 1 every 30m dashboard automerge
 ```
 
 A one-time burst is just as common — fix several issues now, each as its own PR:
@@ -72,7 +72,8 @@ Running `/fix-issues` with no count and no subcommand doesn't start a sprint —
 | `N` | Yes (sprints) | Number of issues to fix (e.g., `30`) |
 | `focus` | No | Prioritize a specific domain (`new`, `correctness`, `codegen`, `ui`, `tests`, or any domain found in your trackers) |
 | `dashboard` | No | Pick the issues from the dashboard's Ready queue instead of the default priority order |
-| `auto` | No | Run without stopping for confirmation: skip the issue-list approval, land each fix, and merge the sprint-report PR |
+| `auto` | No | Run without stopping for confirmation: skip the issue-list approval, land each fix. Does not auto-merge; see `automerge`. |
+| `automerge` | No | Run unattended and auto-merge each fix once CI passes. Implies `auto`. |
 | `every SCHEDULE` | No | Self-schedule recurring runs (`4h`, `30m`, `day at 9am`, `weekday at 9am`) |
 | `now` | No | Run immediately (with `every`: run now AND schedule) |
 | `pr` | No | Land each fix as its own pull request on a named branch |
@@ -162,4 +163,5 @@ Flag a previously-skipped issue so the next sprint re-evaluates it from scratch 
 - A scheduled sprint lasts only as long as the session that created it -- re-run `/fix-issues ... every ...` to restart it after the session ends
 - `every SCHEDULE` always runs autonomously, so adding it implies `auto` even if you don't type `auto`
 - When you don't specify `pr` or `direct`, the landing style falls back to your project's configured default, or to cherry-picking the fix back to main if nothing is configured
+- `auto` runs unattended but does not merge; use `automerge` for unattended + auto-merge.
 - The sprint always runs the full test suite before any fix is committed, and never weakens a test to make it pass

--- a/docs/skills/refine-plan.md
+++ b/docs/skills/refine-plan.md
@@ -29,7 +29,7 @@ If the plan has no remaining phases — everything is already done — `/refine-
 ## Usage
 
 ```
-/refine-plan <plan-file> [rounds N] [auto] [guidance...]
+/refine-plan <plan-file> [rounds N] [auto] [automerge] [guidance...]
 ```
 
 ## Typical usage
@@ -43,7 +43,7 @@ The common form is just the plan file: point `/refine-plan` at the plan you are 
 /refine-plan plans/FEATURE_PLAN.md auto
 ```
 
-You can add trailing free-text guidance to steer what the review pressure-tests (for example, a known change since an earlier phase landed). Add `auto` to have the refined plan opened as a pull request and merged once it passes CI, instead of leaving it committed for you to land yourself.
+You can add trailing free-text guidance to steer what the review pressure-tests (for example, a known change since an earlier phase landed). Add `auto` to have the refined plan opened as a pull request and CI monitored, instead of leaving it committed for you to land yourself. Add `automerge` to also request auto-merge once CI passes.
 
 ## Companion skills
 
@@ -59,10 +59,11 @@ The natural flow is `/draft-plan` (create) → `/run-plan` (execute) → `/refin
 |----------|----------|-------------|
 | `plan-file` | Yes | Path to the plan `.md` file to refine. A bare filename is resolved against your plans directory; a path with a `/` is used as-is. |
 | `rounds N` | No | Maximum review/refine cycles. Default is 2. The process exits early if a round converges (no substantive new issues). |
-| `auto` | No | After the refined plan is committed, open a pull request, monitor CI, and auto-merge. Without `auto`, the refined plan is committed but no PR is opened — you land it yourself. |
+| `auto` | No | After the refined plan is committed, open a pull request and monitor CI. Without `auto`, the refined plan is committed but no PR is opened — you land it yourself. |
+| `automerge` | No | Implies `auto`. Additionally requests auto-merge on the PR once CI passes. Without `automerge`, the PR is opened but merge is left to you. |
 | `guidance...` | No | Any trailing free text becomes guidance that steers what the review focuses on. It is treated as priming for the review, not as fact to act on blindly. |
 
-The default of 2 rounds is lighter than `/draft-plan`'s 3, because this is a refinement pass on an existing plan rather than blank-slate creation. The `auto` token mirrors the same token in `/run-plan`, `/do`, `/fix-issues`, and `/draft-plan`.
+The default of 2 rounds is lighter than `/draft-plan`'s 3, because this is a refinement pass on an existing plan rather than blank-slate creation. The `auto` and `automerge` tokens mirror those in `/run-plan`, `/do`, `/fix-issues`, and `/draft-plan`.
 
 ## Examples
 
@@ -80,7 +81,7 @@ The default of 2 rounds is lighter than `/draft-plan`'s 3, because this is a ref
 - **Mid-execution refresh:** `/refine-plan plans/X.md` — bring the remaining phases in line with what the completed phases actually built.
 - **With context:** `/refine-plan plans/X.md the API signature changed since an earlier phase` — steer the review toward a known change.
 - **More review rounds:** `/refine-plan plans/X.md rounds 3` — push for an extra adversarial pass on a high-stakes plan.
-- **Refine and land:** `/refine-plan plans/X.md auto` — refine, then open and auto-merge the PR.
+- **Refine and land:** `/refine-plan plans/X.md automerge` — refine, then open and auto-merge the PR.
 
 ## Tips & Gotchas
 

--- a/docs/skills/run-plan.md
+++ b/docs/skills/run-plan.md
@@ -22,7 +22,7 @@
 <div class="flow-step"><p>A <strong>verifier subagent</strong> verifies it, and the commit accumulates on the one branch</p></div>
 <div class="flow-step"><p>The <strong>original agent</strong> re-fires the next phase as a fresh turn, looping until the plan is done</p></div>
 <div class="flow-step"><p>After the last phase, the <strong>original agent</strong> opens one PR for the whole plan</p></div>
-<div class="flow-step optional"><p>With <strong>auto</strong> it requests merge; plain <strong>finish</strong> pauses between every phase and leaves the PR for you to merge</p></div>
+<div class="flow-step optional"><p>With <strong>automerge</strong> it requests merge; <strong>auto</strong> runs unattended without merging; plain <strong>finish</strong> pauses between every phase and leaves the PR for you to merge</p></div>
 </div>
 
 </details>
@@ -75,13 +75,14 @@ Run `/run-plan plans/X.md` on its own to do just the next phase interactively. A
 | `phase` | No | A specific phase to run, e.g. `4a`. If omitted, the next incomplete phase is detected automatically |
 | `finish` | No | Run all remaining phases in order until the plan is complete |
 | `status` | No | Show plan progress (read-only — no work is done) |
-| `auto` | No | Run without pausing for approval, and auto-merge the PR in PR mode (see below) |
+| `auto` | No | Run without pausing for approval (unattended mode). Does not auto-merge; see `automerge` |
+| `automerge` | No | Unattended + auto-merge the PR once CI passes. Implies `auto`. |
 | `pr` | No | Land each phase via a pull request on a feature branch |
 | `direct` | No | Work directly on `main`, with no PR and no cherry-pick |
 | `every SCHEDULE` | No | Run on a recurring schedule (`4h`, `30m`, `day at 9am`) |
 | `now` | No | Run immediately (with `every`: run now and schedule) |
 
-`auto` makes the run autonomous: it skips the approval prompts and human-review pauses (the between-phase pause, drift findings, staleness checks, and verifier-fail review) so the skill can run unattended. Where a phase lands as a pull request, `auto` also auto-merges that PR. In cherry-pick or direct mode there is no PR to merge, so `auto` only removes the pauses.
+`auto` makes the run autonomous: it skips the approval prompts and human-review pauses (the between-phase pause, drift findings, staleness checks, and verifier-fail review) so the skill can run unattended. Where a phase lands as a pull request, bare `auto` creates the PR but does NOT auto-merge; add `automerge` to also request auto-merge. In cherry-pick or direct mode there is no PR to merge, so the distinction is irrelevant.
 
 Landing mode is resolved in this order: an explicit `pr` or `direct` argument wins; otherwise the `execution.landing` default in `.claude/zskills-config.json` is used; otherwise it falls back to cherry-pick (work in a worktree, cherry-pick the result to `main`). `direct` mode is rejected when `execution.main_protected` is `true` — use `pr` instead.
 
@@ -124,7 +125,7 @@ Report when the next scheduled run will fire, as both a relative ("~2h 15m") and
 ## Common Patterns
 
 - **Single phase:** `/run-plan plans/X.md` — run the next incomplete phase interactively.
-- **Full autonomous execution:** `/run-plan plans/X.md finish auto pr` — run every remaining phase, each as an auto-merged PR.
+- **Full autonomous execution:** `/run-plan plans/X.md finish automerge pr` — run every remaining phase, each as an auto-merged PR.
 - **Scheduled execution:** `/run-plan plans/X.md auto every 4h now` — schedule recurring runs and start immediately.
 - **Check progress:** `/run-plan plans/X.md status` — see which phases are done, in progress, or blocked.
 - **Resume early:** `/run-plan now` — trigger the active schedule without waiting for the next fire.
@@ -137,3 +138,4 @@ Report when the next scheduled run will fire, as both a relative ("~2h 15m") and
 - A phase whose dependencies aren't done yet stops the run cleanly and reports which prerequisite is missing.
 - The schedule is session-scoped — it ends when the session ends.
 - A failing phase stops the run there; `auto` mode tries one fix cycle before giving up.
+- `auto` runs unattended but does not merge; use `automerge` for unattended + auto-merge.

--- a/docs/skills/work-on-plans.md
+++ b/docs/skills/work-on-plans.md
@@ -29,8 +29,8 @@ If a plan in the queue points at a plan file that no longer exists, `/work-on-pl
 
 ```
 /work-on-plans
-/work-on-plans N [phase|finish] [every SCHEDULE] [now] [continue] [--force]
-/work-on-plans all [phase|finish] [every SCHEDULE] [now] [continue] [--force]
+/work-on-plans N [phase|finish] [automerge] [every SCHEDULE] [now] [continue] [--force]
+/work-on-plans all [phase|finish] [automerge] [every SCHEDULE] [now] [continue] [--force]
 /work-on-plans add <slug> [pos]
 /work-on-plans rank <slug> <pos>
 /work-on-plans remove <slug>
@@ -69,6 +69,7 @@ Run bare, it lists the ready queue. Give it a number to run that many plans from
 | `all` | No | Run every plan in the ready queue |
 | `phase` | No | Run one phase per plan instead of running each to completion |
 | `finish` | No | Run each plan to completion (this is the default) |
+| `automerge` | No | Auto-merge each plan's PR once CI passes. Without it, each PR is created and left at pr-ready for you to review and merge. |
 | `continue` | No | If one plan fails, skip it and keep going instead of stopping |
 | `every SCHEDULE` | No | Run on a recurring schedule (`1h`, `4h`, `day at 9am`); each fire runs the count |
 | `now` | No | With `every`, run immediately as well as scheduling |
@@ -132,11 +133,14 @@ Cancel the active recurring schedule.
 - **Run everything:** `/work-on-plans all finish` — finish every queued plan
 - **Resilient batch:** `/work-on-plans all continue` — if one plan fails, skip it and keep going
 - **Drain over time:** `/work-on-plans 1 finish every 1h now` — run one plan now, then one more each hour
+- **Drain and merge:** `/work-on-plans 3 automerge` — run the top three and auto-merge each PR once CI passes (omit `automerge` to leave them at pr-ready for review)
 - **Curate priorities:** use `add`, `rank`, and `remove` to shape the queue; use `default` to set the baseline mode
 
 ## Tips & Gotchas
 
 - The default mode is `finish` — each plan runs to completion and lands as one pull request. Add `phase` only when you want to pace the work a single phase per plan.
+- Each plan's PR is left at pr-ready for your review by default; it is **not** merged automatically. Add `automerge` if you want each PR to merge once CI passes.
+- `/work-on-plans` always runs unattended, so it does **not** accept the bare `auto` token (passing it is a usage error). This mirrors the rule everywhere else — `auto` never requests a merge; `automerge` is the only token that does. Use `automerge` to merge the batch.
 - A mode you pass on the command line (`phase`/`finish`) applies to that batch only; it does not change the saved mode on queue entries or the queue-wide default.
 - A count combines with a schedule: each scheduled fire runs the count you gave, not the whole queue. A bare `every SCHEDULE` with no count runs everything on each fire.
 - A recurring schedule remembers the mode it was registered with — to change it, `stop` the schedule and register a new one.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -7,9 +7,9 @@ description: >-
   other agents' work, and optionally pushes, lands worktree commits, or
   opens a PR via /land-pr. Positional auto enables auto-merge (PR mode
   only).
-argument-hint: "[pr] [scope] [push|land] [auto]"
+argument-hint: "[pr] [scope] [push|land] [auto|automerge]"
 metadata:
-  version: "2026.06.15+cf08df"
+  version: "2026.06.15+dc691a"
 ---
 
 # /commit [pr] [scope] [push|land] [auto] — Safe Commit Workflow
@@ -41,17 +41,23 @@ FIRST_TOKEN=$(echo "$ARGUMENTS" | awk '{print $1}')
 # The token never falls through to SCOPE_HINT (stripped in both PR-mode
 # parse paths). Setting AUTO_FLAG outside PR mode is a no-op — `push`
 # and `land` modes do not consult it.
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])([aA][uU][tT][oO])($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])([aA][uU][tT][oO])($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 if [[ "$FIRST_TOKEN" == "pr" ]]; then
   # PR subcommand mode
   SCOPE_HINT=$(echo "$ARGUMENTS" | cut -d' ' -f2-)  # rest after 'pr' (may be empty)
-  # Strip the positional `auto` token from SCOPE_HINT so it does not leak
-  # into the PR title / scope-hint downstream. Match `auto` as a
-  # whitespace-bounded token (case-insensitive).
-  SCOPE_HINT=$(echo "$SCOPE_HINT" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
+  # Strip the positional `auto` and `automerge` tokens from SCOPE_HINT so
+  # they do not leak into the PR title / scope-hint downstream.
+  SCOPE_HINT=$(echo "$SCOPE_HINT" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
   # ... see Phase 6 (PR mode) below
 fi
 ```
@@ -104,9 +110,9 @@ if [ "$HAS_EXPLICIT_MODE" -eq 0 ]; then
       # Treat as `/commit pr` — drop into PR subcommand mode below.
       # SCOPE_HINT keeps any scope words from $ARGUMENTS (no `pr` prefix
       # to strip, since the user didn't type it). Strip the positional
-      # `auto` token (AUTO_FLAG was already set above) so it does not
-      # leak into the PR title / downstream scope-hint usage.
-      SCOPE_HINT=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
+      # `auto` and `automerge` tokens (flags already set above) so they
+      # do not leak into the PR title / downstream scope-hint usage.
+      SCOPE_HINT=$(echo "$ARGUMENTS" | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/\1\2/g' | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/\1\2/g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/[[:space:]]+/ /g')
       DEFAULT_MODE="pr"
       ;;
     direct|"")

--- a/skills/commit/modes/pr.md
+++ b/skills/commit/modes/pr.md
@@ -130,13 +130,15 @@ LAND_OUTCOME=__init__
 LANDED_SOURCE="commit"
 LAND_ARGS="--branch=$BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --tracking-id=$BRANCH_SLUG"
 
-# Auto-merge gate (issue #236) — append `--auto` when the caller passed
+# Auto gate (issue #236) — append `--auto` when the caller passed
 # the positional `auto` token (parsed in skills/commit/SKILL.md and
 # propagated as $AUTO_FLAG=1). Mirrors /run-plan, /fix-issues, /do.
-# Without the token, `/land-pr` runs through PR creation +
+# `--automerge` additionally requests auto-merge on the PR.
+# Without `automerge`, `/land-pr` runs through PR creation +
 # CI poll + fix-cycle but does NOT call `gh pr merge --auto --squash`;
 # the PR settles at `pr-ready` for human review.
 [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+[ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
 while :; do
   # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /commit pr.
@@ -235,7 +237,7 @@ while :; do
       else
         LAND_OUTCOME=pr-ready
       fi
-      break ;;  # /land-pr already requested merge if --auto (gated on AUTO_FLAG per issue #236)
+      break ;;  # /land-pr already requested merge if --automerge (gated on AUTOMERGE_FLAG per issue #236)
     pending)
       LAND_OUTCOME=pr-ready
       break ;;  # settle at pr-ready
@@ -327,11 +329,12 @@ rm -f "$TRACK_DIR/requires.land-pr.$BRANCH_SLUG"
 ```
 
 **PR mode does NOT:**
-- Auto-merge **unless the positional `auto` token is passed** (issue #236
-  — `/commit pr auto` or, via config-default-to-pr, `/commit auto`).
-  Without `auto`, `LAND_ARGS` omits `--auto` and the PR settles at
-  `pr-ready` after CI passes; with `auto`, `--auto` is appended and
-  `/land-pr` invokes `gh pr merge --auto --squash`.
+- Auto-merge **unless the positional `automerge` token is passed**
+  (issue #236 — `/commit pr automerge` or, via config-default-to-pr,
+  `/commit automerge`). With bare `auto`, `LAND_ARGS` includes `--auto`
+  (unattended mode) but omits `--automerge`, so the PR settles at
+  `pr-ready` after CI passes. With `automerge`, `--automerge` is appended
+  and `/land-pr` invokes `gh pr merge --auto --squash`.
 - Write `.zskills/landed` markers (`/commit pr` has no worktree)
 - Run Phases 1–5 (all commits must already exist — clean tree is required)
 

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: do
-argument-hint: "<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
+argument-hint: "<description> [--rounds N] [auto|automerge] [every SCHEDULE] [now] | stop [query] | next [query] | now [query]"
 description: >-
   Lightweight task dispatcher for ad-hoc work: documentation, examples,
   refactoring, content updates. Worktree/direct/pr landing modes via flag
   or execution.landing config. Recurring via every SCHEDULE; stop/next
   manage the schedule.
 metadata:
-  version: "2026.06.15+0cc69f"
+  version: "2026.06.15+0ab24d"
 ---
 
 # /do \<description> [--rounds N] [auto] [every SCHEDULE] [now] | stop [query] | next [query] | now [query] — Lightweight Task Dispatcher
@@ -247,8 +247,16 @@ fi
 #   - Phase 4 (Land) as the gate to push/cherry-pick+push (direct/worktree modes)
 # Note: Phase 3 dispatches /verify-changes unconditionally for code
 # changes (issue #713) — AUTO_FLAG no longer gates verification.
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+# 'auto merge' (two words) also counts as automerge
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 # Issue-number parse (claim-work-item Phase 2 / W2.2). Collect ALL `#N`
@@ -962,6 +970,8 @@ TASK_DESCRIPTION=$(echo "$REMAINING" \
   | sed -E 's/(^|[[:space:]])[pP][rR]($|[[:space:]]|[.!?])/ /' \
   | sed -E 's/(^|[[:space:]])[dD][iI][rR][eE][cC][tT]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])worktree($|[[:space:]])/ /' \
+  | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]])/ /' \
+  | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--force($|[[:space:]])/ /' \
   | sed -E 's/(^|[[:space:]])--no-claim($|[[:space:]])/ /' \

--- a/skills/do/modes/pr.md
+++ b/skills/do/modes/pr.md
@@ -420,10 +420,9 @@ description.
 - `$LANDED_SOURCE = "do"`
 - `$WORKTREE_PATH` set (the per-task worktree from Step A5)
 - `--auto` is gated on the positional `auto` token (issue #297 — matches
-  /run-plan, /fix-issues). Without `auto`, auto-merge stays
-  OFF and the PR settles at `pr-ready` after CI passes; with `auto`,
-  `LAND_ARGS` includes `--auto` and `/land-pr`'s existing auto-merge
-  path takes over.
+  /run-plan, /fix-issues). `--automerge` is gated on the `automerge`
+  token. Without `automerge`, the PR settles at `pr-ready` after CI
+  passes; with `automerge`, `/land-pr` requests auto-merge.
 - `<CALLER_PRE_INVOKE_BODY_PREP>` = empty (do's body is fixed at PR
   creation; no per-phase update like /run-plan does)
 - `<CALLER_REBASE_CONFLICT_HANDLER>` = no agent-assisted resolution
@@ -486,9 +485,10 @@ LAND_OUTCOME=__init__
 LANDED_SOURCE="do"
 LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --worktree-path=$WORKTREE_PATH --tracking-id=$TASK_SLUG"
 # Issue #297: positional `auto` token (parsed in pre-flight pre-parse)
-# opts /do pr into /land-pr's auto-merge path. Mirrors
-# /run-plan, /fix-issues.
+# opts /do pr into unattended mode. `automerge` additionally requests
+# auto-merge via /land-pr. Mirrors /run-plan, /fix-issues.
 [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+[ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
 while :; do
   # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /do pr.
@@ -593,7 +593,7 @@ while :; do
       else
         LAND_OUTCOME=pr-ready
       fi
-      break ;;  # /land-pr already requested merge if --auto
+      break ;;  # /land-pr already requested merge if --automerge
     pending)
       LAND_OUTCOME=pr-ready
       break ;;  # settle at pr-ready

--- a/skills/draft-plan/SKILL.md
+++ b/skills/draft-plan/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: draft-plan
 disable-model-invocation: false
-argument-hint: "[output FILE] [rounds N] [auto] [brainstorm|quiz] <description...>"
+argument-hint: "[output FILE] [rounds N] [auto|automerge] [brainstorm|quiz] <description...>"
 description: >-
   Draft a high-quality plan through iterative adversarial review:
   research, draft, review, devil's-advocate, refine — repeated until
   convergence. Output is a plan file ready for /run-plan execution.
 metadata:
-  version: "2026.06.15+e152b7"
+  version: "2026.06.15+ac57fe"
 ---
 
 # /draft-plan [output FILE] [rounds N] \<description...> — Adversarial Plan Drafter
@@ -167,8 +167,15 @@ fi
 
 ```bash
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 ```
@@ -960,6 +967,7 @@ concerns.
       run skill-conformance / hook / fixture suites
 BODY
      LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-plan --worktree-path=$TOPLEVEL --tracking-id=draft-plan.$SLUG --auto"
+     [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
      # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
 

--- a/skills/draft-tests/SKILL.md
+++ b/skills/draft-tests/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-tests
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
+argument-hint: "<plan-file> [rounds N] [auto|automerge] [<guidance>]"
 description: >-
   Draft test specifications into an existing plan through iterative
   adversarial review. Appends a `### Tests` subsection per pending phase
@@ -9,7 +9,7 @@ description: >-
   phases are never modified (checksum-gated). Sister skill to /draft-plan,
   scoped to test specs.
 metadata:
-  version: "2026.06.15+bcc06e"
+  version: "2026.06.15+f151ef"
 ---
 
 # /draft-tests \<plan-file> [rounds N] [<guidance>] — Adversarial Test-Spec Drafter
@@ -175,8 +175,15 @@ fi
 
 ```bash
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 ```

--- a/skills/draft-tests/modes/land.md
+++ b/skills/draft-tests/modes/land.md
@@ -161,9 +161,10 @@ Issue #581: in projects with `execution.landing: pr` +
 `main_protected: true`, the plan with appended test specs is committed
 in the worktree (above) but never reaches main without a `/land-pr`
 dispatch. When the user passed the `auto` positional token, dispatch
-`/land-pr` so the branch pushes, a PR opens, CI runs, and auto-merge
-lands the test-spec-augmented plan on main. Without `auto`, the
-worktree commit stands and the caller lands manually.
+`/land-pr` so the branch pushes, a PR opens, and CI runs. With
+`automerge`, auto-merge lands the test-spec-augmented plan on main;
+with bare `auto`, the PR settles at pr-ready for human review. Without
+either token, the worktree commit stands and the caller lands manually.
 
 ```bash
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
@@ -196,6 +197,7 @@ devil's-advocate + refiner). Completed phases were NOT modified
       CI will run skill-conformance / hook / fixture suites
 BODY
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=draft-tests --worktree-path=$TOPLEVEL --tracking-id=draft-tests.$SLUG --auto"
+  [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
   # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
 

--- a/skills/fix-issues/SKILL.md
+++ b/skills/fix-issues/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: fix-issues
 disable-model-invocation: true
-argument-hint: "N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next"
+argument-hint: "N [<focus>|dashboard] [auto|automerge] [every SCHEDULE] [now] | sync | plan [auto|automerge] | stop | next"
 description: >-
   Orchestrate a batch bug-fixing sprint: dispatch implementers in per-issue
   worktrees, verify, optionally auto-land via /land-pr. Recurring via
   every SCHEDULE; stop/next manage it. sync updates trackers + closes
   already-fixed issues; plan drafts plans for skipped ones.
 metadata:
-  version: "2026.06.15+b4d031"
+  version: "2026.06.15+49b9c8"
 ---
 
 # /fix-issues N [<focus>|dashboard] [auto] [every SCHEDULE] [now] | sync | plan [auto] | stop | next | add <N> [column] [pos] | remove <N> [column] — Batch Bug-Fixing Sprint
@@ -121,8 +121,15 @@ gate stays unchanged.
 ```bash
 # Argument parsing — extract canonical flags from $ARGUMENTS.
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 ```

--- a/skills/fix-issues/modes/pr.md
+++ b/skills/fix-issues/modes/pr.md
@@ -1,6 +1,6 @@
 # /fix-issues — PR Mode (Per-Issue)
 
-Land each verified fix via one PR per issue with rebase, push, CI polling, and auto-merge on success.
+Land each verified fix via one PR per issue with rebase, push, CI polling, and optional auto-merge on success.
 ### PR mode landing
 
 When `LANDING_MODE == pr`, landing replaces cherry-pick with **per-issue
@@ -12,7 +12,7 @@ caller loop `continue`s to the next issue.
 
 **Auto-flag gating.** Rebase, push, PR creation, **CI polling, and the fix cycle ALL run regardless of `$AUTO`** — they're either low-risk (review-surfacing) or reversible (the fix cycle pushes commits to the feature branch, which the user can revert). Goal: by the time the user reviews the PR, it is as clean as the agent could get it.
 
-Only the final `gh pr merge --auto --squash` call is gated on `$AUTO` — and that gate now lives inside `/land-pr`'s `pr-merge.sh` (Phase 1B WI 1.6). **Only `gh pr merge --auto --squash` is gated on `auto`.** Without `auto`, the PR settles at status `pr-ready` after CI passes (or `pr-ci-failing` after fix-cycle exhaustion) and waits for human review and merge on GitHub.
+Only the final `gh pr merge --auto --squash` call is gated on `$AUTOMERGE` — and that gate now lives inside `/land-pr`'s `pr-merge.sh`. **Only `gh pr merge --auto --squash` is gated on `automerge`.** Without `automerge`, the PR settles at status `pr-ready` after CI passes (or `pr-ci-failing` after fix-cycle exhaustion) and waits for human review and merge on GitHub.
 
 **Per-issue /land-pr dispatch.** `/fix-issues pr` no longer owns
 rebase, push, PR creation, CI polling, the fix cycle, the merge call,
@@ -34,8 +34,8 @@ have verified commits on `fix/issue-NNN`.
 `/fix-issues pr` customizations of the canonical pattern:
 - `$LANDED_SOURCE = "fix-issues"`
 - `$WORKTREE_PATH = $ISSUE_WORKTREE` (per-issue worktree)
-- `$AUTO = $AUTO` (auto-merge gated on caller's `--auto` flag, passed
-  through to `/land-pr` via `--auto`)
+- `$AUTO_FLAG` (unattended mode, passed through to `/land-pr` via
+  `--auto`); `$AUTOMERGE_FLAG` (auto-merge, passed via `--automerge`)
 - `$ISSUE_NUM = $ISSUE_NUM` (passed through via `--issue=$ISSUE_NUM`;
   `/land-pr` writes it into the `.zskills/landed` marker's `issue:` field)
 - `<CALLER_PRE_INVOKE_BODY_PREP>` = empty (per-issue body is composed
@@ -135,7 +135,8 @@ BODY
 
   LANDED_SOURCE="fix-issues"
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE --worktree-path=$WORKTREE_PATH --issue=$ISSUE_NUM --tracking-id=$ISSUE_NUM"
-  [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
   while :; do
     # <CALLER_PRE_INVOKE_BODY_PREP> — empty for /fix-issues pr.
@@ -228,7 +229,7 @@ BODY
         else
           LAND_OUTCOME=pr-ready
         fi
-        break ;;  # /land-pr already requested merge if --auto
+        break ;;  # /land-pr already requested merge if --automerge
       pending)
         LAND_OUTCOME=pr-ready
         break ;;  # settle at pr-ready

--- a/skills/fix-issues/modes/sprint.md
+++ b/skills/fix-issues/modes/sprint.md
@@ -658,10 +658,10 @@ if [ "$DASHBOARD_MODE" = "1" ]; then
       # This dispatch fires when the dashboard Ready queue is empty but
       # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
       # content (`git add -A` against the worktree after sync ran), so it
-      # ALWAYS auto-merges regardless of user's `auto` arg — same rationale
-      # as standalone sync's Phase 5 dispatch and the no-actionable ship
-      # branch later in this skill.
-      LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-dashboard-empty --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+      # ALWAYS auto-merges regardless of user's `automerge` arg — same
+      # rationale as standalone sync's Phase 5 dispatch and the no-actionable
+      # ship branch later in this skill.
+      LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-dashboard-empty --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto --automerge"
 
       echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 
@@ -1458,10 +1458,10 @@ If ALL candidates are too vague, too complex, or already attempted:
          # This dispatch fires when Phase 2 found no actionable issues but
          # Phase 1a sync wrote tracker updates. The PR commits only sync-driven
          # content (`git add -A` against the worktree after sync ran, before any
-         # fix work), so it ALWAYS auto-merges regardless of user's `auto` arg —
-         # same rationale as standalone sync's Phase 5 dispatch at the top of
-         # this skill.
-         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto"
+         # fix work), so it ALWAYS auto-merges regardless of user's `automerge`
+         # arg — same rationale as standalone sync's Phase 5 dispatch at the
+         # top of this skill.
+         LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-no-actionable --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID --auto --automerge"
 
          echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 
@@ -2458,8 +2458,8 @@ if [ "${#TRACKER_SCRATCHPADS[@]}" -gt 0 ]; then
         git commit -m "docs(sync): /fix-issues skip-tag rollup sprint $SPRINT_ID"
       fi
     )
-    # Dispatch /land-pr --auto for the tracker PR. Mirrors the
-    # dashboard-empty pattern's LAND_ARGS shape (always --auto because
+    # Dispatch /land-pr --auto --automerge for the tracker PR. Mirrors the
+    # dashboard-empty pattern's LAND_ARGS shape (always automerge because
     # this is sync-only content with no code-review surface).
     TRACKER_LAND_ID="fix-issues.tracker-rollup.${SPRINT_ID}"
     TRACKER_RESULT=$(mktemp)
@@ -2474,7 +2474,7 @@ if [ "${#TRACKER_SCRATCHPADS[@]}" -gt 0 ]; then
     printf 'skill: land-pr\nrequired-by: fix-issues-pr-mode-tracker-rollup\ndate: %s\n' \
       "$(TZ="${TIMEZONE:-UTC}" date -Iseconds)" \
       > "$MAIN_ROOT/.zskills/tracking/$PIPELINE_ID/requires.land-pr.${TRACKER_LAND_ID}"
-    TRACKER_LAND_ARGS="--branch=fix-issues-tracker/$SPRINT_ID --title=\"sync: /fix-issues skip-tag rollup sprint $SPRINT_ID\" --body-file=$TRACKER_BODY --result-file=$TRACKER_RESULT --landed-source=fix-issues-pr-mode-tracker-rollup --worktree-path=$TRACKER_WT --tracking-id=$TRACKER_LAND_ID --auto"
+    TRACKER_LAND_ARGS="--branch=fix-issues-tracker/$SPRINT_ID --title=\"sync: /fix-issues skip-tag rollup sprint $SPRINT_ID\" --body-file=$TRACKER_BODY --result-file=$TRACKER_RESULT --landed-source=fix-issues-pr-mode-tracker-rollup --worktree-path=$TRACKER_WT --tracking-id=$TRACKER_LAND_ID --auto --automerge"
     echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
     # Skill: { skill: "land-pr", args: "$TRACKER_LAND_ARGS" }
     # (Allow-list parser handles result file; mirrors dashboard-empty pattern.)
@@ -2896,7 +2896,8 @@ if [ -n "${WT_PATH:-}" ]; then
     PR_TITLE="sprint-report: $SPRINT_ID"
     SPRINT_BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD)
     LAND_ARGS="--branch=$SPRINT_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sprint --worktree-path=$TOPLEVEL --tracking-id=$SPRINT_LAND_ID"
-    [ "${AUTO:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+    [ "${AUTO_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --auto"
+    [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
     echo "ZSKILLS_PIPELINE_ID=$PIPELINE_ID"
 

--- a/skills/fix-issues/modes/sync.md
+++ b/skills/fix-issues/modes/sync.md
@@ -316,7 +316,7 @@ EOF
    # `gh issue close` calls. The CI-monitor-suppression flag remains
    # omitted (CI monitoring is desired; the orchestrator awaits resting
    # state).
-   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto"
+   LAND_ARGS="--branch=$SYNC_BRANCH --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=fix-issues-sync --worktree-path=$TOPLEVEL --tracking-id=$SYNC_ID --auto --automerge"
 
    # Echo the pipeline id for transcript-propagation (matches /do pr's
    # tier-2 idiom at `skills/do/modes/pr.md:203`). Do NOT env-export

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -2,9 +2,9 @@
 name: land-pr
 user-invocable: false
 description: Helper for PR landing — rebase, push, create-or-detect PR, poll CI, optional auto-merge. Dispatched via the Skill tool by /run-plan, /commit pr, /do pr, /fix-issues pr, /draft-plan, /refine-plan, /draft-tests (and orchestrator agents landing one-off PRs). Returns state via --result-file for caller-driven fix-cycle loops. Not for direct slash invocation — humans should use /commit pr instead.
-argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
+argument-hint: --branch <name> --title <title> --body-file <path> --result-file <path> [--auto] [--automerge] [--worktree-path <path>] [--landed-source <skill>] [--ci-timeout <sec>] [--no-monitor] [--pr <num>] [--issue <num>] [--tracking-id <id>]
 metadata:
-  version: "2026.06.15+e1f067"
+  version: "2026.06.15+1fd1a2"
 ---
 
 # /land-pr — land a feature branch as a PR
@@ -51,7 +51,9 @@ Phase 6 verify caller skills follow it.
 
 Parse `$ARGUMENTS` using the bash-regex idiom that matches `/do`
 and `/commit`. Required: `--branch`, `--title`, `--body-file`, `--result-file`.
-Optional: `--auto` (bool, default false), `--worktree-path`,
+Optional: `--auto` (bool, default false — unattended mode),
+`--automerge` (bool, default false — request auto-merge; implies `--auto`),
+`--worktree-path`,
 `--landed-source` (default `land-pr`), `--ci-timeout` (default 600),
 `--no-monitor` (skip CI poll, return after create), `--pr <num>` (resume
 mode: skip rebase/push/create, jump to monitor), `--issue <num>`
@@ -73,6 +75,7 @@ TITLE=""
 BODY_FILE=""
 RESULT_FILE=""
 AUTO_FLAG=false
+AUTOMERGE_FLAG=false
 WORKTREE_PATH=""
 LANDED_SOURCE="land-pr"
 CI_TIMEOUT=600
@@ -91,6 +94,7 @@ while [ $i -lt ${#ARGS[@]} ]; do
     --body-file)      i=$((i+1)); BODY_FILE="${ARGS[$i]:-}" ;;
     --result-file)    i=$((i+1)); RESULT_FILE="${ARGS[$i]:-}" ;;
     --auto)           AUTO_FLAG=true ;;
+    --automerge)      AUTOMERGE_FLAG=true; AUTO_FLAG=true ;;
     --worktree-path)  i=$((i+1)); WORKTREE_PATH="${ARGS[$i]:-}" ;;
     --landed-source)  i=$((i+1)); LANDED_SOURCE="${ARGS[$i]:-}" ;;
     --ci-timeout)     i=$((i+1)); CI_TIMEOUT="${ARGS[$i]:-}" ;;
@@ -449,9 +453,9 @@ This step closes that loop: detect BEHIND, rebase locally onto current
 churn when many PRs are landing rapidly.
 
 **Skip conditions (skip the whole Step 6b loop):**
-- `$AUTO_FLAG != true` — BEHIND recovery is only useful when auto-merge
-  is requested. Without `--auto`, BEHIND is the caller's problem to
-  resolve manually.
+- `$AUTO_FLAG != true` — BEHIND recovery is only useful when the caller
+  is running unattended. Without `--auto`, BEHIND is the caller's problem
+  to resolve manually.
 - `$STATUS` already set to a failure terminus (`rebase-conflict`,
   `push-failed`, `create-failed`, `monitor-failed`, `rebase-failed`,
   `merge-failed`) — Step 6b shouldn't run after upstream failures.
@@ -641,9 +645,9 @@ if [ -z "$STATUS" ] \
 fi
 ```
 
-### Step 7 — Merge (gated on `--auto`)
+### Step 7 — Merge (gated on `--automerge`)
 
-Always run `pr-merge.sh` — it owns the auto/CI gating internally.
+Always run `pr-merge.sh` — it owns the automerge/CI gating internally.
 
 ```bash
 if [ -f "${CLAUDE_PLUGIN_ROOT}/skills/update-zskills/scripts/zskills-resolve-config.sh" ]; then
@@ -654,7 +658,7 @@ else
 fi
 if [ -n "$PR_NUMBER" ] && [ "$STATUS" != "rebase-conflict" ] && [ "$STATUS" != "rebase-failed" ] && [ "$STATUS" != "push-failed" ] && [ "$STATUS" != "create-failed" ] && [ "$STATUS" != "behind-thrash" ] && [ "$STATUS" != "auto-rebase-conflict" ] && [ "$STATUS" != "auto-rebase-blocked" ]; then
   MERGE_STDOUT=$(bash "$ZSKILLS_SKILLS_ROOT/land-pr/scripts/pr-merge.sh" \
-    --pr "$PR_NUMBER" --auto-flag "$AUTO_FLAG" --ci-status "${CI_STATUS:-not-monitored}")
+    --pr "$PR_NUMBER" --automerge-flag "$AUTOMERGE_FLAG" --ci-status "${CI_STATUS:-not-monitored}")
   MERGE_RC=$?
 
   while IFS='=' read -r KEY VALUE; do

--- a/skills/land-pr/references/caller-loop-pattern.md
+++ b/skills/land-pr/references/caller-loop-pattern.md
@@ -40,8 +40,9 @@ maintainers.
 ```bash
 # === BEGIN CANONICAL /land-pr CALLER LOOP ===
 # Caller fills in: $BRANCH_NAME, $PR_TITLE, $BODY_FILE, $WORKTREE_PATH (optional),
-# $LANDED_SOURCE, $AUTO ("true"/"false"), $CI_MAX_ATTEMPTS (default 2),
-# $ISSUE_NUM (optional), and the fix-cycle agent dispatch block below.
+# $LANDED_SOURCE, $AUTO ("true"/"false"), $AUTOMERGE ("true"/"false"),
+# $CI_MAX_ATTEMPTS (default 2), $ISSUE_NUM (optional), and the fix-cycle
+# agent dispatch block below.
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
 
 ATTEMPT=0
@@ -64,6 +65,7 @@ while :; do
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE"
   [ -n "$WORKTREE_PATH" ] && LAND_ARGS="$LAND_ARGS --worktree-path=$WORKTREE_PATH"
   [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTOMERGE:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --automerge"
   [ -n "$ISSUE_NUM" ] && LAND_ARGS="$LAND_ARGS --issue=$ISSUE_NUM"
 
   # Invoke /land-pr via the Skill tool. The Skill tool loads /land-pr's
@@ -155,7 +157,7 @@ while :; do
 
   case "$CI_STATUS" in
     pass|none|skipped)
-      break ;;  # /land-pr already requested merge if --auto
+      break ;;  # /land-pr already requested merge if --automerge
     pending)
       break ;;  # settle at pr-ready; user / cron can resume with --pr
     not-monitored)

--- a/skills/land-pr/references/failure-modes.md
+++ b/skills/land-pr/references/failure-modes.md
@@ -236,5 +236,5 @@ idempotency contract is co-tested with the detection contract.
   for `gh pr edit` = 0).
 - **monitor pending → re-poll**: first invocation returns `CI_STATUS=pending`;
   second invocation (after CI completes) returns `CI_STATUS=pass`.
-- **merge no-op when --auto-flag=false**: emits `MERGE_REQUESTED=false
+- **merge no-op when --automerge-flag=false**: emits `MERGE_REQUESTED=false
   MERGE_REASON=auto-not-requested`, never invokes `gh pr merge`.

--- a/skills/land-pr/scripts/pr-merge.sh
+++ b/skills/land-pr/scripts/pr-merge.sh
@@ -5,7 +5,7 @@
 # Spec:  plans/PR_LANDING_UNIFICATION.md WI 1.6.
 #
 # Behavior:
-#   1. If --auto-flag != true, emit MERGE_REQUESTED=false MERGE_REASON=auto-not-requested, exit 0.
+#   1. If --automerge-flag != true, emit MERGE_REQUESTED=false MERGE_REASON=auto-not-requested, exit 0.
 #   2. If --ci-status not in {pass, none, skipped}, emit
 #      MERGE_REQUESTED=false MERGE_REASON=ci-not-passing, exit 0.
 #   3. `gh pr merge --auto --squash`. If stderr matches the auto-merge-
@@ -20,9 +20,9 @@
 #      (UNKNOWN if all retries fail).
 #
 # Args:
-#   --pr        <number>
-#   --auto-flag <true|false>
-#   --ci-status <pass|fail|pending|none|skipped|unknown>
+#   --pr             <number>
+#   --automerge-flag <true|false>
+#   --ci-status      <pass|fail|pending|none|skipped|unknown>
 #
 # Stdout (KEY=VALUE):
 #   MERGE_REQUESTED=<bool>
@@ -38,20 +38,20 @@
 set -u
 
 PR_NUMBER=""
-AUTO_FLAG=""
+AUTOMERGE_FLAG=""
 CI_STATUS=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --pr)         shift; PR_NUMBER="${1:-}" ;;
-    --auto-flag)  shift; AUTO_FLAG="${1:-}" ;;
-    --ci-status)  shift; CI_STATUS="${1:-}" ;;
+    --pr)              shift; PR_NUMBER="${1:-}" ;;
+    --automerge-flag)  shift; AUTOMERGE_FLAG="${1:-}" ;;
+    --ci-status)       shift; CI_STATUS="${1:-}" ;;
     *) echo "ERROR: pr-merge.sh: unknown arg: $1" >&2; exit 2 ;;
   esac
   shift || true
 done
 
-for v in PR_NUMBER AUTO_FLAG CI_STATUS; do
+for v in PR_NUMBER AUTOMERGE_FLAG CI_STATUS; do
   if [ -z "${!v}" ]; then
     echo "ERROR: pr-merge.sh: --${v,,} is required" >&2
     exit 2
@@ -63,8 +63,8 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
-# Step 1 — auto-flag != true → not requested.
-if [ "$AUTO_FLAG" != "true" ]; then
+# Step 1 — automerge-flag != true → not requested.
+if [ "$AUTOMERGE_FLAG" != "true" ]; then
   echo "MERGE_REQUESTED=false"
   echo "MERGE_REASON=auto-not-requested"
   exit 0

--- a/skills/refine-plan/SKILL.md
+++ b/skills/refine-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [rounds N] [auto] [<guidance>]"
+argument-hint: "<plan-file> [rounds N] [auto|automerge] [<guidance>]"
 description: >-
   Refine an in-progress plan by reviewing remaining phases against
   completed work. Dispatches reviewer + devil's-advocate agents to surface
@@ -9,7 +9,7 @@ description: >-
   refines until convergence. Completed phases are NEVER modified. Appends
   a Drift Log + Plan Review.
 metadata:
-  version: "2026.06.15+60b6fe"
+  version: "2026.06.15+d087ba"
 ---
 
 # /refine-plan \<plan-file> [rounds N] [<guidance>] — Adversarial Plan Refiner
@@ -164,8 +164,16 @@ parse the rest of the skill reads (`ROUNDS_MAX`, `AUTO_FLAG`, `GUIDANCE`).
 
 # auto — whitespace-anchored, case-insensitive (consumed; not guidance).
 if [ -n "${ZSH_VERSION:-}" ]; then setopt KSH_ARRAYS BASH_REMATCH SH_WORD_SPLIT 2>/dev/null || true; fi
+# automerge — whitespace-anchored, case-insensitive (consumed; not guidance).
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 
@@ -779,6 +787,7 @@ Log\` and \`## Plan Review\` sections appended.
       run skill-conformance / hook / fixture suites
 BODY
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=refine-plan --worktree-path=$TOPLEVEL --tracking-id=refine-plan.$SLUG --auto"
+  [ "${AUTOMERGE_FLAG:-0}" = "1" ] && LAND_ARGS="$LAND_ARGS --automerge"
 
   # Skill: { skill: "land-pr", args: "$LAND_ARGS" }
 

--- a/skills/run-plan/SKILL.md
+++ b/skills/run-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: run-plan
 disable-model-invocation: false
-argument-hint: "<plan-file> [phase|finish|status] [auto] [every SCHEDULE] [now] | stop | next"
+argument-hint: "<plan-file> [phase|finish|status] [auto|automerge] [every SCHEDULE] [now] | stop | next"
 description: >-
   Execute the next phase of a plan: parse status, dispatch implementation
   in a worktree, verify via a separate agent, update progress, write the
@@ -9,7 +9,7 @@ description: >-
   auto-land to main. Self-schedules via cron; use `next` to check, `stop`
   to cancel.
 metadata:
-  version: "2026.06.15+2e2498"
+  version: "2026.06.15+86e095"
 ---
 
 # /run-plan \<plan-file> [phase|finish] [auto] [every SCHEDULE] [now] | stop | next — Plan Phase Executor
@@ -148,10 +148,20 @@ if [[ "$ARGUMENTS" =~ (^|[[:space:]])[fF][iI][nN][iI][sS][hH]($|[[:space:]]) ]];
   fi
 fi
 
+# AUTOMERGE_FLAG: set by `automerge` token or `auto merge` (two words).
+AUTOMERGE_FLAG=0
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO][[:space:]]+[mM][eE][rR][gG][eE]($|[[:space:]]) ]]; then
+  AUTOMERGE_FLAG=1
+fi
+
 # AUTO_FLAG: set by standalone `auto` (regardless of finish), OR by the
-# `finish auto` composite (backward-compatible alias per D2-RP).
+# `finish auto` composite (backward-compatible alias per D2-RP), OR by
+# `automerge` (which implies auto).
 AUTO_FLAG=0
-if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]]; then
+if [[ "$ARGUMENTS" =~ (^|[[:space:]])[aA][uU][tT][oO]($|[[:space:]]) ]] || [ "$AUTOMERGE_FLAG" = "1" ]; then
   AUTO_FLAG=1
 fi
 

--- a/skills/run-plan/modes/pr.md
+++ b/skills/run-plan/modes/pr.md
@@ -351,19 +351,26 @@ RESULT_FILE="/tmp/land-pr-result-$BRANCH_SLUG-$$.txt"
 #   $WORKTREE_PATH = the plan-scoped PR-mode worktree (one per plan, reused across all phases in finish/finish-auto modes; see Issue #191)
 #   $AUTO          = "true" when $AUTO_FLAG=1 (i.e. /run-plan was invoked with `auto`,
 #                    or with the `finish auto` composite alias). Controls whether
-#                    `--auto` is appended to the /land-pr arg vector (auto-merge
-#                    the resulting PR).
+#                    `--auto` is appended to the /land-pr arg vector (unattended mode).
+#   $AUTOMERGE     = "true" when $AUTOMERGE_FLAG=1 (i.e. /run-plan was invoked with
+#                    `automerge`). Controls whether `--automerge` is appended (auto-merge).
 #   $BODY_FILE     = constructed above
 #   $BRANCH_NAME   = the plan-scoped feature branch (one per plan; phase number does NOT appear in branch name)
 #   $PR_TITLE      = constructed above
 LANDED_SOURCE="run-plan"
 # Bind $AUTO from the canonical $AUTO_FLAG bash variable: if `auto` was on
 # the invocation (standalone or via the `finish auto` composite alias), pass
-# `--auto` to /land-pr.
+# `--auto` to /land-pr. Bind $AUTOMERGE from $AUTOMERGE_FLAG: if `automerge`
+# was on the invocation, pass `--automerge` to /land-pr.
 if [ "${AUTO_FLAG:-0}" = "1" ]; then
   AUTO="true"
 else
   AUTO="false"
+fi
+if [ "${AUTOMERGE_FLAG:-0}" = "1" ]; then
+  AUTOMERGE="true"
+else
+  AUTOMERGE="false"
 fi
 
 while :; do
@@ -394,11 +401,12 @@ while :; do
   #     skills/run-plan/scripts/sync-pr-body-progress.sh:146-155.
   #   - gh-pr-edit-failed: WARN-and-continue.
 
-  # Build /land-pr arg vector. --body-file is required; --auto and
-  # --worktree-path are conditional.
+  # Build /land-pr arg vector. --body-file is required; --auto,
+  # --automerge, and --worktree-path are conditional.
   LAND_ARGS="--branch=$BRANCH_NAME --title=\"$PR_TITLE\" --body-file=$BODY_FILE --result-file=$RESULT_FILE --landed-source=$LANDED_SOURCE"
   [ -n "$WORKTREE_PATH" ] && LAND_ARGS="$LAND_ARGS --worktree-path=$WORKTREE_PATH"
   [ "$AUTO" = "true" ] && LAND_ARGS="$LAND_ARGS --auto"
+  [ "${AUTOMERGE:-false}" = "true" ] && LAND_ARGS="$LAND_ARGS --automerge"
   # Pass --tracking-id so /land-pr writes fulfilled.land-pr.<id> on
   # successful merge, satisfying the requires.land-pr.<id> marker written
   # at /run-plan skill entry. Only /run-plan PR mode passes this — the 3
@@ -541,7 +549,7 @@ while :; do
 
   case "$CI_STATUS" in
     pass|none|skipped)
-      break ;;  # /land-pr already requested merge if --auto
+      break ;;  # /land-pr already requested merge if --automerge
     pending)
       break ;;  # settle at pr-ready; user / cron can resume with --pr
     not-monitored)

--- a/skills/work-on-plans/SKILL.md
+++ b/skills/work-on-plans/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: work-on-plans
 disable-model-invocation: true
-argument-hint: "N|all [phase|finish] [every SCHEDULE] [now] [continue] | stop | next | (no args = list ready queue)"
+argument-hint: "N|all [phase|finish] [automerge] [every SCHEDULE] [now] [continue] | stop | next | (no args = list ready queue)"
 description: >-
   Batch-execute the prioritized ready queue from the dashboard: reads
   .zskills/monitor-state.json (plans.ready) and dispatches /run-plan auto
   per entry (mode resolves to `finish` by default; `phase` opts out),
-  honoring each plan's queued mode. N|all composes with every SCHEDULE +
-  now for the queue-worker pattern (N plans per fire). Also manages the
-  queue (add/rank/remove/default) and recurring schedules. Mirrors
-  /fix-issues for bugs.
+  honoring each plan's queued mode. With `automerge`, also requests
+  auto-merge on the PR after CI passes. N|all composes with every
+  SCHEDULE + now for the queue-worker pattern (N plans per fire). Also
+  manages the queue (add/rank/remove/default) and recurring schedules.
+  Mirrors /fix-issues for bugs.
 metadata:
-  version: "2026.06.15+7314ac"
+  version: "2026.06.19+9e9931"
 ---
 
 # /work-on-plans N|all [phase|finish] [every SCHEDULE] [now] [continue] [--force] | default <phase|finish> | stop | next — Batch Plan Executor
@@ -126,6 +127,15 @@ by name (order insensitive, no positional meaning):
 
 - `phase` → `MODE_OVERRIDE=phase` (mutex with `finish`)
 - `finish` → `MODE_OVERRIDE=finish` (mutex with `phase`)
+- `automerge` → `AUTOMERGE=1` (pass `automerge` to `/run-plan`;
+  requests auto-merge on the PR after CI passes)
+- `auto` (or the two-word `auto merge`) → **usage error**, exit 2. The
+  skill always runs unattended, so `auto` carries no meaning here, and
+  `auto` must NOT silently merge — that would auto-merge a whole batch of
+  PRs and break the universal rule that bare `auto` never requests a
+  merge in any skill. Only `automerge` is accepted as the merge token.
+  Print:
+  > /work-on-plans does not accept `auto` (it always runs unattended). Use `automerge` to auto-merge each PR after CI passes, or omit it to leave PRs at pr-ready for review.
 - `continue` → `CONTINUE_ON_FAILURE=1`
 - `every` followed by a SCHEDULE expression → `SCHEDULE` captured;
   register a recurring cron (see Step 7 — `every`). **Composes with

--- a/skills/work-on-plans/modes/execute.md
+++ b/skills/work-on-plans/modes/execute.md
@@ -459,6 +459,13 @@ For each ready entry in `plans.ready[0:N]`:
    - Phase mode → `Skill: { skill: "run-plan", args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto" }`
    - Finish mode → `Skill: { skill: "run-plan", args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto finish" }`
 
+   When the user passed `automerge` to `/work-on-plans` (`AUTOMERGE=1`),
+   insert ` automerge` immediately after `auto` in the args above — e.g.
+   `args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto automerge"` (phase) or
+   `args: "$ZSKILLS_PLANS_DIR/<FILE>.md auto automerge finish"` (finish) —
+   so `/run-plan` requests auto-merge on the PR. Without `automerge`, the
+   plain `auto` directives above stand and the PR settles at pr-ready.
+
    Where `$ZSKILLS_PLANS_DIR/<FILE>.md` is `SLUG_TO_FILE[$SLUG]` rendered as a
    path relative to `$MAIN_ROOT`. **Do not pass a landing-mode flag.**
    `/run-plan` resolves its own landing mode (currently `pr` per

--- a/tests/test-commit-parsing.sh
+++ b/tests/test-commit-parsing.sh
@@ -60,8 +60,8 @@ echo "=== /commit arg-parser — extract-and-run (Phase 3) ==="
 # argument-hint advertises the positional [auto] token (issue #236). Kept as
 # a presence-grep because it asserts a frontmatter UX contract, not parser
 # behavior — but the behavioral AUTO_FLAG cases below are the real guard.
-if grep -qE '^argument-hint: ".*\[auto\].*"' "$SKILL"; then
-  pass "0  argument-hint advertises positional [auto] (issue #236, migrated)"
+if grep -qE '^argument-hint: ".*\[auto' "$SKILL"; then
+  pass "0  argument-hint advertises positional [auto (issue #236, migrated)"
 else
   fail "0  argument-hint [auto]" "missing — issue #236"
 fi

--- a/tests/test-commit-pr-caller-loop.sh
+++ b/tests/test-commit-pr-caller-loop.sh
@@ -296,11 +296,13 @@ fi
 
 # ── Migrated from test-commit.sh Case 5 (prose-gate documentation) ──────
 # The pre-#236 blanket "Auto-merge (no `--auto` passed to `/land-pr`)" must be
-# gone; the gated prose ("unless the positional `auto` token is passed") must
-# document the gate. Behavioral cases 12/13 prove the gate WORKS; this keeps
-# the doc invariant the old test-commit.sh Case 5 asserted.
+# gone; the gated prose ("unless the positional `automerge` token is passed")
+# must document the gate. (Post auto/automerge split: `automerge` is the token
+# that gates the merge request; bare `auto` is unattended-only.) Behavioral
+# cases 12/13 prove the gate WORKS; this keeps the doc invariant the old
+# test-commit.sh Case 5 asserted.
 OLD_BLANKET=$(grep -cE 'Auto-merge \(no `--auto` passed to `/land-pr`\)' "$PR_MODE" 2>/dev/null)
-NEW_GATED=$(grep -cE 'unless the positional `auto` token is passed' "$PR_MODE" 2>/dev/null)
+NEW_GATED=$(grep -cE 'unless the positional `automerge` token is passed' "$PR_MODE" 2>/dev/null)
 if [ "${OLD_BLANKET:-0}" -eq 0 ] && [ "${NEW_GATED:-0}" -ge 1 ]; then
   pass "16 modes/pr.md 'PR mode does NOT' note documents the auto gate (migrated, #236)"
 else

--- a/tests/test-draft-plan-args-smoke.sh
+++ b/tests/test-draft-plan-args-smoke.sh
@@ -95,20 +95,26 @@ else
 fi
 
 # ── Surface 2: AUTO_FLAG regex (extract-and-run) ────────────────────
-# Extract the self-contained AUTO_FLAG fence and run it verbatim.
+# Extract the self-contained AUTOMERGE_FLAG + AUTO_FLAG fence and run it
+# verbatim. The AUTO_FLAG condition references $AUTOMERGE_FLAG (automerge
+# implies auto), so the extracted unit MUST begin at the AUTOMERGE_FLAG=0
+# init — otherwise the eval below hits an unbound $AUTOMERGE_FLAG under
+# `set -u`. Capture from AUTOMERGE_FLAG=0 through the first `fi` that
+# follows AUTO_FLAG=0.
 AUTO_BLOCK=$(awk '
-  /^AUTO_FLAG=0$/{capture=1}
+  /^AUTOMERGE_FLAG=0$/{capture=1}
   capture {print}
-  capture && /^fi$/{exit}
+  /^AUTO_FLAG=0$/{seen_auto=1}
+  capture && seen_auto && /^fi$/{exit}
 ' "$SKILL")
 
 if [ -z "$AUTO_BLOCK" ]; then
-  fail "auto-flag: could not extract AUTO_FLAG fence" "awk extract empty"
+  fail "auto-flag: could not extract AUTOMERGE_FLAG/AUTO_FLAG fence" "awk extract empty"
 else
-  pass "auto-flag: AUTO_FLAG fence extracted from SKILL.md"
+  pass "auto-flag: AUTOMERGE_FLAG/AUTO_FLAG fence extracted from SKILL.md"
   check_auto() { # $1=ARGUMENTS $2=expected(0/1) $3=label
     local ARGUMENTS="$1"
-    local AUTO_FLAG
+    local AUTO_FLAG AUTOMERGE_FLAG
     eval "$AUTO_BLOCK"
     if [ "$AUTO_FLAG" = "$2" ]; then
       pass "auto-flag: $3 -> AUTO_FLAG=$2"
@@ -122,6 +128,7 @@ else
   check_auto "automatic dark mode" 0 "'automatic' (no boundary) rejected"
   check_auto "engage autopilot" 0 "'autopilot' (no boundary) rejected"
   check_auto "use auto-land mode" 0 "'auto-land' (no whitespace boundary) rejected"
+  check_auto "automerge Build the thing" 1 "'automerge' implies auto (AUTO_FLAG=1)"
 fi
 
 # ── Surface 3: STEERING_MODE leading-cluster selector (extract-and-run) ──

--- a/tests/test-draft-tests.sh
+++ b/tests/test-draft-tests.sh
@@ -107,8 +107,8 @@ fi
 
 expect_skill_matches "AC-1.1: frontmatter name"               '^name:[[:space:]]+draft-tests'
 expect_skill_matches "AC-1.1: frontmatter disable-model-invocation" '^disable-model-invocation:[[:space:]]+false'
-expect_skill_matches "AC-1.1: frontmatter argument-hint with [auto] [<guidance>]" \
-  '^argument-hint:[[:space:]]+"<plan-file>[[:space:]]+\[rounds N\][[:space:]]+\[auto\][[:space:]]+\[<guidance>\]"'
+expect_skill_matches "AC-1.1: frontmatter argument-hint with [auto|automerge] [<guidance>]" \
+  '^argument-hint:[[:space:]]+"<plan-file>[[:space:]]+\[rounds N\][[:space:]]+\[auto|automerge\][[:space:]]+\[<guidance>\]"'
 expect_skill_matches "AC-1.1: frontmatter description"        '^description:'
 
 # ----------------------------------------------------------------------

--- a/tests/test-fix-issues-sprint-land-pr.sh
+++ b/tests/test-fix-issues-sprint-land-pr.sh
@@ -395,7 +395,12 @@ patch_block_capturing_land_args() {
   local src="$1" out="$2" capture_file="$3"
   patch_block "$src" "$out"
   awk -v out="$capture_file" '
-    /\[ "\$\{AUTO:-false\}" = "true" \] && LAND_ARGS=/ {
+    /\[ "\$\{AUTO_FLAG:-0\}" = "1" \] && LAND_ARGS=/ {
+      print
+      print "printf \"%s\" \"$LAND_ARGS\" > " out
+      next
+    }
+    /\[ "\$\{AUTOMERGE_FLAG:-0\}" = "1" \] && LAND_ARGS=/ {
       print
       print "printf \"%s\" \"$LAND_ARGS\" > " out
       next
@@ -413,17 +418,17 @@ test_A5_auto_true_emits_flag() {
   export PREPARED_RESULT_FILE="$CASE_DIR/result.txt"
   export PREPARED_BODY_FILE="$CASE_DIR/body.txt"
   mk_result_file "$PREPARED_RESULT_FILE" "STATUS=merged"
-  export AUTO="true"
+  export AUTO_FLAG="1"
   run_block "A-5cap" "$patched" "$CASE_DIR/bin"
   if [ -f "$cap" ] && grep -q -- '--auto' "$cap"; then
     pass "A5: AUTO=true → LAND_ARGS contains --auto"
   else
     fail "A5: AUTO=true → LAND_ARGS contains --auto" "rc=$LAST_RC captured=$(cat "$cap" 2>/dev/null || echo missing) stderr=$(head -5 "$TMP_ROOT/A-5cap.err" 2>/dev/null)"
   fi
-  unset AUTO WT_PATH ZSKILLS_AUDIT_DIR ZSKILLS_REPORTS_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
+  unset AUTO_FLAG AUTOMERGE_FLAG WT_PATH ZSKILLS_AUDIT_DIR ZSKILLS_REPORTS_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
 }
 
-# Case A6: AUTO=false — LAND_ARGS must NOT contain --auto.
+# Case A6: AUTO_FLAG=0 — LAND_ARGS must NOT contain --auto.
 test_A6_auto_false_no_flag() {
   setup_case_a "6" "gnu"
   local patched="$CASE_DIR/block.sh"
@@ -433,18 +438,18 @@ test_A6_auto_false_no_flag() {
   export PREPARED_RESULT_FILE="$CASE_DIR/result.txt"
   export PREPARED_BODY_FILE="$CASE_DIR/body.txt"
   mk_result_file "$PREPARED_RESULT_FILE" "STATUS=merged"
-  export AUTO="false"
+  export AUTO_FLAG="0"
   run_block "A-6cap" "$patched" "$CASE_DIR/bin"
   if [ -f "$cap" ] && ! grep -q -- '--auto' "$cap"; then
     pass "A6: AUTO=false → LAND_ARGS does NOT contain --auto"
   else
     fail "A6: AUTO=false → LAND_ARGS does NOT contain --auto" "captured=$(cat "$cap" 2>/dev/null || echo missing)"
   fi
-  unset AUTO WT_PATH ZSKILLS_AUDIT_DIR ZSKILLS_REPORTS_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
+  unset AUTO_FLAG AUTOMERGE_FLAG WT_PATH ZSKILLS_AUDIT_DIR ZSKILLS_REPORTS_DIR PIPELINE_ID SPRINT_ID COMMIT_CO_AUTHOR PREPARED_RESULT_FILE PREPARED_BODY_FILE || true
 }
 
-# Case A7: AUTO unset + `set -u` — block must NOT crash, LAND_ARGS no --auto.
-#   This pins the fix from issue #337 secondary: `[ "${AUTO:-false}" = ... ]`
+# Case A7: AUTO_FLAG unset + `set -u` — block must NOT crash, LAND_ARGS no --auto.
+#   This pins the fix from issue #337 secondary: `[ "${AUTO_FLAG:-0}" = ... ]`
 #   defaults under set -u; the prior `[ "$AUTO" = "true" ]` would have
 #   triggered `unbound variable`.
 test_A7_auto_unset_no_crash() {
@@ -456,7 +461,7 @@ test_A7_auto_unset_no_crash() {
   export PREPARED_RESULT_FILE="$CASE_DIR/result.txt"
   export PREPARED_BODY_FILE="$CASE_DIR/body.txt"
   mk_result_file "$PREPARED_RESULT_FILE" "STATUS=merged"
-  unset AUTO || true
+  unset AUTO_FLAG AUTOMERGE_FLAG || true
   run_block "A-7cap" "$patched" "$CASE_DIR/bin"
   local err; err=$(cat "$TMP_ROOT/A-7cap.err" 2>/dev/null || echo "")
   if [ "$LAST_RC" -eq 0 ] && ! echo "$err" | grep -qi 'unbound variable' \

--- a/tests/test-fix-issues.sh
+++ b/tests/test-fix-issues.sh
@@ -415,10 +415,10 @@ test_site2_sync_phase5_unconditional_auto() {
   fi
   local content
   content=$(awk -v n="$line" 'NR==n { print }' "$SKILL_SYNC")
-  if echo "$content" | grep -qE -- '--auto"?$'; then
-    pass "site 2: standalone sync LAND_ARGS ends with --auto (unconditional)"
+  if echo "$content" | grep -qE -- '--auto --automerge"?$'; then
+    pass "site 2: standalone sync LAND_ARGS ends with --auto --automerge (unconditional)"
   else
-    fail "site 2: standalone sync LAND_ARGS ends with --auto" "line $line does not end --auto: [$content]"
+    fail "site 2: standalone sync LAND_ARGS ends with --auto --automerge" "line $line does not end --auto --automerge: [$content]"
   fi
 }
 
@@ -434,10 +434,10 @@ test_site3_no_actionable_unconditional_auto() {
   fi
   local content
   content=$(awk -v n="$line" 'NR==n { print }' "$SKILL_SPRINT")
-  if echo "$content" | grep -qE -- '--auto"?$'; then
-    pass "site 3: no-actionable LAND_ARGS ends with --auto (unconditional)"
+  if echo "$content" | grep -qE -- '--auto --automerge"?$'; then
+    pass "site 3: no-actionable LAND_ARGS ends with --auto --automerge (unconditional)"
   else
-    fail "site 3: no-actionable LAND_ARGS ends with --auto" "line $line does not end --auto: [$content]"
+    fail "site 3: no-actionable LAND_ARGS ends with --auto --automerge" "line $line does not end --auto --automerge: [$content]"
   fi
 
   # And the AUTO-conditional must NOT appear immediately after the
@@ -445,7 +445,7 @@ test_site3_no_actionable_unconditional_auto() {
   # confusion).
   local next
   next=$(awk -v n="$line" 'NR==n+1 { print }' "$SKILL_SPRINT")
-  if echo "$next" | grep -qE '\[\s*"\$\{AUTO:-false\}"\s*=\s*"true"\s*\]\s*&&\s*LAND_ARGS='; then
+  if echo "$next" | grep -qE '\[\s*"\$\{AUTO_FLAG:-0\}"\s*=\s*"1"\s*\]\s*&&\s*LAND_ARGS='; then
     fail "site 3: no AUTO-conditional after no-actionable LAND_ARGS" "found on line $((line+1)): [$next]"
   else
     pass "site 3: no AUTO-conditional immediately after no-actionable LAND_ARGS"
@@ -475,7 +475,7 @@ test_site1_sprint_land_honors_auto() {
   # The AUTO-conditional MUST be on the very next line.
   local next
   next=$(awk -v n="$line" 'NR==n+1 { print }' "$SKILL_SPRINT")
-  if echo "$next" | grep -qE '\[\s*"\$\{AUTO:-false\}"\s*=\s*"true"\s*\]\s*&&\s*LAND_ARGS='; then
+  if echo "$next" | grep -qE '\[\s*"\$\{AUTO_FLAG:-0\}"\s*=\s*"1"\s*\]\s*&&\s*LAND_ARGS='; then
     pass "site 1: AUTO-conditional present immediately after sprint-land LAND_ARGS"
   else
     fail "site 1: AUTO-conditional present immediately after sprint-land LAND_ARGS" \

--- a/tests/test-land-pr-scripts.sh
+++ b/tests/test-land-pr-scripts.sh
@@ -571,7 +571,7 @@ cleanup_fixture "$F"
 F=$(new_fixture mode9)
 prep_gh "$F/state-gh" pr_merge 1 exit 1
 prep_gh "$F/state-gh" pr_merge 1 stderr 'pull request auto-merge is not allowed on this repository'
-run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --auto-flag true --ci-status pass
+run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --automerge-flag true --ci-status pass
 if [ "$SUT_RC" -eq 0 ] \
    && [[ "$SUT_OUT" == *"MERGE_REQUESTED=false"* ]] \
    && [[ "$SUT_OUT" == *"MERGE_REASON=auto-merge-disabled-on-repo"* ]]; then
@@ -587,7 +587,7 @@ cleanup_fixture "$F"
 F=$(new_fixture mode10)
 prep_gh "$F/state-gh" pr_merge 1 exit 1
 prep_gh "$F/state-gh" pr_merge 1 stderr 'HTTP 502 Bad Gateway'
-run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --auto-flag true --ci-status pass
+run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --automerge-flag true --ci-status pass
 if [ "$SUT_RC" -eq 30 ] \
    && [[ "$SUT_OUT" == *"MERGE_REASON=gh-error"* ]] \
    && [[ "$SUT_OUT" =~ CALL_ERROR_FILE=([^[:space:]]+) ]] \
@@ -642,10 +642,10 @@ fi
 cleanup_fixture "$F"
 
 # ----------------------------------------------------------------------
-# Idempotency 3 — merge --auto-flag=false → no gh call, MERGE_REQUESTED=false
+# Idempotency 3 — merge --automerge-flag=false → no gh call, MERGE_REQUESTED=false
 # ----------------------------------------------------------------------
 F=$(new_fixture idem3)
-run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --auto-flag false --ci-status pass
+run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --automerge-flag false --ci-status pass
 if [ "$SUT_RC" -eq 0 ] \
    && [[ "$SUT_OUT" == *"MERGE_REQUESTED=false"* ]] \
    && [[ "$SUT_OUT" == *"MERGE_REASON=auto-not-requested"* ]] \
@@ -660,7 +660,7 @@ cleanup_fixture "$F"
 # Idempotency 4 — merge --ci-status=pending → not requested
 # ----------------------------------------------------------------------
 F=$(new_fixture idem4)
-run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --auto-flag true --ci-status pending
+run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr 42 --automerge-flag true --ci-status pending
 if [ "$SUT_RC" -eq 0 ] \
    && [[ "$SUT_OUT" == *"MERGE_REQUESTED=false"* ]] \
    && [[ "$SUT_OUT" == *"MERGE_REASON=ci-not-passing"* ]] \
@@ -704,7 +704,7 @@ fi
 cleanup_fixture "$F"
 
 F=$(new_fixture argerr4)
-run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr abc --auto-flag true --ci-status pass
+run_sut "$F" bash "$SCRIPTS_DIR/pr-merge.sh" --pr abc --automerge-flag true --ci-status pass
 if [ "$SUT_RC" -eq 2 ]; then
   pass "[argerr4] pr-merge.sh non-numeric --pr exits 2"
 else

--- a/tests/test-skill-conformance.sh
+++ b/tests/test-skill-conformance.sh
@@ -609,10 +609,10 @@ check_in_file fix-issues modes/sprint.md "summary referenced from no-actionable 
   'per-fire user-facing summary'
 check_in_file .claude/skills/fix-issues modes/sprint.md "mirror has 6th bucket"               'Author decision needed'
 check_in_file .claude/skills/fix-issues modes/sprint.md "mirror has summary section heading"  'Per-fire user-facing summary'
-# WI 4.6 RELOCATE: the `if [ "$AUTO_FLAG" != "true" ]` literal guard
+# WI 4.6 RELOCATE: the `if [ "$AUTOMERGE_FLAG" != "true" ]` literal guard
 # now lives in /land-pr's pr-merge.sh (Phase 1B WI 1.6). Verify it
 # stays there.
-check_in_file land-pr scripts/pr-merge.sh "auto-merge AUTO_FLAG guard" 'if \[ "\$AUTO_FLAG" != "true" \]; then'
+check_in_file land-pr scripts/pr-merge.sh "auto-merge AUTOMERGE_FLAG guard" 'if \[ "\$AUTOMERGE_FLAG" != "true" \]; then'
 
 # Guard recently-reverted content (see #704, #729, #735).
 # These blocks have been lost-then-restored across rapid PR landings; pin
@@ -682,7 +682,21 @@ for skill in draft-plan refine-plan draft-tests; do
   check_fixed "$skill" "AUTO_FLAG gates dispatch" '${AUTO_FLAG:-0}" = "1"'
   check_fixed "$skill" "Skill tool dispatch line" 'Skill: { skill: "land-pr"'
   check_fixed "$skill" "--auto flag passed to land-pr" '--auto'
-  check       "$skill" "argument-hint contains auto" 'argument-hint:.*\[auto\]'
+  check       "$skill" "argument-hint contains auto" 'argument-hint:.*\[auto'
+done
+
+echo ""
+echo "=== automerge token separation (ZSKILLS_TODO #1) ==="
+# The automerge/auto split: skills parse AUTOMERGE_FLAG separately from
+# AUTO_FLAG. automerge implies auto. /land-pr accepts --automerge and
+# passes --automerge-flag to pr-merge.sh.
+check_fixed land-pr "AUTOMERGE_FLAG init"         'AUTOMERGE_FLAG=false'
+check_fixed land-pr "--automerge arg parse arm"   'AUTOMERGE_FLAG=true; AUTO_FLAG=true'
+check_fixed land-pr "--automerge-flag passed to pr-merge.sh" '--automerge-flag "$AUTOMERGE_FLAG"'
+for skill in run-plan do commit fix-issues draft-plan refine-plan draft-tests; do
+  check_fixed "$skill" "AUTOMERGE_FLAG init"           'AUTOMERGE_FLAG=0'
+  check       "$skill" "automerge token detection"     '\[aA\]\[uU\]\[tT\]\[oO\]\[mM\]\[eE\]\[rR\]\[gG\]\[eE\]'
+  check_fixed "$skill" "AUTOMERGE gates --automerge"   'AUTOMERGE_FLAG:-0}" = "1"'
 done
 
 echo ""
@@ -1901,8 +1915,8 @@ echo "=== /draft-tests — behavior contracts (WI 6.3) ==="
 # count. WI 6.3 is the authoritative enumeration source.
 #
 # 1. Frontmatter shape (incl. `[<guidance>]` positional tail in argument-hint)
-check       draft-tests "frontmatter argument-hint with [auto] [<guidance>]" \
-  '^argument-hint:[[:space:]]+"<plan-file> \[rounds N\] \[auto\] \[<guidance>\]"'
+check       draft-tests "frontmatter argument-hint with [auto|automerge] [<guidance>]" \
+  '^argument-hint:[[:space:]]+"<plan-file> \[rounds N\] \[auto|automerge\] \[<guidance>\]"'
 # 2. Tracking marker basename matches canonical scheme `fulfilled.draft-tests.<id>`
 check_fixed draft-tests "fulfilled marker basename" \
   'fulfilled.draft-tests.$TRACKING_ID'


### PR DESCRIPTION
## Summary

Breaking change: separate the `auto` positional token (now **unattended
mode only**) from a new `automerge` token (**unattended + auto-merge**).
Previously `auto` always requested auto-merge; the safer default is now
"create PR but don't merge."

| User passes | Unattended? | Auto-merge? |
|-------------|-------------|-------------|
| (nothing)   | No          | No          |
| `auto`      | Yes         | No (**changed**) |
| `automerge` | Yes         | Yes         |

`automerge` implies `auto`. `auto merge` (two words) is accepted as a
synonym for `automerge`.

Re-ported hunk-by-hunk from an upstream change bundle (2026-06-10) onto
current `main`, preserving the zsh `setopt` fences and recomputing every
`metadata.version` freshly.

## Changes

- **Chokepoint `/land-pr`**: new `--automerge` flag (sets `AUTO_FLAG`
  too); `pr-merge.sh` parameter renamed `--auto-flag` → `--automerge-flag`
  (the merge gate now keys off automerge, not auto). BEHIND-recovery and
  fix-cycle still gate on `--auto` (unattended), unchanged.
- **8 caller skills** parse `automerge` (+ `auto merge`) into a separate
  `AUTOMERGE_FLAG` and forward `--automerge` independently: `/run-plan`,
  `/do`, `/commit`, `/fix-issues`, `/draft-tests`, `/draft-plan`,
  `/refine-plan`, `/work-on-plans`.
- **Infrastructure paths** that only ship sync/tracker content (no
  code-review surface) now pass `--auto --automerge` unconditionally
  (`/fix-issues` dashboard-empty, no-actionable, tracker-rollup, and
  standalone `sync` Phase 5), preserving their always-merge behavior.
- `.claude/skills/` mirrors regenerated via `mirror-skill.sh`; all 9
  touched skill versions bumped (ET date + content hash).
- Doc pages, CHANGELOG ("Breaking" entry), `docs/plans/AUTOMERGE_TOKEN_PLAN.md`,
  and tests updated.

## Migration

Failure mode is safe: a workflow still using bare `auto` gets a PR
*created but not merged* — the user notices on first run and adds
`automerge`. `/work-on-plans automerge` restores batch-and-merge.

## Test plan

- [x] Full local suite green: **8153/8153 passed, 0 failed**
      (`bash tests/run-all.sh`), incl. skill-conformance (new automerge
      token-separation section), mirror-parity, skill-version, land-pr
      scripts, fix-issues sprint/sync, commit-parsing, draft-tests.
- [x] Two drift-induced failures from the re-port fixed at root:
      `work-on-plans` dispatch-seam (restored the exact pinned `/run-plan`
      directives; express `automerge` as a conditional, not a literal
      `[automerge]` arg) and the commit-pr prose-gate (gating token moved
      `auto` → `automerge` with the breaking change).
- [x] No residual `--auto-flag` anywhere; mirror parity verified.
- [ ] CI green on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
