### PR TITLE
do: treat bypassPermissions as attended, not autonomous

### DIFF
--- a/.claude/hooks/block-bad-cron.sh
+++ b/.claude/hooks/block-bad-cron.sh
@@ -105,10 +105,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-bypassed-land-pr.sh
+++ b/.claude/hooks/block-bypassed-land-pr.sh
@@ -280,10 +280,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-fix-issue-unclaimed.sh
+++ b/.claude/hooks/block-fix-issue-unclaimed.sh
@@ -278,10 +278,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-main-edits.sh
+++ b/.claude/hooks/block-main-edits.sh
@@ -125,10 +125,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-run-plan-unclaimed.sh
+++ b/.claude/hooks/block-run-plan-unclaimed.sh
@@ -273,10 +273,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-stale-skill-version.sh
+++ b/.claude/hooks/block-stale-skill-version.sh
@@ -100,10 +100,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-unsafe-generic.sh
+++ b/.claude/hooks/block-unsafe-generic.sh
@@ -476,10 +476,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/hooks/block-unsafe-project.sh
+++ b/.claude/hooks/block-unsafe-project.sh
@@ -116,10 +116,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/.claude/rules/zskills/managed.md
+++ b/.claude/rules/zskills/managed.md
@@ -443,9 +443,14 @@ to `"block"`.
 coaching is opt-in; per-check overrides in `hooks.*`.** The safety hooks
 follow one rule: a *demotable* check is SILENT by shipped default when a
 human is watching (no nagging — no warning AND no block on a routine git
-workflow) and BLOCKS when the session is autonomous/unwatched
-(`bypassPermissions` mode, an absent/unrecognized permission mode, or a
-live zskills pipeline). On a fresh install with NO config of any kind, an
+workflow) and BLOCKS when the session is autonomous/unwatched (an
+absent/unrecognized permission mode, or a live zskills pipeline).
+`bypassPermissions` (a human running `--dangerously-skip-permissions`) is
+treated as ATTENDED — it is a permission-convenience flag, not an attendance
+signal — so it is no longer auto-classified as autonomous; genuine autonomy
+under bypass is still caught by the live-pipeline arm, and a project that
+wants hard enforcement regardless keeps it via the per-check `"block"`
+toggle (hard checks are unaffected — they block always). On a fresh install with NO config of any kind, an
 attended human is nagged about nothing, while every autonomous/unwatched
 safety guarantee is preserved unchanged. Coaching is opt-in per check via
 the project-only `hooks.*` block in `.claude/zskills-config.json`: set a

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -443,9 +443,14 @@ to `"block"`.
 coaching is opt-in; per-check overrides in `hooks.*`.** The safety hooks
 follow one rule: a *demotable* check is SILENT by shipped default when a
 human is watching (no nagging — no warning AND no block on a routine git
-workflow) and BLOCKS when the session is autonomous/unwatched
-(`bypassPermissions` mode, an absent/unrecognized permission mode, or a
-live zskills pipeline). On a fresh install with NO config of any kind, an
+workflow) and BLOCKS when the session is autonomous/unwatched (an
+absent/unrecognized permission mode, or a live zskills pipeline).
+`bypassPermissions` (a human running `--dangerously-skip-permissions`) is
+treated as ATTENDED — it is a permission-convenience flag, not an attendance
+signal — so it is no longer auto-classified as autonomous; genuine autonomy
+under bypass is still caught by the live-pipeline arm, and a project that
+wants hard enforcement regardless keeps it via the per-check `"block"`
+toggle (hard checks are unaffected — they block always). On a fresh install with NO config of any kind, an
 attended human is nagged about nothing, while every autonomous/unwatched
 safety guarantee is preserved unchanged. Coaching is opt-in per check via
 the project-only `hooks.*` block in `.claude/zskills-config.json`: set a

--- a/docs/guides/zskills-config.md
+++ b/docs/guides/zskills-config.md
@@ -383,14 +383,19 @@ see below.)
 A hook decides whether it is *watched* or *autonomous* from one signal
 (no TTY sniffing, no env vars, no transcript heuristics):
 
-- **Autonomous (enforce)** — the session is running in
-  `bypassPermissions` permission mode, OR the permission-mode field is
+- **Autonomous (enforce)** — the permission-mode field is
   absent/unrecognized (fail-safe → enforce), OR a zskills pipeline is LIVE
   (a `.zskills/tracked` marker at the effective local root or the main
   root, or a fresh `.zskills/inflight/` sentinel). Demotable checks
   **BLOCK** here.
 - **Watched** — everything else (a normal attended session in `default`,
-  `acceptEdits`, or `plan` permission mode with no live pipeline marker).
+  `acceptEdits`, `plan`, or `bypassPermissions` permission mode with no live
+  pipeline marker). `bypassPermissions` (a human running
+  `--dangerously-skip-permissions`) is treated as ATTENDED — it is a
+  permission-convenience flag, not an attendance signal — so it does not by
+  itself classify the session as autonomous; genuine autonomy under bypass
+  is still caught by the live-pipeline arm, and a project that wants hard
+  enforcement regardless keeps it via the per-check `"block"` toggle.
   A demotable check is **SILENT by shipped default** — it does nothing (no
   warning, no block; the permission prompt the session would normally get
   still fires from the harness). Coaching is opt-in: set the per-check

--- a/docs/plans/ENFORCEMENT_V2_PLAN.md
+++ b/docs/plans/ENFORCEMENT_V2_PLAN.md
@@ -2608,3 +2608,47 @@ its rationale and mitigation; none is a plan-text contradiction:
    pre-amendment, so the amendment removes only the warning, not a block. A
    project wanting the warn or hard-deny back sets
    `hooks.main_protection.push_to_main` to `"warn"` / `"block"`.
+
+## Disposition / drift note — 2026-06-22: `bypassPermissions` reclassified as ATTENDED
+
+The original Phase 1–3 predicate classified `bypassPermissions` as one of the
+AUTONOMOUS triggers (the `*)` catch-all returned `enforce-autonomous` for both
+`bypassPermissions` AND absent/unrecognized modes). This categorization is
+REVERSED as of 2026-06-22.
+
+**What changed.** In `zskills_enforcement_predicate`
+(`hooks/_lib/zskills-enforcement.sh`, mirrored verbatim into the eight inlining
+`block-*` hooks + the project `.template` + the `.claude/hooks/` legacy
+mirrors), `bypassPermissions` moves from the `*)` arm into the attended case
+label: `default|acceptEdits|plan` → `default|acceptEdits|plan|bypassPermissions`.
+The `*)` arm still returns `enforce-autonomous`, but now matches ONLY
+absent/unrecognized permission modes (the fail-safe-toward-enforcement default
+is preserved).
+
+**Rationale.** `bypassPermissions` (a human running
+`--dangerously-skip-permissions`) is a permission-CONVENIENCE flag, not an
+ATTENDANCE signal — many humans run it always, and auto-classifying every such
+session as autonomous nagged/blocked attended humans on routine workflows.
+Genuine zskills autonomy is already detected by the `enforce-pipeline` arm (a
+live `.zskills/tracked` marker / `.zskills/inflight/` sentinel), so dropping the
+bypass trigger loses no genuine-autonomy coverage. A project that wants hard
+enforcement under bypass regardless keeps it via the per-check `"block"` toggle
+(forces a block independent of the predicate). HARD checks (destructive
+fs/git/process-kill, `--no-verify`) are UNAFFECTED — they block always,
+regardless of the predicate.
+
+**Test repointing (never weakened).** The bypass-parity DENY assertions across
+`test-block-main-edits.sh`, `test-hooks-bypass-generic.sh`,
+`test-hooks-bypass-project.sh`, `test-plan-claim-hook-deny.sh`, and
+`test-block-fix-issue-unclaimed-ownership.sh` previously relied on
+`bypassPermissions` alone to TRIGGER the demotable-check block. They now plant a
+live `.zskills/tracked` pipeline marker in the fixture (→ `enforce-pipeline` →
+deny), repointing the trigger to a GENUINE autonomy signal so the same block
+path stays exercised. The lib unit test
+(`test-zskills-enforcement-lib.sh`) flips its direct
+`bypassPermissions → enforce-autonomous` assertion to
+`bypassPermissions (no markers) → watched` and `bypassPermissions + live
+pipeline → enforce-pipeline`, keeps the absent/garbage → `enforce-autonomous`
+fail-safe assertions, and adds a regression pin (bypass + no pipeline + unset
+toggle → predicate `watched` AND demotable check resolves `silent`). HARD-check
+assertions (which block always) were left untouched.

--- a/hooks/_lib/zskills-enforcement.sh
+++ b/hooks/_lib/zskills-enforcement.sh
@@ -161,10 +161,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-bad-cron.sh
+++ b/hooks/block-bad-cron.sh
@@ -105,10 +105,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-bypassed-land-pr.sh
+++ b/hooks/block-bypassed-land-pr.sh
@@ -280,10 +280,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-fix-issue-unclaimed.sh
+++ b/hooks/block-fix-issue-unclaimed.sh
@@ -278,10 +278,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-main-edits.sh
+++ b/hooks/block-main-edits.sh
@@ -125,10 +125,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-run-plan-unclaimed.sh
+++ b/hooks/block-run-plan-unclaimed.sh
@@ -273,10 +273,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-stale-skill-version.sh
+++ b/hooks/block-stale-skill-version.sh
@@ -100,10 +100,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-unsafe-generic.sh
+++ b/hooks/block-unsafe-generic.sh
@@ -476,10 +476,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-unsafe-project.sh
+++ b/hooks/block-unsafe-project.sh
@@ -116,10 +116,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/hooks/block-unsafe-project.sh.template
+++ b/hooks/block-unsafe-project.sh.template
@@ -116,10 +116,15 @@ zskills_enforcement_predicate() {
   if [[ "$_json" =~ (^|[^\\])\"permission_mode\"[[:space:]]*:[[:space:]]*\"([a-zA-Z]+)\" ]]; then
     PERM="${BASH_REMATCH[2]}"
   fi
-  # enforce-autonomous iff bypassPermissions OR not a recognized attended
-  # mode (absent/unrecognized — fail-safe TOWARD enforcement).
+  # enforce-autonomous iff the permission mode is ABSENT or UNRECOGNIZED only
+  # (fail-safe TOWARD enforcement). bypassPermissions is treated as ATTENDED:
+  # it's a permission-convenience flag (--dangerously-skip-permissions), NOT an
+  # attendance signal — many humans run it always. Genuine zskills autonomy is
+  # detected by the pipeline-live arm below (.zskills/tracked / inflight
+  # sentinel); projects wanting hard enforcement keep it via the per-check
+  # "block" toggle, which forces a block regardless of this predicate.
   case "$PERM" in
-    default|acceptEdits|plan)
+    default|acceptEdits|plan|bypassPermissions)
       : # attended modes — fall through to the pipeline-live check
       ;;
     *)

--- a/tests/test-block-fix-issue-unclaimed-ownership.sh
+++ b/tests/test-block-fix-issue-unclaimed-ownership.sh
@@ -284,9 +284,13 @@ write_hooks_config() {
   printf '%s' "$2" > "$1/.claude/zskills-config.json"
 }
 
-# ── P1: bypass-parity (foreign-pipeline deny under bypassPermissions) ──────
+# ── P1: bypass-parity (foreign-pipeline deny under bypassPermissions + live
+# pipeline). bypassPermissions is now ATTENDED (a permission-convenience flag,
+# not an attendance signal); the genuine autonomy signal driving the autonomous
+# deny is the live .zskills/tracked pipeline marker planted below. ─
 FP1="$SCRATCH_ROOT/fp1"
 init_fixture "$FP1"
+mkdir -p "$FP1/.zskills"; : > "$FP1/.zskills/tracked"
 write_claim "$FP1" 21 "pipe-A-holder"
 PAYLOAD=$(build_payload_pm 21 "pipe-B-intruder" "bypassPermissions")
 run_hook "$FP1" "$PAYLOAD"
@@ -297,9 +301,12 @@ else
   fail "P1: foreign-pipeline deny under bypass" "stdout=$LAST_STDOUT"
 fi
 
-# ── P2: bypass-parity (no-claim deny under bypassPermissions) ──────────────
+# ── P2: bypass-parity (no-claim deny under bypassPermissions + live pipeline) ─
+# bypassPermissions is ATTENDED; the live .zskills/tracked marker is the genuine
+# autonomy signal that keeps the autonomous deny path exercised.
 FP2="$SCRATCH_ROOT/fp2"
 init_fixture "$FP2"
+mkdir -p "$FP2/.zskills"; : > "$FP2/.zskills/tracked"
 PAYLOAD=$(build_payload_pm 22 "pipe-any" "bypassPermissions")
 run_hook "$FP2" "$PAYLOAD"
 if echo "$LAST_STDOUT" | grep -q '"permissionDecision":"deny"' \

--- a/tests/test-block-main-edits.sh
+++ b/tests/test-block-main-edits.sh
@@ -145,6 +145,22 @@ run_hook() {
   rm -f "$errf"
 }
 
+# run_hook_pipeline: same as run_hook, but plants a live `.zskills/tracked`
+# pipeline marker at BOTH the predicate's local root (CLAUDE_PROJECT_DIR =
+# project_dir) and its main/config root (enf_root) for the duration of the run,
+# then removes them. Used by the bypass-parity DENY cases: bypassPermissions is
+# now ATTENDED (a permission-convenience flag, not an attendance signal), so an
+# autonomous deny must be driven by a GENUINE autonomy signal — a live pipeline
+# marker — not by bypassPermissions alone.
+run_hook_pipeline() {
+  local project_dir="$1" input="$2" enf_root="${3:-$1}"
+  mkdir -p "$project_dir/.zskills" "$enf_root/.zskills"
+  : > "$project_dir/.zskills/tracked"
+  : > "$enf_root/.zskills/tracked"
+  run_hook "$project_dir" "$input" "$enf_root"
+  rm -f "$project_dir/.zskills/tracked" "$enf_root/.zskills/tracked"
+}
+
 # Build an Edit/Write envelope. The tool name varies by tool; both use
 # file_path under tool_input.
 mkenv_edit()   { printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"}}' "$1"; }
@@ -458,9 +474,9 @@ printf '{"execution":{"main_protected":true}}' > "$SANDBOX/.claude/zskills-confi
 # ═══ config_hooks_tamper arm (registry row 49, Settled decision 13) ════════
 CFG="$SANDBOX/.claude/zskills-config.json"
 
-# ── tc1: tamper Edit (hooks in new_string) + BYPASS → DENY (bypass parity 2/5) ─
-run_hook "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
-assert_deny "tc1: tamper Edit + bypass → DENY (bypass parity, config_hooks_tamper)" "$HOOK_OUT"
+# ── tc1: tamper Edit (hooks in new_string) + BYPASS + live pipeline → DENY (bypass parity 2/5) ─
+run_hook_pipeline "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
+assert_deny "tc1: tamper Edit + bypass + live pipeline → DENY (bypass parity, config_hooks_tamper)" "$HOOK_OUT"
 if [[ "$HOOK_OUT" == *'[hooks.main_protection.config_hooks_tamper'* ]]; then
   pass "tc1b: tamper deny names config_hooks_tamper toggle"
 else
@@ -494,9 +510,9 @@ printf '{"execution":{"main_protected":true}}' > "$CFG"
 run_hook "$SANDBOX" "$(mkenv_edit_nonhooks "$CFG" default)"
 assert_silent "tc5: non-hooks config Edit watched → SILENT (falls through to main_edit)" \
   "$HOOK_EXIT" "$HOOK_OUT" "$HOOK_ERR"
-# And the same non-hooks config Edit under BYPASS → DENY via main_edit (not tamper).
-run_hook "$SANDBOX" "$(mkenv_edit_nonhooks "$CFG" bypassPermissions)"
-assert_deny "tc5b: non-hooks config Edit bypass → DENY via main_edit arm" "$HOOK_OUT"
+# And the same non-hooks config Edit under BYPASS + live pipeline → DENY via main_edit (not tamper).
+run_hook_pipeline "$SANDBOX" "$(mkenv_edit_nonhooks "$CFG" bypassPermissions)"
+assert_deny "tc5b: non-hooks config Edit bypass + live pipeline → DENY via main_edit arm" "$HOOK_OUT"
 if [[ "$HOOK_OUT" == *'[hooks.main_protection.main_edit'* ]]; then
   pass "tc5c: non-hooks config Edit deny names main_edit (not tamper)"
 else
@@ -505,7 +521,7 @@ fi
 
 # ── tc6: main_protected ABSENT → tamper arm STILL fires (placement headline, R2-6) ─
 printf '{"execution":{}}' > "$CFG"
-run_hook "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
+run_hook_pipeline "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
 assert_deny "tc6: tamper arm fires even with main_protected absent (placement above gate)" "$HOOK_OUT"
 printf '{"execution":{"main_protected":true}}' > "$CFG"
 
@@ -522,24 +538,24 @@ rm -f "$WORKTREE/.zskills-tracked" "$WORKTREE/.landed"
 run_hook "$WORKTREE" "$(mkenv_edit_hooks "$CFG" default)" "$SANDBOX"
 assert_warn "tc7: worktree-session Edit of MAIN config (watched) → WARN (above worktree-self, DA3)" \
   "$HOOK_EXIT" "$HOOK_OUT" "[hooks.main_protection.config_hooks_tamper"
-run_hook "$WORKTREE" "$(mkenv_edit_hooks "$CFG" bypassPermissions)" "$SANDBOX"
+run_hook_pipeline "$WORKTREE" "$(mkenv_edit_hooks "$CFG" bypassPermissions)" "$SANDBOX"
 assert_deny "tc7b: worktree-session Edit of MAIN config (bypass) → DENY (above worktree-self, DA3)" "$HOOK_OUT"
 
 # ── tc8: group ceiling main_protection.enabled:false + tamper edit → STILL gated ─
 # config_hooks_tamper is EXEMPT from its group's enabled ceiling.
 printf '{"execution":{"main_protected":true},"hooks":{"main_protection":{"enabled":false}}}' > "$CFG"
-run_hook "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
+run_hook_pipeline "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
 assert_deny "tc8: group ceiling enabled:false + tamper edit → STILL gated (ceiling exemption)" "$HOOK_OUT"
 printf '{"execution":{"main_protected":true}}' > "$CFG"
 
 # ── tc9: self-protection — config WITHOUT a config_hooks_tamper value, Edit
 # setting config_hooks_tamper:"off", BYPASS → DENY (gate evaluates pre-write) ─
-run_hook "$SANDBOX" "$(mkenv_edit_tamper_self "$CFG" bypassPermissions)"
+run_hook_pipeline "$SANDBOX" "$(mkenv_edit_tamper_self "$CFG" bypassPermissions)"
 assert_deny "tc9: self-protection — Edit setting config_hooks_tamper:off bypass → DENY (pre-write eval)" "$HOOK_OUT"
 
 # ── tc10: warn AND deny text both carry the recovery line (Settled decision 13) ─
-run_hook "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
-if [[ "$HOOK_OUT" == *'human-reviewed'* ]]; then
+run_hook_pipeline "$SANDBOX" "$(mkenv_edit_hooks "$CFG" bypassPermissions)"
+if [[ "$HOOK_OUT" == *'human-reviewed'* ]] && [[ "$HOOK_OUT" == *'"permissionDecision":"deny"'* ]]; then
   pass "tc10a: tamper DENY text contains the recovery line (human-reviewed)"
 else
   fail "tc10a: tamper DENY text contains the recovery line (human-reviewed)" "out=$HOOK_OUT"

--- a/tests/test-hooks-bypass-generic.sh
+++ b/tests/test-hooks-bypass-generic.sh
@@ -214,13 +214,20 @@ echo "=== ENFORCEMENT_V2 Phase 3: generic-hook demotable parity (#1159) ==="
 # JSON shape: command is the LAST tool_input field; permission_mode is a
 # top-level field BEFORE tool_input so the greedy sed COMMAND extraction does
 # not bleed it in (matches the harness convention).
+# $6=optional "pipeline" → plant a live .zskills/tracked marker (genuine
+# autonomy signal → enforce-pipeline). bypassPermissions is ATTENDED, so a
+# bypass-mode-but-genuinely-autonomous case must carry this marker to still
+# DENY (it can no longer rely on bypassPermissions alone).
 enf_gen_case() {
-  local label="$1" pm="$2" cmd="$3" expect="$4" hooks_cfg="${5:-}"
+  local label="$1" pm="$2" cmd="$3" expect="$4" hooks_cfg="${5:-}" pipeline="${6:-}"
   local d; d=$(mktemp -d)
   ( cd "$d" && git init -q )
   if [ -n "$hooks_cfg" ]; then
     mkdir -p "$d/.claude"
     printf '{"hooks":%s}\n' "$hooks_cfg" > "$d/.claude/zskills-config.json"
+  fi
+  if [ "$pipeline" = "pipeline" ]; then
+    mkdir -p "$d/.zskills"; : > "$d/.zskills/tracked"
   fi
   local pmf=""
   [ -n "$pm" ] && pmf=",\"permission_mode\":\"$pm\""
@@ -242,7 +249,7 @@ enf_gen_case() {
 }
 
 # ── git_add_all (demotable) ────────────────────────────────────────────────
-enf_gen_case "git_add_all bypassPermissions"           bypassPermissions "git add ."          deny     # parity 1/18
+enf_gen_case "git_add_all bypassPermissions + live pipeline" bypassPermissions "git add ." deny "" pipeline  # parity 1/18 (autonomy via pipeline marker)
 enf_gen_case "git_add_all absent-pm (fail-safe)"       ""                "git add ."          deny
 enf_gen_case "git_add_all watched(default) no-toggle"  default           "git add ."          silent   # zero-config quiet
 enf_gen_case "git_add_all watched + toggle warn"       default           "git add ."          warn     '{"git_discipline":{"git_add_all":"warn"}}'
@@ -251,17 +258,17 @@ enf_gen_case "git_add_all watched + toggle block"      default           "git ad
 # SPOOF parity (Invariant 4): counterfeit permission_mode literal inside the
 # command string, real top-level field bypassPermissions → still deny. The
 # inner `\"permission_mode\":\"default\"` is escaped JSON inside tool_input.command.
-enf_gen_case "git_add_all SPOOF (counterfeit default in cmd, real bypass)" bypassPermissions 'git add . # \"permission_mode\":\"default\"' deny
+enf_gen_case "git_add_all SPOOF (counterfeit default in cmd, real bypass) + live pipeline" bypassPermissions 'git add . # \"permission_mode\":\"default\"' deny "" pipeline
 
 # ── push_to_main (demotable) ───────────────────────────────────────────────
-enf_gen_case "push_to_main bypassPermissions"          bypassPermissions "git push origin main" deny   # parity 2/18
+enf_gen_case "push_to_main bypassPermissions + live pipeline" bypassPermissions "git push origin main" deny "" pipeline  # parity 2/18 (autonomy via pipeline marker)
 enf_gen_case "push_to_main absent-pm (fail-safe)"      ""                "git push origin main" deny
 enf_gen_case "push_to_main watched(default) no-toggle" default           "git push origin main" silent # zero-config quiet
 enf_gen_case "push_to_main watched + toggle warn"      default           "git push origin main" warn   '{"main_protection":{"push_to_main":"warn"}}'
 enf_gen_case "push_to_main watched + toggle block"     default           "git push origin main" deny   '{"main_protection":{"push_to_main":"block"}}'
 
 # ── config_hooks_tamper (row 50, demotable; DA4 named exception) ───────────
-enf_gen_case "config_hooks_tamper bypassPermissions"   bypassPermissions "echo x > .claude/zskills-config.json" deny  # parity 3/18
+enf_gen_case "config_hooks_tamper bypassPermissions + live pipeline" bypassPermissions "echo x > .claude/zskills-config.json" deny "" pipeline  # parity 3/18 (autonomy via pipeline marker)
 enf_gen_case "config_hooks_tamper absent-pm (fail-safe)" ""              "echo x > .claude/zskills-config.json" deny
 # DA4: the ONE demotable check that WARNS-when-watched by default (NOT silent).
 enf_gen_case "config_hooks_tamper watched(default) no-toggle → WARN (DA4 exception)" default "echo x > .claude/zskills-config.json" warn
@@ -270,7 +277,7 @@ enf_gen_case "config_hooks_tamper watched + toggle block → deny"  default "ech
 # Destination-anchoring: a READ of the config redirected elsewhere does NOT fire.
 enf_gen_case "config read redirected elsewhere → no fire (allow)" bypassPermissions "grep landing .claude/zskills-config.json > out.txt" silent
 # Recovery line present in the deny body.
-_RD=$(mktemp -d); ( cd "$_RD" && git init -q )
+_RD=$(mktemp -d); ( cd "$_RD" && git init -q ); mkdir -p "$_RD/.zskills"; : > "$_RD/.zskills/tracked"  # live pipeline → enforce-pipeline deny
 _RECOUT=$(printf '{"tool_name":"Bash","permission_mode":"bypassPermissions","tool_input":{"command":"echo x > .claude/zskills-config.json"}}' | ZSKILLS_ENF_CONFIG_ROOT="$_RD" REPO_ROOT="$_RD" bash -c "cd '$_RD' && bash '$HOOK'" 2>/dev/null)
 rm -rf "$_RD"
 if [[ "$_RECOUT" == *"Recovery:"* ]] && [[ "$_RECOUT" == *"human-reviewed"* ]]; then
@@ -280,7 +287,7 @@ else
 fi
 
 # Toggle tag present on a demotable deny (Settled decision 14).
-_TD=$(mktemp -d); ( cd "$_TD" && git init -q )
+_TD=$(mktemp -d); ( cd "$_TD" && git init -q ); mkdir -p "$_TD/.zskills"; : > "$_TD/.zskills/tracked"  # live pipeline → enforce-pipeline deny
 _TAGOUT=$(printf '{"tool_name":"Bash","permission_mode":"bypassPermissions","tool_input":{"command":"git add ."}}' | ZSKILLS_ENF_CONFIG_ROOT="$_TD" REPO_ROOT="$_TD" bash -c "cd '$_TD' && bash '$HOOK'" 2>/dev/null)
 rm -rf "$_TD"
 if [[ "$_TAGOUT" == *"[hooks.git_discipline.git_add_all — block|warn|off in .claude/zskills-config.json"* ]]; then
@@ -293,11 +300,15 @@ fi
 # Each line carries the literal `"permission_mode":"bypassPermissions"` so the
 # Phase-3 AC grep (`grep -rE '"permission_mode"' tests/ | grep -c
 # bypassPermissions` ≥ 23) counts genuine bypass-mode parity fixtures. Each
-# asserts the demotable generic site STILL DENIES under bypassPermissions —
-# autonomous protection unchanged. Run in a clean temp root (no markers).
+# asserts the demotable generic site STILL DENIES under bypassPermissions WHEN
+# a zskills pipeline is genuinely live — autonomous protection unchanged.
+# bypassPermissions is now ATTENDED (a permission-convenience flag), so the
+# genuine-autonomy signal is the live .zskills/tracked marker planted below;
+# the bypass JSON is preserved for the AC parity grep.
 bypass_deny_gen() {
   local label="$1" json="$2"
   local d; d=$(mktemp -d); ( cd "$d" && git init -q )
+  mkdir -p "$d/.zskills"; : > "$d/.zskills/tracked"  # live pipeline → enforce-pipeline deny
   local out; out=$(printf '%s' "$json" | ZSKILLS_ENF_CONFIG_ROOT="$d" REPO_ROOT="$d" bash -c "cd '$d' && bash '$HOOK'" 2>/dev/null)
   rm -rf "$d"
   if [[ "$out" == *'"permissionDecision"'*'deny'* ]]; then pass "bypass-parity-gen: $label"; else fail "bypass-parity-gen: $label — expected deny, got: ${out:0:80}"; fi

--- a/tests/test-hooks-bypass-project.sh
+++ b/tests/test-hooks-bypass-project.sh
@@ -384,21 +384,21 @@ enf_proj_case() {
 }
 
 # ── commit_on_main (demotable) — parity 4/18 ───────────────────────────────
-enf_proj_case "commit_on_main bypassPermissions"          main bypassPermissions "git commit -m x" deny "" "" "stagecode"
+enf_proj_case "commit_on_main bypassPermissions + live pipeline" main bypassPermissions "git commit -m x" deny "" "tracked" "stagecode"
 enf_proj_case "commit_on_main absent-pm (fail-safe)"      main ""                "git commit -m x" deny "" "" "stagecode"
 enf_proj_case "commit_on_main watched(default) → SILENT"  main default           "git commit -m x" silent "" "" "stagecode"
 enf_proj_case "commit_on_main watched + toggle warn"      main default           "git commit -m x" warn '{"main_protection":{"commit_on_main":"warn"}}' "" "stagecode"
 enf_proj_case "commit_on_main watched + toggle block"     main default           "git commit -m x" deny '{"main_protection":{"commit_on_main":"block"}}' "" "stagecode"
 
 # ── cherry_pick_on_main (demotable) — parity 5/18 ──────────────────────────
-enf_proj_case "cherry_pick_on_main bypassPermissions"     main bypassPermissions "git cherry-pick abc123" deny
+enf_proj_case "cherry_pick_on_main bypassPermissions + live pipeline" main bypassPermissions "git cherry-pick abc123" deny "" "tracked"
 enf_proj_case "cherry_pick_on_main watched(default) → SILENT" main default       "git cherry-pick abc123" silent
 
 # ── push_to_main (demotable, 3 forms share the key) — parity 6/18 ──────────
-enf_proj_case "push_to_main form-a (origin main) bypass"  feat/test bypassPermissions "git push origin main" deny
+enf_proj_case "push_to_main form-a (origin main) bypass + live pipeline" feat/test bypassPermissions "git push origin main" deny "" "tracked"
 enf_proj_case "push_to_main form-a watched(default) → SILENT" feat/test default     "git push origin main" silent
-enf_proj_case "push_to_main form-b (feat:main) bypass"    feat/test bypassPermissions "git push origin feat:main" deny
-enf_proj_case "push_to_main form-c (naked on main) bypass" main bypassPermissions "git push" deny
+enf_proj_case "push_to_main form-b (feat:main) bypass + live pipeline" feat/test bypassPermissions "git push origin feat:main" deny "" "tracked"
+enf_proj_case "push_to_main form-c (naked on main) bypass + live pipeline" main bypassPermissions "git push" deny "" "tracked"
 
 # ── requires_unfulfilled (demotable, 2 sites: commit + push) — parity 7/18 ─
 enf_proj_case "requires_unfulfilled (commit) bypass"      feat/test bypassPermissions "git commit -m x" deny "" "tracked" "requires,stagecode"
@@ -415,45 +415,49 @@ enf_proj_case "step_unverified (impl, no verify) bypass"  feat/test bypassPermis
 enf_proj_case "step_unreported (verify, no report) bypass" feat/test bypassPermissions "git commit -m x" deny "" "tracked" "stepverify,stagecode"
 
 # ── logs_add_all (demotable) — parity 10/18 ────────────────────────────────
-enf_proj_case "logs_add_all bypassPermissions"            feat/test bypassPermissions "git add .claude/logs/" deny
+enf_proj_case "logs_add_all bypassPermissions + live pipeline" feat/test bypassPermissions "git add .claude/logs/" deny "" "tracked"
 enf_proj_case "logs_add_all watched(default) → SILENT"    feat/test default           "git add .claude/logs/" silent
 
 # ── test_pipe (demotable) — parity 11/18 ───────────────────────────────────
-enf_proj_case "test_pipe bypassPermissions"               feat/test bypassPermissions "npm test | tail" deny
+enf_proj_case "test_pipe bypassPermissions + live pipeline" feat/test bypassPermissions "npm test | tail" deny "" "tracked"
 enf_proj_case "test_pipe watched(default) → SILENT"       feat/test default           "npm test | tail" silent
 
 # ── full_cmd_unset (demotable) — parity 12/18 ──────────────────────────────
-enf_proj_case "full_cmd_unset bypassPermissions"          feat/test bypassPermissions "npm test | tail" deny "" "" "no-full-cmd"
+enf_proj_case "full_cmd_unset bypassPermissions + live pipeline" feat/test bypassPermissions "npm test | tail" deny "" "tracked" "no-full-cmd"
 enf_proj_case "full_cmd_unset watched(default) → SILENT"  feat/test default           "npm test | tail" silent "" "" "no-full-cmd"
 
 # ── tests_not_run (commit, demotable) — parity 13/18 ───────────────────────
-enf_proj_case "tests_not_run (commit) bypassPermissions"  feat/test bypassPermissions "git commit -m x" deny "" "" "stagecode,no-test-in-transcript"
+enf_proj_case "tests_not_run (commit) bypassPermissions + live pipeline" feat/test bypassPermissions "git commit -m x" deny "" "tracked" "stagecode,no-test-in-transcript"
 enf_proj_case "tests_not_run (commit) watched(default) → SILENT" feat/test default     "git commit -m x" silent "" "" "stagecode,no-test-in-transcript"
 # ── tests_not_run (cherry-pick, demotable) — parity 14/18 ──────────────────
-enf_proj_case "tests_not_run (cherry-pick) bypassPermissions" feat/test bypassPermissions "git cherry-pick abc123" deny "" "" "no-test-in-transcript"
+enf_proj_case "tests_not_run (cherry-pick) bypassPermissions + live pipeline" feat/test bypassPermissions "git cherry-pick abc123" deny "" "tracked" "no-test-in-transcript"
 
 # ── ui_unverified (demotable) — parity 15/18 ───────────────────────────────
 # UI file staged, transcript lacks playwright-cli AND lacks the test cmd so the
 # commit transcript gate is the UI one (use no-test-in-transcript to skip the
 # tests_not_run gate ordering; UI gate fires on the missing playwright-cli).
-enf_proj_case "ui_unverified bypassPermissions"           feat/test bypassPermissions "git commit -m x" deny "" "" "uifile,ui-no-playwright"
+enf_proj_case "ui_unverified bypassPermissions + live pipeline" feat/test bypassPermissions "git commit -m x" deny "" "tracked" "uifile,ui-no-playwright"
 
 # SPOOF parity (Invariant 4): counterfeit permission_mode:"default" inside the
-# command string, real top-level field bypassPermissions → still deny.
-enf_proj_case "commit_on_main SPOOF (counterfeit default in cmd, real bypass)" main bypassPermissions 'git commit -m \"x permission_mode default\"' deny "" "" "stagecode"
+# command string, real top-level field bypassPermissions → parser takes the real
+# field (attended); a live pipeline marker keeps the deny path exercised.
+enf_proj_case "commit_on_main SPOOF (counterfeit default in cmd, real bypass) + live pipeline" main bypassPermissions 'git commit -m \"x permission_mode default\"' deny "" "tracked" "stagecode"
 
 # ── Inline-JSON bypass-parity (Invariant 4, AC parity-coverage floor) ───────
 # Each line carries the literal `"permission_mode":"bypassPermissions"` so the
 # Phase-3 AC grep (`grep -rE '"permission_mode"' tests/ | grep -c
 # bypassPermissions` ≥ 23) counts genuine bypass-mode parity fixtures. These
-# cover the on-main + git-discipline project sites whose deny fires without
-# pipeline markers; the marker-dependent tracking sites are covered by the
-# helper-based cases above (also bypassPermissions). $1=label $2=branch
+# cover the on-main + git-discipline project sites. bypassPermissions is now
+# ATTENDED, so the genuine-autonomy signal is the live .zskills/tracked marker
+# planted below — the bypass JSON is preserved for the AC parity grep. The
+# marker-dependent tracking sites are covered by the helper-based cases above
+# (also bypassPermissions). $1=label $2=branch
 # $3=full-json $4=no-full-cmd? $5=no-test? — minimal fixture controls.
 bypass_deny_proj() {
   local label="$1" branch="$2" json="$3" nofull="${4:-}" notest="${5:-}"
   local d; d=$(mktemp -d)
   mkdir -p "$d/.claude/hooks" "$d/.zskills/tracking"
+  printf 'run-plan.test-plan\n' > "$d/.zskills/tracked"  # live pipeline → enforce-pipeline deny
   cp "$PROJ_HOOK_FILE" "$d/.claude/hooks/block-unsafe-project.sh"
   local fc='"full_cmd": "npm run test:all"'; [ "$nofull" = "nofull" ] && fc='"full_cmd": ""'
   printf '{ "testing": { "unit_cmd": "npm test", %s }, "ui": { "file_patterns": "src/ui/" }, "execution": { "main_protected": true } }\n' "$fc" > "$d/.claude/zskills-config.json"

--- a/tests/test-plan-claim-hook-deny.sh
+++ b/tests/test-plan-claim-hook-deny.sh
@@ -254,8 +254,12 @@ run_hook_capture() {
 ENF_SLUG="enfplan"
 ENF_CMD="bash $REPO_ROOT/skills/create-worktree/scripts/create-worktree.sh --prefix cp $ENF_SLUG"
 
-# ── EP1: bypass-parity — no-claim + bypassPermissions → DENY + names toggle ─
+# ── EP1: bypass-parity — no-claim + bypassPermissions + live pipeline → DENY +
+# names toggle. bypassPermissions is now ATTENDED (a permission-convenience flag,
+# not an attendance signal); the genuine autonomy signal driving the autonomous
+# deny is the live .zskills/tracked pipeline marker planted below. ─
 ep1_fixture=$(setup_fixture "enf_p1" "$ENF_SLUG")
+mkdir -p "$ep1_fixture/.zskills"; : > "$ep1_fixture/.zskills/tracked"
 ep1_payload=$(make_payload_pm "$ENF_CMD" "bypassPermissions")
 run_hook_capture "$ep1_payload" "$ep1_fixture"
 if echo "$PLAN_STDOUT" | grep -q '"permissionDecision":"deny"' \

--- a/tests/test-zskills-enforcement-lib.sh
+++ b/tests/test-zskills-enforcement-lib.sh
@@ -54,7 +54,11 @@ assert_eq() {
 
 # ── PREDICATE ─────────────────────────────────────────────────────────────
 echo "── predicate: permission_mode parse ──"
-assert_eq "predicate bypassPermissions → enforce-autonomous" "enforce-autonomous" \
+# bypassPermissions is ATTENDED: it's a permission-convenience flag, not an
+# attendance signal. With no live pipeline marker it resolves to watched (same
+# as default/acceptEdits/plan). Autonomy is detected by the pipeline-live arms;
+# hard enforcement stays available via the per-check "block" toggle.
+assert_eq "predicate bypassPermissions (no markers) → watched" "watched" \
   "$(zskills_enforcement_predicate '{"permission_mode":"bypassPermissions"}' /nope /nope)"
 assert_eq "predicate default (no markers) → watched" "watched" \
   "$(zskills_enforcement_predicate '{"permission_mode":"default"}' /nope /nope)"
@@ -69,9 +73,17 @@ assert_eq "predicate garbage value → enforce-autonomous (fail-safe)" "enforce-
 
 echo "── predicate: SPOOF cases ──"
 # Counterfeit escaped "permission_mode":"default" embedded in command content,
-# real field is bypassPermissions → must still be enforce-autonomous.
-assert_eq "spoof embedded default + real bypass → enforce-autonomous" "enforce-autonomous" \
+# real top-level field is bypassPermissions → parser must take the REAL field
+# (now attended → watched, no markers), NOT leak the embedded literal.
+assert_eq "spoof embedded default + real bypass → watched" "watched" \
   "$(zskills_enforcement_predicate '{"tool_input":{"command":"echo \"permission_mode\":\"default\""},"permission_mode":"bypassPermissions"}' /nope /nope)"
+# Counterfeit escaped attended literal embedded, real top-level field is GARBAGE
+# → parser must take the real (unrecognized) field → fail-safe enforce-autonomous.
+# This is the discriminating spoof case: embedded "default" would map to watched,
+# but the real "banana" is unrecognized, so the result proves the embedded
+# literal was NOT parsed.
+assert_eq "spoof embedded default + real garbage → enforce-autonomous" "enforce-autonomous" \
+  "$(zskills_enforcement_predicate '{"tool_input":{"command":"echo \"permission_mode\":\"default\""},"permission_mode":"banana"}' /nope /nope)"
 # Counterfeit embedded default, real field ABSENT → fail-safe enforce.
 assert_eq "spoof embedded default + real absent → enforce-autonomous" "enforce-autonomous" \
   "$(zskills_enforcement_predicate '{"tool_input":{"command":"echo \"permission_mode\":\"default\""}}' /nope /nope)"
@@ -83,6 +95,10 @@ LR=$(mktemp -d "$WORK/local-XXXXXX"); MR=$(mktemp -d "$WORK/main-XXXXXX")
 mkdir -p "$LR/.zskills"; touch "$LR/.zskills/tracked"
 assert_eq "DA1 local .zskills/tracked, main clean → enforce-pipeline" "enforce-pipeline" \
   "$(zskills_enforcement_predicate '{"permission_mode":"default"}' "$MR" "$LR")"
+# bypassPermissions is attended, but a LIVE pipeline marker still forces
+# enforce-pipeline — genuine zskills autonomy under bypass is caught here.
+assert_eq "bypassPermissions + live pipeline marker → enforce-pipeline" "enforce-pipeline" \
+  "$(zskills_enforcement_predicate '{"permission_mode":"bypassPermissions"}' "$MR" "$LR")"
 # Legacy .zskills-tracked at the local root.
 rm -f "$LR/.zskills/tracked"; touch "$LR/.zskills-tracked"
 assert_eq "legacy local .zskills-tracked → enforce-pipeline" "enforce-pipeline" \
@@ -115,6 +131,19 @@ touch "$MR4/.zskills/tracking/finished-pipeline/requires.x.123" \
       "$MR4/.zskills/tracking/finished-pipeline/step.1.123"
 assert_eq "DA2 stale tracking subdir, no tracked file → watched" "watched" \
   "$(zskills_enforcement_predicate '{"permission_mode":"default"}' "$MR4" "$LR4")"
+
+echo "── predicate: bypassPermissions-as-attended REGRESSION PIN ──"
+# REGRESSION PIN for the bypassPermissions=attended recategorization: a
+# bypass-mode human with NO live pipeline and an unset per-check toggle must
+# resolve to a SILENT demotable check (no nag, no block). This pins the whole
+# attended path end-to-end: predicate → watched, then a demotable check
+# (main_edit) with the toggle unset → silent.
+MR5=$(mktemp -d "$WORK/main5-XXXXXX"); LR5=$(mktemp -d "$WORK/local5-XXXXXX")
+PIN_PRED="$(zskills_enforcement_predicate '{"permission_mode":"bypassPermissions"}' "$MR5" "$LR5")"
+assert_eq "PIN: bypass + no pipeline + unset toggle → predicate watched" "watched" "$PIN_PRED"
+reset_state
+assert_eq "PIN: bypass-watched + demotable main_edit (unset) → silent" "silent" \
+  "$(zskills_enforcement_mode main_protection main_edit demotable "$PIN_PRED")"
 
 # ── CONFIG_ROOT ───────────────────────────────────────────────────────────
 echo "── config_root resolution ──"


### PR DESCRIPTION
Task: Recategorize bypassPermissions as an attended permission mode in the ENFORCEMENT_V2 predicate, so a human running --dangerously-skip-permissions is no longer auto-classified as autonomous.

The enforcement predicate used `permission_mode` as an attendance proxy and treated `bypassPermissions` (and absent/unrecognized) as autonomous. But bypass mode is a permission convenience, not an attendance signal — a human running `--dangerously-skip-permissions` got the autonomous/block treatment on every session. This moves `bypassPermissions` into the attended arm: genuine autonomy is still detected by the pipeline-live arm and the absent/unrecognized fail-safe, hard checks still block always, and projects keep hard enforcement via the per-check `block` toggle.

Touches all 18 inlined predicate copies + lib + template + regenerated managed.md, the affected hook/enforcement tests (repointed to a genuine autonomy trigger, none weakened; new regression pin added), CLAUDE_TEMPLATE.md, zskills-config.md, and a disposition note in ENFORCEMENT_V2_PLAN.md.

Worktree: /tmp/zskills-do-bypass-attended-mode
Commits: edf75f88 fix(enforcement): treat bypassPermissions as attended, not autonomous
